### PR TITLE
Allow users to be destroyed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,7 +87,9 @@ class User < ActiveRecord::Base
   #
   # @return [User::Email] The user's primary email address record.
   def default_email_record
-    valid_emails = emails.each.select { |email_record| !email_record.marked_for_destruction? }
+    valid_emails = emails.each.select do |email_record|
+      !email_record.destroyed? && !email_record.marked_for_destruction?
+    end
     result = valid_emails.find(&:primary?)
     result ||= valid_emails.first
     result

--- a/app/models/user/email.rb
+++ b/app/models/user/email.rb
@@ -24,6 +24,7 @@ class User::Email < ActiveRecord::Base
   private
 
   def set_new_user_primary_email
+    return if user.destroying?
     fail ActiveRecord::Rollback unless user.set_next_email_as_primary
   end
 end

--- a/lib/extensions/destroy_callbacks.rb
+++ b/lib/extensions/destroy_callbacks.rb
@@ -1,0 +1,1 @@
+module Extensions::DestroyCallbacks; end

--- a/lib/extensions/destroy_callbacks/active_record.rb
+++ b/lib/extensions/destroy_callbacks/active_record.rb
@@ -1,0 +1,1 @@
+module Extensions::DestroyCallbacks::ActiveRecord; end

--- a/lib/extensions/destroy_callbacks/active_record/base.rb
+++ b/lib/extensions/destroy_callbacks/active_record/base.rb
@@ -1,0 +1,21 @@
+module Extensions::DestroyCallbacks::ActiveRecord::Base
+  extend ActiveSupport::Concern
+
+  included do
+    around_destroy :update_status
+  end
+
+  # @return [boolean] True if the record is being destroyed.
+  def destroying?
+    @destroying
+  end
+
+  private
+
+  def update_status
+    @destroying = true
+    yield
+  ensure
+    @destroying = false
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,11 +103,4 @@ RSpec.describe User, type: :model do
       expect(subject.errors[:email].first).to match(/invalid/)
     end
   end
-
-  describe '#destroy' do
-    let(:user) { create(:user) }
-    subject { user.destroy }
-
-    it { is_expected.to be_destroyed }
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,4 +103,11 @@ RSpec.describe User, type: :model do
       expect(subject.errors[:email].first).to match(/invalid/)
     end
   end
+
+  describe '#destroy' do
+    let(:user) { create(:user) }
+    subject { user.destroy }
+
+    it { is_expected.to be_destroyed }
+  end
 end


### PR DESCRIPTION
@lowjoel Seems rails is using inheritance to implement callbacks: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/callbacks.rb#L292

There is no status indicating the record is being destroyed, so `dependent: :delete_all` might be a good solution, otherwise we should not use callbacks.