### PR TITLE
Modify methods of creating administrators in specs

### DIFF
--- a/spec/features/admin/announcement_management_spec.rb
+++ b/spec/features/admin/announcement_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Administration: Announcements', type: :feature do
   let!(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:user, role: :administrator) }
+    let!(:user) { create(:administrator) }
 
     before do
       login_as(user, scope: :user)

--- a/spec/features/admin/announcement_pagination_spec.rb
+++ b/spec/features/admin/announcement_pagination_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Administration: Announcements', type: :feature do
     let!(:instance) { create(:instance) }
 
     with_tenant(:instance) do
-      let!(:user) { create(:user, role: :administrator) }
+      let!(:user) { create(:administrator) }
 
       before do
         create_list(:instance_announcement, 50, instance: instance, creator: user, updater: user)

--- a/spec/features/admin/instance_management_spec.rb
+++ b/spec/features/admin/instance_management_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Administration: Instances', type: :feature do
-  let!(:user) { create(:user, role: :administrator) }
+  let!(:user) { create(:administrator) }
   before { login_as(user, scope: :user) }
 
   describe 'new page' do

--- a/spec/features/admin/system_announcement_pagination_spec.rb
+++ b/spec/features/admin/system_announcement_pagination_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Administration: System announcements', type: :feature do
   describe 'Pagination' do
     subject { page }
 
-    let!(:user) { create(:user, role: :administrator) }
+    let!(:user) { create(:administrator) }
 
     before do
       SystemAnnouncement.delete_all

--- a/spec/features/course/achievement_listing_spec.rb
+++ b/spec/features/course/achievement_listing_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Achievements', type: :feature do
   let!(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:user, role: :administrator) }
+    let!(:user) { create(:administrator) }
     let!(:course) { create(:course) }
     let!(:achievements) do
       create_list(:course_achievement, 10, course: course, creator: user, updater: user)

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Achievements' do
   let!(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:user, role: :administrator) }
+    let!(:user) { create(:administrator) }
     let!(:course) { create(:course) }
 
     before do

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
   let!(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:user, role: :administrator) }
+    let!(:user) { create(:administrator) }
     let!(:course) { create(:course) }
 
     before do

--- a/spec/features/course/announcement_pagination_spec.rb
+++ b/spec/features/course/announcement_pagination_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
     let!(:instance) { create(:instance) }
 
     with_tenant(:instance) do
-      let!(:user) { create(:user, role: :administrator) }
+      let!(:user) { create(:administrator) }
       let!(:course) { create(:course) }
       let!(:announcements) do
         create_list(:course_announcement, 50, course: course, creator: user, updater: user)

--- a/spec/features/course/announcement_sticky_spec.rb
+++ b/spec/features/course/announcement_sticky_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
     let!(:instance) { create(:instance) }
 
     with_tenant(:instance) do
-      let!(:user) { create(:user, role: :administrator) }
+      let!(:user) { create(:administrator) }
       let!(:course) { create(:course) }
 
       before do

--- a/spec/features/course/request_managmement_spec.rb
+++ b/spec/features/course/request_managmement_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Course: Requests' do
   let(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let(:user) { create(:user, role: :administrator) }
+    let(:user) { create(:administrator) }
     let(:course) { create(:course) }
     let!(:unregistered_user) { create(:course_student, course: course) }
     before { login_as(user, scope: :user) }

--- a/spec/features/course/settings_spec.rb
+++ b/spec/features/course/settings_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Course: Settings', type: :feature do
   subject { page }
 
-  let!(:user) { create(:user, role: :administrator) }
+  let!(:user) { create(:administrator) }
   before { login_as(user, scope: :user) }
 
   describe 'index' do

--- a/spec/features/course/student_management_spec.rb
+++ b/spec/features/course/student_management_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Courses: Students' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:user) { create(:user, role: :administrator) }
+    let(:user) { create(:administrator) }
     let!(:course_students) { create_list(:course_student, 3, :approved, course: course) }
     let!(:unregistered_user) { create(:course_user, course: course) }
     before { login_as(user, scope: :user) }

--- a/spec/features/course/unread_status_management_spec.rb
+++ b/spec/features/course/unread_status_management_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'Course: Announcements', type: :feature do
     let!(:instance) { create(:instance) }
 
     with_tenant(:instance) do
-      let!(:first_user) { create(:user, role: :administrator) }
-      let!(:second_user) { create(:user, role: :administrator) }
+      let!(:first_user) { create(:administrator) }
+      let!(:second_user) { create(:administrator) }
       let!(:course) { create(:course) }
 
       describe 'visit announcement' do

--- a/spec/features/course_management_spec.rb
+++ b/spec/features/course_management_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Courses', type: :feature do
   let(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:user, role: :administrator) }
+    let!(:user) { create(:administrator) }
     before { login_as(user, scope: :user) }
 
     describe 'course new page' do

--- a/spec/features/system_announcements_management_spec.rb
+++ b/spec/features/system_announcements_management_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'System announcements', type: :feature do
-  let!(:user) { create(:user, role: :administrator) }
+  let!(:user) { create(:administrator) }
 
   before do
     login_as(user, scope: :user)

--- a/spec/models/course/announcement_spec.rb
+++ b/spec/models/course/announcement_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Course::Announcement, type: :model do
     end
 
     context 'unread status' do
-      let!(:first_user) { create(:user, role: :administrator) }
-      let!(:second_user) { create(:user, role: :administrator) }
+      let!(:first_user) { create(:administrator) }
+      let!(:second_user) { create(:administrator) }
       let!(:course) { create(:course) }
 
       describe 'announcement creation' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Course, type: :model do
     end
 
     describe 'levels' do
-      let!(:user) { create(:user, role: :administrator) }
+      let!(:user) { create(:administrator) }
       let!(:course) { create(:course) }
       let!(:levels) do
         create_list(:course_level, 5, course: course).map(&:experience_points_threshold)


### PR DESCRIPTION
Fix issue #232
Replace `create(:user, role: :administrator)` in specs with `create(:administrator)`