### PR TITLE
Restore length limits to string columns in the database.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,9 +33,9 @@ ActiveRecord::Schema.define(version: 20150617021911) do
   end
 
   create_table "attachments", force: :cascade do |t|
-    t.string   "name",            null: false
+    t.string   "name",            limit: 255, null: false
     t.integer  "attachable_id"
-    t.string   "attachable_type", index: {name: "index_attachments_on_attachable_type_and_attachable_id", with: ["attachable_id"]}
+    t.string   "attachable_type", limit: 255, index: {name: "index_attachments_on_attachable_type_and_attachable_id", with: ["attachable_id"]}
     t.text     "file_upload",     null: false
     t.integer  "creator_id",      null: false, index: {name: "fk__attachments_creator_id"}, foreign_key: {references: "users", name: "fk_attachments_creator_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "updater_id",      null: false, index: {name: "fk__attachments_updater_id"}, foreign_key: {references: "users", name: "fk_attachments_updater_id", on_update: :no_action, on_delete: :no_action}
@@ -99,10 +99,10 @@ ActiveRecord::Schema.define(version: 20150617021911) do
 
   create_table "course_conditions", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",     index: {name: "index_course_conditions_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
+    t.string   "actable_type",     limit: 255, index: {name: "index_course_conditions_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
     t.integer  "course_id",        index: {name: "fk__course_conditions_course_id"}, foreign_key: {references: "courses", name: "fk_course_conditions_course_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "conditional_id"
-    t.string   "conditional_type", index: {name: "index_course_conditions_on_conditional_type_and_conditional_id", with: ["conditional_id"]}
+    t.string   "conditional_type", limit: 255, index: {name: "index_course_conditions_on_conditional_type_and_conditional_id", with: ["conditional_id"]}
     t.integer  "creator_id",       null: false, index: {name: "fk__course_conditions_creator_id"}, foreign_key: {references: "users", name: "fk_course_conditions_creator_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "updater_id",       null: false, index: {name: "fk__course_conditions_updater_id"}, foreign_key: {references: "users", name: "fk_course_conditions_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at",       null: false
@@ -110,14 +110,14 @@ ActiveRecord::Schema.define(version: 20150617021911) do
   end
 
   create_table "course_events", force: :cascade do |t|
-    t.string   "location"
-    t.integer  "event_type", default: 0
+    t.string  "location",   limit: 255
+    t.integer "event_type", default: 0
   end
 
   create_table "course_users", force: :cascade do |t|
     t.integer  "course_id",        null: false, index: {name: "fk__course_users_course_id"}, foreign_key: {references: "courses", name: "fk_course_users_course_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "user_id",          index: {name: "fk__course_users_user_id"}, foreign_key: {references: "users", name: "fk_course_users_user_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "workflow_state",   null: false
+    t.string   "workflow_state",   limit: 255,                 null: false
     t.integer  "role",             default: 0,     null: false
     t.string   "name",             limit: 255,                 null: false
     t.boolean  "phantom",          default: false, null: false
@@ -131,10 +131,10 @@ ActiveRecord::Schema.define(version: 20150617021911) do
 
   create_table "course_experience_points_records", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",   index: {name: "index_course_experience_points_records_on_actable", with: ["actable_id"], unique: true}
+    t.string   "actable_type",   limit: 255, index: {name: "index_course_experience_points_records_on_actable", with: ["actable_id"], unique: true}
     t.integer  "points_awarded", null: false
     t.integer  "course_user_id", null: false, index: {name: "fk__course_experience_points_records_course_user_id"}, foreign_key: {references: "course_users", name: "fk_course_experience_points_records_course_user_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "reason"
+    t.string   "reason",         limit: 255
     t.integer  "creator_id",     null: false, index: {name: "fk__course_experience_points_records_creator_id"}, foreign_key: {references: "users", name: "fk_course_experience_points_records_creator_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "updater_id",     null: false, index: {name: "fk__course_experience_points_records_updater_id"}, foreign_key: {references: "users", name: "fk_course_experience_points_records_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at",     null: false
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20150617021911) do
 
   create_table "course_groups", force: :cascade do |t|
     t.integer  "course_id",  null: false, index: {name: "fk__course_groups_course_id"}, foreign_key: {references: "courses", name: "fk_course_groups_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "name",       default: "", null: false
+    t.string   "name",       limit: 255, default: "", null: false
     t.integer  "creator_id", null: false, index: {name: "fk__course_groups_creator_id"}, foreign_key: {references: "users", name: "fk_course_groups_creator_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "updater_id", null: false, index: {name: "fk__course_groups_updater_id"}, foreign_key: {references: "users", name: "fk_course_groups_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at", null: false
@@ -164,9 +164,9 @@ ActiveRecord::Schema.define(version: 20150617021911) do
 
   create_table "course_lesson_plan_items", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",    index: {name: "index_course_lesson_plan_items_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
+    t.string   "actable_type",    limit: 255, index: {name: "index_course_lesson_plan_items_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
     t.integer  "course_id",       null: false, index: {name: "fk__course_lesson_plan_items_course_id"}, foreign_key: {references: "courses", name: "fk_course_lesson_plan_items_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",           null: false
+    t.string   "title",           limit: 255,                 null: false
     t.text     "description"
     t.boolean  "published",       default: false, null: false
     t.integer  "base_exp",        null: false
@@ -183,7 +183,7 @@ ActiveRecord::Schema.define(version: 20150617021911) do
 
   create_table "course_lesson_plan_milestones", force: :cascade do |t|
     t.integer  "course_id",   index: {name: "fk__course_lesson_plan_milestones_course_id"}, foreign_key: {references: "courses", name: "fk_course_lesson_plan_milestones_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",       null: false
+    t.string   "title",       limit: 255, null: false
     t.text     "description"
     t.datetime "start_time",  null: false
     t.integer  "creator_id",  null: false, index: {name: "fk__course_lesson_plan_milestones_creator_id"}, foreign_key: {references: "users", name: "fk_course_lesson_plan_milestones_creator_id", on_update: :no_action, on_delete: :no_action}
@@ -220,9 +220,9 @@ ActiveRecord::Schema.define(version: 20150617021911) do
   end
 
   create_table "generic_announcements", force: :cascade do |t|
-    t.string   "type",        null: false
+    t.string   "type",        limit: 255, null: false
     t.integer  "instance_id", comment: "The instance this announcement is associated with. This only applies to instance announcements.", index: {name: "fk__generic_announcements_instance_id"}, foreign_key: {references: "instances", name: "fk_generic_announcements_instance_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",       null: false
+    t.string   "title",       limit: 255, null: false
     t.text     "content"
     t.datetime "valid_from",  null: false
     t.datetime "valid_to",    null: false

--- a/lib/extensions/legacy/active_record.rb
+++ b/lib/extensions/legacy/active_record.rb
@@ -1,1 +1,10 @@
 module Extensions::Legacy::ActiveRecord; end
+
+# Undoes rails/rails#14579.
+#
+# We need this because we rely on the fact that +string+ is used for short strings, and +text+ is
+# used for longer strings (possibly those involving newlines). Most of these strings would be
+# used in short messages, like flash messages, or other titles of objects, and we would not like
+# these to be unreasonably long. Schema Plus Validations would add the length limit validations for
+# us, when the database column contains the limits, so we stick with these limits.
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:string][:limit] = 255

--- a/spec/libraries/legacy_spec.rb
+++ b/spec/libraries/legacy_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Extension: Legacy', type: :model do
+  describe 'maximum string column length' do
+    class ExtensionLegacyStringColumnLength < ActiveRecord::Base
+    end
+
+    temporary_table(:extension_legacy_string_column_lengths) do |t|
+      t.string :test
+    end
+    with_temporary_table(:extension_legacy_string_column_lengths) do
+      it 'imposes a limit of 255 characters' do
+        test = ExtensionLegacyStringColumnLength.new(test: '6' * 256)
+        expect(test.valid?).to be_falsey
+        expect(test.errors[:test].find { |e| e =~ /too long/i }).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We utilise the difference between string and text to distinguish between short and long pieces of textual data. It is implicitly assumed that string fields are suited for display in areas with limited space, e.g. flash messages and tables.

Rails 4.2 removed the length limits (see Rails' #14579.) This allows a user to potentially enter a long piece of data, and we would put that string in the flash message (in the guise of 'you have successfully created X'.) Since we use the cookie session store, which has a length limit of 4KB, this would cause an exception at runtime. That also disrupts the page flow of tables, when the title is used to indicate the link to an object.

Since Schema Plus Validations handles the length field properly, this would also prevent the user from submitting such long data.