### PR TITLE
Handle access denied errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ Write your tests to be as compartmentalised from other tests as possible. Compar
 are those that do not depend on any external state to run. This would allow tests to be run in
 parallel.
 
+In Rails, controller specs will always execute the `rescue_from` handlers. In our specs, we 
+disable that by default; to execute controllers with the handlers enabled, declare `run_rescue` 
+within the example group.
+
 ## Developer Tools
 The project's Gemfile contains a few developer tools to help keep the project tidy:
 

--- a/app/controllers/concerns/application_user_concern.rb
+++ b/app/controllers/concerns/application_user_concern.rb
@@ -3,11 +3,17 @@ module ApplicationUserConcern
 
   included do
     before_action :authenticate_user!, unless: :publicly_accessible?
+    rescue_from CanCan::AccessDenied, with: :handle_access_denied
   end
 
-  private
+  protected
 
   def publicly_accessible?
     is_a?(HighVoltage::PagesController)
+  end
+
+  def handle_access_denied(exception)
+    @exception = exception
+    render 'pages/403', status: 403
   end
 end

--- a/app/views/pages/403.html.slim
+++ b/app/views/pages/403.html.slim
@@ -1,0 +1,3 @@
+div.page-header
+  h1 = t('pages.403.header')
+p = simple_format(@exception.message)

--- a/config/locales/en/pages/403.yml
+++ b/config/locales/en/pages/403.yml
@@ -1,0 +1,4 @@
+en:
+  pages:
+    '403':
+      header: 'Access Denied'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe ApplicationController, type: :controller do
 
   describe ApplicationUserConcern do
     context 'when the action raises a CanCan::AccessDenied' do
+      run_rescue
+
       it 'renders the access denied page to /pages/403' do
         post :create
         expect(response).to render_template('pages/403')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe ApplicationController, type: :controller do
     def index
       redirect_to '/'
     end
+
+    def create
+      fail CanCan::AccessDenied
+    end
+
+    def publicly_accessible?
+      true
+    end
   end
 
   describe ApplicationMultitenancyConcern do
@@ -40,7 +48,7 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  describe 'internationalization' do
+  describe ApplicationInternationalizationConcern do
     before { @old_i18n_locale = I18n.locale }
     after { I18n.locale = @old_i18n_locale }
 
@@ -103,6 +111,20 @@ RSpec.describe ApplicationController, type: :controller do
     context 'when the instance does not have a theme' do
       it 'uses the default theme' do
         expect(controller.send(:deduce_theme)).to eq('default')
+      end
+    end
+  end
+
+  describe ApplicationUserConcern do
+    context 'when the action raises a CanCan::AccessDenied' do
+      it 'renders the access denied page to /pages/403' do
+        post :create
+        expect(response).to render_template('pages/403')
+      end
+
+      it 'returns HTTP status 403' do
+        post :create
+        expect(response.status).to eq(403)
       end
     end
   end

--- a/spec/features/course/staff_management_spec.rb
+++ b/spec/features/course/staff_management_spec.rb
@@ -18,7 +18,8 @@ RSpec.feature 'Courses: Staff Management' do
       end
 
       scenario 'Teaching assistants cannot access the staff list' do
-        expect { visit course_users_staff_path(course) }.to raise_error(CanCan::AccessDenied)
+        visit course_users_staff_path(course)
+        expect(page.status_code).to eq(403)
       end
     end
 

--- a/spec/support/controller_exceptions.rb
+++ b/spec/support/controller_exceptions.rb
@@ -1,0 +1,23 @@
+module ControllerExceptions; end
+
+# Test group helpers for allowing exceptions from controller tests to be caught by specs.
+module ControllerExceptions::TestGroupHelpers
+  BYPASS_RESCUE_CONSTANT_NAME = :__controller_exceptions_test_group_helpers_bypass_rescue
+
+  def self.extended(module_)
+    module_.module_eval do
+      let(BYPASS_RESCUE_CONSTANT_NAME) { true }
+      before(:each) do
+        bypass_rescue if send(BYPASS_RESCUE_CONSTANT_NAME)
+      end
+    end
+  end
+
+  def run_rescue
+    let(BYPASS_RESCUE_CONSTANT_NAME) { false }
+  end
+end
+
+RSpec.configure do |config|
+  config.extend ControllerExceptions::TestGroupHelpers, type: :controller
+end


### PR DESCRIPTION
So we don't allow `Cancan::AccessDenied` to bubble through to the exception handler.

This also changes controller specs never to swallow exceptions.