### PR TITLE
Refactor the code needed to create and drop temporary tables used in model tests.

### DIFF
--- a/spec/libraries/time_bounded_spec.rb
+++ b/spec/libraries/time_bounded_spec.rb
@@ -4,99 +4,96 @@ RSpec.describe 'time_bounded', type: :model do
   class TimeBoundedTest < ActiveRecord::Base
   end
 
-  before :all do
-    ActiveRecord::Migration.create_table :time_bounded_tests do |t|
-      t.time_bounded
+  temporary_table(:time_bounded_tests) do |t|
+    t.time_bounded
+  end
+  with_temporary_table(:time_bounded_tests) do
+    before(:context) do
+      [
+        [nil, nil],
+        [nil, 1.day],
+        [-1.day, nil],
+        [-1.day, 1.day]
+      ].each do |pair|
+        options = {}
+        options[:valid_from] = DateTime.now + pair[0] unless pair[0].nil?
+        options[:valid_to] = DateTime.now + pair[1] unless pair[1].nil?
+        TimeBoundedTest.create!(options)
+      end
     end
 
-    [
-      [nil, nil],
-      [nil, 1.day],
-      [-1.day, nil],
-      [-1.day, 1.day]
-    ].each do |pair|
-      options = {}
-      options[:valid_from] = DateTime.now + pair[0] unless pair[0].nil?
-      options[:valid_to] = DateTime.now + pair[1] unless pair[1].nil?
-      TimeBoundedTest.create!(options)
+    it 'gets records which are still valid' do
+      matching_entries = TimeBoundedTest.currently_valid
+      expect(matching_entries).to_not be_empty
+
+      matching_entries.each do |record|
+        expect(record).to be_currently_valid
+        expect(record.valid_from).to satisfy { |v| v.nil? || v <= DateTime.now }
+        expect(record.valid_to).to satisfy { |v| v.nil? || v >= DateTime.now }
+      end
     end
-  end
 
-  after :all do
-    ActiveRecord::Migration.drop_table :time_bounded_tests
-  end
-
-  it 'gets records which are still valid' do
-    matching_entries = TimeBoundedTest.currently_valid
-    expect(matching_entries).to_not be_empty
-
-    matching_entries.each do |record|
-      expect(record).to be_currently_valid
-      expect(record.valid_from).to satisfy { |v| v.nil? || v <= DateTime.now }
-      expect(record.valid_to).to satisfy { |v| v.nil? || v >= DateTime.now }
-    end
-  end
-
-  context 'when the records have neither valid_from nor valid_to' do
-    subject { TimeBoundedTest.new }
-
-    it { is_expected.to be_currently_valid }
-  end
-
-  context 'when the records do not have valid_from' do
-    context 'when the records expire after today' do
-      subject { TimeBoundedTest.new(valid_to: DateTime.now + 1.day) }
+    context 'when the records have neither valid_from nor valid_to' do
+      subject { TimeBoundedTest.new }
 
       it { is_expected.to be_currently_valid }
     end
 
-    context 'when the records expire before today' do
-      subject { TimeBoundedTest.new(valid_to: DateTime.now - 1.day) }
+    context 'when the records do not have valid_from' do
+      context 'when the records expire after today' do
+        subject { TimeBoundedTest.new(valid_to: DateTime.now + 1.day) }
 
-      it { is_expected.to_not be_currently_valid }
-    end
-  end
-
-  context 'when the records do not have valid_to' do
-    context 'when the records become valid after today' do
-      subject { TimeBoundedTest.new(valid_from: DateTime.now + 1.day) }
-
-      it { is_expected.not_to be_currently_valid }
-    end
-
-    context 'when the records become valid before today' do
-      subject { TimeBoundedTest.new(valid_from: DateTime.now - 1.day) }
-
-      it { is_expected.to be_currently_valid }
-    end
-  end
-
-  context 'when the records have both valid_from and valid_to' do
-    context 'when the records have expired' do
-      subject do
-        TimeBoundedTest.new(valid_from: DateTime.now - 1.week,
-                            valid_to: DateTime.now - 1.day)
+        it { is_expected.to be_currently_valid }
       end
 
