### PR TITLE
Do not hide the translations for Rails keys.

### DIFF
--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -7,8 +7,13 @@ RSpec.configure do |config|
       protected
 
       def lookup(_, key, _, _)
-        super
-        key.to_s
+        key = key.to_s
+        result = super
+        if key.start_with?('activerecord', 'attributes', 'errors', 'support')
+          result
+        else
+          key
+        end
       end
     end
     I18n.backend = StubbedI18nBackend.new


### PR DESCRIPTION
So we actually get useful error messages from AR.