### PR TITLE
Add unread notification scope

### DIFF
--- a/app/models/concerns/user_notifications_concern.rb
+++ b/app/models/concerns/user_notifications_concern.rb
@@ -1,0 +1,6 @@
+module UserNotificationsConcern
+  # Get user's unread notifications
+  def unread
+    unread_by(proxy_association.owner)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,10 @@ class User < ActiveRecord::Base
   has_many :instances, through: :instance_users
   has_many :identities, dependent: :destroy, class_name: User::Identity.name
   has_many :activities, inverse_of: :actor, dependent: :destroy, foreign_key: 'actor_id'.freeze
-  has_many :notifications, dependent: :destroy, class_name: UserNotification.name
+  has_many :notifications, dependent: :destroy, class_name: UserNotification.name,
+                           inverse_of: :user do
+    include UserNotificationsConcern
+  end
   has_many :course_users, dependent: :destroy
   has_many :courses, through: :course_users
   has_many :course_group_users, dependent: :destroy, class_name: Course::GroupUser.name

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -152,5 +152,14 @@ RSpec.describe User, type: :model do
         expect { subject }.to change(instance.instance_users, :count).by(1)
       end
     end
+
+    describe '.unread' do
+      let!(:user) { create(:user) }
+      let!(:unread_notification) { create(:user_notification, user: user) }
+
+      it 'returns unread notifications of the user' do
+        expect(user.notifications.unread).to include(unread_notification)
+      end
+    end
   end
 end


### PR DESCRIPTION
Some solutions to load unread notifications
---
1. Like this PR
2. Directly use `UserNotification.popups.unread_by(user)` which just need to add a `popups` scope in current UserNotification Model
3. Define `unread_popups` method in User Model, which performs like `notification.where(notification_type: 'popup').unread_by(self)`
4. Modify unread gem to add a function `unread` which is like `user.unread(class_name)`. With this method, we can query like this `user.unread(UserNotification).popups` 