### PR TITLE
Allow the number of points awarded to students be null, for experience points which are not yet valid.

### DIFF
--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -1,12 +1,22 @@
 class Course::ExperiencePointsRecord < ActiveRecord::Base
   actable
 
-  validates :points_awarded, numericality: { only_integer: true }
   validates :reason, presence: true, if: :manual_exp?
 
   belongs_to :course_user, inverse_of: :experience_points_records
 
+  scope :active, -> { where { points_awarded != nil } }
+
   def manual_exp?
     true
+  end
+
+  # Checks if the current record is active, i.e. it has been granted by a course staff.
+  #
+  # This is necessary for records to be created but not graded, such as that of assessments.
+  #
+  # @return [bool]
+  def active?
+    points_awarded.present?
   end
 end

--- a/db/migrate/20150721055754_change_experience_points_record_points_null.rb
+++ b/db/migrate/20150721055754_change_experience_points_record_points_null.rb
@@ -1,0 +1,5 @@
+class ChangeExperiencePointsRecordPointsNull < ActiveRecord::Migration
+  def change
+    change_column_null :course_experience_points_records, :points_awarded, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150713125423) do
+ActiveRecord::Schema.define(version: 20150721055754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -222,7 +222,7 @@ ActiveRecord::Schema.define(version: 20150713125423) do
   create_table "course_experience_points_records", force: :cascade do |t|
     t.integer  "actable_id"
     t.string   "actable_type",   limit: 255, index: {name: "index_course_experience_points_records_on_actable", with: ["actable_id"], unique: true}
-    t.integer  "points_awarded", null: false
+    t.integer  "points_awarded"
     t.integer  "course_user_id", null: false, index: {name: "fk__course_experience_points_records_course_user_id"}, foreign_key: {references: "course_users", name: "fk_course_experience_points_records_course_user_id", on_update: :no_action, on_delete: :no_action}
     t.string   "reason",         limit: 255
     t.integer  "creator_id",     null: false, index: {name: "fk__course_experience_points_records_creator_id"}, foreign_key: {references: "users", name: "fk_course_experience_points_records_creator_id", on_update: :no_action, on_delete: :no_action}

--- a/spec/factories/course_experience_points_records.rb
+++ b/spec/factories/course_experience_points_records.rb
@@ -3,5 +3,9 @@ FactoryGirl.define do
     course_user
     points_awarded { rand(1..20) * 100 }
     reason 'EXP for some event'
+
+    trait :inactive do
+      points_awarded nil
+    end
   end
 end

--- a/spec/models/course/experience_points_record_spec.rb
+++ b/spec/models/course/experience_points_record_spec.rb
@@ -7,13 +7,34 @@ RSpec.describe Course::ExperiencePointsRecord, type: :model do
 
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do
-    context 'when manual' do
-      subject { build :course_experience_points_record }
+    let(:course) { create(:course) }
+    let(:course_user) { create(:course_user, course: course) }
+
+    describe '.active' do
+      it 'only returns active records' do
+        active = create_list(:course_experience_points_record, 2,  course_user: course_user)
+        create_list(:course_experience_points_record, 2, :inactive, course_user: course_user)
+        expect(course_user.experience_points_records.active).to contain_exactly(*active)
+      end
+    end
+
+    describe '#active?' do
+      context 'when the record has null for the number of points awarded' do
+        it 'is inactive' do
+          record = build_stubbed(:course_experience_points_record,
+                                 points_awarded: nil, course_user: course_user)
+          expect(record).not_to be_active
+        end
+      end
+    end
+
+    context 'when manually created' do
+      subject { build(:course_experience_points_record) }
 
       it { is_expected.to be_valid }
       it { is_expected.to be_manual_exp }
 
-      context 'with no reason' do
+      context 'when the record does not have a reason' do
         before { subject.reason = nil }
         it { is_expected.to be_invalid }
       end


### PR DESCRIPTION
This is necessary for assessment submissions, where creating the assessments does not yield any experience points until graded. @kxmbrian 