### PR TITLE
Improved controller error-handling

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -32,8 +32,12 @@ class Admin::AnnouncementsController < Admin::Controller
   end
 
   def destroy
-    redirect_to admin_announcements_path,
-                success: t('.success', title: @announcement.title) if @announcement.destroy
+    if @announcement.destroy
+      redirect_to admin_announcements_path,
+                  success: t('.success', title: @announcement.title)
+    else
+      redirect_to admin_announcements_path, danger: t('.failure')
+    end
   end
 
   private

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -36,7 +36,8 @@ class Admin::AnnouncementsController < Admin::Controller
       redirect_to admin_announcements_path,
                   success: t('.success', title: @announcement.title)
     else
-      redirect_to admin_announcements_path, danger: t('.failure')
+      redirect_to admin_announcements_path,
+                  danger: t('.failure', error: @announcement.errors.full_messages.to_sentence)
     end
   end
 

--- a/app/controllers/admin/system_announcements_controller.rb
+++ b/app/controllers/admin/system_announcements_controller.rb
@@ -35,7 +35,8 @@ class Admin::SystemAnnouncementsController < Admin::Controller
                   success: t('.success',
                              title: @system_announcement.title)
     else
-      redirect_to admin_system_announcements_path, danger: t('.failure')
+      redirect_to admin_system_announcements_path,
+                  danger: t('.failure', @system_announcement.errors.full_messages.to_sentence)
     end
   end
 

--- a/app/controllers/admin/system_announcements_controller.rb
+++ b/app/controllers/admin/system_announcements_controller.rb
@@ -30,9 +30,13 @@ class Admin::SystemAnnouncementsController < Admin::Controller
   end
 
   def destroy
-    redirect_to admin_system_announcements_path,
-                success: t('.success',
-                           title: @system_announcement.title) if @system_announcement.destroy
+    if @system_announcement.destroy
+      redirect_to admin_system_announcements_path,
+                  success: t('.success',
+                             title: @system_announcement.title)
+    else
+      redirect_to admin_system_announcements_path, danger: t('.failure')
+    end
   end
 
   private

--- a/app/controllers/course/achievements_controller.rb
+++ b/app/controllers/course/achievements_controller.rb
@@ -33,7 +33,8 @@ class Course::AchievementsController < Course::ComponentController
       redirect_to(course_achievements_path(current_course),
                   success: t('.success', title: @achievement.title))
     else
-      redirect_to course_achievements_path, danger: t('.failure')
+      redirect_to course_achievements_path,
+                  danger: t('.failure', @achievement.errors.full_messages.to_sentence)
     end
   end
 

--- a/app/controllers/course/achievements_controller.rb
+++ b/app/controllers/course/achievements_controller.rb
@@ -29,9 +29,12 @@ class Course::AchievementsController < Course::ComponentController
   end
 
   def destroy #:nodoc:
-    @achievement.destroy
-    redirect_to(course_achievements_path(current_course),
-                success: t('.success', title: @achievement.title))
+    if @achievement.destroy
+      redirect_to(course_achievements_path(current_course),
+                  success: t('.success', title: @achievement.title))
+    else
+      redirect_to course_achievements_path, danger: t('.failure')
+    end
   end
 
   private

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -41,7 +41,7 @@ class Course::AnnouncementsController < Course::ComponentController
                   success: t('.success', title: @announcement.title))
     else
       redirect_to(course_announcements_path(current_course),
-                  danger: t('.failure'))
+                  danger: t('.failure', @announcement.errors.full_messages.to_sentence))
     end
   end
 

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -36,8 +36,13 @@ class Course::AnnouncementsController < Course::ComponentController
   end
 
   def destroy #:nodoc:
-    redirect_to(course_announcements_path(current_course),
-                success: t('.success', title: @announcement.title)) if @announcement.destroy
+    if @announcement.destroy
+      redirect_to(course_announcements_path(current_course),
+                  success: t('.success', title: @announcement.title))
+    else
+      redirect_to(course_announcements_path(current_course),
+                  danger: t('.failure'))
+    end
   end
 
   private

