### PR TITLE
Update schema.rb to support rails 4.2

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,17 +16,16 @@ ActiveRecord::Schema.define(version: 20150316080645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "instances", force: true do |t|
-    t.string "name", null: false
-    t.string "host", null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application"
-    t.index ["host"], :name => "index_instances_on_host", :unique => true, :case_sensitive => false
+  create_table "instances", force: :cascade do |t|
+    t.string "name", limit: 255, null: false
+    t.string "host", limit: 255, null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application", index: {name: "index_instances_on_host", unique: true, case_sensitive: false}
   end
 
-  create_table "users", force: true do |t|
-    t.string   "name",                                null: false
+  create_table "users", force: :cascade do |t|
+    t.string   "name",                   limit: 255,              null: false
     t.integer  "role",                   default: 0,  null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+    t.string   "encrypted_password",     limit: 255, default: "", null: false
+    t.string   "reset_password_token",   limit: 255, index: {name: "index_users_on_reset_password_token", unique: true}
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",          default: 0,  null: false
@@ -36,149 +35,106 @@ ActiveRecord::Schema.define(version: 20150316080645) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
   end
 
-  create_table "courses", force: true do |t|
-    t.integer  "instance_id",             null: false
-    t.string   "title",                   null: false
+  create_table "courses", force: :cascade do |t|
+    t.integer  "instance_id", null: false, index: {name: "fk__courses_instance_id"}, foreign_key: {references: "instances", name: "fk_courses_instance_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "title",       limit: 255,             null: false
     t.text     "description"
     t.integer  "status",      default: 0, null: false
-    t.datetime "start_at",                null: false
-    t.datetime "end_at",                  null: false
-    t.integer  "creator_id",              null: false
-    t.integer  "updater_id",              null: false
+    t.datetime "start_at",    null: false
+    t.datetime "end_at",      null: false
+    t.integer  "creator_id",  null: false, index: {name: "fk__courses_creator_id"}, foreign_key: {references: "users", name: "fk_courses_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",  null: false, index: {name: "fk__courses_updater_id"}, foreign_key: {references: "users", name: "fk_courses_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["creator_id"], :name => "fk__courses_creator_id"
-    t.index ["instance_id"], :name => "fk__courses_instance_id"
-    t.index ["updater_id"], :name => "fk__courses_updater_id"
-    t.foreign_key ["creator_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_courses_creator_id"
-    t.foreign_key ["instance_id"], "instances", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_courses_instance_id"
-    t.foreign_key ["updater_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_courses_updater_id"
   end
 
-  create_table "course_achievements", force: true do |t|
-    t.integer  "course_id",   null: false
-    t.string   "title",       null: false
+  create_table "course_achievements", force: :cascade do |t|
+    t.integer  "course_id",   null: false, index: {name: "fk__course_achievements_course_id"}, foreign_key: {references: "courses", name: "fk_course_achievements_course_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "title",       limit: 255, null: false
     t.text     "description"
     t.integer  "weight",      null: false
     t.boolean  "published",   null: false
-    t.integer  "creator_id",  null: false
-    t.integer  "updater_id",  null: false
+    t.integer  "creator_id",  null: false, index: {name: "fk__course_achievements_creator_id"}, foreign_key: {references: "users", name: "fk_course_achievements_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",  null: false, index: {name: "fk__course_achievements_updater_id"}, foreign_key: {references: "users", name: "fk_course_achievements_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-    t.index ["course_id"], :name => "fk__course_achievements_course_id"
-    t.index ["creator_id"], :name => "fk__course_achievements_creator_id"
-    t.index ["updater_id"], :name => "fk__course_achievements_updater_id"
-    t.foreign_key ["course_id"], "courses", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_achievements_course_id"
-    t.foreign_key ["creator_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_achievements_creator_id"
-    t.foreign_key ["updater_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_achievements_updater_id"
   end
 
-  create_table "course_announcements", force: true do |t|
-    t.integer  "course_id",                  null: false
-    t.string   "title",                      null: false
+  create_table "course_announcements", force: :cascade do |t|
+    t.integer  "course_id",  null: false, index: {name: "fk__course_announcements_course_id"}, foreign_key: {references: "courses", name: "fk_course_announcements_course_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "title",      limit: 255,                 null: false
     t.text     "content"
     t.boolean  "sticky",     default: false, null: false
-    t.datetime "valid_from",                 null: false
-    t.datetime "valid_to",                   null: false
-    t.integer  "creator_id",                 null: false
-    t.integer  "updater_id",                 null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.index ["course_id"], :name => "fk__course_announcements_course_id"
-    t.index ["creator_id"], :name => "fk__course_announcements_creator_id"
-    t.index ["updater_id"], :name => "fk__course_announcements_updater_id"
-    t.foreign_key ["course_id"], "courses", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_announcements_course_id"
-    t.foreign_key ["creator_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_announcements_creator_id"
-    t.foreign_key ["updater_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_announcements_updater_id"
+    t.datetime "valid_from", null: false
+    t.datetime "valid_to",   null: false
+    t.integer  "creator_id", null: false, index: {name: "fk__course_announcements_creator_id"}, foreign_key: {references: "users", name: "fk_course_announcements_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id", null: false, index: {name: "fk__course_announcements_updater_id"}, foreign_key: {references: "users", name: "fk_course_announcements_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "course_users", force: true do |t|
-    t.integer  "course_id",                        null: false
-    t.integer  "user_id",                          null: false
+  create_table "course_users", force: :cascade do |t|
+    t.integer  "course_id",        null: false, index: {name: "fk__course_users_course_id"}, foreign_key: {references: "courses", name: "fk_course_users_course_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "user_id",          null: false, index: {name: "fk__course_users_user_id"}, foreign_key: {references: "users", name: "fk_course_users_user_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "role",             default: 0,     null: false
-    t.string   "name",                             null: false
+    t.string   "name",             limit: 255,                 null: false
     t.boolean  "phantom",          default: false, null: false
     t.datetime "last_active_time"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["course_id", "user_id"], :name => "index_course_users_on_course_id_and_user_id", :unique => true
-    t.index ["course_id"], :name => "fk__course_users_course_id"
-    t.index ["user_id"], :name => "fk__course_users_user_id"
-    t.foreign_key ["course_id"], "courses", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_users_course_id"
-    t.foreign_key ["user_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_course_users_user_id"
   end
+  add_index "course_users", ["course_id", "user_id"], name: "index_course_users_on_course_id_and_user_id", unique: true
 
-  create_table "instance_announcements", force: true do |t|
-    t.integer  "instance_id", null: false
-    t.string   "title",       null: false
+  create_table "instance_announcements", force: :cascade do |t|
+    t.integer  "instance_id", null: false, index: {name: "fk__instance_announcements_instance_id"}, foreign_key: {references: "instances", name: "fk_instance_announcements_instance_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "title",       limit: 255, null: false
     t.text     "content"
     t.datetime "valid_from",  null: false
     t.datetime "valid_to",    null: false
-    t.integer  "creator_id",  null: false
-    t.integer  "updater_id",  null: false
+    t.integer  "creator_id",  null: false, index: {name: "fk__instance_announcements_creator_id"}, foreign_key: {references: "users", name: "fk_instance_announcements_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",  null: false, index: {name: "fk__instance_announcements_updater_id"}, foreign_key: {references: "users", name: "fk_instance_announcements_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-    t.index ["creator_id"], :name => "fk__instance_announcements_creator_id"
-    t.index ["instance_id"], :name => "fk__instance_announcements_instance_id"
-    t.index ["updater_id"], :name => "fk__instance_announcements_updater_id"
-    t.foreign_key ["creator_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_instance_announcements_creator_id"
-    t.foreign_key ["instance_id"], "instances", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_instance_announcements_instance_id"
-    t.foreign_key ["updater_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_instance_announcements_updater_id"
   end
 
-  create_table "instance_users", force: true do |t|
-    t.integer  "instance_id",             null: false
-    t.integer  "user_id",                 null: false
+  create_table "instance_users", force: :cascade do |t|
+    t.integer  "instance_id", null: false, index: {name: "fk__instance_users_instance_id"}, foreign_key: {references: "instances", name: "fk_instance_users_instance_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "user_id",     null: false, index: {name: "index_instance_users_on_user_id", unique: true}, foreign_key: {references: "users", name: "fk_instance_users_user_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "role",        default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["instance_id", "user_id"], :name => "index_instance_users_on_instance_id_and_user_id", :unique => true
-    t.index ["instance_id"], :name => "fk__instance_users_instance_id"
-    t.index ["user_id"], :name => "index_instance_users_on_user_id", :unique => true
-    t.foreign_key ["instance_id"], "instances", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_instance_users_instance_id"
-    t.foreign_key ["user_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_instance_users_user_id"
   end
+  add_index "instance_users", ["instance_id", "user_id"], name: "index_instance_users_on_instance_id_and_user_id", unique: true
 
-  create_table "read_marks", force: true do |t|
+  create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"
-    t.string   "readable_type", null: false
-    t.integer  "user_id",       null: false
+    t.string   "readable_type", limit: 255, null: false
+    t.integer  "user_id",       null: false, index: {name: "fk__read_marks_user_id"}, foreign_key: {references: "users", name: "fk_read_marks_user_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "timestamp"
-    t.index ["user_id", "readable_type", "readable_id"], :name => "index_read_marks_on_user_id_and_readable_type_and_readable_id"
-    t.index ["user_id"], :name => "fk__read_marks_user_id"
-    t.foreign_key ["user_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_read_marks_user_id"
   end
+  add_index "read_marks", ["user_id", "readable_type", "readable_id"], name: "index_read_marks_on_user_id_and_readable_type_and_readable_id"
 
-  create_table "system_announcements", force: true do |t|
-    t.string   "title",      null: false
+  create_table "system_announcements", force: :cascade do |t|
+    t.string   "title",      limit: 255, null: false
     t.text     "content"
     t.datetime "valid_from", null: false
     t.datetime "valid_to",   null: false
-    t.integer  "creator_id", null: false
-    t.integer  "updater_id", null: false
+    t.integer  "creator_id", null: false, index: {name: "fk__system_announcements_creator_id"}, foreign_key: {references: "users", name: "fk_system_announcements_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id", null: false, index: {name: "fk__system_announcements_updater_id"}, foreign_key: {references: "users", name: "fk_system_announcements_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["creator_id"], :name => "fk__system_announcements_creator_id"
-    t.index ["updater_id"], :name => "fk__system_announcements_updater_id"
-    t.foreign_key ["creator_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_system_announcements_creator_id"
-    t.foreign_key ["updater_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_system_announcements_updater_id"
   end
 
-  create_table "user_emails", force: true do |t|
+  create_table "user_emails", force: :cascade do |t|
     t.boolean  "primary",              default: false, null: false
-    t.integer  "user_id",                              null: false
-    t.string   "email",                                null: false
-    t.string   "confirmation_token"
+    t.integer  "user_id",              null: false, index: {name: "index_user_emails_on_user_id_and_primary", with: ["primary"], unique: true, where: "(\"primary\" <> false)"}, foreign_key: {references: "users", name: "fk_user_emails_user_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "email",                limit: 255,                 null: false, index: {name: "index_user_emails_on_email", unique: true, case_sensitive: false}
+    t.string   "confirmation_token",   limit: 255, index: {name: "index_user_emails_on_confirmation_token", unique: true}
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
-    t.index ["confirmation_token"], :name => "index_user_emails_on_confirmation_token", :unique => true
-    t.index ["email"], :name => "index_user_emails_on_email", :unique => true, :case_sensitive => false
-    t.index ["user_id", "primary"], :name => "index_user_emails_on_user_id_and_primary", :unique => true, :conditions => "(\"primary\" <> false)"
-    t.foreign_key ["user_id"], "users", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_user_emails_user_id"
+    t.string   "unconfirmed_email",    limit: 255
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 20150316080645) do
   add_index "instance_users", ["instance_id", "user_id"], name: "index_instance_users_on_instance_id_and_user_id", unique: true
 
   create_table "read_marks", force: :cascade do |t|
-    t.integer  "readable_id"
+    t.integer  "readable_id",   foreign_key: false
     t.string   "readable_type", limit: 255, null: false
     t.integer  "user_id",       null: false, index: {name: "fk__read_marks_user_id"}, foreign_key: {references: "users", name: "fk_read_marks_user_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "timestamp"


### PR DESCRIPTION
Just found that after the migration to Rails 4.2 #50, our schema file was broken. 

<code>rake db:schema:load</code> will give errors.

Run <code> db:schema:dump</code> in this PR.

Noticed that there are also syntax changed:

Before:
```
create_table "courses", force: true do |t|
  t.integer "instance_id", null: false
  t.index ["instance_id"], :name => "fk__courses_instance_id"
  t.foreign_key ["instance_id"], "instances", ["id"], :on_update => :no_action, :on_delete => :no_action, :name => "fk_courses_instance_id"
end
```

Now:
```
create_table "instances", force: :cascade do |t|
  t.integer "instance_id", null: false, index: {name: "fk__courses_instance_id"}, foreign_key: {references: "instances", name: "fk_courses_instance_id", on_update: :no_action, on_delete: :no_action}
end
```
