### PR TITLE
Add missing assessment factories

### DIFF
--- a/lib/extensions/destroy_callbacks/active_record/base.rb
+++ b/lib/extensions/destroy_callbacks/active_record/base.rb
@@ -1,6 +1,15 @@
 module Extensions::DestroyCallbacks::ActiveRecord::Base
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def actable(*args)
+      args.unshift({}) if args.empty?
+      options = args.extract_options!
+      args.push(options.reverse_merge(dependent: :destroy))
+      super(*args)
+    end
+  end
+
   included do
     around_destroy :update_status
   end
@@ -13,6 +22,7 @@ module Extensions::DestroyCallbacks::ActiveRecord::Base
   private
 
   def update_status
+    return if destroying? # Works around Rails #13609
     @destroying = true
     yield
   ensure

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -2,8 +2,23 @@ FactoryGirl.define do
   sequence(:course_assessment_assessment_name) { |n| "Assessment #{n}" }
   factory :course_assessment_assessment, class: Course::Assessment, aliases: [:assessment],
                                          parent: :course_lesson_plan_item do
-    tab { build(:course_assessment_tab, course: course) }
+    tab do
+      category = course.assessment_categories.first
+      category.try(:tabs).try(:first) || build(:course_assessment_tab, course: course)
+    end
     title { generate(:course_assessment_assessment_name) }
     base_exp 1000
+
+    trait :with_mcq_question do
+      after(:build) do |assessment|
+        assessment.questions += [
+          build(:course_assessment_question_multiple_response, assessment: assessment)
+        ]
+      end
+    end
+
+    trait :with_all_question_types do
+      with_mcq_question
+    end
   end
 end

--- a/spec/factories/course_assessment_question_multiple_response_options.rb
+++ b/spec/factories/course_assessment_question_multiple_response_options.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :course_assessment_question_multiple_response_option,
+          class: Course::Assessment::Question::MultipleResponseOption do
+    question { build(:course_assessment_question_multiple_response) }
+    correct false
+    option 'Option'
+  end
+end

--- a/spec/factories/course_assessment_question_multiple_responses.rb
+++ b/spec/factories/course_assessment_question_multiple_responses.rb
@@ -2,5 +2,13 @@ FactoryGirl.define do
   factory :course_assessment_question_multiple_response,
           class: Course::Assessment::Question::MultipleResponse,
           parent: :course_assessment_question do
+    options do
+      [
+        build(:course_assessment_question_multiple_response_option,
+              question: nil, correct: true, option: 'true'),
+        build(:course_assessment_question_multiple_response_option,
+              question: nil, option: 'false')
+      ]
+    end
   end
 end

--- a/spec/features/course/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment_attempt_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:category) { course.assessment_categories.first }
-    let(:assessment) { create(:assessment, course: course, tab: category.tabs.first) }
+    let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
     before { login_as(user, scope: :user) }
 
     context 'As a Course Student' do


### PR DESCRIPTION
The assessment factories for MRQs did not generate options. This fixes that.

Also, as part of this, AR relations can now be `dependent: destroy` bidirectionally, working around Rails' issue 13609 (not linked to prevent polluting the Rails thread)

This is needed for my next PR, which implements attempting assessments.