### PR TITLE
More Rubocop warning suppressions.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ AllCops:
 Metrics/LineLength:
   Max: 100
 
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
 Style/DotPosition:
   EnforcedStyle: trailing
 

--- a/db/migrate/.rubocop.yml
+++ b/db/migrate/.rubocop.yml
@@ -4,5 +4,8 @@ inherit_from:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/AbcSize:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
 - We still use HABTM if the join table stores no information.
 - Do not worry about ABC Size for migrations, because it's a DSL.