### PR TITLE
Notification framework

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'settings_on_rails'
 gem 'migration_comments'
 # Manage read/unread status
 gem 'unread'
+# Manage activities and notifications
+gem 'public_activity'
 # Extension for validating hostnames and domain names
 gem 'validates_hostname'
 # A Ruby state machine library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,11 @@ GEM
     pg (0.17.1)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
+    public_activity (1.4.2)
+      actionpack (>= 3.0.0)
+      activerecord (>= 3.0)
+      i18n (>= 0.5.0)
+      railties (>= 3.0.0)
     puma (2.11.3)
       rack (>= 1.1, < 2.0)
     rack (1.6.1)
@@ -456,6 +461,7 @@ DEPENDENCIES
   mini_magick
   momentjs-rails (>= 2.8.1)
   pg (~> 0.17.0)
+  public_activity
   puma
   rails (~> 4.2.1)
   rails-assets-jquery-ujs (~> 1.0.3)!

--- a/app/controllers/concerns/course/activities_concern.rb
+++ b/app/controllers/concerns/course/activities_concern.rb
@@ -1,0 +1,16 @@
+module Course::ActivitiesConcern
+  extend ActiveSupport::Concern
+
+  # Load recent activity feeds
+  #
+  # @param [Course] course course which activities are related to
+  # @param [Integer] number number of activities that will be loaded
+  #
+  # @return [Array<Activity>]
+  def recent_activities(course, count: nil)
+    result = Activity.joins(:notification).where(notifications: { activity_feed: true }).
+             where(owner: course).order(created_at: :desc).includes(:trackable, :recipient)
+    result = result.first(count) unless count.nil?
+    result
+  end
+end

--- a/app/controllers/concerns/course/notifications_concern.rb
+++ b/app/controllers/concerns/course/notifications_concern.rb
@@ -1,0 +1,16 @@
+module Course::NotificationsConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :load_unread_popups
+  end
+
+  private
+
+  def load_unread_popups #:nodoc:
+    return [] unless current_course && current_user
+    notifications_id = Notification.where(popup: true).unread_by(current_user).select(:id)
+    @popups = Activity.where(owner: current_course, notification_id: notifications_id).
+              includes(:recipient, :trackable)
+  end
+end

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -1,5 +1,6 @@
 class Course::Controller < ApplicationController
   load_and_authorize_resource :course
+  include NotificationsConcern
 
   # Gets the sidebar elements.
   #

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -1,4 +1,6 @@
 class Course::CoursesController < Course::Controller
+  include ActivitiesConcern
+
   def show # :nodoc:
     render layout: 'course'
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,2 @@
+class ApplicationMailer < ActionMailer::Base
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,18 @@
+class NotificationMailer < ApplicationMailer
+  layout 'notifications/email'
+
+  # Send email using input template
+  #
+  # @param [User] recipient who does this email send for
+  # @param [Object] sender who sends out this email
+  # @param [Object] object what does this email about
+  # @param [String] template_url the path of email's template
+  def notify(recipient, sender, object, template_url)
+    @recipient = recipient
+    @sender = sender
+    @object = object
+    mail(to: recipient.email) do |format|
+      format.html { render template_url }
+    end
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,4 @@
+# Activity model for customisation & custom methods
+class Activity < PublicActivity::Activity
+  belongs_to :notification, inverse_of: :activity, dependent: :destroy
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,4 +1,16 @@
 # Activity model for customisation & custom methods
 class Activity < PublicActivity::Activity
   belongs_to :notification, inverse_of: :activity, dependent: :destroy
+
+  # Translate the key of activity to path with a given type of notification
+  #
+  # @example template_path(:popup) => /ClassName/notifications/ActivityType/popup
+  #
+  # @param [Symbol] notification_type the type of notification
+  # @return [String]
+  def template_path(notification_type)
+    return unless [:activity_feed, :email, :popup].include?(notification_type)
+    path = key.split('.')
+    format("/%s/#{notification_type}", path.join('/'))
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -2,4 +2,57 @@ class Notification < ActiveRecord::Base
   acts_as_readable on: :updated_at
 
   has_one :activity, inverse_of: :notification, dependent: :destroy
