### PR TITLE
Super DRY Coursemology!

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -9,7 +9,7 @@ class Admin::AdminController < Admin::Controller
   end
 
   def update_components #:nodoc:
-    @settings.update(params.require(:instance_settings_effective))
+    @settings.update(params.require(:settings_effective))
     if current_tenant.save
       redirect_to admin_components_path, success: t('.success')
     else

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -39,6 +39,6 @@ class Admin::AnnouncementsController < Admin::Controller
   private
 
   def announcement_params
-    params.require(:instance_announcement).permit(:title, :content, :valid_from, :valid_to)
+    params.require(:announcement).permit(:title, :content, :valid_from, :valid_to)
   end
 end

--- a/app/controllers/course/achievements_controller.rb
+++ b/app/controllers/course/achievements_controller.rb
@@ -37,6 +37,6 @@ class Course::AchievementsController < Course::ComponentController
   private
 
   def achievement_params #:nodoc:
-    params.require(:course_achievement).permit(:title, :description, :weight, :published)
+    params.require(:achievement).permit(:title, :description, :weight, :published)
   end
 end

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -43,6 +43,6 @@ class Course::AnnouncementsController < Course::ComponentController
   private
 
   def announcement_params #:nodoc:
-    params.require(:course_announcement).permit(:title, :content, :sticky, :valid_from, :valid_to)
+    params.require(:announcement).permit(:title, :content, :sticky, :valid_from, :valid_to)
   end
 end

--- a/app/helpers/application_widgets_helper.rb
+++ b/app/helpers/application_widgets_helper.rb
@@ -1,64 +1,167 @@
 module ApplicationWidgetsHelper
-  # Create a edit button with icon
+  # Create a +new+ button.
   #
-  # @param [String, Hash] options The url or the url options which will be passed to `link_to`.
-  #
-  # @param [Hash] html_options The options to specify the class and title of the button.
-  # @return [String] The string including embedded HTML which displays the button with a link to
-  #                  path.
-  def edit_button(options, html_options = {})
-    html_options = html_options.dup
-
-    html_options[:class] = deduce_css_class(html_options[:class], 'btn-default')
-    html_options[:title] ||= t('common.edit')
-
-    link_to(options, html_options) do
-      fa_icon 'edit'
-    end
+  # @return [String] The HTML for the button.
+  # @overload new_button(path, html_options = nil, &block)
+  #   Creates a +new+ button, pointing to the given path and HTML options. This would yield a
+  #   button with an icon, unless a block is provided.
+  #   @param [String] path The path to link to.
+  #   @param [Hash] html_options The HTML options for the button.
+  #   @param [Proc] block The block to use for displaying the link.
+  # @overload new_button(resource, html_options = nil, &block)
+  #   Creates a +new+ button, pointing to the given resource. The URL is resolved using +url_for+.
+  #   This would yield a button with an icon, unless a block is provided.
+  #   @param [Array|Object] path The resource to link to.
+  #   @param [Hash] html_options The HTML options for the button.
+  #   @param [Proc] block The block to use for displaying the link.
+  # @overload new_button(body, path, html_options = nil)
+  #   Creates a +new+ button, pointing to the given path and HTML options. This would create a
+  #   button with the given body.
+  # @overload new_button(body, resource, html_options = nil)
+  #   Creates a +new+ button, pointing to the given resource. The URL is resolved using +url_for+.
+  #   This would create a button with the given body.
+  def new_button(name, options = nil, html_options = nil, &block)
+    name, options, html_options = [nil, name, options] unless html_options
+    options = [:new] + [*options] unless options.is_a?(String)
+    block ||= proc { fa_icon 'file'.freeze }
+    resource_button(:new, 'btn-primary'.freeze, name || block, options, html_options.try(:dup))
   end
 
-  # Create a delete button with icon
+  # Create a +edit+ button.
   #
-  # @param [String, Hash] options The url or the url options which will be passed to `link_to`.
+  # @return [String] The HTML for the button.
+  # @overload edit_button(path, html_options = nil, &block)
+  #   Creates a +edit+ button, pointing to the given path and HTML options. This would yield a
+  #   button with an icon, unless a block is provided.
+  #   @param [String] path The path to link to.
+  #   @param [Hash] html_options The HTML options for the button.
+  #   @param [Proc] block The block to use for displaying the link.
+  # @overload edit_button(resource, html_options = nil, &block)
+  #   Creates a +edit+ button, pointing to the given resource. The URL is resolved using +url_for+.
+  #   This would yield a button with an icon, unless a block is provided.
+  #   @param [Array|Object] path The resource to link to.
+  #   @param [Hash] html_options The HTML options for the button.
+  #   @param [Proc] block The block to use for displaying the link.
+  # @overload edit_button(body, path, html_options = nil)
+  #   Creates a +edit+ button, pointing to the given path and HTML options. This would create a
+  #   button with the given body.
+  # @overload edit_button(body, resource, html_options = nil)
+  #   Creates a +edit+ button, pointing to the given resource. The URL is resolved using +url_for+.
+  #   This would create a button with the given body.
+  def edit_button(name, options = nil, html_options = nil, &block)
+    name, options, html_options = [nil, name, options] unless html_options
+    options = [:edit] + [*options] unless options.is_a?(String)
+    block ||= proc { fa_icon 'edit'.freeze }
+    resource_button(:edit, 'btn-default'.freeze, name || block, options, html_options.try(:dup))
+  end
+
+  # Create a +delete+ button.
   #
