### PR TITLE
Implement conditions UI for achievements

### DIFF
--- a/app/controllers/concerns/course/achievement_conditional_concern.rb
+++ b/app/controllers/concerns/course/achievement_conditional_concern.rb
@@ -1,9 +1,22 @@
 module Course::AchievementConditionalConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :add_conditional_breadcrumbs
+  end
+
   def return_to_path
     edit_course_achievement_path(current_course, @conditional)
   end
 
   def set_conditional
     @conditional = Course::Achievement.find(params[:achievement_id])
+  end
+
+  private
+
+  def add_conditional_breadcrumbs
+    add_breadcrumb :index, :course_achievements_path
+    add_breadcrumb @conditional.title, edit_course_achievement_path(current_course, @conditional)
   end
 end

--- a/app/controllers/concerns/course/achievement_conditional_concern.rb
+++ b/app/controllers/concerns/course/achievement_conditional_concern.rb
@@ -1,6 +1,6 @@
 module Course::AchievementConditionalConcern
   def return_to_path
-    course_achievements_path(current_course)
+    edit_course_achievement_path(current_course, @conditional)
   end
 
   def set_conditional

--- a/app/controllers/course/condition/achievements_controller.rb
+++ b/app/controllers/course/condition/achievements_controller.rb
@@ -31,7 +31,7 @@ class Course::Condition::AchievementsController < Course::ConditionsController
     if @achievement_condition.destroy
       redirect_to return_to_path, success: t('course.condition.achievements.destroy.success')
     else
-      redirect_to return_to_path, alert: t('course.condition.achievements.destroy.error')
+      redirect_to return_to_path, danger: t('course.condition.achievements.destroy.error')
     end
   end
 

--- a/app/controllers/course/condition/achievements_controller.rb
+++ b/app/controllers/course/condition/achievements_controller.rb
@@ -38,6 +38,6 @@ class Course::Condition::AchievementsController < Course::ConditionsController
   private
 
   def achievement_condition_params
-    params.require(:course_condition_achievement).permit(:achievement_id)
+    params.require(:condition_achievement).permit(:achievement_id)
   end
 end

--- a/app/controllers/course/condition/levels_controller.rb
+++ b/app/controllers/course/condition/levels_controller.rb
@@ -37,6 +37,6 @@ class Course::Condition::LevelsController < Course::ConditionsController
   private
 
   def level_condition_params
-    params.require(:course_condition_level).permit(:minimum_level)
+    params.require(:condition_level).permit(:minimum_level)
   end
 end

--- a/app/controllers/course/condition/levels_controller.rb
+++ b/app/controllers/course/condition/levels_controller.rb
@@ -30,7 +30,7 @@ class Course::Condition::LevelsController < Course::ConditionsController
     if @level_condition.destroy
       redirect_to return_to_path, success: t('course.condition.levels.destroy.success')
     else
-      redirect_to return_to_path, alert: t('course.condition.levels.destroy.error')
+      redirect_to return_to_path, danger: t('course.condition.levels.destroy.error')
     end
   end
 

--- a/app/views/course/achievements/_form.html.slim
+++ b/app/views/course/achievements/_form.html.slim
@@ -7,7 +7,7 @@
 
   = f.input :published
 
-  - if @achievement && !@achievement.new_record?
+  - if @achievement.try(:persisted?)
     h2
       span = t('course.condition.header')
       div.dropdown.pull-right
@@ -33,4 +33,3 @@
                    locals: { course: current_course }
 
   = f.button :submit
-

--- a/app/views/course/achievements/_form.html.slim
+++ b/app/views/course/achievements/_form.html.slim
@@ -7,4 +7,30 @@
 
   = f.input :published
 
+  - if @achievement && !@achievement.new_record?
+    h2
+      span = t('course.condition.header')
+      div.dropdown.pull-right
+        button.btn.btn-primary.dropdown-toggle#new-condition-dropdown-btn [data-toggle="dropdown"
+                                                                           aria-haspopup="true"]
+          span = t('course.condition.new.header')
+        ul.dropdown-menu.dropdown-menu-right aria-labelledby="new-condition-dropdown-btn"
+          li = link_to t('course.condition.achievements.new.header'),
+                       new_course_achievement_condition_achievement_path(current_course,
+                                                                         @achievement)
+          li = link_to t('course.condition.levels.new.header'),
+                       new_course_achievement_condition_level_path(current_course,
+                                                                   @achievement)
+    table.table.table-hover
+      thead
+        tr
+          th = t('course.condition.type.header')
+          th = t('course.condition.description.header')
+      tbody
+        - @achievement.conditions.includes(:conditional).each do |condition|
+          = render object: condition,
+                   partial: condition.specific.class.name.underscore,
+                   locals: { course: current_course }
+
   = f.button :submit
