### PR TITLE
Allow users to not authorise Facebook to give their emails to Coursemology.

### DIFF
--- a/app/models/concerns/user_omniauth_facebook_concern.rb
+++ b/app/models/concerns/user_omniauth_facebook_concern.rb
@@ -6,10 +6,11 @@ module UserOmniauthFacebookConcern
     # This is a override of `Devise::Models::Registerable::ClassMethods#new_with_session`
     def new_with_session(params, session)
       super.tap do |user|
-        facebook_data = session['devise.facebook_data']
-        if facebook_data && (info = facebook_data['info'])
-          user.assign_attributes(name: info['name'], email: info['email'])
-          user.identities.build(provider: facebook_data['provider'], uid: facebook_data['uid'])
+        facebook_data = session['devise.facebook_data'].try(:deep_symbolize_keys)
+        if facebook_data && (info = facebook_data[:info])
+          user.name ||= info[:name] if info[:name]
+          user.email ||= info[:email] if info[:email]
+          user.identities.build(facebook_data.slice(:provider, :uid))
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,13 +116,28 @@ RSpec.describe User, type: :model do
 
   describe '.new_with_session' do
     context 'when facebook data is provided' do
+      let(:params) { {} }
       let(:facebook_data) { OmniAuth.config.mock_auth[:facebook] }
       let(:session) { { 'devise.facebook_data' => facebook_data } }
-      subject { User.new_with_session({}, session) }
+      subject { User.new_with_session(params, session) }
 
       it 'builds the user with information from facebook' do
         expect(subject.name).to eq(facebook_data.info.name)
         expect(subject.email).to eq(facebook_data.info.email)
+      end
+
+      context 'when the user did not authorize access to his email address' do
+        let(:facebook_data) do
+          OmniAuth.config.mock_auth[:facebook].tap do |facebook|
+            facebook[:info].except(:email)
+          end
+        end
+        let(:email) { generate(:email) }
+        let(:params) { { email: email } }
+
+        it 'does not override the value provided in the params' do
+          expect(subject.email).to eq(email)
+        end
       end
     end
   end


### PR DESCRIPTION
This adds specs to test the workflow when the user signs in using Facebook Login, but did not authorise the email address permission.