### PR TITLE
Do not lock the gemfile to mswin64 for compatibility with bundle on Unix systems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,6 @@ GEM
     yard (0.8.7.6)
 
 PLATFORMS
-  mswin64
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
Closes #26.