### PR TITLE
change hostname in factory from '_' to '-'

### DIFF
--- a/spec/factories/instances.rb
+++ b/spec/factories/instances.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   base_time = Time.now.to_i
   sequence :host do |n|
-    "local_#{base_time}_#{n}.com"
+    "local-#{base_time}-#{n}.com"
   end
 
   factory :instance do


### PR DESCRIPTION
Underscore('_') is not a valid host name character

>hostname labels may contain only the ASCII letters 'a' through 'z' (in a case-insensitive manner), the digits '0' through '9', and the hyphen ('-'). The original specification of hostnames in RFC 952, mandated that labels could not start with a digit or with a hyphen, and must not end with a hyphen. 

REF: http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names