### PR TITLE
File/attachment upload framework (Non JavaScript version)

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,0 +1,8 @@
+class Attachment < ActiveRecord::Base
+  stampable
+
+  belongs_to :creator, class_name: User.name
+  belongs_to :attachable, polymorphic: true
+
+  mount_uploader :file_upload, FileUploader
+end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+class FileUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process :scale => [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process :resize_to_fit => [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_white_list
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+
+end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -8,6 +8,7 @@ class FileUploader < CarrierWave::Uploader::Base
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog
+  before :cache, :save_original_filename
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -18,7 +19,8 @@ class FileUploader < CarrierWave::Uploader::Base
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url
   #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #   # ActionController::Base.helpers.
+  #       asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
   #
   #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
   # end
@@ -47,4 +49,7 @@ class FileUploader < CarrierWave::Uploader::Base
   #   "something.jpg" if original_filename
   # end
 
+  def save_original_filename(file)
+    model.name = file.original_filename if file.respond_to?(:original_filename)
+  end
 end

--- a/app/views/layouts/_attachment_uploader.html.slim
+++ b/app/views/layouts/_attachment_uploader.html.slim
@@ -1,0 +1,14 @@
+- if form_builder.object.attachments.count > 0
+  strong = t('.uploaded')
+
+= form_builder.fields_for :attachments do |sub_builder|
+  div
+    - if sub_builder.object.persisted?
+      = link_to sub_builder.object.name, attachment_path(sub_builder.object)
+
+      = sub_builder.check_box :_destroy
+      = sub_builder.label :_destroy, t('.remove')
+    - else
+      = sub_builder.label t('.new_file')
+      = sub_builder.file_field :file_upload
+      = sub_builder.hidden_field :file_upload_cache

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,10 @@ en:
       more_announcements: 'More Announcements...'
     course_settings:
       title: 'Settings'
+    attachment_uploader:
+      uploaded: 'Uploaded Files:'
+      new_file: 'Upload New File'
+      remove: 'Remove'
   admin:
     navbar:
       announcements: 'Announcements'

--- a/db/migrate/20150309030221_create_attachments.rb
+++ b/db/migrate/20150309030221_create_attachments.rb
@@ -1,0 +1,12 @@
+class CreateAttachments < ActiveRecord::Migration
+  def change
+    create_table :attachments do |t|
+      t.string :name, null: false
+      t.references :attachable, polymorphic: true, index: true
+      t.text :file_upload, null: false
+
+      t.userstamps null: false, foreign_key: { references: :users }
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,11 +16,6 @@ ActiveRecord::Schema.define(version: 20150316080645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "instances", force: :cascade do |t|
-    t.string "name", limit: 255, null: false
-    t.string "host", limit: 255, null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application", index: {name: "index_instances_on_host", unique: true, case_sensitive: false}
-  end
-
   create_table "users", force: :cascade do |t|
     t.string   "name",                   limit: 255,              null: false
     t.integer  "role",                   default: 0,  null: false
@@ -35,6 +30,22 @@ ActiveRecord::Schema.define(version: 20150316080645) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "attachments", force: :cascade do |t|
+    t.string   "name",            null: false
+    t.integer  "attachable_id"
+    t.string   "attachable_type", index: {name: "index_attachments_on_attachable_type_and_attachable_id", with: ["attachable_id"]}
+    t.text     "file_upload",     null: false
+    t.integer  "creator_id",      null: false, index: {name: "fk__attachments_creator_id"}
+    t.integer  "updater_id",      null: false, index: {name: "fk__attachments_updater_id"}, foreign_key: {references: "users", name: "fk_attachments_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  create_table "instances", force: :cascade do |t|
+    t.string "name", limit: 255, null: false
+    t.string "host", limit: 255, null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application", index: {name: "index_instances_on_host", unique: true, case_sensitive: false}
   end
 
   create_table "courses", force: :cascade do |t|

--- a/lib/extensions/action_controller/base.rb
+++ b/lib/extensions/action_controller/base.rb
@@ -1,4 +1,13 @@
 module Extensions::ActionController::Base
+  module ClassMethods
+    # Method from ActsAsAttachable framework.
+    # Declared this function in controller to let it accepts attachments.
+    # Should be declared after load_and_authorize_resources.
+    def accepts_attachments
+      before_action :build_attachments, only: [:new, :edit]
+    end
+  end
+
   # Gets the current layout used by this controller.
   #
   # @return [String] The layout used by the current controller.
@@ -32,6 +41,13 @@ module Extensions::ActionController::Base
       reverse!
   end
 
+  # Method from ActsAsAttachable framework.
+  # Permit attachments params in strong parameters.
+  # @return [Hash] The params required by the framework.
+  def attachments_params
+    { attachments_attributes: [:id, :attachment, :attachment_cache, :_destroy] }
+  end
+
   # Gets the superclass hierarchy for the given class. Object is not part of the returned result.
   #
   # @param klass [Class] The class to obtain the hierarchy of.
@@ -56,5 +72,16 @@ module Extensions::ActionController::Base
     layout_method = klass.instance_method(:_layout)
     layout = layout_method.bind(self_)
     layout.call
+  end
+
+  private
+
+  def build_attachments
+    @attachable = instance_variable_get('@' + attachable_item_name)
+    @attachable.attachments.build if @attachable
+  end
+
+  def attachable_item_name
+    params[:controller].split('/').last.singularize
   end
 end

--- a/lib/extensions/action_view/helpers/form_builder.rb
+++ b/lib/extensions/action_view/helpers/form_builder.rb
@@ -1,0 +1,7 @@
+module Extensions::ActionView::Helpers::FormBuilder
+  # Method from ActsAsAttachable framework.
+  # Hepler to support f.attachments in form
+  def attachments
+    @template.render 'layouts/attachment_uploader', form_builder: self
+  end
+end

--- a/lib/extensions/active_record/base.rb
+++ b/lib/extensions/active_record/base.rb
@@ -1,12 +1,20 @@
 module Extensions::ActiveRecord::Base
-  def self.included(class_)
-    class_.class_eval do
-      def self.currently_valid
-        where do
-          (valid_from.nil? || valid_from <= DateTime.now) &&
-            (valid_to.nil? || valid_to >= DateTime.now)
-        end
+  module ClassMethods
+    def currently_valid
+      where do
+        (valid_from.nil? || valid_from <= DateTime.now) &&
+          (valid_to.nil? || valid_to >= DateTime.now)
       end
+    end
+
+    # Functions from ActsAsAttachable framework.
+    # This function should be declared in model, to it have attachments.
+    def acts_as_attachable
+      has_many :attachments, as: :attachable
+
+      accepts_nested_attributes_for :attachments,
+                                    allow_destroy: true,
+                                    reject_if: -> (params) { params[:attachment].blank? }
     end
   end
 

--- a/spec/factories/attachment.rb
+++ b/spec/factories/attachment.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :attachment do
+    name 'Attachment'
+    file_upload do
+      Rack::Test::UploadedFile.new(File.join(Rails.root, '/spec/fixtures/files/text.txt'))
+    end
+    creator
+    updater
+  end
+end

--- a/spec/fixtures/files/text.txt
+++ b/spec/fixtures/files/text.txt
@@ -1,0 +1,1 @@
+This is a test file

--- a/spec/libraries/acts_as_attachable_spec.rb
+++ b/spec/libraries/acts_as_attachable_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'ActsAsAttachable' do
+  class SampleModel < ActiveRecord::Base
+    def self.columns
+      []
+    end
+
+    acts_as_attachable
+  end
+
+  describe SampleModel do
+    it { is_expected.to have_many(:attachments) }
+  end
+
+  describe 'controller' do
+    class SampleController < ActionController::Base; end
+
+    context 'class methods' do
+      subject { SampleController }
+
+      it { is_expected.to respond_to(:accepts_attachments) }
+    end
+
+    context 'instance methods' do
+      subject { SampleController.new }
+
+      it { is_expected.to respond_to(:attachments_params) }
+    end
+  end
+
+  describe 'form_builder helper' do
+    class SampleView < ActionView::Base; end
+    class SampleFormBuilder < ActionView::Helpers::FormBuilder; end
+
+    let(:template) { SampleView.new }
+    let(:resource) { SampleModel.new }
+    subject { SampleFormBuilder.new(:sample, resource, template, {}) }
+
+    it { is_expected.to respond_to(:attachments) }
+  end
+end

--- a/spec/uploaders/file_uploader_spec.rb
+++ b/spec/uploaders/file_uploader_spec.rb
@@ -1,0 +1,27 @@
+require 'carrierwave/test/matchers'
+
+RSpec.describe FileUploader, type: :model do
+  include CarrierWave::Test::Matchers
+
+  let(:attachment) { create(:attachment) }
+
+  before do
+    @uploader = FileUploader.new(attachment, :file_upload)
+
+    File.open(File.join(Rails.root, '/spec/fixtures/files/text.txt')) do |f|
+      @uploader.store!(f)
+    end
+  end
+
+  after do
+    @uploader.remove!
+  end
+
+  it 'uploads the file' do
+    expect(File.exist?(@uploader.file.path)).to eq true
+  end
+
+  it 'sets the correct permission' do
+    expect(@uploader).to have_permissions(0644)
+  end
+end


### PR DESCRIPTION
Depends on #145 

Changes in this PR
1. Added an Attachment Model (using carrier wave file uploader)
2. Declared a 'act_as_attachable'  framework

If any object wants to be able to have an attachment, it needs:

1.  declare <code>act_as_attachable</code> in model
2. declare <code> accept_attachments </code> in controller and permit <code>attachments_params</code> in strong parameters
3. render uploader  in forms 

I've a demo to show how to enable file uploads in announcements:
https://github.com/coursemology-collab/coursemology2/commit/4274ab4734868bd39f7a02483799d7beab2f75d8

And the UI for it will looks like this:
![screen shot 2015-03-09 at 1 06 54 pm](https://cloud.githubusercontent.com/assets/4983239/6550201/4baca512-c65d-11e4-86ee-209c6e0ad2a1.png)