-  # @param [Hash] html_options The options to specify the class and title of the button.
-  # @return [String] The string including embedded HTML which displays the button with a link to
-  #                  path.
-  def delete_button(options, html_options = {})
-    html_options = html_options.dup
+  # @return [String] The HTML for the button.
+  # @overload delete_button(path, html_options = nil, &block)
+  #   Creates a +delete+ button, pointing to the given path and HTML options. This would yield a
+  #   button with an icon, unless a block is provided.
+  #   @param [String] path The path to link to.
+  #   @param [Hash] html_options The HTML options for the button.
+  #   @param [Proc] block The block to use for displaying the link.
+  # @overload delete_button(resource, html_options = nil, &block)
+  #   Creates a +delete+ button, pointing to the given resource. The URL is resolved using
+  #   +url_for+. This would yield a button with an icon, unless a block is provided.
+  #   @param [Array|Object] path The resource to link to.
+  #   @param [Hash] html_options The HTML options for the button.
+  #   @param [Proc] block The block to use for displaying the link.
+  # @overload delete_button(body, path, html_options = nil)
+  #   Creates a +delete+ button, pointing to the given path and HTML options. This would create a
+  #   button with the given body.
+  # @overload delete_button(body, resource, html_options = nil)
+  #   Creates a +delete+ button, pointing to the given resource. The URL is resolved using
+  #   +url_for+. This would create a button with the given body.
+  def delete_button(name, options = nil, html_options = nil, &block)
+    name, options, html_options = [nil, name, options] unless html_options
+    block ||= proc { fa_icon 'trash'.freeze }
 
-    html_options[:class] = deduce_css_class(html_options[:class], 'btn-danger')
-    html_options[:title] ||= t('common.delete')
-    html_options[:data] ||= {}
-    html_options[:data][:confirm] ||= t('common.delete_confirm')
-    html_options[:method] ||= :delete
-
-    link_to(options, html_options) do
-      fa_icon 'trash'
-    end
+    html_options = html_options.try(:dup) || {}
+    html_options.reverse_merge!(method: :delete,
+                                data: { confirm: t('helpers.buttons.delete_confirm_message') })
+    resource_button(:delete, 'btn-danger'.freeze, name || block, options, html_options)
   end
 
   private
 
-  # Deduce css classes of button from custom types and default type
+  # Creates a button for creating, editing, or deleting resources.
   #
-  # @param [Array<String>] custom_types types specified by user
-  # @param [String] default_type default type to use if no custom type
-  # @return [Array<String>] deduced css classes
-  def deduce_css_class(custom_types, default_type)
-    css_class = [*custom_types]
-    css_class |= ['btn']
-    css_class << default_type unless button_type_specified?(css_class)
-    css_class
+  # @param [Symbol] key The key of the button. This can be +:new+, +:edit+, or +:delete+, and is
+  #   used to look up an appropriate translation.
+  # @param [String] default_class The default CSS class to be applied to the button.
+  # @param [String|Proc] body The string to use as the body of the button, or a block which would
+  #   be evaluated to give the body of the button.
+  # @param [Hash|nil] url_options The options to pass to +url_for+.
+  # @param [Hash|nil] html_options A hash of mutable options to pass to +link_to+.
+  def resource_button(key, default_class, body, url_options, html_options)
+    html_options ||= {}
+    html_options[:class] = deduce_resource_button_class(key, html_options[:class], default_class)
+    if !url_options.nil? && !url_options.is_a?(String)
+      html_options[:title] ||= deduce_resource_button_title(key, url_options)
+    end
+
+    if body.is_a?(Proc)
+      link_to(url_options, html_options, &body)
+    else
+      link_to(body, url_options, html_options)
+    end
   end
 
-  # Checks whether the given css_class have specified a button type or not
+  # Deduce the CSS classes to be applied to the button from the user-specified classes and default
+  # class.
   #
-  # @param [Array<String>] css_class the css classes to be checked
-  # @return [Boolean] true if the button type is specified otherwise false
-  def button_type_specified?(css_class)
-    available_button_types = ['btn-default', 'btn-primary', 'btn-success',
-                              'btn-info', 'btn-warning',  'btn-danger'].freeze
-    css_class.find { |type| available_button_types.include?(type) } ? true : false
+  # @param [String|Symbol] key The key of the button, as passed to +resource_button+.
+  # @param [Array<String>] custom_classes The CSS classes specified by the user.
+  # @param [String] default_type The default class to use if there is no explicit button class.
+  # @return [Array<String>] The deduced set of CSS classes to apply.
+  def deduce_resource_button_class(key, custom_classes, default_type)
+    custom_classes = Set[*custom_classes]
+    custom_classes |= ['btn'].freeze
+    custom_classes << default_type unless resource_button_type_specified?(custom_classes)
+    custom_classes << key
+    custom_classes.to_a
+  end
+
+  # Checks whether the given CSS classes have an explicit button type specified.
+  #
+  # @param [Set<String>] css_classes The list of CSS classes specified.
+  # @return [Boolean] +true+ if the button type is specified.
+  def resource_button_type_specified?(css_classes)
+    available_button_types = Set['btn-default', 'btn-primary', 'btn-success',
+                                 'btn-info', 'btn-warning', 'btn-danger'].freeze
+    css_classes.intersect?(available_button_types)
+  end
+
+  # Deduces the title to be given to the button given the button type and the URL arguments.
+  #
+  # @param [Symbol] button_type The type of the button to generate a title for.
+  # @param [Symbol|Array|ActiveRecord::Base] resource The resource to deduce the title for.
+  def deduce_resource_button_title(button_type, resource)
+    resource = resource.last if resource.is_a?(Array)
+    object_name = deduce_resource_object_name(resource)
+    resource_name = resource.try(:model_name).try(:human) || object_name.humanize
+
+    keys = []
+    keys << :"helpers.buttons.#{object_name}.#{button_type}" if object_name
+    keys << :"helpers.buttons.#{button_type}"
+    keys << "#{button_type.to_s.humanize} #{resource_name}" if resource_name
+    t(keys.shift, model: resource_name, default: keys)
+  end
+
+  # Deduces the object name of the resource. This is the name used to construct the translation
+  # string and is also used as a name for sending form data.
+  #
+  # @param [Symbol|ActiveRecord::Base] resource The resource to deduce the title for.
+  # @return [String] The object name of the resource.
+  def deduce_resource_object_name(resource)
+    if resource.is_a?(Symbol)
+      resource.to_s
+    else
+      model_name_from_record_or_class(resource).param_key
+    end
   end
 end

