### PR TITLE
Fixes the nondeterminism in the global announcement spec.

### DIFF
--- a/spec/features/global_announcements_spec.rb
+++ b/spec/features/global_announcements_spec.rb
@@ -39,7 +39,12 @@ RSpec.describe 'Global announcements', type: :feature do
 
     describe 'many valid global announcements' do
       let(:announcements) do
-        build_list(:instance_announcement, 2, instance: instance, creator: user, updater: user)
+        [
+          build(:instance_announcement, valid_from: Time.zone.now - 1.second, instance: instance,
+                                        creator: user, updater: user),
+          build(:instance_announcement, valid_from: Time.zone.now, instance: instance,
+                                        creator: user, updater: user)
+        ]
       end
 
       before do


### PR DESCRIPTION
Both announcements will have the same time (within measurement error) so either could have been displayed. Make the time difference explicit.