### PR TITLE
Implement aggregate failures for feature specs.

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -20,4 +20,7 @@ end
 
 RSpec.configure do |config|
   config.include Capybara::TestGroupHelpers::FeatureHelpers, type: :feature
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true if !meta.key?(:aggregate_failures) && meta[:type] == :feature
+  end
 end


### PR DESCRIPTION
This allows us to run more specs without running the entire request, and yet get useful feedback about what failed.