--- a/app/helpers/route_overrides_helper.rb
+++ b/app/helpers/route_overrides_helper.rb
@@ -32,8 +32,5 @@ module RouteOverridesHelper
     end
   end
 
-  map_route :course_course_achievement_condition_course_condition_achievement,
-            to: :course_achievement_condition_achievement
-  map_route :course_course_achievement_condition_course_condition_level,
-            to: :course_achievement_condition_level
+  map_route :course_course_user, to: :course_user
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -21,6 +21,10 @@ class Course < ActiveRecord::Base
   delegate :staff, to: :course_users
   delegate :has_user?, to: :course_users
 
+  def self.use_relative_model_naming?
+    true
+  end
+
   private
 
   # Set default values

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -26,6 +26,10 @@ class Instance < ActiveRecord::Base
            class_name: Instance::Announcement.name
   has_many :courses
 
+  def self.use_relative_model_naming?
+    true
+  end
+
   private
 
   def should_validate_host? #:nodoc:

--- a/app/views/admin/admin/components.html.slim
+++ b/app/views/admin/admin/components.html.slim
@@ -11,4 +11,4 @@ h2 = t('.header')
           th = f.label
           td = f.check_box
 
-  = f.button :submit, class: 'btn-primary'
+  = f.button :submit

--- a/app/views/admin/announcements/_announcement.html.slim
+++ b/app/views/admin/announcements/_announcement.html.slim
@@ -6,8 +6,8 @@
     = announcement.title
   - if can? :manage, announcement.class
     div.pull-right
-      = edit_button(edit_admin_announcement_path(announcement))
-      = delete_button(admin_announcement_path(announcement))
+      = edit_button([:admin, announcement])
+      = delete_button([:admin, announcement])
 
   h3.timestamp
     => format_datetime(announcement.valid_from)

--- a/app/views/admin/announcements/_form.html.slim
+++ b/app/views/admin/announcements/_form.html.slim
@@ -3,4 +3,4 @@
   = f.input :content
   = f.input :valid_from
   = f.input :valid_to
-  = f.button :submit, class: 'btn-primary'
+  = f.button :submit

--- a/app/views/admin/announcements/index.html.slim
+++ b/app/views/admin/announcements/index.html.slim
@@ -3,9 +3,7 @@ div.page-header
     = t('.header')
     - if can?(:manage, Instance::Announcement)
       div.pull-right
-        = link_to(t('.new'),
-          new_admin_announcement_path,
-          class: ['btn', 'btn-primary'])
+        = new_button([:admin, :announcement])
 = render partial: 'announcement', collection: @announcements
 
 = paginate @announcements

--- a/app/views/admin/instances/_form.html.slim
+++ b/app/views/admin/instances/_form.html.slim
@@ -3,4 +3,4 @@
 
   = f.input :host
 
-  = f.button :submit, class: 'btn-primary'
+  = f.button :submit

--- a/app/views/admin/instances/index.html.slim
+++ b/app/views/admin/instances/index.html.slim
@@ -1,6 +1,6 @@
 h1 = t('.header')
 
-= link_to t('.new_instance'), new_admin_instance_path, class: 'btn btn-primary'
+= new_button([:admin, :instance])
 
 table.table.table-middle-align
   thead

--- a/app/views/admin/system_announcements/_form.html.slim
+++ b/app/views/admin/system_announcements/_form.html.slim
@@ -7,4 +7,4 @@
 
   = f.input :valid_to
 
-  = f.button :submit, class: 'btn-primary'
+  = f.button :submit

--- a/app/views/admin/system_announcements/_system_announcement.html.slim
+++ b/app/views/admin/system_announcements/_system_announcement.html.slim
@@ -9,9 +9,9 @@ hr
 
   - if can? :manage, system_announcement.class
     div.pull-right
-      = edit_button(edit_admin_system_announcement_path(system_announcement))
+      = edit_button([:admin, system_announcement])
 
-      = delete_button(admin_system_announcement_path(system_announcement))
+      = delete_button([:admin, system_announcement])
 
   div.timestamp
     = format_datetime(system_announcement.valid_from)

--- a/app/views/admin/system_announcements/index.html.slim
+++ b/app/views/admin/system_announcements/index.html.slim
@@ -1,7 +1,7 @@
 h1 = t('.header')
 
 - if can?(:create, SystemAnnouncement)
-  = link_to t('.new'), new_admin_system_announcement_path, class: 'btn btn-primary'
+  = new_button([:admin, :system_announcement])
 
 = render @system_announcements
 