--- a/app/controllers/course/levels_controller.rb
+++ b/app/controllers/course/levels_controller.rb
@@ -23,7 +23,7 @@ class Course::LevelsController < Course::ComponentController
                   success: t('.success',
                              threshold: @level.experience_points_threshold))
     else
-      redirect_to(course_levels_path(current_course), failure: t('.failure'))
+      redirect_to(course_levels_path(current_course), danger: t('.failure'))
     end
   end
 

--- a/app/controllers/course/levels_controller.rb
+++ b/app/controllers/course/levels_controller.rb
@@ -23,7 +23,8 @@ class Course::LevelsController < Course::ComponentController
                   success: t('.success',
                              threshold: @level.experience_points_threshold))
     else
-      redirect_to(course_levels_path(current_course), danger: t('.failure'))
+      redirect_to(course_levels_path(current_course),
+                  danger: t('.failure', @level.errors.full_messages.to_sentence))
     end
   end
 

--- a/app/views/admin/announcements/_form.html.slim
+++ b/app/views/admin/announcements/_form.html.slim
@@ -1,4 +1,6 @@
 = simple_form_for @announcement, resource: :admin_announcement do |f|
+  = f.error_notification
+  = f.error :admin_announcement
   = f.input :title
   = f.input :content
   = f.input :valid_from

--- a/app/views/admin/instances/_form.html.slim
+++ b/app/views/admin/instances/_form.html.slim
@@ -1,4 +1,6 @@
 = simple_form_for @instance, resource: :admin_instance do |f|
+  = f.error_notification
+  = f.error :admin_instance
   = f.input :name
 
   = f.input :host

--- a/app/views/admin/system_announcements/_form.html.slim
+++ b/app/views/admin/system_announcements/_form.html.slim
@@ -1,4 +1,6 @@
 = simple_form_for @system_announcement, resource: :admin_system_announcement do |f|
+  = f.error_notification
+  = f.error :admin_system_announcement
   = f.input :title
 
   = f.input :content

--- a/app/views/course/achievements/_form.html.slim
+++ b/app/views/course/achievements/_form.html.slim
@@ -1,4 +1,6 @@
 = simple_form_for [current_course, @achievement], resource: :course_achievement do |f|
+  = f.error_notification
+  = f.error :course_achievement
   = f.input :title
 
   = f.input :description

--- a/app/views/course/announcements/_form.html.slim
+++ b/app/views/course/announcements/_form.html.slim
@@ -1,4 +1,6 @@
 = simple_form_for [current_course, @announcement], resource: :course_announcement do |f|
+  = f.error_notification
+  = f.error :course_announcement
   = f.input :title
 
   = f.input :content

--- a/app/views/course/condition/achievements/_form.html.slim
+++ b/app/views/course/condition/achievements/_form.html.slim
@@ -1,5 +1,7 @@
 = simple_form_for [current_course, @conditional, @achievement_condition],
                   resource: :course_achievement_condition_achievement do |f|
+  = f.error_notification
+  = f.error :course_achievement_condition_achievement
   = f.input :achievement_id, collection: Course::Achievement.all
 
   = f.submit

--- a/app/views/course/condition/levels/_form.html.slim
+++ b/app/views/course/condition/levels/_form.html.slim
@@ -1,5 +1,7 @@
 = simple_form_for [current_course, @conditional, @level_condition],
                   resource: :course_achievement_condition_level do |f|
+  = f.error_notification
+  = f.error :course_achievement_condition_level
   = f.input :minimum_level, as: :integer, input_html: { min: '1', step: 'any' }
 
   = f.submit

--- a/app/views/course/levels/_form.html.slim
+++ b/app/views/course/levels/_form.html.slim
@@ -1,3 +1,5 @@
 = simple_form_for [current_course, @level], resource: :course_level do |f|
+  = f.error_notification
+  = f.error :course_level
   = f.input :experience_points_threshold, hint: t('.description')
   = f.button :submit

--- a/app/views/course/users/requests.html.slim
+++ b/app/views/course/users/requests.html.slim
@@ -20,6 +20,8 @@ div.users
         - @course_users.each do |user|
           = simple_form_for [current_course, user], resource: :course_user, \
             wrapper: :inline_form do |f|
