### PR TITLE
Reduce state dependencies.

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe ApplicationController, type: :controller do
       expect(ActsAsTenant.current_tenant).to eq(Instance.default)
     end
 
-    let(:instance) do
-      default_instance = Instance.default
-      Instance.where { id << [default_instance] }.take
-    end
+    let(:instance) { create(:instance) }
 
     it 'checks hosts in a case insensitive manner' do
       @request.headers['host'] = instance.host.upcase
@@ -44,6 +41,9 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   describe 'internationalization' do
+    before { @old_i18n_locale = I18n.locale }
+    after { I18n.locale = @old_i18n_locale }
+
     context 'when http accept language is present' do
       before { @request.env['HTTP_ACCEPT_LANGUAGE'] = 'zh-cn' }
 

--- a/spec/models/course/achievement_spec.rb
+++ b/spec/models/course/achievement_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe Course::Achievement, type: :model do
     describe '.default_scope' do
       it 'orders by ascending weight' do
         weights = Course::Achievement.all.map(&:weight)
-        prev_weights = [0] + weights[0..-2]
-        zipped_weights = prev_weights.zip(weights)
-        greater_than_previous = zipped_weights.map { |(a, b)| a <= b }
-        expect(greater_than_previous.all?).to be_truthy
+        expect(weights.length).not_to eq(0)
+        expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
       end
     end
   end


### PR DESCRIPTION
 - I18n specs change global state (the active I18n locale) and need to be reset when the spec is finished.
 - The instance deduction spec can fail if no other instances exist in the database.