### PR TITLE
Remove hardcoded ruby version from scripts in bin folder

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
-#!/usr/bin/env ruby2.1
+#!/usr/bin/env ruby
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby2.1
+#!/usr/bin/env ruby
 begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby2.1
+#!/usr/bin/env ruby
 begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError


### PR DESCRIPTION
This allows rbenv to handle the ruby version correctly.