-      it { is_expected.not_to be_currently_valid }
+      context 'when the records expire before today' do
+        subject { TimeBoundedTest.new(valid_to: DateTime.now - 1.day) }
+
+        it { is_expected.to_not be_currently_valid }
+      end
     end
 
-    context 'when the records have not become valid' do
-      subject do
-        TimeBoundedTest.new(valid_from: DateTime.now + 1.day,
-                            valid_to: DateTime.now + 1.week)
+    context 'when the records do not have valid_to' do
+      context 'when the records become valid after today' do
+        subject { TimeBoundedTest.new(valid_from: DateTime.now + 1.day) }
+
+        it { is_expected.not_to be_currently_valid }
       end
 
-      it { is_expected.not_to be_currently_valid }
+      context 'when the records become valid before today' do
+        subject { TimeBoundedTest.new(valid_from: DateTime.now - 1.day) }
+
+        it { is_expected.to be_currently_valid }
+      end
     end
 
-    context 'when the records are become valid' do
-      subject do
-        TimeBoundedTest.new(valid_from: DateTime.now - 1.week,
-                            valid_to: DateTime.now + 1.week)
+    context 'when the records have both valid_from and valid_to' do
+      context 'when the records have expired' do
+        subject do
+          TimeBoundedTest.new(valid_from: DateTime.now - 1.week,
+                              valid_to: DateTime.now - 1.day)
+        end
+
+        it { is_expected.not_to be_currently_valid }
       end
 
-      it { is_expected.to be_currently_valid }
+      context 'when the records have not become valid' do
+        subject do
+          TimeBoundedTest.new(valid_from: DateTime.now + 1.day,
+                              valid_to: DateTime.now + 1.week)
+        end
+
+        it { is_expected.not_to be_currently_valid }
+      end
+
+      context 'when the records are become valid' do
+        subject do
+          TimeBoundedTest.new(valid_from: DateTime.now - 1.week,
+                              valid_to: DateTime.now + 1.week)
+        end
+
+        it { is_expected.to be_currently_valid }
+      end
     end
   end
 end

--- a/spec/support/migration.rb
+++ b/spec/support/migration.rb
@@ -1,0 +1,48 @@
+# Test group helpers for creating tables.
+module ActiveRecord::Migration::TestGroupHelpers
+  # Defines a temporary table that is instantiated when needed, within a `with_temporary_table`
+  # block.
+  #
+  # @param table_name Symbol The name of the table to define.
+  # @param proc Proc The table definition, same as that of a block given to
+  #                  `ActiveRecord::Migration::create_table`
+  def temporary_table(table_name, &proc)
+    define_method(table_name) do
+      proc
+    end
+  end
+
+  # Using the temporary table defined previously, run the examples in this group.
+  #
+  # @param table_name Symbol The name of the table to use.
+  # @param proc Proc The examples requiring the use of the temporary table.
+  def with_temporary_table(table_name, &proc)
+    context "with temporary table #{table_name}" do |*params|
+      before(:context) do
+        ActiveRecord::Migration::TestGroupHelpers.before_context(table_name, send(table_name))
+      end
+
+      after(:context) do
+        ActiveRecord::Migration::TestGroupHelpers.after_context(table_name)
+      end
+
+      instance_exec(*params, &proc)
+    end
+  end
+
+  def self.before_context(table_name, table_definition)
+    ActiveRecord::Migration.suppress_messages do
+      ActiveRecord::Migration.create_table(table_name, &table_definition)
+    end
+  end
+
+  def self.after_context(table_name)
+    ActiveRecord::Migration.suppress_messages do
+      ActiveRecord::Migration.drop_table(table_name)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.extend ActiveRecord::Migration::TestGroupHelpers, type: :model
+end


### PR DESCRIPTION
This also removes the log messages from ActiveRecord::Migration, which @wangqiang1208 said was noisy :stuck_out_tongue: 