### PR TITLE
Redesign Notification Framework

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'settings_on_rails'
 gem 'migration_comments'
 # Manage read/unread status
 gem 'unread'
+# Manage activities and notifications
+gem 'public_activity'
 # Extension for validating hostnames and domain names
 gem 'validates_hostname'
 # A Ruby state machine library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,11 @@ GEM
     pg (0.17.1)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
+    public_activity (1.4.2)
+      actionpack (>= 3.0.0)
+      activerecord (>= 3.0)
+      i18n (>= 0.5.0)
+      railties (>= 3.0.0)
     puma (2.11.3)
       rack (>= 1.1, < 2.0)
     rack (1.6.1)
@@ -398,8 +403,6 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2015.4)
-      tzinfo (>= 1.0.0)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -415,14 +418,12 @@ GEM
     valuable (0.9.9)
     warden (1.2.3)
       rack (>= 1.0)
-    wdm (0.1.0)
     workflow (1.2.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
 
 PLATFORMS
-  mswin64
   ruby
 
 DEPENDENCIES
@@ -456,6 +457,7 @@ DEPENDENCIES
   mini_magick
   momentjs-rails (>= 2.8.1)
   pg (~> 0.17.0)
+  public_activity
   puma
   rails (~> 4.2.1)
   rails-assets-jquery-ujs (~> 1.0.3)!

--- a/app/controllers/concerns/course/activities_concern.rb
+++ b/app/controllers/concerns/course/activities_concern.rb
@@ -1,0 +1,13 @@
+module Course::ActivitiesConcern
+  extend ActiveSupport::Concern
+
+  def recent_activities(course, number: false)
+    if number
+      Activity.where(owner: course).where.not('key like ?', '%notify').
+        order('created_at desc').includes(:trackable, :recipient).first(number)
+    else
+      Activity.where(owner: course).where.not('key like ?', '%notify').
+        order('created_at desc').includes(:trackable, :recipient)
+    end
+  end
+end

--- a/app/controllers/concerns/course/activities_concern.rb
+++ b/app/controllers/concerns/course/activities_concern.rb
@@ -1,6 +1,13 @@
 module Course::ActivitiesConcern
   extend ActiveSupport::Concern
 
+  # Load recent activity feeds
+  #
+  # @param [Course] course course which activities are related to
+  # @param [Hash]
+  # @option [Integer] :number The number of activities that will be loaded
+  #
+  # @return [Array<Activity>]
   def recent_activities(course, number: false)
     if number
       Activity.where(owner: course).where.not('key like ?', '%notify').

--- a/app/controllers/concerns/course/notifications_concern.rb
+++ b/app/controllers/concerns/course/notifications_concern.rb
@@ -1,0 +1,15 @@
+module Course::NotificationsConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :load_unread_popups
+  end
+
+  private
+
+  def load_unread_popups #:nodoc:
+    return [] unless current_course && current_user
+    @popups = NotificationStyle.where(notification_type: :popup).unread_by(current_user).
+              joins(:activity).where(activity: { owner_id: current_course.id })
+  end
+end

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -1,5 +1,6 @@
 class Course::Controller < ApplicationController
   load_and_authorize_resource :course
+  include NotificationsConcern
 
   # Gets the sidebar elements.
   #

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -1,5 +1,8 @@
 class Course::CoursesController < Course::Controller
+  include ActivitiesConcern
+
   def show #:nodoc:
+    @activities = recent_activities(current_course, number: 20)
   end
 
   def new #:nodoc:

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,2 @@
+class ApplicationMailer < ActionMailer::Base
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,12 @@
+class NotificationMailer < ApplicationMailer
+  layout 'notifications/email'
+
+  def notify(recipient, owner, trackable, template_url)
+    @recipient = recipient
+    @owner = owner
+    @trackable = trackable
+    mail(to: recipient.email) do |format|
+      format.html { render template_url }
+    end
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,11 +2,10 @@
 class Activity < PublicActivity::Activity
   has_many :notification_styles, inverse_of: :activity, dependent: :destroy
 
-  # overwrite public_activity gem's method to set template path for us
-  def template_path(key, partial_root)
+  def template_path
+    partial_root = ''
     path = key.split('.')
-    path.delete_at(0) if path[0] == 'activity'
     path.unshift partial_root
-    path.join('/') + 'activity_feed'
+    path.join('/') + '/activity_feed'
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,6 +2,10 @@
 class Activity < PublicActivity::Activity
   has_many :notification_styles, inverse_of: :activity, dependent: :destroy
 
+  # Translate the key of activity to path
+  #   The path will be /ClassName/notifications/activity_type/activity_feed
+  #
+  # @return [String]
   def template_path
     partial_root = ''
     path = key.split('.')

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,12 @@
+# Activity model for customisation & custom methods
+class Activity < PublicActivity::Activity
+  has_many :notification_styles, inverse_of: :activity, dependent: :destroy
+
+  # overwrite public_activity gem's method to set template path for us
+  def template_path(key, partial_root)
+    path = key.split('.')
+    path.delete_at(0) if path[0] == 'activity'
+    path.unshift partial_root
+    path.join('/') + 'activity_feed'
+  end
+end

--- a/app/models/concerns/notify_concern.rb
+++ b/app/models/concerns/notify_concern.rb
@@ -3,6 +3,14 @@ module NotifyConcern
     base.include(PublicActivity::Common)
   end
 
+  # Send notifications according to input types based on object which calls the method.
+  #
+  # @param [Object] recipient who does these notifications send for
+  # @param [Object] sender who generate this notification
+  # @param [Hash] types which kinds of notifications you want to send
+  # @option types [Symbol] :activity The type of activity
+  # @option types [True] :popup Enable to send a popup notification
+  # @option types [True] :email Enable to send an email notification
   def notify(recipient, sender, types: {})
     key = customize_key(types[:activity])
     activity_record = create_activity key: key, owner: sender, recipient: recipient
@@ -12,11 +20,20 @@ module NotifyConcern
 
   private
 
+  # Save popup notification record in database based on a given activity record
+  #
+  # @param [Activity] activity_record Activity that the popup notification based on
   def popup_notify(activity_record)
     popup = NotificationStyle.new(activity_id: activity_record.id, notification_type: :popup)
     popup.save
   end
 
+  # Save email notification record in database and send out the email based on a given
+  #   activity record
+  #
+  # @param [Object] recipient who does these notifications send for
+  # @param [Object] sender who sends this notification
+  # @param [Activity] activity_record Activity that the email notification based on
   def email_notify(recipient, sender, activity_record)
     email = NotificationStyle.new(activity_id: activity_record.id, notification_type: :email)
     email.save
@@ -24,6 +41,13 @@ module NotifyConcern
     NotificationMailer.notify(recipient, sender, self, template).deliver_now
   end
 
+  # Customize the key of activity
+  #
+  # @example customize_key(:created) => SomeObjects.notifications.created
+  # @example customize_key(nil) => SomeObjects.notifications.notify
+  #
+  # @param [Symbol] activity The type of activity
+  # @return [String]
   def customize_key(activity)
     if activity
       "#{self.class.name.underscore.pluralize}.notifications.#{activity}"
@@ -32,6 +56,11 @@ module NotifyConcern
     end
   end
 
+  # Get email notification's template path from the key of activity which this notification is
+  #   based on
+  #
+  # @param [Symbol] activity The type of activity
+  # @return [String]
   def email_template(key)
     partial_root = '/'
     path = key.split('.')

--- a/app/models/concerns/notify_concern.rb
+++ b/app/models/concerns/notify_concern.rb
@@ -1,0 +1,41 @@
+module NotifyConcern
+  def self.included(base)
+    base.include(PublicActivity::Common)
+  end
+
+  def notify(recipient, sender, types: {})
+    key = customize_key(types[:activity])
+    activity_record = create_activity key: key, owner: sender, recipient: recipient
+    popup_notify(activity_record) if types.key?(:popup)
+    email_notify(recipient, sender, activity_record) if types.key?(:email)
+  end
+
+  private
+
+  def popup_notify(activity_record)
+    popup = NotificationStyle.new(activity_id: activity_record.id, notification_type: :popup)
+    popup.save
+  end
+
+  def email_notify(recipient, sender, activity_record)
+    email = NotificationStyle.new(activity_id: activity_record.id, notification_type: :email)
+    email.save
+    template = email_template(activity_record.key)
+    NotificationMailer.notify(recipient, sender, self, template).deliver_now
+  end
+
+  def customize_key(activity)
+    if activity
+      "#{self.class.name.underscore.pluralize}.notifications.#{activity}"
+    else
+      "#{self.class.name.underscore.pluralize}.notifications.notify"
+    end
+  end
+
+  def email_template(key)
+    partial_root = '/'
+    path = key.split('.')
+    path.unshift partial_root
+    path.join('/') + '/email'
+  end
+end

--- a/app/models/notification_style.rb
+++ b/app/models/notification_style.rb
@@ -1,3 +1,12 @@
 class NotificationStyle < ActiveRecord::Base
   belongs_to :activity, inverse_of: :notification_styles, dependent: :destroy
+
+  acts_as_readable on: :updated_at
+
+  def template_path
+    partial_root = ''
+    path = activity.key.split('.')
+    path.unshift partial_root
+    path.join('/') + "/#{notification_type}"
+  end
 end

--- a/app/models/notification_style.rb
+++ b/app/models/notification_style.rb
@@ -3,6 +3,10 @@ class NotificationStyle < ActiveRecord::Base
 
   acts_as_readable on: :updated_at
 
+  # Translate the key of activity which this notification is based on to path
+  #   The path will be /ClassName/notifications/activity_type/notification_type
+  #
+  # @return [String]
   def template_path
     partial_root = ''
     path = activity.key.split('.')

--- a/app/models/notification_style.rb
+++ b/app/models/notification_style.rb
@@ -1,0 +1,3 @@
+class NotificationStyle < ActiveRecord::Base
+  belongs_to :activity, inverse_of: :notification_styles, dependent: :destroy
+end

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -1,2 +1,7 @@
 h1
   = @course.title
+
+- @activities.each do |activity|
+  div.activity
+    = link_to_user(activity.recipient)
+    = render_activity(activity, display: activity.key_to_path, root: '/')

--- a/app/views/layouts/notifications/email.html.slim
+++ b/app/views/layouts/notifications/email.html.slim
@@ -1,0 +1,10 @@
+h4
+  = I18n.t('notification_mailer.notification.greeting', user: @recipient.name)
+
+= yield
+
+h4
+  = I18n.t('notification_mailer.notification.complimentary_close')
+
+h4
+  = I18n.t('notification_mailer.notification.sign_off')

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,10 @@ class Application < Rails::Application
   # Do not swallow errors in after_commit/after_rollback callbacks.
   config.active_record.raise_in_transactional_callbacks = true
 
+  # Action Mailer default settings
+  config.action_mailer.default_options = { from: 'noreply@coursemology.org',
+                                           'Content-Transfer-Encoding' => '7bit' }
+
   config.eager_load_paths << "#{Rails.root}/lib/autoload"
   config.eager_load_paths << "#{Rails.root}/app/models/components"
   config.eager_load_paths << "#{Rails.root}/app/controllers/components"

--- a/config/locales/en/notifications.yml
+++ b/config/locales/en/notifications.yml
@@ -1,0 +1,6 @@
+en:
+  notification_mailer:
+    notification:
+      greeting: "Hello, %{user}:"
+      complimentary_close: 'Best Regards,'
+      sign_off: 'The Coursemology Team'

--- a/db/migrate/20150515041839_create_activities.rb
+++ b/db/migrate/20150515041839_create_activities.rb
@@ -1,0 +1,23 @@
+# Migration responsible for creating a table with activities
+class CreateActivities < ActiveRecord::Migration
+  # Create table
+  def self.up
+    create_table :activities do |t|
+      t.belongs_to :trackable, polymorphic: true
+      t.belongs_to :owner, polymorphic: true
+      t.string :key
+      t.text :parameters
+      t.belongs_to :recipient, polymorphic: true
+
+      t.timestamps
+    end
+
+    add_index :activities, [:trackable_id, :trackable_type]
+    add_index :activities, [:owner_id, :owner_type]
+    add_index :activities, [:recipient_id, :recipient_type]
+  end
+  # Drop table
+  def self.down
+    drop_table :activities
+  end
+end

--- a/db/migrate/20150519061618_create_notifications.rb
+++ b/db/migrate/20150519061618_create_notifications.rb
@@ -1,0 +1,10 @@
+class CreateNotificationStyles < ActiveRecord::Migration
+  def change
+    create_table :notification_styles do |t|
+      t.references :activity, index: true, foreign_key: true
+      t.string :notification_type
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150515041839) do
+ActiveRecord::Schema.define(version: 20150519061618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -187,6 +187,13 @@ ActiveRecord::Schema.define(version: 20150515041839) do
     t.datetime "updated_at",  null: false
   end
   add_index "instance_users", ["instance_id", "user_id"], name: "index_instance_users_on_instance_id_and_user_id", unique: true
+
+  create_table "notification_styles", force: :cascade do |t|
+    t.integer  "activity_id",       index: {name: "index_notifications_on_activity_id"}, foreign_key: {references: "activities", name: "fk_notifications_activity_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "notification_type"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
 
   create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150512015621) do
+ActiveRecord::Schema.define(version: 20150515041839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "activities", force: :cascade do |t|
+    t.integer  "trackable_id",   index: {name: "index_activities_on_trackable_id_and_trackable_type", with: ["trackable_type"]}
+    t.string   "trackable_type"
+    t.integer  "owner_id",       index: {name: "index_activities_on_owner_id_and_owner_type", with: ["owner_type"]}
+    t.string   "owner_type"
+    t.string   "key"
+    t.text     "parameters"
+    t.integer  "recipient_id",   index: {name: "index_activities_on_recipient_id_and_recipient_type", with: ["recipient_type"]}
+    t.string   "recipient_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                   limit: 255,              null: false

--- a/lib/extensions/active_record/base.rb
+++ b/lib/extensions/active_record/base.rb
@@ -32,6 +32,12 @@ module Extensions::ActiveRecord::Base
     def acts_as_lesson_plan_item
       acts_as :lesson_plan_item, class_name: Course::LessonPlanItem.name
     end
+
+    # Functions from notification framework.
+    # This function should be declared in model, to send out notifications.
+    def acts_as_notifiable
+      include NotifyConcern
+    end
   end
 
   # @return [Bool] True if valid_from is a future time

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :activity do
+    trackable_id nil
+    trackable_type 'test'
+    owner_id nil
+    owner_type 'test'
+    key 'test'
+    parameters nil
+    recipient_id nil
+    recipient_type 'test'
+  end
+end

--- a/spec/factories/notification_styles.rb
+++ b/spec/factories/notification_styles.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :notification_style do
+    activity_id nil
+    notification_type 'popup'
+  end
+end

--- a/spec/factories/notification_styles.rb
+++ b/spec/factories/notification_styles.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :notification_style do
     activity_id nil
-    notification_type 'popup'
+    notification_type 'test'
   end
 end

--- a/spec/fixtures/notification_mailer/test_email.html.slim
+++ b/spec/fixtures/notification_mailer/test_email.html.slim
@@ -1,0 +1,5 @@
+- message.subject = 'test mailer'
+h3
+ = 'This is a test'
+h3
+ = @trackable.email

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe NotificationMailer, type: :mailer do
+  describe 'Notification email' do
+    TEMPLATE_URL = '../../spec/fixtures/notification_mailer/test_email.html.slim'
+    let(:user) { create(:user, name: 'tester') }
+    let(:mail) do
+      NotificationMailer.notify(user, nil, user, TEMPLATE_URL)
+    end
+    it 'renders the headers' do
+      expect(mail.subject).to eq('test mailer')
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the template' do
+      expect(mail.body.encoded).to match('This is a test')
+    end
+
+    it 'uses input object in template' do
+      expect(mail.body.encoded).to match(user.email)
+    end
+
+    it 'shows layout content' do
+      expect(mail.body.encoded).to match(I18n.t('notification_mailer.notification.greeting',
+                                                user: user.name))
+      expect(mail.body.encoded).
+        to match(I18n.t('notification_mailer.notification.complimentary_close'))
+      expect(mail.body.encoded).to match(I18n.t('notification_mailer.notification.sign_off'))
+    end
+  end
+end

--- a/spec/models/notification_style_spec.rb
+++ b/spec/models/notification_style_spec.rb
@@ -1,4 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe NotificationStyle, type: :model do
+  it { is_expected.to belong_to(:activity).inverse_of(:notification_styles) }
+
+  describe 'notification' do
+    let!(:user) { create(:user, role: :administrator) }
+    let!(:activity) { create(:activity, trackable: user, owner: user, key: 'test.created') }
+    let!(:notification_style) do
+      create(:notification_style, activity: activity, notification_type: :popup)
+    end
+
+    context 'when create a notification' do
+      it 'is unread' do
+        expect(NotificationStyle.unread_by(user).count).to_not eq(0)
+      end
+
+      it 'contains correct activity information' do
+        notification = NotificationStyle.find_by(notification_type: :popup)
+        expect(notification.activity).to eq(activity)
+      end
+    end
+
+    context 'when get path from key' do
+      it 'returns correct path though key' do
+        notification = NotificationStyle.find_by(notification_type: :popup)
+        expect(notification.template_path).to eq('/test/created/popup')
+      end
+    end
+  end
 end

--- a/spec/models/notification_style_spec.rb
+++ b/spec/models/notification_style_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe NotificationStyle, type: :model do
+end


### PR DESCRIPTION
How to store data
==============
**Activity is a kind of record to note who did what. Notifications are based on activities. Since there are some activities then we need to notify users what happened. So the activities should have many kinds of notification styles**

activities table
-------------------
This table is provided by public_activity gem which will mainly store:
* owner:   We regard this field as the sender of this activity. Most of time should be course
* trackable:   The object that is involved in this activity. (e.g. Achievement, Level ...)
* recipient:   The receiver of this activity. Most of time should be User object.
* key:   The key which indicates the path of template

notification_styles table
------------------------
* activity:  References activities table
* notification_type: The style used to show the notification

What if we just want to send a popup or any other notification types without an existing activity record? We can create a fake activity as the type of :notify. So that we can also store our data. And this kind of activity( :notify) will not be loaded when we want to load recent activities in course show page.

To create a notification:
===================
First you should add `acts_as_notifiable` in the **Model** that you want to send out notifications or activity feeds.( e.g. Level, achievement...)
Use API: `object.notify(recipient, sender, types: {})`. Object stands for the instance of your model
For example, if you want to create three types of notifications based on a achievement object for a user in a course:
`object.notify(user, course, types: { activity: :ActivityType, popup: true, email: true } )`

This notification is for a given user, so the recipient should be the user. Usually, most notifications are sent out by the course like (achievement, level, announcement). So the course should be the sender of this notification. 

`popup: , email: , activity:` are all optional. You can create any combinations of notifications among them. But it certainly doesn't make sense if you do not input any type.

popup: 
---------------
Could be set as enable by `popup: true`. After that You should provide styles in **view/ModelName/notifications/ActivityType/_popup** file. Activity type here will be the type that you input in the API's `activity:` field. If you did not filling this field, the Activity type will be **notify**

email: 
--------
Could be set as enable by `email: true`. After that, you should provide email style in **view/ModelName/notifications/ActivityType/_email** file. In that file you may want to use `message.subject =` to set your email's subject. Meanwhile your email will also use **view/layouts/notifications/email.html.slim** as its layout.

activity:
----------
Could take in a **symbol** as the type name of activity. ( e.g. If one object is created in some controller, you may need to create an activity as `:created`) Activities are shown in course's show view. But you need to provide templates for each kind of activity type you have generated in **view/ModelName/notifications/ActivityType/_activity_feed** file. 

For example, if someone reached some level. You may want to create an :updated activity for level object. To show this activity, you should provide the template. In that template, you may want to write:
        `I18n.t('reached') a.trackable.level_number`  (you can use a.trackable to get your object record in your template)