+

--- a/app/views/course/condition/_achievement.html.slim
+++ b/app/views/course/condition/_achievement.html.slim
@@ -1,6 +1,6 @@
 = content_tag_for(:tr, achievement)
   td = t('course.condition.achievement')
-  td = achievement.specific.achievement.title
+  td.achievement-condition-content = achievement.specific.achievement.title
 
   td
     = edit_button([course, achievement.conditional, achievement.specific])

--- a/app/views/course/condition/_achievement.html.slim
+++ b/app/views/course/condition/_achievement.html.slim
@@ -1,0 +1,8 @@
+= content_tag_for(:tr, achievement)
+  td = t('course.condition.achievement')
+  td = achievement.specific.achievement.title
+
+  td
+    = edit_button([course, achievement.conditional, achievement.specific])
+    = delete_button([course, achievement.conditional, achievement.specific])
+

--- a/app/views/course/condition/_level.html.slim
+++ b/app/views/course/condition/_level.html.slim
@@ -1,6 +1,6 @@
 = content_tag_for(:tr, level)
   td = t('course.condition.level')
-  td = level.specific.minimum_level
+  td.level-condition-content = level.specific.minimum_level
 
   td
     = edit_button([course, level.conditional, level.specific])

--- a/app/views/course/condition/_level.html.slim
+++ b/app/views/course/condition/_level.html.slim
@@ -1,0 +1,8 @@
+= content_tag_for(:tr, level)
+  td = t('course.condition.level')
+  td = level.specific.minimum_level
+
+  td
+    = edit_button([course, level.conditional, level.specific])
+    = delete_button([course, level.conditional, level.specific])
+

--- a/app/views/course/condition/achievements/_achievement.html.slim
+++ b/app/views/course/condition/achievements/_achievement.html.slim
@@ -1,8 +1,0 @@
-= div_for(achievement)
-  label Achievement
-  '
-  = achievement.achievement.title
-
-  = edit_button([:edit, course, conditional, :condition, achievement])
-  '
-  = delete_button([course, conditional, :condition, achievement])

--- a/app/views/course/condition/achievements/_form.html.slim
+++ b/app/views/course/condition/achievements/_form.html.slim
@@ -4,4 +4,4 @@
   = f.error :course_achievement_condition_achievement
   = f.input :achievement_id, collection: Course::Achievement.all
 
-  = f.submit
+  = f.button :submit

--- a/app/views/course/condition/achievements/edit.html.slim
+++ b/app/views/course/condition/achievements/edit.html.slim
@@ -1,3 +1,3 @@
 = page_header
 = render 'form'
-= link_to t('common.back'), return_to_path
+- add_breadcrumb t('course.condition.achievements.edit.header')

--- a/app/views/course/condition/achievements/new.html.slim
+++ b/app/views/course/condition/achievements/new.html.slim
@@ -1,3 +1,3 @@
 = page_header
 = render 'form'
-= link_to t('common.back'), return_to_path
+- add_breadcrumb t('course.condition.achievements.new.header')

--- a/app/views/course/condition/levels/_form.html.slim
+++ b/app/views/course/condition/levels/_form.html.slim
@@ -4,4 +4,4 @@
   = f.error :course_achievement_condition_level
   = f.input :minimum_level, as: :integer, input_html: { min: '1', step: 'any' }
 
-  = f.submit
+  = f.button :submit

--- a/app/views/course/condition/levels/_level.html.slim
+++ b/app/views/course/condition/levels/_level.html.slim
@@ -1,8 +1,0 @@
-= div_for(level)
-  label Level
-  '
-  = level.minimum_level
-
-  = edit_button([:edit, course, conditional, :condition, level])
-  '
-  = delete_button([course, conditional, :condition, level])

--- a/app/views/course/condition/levels/edit.html.slim
+++ b/app/views/course/condition/levels/edit.html.slim
@@ -1,3 +1,3 @@
 = page_header
 = render 'form'
-= link_to t('common.back'), return_to_path
+- add_breadcrumb t('course.condition.levels.edit.header')

--- a/app/views/course/condition/levels/new.html.slim
+++ b/app/views/course/condition/levels/new.html.slim
@@ -1,3 +1,3 @@
 = page_header
 = render 'form'
-= link_to t('common.back'), return_to_path
+- add_breadcrumb t('course.condition.levels.new.header')

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -95,6 +95,8 @@ ignore_unused:
 - 'simple_form.{yes,no}'
 - 'simple_form.{placeholders,hints,labels}.*'
 - 'simple_form.{error_notification,required}.:'