+
+  # Send notifications according to input types and objects
+  #
+  # @param [Object] recipient who does these notifications send for
+  # @param [Object] sender who generate these notifications
+  # @param [Object] object what is these notifications about
+  # @param [Symbol] activity which kind of activity will these notifications be based on
+  # @param [Array<Symbol>] types which kinds of notifications that will be sent. Could take in
+  #   any combination of :activity_feed, :email and :popup
+  def self.notify(recipient, sender, object, activity: :notify, types: [])
+    key = customize_key(object, activity)
+    notification = Notification.new(activity_feed: types.include?(:activity_feed),
+                                    email: types.include?(:email), popup: types.include?(:popup))
+    notification.build_activity(recipient: recipient, owner: sender, trackable: object,
+                                key: key, notification: notification)
+    email_notify(recipient, sender, activity) if notification.email
+    notification.save
+  end
+
+  class << self
+    private
+
+    # Send out the email based on a given activity record
+    #
+    # @param [Object] recipient who does these notifications send for
+    # @param [Object] sender who sends this notification
+    # @param [Activity] activity the activity which belongs to this notification
+    def email_notify(recipient, sender, activity)
+      template = email_template(activity.key)
+      NotificationMailer.notify(recipient, sender, activity.trackable, template).deliver_now
+    end
+
+    # Customize the key of activity
+    #
+    # @example customize_key(@course,:created) => courses.notifications.created
+    #
+    # @param [Object] object The object that will be tracked
+    # @param [Symbol] activity The type name of activity
+    # @return [String]
+    def customize_key(object, activity)
+      "#{object.class.name.underscore.pluralize}.notifications.#{activity}"
+    end
+
+    # Get email notification's template path from the key of activity which this notification is
+    #   based on
+    #
+    # @param [Symbol] activity The type of activity
+    # @return [String]
+    def email_template(key)
+      path = key.split('.')
+      format('/%s/email', path.join('/'))
+    end
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,3 +1,5 @@
 class Notification < ActiveRecord::Base
   acts_as_readable on: :updated_at
+
+  has_one :activity, inverse_of: :notification, dependent: :destroy
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,3 @@
+class Notification < ActiveRecord::Base
+  acts_as_readable on: :updated_at
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -17,7 +17,7 @@ class Notification < ActiveRecord::Base
                                     email: types.include?(:email), popup: types.include?(:popup))
     notification.build_activity(recipient: recipient, owner: sender, trackable: object,
                                 key: key, notification: notification)
-    email_notify(recipient, sender, activity) if notification.email
+    email_notify(recipient, sender, notification.activity) if notification.email
     notification.save
   end
 
@@ -30,7 +30,7 @@ class Notification < ActiveRecord::Base
     # @param [Object] sender who sends this notification
     # @param [Activity] activity the activity which belongs to this notification
     def email_notify(recipient, sender, activity)
-      template = email_template(activity.key)
+      template = activity.template_path(:email)
       NotificationMailer.notify(recipient, sender, activity.trackable, template).deliver_now
     end
 
@@ -43,16 +43,6 @@ class Notification < ActiveRecord::Base
     # @return [String]
     def customize_key(object, activity)
       "#{object.class.name.underscore.pluralize}.notifications.#{activity}"
-    end
-
-    # Get email notification's template path from the key of activity which this notification is
-    #   based on
-    #
-    # @param [Symbol] activity The type of activity
-    # @return [String]
-    def email_template(key)
-      path = key.split('.')
-      format('/%s/email', path.join('/'))
     end
   end
 end

--- a/app/views/layouts/notifications/email.html.slim
+++ b/app/views/layouts/notifications/email.html.slim
@@ -1,0 +1,10 @@
+h4
+  = I18n.t('notification_mailer.notification.greeting', user: @recipient.name)
+
+= yield
+
+h4
+  = I18n.t('notification_mailer.notification.complimentary_close')
+
+h4
+  = I18n.t('notification_mailer.notification.sign_off')

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,10 @@ class Application < Rails::Application
   # Do not swallow errors in after_commit/after_rollback callbacks.
   config.active_record.raise_in_transactional_callbacks = true
 
+  # Action Mailer default settings
+  config.action_mailer.default_options = { from: 'noreply@example.com',
+                                           'Content-Transfer-Encoding' => '7bit' }
+
   config.eager_load_paths << "#{Rails.root}/lib/autoload"
   config.eager_load_paths << "#{Rails.root}/app/models/components"
   config.eager_load_paths << "#{Rails.root}/app/controllers/components"

--- a/config/locales/en/notifications.yml
+++ b/config/locales/en/notifications.yml
@@ -1,0 +1,6 @@
+en:
+  notification_mailer:
+    notification:
+      greeting: "Hello, %{user}:"
+      complimentary_close: 'Best Regards,'
+      sign_off: 'The Coursemology Team'

