### PR TITLE
Fix RSpec db:seed not called

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,6 +25,10 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# Ensure that all database seeds are in the database.
+Application.load_tasks
+Rake::Task['db:seed'].invoke
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -48,10 +52,4 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
-
-  # Ensure that all database seeds are in the database.
-  config.before(:suite) do
-    Application.load_tasks
-    Rake::Task['db:seed'].invoke
-  end
 end


### PR DESCRIPTION
Fix #137 

The error was caused by FactoryGril.lint

This PR lets <code> Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f } </code>  be required after configure, so that <code>db:seed</code> will be called before FactoryGirl.lint