### PR TITLE
Fix Travis integration config option in .coveralls.yml.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service_name: travis
+service_name: travis-ci


### PR DESCRIPTION
"Another important option is service_name which allows you to specify where Coveralls should look to find additional information about your builds. This can be any string, but using travis-ci or travis-pro will allow Coveralls to fetch branch data, comment on pull requests, and more."
