### PR TITLE
Create Duplicator ComponentHost to allow components to register

### DIFF
--- a/app/models/components/course/model_component_host.rb
+++ b/app/models/components/course/model_component_host.rb
@@ -44,6 +44,14 @@ class Course::ModelComponentHost
     end
   end
 
+  module Duplicator
+    extend ActiveSupport::Concern
+
+    def initialize_duplicate(_duplicator, _other)
+      fail 'Implement your own initialize_duplicate method for this component.'
+    end
+  end
+
   const_get(:Component).module_eval do
     const_set(:ClassMethods, ::Module.new) unless const_defined?(:ClassMethods)
     include CourseComponentMethods

--- a/app/models/components/course/model_component_host.rb
+++ b/app/models/components/course/model_component_host.rb
@@ -44,11 +44,15 @@ class Course::ModelComponentHost
     end
   end
 
-  module Duplicator
+  module Duplicable
     extend ActiveSupport::Concern
 
     def initialize_duplicate(_duplicator, _other)
-      fail 'Implement your own initialize_duplicate method for this component.'
+      fail "Implement your own initialize_duplicate method for this component."
+    end
+
+    def duplicator_display_string
+      fail "Return the string to display on the duplication UI page."
     end
   end
 


### PR DESCRIPTION
themselves for duplication

Components which include Duplicator::ModelComponentHost::Component will
have to override the initialize_duplicate method.