+- 'helpers.submit.*.create'
+- 'helpers.submit.*.update'
 # Keys used dynamically by the page_header helper
 - '*.*.header'
 

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -25,6 +25,12 @@ en:
       announcements:
         index: :'course.announcements.index.header'
         new: :'course.announcements.new.header'
+      achievement:
+        condition:
+          levels:
+            index: :'course.achievements.index.header'
+          achievements:
+            index: :'course.achievements.index.header'
       achievements:
         index: :'course.achievements.index.header'
         new: :'course.achievements.new.header'

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -11,6 +11,13 @@ en:
     plain_text_link: '%{text} (%{url})'
     time_range: '%{from} to %{to}'
   helpers:
+    submit:
+      condition_level:
+        create: 'Create Level Condition'
+        update: 'Update Level Condition'
+      condition_achievement:
+        create: 'Create Achievement Condition'
+        update: 'Update Achievement Condition'
     buttons:
       new: 'New %{model}'
       edit: 'Edit %{model}'

--- a/config/locales/en/course/condition/achievements.yml
+++ b/config/locales/en/course/condition/achievements.yml
@@ -1,6 +1,7 @@
 en:
   course:
     condition:
+      achievement: 'Achievement'
       achievements:
         new:
           header: 'New Achievement Condition'

--- a/config/locales/en/course/condition/condition.yml
+++ b/config/locales/en/course/condition/condition.yml
@@ -1,0 +1,10 @@
+en:
+  course:
+    condition:
+      header: 'Conditions'
+      new:
+        header: 'New...'
+      type:
+        header: 'Type'
+      description:
+        header: 'Description'

--- a/config/locales/en/course/condition/levels.yml
+++ b/config/locales/en/course/condition/levels.yml
@@ -1,6 +1,7 @@
 en:
   course:
     condition:
+      level: 'Level'
       levels:
         new:
           header: 'New Level Condition'

--- a/spec/controllers/course/achievement_condition_achievements_controller_spec.rb
+++ b/spec/controllers/course/achievement_condition_achievements_controller_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
   let!(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:administrator) }
-    let!(:course) { create(:course) }
+    let(:user) { create(:administrator) }
+    let(:course) { create(:course) }
 
     before { sign_in(user) }
 
@@ -15,7 +15,7 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
           allow(stub).to receive(:destroy).and_return(false)
         end
       end
-      let!(:achievement) do
+      let(:achievement) do
         create(:course_achievement,
                course: course,
                conditions: [achievement_condition])
@@ -28,7 +28,7 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
                id: achievement_condition
       end
 
-      context 'upon destroy failure' do
+      context 'when destroy fails' do
         before do
           controller.instance_variable_set(:@achievement_condition, achievement_condition)
           controller.instance_variable_set(:@conditional, achievement)
@@ -48,7 +48,7 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
           allow(stub).to receive(:save).and_return(false)
         end
       end
-      let!(:achievement) do
+      let(:achievement) do
         create(:course_achievement,
                course: course,
                conditions: [achievement_condition])
@@ -60,7 +60,7 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
              achievement_id: achievement
       end
 
-      context 'upon create failure' do
+      context 'when create fails' do
         before do
           controller.instance_variable_set(:@achievement_condition, achievement_condition)
           controller.instance_variable_set(:@conditional, achievement)
@@ -80,7 +80,7 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
           allow(stub).to receive(:update).and_return(false)
         end
       end
-      let!(:achievement) do
+      let(:achievement) do
         create(:course_achievement,
                course: course,
                conditions: [achievement_condition])
@@ -94,7 +94,7 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
               condition_achievement: { achievement_id: achievement.id }
       end
 
-      context 'upon update failure' do
+      context 'when update fails' do
         before do
           controller.instance_variable_set(:@achievement_condition, achievement_condition)
           controller.instance_variable_set(:@conditional, achievement)

