### PR TITLE
Course Sidebar module fix

### DIFF
--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -18,6 +18,6 @@ class Course::Controller < ApplicationController
       module_.get_sidebar_items(self)
     end
 
-    array_of_module_arrays.flatten!
+    array_of_module_arrays.tap { |arr| arr.flatten! }
   end
 end

--- a/spec/controllers/course/controller_spec.rb
+++ b/spec/controllers/course/controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Course::Controller, type: :controller do
+  describe '#sidebar' do
+    it 'returns an empty array when no modules included' do
+      allow(Course::CoursesController).to receive(:modules).and_return([])
+      expect(controller.sidebar).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Now if there were no modules included, the sidebar function will return nil, which is not expected.