+            = f.error_notification
+            = f.error :course_user
             tr
               th = f.input :name
               td = f.object.user.email

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -17,6 +17,8 @@ div.users
       tbody
         - @course_users.each do |user|
           = simple_form_for [current_course, user], resource: :course_user do |f|
+            = f.error_notification
+            = f.error :course_user
             tr
               th = f.input :name
               td = f.object.user.email

--- a/app/views/course/users/students.html.slim
+++ b/app/views/course/users/students.html.slim
@@ -16,6 +16,8 @@ div.users
       tbody
         - @course_users.each do |user|
           = simple_form_for [current_course, user], resource: :course_user do |f|
+            = f.error_notification
+            = f.error :course_user
             tr
               th = f.input :name
               td = f.object.user.email

--- a/config/locales/en/admin/announcements.yml
+++ b/config/locales/en/admin/announcements.yml
@@ -13,4 +13,4 @@ en:
         success: "Announcement %{title} was updated."
       destroy:
         success: "Announcement %{title} was deleted."
-        failure: 'An error occurred. Please try again.'
+        failure: 'Failed to delete announcement: %{error}'

--- a/config/locales/en/admin/announcements.yml
+++ b/config/locales/en/admin/announcements.yml
@@ -13,3 +13,4 @@ en:
         success: "Announcement %{title} was updated."
       destroy:
         success: "Announcement %{title} was deleted."
+        failure: 'An error occurred. Please try again.'

--- a/config/locales/en/admin/system_announcements.yml
+++ b/config/locales/en/admin/system_announcements.yml
@@ -13,4 +13,4 @@ en:
         success: "System Announcement %{title} was updated."
       destroy:
         success: "System Announcement %{title} was deleted."
-        failure: 'An error occurred. Please try again.'
+        failure: 'Failed to delete announcement: %{error}'

--- a/config/locales/en/admin/system_announcements.yml
+++ b/config/locales/en/admin/system_announcements.yml
@@ -13,3 +13,4 @@ en:
         success: "System Announcement %{title} was updated."
       destroy:
         success: "System Announcement %{title} was deleted."
+        failure: 'An error occurred. Please try again.'

--- a/config/locales/en/course/achievements.yml
+++ b/config/locales/en/course/achievements.yml
@@ -17,3 +17,4 @@ en:
         success: "Achievement %{title} was updated."
       destroy:
         success: "Achievement %{title} was deleted."
+        failure: 'An error occurred. Please try again.'

--- a/config/locales/en/course/achievements.yml
+++ b/config/locales/en/course/achievements.yml
@@ -17,4 +17,4 @@ en:
         success: "Achievement %{title} was updated."
       destroy:
         success: "Achievement %{title} was deleted."
-        failure: 'An error occurred. Please try again.'
+        failure: 'Failed to delete achievement: %{error}'

--- a/config/locales/en/course/announcements.yml
+++ b/config/locales/en/course/announcements.yml
@@ -14,4 +14,4 @@ en:
         success: "Announcement %{title} was updated."
       destroy:
         success: "Announcement %{title} was deleted."
-        failure: 'An error occurred. Please try again.'
+        failure: 'Failed to delete announcement: %{error}'

--- a/config/locales/en/course/announcements.yml
+++ b/config/locales/en/course/announcements.yml
@@ -14,3 +14,4 @@ en:
         success: "Announcement %{title} was updated."
       destroy:
         success: "Announcement %{title} was deleted."
+        failure: 'An error occurred. Please try again.'

--- a/config/locales/en/course/levels.yml
+++ b/config/locales/en/course/levels.yml
@@ -12,6 +12,6 @@ en:
         success: "Level created with threshold at %{threshold} experience points."
       destroy:
         success: "Level with threshold at %{threshold} experience points removed."
-        failure: "Failed to remove level."
+        failure: 'Failed to remove level.'
       form:
         description: "A student will achieve this level when the student's experience points equals or exceeds this value."

--- a/config/locales/en/course/levels.yml
+++ b/config/locales/en/course/levels.yml
@@ -12,6 +12,6 @@ en:
         success: "Level created with threshold at %{threshold} experience points."
       destroy:
         success: "Level with threshold at %{threshold} experience points removed."
-        failure: 'Failed to remove level.'
+        failure: 'Failed to remove level: %{error}'
       form:
         description: "A student will achieve this level when the student's experience points equals or exceeds this value."