--- a/app/views/course/achievements/_achievement.html.slim
+++ b/app/views/course/achievements/_achievement.html.slim
@@ -15,6 +15,6 @@
     - else
       = t('common.no')
   td
-    = edit_button(edit_course_achievement_path(current_course, achievement))
+    = edit_button([current_course, achievement])
 
-    = delete_button(course_achievement_path(current_course, achievement))
+    = delete_button([current_course, achievement])

--- a/app/views/course/achievements/_form.html.slim
+++ b/app/views/course/achievements/_form.html.slim
@@ -5,4 +5,4 @@
 
   = f.input :published
 
-  = f.button :submit, class: 'btn-primary'
+  = f.button :submit

--- a/app/views/course/achievements/index.html.slim
+++ b/app/views/course/achievements/index.html.slim
@@ -1,7 +1,7 @@
 h1 = t('.header')
 
 - if can?(:create, Course::Achievement)
-  = link_to t('.new'), new_course_achievement_path(current_course), class: 'btn btn-primary'
+  = new_button([current_course, :achievement])
 
 table.table.achievement-list
   thead

--- a/app/views/course/announcements/_announcement.html.slim
+++ b/app/views/course/announcements/_announcement.html.slim
@@ -8,9 +8,9 @@ hr
 
   - if can?(:manage, Course::Announcement)
     div.pull-right
-      = edit_button(edit_course_announcement_path(current_course, announcement))
+      = edit_button([current_course, announcement])
 
-      = delete_button(course_announcement_path(current_course, announcement))
+      = delete_button([current_course, announcement])
 
   div.timestamp
     = format_datetime(announcement.valid_from)

--- a/app/views/course/announcements/_form.html.slim
+++ b/app/views/course/announcements/_form.html.slim
@@ -9,4 +9,4 @@
 
   = f.input :valid_to
 
-  = f.button :submit, class: 'btn-primary'
+  = f.button :submit

--- a/app/views/course/announcements/index.html.slim
+++ b/app/views/course/announcements/index.html.slim
@@ -1,7 +1,7 @@
 h1 = t('.header')
 
 - if can?(:create, Course::Announcement)
-  = link_to t('.new'), new_course_announcement_path(current_course), class: 'btn btn-primary'
+  = new_button([current_course, :announcement])
 
 = render @announcements
 

--- a/app/views/course/courses/index.html.slim
+++ b/app/views/course/courses/index.html.slim
@@ -3,9 +3,7 @@ div.page-header
     = t('.header')
     - if can?(:create, Course)
       div.pull-right
-        = link_to(t('.new'),
-                  new_course_path,
-                  class: ['btn', 'btn-primary'])
+        = new_button(:course)
 
 = render @courses
 

--- a/app/views/course/courses/new.html.slim
+++ b/app/views/course/courses/new.html.slim
@@ -7,4 +7,4 @@ h2= t('.header')
   = f.input :description, label: t('course.courses.form.description_label'),
             placeholder: t('course.courses.form.description_placeholder')
 
-  = f.button :submit, class: 'btn-primary'
+  = f.button :submit

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -24,6 +24,4 @@ div.users
               td = f.input :phantom
               td
                 = f.button :submit
-                = link_to course_user_path(current_course, f.object), data: { method: :delete },
-                          class: ['btn', 'btn-danger'], title: t('common.delete') do
-                  = fa_icon :trash
+                = delete_button course_user_path(current_course, f.object)

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -23,5 +23,6 @@ div.users
               td = f.input :role, as: :select, collection: CourseUser.roles.keys
               td = f.input :phantom
               td
-                = f.button :submit
+                = f.button :submit do
+                  = fa_icon :save
                 = delete_button([current_course, f.object])

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -24,4 +24,4 @@ div.users
               td = f.input :phantom
               td
                 = f.button :submit
-                = delete_button course_user_path(current_course, f.object)
+                = delete_button([current_course, f.object])

--- a/app/views/course/users/students.html.slim
+++ b/app/views/course/users/students.html.slim
@@ -22,4 +22,4 @@ div.users
               td = f.input :phantom
               td
                 = f.button :submit
-                = delete_button course_user_path(current_course, f.object)
+                = delete_button([current_course, f.object])

--- a/app/views/course/users/students.html.slim
+++ b/app/views/course/users/students.html.slim
@@ -22,6 +22,4 @@ div.users
               td = f.input :phantom
               td
                 = f.button :submit
-                = link_to course_user_path(current_course, f.object), data: { method: :delete },
-                          class: ['btn', 'btn-danger'], title: t('common.delete') do
-                  = fa_icon :trash
+                = delete_button course_user_path(current_course, f.object)

--- a/app/views/course/users/students.html.slim
+++ b/app/views/course/users/students.html.slim
@@ -21,5 +21,6 @@ div.users
               td = f.object.user.email
               td = f.input :phantom
               td
-                = f.button :submit
+                = f.button :submit do
+                  = fa_icon :save
                 = delete_button([current_course, f.object])

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -89,6 +89,7 @@ ignore_unused:
 - 'activerecord.attributes.*'
 - 'breadcrumbs.*'
 - 'errors.messages.*'
+- 'helpers.buttons.*'
 - '{devise,kaminari,will_paginate}.*'
 - 'simple_form.{yes,no}'
 - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en/admin/announcements.yml
+++ b/config/locales/en/admin/announcements.yml
@@ -3,7 +3,6 @@ en:
     announcements:
       index:
         header: 'Announcements'
-        new: 'New Announcement'
       new:
         header: 'Create Announcement'
       create:

