### PR TITLE
Fix unread_status_management_spec

### DIFF
--- a/spec/features/course/unread_status_management_spec.rb
+++ b/spec/features/course/unread_status_management_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
 
         before do
           login_as(first_user)
-          visit course_achievements_path(course)
+          visit course_path(course)
         end
 
         it 'shows the correct number of unread items' do


### PR DESCRIPTION
* Replace visiting course achievement path with visiting course path
    when check if sidebar shows correct number of unread items