### PR TITLE
Ignore the bundle directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-# Ignore bundler config.
+# Ignore bundler config and gems.
 /.bundle
+/vendor/bundle
 
 # Ignore user-specific Intellij project files
 /.idea/dictionaries/*


### PR DESCRIPTION
Prevent people from accidentally `git add`-ing the bundle!