### PR TITLE
Silence the Assignment Branch Condition cop in specs.

### DIFF
--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from:
+  - ../.rubocop.yml
+
+Metrics/AbcSize:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false


### PR DESCRIPTION
Because RSpec is a DSL, the ABC metric of a block or method would be exceptionally high. It also does not mean much in the context of a DSL.