### PR TITLE
Refactor attachment framework

### DIFF
--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -1,4 +1,4 @@
 class Course::Material < ActiveRecord::Base
-  acts_as_attachable
+  has_one_attachment
   belongs_to :folder, inverse_of: :materials, class_name: Course::Material::Folder.name
 end

--- a/app/views/layouts/_attachment_uploader.html.slim
+++ b/app/views/layouts/_attachment_uploader.html.slim
@@ -1,14 +1,14 @@
-- if form_builder.object.attachments.count > 0
-  strong = t('.uploaded')
-
-= form_builder.fields_for :attachments do |sub_builder|
+- if multiple
+  - if f.object.attachments.any?
+    strong = t('.uploaded_files')
+    - f.object.attachments.each do |attachment|
+      = link_to attachment.name, '#'
   div
-    - if sub_builder.object.persisted?
-      = link_to sub_builder.object.name, attachment_path(sub_builder.object)
-
-      = sub_builder.check_box :_destroy
-      = sub_builder.label :_destroy, t('.remove')
-    - else
-      = sub_builder.label t('.new_file')
-      = sub_builder.file_field :file_upload
-      = sub_builder.hidden_field :file_upload_cache
+    strong = t('.new_files')
+    = f.file_field :files, multiple: true
+- else
+  - if f.object.attachment.present?
+    strong => t('.uploaded_file')
+    = link_to f.object.attachment.name, '#'
+  div
+    = f.file_field :file

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -25,9 +25,9 @@ en:
     course_users:
       title: 'Manage Users'
     attachment_uploader:
-      uploaded: 'Uploaded Files:'
-      new_file: 'Upload New File'
-      remove: 'Remove'
+      uploaded_files: 'Uploaded Files:'
+      uploaded_file: 'Uploaded File:'
+      new_files: 'Upload New Files'
     mailer:
       greeting: 'Hello, %{user}:'
       complimentary_close: 'Best Regards,'

--- a/lib/extensions/attachable/action_controller/base.rb
+++ b/lib/extensions/attachable/action_controller/base.rb
@@ -1,26 +1,8 @@
 module Extensions::Attachable::ActionController::Base
-  module ClassMethods
-    # Declared this function in controller to let it accepts attachments.
-    # Should be declared after load_and_authorize_resources.
-    def accepts_attachments
-      before_action :build_attachments, only: [:new, :edit]
-    end
-  end
-
   # Permit attachments params in strong parameters.
   # @return [Hash] The params required by the framework.
   def attachments_params
-    { attachments_attributes: [:id, :attachment, :attachment_cache, :_destroy] }
+    [:file, files: []]
   end
-
-  private
-
-  def build_attachments
-    @attachable = instance_variable_get('@' + attachable_item_name)
-    @attachable.attachments.build if @attachable
-  end
-
-  def attachable_item_name
-    params[:controller].split('/').last.singularize
-  end
+  alias_method :attachment_params, :attachments_params
 end

--- a/lib/extensions/attachable/action_view/helpers/form_builder.rb
+++ b/lib/extensions/attachable/action_view/helpers/form_builder.rb
@@ -2,6 +2,8 @@ module Extensions::Attachable::ActionView::Helpers::FormBuilder
   # Method from ActsAsAttachable framework.
   # Hepler to support f.attachments in form
   def attachments
-    @template.render 'layouts/attachment_uploader', form_builder: self
+    multiple = !object.respond_to?(:attachment)
+    @template.render 'layouts/attachment_uploader', f: self, multiple: multiple
   end
+  alias_method :attachment, :attachments
 end

--- a/lib/extensions/attachable/active_record/base.rb
+++ b/lib/extensions/attachable/active_record/base.rb
@@ -1,12 +1,45 @@
 module Extensions::Attachable::ActiveRecord::Base
   module ClassMethods
     # This function should be declared in model, to it have attachments.
-    def acts_as_attachable
-      has_many :attachments, as: :attachable, inverse_of: :attachable
+    def has_many_attachments # rubocop:disable Style/PredicateName
+      has_many :attachments, as: :attachable, inverse_of: :attachable,
+                             dependent: :destroy, autosave: true
 
-      accepts_nested_attributes_for :attachments,
-                                    allow_destroy: true,
-                                    reject_if: -> (params) { params[:attachment].blank? }
+      define_method(:files=) do |files|
+        files.each do |file|
+          attachments.build.file_upload = file
+        end
+      end
+    end
+
+    def has_one_attachment # rubocop:disable Style/PredicateName
+      include SingularInstanceMethods
+
+      validates :attachments, length: { maximum: 1 }
+
+      has_many :attachments, as: :attachable, inverse_of: :attachable,
+                             dependent: :destroy, autosave: true
+    end
+  end
+
+  module SingularInstanceMethods
+    def attachment
+      attachments[0]
+    end
+
+    def attachment=(attachment)
+      attachments.clear
+      attachments << attachment
+    end
+
+    def build_attachment(attributes = {})
+      attachments.clear
+      attachments.build(attributes)
+    end
+
+    def file=(file)
+      build_attachment if !attachment || attachment.new_record?
+      attachment.file_upload = file
     end
   end
 end

--- a/spec/models/course/material_spec.rb
+++ b/spec/models/course/material_spec.rb
@@ -2,5 +2,4 @@ require 'rails_helper'
 
 RSpec.describe Course::Material, type: :model do
   it { is_expected.to belong_to(:creator) }
-  it { is_expected.to have_many(:attachments) }
 end


### PR DESCRIPTION
 1. Allowing model to have one or more attachments, and the corresponding view
 2. Changed from accepts_nested_attributes to defining the `file=` function, and create attachments through files. (this will also allow us to create both material and attachment in the same time, which I've showed in the next PR)