--- a/spec/controllers/course/achievement_condition_achievements_controller_spec.rb
+++ b/spec/controllers/course/achievement_condition_achievements_controller_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe Course::Achievement::Condition::AchievementsController, type: :controller do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:administrator) }
+    let!(:course) { create(:course) }
+
+    before { sign_in(user) }
+
+    describe '#destroy' do
+      let(:achievement_condition) do
+        create(:course_condition_achievement, course: course).tap do |stub|
+          allow(stub).to receive(:destroy).and_return(false)
+        end
+      end
+      let!(:achievement) do
+        create(:course_achievement,
+               course: course,
+               conditions: [achievement_condition])
+      end
+
+      subject do
+        delete :destroy,
+               course_id: course,
+               achievement_id: achievement,
+               id: achievement_condition
+      end
+
+      context 'upon destroy failure' do
+        before do
+          controller.instance_variable_set(:@achievement_condition, achievement_condition)
+          controller.instance_variable_set(:@conditional, achievement)
+          subject
+        end
+
+        it 'redirects with a flash message' do
+          it { is_expected.to redirect_to(edit_course_achievement_path(course, achievement)) }
+          expect(flash[:danger]).to eq(I18n.t('course.condition.achievements.destroy.error'))
+        end
+      end
+    end
+
+    describe '#create' do
+      let(:achievement_condition) do
+        create(:course_condition_achievement, course: course).tap do |stub|
+          allow(stub).to receive(:save).and_return(false)
+        end
+      end
+      let!(:achievement) do
+        create(:course_achievement,
+               course: course,
+               conditions: [achievement_condition])
+      end
+
+      subject do
+        post :create,
+             course_id: course,
+             achievement_id: achievement
+      end
+
+      context 'upon create failure' do
+        before do
+          controller.instance_variable_set(:@achievement_condition, achievement_condition)
+          controller.instance_variable_set(:@conditional, achievement)
+          subject
+        end
+
+        it 'redirects' do
+          path = new_course_achievement_condition_achievement_path(course, achievement,
+                                                                   achievement_condition)
+          it { is_expected.to redirect_to(path) }
+        end
+      end
+    end
+    describe '#update' do
+      let(:achievement_condition) do
+        create(:course_condition_achievement, course: course).tap do |stub|
+          allow(stub).to receive(:update).and_return(false)
+        end
+      end
+      let!(:achievement) do
+        create(:course_achievement,
+               course: course,
+               conditions: [achievement_condition])
+      end
+
+      subject do
+        patch :update,
+              course_id: course,
+              achievement_id: achievement,
+              id: achievement_condition,
+              condition_achievement: { achievement_id: achievement.id }
+      end
+
+      context 'upon update failure' do
+        before do
+          controller.instance_variable_set(:@achievement_condition, achievement_condition)
+          controller.instance_variable_set(:@conditional, achievement)
+          subject
+        end
+
+        it 'redirects' do
+          path = edit_course_achievement_condition_achievement_path(course, achievement,
+                                                                    achievement_condition)
+          it { is_expected.to redirect_to(path) }
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/achievement_condition_levels_controller_spec.rb
+++ b/spec/controllers/course/achievement_condition_levels_controller_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe Course::Achievement::Condition::LevelsController, type: :controller do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:administrator) }
+    let!(:course) { create(:course) }
+
+    before { sign_in(user) }
+
+    describe '#destroy' do
+      let(:level_condition) do
+        create(:course_condition_level, course: course).tap do |stub|
+          allow(stub).to receive(:destroy).and_return(false)
+        end
+      end
+      let!(:achievement) do
+        create(:course_achievement,
+               course: course,
+               conditions: [level_condition])
+      end
+
+      subject do
+        delete :destroy,
+               course_id: course,
+               achievement_id: achievement,
+               id: level_condition
+      end
+
+      context 'upon destroy failure' do
+        before do
+          controller.instance_variable_set(:@level_condition, level_condition)
+          controller.instance_variable_set(:@conditional, achievement)
+          subject
+        end
+
+        it 'redirects with a flash message' do
+          it { is_expected.to redirect_to(edit_course_achievement_path(course, achievement)) }
+          expect(flash[:danger]).to eq(I18n.t('course.condition.levels.destroy.error'))
+        end
+      end
+    end
+
+    describe '#create' do
+      let(:level_condition) do
+        create(:course_condition_level, course: course).tap do |stub|
+          allow(stub).to receive(:save).and_return(false)
+        end
+      end
+      let!(:achievement) do
+        create(:course_achievement,
+               course: course,
+               conditions: [level_condition])
+      end
+
+      subject do
+        post :create,
+             course_id: course,
+             achievement_id: achievement
+      end
+
+      context 'upon create failure' do
+        before do
+          controller.instance_variable_set(:@level_condition, level_condition)
+          controller.instance_variable_set(:@conditional, achievement)
+          subject
+        end
+
+        it 'redirects' do
+          path = new_course_achievement_condition_level_path(course, achievement, level_condition)
+          it { is_expected.to redirect_to(path) }
+        end
+      end
+    end
+    describe '#update' do
+      let(:min_level) { 7 }
+      let(:level_condition) do
+        create(:course_condition_level, course: course, minimum_level: min_level).tap do |stub|
+          allow(stub).to receive(:update).and_return(false)
+        end
+      end
+      let!(:achievement) do
+        create(:course_achievement,
+               course: course,
+               conditions: [level_condition])
+      end
+
+      subject do
+        patch :update,
+              course_id: course,
+              achievement_id: achievement,
+              id: level_condition,
+              condition_level: { minimum_level: min_level }
+      end
+
+      context 'upon update failure' do
+        before do
+          controller.instance_variable_set(:@level_condition, level_condition)
+          controller.instance_variable_set(:@conditional, achievement)
+          subject
+        end
+
+        it 'redirects' do
+          path = edit_course_achievement_condition_level_path(course, achievement, level_condition)
+          it { is_expected.to redirect_to(path) }
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/achievement_condition_levels_controller_spec.rb
+++ b/spec/controllers/course/achievement_condition_levels_controller_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement::Condition::LevelsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:administrator) }
-    let!(:course) { create(:course) }
+    let(:user) { create(:administrator) }
+    let(:course) { create(:course) }
 
     before { sign_in(user) }
 
