### PR TITLE
add name to instances

### DIFF
--- a/db/migrate/20150106073750_add_name_to_instances.rb
+++ b/db/migrate/20150106073750_add_name_to_instances.rb
@@ -1,0 +1,5 @@
+class AddNameToInstances < ActiveRecord::Migration
+  def change
+    add_column :instances, :name, :string, null: false, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141222074908) do
+ActiveRecord::Schema.define(version: 20150106073750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "instances", force: true do |t|
+    t.string "name", null: false
     t.string "host", null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application"
     t.index ["host"], :name => "index_instances_on_host", :unique => true, :case_sensitive => false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,4 +7,4 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 #
 # Remember to ensure that the commands in this file are idempotent!
-Instance.find_or_create_by(host: '*')
+Instance.find_or_create_by(name: 'Default', host: '*')

--- a/spec/factories/instances.rb
+++ b/spec/factories/instances.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
   end
 
   factory :instance do
+    sequence(:name) { |n| "Instance#{n}" }
     host
   end
 end


### PR DESCRIPTION
Changs in this PR:

1. add a name field to instance table (Instance management page requires this field)

2. fix factory and seeds files