--- a/db/migrate/20150528085404_create_notifications.rb
+++ b/db/migrate/20150528085404_create_notifications.rb
@@ -1,0 +1,11 @@
+class CreateNotifications < ActiveRecord::Migration
+  def change
+    create_table :notifications do |t|
+      t.boolean :activity_feed
+      t.boolean :email
+      t.boolean :popup
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150528092025_create_activities.rb
+++ b/db/migrate/20150528092025_create_activities.rb
@@ -1,0 +1,26 @@
+# Migration responsible for creating a table with activities
+class CreateActivities < ActiveRecord::Migration
+  # Create table
+  def self.up
+    create_table :activities do |t|
+      t.belongs_to :trackable, polymorphic: true
+      t.belongs_to :owner, polymorphic: true
+      t.string :key
+      t.text :parameters
+      t.belongs_to :recipient, polymorphic: true
+      t.references :notification, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :activities, [:trackable_id, :trackable_type]
+    add_index :activities, [:owner_id, :owner_type]
+    add_index :activities, [:recipient_id, :recipient_type]
+    add_index :activities, :notification_id, unique: true
+  end
+
+  # Drop table
+  def self.down
+    drop_table :activities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150513111716) do
+ActiveRecord::Schema.define(version: 20150528092025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "notifications", force: :cascade do |t|
+    t.boolean  "activity_feed"
+    t.boolean  "email"
+    t.boolean  "popup"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  create_table "activities", force: :cascade do |t|
+    t.integer  "trackable_id",    index: {name: "index_activities_on_trackable_id_and_trackable_type", with: ["trackable_type"]}
+    t.string   "trackable_type",  index: {name: "fk__activities_trackable_id", with: ["trackable_id"]}
+    t.integer  "owner_id",        index: {name: "index_activities_on_owner_id_and_owner_type", with: ["owner_type"]}
+    t.string   "owner_type",      index: {name: "fk__activities_owner_id", with: ["owner_id"]}
+    t.string   "key"
+    t.text     "parameters"
+    t.integer  "recipient_id",    index: {name: "index_activities_on_recipient_id_and_recipient_type", with: ["recipient_type"]}
+    t.string   "recipient_type",  index: {name: "fk__activities_recipient_id", with: ["recipient_id"]}
+    t.integer  "notification_id", index: {name: "fk__activities_notification_id"}, foreign_key: {references: "notifications", name: "fk_activities_notification_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+  add_index "activities", ["notification_id"], name: "index_activities_on_notification_id", unique: true
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                   limit: 255,              null: false
@@ -199,14 +222,6 @@ ActiveRecord::Schema.define(version: 20150513111716) do
     t.datetime "updated_at",  null: false
   end
   add_index "instance_users", ["instance_id", "user_id"], name: "index_instance_users_on_instance_id_and_user_id", unique: true
-
-  create_table "notifications", force: :cascade do |t|
-    t.boolean  "activity_feed"
-    t.boolean  "email"
-    t.boolean  "popup"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-  end
 
   create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -200,6 +200,14 @@ ActiveRecord::Schema.define(version: 20150513111716) do
   end
   add_index "instance_users", ["instance_id", "user_id"], name: "index_instance_users_on_instance_id_and_user_id", unique: true
 
+  create_table "notifications", force: :cascade do |t|
+    t.boolean  "activity_feed"
+    t.boolean  "email"
+    t.boolean  "popup"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
   create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"
     t.string   "readable_type", limit: 255, null: false

--- a/spec/controllers/course/courses_controller_spec.rb
+++ b/spec/controllers/course/courses_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Course::CoursesController, type: :controller do
+  let!(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    describe '#recent_activities' do
+      before do
+        Notification.notify(nil, course, nil, activity: :created, types: [:activity_feed])
+        Notification.notify(nil, course, nil, activity: :created, types: [:activity_feed])
+      end
+
+      it 'returns recent activities' do
+        get(:show, id: course.id)
+        expect(controller.recent_activities(course).count).to eq(2)
+        expect(controller.recent_activities(course, count: 1).count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :activity do
+    trackable_id nil
+    trackable_type nil
+    owner_id nil
+    owner_type nil
+    key nil
+    parameters nil
+    recipient_id nil
+    recipient_type nil
+    notification_id nil
+  end
+end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :notification do
+    activity_feed false
+    email false
+    popup false
+  end
+end

--- a/spec/fixtures/notification_mailer/test_email.html.slim
+++ b/spec/fixtures/notification_mailer/test_email.html.slim
@@ -1,0 +1,5 @@
+- message.subject = 'test mailer'
+h3
+ = 'This is a test'
+h3
+ = @object.email

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe NotificationMailer, type: :mailer do
+end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,4 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe NotificationMailer, type: :mailer do
+  describe 'Notification email' do
+    TEMPLATE_URL = '../../spec/fixtures/notification_mailer/test_email.html.slim'
+    let(:user) { create(:user, name: 'tester') }
+    let(:mail) do
+      NotificationMailer.notify(user, user, user, TEMPLATE_URL)
+    end
+    it 'renders the headers' do
+      expect(mail.subject).to eq('test mailer')
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the template' do
+      expect(mail.body.encoded).to match('This is a test')
+    end
+
+    it 'uses input object in template' do
+      expect(mail.body.encoded).to match(user.email)
+    end
+
+    it 'shows layout content' do
+      expect(mail.body.encoded).to match(I18n.t('notification_mailer.notification.greeting',
+                                                user: user.name))
+      expect(mail.body.encoded).
+        to match(I18n.t('notification_mailer.notification.complimentary_close'))
+      expect(mail.body.encoded).to match(I18n.t('notification_mailer.notification.sign_off'))
+    end
+  end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Activity, type: :model do
+  describe '#template_path' do
+    let!(:user) { create(:user, role: :administrator) }
+    let!(:activity) { create(:activity, key: 'test.notifications.tested') }
+
+    context 'when translate key to path' do
+      it 'returns a correct path' do
+        expect(activity.template_path(:popup)).to eq('/test/notifications/tested/popup')
+        expect(activity.template_path(:activity_feed)).
+          to eq('/test/notifications/tested/activity_feed')
+        expect(activity.template_path(:email)).to eq('/test/notifications/tested/email')
+      end
+    end
+
+    context 'when translate key to unknown type path' do
+      it 'returns nil' do
+        expect(activity.template_path(:coursemology)).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,4 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Notification, type: :model do
+  describe '#notify' do
+    let!(:user) { create(:user, role: :administrator) }
+
+    context 'when create a notification with a given activity record' do
+      before do
+        Notification.notify(user, user, user, activity: :created, types: [:activity_feed, :popup])
+      end
+
+      it 'is unread' do
+        expect(Notification.unread_by(user).count).to_not eq(0)
+      end
+
+      it 'saves correct activity and notification information in database' do
+        activity = Activity.find_by(recipient: user)
+        expect(activity.notification.activity_feed).to eq(true)
+        expect(activity.notification.popup).to eq(true)
+        expect(activity.notification.email).to eq(false)
+      end
+    end
+
+    context 'when create a notification without an activity record' do
+      before do
+        Notification.notify(user, user, user, types: [:popup])
+      end
+
+      it 'create a fake activity as the type of notify' do
+        activity = Activity.find_by("key like '%notify'")
+        expect(activity.notification.activity_feed).to eq(false)
+        expect(activity.notification.popup).to eq(true)
+        expect(activity.notification.email).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
How to store data
==============

activities table
-------------------
This table is provided by public_activity gem which will mainly store( without notification_id ):
* owner:   We regard this field as the sender of this activity. Most of time should be course
* trackable:   The object that is involved in this activity. (e.g. Achievement, Level ...)
* recipient:   The receiver of this activity. Most of time should be User object.
* key:   The key which indicates the path of template and the type of activity
* notification_id:  References notification which this activity record belongs to

An 'notification_id' column is added to support the relation between activity and notification: **a notification has one activity record and an activity belongs to a notification**

notifications table
------------------------
* activity_feed:  whether to show an activity in the style of "activity_feed" 
* popup:  whether to show an activity in the style of "popup"
* email:  whether to show an activity in the style of "email"

A notification is sent based on a provided activity record. What if we just want to send a notification without a given activity record?
We can create a fake activity as the type of :notify. So that we can also store our data.

To create a notification:
===================
Use API: `Notification.notify(recipient, sender, object, activity: :notify, types: {})`. Object stands for the instance( e.g. level, achievement...)
For example, if you want to create three types of notifications based on an achievement object for a user in a course, you should use:
`object.notify(user, course, @achievement,  activity: :ActivityType, types: [ :activity_feed, :popup, :email ])`

This notification is for a given user, so the recipient should be the user. Usually, most notifications are sent out by the course( e.g. gain achievement, level up, new announcement). So the course should be the sender of this notification. 

`popup: , email: , activity_feed:` are all optional. You can create any combinations of notifications among them. But it certainly doesn't make sense if you do not input any type.

popup: 
---------------
Could be set as enable by `popup: true`. After that You should provide styles in **view/ModelName/notifications/ActivityType/_popup** file. Activity type here will be the type that you input in the API's `activity:` field. If you do not filling this field, the Activity type will be **notify**

email: 
--------
Could be set as enable by `email: true`. After that, you should provide email style in **view/ModelName/notifications/ActivityType/_email** file. In that file you may want to use `message.subject =` to set your email's subject. Meanwhile your email will also use **view/layouts/notifications/email.html.slim** as its layout.

activity:
----------
Could take in a **symbol** as the type name of activity. ( e.g. If one object is created in some controller, you may need to create an activity as `:created`) Activities are shown in course's show view if you input **activity_feed** in API's types field. But you need to provide templates for each kind of activity type you have generated in **view/ModelName/notifications/ActivityType/_activity_feed** file. 

For example, if someone reached some level. You may want to create an :updated activity for level object. To show this activity, you should provide the template. In that template, you may want to write:
        `I18n.t('reached') a.trackable.level_number`  (you can use a.trackable to get your object record in your template. Also you can use a.owner, a.recipient to get those objects)
