### PR TITLE
Factor out helpers for defining course users.

### DIFF
--- a/app/models/components/ability_host.rb
+++ b/app/models/components/ability_host.rb
@@ -1,6 +1,54 @@
 class AbilityHost
   include Componentize
 
+  # Helpers for defining abilities associated with a course user.
+  module CourseHelpers
+    protected
+
+    # Creates a hash which allows referencing a set of course users.
+    #
+    # @param [Array<Symbol>] roles The roles {CourseUser::Roles} which should be referenced by this
+    #   rule.
+    # @return [Hash] This hash is relative to a Course.
+    def course_user_hash(*roles)
+      course_users = { user_id: user.id,
+                       workflow_state: 'approved' }
+      unless roles.empty?
+        # Remove the map when Rails 5 is released.
+        course_users[:role] = roles.map do |role|
+          [CourseUser.roles[role], role.to_s]
+        end.flatten!
+      end
+
+      { course_users: course_users }
+    end
+
+    # @return [Hash] The hash is relative to a component which has a +belongs_to+ association with
+    #   a Course.
+    def course_course_user_hash(*roles)
+      { course: course_user_hash(*roles) }
+    end
+
+    alias_method :course_all_course_users_hash, :course_course_user_hash
+
+    # @return [Hash] The hash is relative to a component which has a +belongs_to+ association with
+    #   a Course.
+    def course_staff_hash
+      course_course_user_hash(*CourseUser::STAFF_ROLES.to_a)
+    end
+
+    # @return [Hash] The hash is relative to a component which has a +belongs_to+ association with
+    #   a Course.
+    def course_managers_hash
+      course_course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
+    end
+  end
+
+  # Open the Componentize Base Component.
+  const_get(:Component).module_eval do
+    include CourseHelpers
+  end
+
   # Eager load all the components declared.
   eager_load_components(__dir__)
 end

--- a/app/models/components/course/course_ability_component.rb
+++ b/app/models/components/course/course_ability_component.rb
@@ -13,6 +13,8 @@ module Course::CourseAbilityComponent
     super
   end
 
+  private
+
   def allow_showing_open_courses
     # TODO: Replace with just the symbols when Rails 5 is released.
     can [:read, :register], Course, status: [Course.statuses[:published], Course.statuses[:opened],
@@ -24,29 +26,15 @@ module Course::CourseAbilityComponent
   end
 
   def allow_registered_users_showing_course
-    can [:read], Course, course_users: { user_id: user.id, workflow_state: ['approved'] }
+    can [:read], Course, course_user_hash
   end
 
   def allow_owners_managing_course
-    can :manage, Course, course_users: { user_id: user.id,
-                                         workflow_state: 'approved',
-                                         role: [CourseUser.roles[:manager],
-                                                CourseUser.roles[:owner],
-                                                'manager', 'owner'] }
-
-    can :manage, CourseUser, course: { course_users: { user_id: user.id,
-                                                       workflow_state: 'approved',
-                                                       role: [CourseUser.roles[:manager],
-                                                              CourseUser.roles[:owner],
-                                                              'manager', 'owner'] } }
+    can :manage, Course, course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
+    can :manage, CourseUser, course_managers_hash
   end
 
   def allow_staff_manage_users
-    can [:show_users, :manage_users], Course,
-        course_users: { user_id: user.id, workflow_state: 'approved',
-                        role: [CourseUser.roles[:manager],
-                               CourseUser.roles[:owner],
-                               CourseUser.roles[:teaching_assistant],
-                               'manager', 'owner', 'teaching_assistant'] }
+    can [:show_users, :manage_users], Course, course_user_hash(*CourseUser::STAFF_ROLES.to_a)
   end
 end

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -11,32 +11,16 @@ module Course::Assessment::AssessmentAbility
 
   private
 
-  def course_user_hash(*roles)
-    { course: { course_users: { user_id: user.id,
-                                workflow_state: 'approved',
-                                role: roles.map do |role|
-                                  [CourseUser.roles[role], role.to_s]
-                                end.flatten! } } }
-  end
-
-  def all_course_users_hash
-    course_user_hash(*CourseUser.roles.keys)
-  end
-
-  def staff_hash
-    course_user_hash(*CourseUser::STAFF_ROLES.to_a)
-  end
-
   def allow_students_show_assessments
-    can :show, Course::Assessment, tab: { category: all_course_users_hash }
+    can :read, Course::Assessment, tab: { category: course_all_course_users_hash }
   end
 
   def allow_students_attempt_assessment
-    can :attempt, Course::Assessment, tab: { category: all_course_users_hash }
+    can :attempt, Course::Assessment, tab: { category: course_all_course_users_hash }
     can [:create, :update], Course::Assessment::Submission, course_user: { user_id: user.id }
   end
 
   def allow_staff_manage_assessments
-    can :manage, Course::Assessment, tab: { category: staff_hash }
+    can :manage, Course::Assessment, tab: { category: course_staff_hash }
   end
 end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -8,6 +8,9 @@ class CourseUser < ActiveRecord::Base
   # A set of roles which comprise the staff of a course.
   STAFF_ROLES = Set[:teaching_assistant, :manager, :owner].freeze
 
+  # A set of roles which comprise the managers of a course.
+  MANAGER_ROLES = Set[:manager, :owner].freeze
+
   workflow do
     state :requested do
       event :approve, transitions_to: :approved


### PR DESCRIPTION
This allows the logic to be reusable. The hash only applies to users who are currently in the approved state.