### PR TITLE
Add unread state management in GenericAnnouncement related models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'settings_on_rails'
 # Table and column comments
 gem 'migration_comments'
 # Manage read/unread status
-gem 'unread', github: 'ledermann/unread'
+gem 'unread'
 # Extension for validating hostnames and domain names
 gem 'validates_hostname'
 # A Ruby state machine library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,6 @@ GIT
       uniform_notifier (~> 1.9.0)
 
 GIT
-  remote: git://github.com/ledermann/unread.git
-  revision: 0bfcb4f31c31599a601b02ba9ab606dd0bd32d29
-  specs:
-    unread (0.6.1)
-      activerecord (>= 3)
-
-GIT
   remote: git://github.com/lowjoel/acts_as_tenant.git
   revision: 9d4d29ca64225953000de30ca99154b7d42d4a13
   branch: allow-inverse-of
@@ -446,6 +439,8 @@ GEM
       unf_ext
     unf_ext (0.0.7.1)
     uniform_notifier (1.9.0)
+    unread (0.6.3)
+      activerecord (>= 3)
     validates_hostname (1.0.5)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
@@ -526,7 +521,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
-  unread!
+  unread
   validates_hostname
   wdm (>= 0.0.3)
   workflow

--- a/app/models/generic_announcement.rb
+++ b/app/models/generic_announcement.rb
@@ -3,6 +3,9 @@
 # This is the abstract single-table inheritance table used for both announcement types.
 class GenericAnnouncement < ActiveRecord::Base
   after_initialize :set_defaults, if: :new_record?
+  acts_as_readable on: :updated_at
+  after_create :mark_as_read_by_creator
+  after_update :mark_as_read_by_updater
 
   belongs_to :instance, inverse_of: :announcements
 
@@ -23,11 +26,6 @@ class GenericAnnouncement < ActiveRecord::Base
 
   default_scope { system_announcements_first.order(start_at: :desc) }
 
-  def unread?(_)
-    # TODO: Implement
-    false
-  end
-
   def sticky?
     false
   end
@@ -38,5 +36,15 @@ class GenericAnnouncement < ActiveRecord::Base
   def set_defaults
     self.start_at ||= Time.zone.now
     self.end_at ||= 7.days.from_now
+  end
+
+  # Mark announcement as read for the creator
+  def mark_as_read_by_creator
+    mark_as_read! for: creator
+  end
+
+  # Mark announcement as read for the updater
+  def mark_as_read_by_updater
+    mark_as_read! for: updater
   end
 end

--- a/spec/models/generic_announcement_spec.rb
+++ b/spec/models/generic_announcement_spec.rb
@@ -62,5 +62,22 @@ RSpec.describe GenericAnnouncement, type: :model do
         expect(announcements).to include(*active_instance_announcements)
       end
     end
+
+    describe 'unread state' do
+      let(:creator) { create(:creator) }
+      let!(:user) { create(:user) }
+      let!(:system_announcement) { create(:system_announcement, creator: creator) }
+      let!(:instance_announcement) { create(:instance_announcement, creator: creator) }
+
+      it 'has been read by the creator' do
+        expect(creator.have_read?(instance_announcement)).to eq(true)
+        expect(creator.have_read?(system_announcement)).to eq(true)
+      end
+
+      it 'is unread by other users' do
+        expect(user.have_read?(instance_announcement)).to eq(false)
+        expect(user.have_read?(system_announcement)).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
* Use unread gem in GenericAnnouncement model. It can also be used in its 
  child models( SystemAnnouncement, InstanceAnnouncement).

Fix #477 