### PR TITLE
Refactor course component host

### DIFF
--- a/app/controllers/components/course/achievements_component.rb
+++ b/app/controllers/components/course/achievements_component.rb
@@ -1,7 +1,7 @@
 class Course::AchievementsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
-  sidebar do
+  def sidebar_items
     [
       {
         key: :achievements,

--- a/app/controllers/components/course/achievements_component.rb
+++ b/app/controllers/components/course/achievements_component.rb
@@ -1,4 +1,4 @@
-class Course::AchievementsComponent
+class Course::AchievementsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   sidebar do

--- a/app/controllers/components/course/announcements_component.rb
+++ b/app/controllers/components/course/announcements_component.rb
@@ -1,19 +1,19 @@
 class Course::AnnouncementsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
-  sidebar do
+  def sidebar_items
     [
       {
         key: :announcements,
         title: I18n.t('course.announcements.sidebar_title'),
         weight: 1,
         path: course_announcements_path(current_course),
-        unread: Course::AnnouncementsComponent.unread_count(current_course, current_user)
+        unread: unread_count
       }
     ]
   end
 
-  settings do
+  def settings_items
     [
       {
         title: t('layouts.course_admin.announcement_settings.title'),
@@ -24,8 +24,10 @@ class Course::AnnouncementsComponent < SimpleDelegator
     ]
   end
 
-  def self.unread_count(course, user)
-    return 0 if course.nil? || user.nil?
-    course.announcements.unread_by(user).count
+  private
+
+  def unread_count
+    return 0 if current_course.nil? || current_user.nil?
+    current_course.announcements.unread_by(current_user).count
   end
 end

--- a/app/controllers/components/course/announcements_component.rb
+++ b/app/controllers/components/course/announcements_component.rb
@@ -24,9 +24,8 @@ class Course::AnnouncementsComponent < SimpleDelegator
       {
         title: t('layouts.course_admin.announcement_settings.title'),
         type: :settings,
-        controller: 'course/admin/announcement_settings',
-        action: 'edit',
-        weight: 4
+        weight: 4,
+        path: course_admin_announcements_path(current_course)
       }
     ]
   end

--- a/app/controllers/components/course/announcements_component.rb
+++ b/app/controllers/components/course/announcements_component.rb
@@ -1,4 +1,4 @@
-class Course::AnnouncementsComponent
+class Course::AnnouncementsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   sidebar do

--- a/app/controllers/components/course/announcements_component.rb
+++ b/app/controllers/components/course/announcements_component.rb
@@ -2,6 +2,12 @@ class Course::AnnouncementsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   def sidebar_items
+    main_sidebar_items + settings_sidebar_items
+  end
+
+  private
+
+  def main_sidebar_items
     [
       {
         key: :announcements,
@@ -13,18 +19,17 @@ class Course::AnnouncementsComponent < SimpleDelegator
     ]
   end
 
-  def settings_items
+  def settings_sidebar_items
     [
       {
         title: t('layouts.course_admin.announcement_settings.title'),
+        type: :settings,
         controller: 'course/admin/announcement_settings',
         action: 'edit',
         weight: 4
       }
     ]
   end
-
-  private
 
   def unread_count
     return 0 if current_course.nil? || current_user.nil?

--- a/app/controllers/components/course/component_host.rb
+++ b/app/controllers/components/course/component_host.rb
@@ -104,23 +104,14 @@ class Course::ComponentHost
   # Sidebar elements have the given format:
   #
   #   {
-  #      key: :sidebar_item_key, # The unique key of the item to identify it among others.
+  #      key: :item_key, # The unique key of the item to identify it among others. Can be nil if
+  #                      # there is no need to distinguish between items.
   #      title: 'Sidebar Item Title',
-  #      type: :admin, # Will be considered as `:normal` if not set
-  #      weight: 100,
+  #      type: :admin, # Will be considered as +:normal+ if not set. Currently +:normal+, +:admin+,
+  #                    # and +:settings+ are used.
+  #      weight: 100, # The default weight of the item. Larger weights (heavier items) sink.
   #      path: path_to_the_component,
-  #      unread: 0 # or nil
-  #   }
-  # Gets the settings items.
-  #
-  # Settings elements have the given format:
-  #
-  #   {
-  #      title: 'Settings Item Title',
-  #      type: :settings,
-  #      controller: controller name, String or Symbol,
-  #      action: action name, String or Symbol,
-  #      weight: 1 # The weight which determines the order of the item
+  #      unread: 0 # Number of unread items. Can be +nil+, if not needed.
   #   }
   #
   # The elements are rendered on all Course controller subclasses as part of a nested template.

--- a/app/controllers/components/course/component_host.rb
+++ b/app/controllers/components/course/component_host.rb
@@ -13,18 +13,6 @@ class Course::ComponentHost
     end
   end
 
-  module Settings
-    extend ActiveSupport::Concern
-
-    # Gets the settings items from this component.
-    #
-    # @return [Array] An array of hashes containing the settings items exposed by this component.
-    #   See #{Course::ComponentHost#settings} for the format.
-    def settings_items
-      []
-    end
-  end
-
   module Enableable
     extend ActiveSupport::Concern
 
@@ -51,7 +39,6 @@ class Course::ComponentHost
     const_set(:ClassMethods, ::Module.new) unless const_defined?(:ClassMethods)
 
     include Sidebar
-    include Settings
     include Enableable
   end
 
@@ -109,30 +96,27 @@ class Course::ComponentHost
   # Sidebar elements have the given format:
   #
   #   {
-  #      key: :sidebar_item_key # The unique key of the item, which will be used in sidebar settings
-  #      title: 'Sidebar Item Title'
-  #      type: :admin # Will be considered as `:normal` if not set
-  #      weight: 100
-  #      path: path_to_the_component
+  #      key: :sidebar_item_key, # The unique key of the item to identify it among others.
+  #      title: 'Sidebar Item Title',
+  #      type: :admin, # Will be considered as `:normal` if not set
+  #      weight: 100,
+  #      path: path_to_the_component,
   #      unread: 0 # or nil
   #   }
-  #
-  # The elements are rendered on all Course controller subclasses as part of a nested template.
-  def sidebar_items
-    @sidebar_items ||= components.map(&:sidebar_items).tap(&:flatten!)
-  end
-
   # Gets the settings items.
   #
   # Settings elements have the given format:
   #
   #   {
-  #      title: 'Settings Item Title'
-  #      controller: controller name, String or Symbol
-  #      action: action name, String or Symbol
+  #      title: 'Settings Item Title',
+  #      type: :settings,
+  #      controller: controller name, String or Symbol,
+  #      action: action name, String or Symbol,
   #      weight: 1 # The weight which determines the order of the item
   #   }
-  def settings
-    @settings ||= components.map(&:settings_items).tap(&:flatten!)
+  #
+  # The elements are rendered on all Course controller subclasses as part of a nested template.
+  def sidebar_items
+    @sidebar_items ||= components.map(&:sidebar_items).tap(&:flatten!)
   end
 end

--- a/app/controllers/components/course/component_host.rb
+++ b/app/controllers/components/course/component_host.rb
@@ -63,6 +63,14 @@ class Course::ComponentHost
     enabled_components.map { |component| component.new(@context) }
   end
 
+  # Gets the component instance with the given key.
+  #
+  # @param [String|Symbol] component_key The key of the component to find.
+  # @return [nil|Object] The component with the given key, or nil if it is not enabled.
+  def [](component_key)
+    components.find { |component| component.key.to_s == component_key.to_s }
+  end
+
   # Apply preferences to all the components, returns the enabled components.
   #
   # @return [Array<Class>] array of enabled components

--- a/app/controllers/components/course/component_host.rb
+++ b/app/controllers/components/course/component_host.rb
@@ -4,70 +4,24 @@ class Course::ComponentHost
   module Sidebar
     extend ActiveSupport::Concern
 
-    def get_sidebar_items
-      self.class.get_sidebar_items(self)
-    end
-
-    module ClassMethods
-      # Class method to declare the proc handling the sidebar menu items.
-      #
-      # @param [Proc] proc The proc handling the sidebar for the given component. The proc will be
-      #   +instance_eval+ed in the context of the controller handling the current
-      #   request. This proc must return an array of hashes, each describing one
-      #   menu item.
-      def sidebar(&proc)
-        self.sidebar_proc = proc
-      end
-
-      # Class method to get the sidebar items from this component, in the context of the given
-      # controller instance.
-      #
-      # @param [Course::Controller] controller The controller handling the current request.
-      # @return [Array] An array of hashes containing the sidebar items exposed by this component.
-      def get_sidebar_items(controller)
-        return [] unless sidebar_proc
-
-        controller.instance_exec(&sidebar_proc)
-      end
-
-      private
-
-      attr_accessor :sidebar_proc
+    # Get the sidebar items from this component.
+    #
+    # @return [Array] An array of hashes containing the sidebar items exposed by this component.
+    #   See #{Course::ComponentHost#sidebar} for the format.
+    def sidebar_items
+      []
     end
   end
 
   module Settings
     extend ActiveSupport::Concern
 
-    def get_settings_items
-      self.class.get_settings_items(self)
-    end
-
-    module ClassMethods
-      # Class method to declare the proc handling the course settings items.
-      #
-      # @param [Proc] proc The proc handling the settings for the given component. The proc will be
-      #   +instance_eval+ed in the context of the controller handling the current
-      #   request. This proc must return an array of hashes, each describing one
-      #   component settings page.
-      def settings(&proc)
-        self.settings_proc = proc
-      end
-
-      # Class method to get the settings items from this component, in the context of the given
-      # controller instance.
-      #
-      # @param [Course::Controller] controller The controller handling the current request.
-      # @return [Array] An array of hashes containing the settings items exposed by this component.
-      def get_settings_items(controller)
-        return [] unless settings_proc
-
-        controller.instance_exec(&settings_proc)
-      end
-
-      private
-
-      attr_accessor :settings_proc
+    # Gets the settings items from this component.
+    #
+    # @return [Array] An array of hashes containing the settings items exposed by this component.
+    #   See #{Course::ComponentHost#settings} for the format.
+    def settings_items
+      []
     end
   end
 
@@ -104,10 +58,10 @@ class Course::ComponentHost
   # Eager load all the components declared.
   eager_load_components(File.join(__dir__, '../'))
 
-  # Initialize the component host instance
+  # Initializes the component host instance.
   #
-  # @param [#settings] instance_settings Instance settings object
-  # @param [#settings] course_settings Course settings object
+  # @param [#settings] instance_settings Instance settings object.
+  # @param [#settings] course_settings Course settings object.
   # @param context The context to execute all component instance methods on.
   def initialize(instance_settings, course_settings, context)
     @instance_settings = instance_settings
@@ -165,7 +119,7 @@ class Course::ComponentHost
   #
   # The elements are rendered on all Course controller subclasses as part of a nested template.
   def sidebar_items
-    @sidebar_items ||= components.map(&:get_sidebar_items).tap(&:flatten!)
+    @sidebar_items ||= components.map(&:sidebar_items).tap(&:flatten!)
   end
 
   # Gets the settings items.
@@ -179,6 +133,6 @@ class Course::ComponentHost
   #      weight: 1 # The weight which determines the order of the item
   #   }
   def settings
-    @settings ||= components.map(&:get_settings_items).tap(&:flatten!)
+    @settings ||= components.map(&:settings_items).tap(&:flatten!)
   end
 end

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -2,6 +2,12 @@ class Course::CoursesComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   def sidebar_items
+    admin_sidebar_items + settings_sidebar_items
+  end
+
+  private
+
+  def admin_sidebar_items
     [
       {
         key: :settings,
@@ -13,26 +19,41 @@ class Course::CoursesComponent < SimpleDelegator
     ]
   end
 
-  def settings_items
+  def settings_sidebar_items
     [
-      {
-        title: t('layouts.course_admin.title'),
-        controller: 'course/admin/admin',
-        action: 'index',
-        weight: 1
-      },
-      {
-        title: t('layouts.course_admin.component_settings.title'),
-        controller: 'course/admin/component_settings',
-        action: 'edit',
-        weight: 2
-      },
-      {
-        title: t('layouts.course_admin.sidebar_settings.title'),
-        controller: 'course/admin/sidebar_settings',
-        action: 'edit',
-        weight: 3
-      }
+      settings_index_item,
+      settings_components_item,
+      settings_sidebar_item
     ]
+  end
+
+  def settings_index_item
+    {
+      title: t('layouts.course_admin.title'),
+      type: :settings,
+      controller: 'course/admin/admin',
+      action: 'index',
+      weight: 1
+    }
+  end
+
+  def settings_components_item
+    {
+      title: t('layouts.course_admin.component_settings.title'),
+      type: :settings,
+      controller: 'course/admin/component_settings',
+      action: 'edit',
+      weight: 2
+    }
+  end
+
+  def settings_sidebar_item
+    {
+      title: t('layouts.course_admin.sidebar_settings.title'),
+      type: :settings,
+      controller: 'course/admin/sidebar_settings',
+      action: 'edit',
+      weight: 3
+    }
   end
 end

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -10,7 +10,6 @@ class Course::CoursesComponent < SimpleDelegator
   def admin_sidebar_items
     [
       {
-        key: :settings,
         title: t('layouts.course_admin.title'),
         type: :admin,
         weight: 4,
@@ -31,9 +30,8 @@ class Course::CoursesComponent < SimpleDelegator
     {
       title: t('layouts.course_admin.title'),
       type: :settings,
-      controller: 'course/admin/admin',
-      action: 'index',
-      weight: 1
+      weight: 1,
+      path: course_admin_path(current_course)
     }
   end
 
@@ -41,9 +39,8 @@ class Course::CoursesComponent < SimpleDelegator
     {
       title: t('layouts.course_admin.component_settings.title'),
       type: :settings,
-      controller: 'course/admin/component_settings',
-      action: 'edit',
-      weight: 2
+      weight: 2,
+      path: course_admin_components_path(current_course)
     }
   end
 
@@ -51,9 +48,8 @@ class Course::CoursesComponent < SimpleDelegator
     {
       title: t('layouts.course_admin.sidebar_settings.title'),
       type: :settings,
-      controller: 'course/admin/sidebar_settings',
-      action: 'edit',
-      weight: 3
+      weight: 3,
+      path: course_admin_sidebar_path(current_course)
     }
   end
 end

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -1,4 +1,4 @@
-class Course::CoursesComponent
+class Course::CoursesComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   sidebar do

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -1,7 +1,7 @@
 class Course::CoursesComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
-  sidebar do
+  def sidebar_items
     [
       {
         key: :settings,
@@ -13,7 +13,7 @@ class Course::CoursesComponent < SimpleDelegator
     ]
   end
 
-  settings do
+  def settings_items
     [
       {
         title: t('layouts.course_admin.title'),

--- a/app/controllers/components/course/groups_component.rb
+++ b/app/controllers/components/course/groups_component.rb
@@ -1,4 +1,4 @@
-class Course::GroupsComponent
+class Course::GroupsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   sidebar do

--- a/app/controllers/components/course/groups_component.rb
+++ b/app/controllers/components/course/groups_component.rb
@@ -1,7 +1,7 @@
 class Course::GroupsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
-  sidebar do
+  def sidebar_items
     [
       {
         key: :groups,

--- a/app/controllers/components/course/lesson_plan_component.rb
+++ b/app/controllers/components/course/lesson_plan_component.rb
@@ -1,4 +1,4 @@
-class Course::LessonPlanComponent
+class Course::LessonPlanComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   sidebar do

--- a/app/controllers/components/course/lesson_plan_component.rb
+++ b/app/controllers/components/course/lesson_plan_component.rb
@@ -1,7 +1,7 @@
 class Course::LessonPlanComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
-  sidebar do
+  def sidebar_items
     [
       {
         key: :lesson_plan,

--- a/app/controllers/components/course/levels_component.rb
+++ b/app/controllers/components/course/levels_component.rb
@@ -1,7 +1,7 @@
 class Course::LevelsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
-  sidebar do
+  def sidebar_items
     [
       {
         key: :levels,

--- a/app/controllers/components/course/levels_component.rb
+++ b/app/controllers/components/course/levels_component.rb
@@ -1,4 +1,4 @@
-class Course::LevelsComponent
+class Course::LevelsComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   sidebar do

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -1,7 +1,7 @@
 class Course::UsersComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
-  sidebar do
+  def sidebar_items
     [
       {
         key: :users,

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -4,12 +4,10 @@ class Course::UsersComponent < SimpleDelegator
   def sidebar_items
     [
       {
-        key: :users,
         title: t('layouts.course_users.title'),
         type: :admin,
         weight: 1,
-        path: course_users_students_path(current_course),
-        action: 'students'
+        path: course_users_students_path(current_course)
       }
     ]
   end

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -1,4 +1,4 @@
-class Course::UsersComponent
+class Course::UsersComponent < SimpleDelegator
   include Course::ComponentHost::Component
 
   sidebar do

--- a/app/controllers/course/admin/sidebar_settings_controller.rb
+++ b/app/controllers/course/admin/sidebar_settings_controller.rb
@@ -17,8 +17,7 @@ class Course::Admin::SidebarSettingsController < Course::Admin::Controller
 
   # Load our settings adapter to handle component settings
   def load_settings
-    @settings = Course::Settings::Sidebar.new(current_course.settings,
-                                              all_sidebar_items(type: :normal))
+    @settings = Course::Settings::Sidebar.new(current_course.settings, sidebar_items(type: :normal))
   end
 
   def settings_sidebar_params #:nodoc:

--- a/app/models/course/settings/sidebar_item.rb
+++ b/app/models/course/settings/sidebar_item.rb
@@ -23,6 +23,7 @@ class Course::Settings::SidebarItem
 
   # @return [Fixnum] The weight of the item.
   def weight
-    @settings.settings(id).weight || @sidebar_item[:weight]
+    result = @settings.settings(id).weight if id
+    result || @sidebar_item[:weight]
   end
 end

--- a/app/views/course/admin/component_settings/edit.html.slim
+++ b/app/views/course/admin/component_settings/edit.html.slim
@@ -5,7 +5,7 @@
       th = t('.name')
       th = t('.enabled')
     tbody
-      - instance_components = controller.current_component_host.instance_components
+      - instance_components = controller.current_component_host.instance_enabled_components
       - collection = instance_components.map { |c| [c.name, c.key.to_s] }
       = f.collection_check_boxes :enabled_component_ids, collection, :last, :first do |f|
         tr

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -5,9 +5,9 @@
     div.col-lg-2.col-md-3.col-sm-4
       nav role='navigation'
         div.collapse.navbar-collapse#course-navigation-navbar
-          = sidebar_items(controller.ordered_sidebar_items(type: :normal))
+          = sidebar_items(controller.sidebar_items(type: :normal))
           h5 = t('.administration')
-          = sidebar_items(controller.ordered_sidebar_items(type: :admin))
+          = sidebar_items(controller.sidebar_items(type: :admin))
 
     div.col-lg-10.col-md-9.col-sm-8
       = yield

--- a/app/views/layouts/course_admin.html.slim
+++ b/app/views/layouts/course_admin.html.slim
@@ -1,9 +1,5 @@
 = render within_layout: controller.parent_layout(of_layout: 'course_admin') do
-  ul.nav.nav-tabs role='tablist'
+  = tabs do
     - controller.sidebar_items(type: :settings).each do |item|
-      - if item[:controller].to_s == params[:controller]
-        = content_tag(:li, link_to(t(item[:title]), '#'), class: 'active')
-      - else
-        = content_tag(:li, link_to(t(item[:title]), controller: item[:controller],
-                      action: item[:action]))
+      = nav_to(item[:title], item[:path])
   = yield

--- a/app/views/layouts/course_admin.html.slim
+++ b/app/views/layouts/course_admin.html.slim
@@ -1,6 +1,6 @@
 = render within_layout: controller.parent_layout(of_layout: 'course_admin') do
   ul.nav.nav-tabs role='tablist'
-    - controller.settings.each do |item|
+    - controller.sidebar_items(type: :settings).each do |item|
       - if item[:controller].to_s == params[:controller]
         = content_tag(:li, link_to(t(item[:title]), '#'), class: 'active')
       - else

--- a/spec/components/course/component_host_spec.rb
+++ b/spec/components/course/component_host_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Course::ComponentHost, type: :controller do
       describe '#components' do
         subject { component_host.components }
 
+        it 'includes instances of every enabled component' do
+          expect(subject.map(&:class)).to contain_exactly(*component_host.enabled_components)
+        end
+      end
+
+      describe '#enabled_components' do
+        subject { component_host.enabled_components }
+
         context 'without preferences' do
           it 'returns the default enabled components' do
             expect(subject.count).to eq(default_enabled_components.count)

--- a/spec/components/course/component_host_spec.rb
+++ b/spec/components/course/component_host_spec.rb
@@ -98,13 +98,6 @@ RSpec.describe Course::ComponentHost, type: :controller do
           expect(component_host.sidebar_items).to eq([])
         end
       end
-
-      describe '#settings' do
-        it 'returns an empty array when no components included' do
-          allow(controller).to receive(:settings).and_return([])
-          expect(controller.settings).to eq([])
-        end
-      end
     end
   end
 end

--- a/spec/components/course/component_host_spec.rb
+++ b/spec/components/course/component_host_spec.rb
@@ -1,11 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Course::ComponentHost, type: :controller do
+  controller do
+  end
+
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do
     describe 'component preferences' do
       let(:course) { create(:course, instance: instance) }
-      let(:component_host) { Course::ComponentHost.new(instance.settings, course.settings) }
+      let(:component_host) do
+        Course::ComponentHost.new(instance.settings, course.settings, controller)
+      end
       let(:default_enabled_components) do
         Course::ComponentHost.components.select(&:enabled_by_default?)
       end
@@ -76,6 +81,20 @@ RSpec.describe Course::ComponentHost, type: :controller do
               expect(subject.include?(sample_component)).to be_falsey
             end
           end
+        end
+      end
+
+      describe '#sidebar_items' do
+        it 'returns an empty array when no components included' do
+          allow(component_host).to receive(:components).and_return([])
+          expect(component_host.sidebar_items).to eq([])
+        end
+      end
+
+      describe '#settings' do
+        it 'returns an empty array when no components included' do
+          allow(controller).to receive(:settings).and_return([])
+          expect(controller.settings).to eq([])
         end
       end
     end

--- a/spec/components/course/component_host_spec.rb
+++ b/spec/components/course/component_host_spec.rb
@@ -23,6 +23,29 @@ RSpec.describe Course::ComponentHost, type: :controller do
         end
       end
 
+      describe '#[]' do
+        subject { component_host }
+
+        context 'when the key specified does not exist' do
+          it 'returns nil' do
+            expect(subject['i_do_not_exist']).to be_nil
+          end
+        end
+
+        context 'when the key provided is a string' do
+          it 'returns the correct component' do
+            expect(subject['dummy_course_module']).to be_a(DummyCourseModule)
+          end
+        end
+
+        context 'when the key provided is a symbol' do
+          it 'returns the correct component' do
+            expect(subject[:dummy_course_module]).to be_a(DummyCourseModule)
+          end
+        end
+        it ''
+      end
+
       describe '#enabled_components' do
         subject { component_host.enabled_components }
 

--- a/spec/components/course_components_spec.rb
+++ b/spec/components/course_components_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe 'Course Modules', type: :controller do
     before { allow(controller).to receive(:current_course).and_return(course) }
 
     it 'gathers all modules\' sidebar callbacks' do
-      expect(controller.all_sidebar_items(type: :normal)).to include(NORMAL_SIDEBAR_ITEM)
-      expect(controller.all_sidebar_items(type: :normal)).not_to include(ADMIN_SIDEBAR_ITEM)
-      expect(controller.all_sidebar_items(type: :admin)).to include(ADMIN_SIDEBAR_ITEM)
-      expect(controller.all_sidebar_items(type: :admin)).not_to include(NORMAL_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :normal)).to include(NORMAL_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :normal)).not_to include(ADMIN_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :admin)).to include(ADMIN_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :admin)).not_to include(NORMAL_SIDEBAR_ITEM)
     end
 
     it 'gathers all modules\' settings callback' do

--- a/spec/components/course_components_spec.rb
+++ b/spec/components/course_components_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe 'Course Modules', type: :controller do
   class DummyCourseModule
     include Course::ComponentHost::Component
 
+    def initialize(*)
+    end
+
     sidebar do
       [NORMAL_SIDEBAR_ITEM, ADMIN_SIDEBAR_ITEM]
     end

--- a/spec/components/course_components_spec.rb
+++ b/spec/components/course_components_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe 'Course Modules', type: :controller do
     def initialize(*)
     end
 
-    sidebar do
+    def sidebar_items
       [NORMAL_SIDEBAR_ITEM, ADMIN_SIDEBAR_ITEM]
     end
 
-    settings do
+    def settings_items
       [EXPECTED_SETTINGS_ITEM]
     end
   end

--- a/spec/components/course_components_spec.rb
+++ b/spec/components/course_components_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe 'Course Modules', type: :controller do
     unread: -1
   }
 
-  EXPECTED_SETTINGS_ITEM = {
+  SETTINGS_SIDEBAR_ITEM = {
     title: 'DummyCourseModule',
+    type: :settings,
     controller: :'course/admin/admin',
     action: :index,
     weight: 1
@@ -34,11 +35,7 @@ RSpec.describe 'Course Modules', type: :controller do
     end
 
     def sidebar_items
-      [NORMAL_SIDEBAR_ITEM, ADMIN_SIDEBAR_ITEM]
-    end
-
-    def settings_items
-      [EXPECTED_SETTINGS_ITEM]
+      [NORMAL_SIDEBAR_ITEM, ADMIN_SIDEBAR_ITEM, SETTINGS_SIDEBAR_ITEM]
     end
   end
 
@@ -50,12 +47,13 @@ RSpec.describe 'Course Modules', type: :controller do
     it 'gathers all modules\' sidebar callbacks' do
       expect(controller.sidebar_items(type: :normal)).to include(NORMAL_SIDEBAR_ITEM)
       expect(controller.sidebar_items(type: :normal)).not_to include(ADMIN_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :normal)).not_to include(SETTINGS_SIDEBAR_ITEM)
       expect(controller.sidebar_items(type: :admin)).to include(ADMIN_SIDEBAR_ITEM)
       expect(controller.sidebar_items(type: :admin)).not_to include(NORMAL_SIDEBAR_ITEM)
-    end
-
-    it 'gathers all modules\' settings callback' do
-      expect(controller.settings).to include(EXPECTED_SETTINGS_ITEM)
+      expect(controller.sidebar_items(type: :admin)).not_to include(SETTINGS_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :settings)).to include(SETTINGS_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :settings)).not_to include(ADMIN_SIDEBAR_ITEM)
+      expect(controller.sidebar_items(type: :settings)).not_to include(NORMAL_SIDEBAR_ITEM)
     end
   end
 end

--- a/spec/controllers/course/admin/component_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/component_settings_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Course::Admin::ComponentSettingsController, type: :controller do
     describe '#update' do
       let(:ids_to_enable) do
         allow(controller).to receive(:current_course).and_return(course)
-        all_components = controller.current_component_host.instance_components
+        all_components = controller.current_component_host.instance_enabled_components
         all_component_ids = all_components.map { |c| c.key.to_s }
         all_component_ids.sample(1 + rand(all_component_ids.count))
       end

--- a/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Course::Admin::SidebarSettingsController, type: :controller do
 
     describe '#update' do
       before { allow(controller).to receive(:current_course).and_return(course) }
-      let(:sample_item) { controller.all_sidebar_items(type: :normal).sample }
+      let(:sample_item) { controller.sidebar_items(type: :normal).sample }
       let(:weight) { 10 }
       let(:sidebar_item_attributes) do
         id = generate(:nested_attribute_new_id)
@@ -43,14 +43,13 @@ RSpec.describe Course::Admin::SidebarSettingsController, type: :controller do
 
       context 'when the weight is the heaviest' do
         let(:weight) do
-          heaviest_item = controller.all_sidebar_items(type: :normal).
-                          max_by { |item| item[:weight] }
+          heaviest_item = controller.sidebar_items(type: :normal).max_by { |item| item[:weight] }
           heaviest_item[:weight] + 1
         end
 
         it 'reorders the item to the bottom' do
           subject
-          last_item = controller.ordered_sidebar_items(type: :normal).last
+          last_item = controller.sidebar_items(type: :normal).last
           expect(last_item[:key]).to eq(sample_item[:key])
         end
       end

--- a/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Course::Admin::SidebarSettingsController, type: :controller do
 
       context 'when the weight is the heaviest' do
         let(:weight) do
-          heaviest_item = controller.sidebar_items(type: :normal).max_by { |item| item[:weight] }
+          heaviest_item = controller.current_component_host.sidebar_items.
+                          max_by { |item| item[:weight] }
           heaviest_item[:weight] + 1
         end
 

--- a/spec/controllers/course/controller_spec.rb
+++ b/spec/controllers/course/controller_spec.rb
@@ -58,36 +58,22 @@ RSpec.describe Course::Controller, type: :controller do
       end
     end
 
-    describe '#all_sidebar_items' do
-      it 'returns an empty array when no components included' do
-        allow(controller).to receive_message_chain('current_component_host.components').
-          and_return([])
-        expect(controller.all_sidebar_items).to eq([])
-      end
-    end
-
-    describe '#ordered_sidebar_items' do
+    describe '#sidebar_items' do
       it 'orders the sidebar items by ascending weight' do
         allow(controller).to receive(:current_course).and_return(course)
-        weights = controller.ordered_sidebar_items.map { |item| item[:weight] }
+        weights = controller.sidebar_items.map { |item| item[:weight] }
         expect(weights.length).not_to eq(0)
         expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
       end
     end
 
     describe '#settings' do
-      it 'returns an empty array when no components included' do
-        allow(controller).to receive_message_chain('current_component_host.components').
-          and_return([])
-        expect(controller.settings).to eq([])
+      it 'orders the settings items by ascending weight' do
+        allow(controller).to receive(:current_course).and_return(course)
+        weights = controller.settings.map { |item| item[:weight] }
+        expect(weights.length).not_to eq(0)
+        expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
       end
-    end
-
-    it 'orders the settings items by ascending weight' do
-      allow(controller).to receive(:current_course).and_return(course)
-      weights = controller.settings.map { |item| item[:weight] }
-      expect(weights.length).not_to eq(0)
-      expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
     end
   end
 end

--- a/spec/controllers/course/controller_spec.rb
+++ b/spec/controllers/course/controller_spec.rb
@@ -66,14 +66,5 @@ RSpec.describe Course::Controller, type: :controller do
         expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
       end
     end
-
-    describe '#settings' do
-      it 'orders the settings items by ascending weight' do
-        allow(controller).to receive(:current_course).and_return(course)
-        weights = controller.settings.map { |item| item[:weight] }
-        expect(weights.length).not_to eq(0)
-        expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
-      end
-    end
   end
 end


### PR DESCRIPTION
The old design had all course component hosts exist as classes, and only class methods exist.

This created an asymmetry with the rest of the settings framework design -- there was a distinction between the class and instances of the class. This meant that the components that existed had to juggle state internally within a method.

Now there is a separation between the class (declaration) and the instance (instantiated during the execution of a controller). This allows components to access the controller which is handling the request (via a delegator.)

This is to allow components to be self-contained: they can manage their own configuration etc.