### PR TITLE
Add Course::LessonPlanItem model

### DIFF
--- a/app/models/course/lesson_plan_item.rb
+++ b/app/models/course/lesson_plan_item.rb
@@ -1,0 +1,26 @@
+class Course::LessonPlanItem < ActiveRecord::Base
+  actable
+  stampable
+  validates :base_exp, numericality: { only_integer: true }
+  validates :time_bonus_exp, numericality: { only_integer: true }
+  validates :extra_bonus_exp, numericality: { only_integer: true }
+
+  after_initialize :set_default_values, if: :new_record?
+
+  # Gives the maximum number of EXP Points that an EXP-awarding item
+  # is allocated to give, which is the sum of base and bonus EXPs.
+  #
+  # @return [Integer] Maximum EXP awardable.
+  def total_exp
+    base_exp + time_bonus_exp + extra_bonus_exp
+  end
+
+  private
+
+  # Sets default EXP values
+  def set_default_values
+    self.base_exp ||= 0
+    self.time_bonus_exp ||= 0
+    self.extra_bonus_exp ||= 0
+  end
+end

--- a/db/migrate/20150411065243_create_course_lesson_plan_items.rb
+++ b/db/migrate/20150411065243_create_course_lesson_plan_items.rb
@@ -1,0 +1,16 @@
+class CreateCourseLessonPlanItems < ActiveRecord::Migration
+  def change
+    create_table :course_lesson_plan_items do |t|
+      t.actable index: :unique
+
+      t.integer :base_exp, null: false
+      t.integer :time_bonus_exp, null: false
+      t.integer :extra_bonus_exp, null: false
+      t.timestamp :start_time
+      t.timestamp :bonus_end_time
+      t.timestamp :end_time
+      t.userstamps null: false, foreign_key: { references: :users }
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,6 +115,21 @@ ActiveRecord::Schema.define(version: 20150426062133) do
   end
   add_index "course_users", ["course_id", "user_id"], name: "index_course_users_on_course_id_and_user_id", unique: true
 
+  create_table "course_lesson_plan_items", force: :cascade do |t|
+    t.integer  "actable_id"
+    t.string   "actable_type",    index: {name: "index_course_lesson_plan_items_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
+    t.integer  "base_exp",        null: false
+    t.integer  "time_bonus_exp",  null: false
+    t.integer  "extra_bonus_exp", null: false
+    t.datetime "start_time"
+    t.datetime "bonus_end_time"
+    t.datetime "end_time"
+    t.integer  "creator_id",      null: false, index: {name: "fk__course_lesson_plan_items_creator_id"}, foreign_key: {references: "users", name: "fk_course_lesson_plan_items_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",      null: false, index: {name: "fk__course_lesson_plan_items_updater_id"}, foreign_key: {references: "users", name: "fk_course_lesson_plan_items_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
   create_table "instance_announcements", force: :cascade do |t|
     t.integer  "instance_id", null: false, index: {name: "fk__instance_announcements_instance_id"}, foreign_key: {references: "instances", name: "fk_instance_announcements_instance_id", on_update: :no_action, on_delete: :no_action}
     t.string   "title",       limit: 255, null: false

--- a/spec/factories/course_lesson_plan_items.rb
+++ b/spec/factories/course_lesson_plan_items.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :course_lesson_plan_item, class: 'Course::LessonPlanItem' do
+    creator
+    updater
+    base_exp          { rand(1..10) * 100 }
+    time_bonus_exp    { rand(1..10) * 100 }
+    extra_bonus_exp   { rand(1..10) * 100 }
+    start_time 1.days.from_now
+    bonus_end_time 2.days.from_now
+    end_time 3.days.from_now
+  end
+end

--- a/spec/models/course/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan_item_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Course::LessonPlanItem, type: :model do
+  it { is_expected.to validate_numericality_of(:base_exp).only_integer }
+  it { is_expected.to validate_numericality_of(:time_bonus_exp).only_integer }
+  it { is_expected.to validate_numericality_of(:extra_bonus_exp).only_integer }
+
+  let!(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:lesson_plan_item) { FactoryGirl.create :course_lesson_plan_item }
+    describe '#total_exp' do
+      it 'equals base exp plus bonuses' do
+        sum = lesson_plan_item.base_exp +
+              lesson_plan_item.time_bonus_exp +
+              lesson_plan_item.extra_bonus_exp
+        expect(lesson_plan_item.total_exp).to eq sum
+      end
+    end
+
+    describe '#set_default_values' do
+      subject { Course::LessonPlanItem.new.total_exp }
+      it { is_expected.to eq 0 }
+    end
+  end
+end


### PR DESCRIPTION
This PR is for the lesson plan item model as per https://github.com/Coursemology/coursemology2/wiki/EXP-Points-and-Levels.

Please merge #182 first.