### PR TITLE
Do not include all application helpers by default.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,12 @@
 # :nodoc:
 module ApplicationHelper
+  include FontAwesome::Rails::IconHelper
+
   include ApplicationThemingHelper
   include ApplicationAnnouncementsHelper
   include ApplicationWidgetsHelper
   include ApplicationCocoonHelper
+  include RouteOverridesHelper
 
   # Checks if the current page has a sidebar.
   #

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,9 @@ class Application < Rails::Application
   config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
   # config.i18n.default_locale = :de
 
+  # Action Controller default settings
+  config.action_controller.include_all_helpers = false
+
   # Action Mailer default settings
   config.action_mailer.default_options = { from: ENV['EMAIL_FROM_ADDRESS'] }
 


### PR DESCRIPTION
As discussed in: http://thepugautomatic.com/2012/08/helpers/.

Having all application helpers included would expose unnecessary (and potentially dysfunctional) methods to all views.