### PR TITLE
Fix spec helpers

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,10 +1,14 @@
 FactoryGirl.define do
+  sequence :name do |n|
+    "user #{n}"
+  end
+
   factory :user, aliases: [:creator, :updater]  do
     transient do
       emails_count 1
     end
 
-    name 'user'
+    name
     role :normal
     password 'lolololol'
 

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -14,7 +14,7 @@ module ActsAsTenant::TestGroupHelpers
         after(:each) do
           ActsAsTenant.current_tenant = nil
         end
-        instance_exec(*params, &proc)
+        module_exec(*params, &proc)
       end
     end
   end
@@ -31,7 +31,7 @@ module ActsAsTenant::TestGroupHelpers
         before(:each) do
           @request.headers['host'] = send(tenant).host
         end
-        instance_exec(*params, &proc)
+        module_exec(*params, &proc)
       end
     end
   end
@@ -53,7 +53,7 @@ module ActsAsTenant::TestGroupHelpers
         end
         after(:each) { Capybara.app_host = @saved_host }
 
-        instance_exec(*params, &proc)
+        module_exec(*params, &proc)
       end
     end
   end

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -74,9 +74,7 @@ module ActsAsTenant::TestExampleHelpers
 end
 
 RSpec.configure do |config|
-  config.extend ActsAsTenant::TestGroupHelpers::ModelHelpers, type: :model
-  config.extend ActsAsTenant::TestGroupHelpers::ModelHelpers, type: :helper
-  config.extend ActsAsTenant::TestGroupHelpers::ModelHelpers, type: :view
+  config.extend ActsAsTenant::TestGroupHelpers::ModelHelpers
   config.extend ActsAsTenant::TestGroupHelpers::ControllerHelpers, type: :controller
   config.extend ActsAsTenant::TestGroupHelpers::FeatureHelpers, type: :feature
   config.include ActsAsTenant::TestExampleHelpers::FeatureHelpers, type: :feature

--- a/spec/support/migration.rb
+++ b/spec/support/migration.rb
@@ -26,7 +26,7 @@ module ActiveRecord::Migration::TestGroupHelpers
         ActiveRecord::Migration::TestGroupHelpers.after_context(table_name)
       end
 
-      instance_exec(*params, &proc)
+      module_exec(*params, &proc)
     end
   end
 


### PR DESCRIPTION
 - `with_tenant` should allow local helper definitions
 - Allow us to generate arbitrary names
 - Allow `with_tenant` to be used with any kind of specs