--- a/config/locales/en/admin/instances.yml
+++ b/config/locales/en/admin/instances.yml
@@ -3,7 +3,6 @@ en:
     instances:
       index:
         header: 'Instance Management'
-        new_instance: 'New'
         name: 'Name'
         host_name: 'Host Name'
         users: 'Total Users'

--- a/config/locales/en/admin/system_announcements.yml
+++ b/config/locales/en/admin/system_announcements.yml
@@ -3,7 +3,6 @@ en:
     system_announcements:
       index:
         header: 'System Announcements'
-        new: 'New System Announcement'
       new:
         header: 'New System Announcement'
       create:

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -2,10 +2,13 @@ en:
   common:
     'yes': 'Yes'
     'no': 'No'
-    edit: 'Edit'
-    delete: 'Delete'
-    delete_confirm: 'Are you sure?'
     back: 'Back'
     name: 'Name'
     email: 'Email'
     role: 'Role'
+  helpers:
+    buttons:
+      new: 'New %{model}'
+      edit: "Edit %{model}"
+      delete: "Delete %{model}"
+      delete_confirm_message: 'Are you sure?'

--- a/config/locales/en/course/achievements.yml
+++ b/config/locales/en/course/achievements.yml
@@ -4,7 +4,6 @@ en:
       sidebar_title: 'Achievements'
       index:
         header: 'Achievements'
-        new: 'New'
         description: 'Description'
         requirements: 'Requirements'
         published: 'Published'

--- a/config/locales/en/course/announcements.yml
+++ b/config/locales/en/course/announcements.yml
@@ -4,7 +4,6 @@ en:
       sidebar_title: 'Announcements'
       index:
         header: 'Announcements'
-        new: 'New'
       new:
         header: 'New Announcement'
       edit:

--- a/config/locales/en/course/courses.yml
+++ b/config/locales/en/course/courses.yml
@@ -3,7 +3,6 @@ en:
     courses:
       index:
         header: 'Courses'
-        new: 'New Course'
       show:
         register: 'Register'
         already_registered: 'You have already registered for the course.'

--- a/spec/controllers/admin/admin_controller_spec.rb
+++ b/spec/controllers/admin/admin_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::AdminController, type: :controller do
         all_component_ids.sample(1 + rand(all_component_ids.count))
       end
       let(:components_params) { { enabled_component_ids: ids_to_enable } }
-      subject { post :update_components, instance_settings_effective: components_params }
+      subject { post :update_components, settings_effective: components_params }
 
       context 'enable/disable components' do
         let(:settings) do

--- a/spec/features/admin/announcement_management_spec.rb
+++ b/spec/features/admin/announcement_management_spec.rb
@@ -16,10 +16,12 @@ RSpec.describe 'Administration: Announcements', type: :feature do
       before { visit new_admin_announcement_path }
 
       context 'with invalid information' do
-        before { click_button I18n.t('helpers.submit.instance_announcement.create') }
+        before do
+          click_button I18n.t('helpers.submit.announcement.create')
+        end
 
         it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.instance_announcement.create'))
+          expect(page).to have_button(I18n.t('helpers.submit.announcement.create'))
         end
 
         it 'shows errors' do
@@ -31,19 +33,19 @@ RSpec.describe 'Administration: Announcements', type: :feature do
         let(:announcement) { build(:instance_announcement, instance: instance) }
 
         before do
-          fill_in 'instance_announcement[title]',      with: announcement.title
-          fill_in 'instance_announcement[content]',    with: announcement.content
-          fill_in 'instance_announcement[valid_from]', with: announcement.valid_from
-          fill_in 'instance_announcement[valid_to]',   with: announcement.valid_to
+          fill_in 'announcement[title]',      with: announcement.title
+          fill_in 'announcement[content]',    with: announcement.content
+          fill_in 'announcement[valid_from]', with: announcement.valid_from
+          fill_in 'announcement[valid_to]',   with: announcement.valid_to
         end
 
         it 'creates an announcement' do