@@ -15,7 +15,7 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
           allow(stub).to receive(:destroy).and_return(false)
         end
       end
-      let!(:achievement) do
+      let(:achievement) do
         create(:course_achievement,
                course: course,
                conditions: [level_condition])
@@ -28,7 +28,7 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
                id: level_condition
       end
 
-      context 'upon destroy failure' do
+      context 'when destroy fails' do
         before do
           controller.instance_variable_set(:@level_condition, level_condition)
           controller.instance_variable_set(:@conditional, achievement)
@@ -60,7 +60,7 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
              achievement_id: achievement
       end
 
-      context 'upon create failure' do
+      context 'when create fails' do
         before do
           controller.instance_variable_set(:@level_condition, level_condition)
           controller.instance_variable_set(:@conditional, achievement)
@@ -73,6 +73,7 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
         end
       end
     end
+
     describe '#update' do
       let(:min_level) { 7 }
       let(:level_condition) do
@@ -94,7 +95,7 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
               condition_level: { minimum_level: min_level }
       end
 
-      context 'upon update failure' do
+      context 'when update fails' do
         before do
           controller.instance_variable_set(:@level_condition, level_condition)
           controller.instance_variable_set(:@conditional, achievement)

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -1,250 +1,186 @@
 require 'rails_helper'
 
