### PR TITLE
Implement an effective settings model adapter

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -9,7 +9,7 @@ class Admin::AdminController < Admin::Controller
   end
 
   def update_components #:nodoc:
-    @settings.update(params.require(:instance_settings))
+    @settings.update(params.require(:instance_settings_effective))
     if current_tenant.save
       redirect_to admin_components_path, success: t('.success')
     else
@@ -22,7 +22,7 @@ class Admin::AdminController < Admin::Controller
 
   # Load our settings adapter to handle component settings
   def load_settings
-    @settings = Instance::Settings.new(current_tenant)
+    @settings = Instance::Settings::Effective.new(current_tenant, Course::ComponentHost)
   end
 
   # Checks if the current request is the components page.

--- a/app/models/instance/settings/effective.rb
+++ b/app/models/instance/settings/effective.rb
@@ -1,0 +1,42 @@
+class Instance::Settings::Effective < Instance::Settings
+  # @param (see Instance::Settings#initialize)
+  # @param [#components] component_host The component host for which to query settings for.
+  def initialize(settings, component_host)
+    super(settings)
+    @component_host = component_host
+  end
+
+  private
+
+  # This overrides #components_enabled_statuses to merge in defaults from the component host.
+  #
+  # @return [Array<Instance::Settings::BooleanValue>] The enabled status for every component, and
+  #   only every components which exist.
+  def components_enabled_statuses
+    existing_components = Set[*@component_host.components.map { |c| c.key.to_s }]
+    enabled_statuses = super.select { |c| existing_components.include?(c.id) }
+
+    augment_enabled_statuses_defaults(enabled_statuses)
+  end
+
+  # Augments the current array of enabled statuses with defaults for components which do not have
+  # a configuration.
+  #
+  # @param [Array<Instance::Settings::BooleanValue>] enabled_statuses The array of enable statuses
+  #   currently stored in the settings.
+  # @return [Array<Instance::Settings::BooleanValue] The array of enable statuses with the defaults
+  #   augmented for undefined components.
+  def augment_enabled_statuses_defaults(enabled_statuses)
+    enabled_statuses = enabled_statuses.dup
+    configured_components = Set[*enabled_statuses.map(&:id)]
+
+    @component_host.components.each do |component|
+      next if configured_components.include?(component.key.to_s)
+      id = component.key.to_s
+      value = component.enabled_by_default?
+      enabled_statuses << Instance::Settings::BooleanValue.new(id: id, value: value)
+    end
+
+    enabled_statuses
+  end
+end

--- a/spec/controllers/admin/admin_controller_spec.rb
+++ b/spec/controllers/admin/admin_controller_spec.rb
@@ -17,10 +17,12 @@ RSpec.describe Admin::AdminController, type: :controller do
         all_component_ids.sample(1 + rand(all_component_ids.count))
       end
       let(:components_params) { { enabled_component_ids: ids_to_enable } }
-      subject { post :update_components, instance_settings: components_params }
+      subject { post :update_components, instance_settings_effective: components_params }
 
       context 'enable/disable components' do
-        let(:settings) { Instance::Settings.new(instance.reload) }
+        let(:settings) do
+          Instance::Settings::Effective.new(instance.reload, Course::ComponentHost)
+        end
 
         it 'enables the component to enabled and disables all other components' do
           subject

--- a/spec/features/admin/components_settings_spec.rb
+++ b/spec/features/admin/components_settings_spec.rb
@@ -6,18 +6,22 @@ RSpec.feature 'Administration: Components', type: :feature do
   with_tenant(:instance) do
     let(:admin) { create(:administrator) }
     let(:components)  { Course::ComponentHost.components }
-    let(:sample_component_id) { "instance_settings_enabled_component_ids_#{components.sample.key}" }
+    let(:sample_component_id) do
+      "instance_settings_effective_enabled_component_ids_#{components.sample.key}"
+    end
 
     before { login_as(admin, scope: :user) }
 
     scenario 'Admin visits the page' do
       visit admin_components_path
 
+      settings = Instance::Settings::Effective.new(instance.reload.settings, Course::ComponentHost)
+      enabled_components = settings.enabled_component_ids
       components.each do |component|
         expect(page).to have_selector('th', text: component.name)
-        enabled = instance.reload.settings(:components, component.key).enabled
-        checkbox = find("#instance_settings_enabled_component_ids_#{component.key}")
-        if enabled
+
+        checkbox = find("#instance_settings_effective_enabled_component_ids_#{component.key}")
+        if enabled_components.include?(component.key.to_s)
           expect(checkbox).to be_checked
         else
           expect(checkbox).not_to be_checked

--- a/spec/models/instance/settings/effective_spec.rb
+++ b/spec/models/instance/settings/effective_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+RSpec.describe Instance::Settings::Effective, type: :model do
+  let(:settings) do
+    mock_settings(components: {
+      A: { enabled: true }
+    })
+  end
+
+  let(:component_host) { Course::ComponentHost }
+  let(:default_enabled_components) do
+    component_host.components.select(&:enabled_by_default?)
+  end
+  let(:default_enabled_component_ids) { default_enabled_components.map { |c| c.key.to_s } }
+  subject { Instance::Settings::Effective.new(settings, component_host) }
+
+  describe '#enabled_component_ids' do
+    context 'when no configuration is defined' do
+      it 'falls back to the defaults' do
+        expect(subject.enabled_component_ids).to include(*default_enabled_component_ids)
+      end
+
+      it 'does not contain removed components' do
+        expect(subject.enabled_component_ids).to contain_exactly(*default_enabled_component_ids)
+      end
+    end
+  end
+end

