### PR TITLE
Extra gem configuration

### DIFF
--- a/app/controllers/concerns/application_announcements_concern.rb
+++ b/app/controllers/concerns/application_announcements_concern.rb
@@ -2,6 +2,6 @@ module ApplicationAnnouncementsConcern
   extend ActiveSupport::Concern
 
   def global_announcements
-    GenericAnnouncement.for_instance(ActsAsTenant.current_tenant).currently_valid
+    GenericAnnouncement.for_instance(current_tenant).currently_valid
   end
 end

--- a/app/controllers/concerns/application_multitenancy_concern.rb
+++ b/app/controllers/concerns/application_multitenancy_concern.rb
@@ -4,6 +4,8 @@ module ApplicationMultitenancyConcern
   included do
     set_current_tenant_through_filter
     before_action :deduce_and_set_current_tenant
+
+    helper_method :current_tenant
   end
 
   private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,6 +50,7 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.rails_logger = true
     Bullet.add_footer = true
+    Bullet.counter_cache_enable = false
   end
 end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,5 +50,6 @@ Rails.application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.raise = true
+    Bullet.counter_cache_enable = false
   end
 end

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -78,4 +78,6 @@ RSpec.configure do |config|
   config.extend ActsAsTenant::TestGroupHelpers::ControllerHelpers, type: :controller
   config.extend ActsAsTenant::TestGroupHelpers::FeatureHelpers, type: :feature
   config.include ActsAsTenant::TestExampleHelpers::FeatureHelpers, type: :feature
+
+  config.backtrace_exclusion_patterns << %r{/spec/support/acts_as_tenant\.rb}
 end


### PR DESCRIPTION
 - Simplify some ActsAsTenant code
 - Ignore acts_as_tenant.rb from RSpec backtraces
 - Do not report counter cache warnings from Bullet.