### PR TITLE
Fix n+1 query when listing instances.

### DIFF
--- a/app/controllers/admin/instances_controller.rb
+++ b/app/controllers/admin/instances_controller.rb
@@ -2,6 +2,7 @@ class Admin::InstancesController < Admin::Controller
   load_and_authorize_resource
 
   def index #:nodoc:
+    @instances = @instances.with_course_count.with_user_count
   end
 
   def new #:nodoc:

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -2,6 +2,9 @@ class Instance < ActiveRecord::Base
   has_settings_on :settings
 
   class << self
+    # Finds the default instance.
+    #
+    # @return [Instance]
     def default
       result = first
       fail 'Unknown instance. Did you run rake db:seed?' unless result
@@ -12,6 +15,7 @@ class Instance < ActiveRecord::Base
     #
     # @param [String] host The host to look up. This is case insensitive, however prefixes (such
     #   as www) are not handled automatically.
+    # @return [Instance]
     def find_tenant_by_host(host)
       where { lower(self.host) == lower(host) }.take
     end
@@ -19,12 +23,38 @@ class Instance < ActiveRecord::Base
 
   validates :host, hostname: true, if: :should_validate_host?
 
+  # @!attribute [r] instance_users
+  #   @note You are scoped by the current tenant, you might not see all.
   has_many :instance_users
+  # @!attribute [r] users
+  #   @note You are scoped by the current tenant, you might not see all.
   has_many :users, through: :instance_users
 
+  # @!attribute [r] announcements
+  #   @note You are scoped by the current tenant, you might not see all.
   has_many :announcements, -> { order(valid_from: :desc) },
            class_name: Instance::Announcement.name
+  # @!attribute [r] courses
+  #   @note You are scoped by the current tenant, you might not see all.
   has_many :courses
+
+  # @!method self.with_course_count
+  #   Augments all returned records with the number of courses in that instance.
+  scope :with_course_count, (lambda do
+    joins { courses.outer }.
+      select { 'instances.*' }.
+      select { count(courses.id).as(course_count) }.
+      group { instances.id }
+  end)
+
+  # @!method self.with_user_count
+  #   Augments all returned records with the number of users in that instance.
+  scope :with_user_count, (lambda do
+    joins { instance_users.outer }.
+      select { 'instances.*' }.
+      select { count(instance_users.id).as(user_count) }.
+      group { instances.id }
+  end)
 
   def self.use_relative_model_naming?
     true

--- a/app/views/admin/instances/_instance.html.slim
+++ b/app/views/admin/instances/_instance.html.slim
@@ -5,6 +5,6 @@ tr
 
   td = instance.host
 
-  td = InstanceUser.unscoped.where(instance_id: instance.id).count
+  td = instance.user_count
 
-  td = Course.unscoped.where(instance_id: instance.id).count
+  td = instance.course_count


### PR DESCRIPTION
Page load time reduced (in my case) from 4.3s to 0.99s.

That's with 1180 instances.