### PR TITLE
Allow bundler versions >= 1.10.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'tzinfo-data', platforms: [:mswin, :mswin64]
 
 # Lock down Bundle version as new versions will cause noisy
 # changes in the Gemfile.lock file
-gem 'bundler', '1.10.3'
+gem 'bundler', '>= 1.10.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,7 +428,7 @@ DEPENDENCIES
   bootstrap-select-rails
   bootstrap3-datetimepicker-rails
   bullet
-  bundler (= 1.10.3)
+  bundler (>= 1.10.3)
   cancancan (~> 1.9)
   capybara
   carrierwave!


### PR DESCRIPTION
Bundler 1.10.3 added extra lines in Gemfile.lock indicating which
version of Bundler was used. Use at least this version. Allow newer
versions to get the benefits of updates.

[ci skip]