-RSpec.describe 'Course: Achievements' do
-  subject { page }
-
+RSpec.feature 'Course: Achievements' do
   let!(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let!(:user) { create(:administrator) }
-    let!(:course) { create(:course) }
+    let(:user) { create(:administrator) }
+    let(:course) { create(:course) }
 
     before do
       login_as(user, scope: :user)
     end
 
-    describe 'creating achievements' do
-      before { visit new_course_achievement_path(course) }
-      subject { click_button I18n.t('helpers.submit.achievement.create') }
+    context 'As a Course Manager' do
 
-      context 'when creating an invalid achievement' do
-        before { subject }
+      scenario 'I can create an achievement' do
+        # Fields not yet filled
+        visit new_course_achievement_path(course)
+        click_button I18n.t('helpers.submit.achievement.create')
+        expect(page).to have_button(I18n.t('helpers.submit.achievement.create'))
+        expect(page).to have_css('div.has-error')
 
-        it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.achievement.create'))
-        end
-
-        it 'shows errors' do
-          expect(page).to have_css('div.has-error')
-        end
+        achievement = build(:course_achievement, course: course)
+        fill_in 'achievement_title', with: achievement.title
+        fill_in 'achievement_description', with: achievement.description
+        expect do
+          click_button I18n.t('helpers.submit.achievement.create')
+        end.to change(course.achievements, :count).by(1)
+        expect(page).to have_selector('div', text: I18n.t('course.achievements.create.success'))
+        expect(current_path).to eq(course_achievements_path(course))
       end
 
-      context 'when creating a valid achievement' do
-        let(:achievement) { build(:course_achievement, course: course) }
-
-        before do
-          fill_in 'achievement_title',    with: achievement.title
-          fill_in 'achievement_description',  with: achievement.description
-        end
-
-        it 'creates an achievement' do
-          expect { subject }.to change(course.achievements, :count).by(1)
-        end
-
-        context 'when creation succeeds' do
-          before { subject }
-
-          it 'shows the success message' do
-            expect(page).to have_selector('div', text: I18n.t('course.achievements.create.success'))
-          end
-
-          it 'redirects the user to the index page' do
-            expect(current_path).to eq(course_achievements_path(course))
-          end
-        end
-      end
-    end
-
-    describe 'editing achievements' do
-      let!(:achievement) { create(:course_achievement, course: course) }
-
-      before { visit edit_course_achievement_path(course, achievement) }
-
-      context 'when editing an achievement' do
-        it { is_expected.to have_field('achievement_title', with: achievement.title) }
-        it 'shows achievement description' do
-          expect(page).to have_field('achievement_description',
-                                     with: achievement.description)
-        end
-        it { is_expected.to have_checked_field('achievement_published') }
-      end
-
-      context 'when fields are invalid' do
-        before do
-          fill_in 'achievement_title', with: ''
-          subject
-        end
-        subject { click_button I18n.t('helpers.submit.achievement.update') }
-
-        it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.achievement.update'))
-        end
-
-        it 'shows errors' do
-          expect(page).to have_css('div.has-error')
-        end
-      end
-
-      context 'when fields are valid' do
-        let(:new_title)  { 'New Title' }
-        let(:new_description) { 'New description' }
-
-        before do
-          fill_in 'achievement_title',        with: new_title
-          fill_in 'achievement_description',      with: new_description
-          click_button I18n.t('helpers.submit.achievement.update')
-        end
-
-        it 'redirects the user to index page' do
-          expect(current_path).to eq course_achievements_path(course)
-        end
-
-        it 'shows the success message' do
-          expect(page).to have_selector('div', I18n.t('course.achievements.update.success'))
-        end
-
-        it 'changes the attributes' do
-          expect(achievement.reload.title).to eq(new_title)
-          expect(achievement.reload.description).to eq(new_description)
-        end
-      end
-
-      context 'when managing achievement conditions' do
-        let(:achievement) { create(:course_achievement, course: course) }
-        it do
-          is_expected.to have_selector(:link_or_button,
-                                       I18n.t('course.condition.achievements.new.header'))
-        end
-        context 'when creating an achievement condition' do
-          before do
-            click_link I18n.t('course.condition.achievements.new.header')
-            expect(current_path).
-              to eq(new_course_achievement_condition_achievement_path(course, achievement))
-            find('#condition_achievement_achievement_id').
-              find(:css, "option[value='#{achievement.id}']").
-              select_option
-            click_button I18n.t('helpers.submit.condition_achievement.create')
-          end
-          it 'creates an achievement condition correctly' do
-            expect(current_path).to eq edit_course_achievement_path(course, achievement)
-            expect(page).to have_selector('tr.condition > td:nth-child(2)', text: achievement.title)
-          end
-        end
-        context 'when editing and deleting achievement conditions' do
-          let!(:achievement_which_is_condition) { create(:course_achievement, course: course) }
-          let(:achievement_condition) do
-            create(:course_condition_achievement,
-                   course: course, achievement: achievement_which_is_condition)
-          end
-          let!(:some_other_achievement) { create(:course_achievement, course: course) }
-          let!(:achievement) do
-            create(:course_achievement, course: course, conditions: [achievement_condition])
-          end
-
-          it 'editing an achievement condition' do
-            expect(current_path).to eq edit_course_achievement_path(course, achievement)
-            expect(page).to have_selector('tr.condition > td:nth-child(2)',
-                                          text: achievement_which_is_condition.title)
-            condition_edit_path =
-              edit_course_achievement_condition_achievement_path(course,
-                                                                 achievement,
-                                                                 achievement_condition)
-            find_link(nil, href: condition_edit_path).click
-
-            find('#condition_achievement_achievement_id').
-              find(:css, "option[value='#{some_other_achievement.id}']").
-              select_option
-            click_button I18n.t('helpers.submit.condition_achievement.update')
-            expect(current_path).to eq edit_course_achievement_path(course, achievement)
-            expect(page).to have_selector('tr.condition > td:nth-child(2)',
-                                          text: some_other_achievement.title)
-          end
-
-          it 'deleting an achievement condition' do
-            condition_delete_path =
-              course_achievement_condition_achievement_path(course, achievement,
-                                                            achievement_condition)
-            expect do
-              find_link(nil, href: condition_delete_path).click
-            end.to change { achievement.conditions.count }.by(-1)
-            expect(page).not_to have_selector('tr.condition > td:nth-child(2)',
-                                              text: achievement_which_is_condition.title)
-          end
-        end
-      end
-
-      context 'when managing level conditions' do
-        it do
-          is_expected.to have_selector(:link_or_button,
-                                       I18n.t('course.condition.levels.new.header'))
-        end
-        context 'when creating a level condition' do
-          before do
-            click_link I18n.t('course.condition.levels.new.header')
-            expect(current_path).to eq(new_course_achievement_condition_level_path(course,
-                                                                                   achievement))
-            fill_in 'minimum_level', with: '10'
-            click_button I18n.t('helpers.submit.condition_level.create')
-          end
-          it 'creates a level condition correctly' do
-            expect(current_path).to eq edit_course_achievement_path(course, achievement)
-            expect(page).to have_selector('tr.condition > td:nth-child(2)', text: '10')
-          end
-        end
-
-        context 'when editing and deleting level conditions' do
-          let(:level_condition) { create(:course_condition_level, course: course) }
-          let!(:achievement) do
-            create(:course_achievement, course: course, conditions: [level_condition])
-          end
-
-          it 'editing a level condition' do
-            expect(current_path).to eq edit_course_achievement_path(course, achievement)
-            expect(page).to have_selector('tr.condition > td:nth-child(2)', text: '1')
-            condition_edit_path = edit_course_achievement_condition_level_path(course,
-                                                                               achievement,
-                                                                               level_condition)
-            find_link(nil, href: condition_edit_path).click
-            fill_in 'minimum_level', with: '13'
-            click_button I18n.t('helpers.submit.condition_level.update')
-            expect(current_path).to eq edit_course_achievement_path(course, achievement)
-            expect(page).to have_selector('tr.condition > td:nth-child(2)', text: '13')
-          end
-
-          it 'deleting a level condition' do
-            condition_delete_path = course_achievement_condition_level_path(course,
-                                                                            achievement,
-                                                                            level_condition)
-            expect do
-              find_link(nil, href: condition_delete_path).click
-            end.to change { achievement.conditions.count }.by(-1)
-            expect(page).not_to have_selector('tr.condition > td:nth-child(2)', text: '1')
-          end
-        end
-      end
-    end
-
-    describe 'achievement destruction' do
-      let!(:achievement) { create(:course_achievement, course: course) }
-      let(:achievement_path) { course_achievement_path(course, achievement) }
-
-      before { visit course_achievements_path(course) }
-
-      it 'deletes the achievement' do
+      scenario 'I can delete an achievement' do
+        visit new_course_achievement_path(course)
+        achievement = create(:course_achievement, course: course)
+        achievement_path = course_achievement_path(course, achievement)
+        visit course_achievements_path(course)
         expect do
           # Show and delete have the same URL, difference is in the request method
           # find the 2nd link that matches the path [2], this is the delete button
           find_link(nil, href: achievement_path, between: 2..2).click
         end.to change(course.achievements, :count).by(-1)
+        expect(page).to have_selector('div',
+                                      text: I18n.t('course.achievements.destroy.success'))
       end
 
-      context 'when an achievement is deleted' do
-        before { find_link(nil, href: achievement_path, between: 2..2).click }
+      scenario 'I can edit an achievement' do
+        achievement = create(:course_achievement, course: course)
+        visit edit_course_achievement_path(course, achievement)
+        expect(page).to have_field('achievement_title', with: achievement.title)
+        expect(page).to have_field('achievement_description', with: achievement.description)
+        expect(page).to have_checked_field('achievement_published')
 
-        it 'shows the success message' do
-          expect(page).to have_selector('div',
-                                        text: I18n.t('course.achievements.destroy.success'))
-        end
+        # Invalid fields
+        fill_in 'achievement_title', with: ''
+        click_button I18n.t('helpers.submit.achievement.update')
+        expect(page).to have_button(I18n.t('helpers.submit.achievement.update'))
+        expect(page).to have_css('div.has-error')
+
+        new_title = 'New Title'
+        new_description = 'New description'
+        fill_in 'achievement_title', with: new_title
+        fill_in 'achievement_description', with: new_description
+        click_button I18n.t('helpers.submit.achievement.update')
+        expect(current_path).to eq course_achievements_path(course)
+        expect(page).to have_selector('div', I18n.t('course.achievements.update.success'))
+        expect(achievement.reload.title).to eq(new_title)
+        expect(achievement.reload.description).to eq(new_description)
+      end
+
+      scenario 'I can create an achievement condition' do
+        achievement = create(:course_achievement, course: course)
+        visit edit_course_achievement_path(course, achievement)
+        condition_achievement = create(:course_achievement, course: course)
+        expect(page).to have_selector(:link_or_button,
+                                      I18n.t('course.condition.achievements.new.header'))
+        click_link I18n.t('course.condition.achievements.new.header')
+        expect(current_path).
+          to eq(new_course_achievement_condition_achievement_path(course, achievement))
+        find('#condition_achievement_achievement_id').
+          find(:css, "option[value='#{condition_achievement.id}']").
+          select_option
+        click_button I18n.t('helpers.submit.condition_achievement.create')
+        expect(current_path).to eq edit_course_achievement_path(course, achievement)
+        expect(page).to have_selector('tr.condition > td.achievement-condition-content',
+                                      text: condition_achievement.title)
+      end
+
+      scenario 'I can edit an achievement condition' do
+        achievement_to_change_to = create(:course_achievement, course: course)
+        achievement_condition, achievement, other_achievement =
+          create_achievement_condition
+        visit edit_course_achievement_path(course, achievement)
+        expect(current_path).to eq edit_course_achievement_path(course, achievement)
+        expect(page).to have_selector('tr.condition > td.achievement-condition-content',
+                                      text: other_achievement.title)
+        condition_edit_path =
+          edit_course_achievement_condition_achievement_path(course,
+                                                             achievement,
+                                                             achievement_condition)
+        find_link(nil, href: condition_edit_path).click
+
+        find('#condition_achievement_achievement_id').
+          find(:css, "option[value='#{achievement_to_change_to.id}']").
+          select_option
+        click_button I18n.t('helpers.submit.condition_achievement.update')
+        expect(current_path).to eq edit_course_achievement_path(course, achievement)
+        expect(page).to have_selector('tr.condition > td.achievement-condition-content',
+                                      text: achievement_to_change_to.title)
+      end
+
+      scenario 'I can delete an achievement condition' do
+        achievement_condition, achievement, other_achievement =
+          create_achievement_condition
+        visit edit_course_achievement_path(course, achievement)
+        condition_delete_path =
+          course_achievement_condition_achievement_path(course, achievement,
+                                                        achievement_condition)
+        expect do
+          find_link(nil, href: condition_delete_path).click
+        end.to change { achievement.conditions.count }.by(-1)
+        expect(page).not_to have_selector('tr.condition > td.achievement-condition-content',
+                                          text: other_achievement.title)
+      end
+
+      scenario 'I can create a level condition' do
+        achievement = create(:course_achievement, course: course)
+        visit edit_course_achievement_path(course, achievement)
+        expect(page).to have_selector(:link_or_button,
+                                      I18n.t('course.condition.levels.new.header'))
+        click_link I18n.t('course.condition.levels.new.header')
+        expect(current_path).to eq(new_course_achievement_condition_level_path(course,
+                                                                               achievement))
+        fill_in 'minimum_level', with: '10'
+        click_button I18n.t('helpers.submit.condition_level.create')
+        expect(current_path).to eq edit_course_achievement_path(course, achievement)
+        expect(page).to have_selector('tr.condition > td.level-condition-content', text: '10')
+      end
+
+      scenario 'I can edit a level condition' do
+        level_condition, achievement = create_level_condition
+        visit edit_course_achievement_path(course, achievement)
+        expect(current_path).to eq edit_course_achievement_path(course, achievement)
+        expect(page).to have_selector('tr.condition > td.level-condition-content', text: '1')
+        condition_edit_path = edit_course_achievement_condition_level_path(course,
+                                                                           achievement,
+                                                                           level_condition)
+        find_link(nil, href: condition_edit_path).click
+        fill_in 'minimum_level', with: '13'
+        click_button I18n.t('helpers.submit.condition_level.update')
+        expect(current_path).to eq edit_course_achievement_path(course, achievement)
+        expect(page).to have_selector('tr.condition > td.level-condition-content', text: '13')
+      end
+
+      scenario 'I can delete a level condition' do
+        level_condition, achievement = create_level_condition
+        visit edit_course_achievement_path(course, achievement)
+        condition_delete_path = course_achievement_condition_level_path(course,
+                                                                        achievement,
+                                                                        level_condition)
+        expect do
+          find_link(nil, href: condition_delete_path).click
+        end.to change { achievement.conditions.count }.by(-1)
+        expect(page).not_to have_selector('tr.condition > td.level-condition-content', text: '1')
+      end
+
+      def create_achievement_condition
+        other_achievement = create(:course_achievement, course: course)
+        achievement_condition =
+          create(:course_condition_achievement,
+                 course: course, achievement: other_achievement)
+        achievement = create(:course_achievement,
+                             course: course,
+                             conditions: [achievement_condition])
+        [achievement_condition, achievement, other_achievement]
+      end
+
+      def create_level_condition
+        level_condition = create(:course_condition_level, course: course)
+        achievement = create(:course_achievement,
+                             course: course,
+                             conditions: [level_condition])
+        [level_condition, achievement]
       end
     end
   end


### PR DESCRIPTION
Fixes #360. Implements a table view for achievements which links to existing condition pages (which have also been tidied up).

The condition pages are generic and can be used by future conditionals. The type of conditional is used to add the right entries to the breadcrumb.