### PR TITLE
Standardised page headers

### DIFF
--- a/app/views/announcements/index.html.slim
+++ b/app/views/announcements/index.html.slim
@@ -1,5 +1,3 @@
-div.page-header
-  h1
-    = t('.header')
+= page_header
 = render partial: 'system/admin/announcements/announcement', collection: @announcements
 

--- a/app/views/course/achievements/edit.html.slim
+++ b/app/views/course/achievements/edit.html.slim
@@ -1,3 +1,2 @@
-h2= t('.header')
-
+= page_header
 = render 'form'

--- a/app/views/course/achievements/new.html.slim
+++ b/app/views/course/achievements/new.html.slim
@@ -1,4 +1,3 @@
-h2 = t('.header')
-
+= page_header
 = render 'form'
 

--- a/app/views/course/announcements/edit.html.slim
+++ b/app/views/course/announcements/edit.html.slim
@@ -1,3 +1,2 @@
-h2= t('.header')
-
+= page_header
 = render 'form'

--- a/app/views/course/announcements/new.html.slim
+++ b/app/views/course/announcements/new.html.slim
@@ -1,3 +1,2 @@
-h2= t('.header')
-
+= page_header
 = render 'form'

--- a/app/views/course/condition/achievements/_achievement.html.slim
+++ b/app/views/course/condition/achievements/_achievement.html.slim
@@ -1,4 +1,4 @@
-div
+= div_for(achievement)
   label Achievement
   '
   = achievement.achievement.title

--- a/app/views/course/condition/achievements/edit.html.slim
+++ b/app/views/course/condition/achievements/edit.html.slim
@@ -1,5 +1,3 @@
-h2= t('.header')
-
+= page_header
 = render 'form'
-
 = link_to t('common.back'), return_to_path

--- a/app/views/course/condition/achievements/new.html.slim
+++ b/app/views/course/condition/achievements/new.html.slim
@@ -1,5 +1,3 @@
-h2= t('.header')
-
+= page_header
 = render 'form'
-
 = link_to t('common.back'), return_to_path

--- a/app/views/course/condition/levels/_level.html.slim
+++ b/app/views/course/condition/levels/_level.html.slim
@@ -1,4 +1,4 @@
-div
+= div_for(level)
   label Level
   '
   = level.minimum_level

--- a/app/views/course/condition/levels/edit.html.slim
+++ b/app/views/course/condition/levels/edit.html.slim
@@ -1,5 +1,3 @@
-h2= t('.header')
-
+= page_header
 = render 'form'
-
 = link_to t('common.back'), return_to_path

--- a/app/views/course/condition/levels/new.html.slim
+++ b/app/views/course/condition/levels/new.html.slim
@@ -1,5 +1,3 @@
-h2= t('.header')
-
+= page_header
 = render 'form'
-
 = link_to t('common.back'), return_to_path

--- a/app/views/course/courses/new.html.slim
+++ b/app/views/course/courses/new.html.slim
@@ -1,5 +1,4 @@
-h2= t('.header')
-
+= page_header
 = simple_form_for @course do |f|
   = f.input :title, label: t('course.courses.form.title_label'),
             placeholder: t('course.courses.form.title_placeholder')

--- a/app/views/course/groups/edit.html.slim
+++ b/app/views/course/groups/edit.html.slim
@@ -1,5 +1,4 @@
-h2= t('.header')
-
+= page_header
 = simple_form_for [current_course, @group] do |f|
   = f.input :name
 

--- a/app/views/course/groups/index.html.slim
+++ b/app/views/course/groups/index.html.slim
@@ -1,6 +1,5 @@
-h1 = t('.header')
-
-= new_button([current_course, :group])
+= page_header do
+  = new_button([current_course, :group]) if can?(:create, Course::Group)
 
 table.table.table-hover
   thead

--- a/app/views/course/groups/new.html.slim
+++ b/app/views/course/groups/new.html.slim
@@ -1,5 +1,4 @@
-h2= t('.header')
-
+= page_header
 = simple_form_for [current_course, @group] do |f|
   = f.input :name
 

--- a/app/views/course/levels/new.html.slim
+++ b/app/views/course/levels/new.html.slim
@@ -1,3 +1,2 @@
-h1 = t('.header')
-
+= page_header
 = render 'form'

--- a/app/views/course/settings/components.html.slim
+++ b/app/views/course/settings/components.html.slim
@@ -1,4 +1,4 @@
-h2 = t('.header')
+= page_header
 = simple_form_for @settings, url: course_components_path do |f|
   table.table.table-hover
     thead

--- a/app/views/system/admin/announcements/edit.html.slim
+++ b/app/views/system/admin/announcements/edit.html.slim
@@ -1,3 +1,2 @@
-h2
-  = t('.header')
+= page_header
 = render 'form'

--- a/app/views/system/admin/announcements/new.html.slim
+++ b/app/views/system/admin/announcements/new.html.slim
@@ -1,3 +1,2 @@
-h2
-  = t('.header')
+= page_header
 = render 'form'

--- a/app/views/system/admin/instances/edit.html.slim
+++ b/app/views/system/admin/instances/edit.html.slim
@@ -1,3 +1,2 @@
-h1 = t('.header')
-
+= page_header
 = render 'form'

--- a/app/views/system/admin/instances/new.html.slim
+++ b/app/views/system/admin/instances/new.html.slim
@@ -1,3 +1,2 @@
-h1 = t('.header')
-
+= page_header
 = render 'form'

--- a/app/views/system/admin/system_announcements/edit.html.slim
+++ b/app/views/system/admin/system_announcements/edit.html.slim
@@ -1,4 +1,2 @@
-h2
-  = t('.header')
-
+= page_header
 = render 'form'

--- a/app/views/system/admin/system_announcements/new.html.slim
+++ b/app/views/system/admin/system_announcements/new.html.slim
@@ -1,4 +1,2 @@
-h2
-  = t('.header')
-
+= page_header
 = render 'form'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -93,10 +93,12 @@ ignore_unused:
 - 'simple_form.{yes,no}'
 - 'simple_form.{placeholders,hints,labels}.*'
 - 'simple_form.{error_notification,required}.:'
-- 'system.admin.*.*.header'
-- 'system.admin.admin.components.header'
+# Keys used dynamically by the page_header helper
+- 'admin.*.*.header'
 - 'course.*.*.header'
-- 'course.users.*.header'
+- 'announcements.index.header'
+- 'system.admin.*.*.header'
+
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:


### PR DESCRIPTION
Addresses the remaining problems in #226. All `.header` keys in views replaced with `page_title`. The only remaining `\bh(1|2)` tags are don't use `.header`.