### PR TITLE
Add some migration helpers to pick sane defaults in migrations

### DIFF
--- a/lib/extensions/active_record.rb
+++ b/lib/extensions/active_record.rb
@@ -1,0 +1,1 @@
+module Extensions::ActiveRecord; end

--- a/lib/extensions/active_record/connection_adapters.rb
+++ b/lib/extensions/active_record/connection_adapters.rb
@@ -1,0 +1,1 @@
+module Extensions::ActiveRecord::ConnectionAdapters; end

--- a/lib/extensions/active_record/connection_adapters/table_definition.rb
+++ b/lib/extensions/active_record/connection_adapters/table_definition.rb
@@ -1,0 +1,14 @@
+module Extensions::ActiveRecord::ConnectionAdapters::TableDefinition
+  def self.included(module_)
+    module_.alias_method_chain :userstamps, :compatibility
+  end
+
+  def time_bounded(*args)
+    datetime :valid_from, *args
+    datetime :valid_to, *args
+  end
+
+  def userstamps_with_compatibility(*args)
+    userstamps_without_compatibility(false, *args)
+  end
+end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -41,3 +41,9 @@ end
 CoverageHelper.load('codeclimate-test-reporter') do
   CodeClimate::TestReporter.start
 end
+
+# Code coverage exclusions
+SimpleCov.start do
+  # Helpers for schema migrations. We don't test schema migrations, so these would never run.
+  add_filter '/lib/extensions/active_record/connection_adapters/table_definition.rb'
+end


### PR DESCRIPTION
Currently implemented:
 - `t.userstamps` will not allow you to specify `compatibility: true`, requiring you to use `updater_id` and `creator_id` since we enforce foreign keys
 - `t.time_bounded` creates a `valid_from` and `valid_to` column pair.