### PR TITLE
Undo hound's default for detect vs find.

### DIFF
--- a/.rubocop.unhound.yml
+++ b/.rubocop.unhound.yml
@@ -39,6 +39,7 @@ ClassVars:
 
 CollectionMethods:
   PreferredMethods:
+    find: 'find'
     detect: 'find'
 
 ColonMethodCall:


### PR DESCRIPTION
![lol](http://24.media.tumblr.com/5b8557ed697342ccc5af437d798121c6/tumblr_mmm9mbNe381rw9dz1o1_500.gif)
See https://github.com/thoughtbot/hound/issues/540#issuecomment-68283585