### PR TITLE
Allow rendering a partial with a prefix.

### DIFF
--- a/lib/extensions/render_collection_with_prefix_suffix.rb
+++ b/lib/extensions/render_collection_with_prefix_suffix.rb
@@ -1,0 +1,1 @@
+module Extensions::RenderCollectionWithPrefixSuffix; end

--- a/lib/extensions/render_collection_with_prefix_suffix/action_view.rb
+++ b/lib/extensions/render_collection_with_prefix_suffix/action_view.rb
@@ -1,0 +1,1 @@
+module Extensions::RenderCollectionWithPrefixSuffix::ActionView; end

--- a/lib/extensions/render_collection_with_prefix_suffix/action_view/partial_renderer.rb
+++ b/lib/extensions/render_collection_with_prefix_suffix/action_view/partial_renderer.rb
@@ -1,0 +1,23 @@
+module Extensions::RenderCollectionWithPrefixSuffix::ActionView::PartialRenderer
+  module PrependMethods
+    # Adds support for the +prefix+ and +suffix+ options to {render partial:}.
+    #
+    # This allows for a prefix or suffix to be specified when rendering a polymorphic collection, so
+    # that different partials can be used for different contexts.
+    #
+    # @example Rendering a collection of objects
+    #   @collection = [event, assessment]
+    #   render partial: @collection, prefix: 'lesson_plan'
+    #   # Renders event/_lesson_plan_event.html
+    #   # Renders assessment/_lesson_plan_assessment.html
+    def partial_path(*)
+      result = super
+      return result unless @options.key?(:prefix) || @options.key?(:suffix)
+
+      dirname, basename = File.split(result)
+      basename = basename.prepend("#{@options[:prefix]}_") if @options.key?(:prefix)
+      basename = basename.concat("_#{@options[:suffix]}") if @options.key?(:suffix)
+      File.join(dirname, basename)
+    end
+  end
+end

--- a/spec/fixtures/libraries/render_partial_with_prefix_suffix/_base.html
+++ b/spec/fixtures/libraries/render_partial_with_prefix_suffix/_base.html
@@ -1,0 +1,1 @@
+<div class="base"></div>

--- a/spec/fixtures/libraries/render_partial_with_prefix_suffix/_base_suffix.html
+++ b/spec/fixtures/libraries/render_partial_with_prefix_suffix/_base_suffix.html
@@ -1,0 +1,1 @@
+<div class="suffix"></div>

--- a/spec/fixtures/libraries/render_partial_with_prefix_suffix/_prefix_base.html
+++ b/spec/fixtures/libraries/render_partial_with_prefix_suffix/_prefix_base.html
@@ -1,0 +1,1 @@
+<div class="prefix"></div>

--- a/spec/libraries/render_partial_with_prefix_suffix_spec.rb
+++ b/spec/libraries/render_partial_with_prefix_suffix_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Extension: render partial with prefix/suffix', type: :view do
+  let(:views_directory) do
+    path = Pathname.new("#{__dir__}/../fixtures/libraries/render_partial_with_prefix_suffix")
+    path.realpath
+  end
+  let(:collection) do
+    [self.class::Object.new]
+  end
+
+  before do
+    controller.prepend_view_path views_directory
+  end
+
+  class self::Object
+    def to_partial_path
+      'base'
+    end
+  end
+
+  it 'properly uses the prefix' do
+    render partial: collection, prefix: 'prefix'
+    expect(rendered).to have_tag('div.prefix')
+    expect(rendered).not_to have_tag('div.base')
+    expect(rendered).not_to have_tag('div.suffix')
+  end
+
+  it 'properly uses the suffix' do
+    render partial: collection, suffix: 'suffix'
+    expect(rendered).not_to have_tag('div.prefix')
+    expect(rendered).not_to have_tag('div.base')
+    expect(rendered).to have_tag('div.suffix')
+  end
+end


### PR DESCRIPTION
This is exceptionally useful when rendering a polymorphic collection: we want to use to_partial_path, but also depending on the context we are using it, different partials might need to be used. This allows a view to specify the prefix/suffix of a partial, which will be used together with the generated partial path, to customise the partial used in a context.