### PR TITLE
Explicitly number Course::Event event_type enum

### DIFF
--- a/app/models/course/event.rb
+++ b/app/models/course/event.rb
@@ -1,5 +1,5 @@
 class Course::Event < ActiveRecord::Base
   acts_as_lesson_plan_item
 
-  enum event_type: [:others, :lecture, :recitation, :tutorial]
+  enum event_type: { other: 0, lecture: 1, recitation: 2, tutorial: 3 }
 end


### PR DESCRIPTION
Otherwise, bug will arise when event_types are reordered.