### PR TITLE
Scope settings under :components before pass to component_host

### DIFF
--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -60,7 +60,7 @@ class Course::Controller < ApplicationController
   # @return [Course::ComponentHost] The instance of component host using settings from instance and
   #                                 course
   def current_component_host
-    @current_component_host ||= Course::ComponentHost.new(current_tenant.settings,
-                                                          current_course.settings)
+    @current_component_host ||= Course::ComponentHost.new(current_tenant.settings(:components),
+                                                          current_course.settings(:components))
   end
 end


### PR DESCRIPTION
As #156 did, our components settings are under key <code>:components</code> now