### PR TITLE
Restore Capybara's app_host after testing

### DIFF
--- a/spec/features/course/achievement_listing_spec.rb
+++ b/spec/features/course/achievement_listing_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Achievement listing' do
+RSpec.describe 'Achievement listing', type: :feature do
   subject { page }
 
   let!(:instance) { create(:instance) }

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Announcement management' do
+RSpec.describe 'Announcement management', type: :feature do
   subject { page }
 
   let!(:instance) { create(:instance) }

--- a/spec/features/user_signup_spec.rb
+++ b/spec/features/user_signup_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'User signup', type: :feature do
       fill_in 'user_password_confirmation', with: valid_user.password
     end
 
-    it 'creates a course' do
+    it 'creates a user' do
       expect { click_button 'Sign up' }.to change(User, :count).by(1)
     end
   end

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -1,20 +1,43 @@
 # Test group helpers for setting the tenant for tests.
-module ActsAsTenant::TestGroupHelpers
-  # Sets the current tenant when running this group of tests.
-  #
-  # @param tenant [Symbol] The symbol containing the tenant to use for this group of
-  #                        tests. The tenant must have been set using a let construct.
-  # @param proc [Proc] The block containing the test definitions.
-  def with_tenant(tenant, &proc)
-    context "with tenant #{tenant.inspect}" do |*params|
-      before(:each) do
-        ActsAsTenant.current_tenant = send(tenant)
-        Capybara.app_host = 'http://' + send(tenant).host
+module ActsAsTenant
+  module TestGroupHelpers
+    # Sets the current tenant when running this group of tests.
+    #
+    # @param tenant [Symbol] The symbol containing the tenant to use for this group of
+    #                        tests. The tenant must have been set using a let construct.
+    # @param proc [Proc] The block containing the test definitions.
+    def with_tenant(tenant, &proc)
+      context "with tenant #{tenant.inspect}" do |*params|
+        before(:each) do
+          ActsAsTenant.current_tenant = send(tenant)
+        end
+        after(:each) do
+          ActsAsTenant.current_tenant = nil
+        end
+        instance_exec(*params, &proc)
       end
-      after(:each) do
-        ActsAsTenant.current_tenant = nil
+    end
+  end
+
+  module RequestTestHelpers
+    include TestGroupHelpers
+    # Sets the current tenant and host when running this group of tests.
+    #
+    # @param tenant [Symbol] The symbol containing the tenant to use for this group of
+    #                        tests. The tenant must have been set using a let construct.
+    # @param proc [Proc] The block containing the test definitions.
+    def with_tenant(tenant, &proc)
+      super(tenant) do
+        before(:each) do
+          @saved_host = Capybara.app_host
+          # Capybara's app_host is for remote testing, it's not recommend to change it for
+          # multiple times. However, currently we cannot find a better way to do this
+          Capybara.app_host = 'http://' + send(tenant).host
+        end
+        after(:each) { Capybara.app_host = @saved_host }
+
+        instance_exec(&proc)
       end
-      instance_exec(*params, &proc)
     end
   end
 end
@@ -22,5 +45,5 @@ end
 RSpec.configure do |config|
   config.extend ActsAsTenant::TestGroupHelpers, type: :model
   config.extend ActsAsTenant::TestGroupHelpers, type: :view
-  config.extend ActsAsTenant::TestGroupHelpers, type: :feature
+  config.extend ActsAsTenant::RequestTestHelpers, type: :feature
 end


### PR DESCRIPTION
Fix this exception <code> the scheme http does not accept registry part: * (or bad hostname?) </code>

This was because our test cases set Capybara.app_host after testing, and app_host becomes <code>*</code>