### PR TITLE
Implement an Internationalisation Lookup cascade

### DIFF
--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -1,19 +1,39 @@
 RSpec.configure do |config|
-  # Check that the factories are all valid.
   config.before(:suite) do
-    # The Stubbed I18n backend will return the translation key, while having the same behaviour
-    # as the standard backend. This allows tests to be written without assuming the translation.
+    # The Stubbed I18n backend will allow certain translation keys to be returned directly, ignoring
+    # the presence (or absence) of actual translations. This allows tests to be written without
+    # assuming the translation.
     class StubbedI18nBackend < I18n::Backend::Simple
       protected
 
       def lookup(_, key, _, _)
         key = key.to_s
         result = super
-        if key.start_with?('activerecord', 'attributes', 'errors', 'support')
+        if always_return_key?(key)
+          key
+        elsif always_return_actual?(key) || result.nil?
           result
         else
           key
         end
+      end
+
+      private
+
+      # Keys which should always be returned instead of the actual translation.
+      #
+      # @param [String] key The key to check.
+      # @return [Boolean]
+      def always_return_key?(key)
+        key.start_with?('activerecord.attributes.', 'user.', 'sample.', 'helpers.')
+      end
+
+      # Keys which should always return the actual translation.
+      #
+      # @param [String] key The key to check.
+      # @return [Boolean]
+      def always_return_actual?(key)
+        key.start_with?('errors.', 'support.')
       end
     end
     I18n.backend = StubbedI18nBackend.new


### PR DESCRIPTION
If the key does not exist, be sure to return nil, so that cascaded lookups function correctly.

Exceptions need to be made to ensure that important translations are preserved.