### PR TITLE
`form_for` with overriden resource route

### DIFF
--- a/lib/extensions/action_view/helpers/form_helper.rb
+++ b/lib/extensions/action_view/helpers/form_helper.rb
@@ -1,0 +1,57 @@
+module Extensions::ActionView::Helpers::FormHelper
+  def self.included(module_)
+    module_.alias_method_chain :form_for, :resource
+  end
+
+  def form_for_with_resource(record, options, &proc)
+    case options[:resource]
+    when Symbol
+      raise ArgumentError, ':resource and :url cannot be specified simultaneously' if options[:url]
+      helper_module = Extensions::ActionView::Helpers::FormHelper
+      helper = helper_module.url_helper_for_resource(record, options.delete(:resource))
+      options[:url] = send(helper, *record)
+    when nil
+    else
+      raise ArgumentError, 'Resource must be a symbol with the stem of route helper'
+    end
+
+    form_for_without_resource(record, options, &proc)
+  end
+
+  # Gets the URL for the record. This follows the pluralisation rules for Rails routes, where the
+  # CREATE action is plural, and the PUT action is singular.
+  #
+  # @param record [Array<ActiveRecord::Base>|ActionRecord::Base] The record to build the route from.
+  # @param helper [Symbol] The symbol with the stem of the URL helper.
+  # @return [Symbol] The appropriate URL helper to call.
+  def self.url_helper_for_resource(record, helper)
+    resource = record
+    resource = resource.last if resource.is_a?(Array)
+
+    inflect_path(helper, resource.new_record?)
+  end
+
+  # Inflects the path according to the plurality specified.
+  #
+  # @param stem [Symbol] The path to inflect.
+  # @param plural [Boolean] Whether to make the path plural.
+  # @return [String] The stem, in the given plurality.
+  def self.inflect_path(stem, plural)
+    components = stem.to_s.underscore.split('_')
+    suffix =
+      if ['path', 'url'].include?(components.last)
+        components.pop
+      else
+        'path'
+      end
+    name = components.pop
+    name =
+      if plural
+        name.pluralize
+      else
+        name.singularize
+      end
+    components.push(name, suffix)
+    components.join('_').to_sym
+  end
+end

--- a/spec/libraries/form_for_resource_spec.rb
+++ b/spec/libraries/form_for_resource_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'form_for resource', type: :view do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    it 'does not allow :url to be used with :resource' do
+      expect do
+        form_for(build(:course), resource: :course, url: courses_path) {}
+      end.to raise_error(ArgumentError)
+    end
+
+    context 'when the resource is new' do
+      subject { form_for(build(:course), resource: :course) {} }
+      it 'generates the plural route' do
+        expect(subject).to have_form(courses_path, :post)
+      end
+    end
+
+    context 'when the resource is persisted' do
+      let(:course) { create(:course) }
+      subject { form_for(course, resource: :course) {} }
+      it 'generates the singular route' do
+        expect(subject).to have_form(course_path(course), :post)
+      end
+    end
+  end
+end

--- a/spec/libraries/form_for_resource_spec.rb
+++ b/spec/libraries/form_for_resource_spec.rb
@@ -9,8 +9,18 @@ describe 'form_for resource', type: :view do
       end.to raise_error(ArgumentError)
     end
 
+    it 'requires :resource to be a symbol' do
+      expect do
+        form_for(build(:course), resource: 'course') {}
+      end.to raise_error(ArgumentError)
+    end
+
+    it 'automatically adds the `path` suffix for route helpers' do
+      expect(form_for(build(:course), resource: :course) {}).to have_form(courses_path, :post)
+    end
+
     context 'when the resource is new' do
-      subject { form_for(build(:course), resource: :course) {} }
+      subject { form_for(build(:course), resource: :course_path) {} }
       it 'generates the plural route' do
         expect(subject).to have_form(courses_path, :post)
       end
@@ -18,7 +28,7 @@ describe 'form_for resource', type: :view do
 
     context 'when the resource is persisted' do
       let(:course) { create(:course) }
-      subject { form_for(course, resource: :course) {} }
+      subject { form_for(course, resource: :course_path) {} }
       it 'generates the singular route' do
         expect(subject).to have_form(course_path(course), :post)
       end

--- a/spec/libraries/render_within_layout_spec.rb
+++ b/spec/libraries/render_within_layout_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'render_within_layout', type: :view do
+describe 'render within_layout', type: :view do
   let(:views_directory) do
     path = Pathname.new("#{__dir__}/../fixtures/libraries/render_within_layout")
     path.realpath

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -21,5 +21,6 @@ end
 
 RSpec.configure do |config|
   config.extend ActsAsTenant::TestGroupHelpers, type: :model
+  config.extend ActsAsTenant::TestGroupHelpers, type: :view
   config.extend ActsAsTenant::TestGroupHelpers, type: :feature
 end


### PR DESCRIPTION
Since we have a complex URL structure which does not correspond one-to-one with the models, our form targets might not always be possibly automatically generated.

This creates a new option which accepts a symbol, the stem of the route helper, and generates the correct target for the form, depending on the provided resource.