### PR TITLE
Polishing User Invitations

### DIFF
--- a/app/models/components/course/course_ability_component.rb
+++ b/app/models/components/course/course_ability_component.rb
@@ -29,11 +29,13 @@ module Course::CourseAbilityComponent
 
   def allow_owners_managing_course
     can :manage, Course, course_users: { user_id: user.id,
+                                         workflow_state: 'approved',
                                          role: [CourseUser.roles[:manager],
                                                 CourseUser.roles[:owner],
                                                 'manager', 'owner'] }
 
     can :manage, CourseUser, course: { course_users: { user_id: user.id,
+                                                       workflow_state: 'approved',
                                                        role: [CourseUser.roles[:manager],
                                                               CourseUser.roles[:owner],
                                                               'manager', 'owner'] } }
@@ -41,9 +43,10 @@ module Course::CourseAbilityComponent
 
   def allow_staff_manage_users
     can [:show_users, :manage_users], Course,
-        course_users: { user_id: user.id, role: [CourseUser.roles[:manager],
-                                                 CourseUser.roles[:owner],
-                                                 CourseUser.roles[:teaching_assistant],
-                                                 'manager', 'owner', 'teaching_assistant'] }
+        course_users: { user_id: user.id, workflow_state: 'approved',
+                        role: [CourseUser.roles[:manager],
+                               CourseUser.roles[:owner],
+                               CourseUser.roles[:teaching_assistant],
+                               'manager', 'owner', 'teaching_assistant'] }
   end
 end

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -20,9 +20,9 @@ div.users
             = f.error_notification
             = f.error :course_user
             tr
-              th = f.input :name
+              th = f.input :name, label: false
               td = f.object.user.email
-              td = f.input :role, as: :select, collection: CourseUser.roles.keys
+              td = f.input :role, as: :select, collection: CourseUser.roles.keys, label: false
               td = f.input :phantom
               td
                 = f.button :submit do

--- a/app/views/course/users/students.html.slim
+++ b/app/views/course/users/students.html.slim
@@ -19,9 +19,9 @@ div.users
             = f.error_notification
             = f.error :course_user
             tr
-              th = f.input :name
+              th = f.input :name, label: false
               td = f.object.user.email
-              td = f.input :phantom
+              td = f.input :phantom, label: false
               td
                 = f.button :submit do
                   = fa_icon :save

--- a/spec/controllers/course/user_invitations_controller_spec.rb
+++ b/spec/controllers/course/user_invitations_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Course::UserInvitationsController, type: :controller do
       subject { post :create, course_id: course, course: invite_params }
 
       context 'when a course manager visits the page' do
-        let!(:course_lecturer) { create(:course_manager, course: course, user: user) }
+        let!(:course_lecturer) { create(:course_manager, :approved, course: course, user: user) }
 
         it { is_expected.to redirect_to(course_users_invitations_path(course)) }
 

--- a/spec/controllers/course/user_registrations_controller_spec.rb
+++ b/spec/controllers/course/user_registrations_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
           end
 
           context 'when the user is a manager of the course' do
-            let!(:course_manager) { create(:course_manager, course: course, user: user) }
+            let!(:course_manager) { create(:course_manager, :approved, course: course, user: user) }
 
             it { expect { subject }.not_to change { course.course_users.reload.count } }
             it { is_expected.to redirect_to(course_path(course)) }

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Course::UsersController, type: :controller do
       subject { get :students, course_id: course }
 
       context 'when a course manager visits the page' do
-        let!(:course_lecturer) { create(:course_manager, course: course, user: user) }
+        let!(:course_lecturer) { create(:course_manager, :approved, course: course, user: user) }
 
         it { is_expected.to render_template(:students) }
       end
@@ -37,7 +37,7 @@ RSpec.describe Course::UsersController, type: :controller do
       subject { get :staff, course_id: course }
 
       context 'when a course manager visits the page' do
-        let!(:course_lecturer) { create(:course_manager, course: course, user: user) }
+        let!(:course_lecturer) { create(:course_manager, :approved, course: course, user: user) }
 
         it { is_expected.to render_template(:staff) }
       end
@@ -59,7 +59,10 @@ RSpec.describe Course::UsersController, type: :controller do
       let(:updated_course_user) { { role: :teaching_assistant } }
 
       context 'when the user is a manager' do
-        let!(:course_user) { create(:course_manager, course: course, user: user) }
+        let!(:logged_in_course_user) do
+          create(:course_manager, :approved, course: course, user: user)
+        end
+        let(:course_user) { create(:course_manager, course: course) }
 
         it 'updates the Course User' do
           expect { subject }.to change { course_user.reload.role }.to('teaching_assistant')
@@ -113,7 +116,7 @@ RSpec.describe Course::UsersController, type: :controller do
       let!(:course_user_to_delete) { create(:course_user, course: course, user: create(:user)) }
 
       context 'when the user is a manager' do
-        let!(:course_user) { create(:course_manager, course: course, user: user) }
+        let!(:course_user) { create(:course_manager, :approved, course: course, user: user) }
 
         it 'destroys the registration record' do
           expect { subject }.to change { course.course_users.reload.count }.by(-1)

--- a/spec/features/course/student_management_spec.rb
+++ b/spec/features/course/student_management_spec.rb
@@ -36,10 +36,10 @@ RSpec.feature 'Courses: Students' do
 
       visit course_users_students_path(course)
       within find_field('course_user_name', with: user_to_change.name).find(:xpath, '../../..') do
-        check 'phantom'
+        check 'course_user_phantom'
         click_button 'submit'
 
-        expect(page).to have_checked_field('phantom')
+        expect(page).to have_checked_field('course_user_phantom')
       end
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Course, type: :model do
       let(:course) { create(:course, creator: owner, updater: owner) }
       let(:course_owner) { course.course_users.find_by!(user: owner) }
       let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
-      let(:manager) { create(:course_manager, course: course) }
+      let(:manager) { create(:course_manager, :approved, course: course) }
 
       it 'returns all the staff in course' do
         expect(course.staff).to contain_exactly(teaching_assistant, manager, course_owner)


### PR DESCRIPTION
 - Remove unnecessary labels.
 - Grant users staff abilities when they are approved.

Fixes #223.