--- a/spec/models/instance/settings_spec.rb
+++ b/spec/models/instance/settings_spec.rb
@@ -5,30 +5,12 @@ RSpec.describe Instance::Settings, type: :model do
   ENABLED_COMPONENTS = [:A, :C, :E]
 
   let(:settings) do
-    class MockSettings
-      def stub_method(name, &block)
-        (class << self; self; end).class_eval do
-          define_method(name, &block)
-        end
-      end
+    components = {}
+    ALL_COMPONENTS.each do |component|
+      components[component] ||= { enabled: ENABLED_COMPONENTS.include?(component) }
     end
-
-    component_settings = Struct.new(:enabled)
-    components_settings = MockSettings.new
-    component_settings_store = {}
-    components_settings.stub_method(:settings) do |symbol|
-      enabled = ENABLED_COMPONENTS.include?(symbol)
-      component_settings_store[symbol] ||= component_settings.new(enabled)
-    end
-    components_settings.stub_method(:map) do |&block|
-      ALL_COMPONENTS.map { |symbol| [symbol, settings(symbol)] }.map(&block)
-    end
-    instance_settings = MockSettings.new
-    instance_settings.stub_method(:settings) do |_|
-      components_settings
-    end
-
-    instance_settings
+    hash = { components: components }
+    mock_settings(hash)
   end
 
   subject { Instance::Settings.new(settings) }

--- a/spec/models/instance/settings_spec.rb
+++ b/spec/models/instance/settings_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Instance::Settings, type: :model do
-  ALL_COMPONENTS = [:A, :B, :C, :D, :E, :F]
-  ENABLED_COMPONENTS = [:A, :C, :E]
+  let(:all_components) { [:A, :B, :C, :D, :E, :F].freeze }
+  let(:enabled_components) { [:A, :C, :E].freeze }
 
   let(:settings) do
     components = {}
-    ALL_COMPONENTS.each do |component|
-      components[component] ||= { enabled: ENABLED_COMPONENTS.include?(component) }
+    all_components.each do |component|
+      components[component] ||= { enabled: enabled_components.include?(component) }
     end
     hash = { components: components }
     mock_settings(hash)
@@ -15,29 +15,22 @@ RSpec.describe Instance::Settings, type: :model do
 
   subject { Instance::Settings.new(settings) }
 
-  describe 'mocks' do
-    it 'has many components' do
-      expect(subject.send(:settings, :components).settings(:A).enabled).to be_truthy
-      expect(subject.send(:settings, :components).settings(:B).enabled).to be_falsey
-    end
-  end
-
   describe '#enabled_components' do
     it 'retrieves only enabled components' do
       enabled_component_ids = subject.enabled_components.map(&:id)
-      expect(enabled_component_ids).to contain_exactly(*ENABLED_COMPONENTS)
+      expect(enabled_component_ids).to contain_exactly(*enabled_components)
     end
   end
 
   describe '#enabled_component_ids' do
     it 'retrieves only enabled components' do
-      expect(subject.enabled_component_ids).to contain_exactly(*ENABLED_COMPONENTS)
+      expect(subject.enabled_component_ids).to contain_exactly(*enabled_components)
     end
   end
 
   describe '#enabled_component_ids=' do
     it 'sets the enabled components' do
-      new_enabled_components = ENABLED_COMPONENTS + [:B]
+      new_enabled_components = enabled_components + [:B]
       subject.enabled_component_ids = new_enabled_components
       expect(subject.enabled_component_ids).to contain_exactly(*new_enabled_components)
     end

--- a/spec/support/settings_on_rails.rb
+++ b/spec/support/settings_on_rails.rb
@@ -1,0 +1,36 @@
+module SettingsOnRails::TestHelpers
+  # Creates a mock Settings object from the given hash.
+  #
+  # @param [Hash] hash The settings to mock.
+  def mock_settings(hash = {})
+    SettingsOnRails::TestHelpers.create_mock_hash(hash)
+  end
+
+  class << self
+    def create_mock_hash(result = HashWithIndifferentAccess.new)
+      result = OpenStruct.new(result)
+      stub_hashes!(result)
+      result.each_pair do |key, value|
+        next unless value.is_a?(Hash)
+        result[key] = create_mock_hash(value)
+      end
+
+      result
+    end
+
+    private
+
+    def stub_hashes!(result)
+      result.singleton_class.instance_eval { alias_method :settings, :[] }
+      result.define_singleton_method(:map) do |&proc|
+        [].tap do |map_result|
+          each_pair { |key, value| map_result << proc.call(key, value) }
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include SettingsOnRails::TestHelpers, type: :model
+end


### PR DESCRIPTION
This can be used to load the configuration from the instance and course, and then to display the real settings in use when no explicit configuration has been specified.

@allenwq 