-          expect { click_button I18n.t('helpers.submit.instance_announcement.create') }.to change(
+          expect { click_button I18n.t('helpers.submit.announcement.create') }.to change(
             Instance::Announcement, :count).by(1)
         end
 
         context 'after creation' do
-          before { click_button I18n.t('helpers.submit.instance_announcement.create') }
+          before { click_button I18n.t('helpers.submit.announcement.create') }
 
           it 'shows the success message' do
             expect(page).to have_selector('div',
@@ -63,30 +65,30 @@ RSpec.describe 'Administration: Announcements', type: :feature do
       before { visit edit_admin_announcement_path(announcement) }
 
       context 'page rendering' do
-        it { is_expected.to have_field('instance_announcement[title]', with: announcement.title) }
+        it { is_expected.to have_field('announcement[title]', with: announcement.title) }
 
         it do
-          is_expected.to have_field('instance_announcement[content]', with: announcement.content)
+          is_expected.to have_field('announcement[content]', with: announcement.content)
         end
 
         it do
-          is_expected.to have_field('instance_announcement[valid_from]',
+          is_expected.to have_field('announcement[valid_from]',
                                     with: announcement.valid_from)
         end
 
         it do
-          is_expected.to have_field('instance_announcement[valid_to]', with: announcement.valid_to)
+          is_expected.to have_field('announcement[valid_to]', with: announcement.valid_to)
         end
       end
 
       context 'with invalid information' do
         before do
-          fill_in 'instance_announcement[title]', with: ''
-          click_button I18n.t('helpers.submit.instance_announcement.update')
+          fill_in 'announcement[title]', with: ''
+          click_button I18n.t('helpers.submit.announcement.update')
         end
 
         it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.instance_announcement.update'))
+          expect(page).to have_button(I18n.t('helpers.submit.announcement.update'))
         end
 
         it 'shows errors' do
@@ -99,9 +101,9 @@ RSpec.describe 'Administration: Announcements', type: :feature do
         let(:new_content) { 'New content' }
 
         before do
-          fill_in 'instance_announcement[title]',        with: new_title
-          fill_in 'instance_announcement[content]',      with: new_content
-          click_button I18n.t('helpers.submit.instance_announcement.update')
+          fill_in 'announcement[title]',        with: new_title
+          fill_in 'announcement[content]',      with: new_content
+          click_button I18n.t('helpers.submit.announcement.update')
         end
 
         it 'redirects the user to index page' do
@@ -130,7 +132,7 @@ RSpec.describe 'Administration: Announcements', type: :feature do
       end
 
       context 'management buttons' do
-        it { is_expected.to have_link(I18n.t('admin.announcements.index.new')) }
+        it { is_expected.to have_link(nil, href: new_admin_announcement_path) }
       end
 
       it 'shows all announcements' do

--- a/spec/features/admin/components_settings_spec.rb
+++ b/spec/features/admin/components_settings_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Administration: Components', type: :feature do
     let(:admin) { create(:administrator) }
     let(:components)  { Course::ComponentHost.components }
     let(:sample_component_id) do
-      "instance_settings_effective_enabled_component_ids_#{components.sample.key}"
+      "settings_effective_enabled_component_ids_#{components.sample.key}"
     end
 
     before { login_as(admin, scope: :user) }
@@ -20,7 +20,7 @@ RSpec.feature 'Administration: Components', type: :feature do
       components.each do |component|
         expect(page).to have_selector('th', text: component.name)
 
-        checkbox = find("#instance_settings_effective_enabled_component_ids_#{component.key}")
+        checkbox = find("#settings_effective_enabled_component_ids_#{component.key}")
         if enabled_components.include?(component.key.to_s)
           expect(checkbox).to be_checked
         else
@@ -32,7 +32,7 @@ RSpec.feature 'Administration: Components', type: :feature do
     scenario 'Enable a component' do
       visit admin_components_path
 
-      page.check(sample_component_id)
+      check(sample_component_id)
       click_button('submit')
       expect(page).to have_checked_field(sample_component_id)
     end
@@ -40,7 +40,7 @@ RSpec.feature 'Administration: Components', type: :feature do
     scenario 'Disable a component' do
       visit admin_components_path
 
-      page.uncheck(sample_component_id)
+      uncheck(sample_component_id)
       click_button('submit')
       expect(page).to have_unchecked_field(sample_component_id)
     end

--- a/spec/features/course/achievement_listing_spec.rb
+++ b/spec/features/course/achievement_listing_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Course: Achievements', type: :feature do
     end
 
     context 'management buttons' do
-      it { is_expected.to have_link(I18n.t('course.achievements.index.new')) }
+      it { is_expected.to have_link(nil, href: new_course_achievement_path(course)) }
     end
 
     it 'shows all achievements' do

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'Course: Achievements' do
 
     describe 'achievement creation' do
       before { visit new_course_achievement_path(course) }
-      subject { click_button I18n.t('helpers.submit.course_achievement.create') }
+      subject { click_button I18n.t('helpers.submit.achievement.create') }
 
       context 'with invalid information' do
         before { subject }
 
         it 'stays on the same page' do
-          expect(page).to have_button('helpers.submit.course_achievement.create')
+          expect(page).to have_button('helpers.submit.achievement.create')
         end
 
         it 'shows errors' do
@@ -33,8 +33,8 @@ RSpec.describe 'Course: Achievements' do
         let(:achievement) { build(:course_achievement, course: course) }
 
         before do
-          fill_in 'course_achievement_title',    with: achievement.title
-          fill_in 'course_achievement_description',  with: achievement.description
+          fill_in 'achievement_title',    with: achievement.title
+          fill_in 'achievement_description',  with: achievement.description
         end
 
         it 'creates an achievement' do
@@ -61,23 +61,23 @@ RSpec.describe 'Course: Achievements' do
       before { visit edit_course_achievement_path(course, achievement) }
 
       context 'page rendering' do
-        it { is_expected.to have_field('course_achievement_title', with: achievement.title) }
+        it { is_expected.to have_field('achievement_title', with: achievement.title) }
         it 'shows achievement description' do
-          expect(page).to have_field('course_achievement_description',
+          expect(page).to have_field('achievement_description',
                                      with: achievement.description)
         end
-        it { is_expected.to have_checked_field('course_achievement_published') }
+        it { is_expected.to have_checked_field('achievement_published') }
       end
 
       context 'with invalid information' do
         before do
-          fill_in 'course_achievement_title', with: ''
+          fill_in 'achievement_title', with: ''
           subject
         end
-        subject { click_button I18n.t('helpers.submit.course_achievement.update') }
+        subject { click_button I18n.t('helpers.submit.achievement.update') }
 
         it 'stays on the same page' do
-          expect(page).to have_button('helpers.submit.course_achievement.update')
+          expect(page).to have_button('helpers.submit.achievement.update')
         end
 
         it 'shows errors' do
@@ -90,9 +90,9 @@ RSpec.describe 'Course: Achievements' do
         let(:new_description) { 'New description' }
 
         before do
-          fill_in 'course_achievement_title',        with: new_title
-          fill_in 'course_achievement_description',      with: new_description
-          click_button I18n.t('helpers.submit.course_achievement.update')
+          fill_in 'achievement_title',        with: new_title
+          fill_in 'achievement_description',      with: new_description
+          click_button I18n.t('helpers.submit.achievement.update')
         end
 
         it 'redirects the user to index page' do

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe 'Course: Announcements', type: :feature do
       before { visit new_course_announcement_path(course) }
 
       context 'with invalid information' do
-        before { click_button I18n.t('helpers.submit.course_announcement.create') }
+        before { click_button I18n.t('helpers.submit.announcement.create') }
 
         it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.course_announcement.create'))
+          expect(page).to have_button(I18n.t('helpers.submit.announcement.create'))
         end
 
         it 'shows errors' do
@@ -30,11 +30,11 @@ RSpec.describe 'Course: Announcements', type: :feature do
 
       context 'with valid information' do
         let(:announcement) { build(:course_announcement, course: course) }
-        subject { click_button I18n.t('helpers.submit.course_announcement.create') }
+        subject { click_button I18n.t('helpers.submit.announcement.create') }
 
         before do
-          fill_in 'course_announcement_title',    with: announcement.title
-          fill_in 'course_announcement_content',  with: announcement.content
+          fill_in 'announcement_title',    with: announcement.title
+          fill_in 'announcement_content',  with: announcement.content
         end
 
         it 'creates an announcement' do
@@ -62,26 +62,26 @@ RSpec.describe 'Course: Announcements', type: :feature do
       before { visit edit_course_announcement_path(course, announcement) }
 
       context 'page rendering' do
-        it { is_expected.to have_field('course_announcement_title', with: announcement.title) }
-        it { is_expected.to have_field('course_announcement_content', with: announcement.content) }
+        it { is_expected.to have_field('announcement_title', with: announcement.title) }
+        it { is_expected.to have_field('announcement_content', with: announcement.content) }
         it do
-          is_expected.to have_field('course_announcement[valid_from]',
+          is_expected.to have_field('announcement[valid_from]',
                                     with: announcement.valid_from)
         end
         it do
-          is_expected.to have_field('course_announcement[valid_to]', with: announcement.valid_to)
-          click_button I18n.t('helpers.submit.course_announcement.update')
+          is_expected.to have_field('announcement[valid_to]', with: announcement.valid_to)
+          click_button I18n.t('helpers.submit.announcement.update')
         end
       end
 
       context 'with invalid information' do
         before do
-          fill_in 'course_announcement_title', with: ''
-          click_button I18n.t('helpers.submit.course_announcement.update')
+          fill_in 'announcement_title', with: ''
+          click_button I18n.t('helpers.submit.announcement.update')
         end
 
         it 'stays on the same page' do
-          expect(page).to have_button('helpers.submit.course_announcement.update')
+          expect(page).to have_button('helpers.submit.announcement.update')
         end
 
         it 'shows errors' do
@@ -94,9 +94,9 @@ RSpec.describe 'Course: Announcements', type: :feature do
         let(:new_content) { 'New content' }
 
         before do
-          fill_in 'course_announcement_title',        with: new_title
-          fill_in 'course_announcement_content',      with: new_content
-          click_button I18n.t('helpers.submit.course_announcement.update')
+          fill_in 'announcement_title',        with: new_title
+          fill_in 'announcement_content',      with: new_content
+          click_button I18n.t('helpers.submit.announcement.update')
         end
 
         it 'redirects the user to index page' do
@@ -125,7 +125,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
       end
 
       context 'management buttons' do
-        it { is_expected.to have_link(I18n.t('course.announcements.index.new')) }
+        it { is_expected.to have_link(nil, href: new_course_announcement_path(course)) }
       end
 
       it 'shows all announcements' do

--- a/spec/features/course/announcement_sticky_spec.rb
+++ b/spec/features/course/announcement_sticky_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
         end
 
         before { visit course_announcements_path(course) }
-        subject { first('div.course_announcement') }
+        subject { first('div.announcement') }
 
         it 'shows sticky announcement on top' do
           expect(subject).to have_selector('h2', text: sticky_announcement.title)

--- a/spec/features/course_management_spec.rb
+++ b/spec/features/course_management_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Courses' do
 
       visit courses_path
       expect(all('.course').count).to eq(1)
-      expect(subject).to have_link(I18n.t('course.courses.index.new'), href: new_course_path)
+      expect(subject).to have_link(nil, href: new_course_path)
     end
 
     scenario 'Users can create a new course' do

--- a/spec/features/system_announcements_management_spec.rb
+++ b/spec/features/system_announcements_management_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'System announcements', type: :feature do
     subject { page }
 
     context 'management buttons' do
-      it { is_expected.to have_link(I18n.t('admin.system_announcements.index.new')) }
+      it { is_expected.to have_link(nil, href: new_admin_system_announcement_path) }
     end
 
     it 'shows all announcements' do

--- a/spec/helpers/application_widgets_helper_spec.rb
+++ b/spec/helpers/application_widgets_helper_spec.rb
@@ -1,0 +1,184 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationWidgetsHelper, type: :helper do
+  def stub_resource_button
+    helper.define_singleton_method(:resource_button) do |_, _, _, url_options, _|
+      url_options
+    end
+  end
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '#new_button' do
+      let(:announcement) { create(:course_announcement) }
+      let(:url_options) { new_course_announcement_path(announcement.course) }
+      subject { helper.new_button(url_options) }
+
+      it 'defaults to a btn-primary class' do
+        expect(subject).to have_tag('a.btn.btn-primary')
+      end
+      it 'defaults to a file button' do
+        expect(subject).to have_tag('i.fa-file')
+      end
+
+      context 'when URL options are specified' do
+        before { stub_resource_button }
+        context 'when a string is specified' do
+          it 'is not modified' do
+            expect(subject).to eq(url_options)
+          end
+        end
+
+        context 'when a symbol is specified' do
+          let(:url_options) { [announcement.course, :announcement] }
+          it 'adds a :new at the start of the URL options' do
+            expect(subject).to eq([:new] + url_options)
+          end
+        end
+      end
+    end
+
+    describe '#edit_button' do
+      let(:announcement) { create(:course_announcement) }
+      let(:url_options) { [announcement.course, announcement] }
+      subject { helper.edit_button(url_options) }
+
+      it 'defaults to a btn-default class' do
+        expect(subject).to have_tag('a.btn.btn-default')
+      end
+      it 'defaults to a file button' do
+        expect(subject).to have_tag('i.fa-edit')
+      end
+
+      context 'when URL options are specified' do
+        before { stub_resource_button }
+        context 'when a string is specified' do
+          let(:url_options) { edit_course_announcement_path(announcement.course, announcement) }
+          it 'is not modified' do
+            expect(subject).to eq(url_options)
+          end
+        end
+
+        context 'when a resource is specified' do
+          let(:url_options) { [announcement.course, announcement] }
+          it 'adds a :edit at the start of the URL options' do
+            expect(subject).to eq([:edit] + url_options)
+          end
+        end
+      end
+    end
+
+    describe '#delete_button' do
+      let(:announcement) { create(:course_announcement) }
+      subject { helper.delete_button([announcement.course, announcement]) }
+      it 'defaults to a btn-primary class' do
+        expect(subject).to have_tag('a.btn.btn-danger')
+      end
+      it 'defaults to a file button' do
+        expect(subject).to have_tag('i.fa-trash')
+      end
+      it 'sets the method as delete' do
+        expect(subject).to have_tag('a', with: { 'data-method' => 'delete' })
+      end
+    end
+
+    describe '#resource_button' do
+      let(:announcement) { build(:course_announcement) }
+      before { I18n.backend.store_translations(:en, en: { helpers: { buttons: { new: 'new' } } }) }
+      after { I18n.backend.store_translations(:en, en: { helpers: { buttons: { new: nil } } }) }
+
+      let(:body) { 'meh' }
+      subject do
+        helper.send(:resource_button, :new, 'btn-warning', body,
+                    [announcement.course, announcement], nil)
+      end
+
+      it 'uses the key to determine the translation' do
+        expect(subject).to have_tag('a.btn.btn-warning', text: body)
+      end
+
+      it 'adds the key to the button classes' do
+        expect(subject).to have_tag('a.btn.new', text: body)
+      end
+
+      context 'when a block is provided to the body argument' do
+        let(:text) { 'block!' }
+        let(:body) { proc { text } }
+        it 'calls the block to provide the body of the link' do
+          expect(subject).to have_tag('a.btn.btn-warning', text: text)
+        end
+      end
+
+      context 'when a resource is provided to the url_options argument' do
+        it 'gives the title to the link' do
+          title = 'helpers.buttons.announcement.new'
+          expect(subject).to have_tag('a', with: { title: title })
+        end
+      end
+    end
+
+    describe '#deduce_resource_button_class' do
+      let(:specified_classes) { [] }
+      let(:default_class) { 'ignore' }
+      let(:key) { :new }
+      subject { helper.send(:deduce_resource_button_class, key, specified_classes, default_class) }
+
+      it 'adds the btn class' do
+        expect(subject).to include('btn')
+      end
+
+      it 'adds the key' do
+        expect(subject).to include(key)
+      end
+
+      context 'when a button type is specified' do
+        let(:specified_classes) { ['btn-default'] }
+        it 'does not add the specified default class' do
+          expect(subject).not_to include(default_class)
+        end
+      end
+
+      context 'when no button type is specified' do
+        it 'adds the specified default class' do
+          expect(subject).to include('ignore')
+        end
+      end
+    end
+
+    describe '#deduce_resource_button_title' do
+      before { helper.define_singleton_method(:t) { |key, hash| [key] + hash[:default] } }
+      let(:announcement) { build(:course_announcement) }
+      subject { helper.send(:deduce_resource_button_title, :edit, url_options) }
+
+      context 'when given an array of resources' do
+        let(:url_options) { [announcement] }
+        it 'picks the last resource' do
+          expect(subject).to contain_exactly(
+            :'helpers.buttons.announcement.edit',
+            :'helpers.buttons.edit',
+            'Edit Announcement')
+        end
+      end
+
+      context 'when given a single resource' do
+        let(:url_options) { announcement }
+        it 'looks up the model name' do
+          expect(subject).to contain_exactly(
+            :'helpers.buttons.announcement.edit',
+            :'helpers.buttons.edit',
+            'Edit Announcement')
+        end
+      end
+
+      context 'when given a symbol' do
+        let(:url_options) { :announcement }
+        it 'guesses the human name of the symbol' do
+          expect(subject).to contain_exactly(
+            :'helpers.buttons.announcement.edit',
+            :'helpers.buttons.edit',
+            'Edit Announcement')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Paying homage to matz. Depends on #310 and #312.

 - Remove the need for most of the route overrides.
 - Use the button helpers, which now include helpers for new, edit, and delete.
 - Remove `btn-primary` from the classes which need to be specified for submit buttons.