### PR TITLE
Module settings models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,5 +138,8 @@ gem 'carrierwave', github: 'carrierwaveuploader/carrierwave'
 # Required by carrierwave, for image resizing
 gem 'mini_magick'
 
+# Instance/Course settings
+gem 'settings_on_rails'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,8 @@ GEM
       schema_plus_core (~> 0.1)
     schema_validations (1.1.0)
       schema_plus
+    settings_on_rails (0.2.2)
+      activerecord (>= 3.1)
     should_not (1.1.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -436,6 +438,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   schema_plus (~> 2.0.beta, > 2.0.0.pre14)
   schema_validations
+  settings_on_rails
   should_not
   shoulda-matchers
   simple_form

--- a/app/models/concerns/module_host_settings_concern.rb
+++ b/app/models/concerns/module_host_settings_concern.rb
@@ -1,0 +1,35 @@
+module ModuleHostSettingsConcern
+  extend ActiveSupport::Concern
+
+  included do
+    has_settings_on :settings
+
+    after_initialize :set_default_settings, if: :new_record?
+  end
+
+  # Apply preferences to all the modules, returns the enabled modules.
+  #
+  # @return [Array] array of enabled modules
+  def enabled_modules
+    modules.select do |m|
+      enabled = settings(m.key).enabled
+      enabled.nil? ? m.enabled_by_default? : enabled
+    end
+  end
+
+  # Apply preferences to all the modules, returns the disabled modules.
+  #
+  # @return [Array] array of disabled modules
+  def disabled_modules
+    modules - enabled_modules
+  end
+
+  private
+
+  # Set settings to the defaults
+  def set_default_settings
+    modules.map do |m|
+      settings(m.key).enabled = m.enabled_by_default?
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,6 @@
 class Course < ActiveRecord::Base
+  include ModuleHostSettingsConcern
+
   acts_as_tenant(:instance)
   stampable
 
@@ -12,6 +14,11 @@ class Course < ActiveRecord::Base
 
   has_many :announcements, inverse_of: :course, dependent: :destroy
   has_many :achievements, inverse_of: :course, dependent: :destroy
+
+  # @return [Array] array of all available modules
+  def modules
+    Instance.current.enabled_modules
+  end
 
   private
 

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -1,4 +1,6 @@
 class Instance < ActiveRecord::Base
+  include ModuleHostSettingsConcern
+
   class << self
     def default
       result = first
@@ -28,4 +30,9 @@ class Instance < ActiveRecord::Base
   has_many :users, through: :instance_users
 
   has_many :announcements, class_name: Instance::Announcement.name
+
+  # @return [Array] array of all available modules
+  def modules
+    Course::ModuleHost.modules
+  end
 end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -6,6 +6,13 @@ class Instance < ActiveRecord::Base
       result
     end
 
+    # Returns the current instance from ActsAsTenant
+    #
+    # @return [Instance] current instance
+    def current
+      ActsAsTenant.current_tenant
+    end
+
     # Finds the given tenant by host.
     #
     # @param host [String] The host to look up. This is case insensitive, however prefixes (such

--- a/db/migrate/20150413043822_add_settings_to_instances_and_courses.rb
+++ b/db/migrate/20150413043822_add_settings_to_instances_and_courses.rb
@@ -1,0 +1,6 @@
+class AddSettingsToInstancesAndCourses < ActiveRecord::Migration
+  def change
+    add_column :instances, :settings, :text
+    add_column :courses, :settings, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,8 +44,9 @@ ActiveRecord::Schema.define(version: 20150426062133) do
   end
 
   create_table "instances", force: :cascade do |t|
-    t.string "name", limit: 255, null: false
-    t.string "host", limit: 255, null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application", index: {name: "index_instances_on_host", unique: true, case_sensitive: false}
+    t.string "name",     limit: 255, null: false
+    t.string "host",     limit: 255, null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application", index: {name: "index_instances_on_host", unique: true, case_sensitive: false}
+    t.text   "settings"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -54,6 +55,7 @@ ActiveRecord::Schema.define(version: 20150426062133) do
     t.text     "description"
     t.text     "logo"
     t.integer  "status",      default: 0, null: false
+    t.text     "settings"
     t.datetime "start_at",    null: false
     t.datetime "end_at",      null: false
     t.integer  "creator_id",  null: false, index: {name: "fk__courses_creator_id"}, foreign_key: {references: "users", name: "fk_courses_creator_id", on_update: :no_action, on_delete: :no_action}

--- a/lib/autoload/modular.rb
+++ b/lib/autoload/modular.rb
@@ -136,5 +136,19 @@ module Modular
 
   module Module
     extend ActiveSupport::Concern
+
+    module ClassMethods
+      # @return [Boolean] the default enabled status of the module
+      def enabled_by_default?
+        true
+      end
+
+      # Unique key of the module, to serve as the key in module_preference_objects and translations
+      #
+      # @return [Symbol] the key
+      def key
+        name.underscore.sub('/', '_').to_sym
+      end
+    end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -16,5 +16,105 @@ RSpec.describe Course, type: :model do
       it { is_expected.not_to be_published }
       it { is_expected.not_to be_opened }
     end
+
+    describe 'module preferences' do
+      let(:course) { create(:course, instance: instance) }
+      let(:all_modules) { instance.enabled_modules }
+
+      describe '#set_default_settings' do
+        it 'initializes the default values' do
+          all_modules.each do |m|
+            expect(course.settings(m.key).enabled).to eq m.enabled_by_default?
+          end
+        end
+      end
+
+      describe '#enabled_modules' do
+        let(:enabled_modules) { course.enabled_modules }
+
+        context 'without preference' do
+          it 'returns the default enabled modules' do
+            default_enabled_modules = all_modules.select(&:enabled_by_default?)
+            expect(enabled_modules.count).to eq default_enabled_modules.count
+            default_enabled_modules.each do |m|
+              expect(enabled_modules.include?(m)).to eq true
+            end
+          end
+        end
+
+        context 'with preference' do
+          let(:sample_module) { all_modules.first }
+          context 'disable a module in course' do
+            before do
+              course.settings(sample_module.key).enabled = false
+              course.save
+            end
+
+            it 'does not include the disabled module' do
+              expect(enabled_modules.include?(sample_module)).to eq false
+            end
+          end
+
+          context 'disable a module in instance' do
+            before do
+              instance.settings(sample_module.key).enabled = false
+              instance.save
+            end
+
+            it 'does not include the disabled module' do
+              expect(enabled_modules.include?(sample_module)).to eq false
+            end
+          end
+
+          context 'enable a module' do
+            before do
+              course.settings(sample_module.key).enabled = true
+              course.save
+            end
+
+            it 'includes the disabled module' do
+              expect(enabled_modules.include?(sample_module)).to eq true
+            end
+          end
+        end
+      end
+
+      describe '#disabled_modules' do
+        let(:disabled_modules) { course.disabled_modules }
+
+        context 'without preference' do
+          it 'returns the default disabled modules' do
+            default_disabled_modules = all_modules.select { |m| !m.enabled_by_default? }
+            expect(disabled_modules.count).to eq default_disabled_modules.count
+            default_disabled_modules.each do |m|
+              expect(disabled_modules.include?(m)).to eq true
+            end
+          end
+        end
+
+        context 'with preference' do
+          let(:sample_module) { all_modules.first }
+          context 'disable a module' do
+            before do
+              course.settings(sample_module.key).enabled = false
+            end
+
+            it 'includes the disabled module' do
+              expect(disabled_modules.include?(sample_module)).to eq true
+            end
+          end
+
+          context 'enable a module' do
+            before do
+              course.settings(sample_module.key).enabled = true
+            end
+
+            it 'does not include the enabled module' do
+              expect(disabled_modules.include?(sample_module)).to eq false
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -64,4 +64,88 @@ RSpec.describe Instance, type: :model do
       expect(found_instance).to eq(first_instance)
     end
   end
+
+  describe 'module preferences' do
+    let(:instance) { create(:instance) }
+    let(:all_modules) { Course::ModuleHost.modules }
+
+    describe '#set_default_settings' do
+      it 'initializes the default values' do
+        all_modules.each do |m|
+          expect(instance.settings(m.key).enabled).to eq m.enabled_by_default?
+        end
+      end
+    end
+
+    describe '#enabled_modules' do
+      let(:enabled_modules) { instance.enabled_modules }
+
+      context 'without preference' do
+        it 'returns the default enabled modules' do
+          default_enabled_modules = all_modules.select(&:enabled_by_default?)
+          expect(enabled_modules.count).to eq default_enabled_modules.count
+          default_enabled_modules.each do |m|
+            expect(enabled_modules.include?(m)).to eq true
+          end
+        end
+      end
+
+      context 'with preference' do
+        let(:sample_module) { all_modules.first }
+        context 'disable a module' do
+          before do
+            instance.settings(sample_module.key).enabled = false
+            instance.save
+          end
+
+          it 'does not include the disabled module' do
+            expect(enabled_modules.include?(sample_module)).to eq false
+          end
+        end
+
+        context 'enable a module' do
+          before { instance.settings(sample_module.key).enabled = true }
+
+          it 'includes the disabled module' do
+            expect(enabled_modules.include?(sample_module)).to eq true
+          end
+        end
+      end
+    end
+
+    describe '#disabled_modules' do
+      let(:disabled_modules) { instance.disabled_modules }
+
+      context 'without preference' do
+        it 'returns the default disabled modules' do
+          default_disabled_modules = all_modules.select { |m| !m.enabled_by_default? }
+          expect(disabled_modules.count).to eq default_disabled_modules.count
+          default_disabled_modules.each do |m|
+            expect(disabled_modules.include?(m)).to eq true
+          end
+        end
+      end
+
+      context 'with preference' do
+        let(:sample_module) { all_modules.first }
+        context 'disable a module' do
+          before { instance.settings(sample_module.key).enabled = false }
+
+          it 'includes the disabled module' do
+            expect(disabled_modules.include?(sample_module)).to eq true
+          end
+        end
+
+        context 'enable a module' do
+          before do
+            instance.settings(sample_module.key).enabled = true
+          end
+
+          it 'does not include the enabled module' do
+            expect(disabled_modules.include?(sample_module)).to eq false
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Instance, type: :model do
     end
   end
 
+  describe '.current' do
+    let(:current_instance) { ActsAsTenant.current_tenant }
+
+    it 'returns the current instance' do
+      expect(Instance.current).to eq(current_instance)
+    end
+  end
+
   describe '.find_tenant_by_host' do
     before do
       @instances = create_list(:instance, 3)


### PR DESCRIPTION
Support turn on/off modules in instances/courses.
Add a ModuleSettingsConcern in this PR, which lets instance and course have following functions:
```ruby
@instance.modules # all the available modules 
@instance.enabled_modules
@instance.disabled_modules

# If a module was disabled in that instance, course will not able to see it
@course.modules
@course.enabled_modules
@course.disabled_modules
```