### PR TITLE
Always set the active stamper before any example is run

### DIFF
--- a/spec/support/userstamp.rb
+++ b/spec/support/userstamp.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.before(:example) do
+    User.stamper = build(:user)
+  end
+  config.after(:example) do
+    User.reset_stamper
+  end
+end


### PR DESCRIPTION
So that we do not trip updater/creator validation. For controllers, this is done automatically (like the active tenant)