### PR TITLE
Support mswin64, by using Bundler 1.8.0 or later.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
 bundler_args: "--without development:production --deployment"
 cache: bundler
 
+before_install:
+  - gem update bundler
+
 before_script:
   - psql -c 'create database coursemology_test;' -U postgres
   - bundle exec rake db:setup

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 source 'https://rails-assets.org'
 
 # For Windows devs
-gem 'tzinfo-data', platforms: [:mswin]
+gem 'tzinfo-data', platforms: [:mswin, :mswin64]
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.1.8'
@@ -55,7 +55,7 @@ group :development do
   gem 'rails-dev-tweaks'
   gem 'rails-dev-boost', github: 'thedarkone/rails-dev-boost'
   gem 'rails-flog', require: 'flog'
-  gem 'wdm', '>= 0.0.3', platforms: [:mswin]
+  gem 'wdm', '>= 0.0.3', platforms: [:mswin, :mswin64]
 
   # Helps to prevent database slowdowns
   gem 'lol_dba'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,7 @@ GEM
     yard (0.8.7.6)
 
 PLATFORMS
+  mswin64
   ruby
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Major changes:
 ## Installation
 ### System requirements
  - [nodejs](http://nodejs.org) (as a JavaScript runtime for [execjs](https://github.com/sstephenson/execjs))
+ - [bundler](http://bundler.io) 1.8.0 or later
 
 ### Procedure
  1. Install dependencies using `bundle install`


### PR DESCRIPTION
This should not break non-Windows installs. (See the Travis build)