--- a/spec/controllers/admin/announcements_controller_spec.rb
+++ b/spec/controllers/admin/announcements_controller_spec.rb
@@ -1,4 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe Admin::AnnouncementsController, type: :controller do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:user) { create(:administrator) }
+    let!(:announcement_stub) do
+      stub = create(:instance_announcement, instance: instance)
+      allow(stub).to receive(:destroy).and_return(false)
+      stub
+    end
+
+    before { sign_in(user) }
+
+    describe '#destroy' do
+      subject { delete :destroy, id: announcement_stub }
+
+      context 'upon destroy failure' do
+        before do
+          controller.instance_variable_set(:@announcement, announcement_stub)
+          subject
+        end
+
+        it 'redirects with a flash message' do
+          it { is_expected.to redirect_to(admin_announcements_path) }
+          expect(flash[:danger]).to eq(I18n.t('admin.announcements.destroy.failure', error: ''))
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/system_announcements_controller_spec.rb
+++ b/spec/controllers/admin/system_announcements_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SystemAnnouncementsController, type: :controller do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:user) { create(:administrator) }
+    let!(:system_announcement_stub) do
+      stub = create(:system_announcement)
+      allow(stub).to receive(:destroy).and_return(false)
+      stub
+    end
+
+    before { sign_in(user) }
+
+    describe '#destroy' do
+      subject { delete :destroy, id: system_announcement_stub }
+
+      context 'upon destroy failure' do
+        before do
+          controller.instance_variable_set(:@system_announcement, system_announcement_stub)
+          subject
+        end
+
+        it 'redirects with a flash message' do
+          it { is_expected.to redirect_to(admin_system_announcements_path) }
+          expect(flash[:danger]).to(eq(I18n.t('admin.system_announcements.destroy.failure',
+                                              error: '')))
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/achievements_controller_spec.rb
+++ b/spec/controllers/course/achievements_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Course::AchievementsController, type: :controller do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:administrator) }
+    let!(:course) { create(:course) }
+    let!(:achievement_stub) do
+      stub = create(:course_achievement, course: course)
+      allow(stub).to receive(:destroy).and_return(false)
+      stub
+    end
+
+    before { sign_in(user) }
+
+    describe '#destroy' do
+      subject { delete :destroy, course_id: course, id: achievement_stub }
+
+      context 'upon destroy failure' do
+        before do
+          controller.instance_variable_set(:@achievement, achievement_stub)
+          subject
+        end
+
+        it 'redirects with a flash message' do
+          it { is_expected.to redirect_to(course_achievements_path(course)) }
+          expect(flash[:danger]).to eq(I18n.t('course.achievements.destroy.failure', error: ''))
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/announcements_controller_spec.rb
+++ b/spec/controllers/course/announcements_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Course::AnnouncementsController, type: :controller do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:administrator) }
+    let!(:course) { create(:course) }
+    let!(:announcement_stub) do
+      stub = create(:course_announcement, course: course)
+      allow(stub).to receive(:destroy).and_return(false)
+      stub
+    end
+
+    before { sign_in(user) }
+
+    describe '#destroy' do
+      subject { delete :destroy, course_id: course, id: announcement_stub }
+
+      context 'upon destroy failure' do
+        before do
+          controller.instance_variable_set(:@announcement, announcement_stub)
+          subject
+        end
+
+        it 'redirects with a flash message' do
+          it { is_expected.to redirect_to(course_announcements_path(course)) }
+          expect(flash[:danger]).to eq(I18n.t('course.announcements.destroy.failure', error: ''))
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/levels_controller_spec.rb
+++ b/spec/controllers/course/levels_controller_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe Course::LevelsController, type: :controller do
           subject
         end
 
-        it { is_expected.to redirect_to(course_levels_path(course)) }
+        it 'redirects with a flash message' do
+          it { is_expected.to redirect_to(course_levels_path(course)) }
+          expect(flash[:danger]).to eq(I18n.t('course.levels.destroy.failure', error: ''))
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #200. Error-handling for `delete` is done via `redirect_to`, which shows a flash message. `create` and `update` are handled via `simple_form_for`'s helpers.