### PR TITLE
Implement attempting MRQ questions

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -33,8 +33,11 @@ class Course::Assessment::SubmissionsController < Course::Assessment::Controller
 
   def update_params
     @update_params ||= begin
-      params.require(:submission).permit(:updated_at,
-        answers_attributes: [:id, actable_attributes: []]
+      params.require(:submission).permit(
+        answers_attributes: [
+          :id,
+          actable_attributes: [:id, option_ids: []]
+        ]
       )
     end
   end

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -2,6 +2,7 @@ class Course::Assessment::SubmissionsController < Course::Assessment::Controller
   before_action :authorize_assessment, only: :create
   load_and_authorize_resource :submission, class: Course::Assessment::Submission.name,
                                            through: :assessment
+  before_action :load_or_create_answers, only: [:edit, :update]
 
   def create
     if @submission.save
@@ -31,10 +32,24 @@ class Course::Assessment::SubmissionsController < Course::Assessment::Controller
   end
 
   def update_params
-    @update_params ||= params.require(:submission).permit
+    @update_params ||= begin
+      params.require(:submission).permit(:updated_at,
+        answers_attributes: [:id, actable_attributes: []]
+      )
+    end
   end
 
   def authorize_assessment
     authorize!(:attempt, @assessment)
+  end
+
+  def load_or_create_answers
+    @answers = questions_to_attempt.attempt(@submission).tap do |answers|
+      answers.each { |answer| answer.save! if answer.new_record? }
+    end
+  end
+
+  def questions_to_attempt
+    @questions_to_attempt ||= @submission.assessment.questions
   end
 end

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -5,6 +5,7 @@ class Course::Assessment::SubmissionsController < Course::Assessment::Controller
   before_action :load_or_create_answers, only: [:edit, :update]
 
   def create
+    fail IllegalStateError if @assessment.questions.empty?
     if @submission.save
       redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission)
     else

--- a/app/models/concerns/course/assessment/questions_concern.rb
+++ b/app/models/concerns/course/assessment/questions_concern.rb
@@ -1,0 +1,23 @@
+module Course::Assessment::QuestionsConcern
+  extend ActiveSupport::Concern
+
+  # Attempts the given set of questions.
+  #
+  # This will create answers for questions without any answers which are not being attempted, and
+  # return them in the same order as specified.
+  #
+  # @param [Course::Assessment::Submission] submission The submission which will contain the
+  #   answers.
+  # @return [Array<Course::Assessment::Answer>] The answers for the questions, in the same order
+  #   specified. Newly initialized answers will not be persisted.
+  def attempt(submission)
+    attempting_answers = submission.answers.latest_answers.
+                         merge(submission.answers.with_attempting_state).
+                         where(question: self).
+                         map { |answer| [answer.question, answer] }.to_h
+
+    map do |question|
+      attempting_answers.fetch(question) { question.attempt(submission) }
+    end
+  end
+end

--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -1,0 +1,7 @@
+module Course::Assessment::Submission::AnswersConcern
+  extend ActiveSupport::Concern
+
+  def latest_answers
+    all
+  end
+end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -6,7 +6,9 @@ class Course::Assessment < ActiveRecord::Base
 
   belongs_to :tab, inverse_of: :assessments
 
-  has_many :questions, dependent: :destroy
+  has_many :questions, inverse_of: :assessment, dependent: :destroy do
+    include Course::Assessment::QuestionsConcern
+  end
   has_many :multiple_response_questions,
            through: :questions, source: :actable,
            source_type: Course::Assessment::Question::MultipleResponse.name

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -13,6 +13,14 @@ class Course::Assessment::Answer < ActiveRecord::Base
     state :graded
   end
 
+  validate :validate_consistent_assessment
+
   belongs_to :submission, inverse_of: :answers
   belongs_to :question, inverse_of: nil
+
+  private
+
+  def validate_consistent_assessment
+    errors.add(:question, :consistent_assessment) if question.assessment != submission.assessment
+  end
 end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -16,7 +16,9 @@ class Course::Assessment::Answer < ActiveRecord::Base
   validate :validate_consistent_assessment
 
   belongs_to :submission, inverse_of: :answers
-  belongs_to :question, inverse_of: nil
+  belongs_to :question, class_name: Course::Assessment::Question.name, inverse_of: nil
+
+  accepts_nested_attributes_for :actable
 
   private
 

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -1,5 +1,17 @@
 class Course::Assessment::Answer < ActiveRecord::Base
+  include Workflow
   actable
+
+  workflow do
+    state :attempting do
+      event :submit, transitions_to: :submitted
+    end
+    state :submitted do
+      event :unsubmit, transitions_to: :attempting
+      event :grade, transitions_to: :graded
+    end
+    state :graded
+  end
 
   belongs_to :submission, inverse_of: :answers
   belongs_to :question, inverse_of: nil

--- a/app/models/course/assessment/answer/multiple_response.rb
+++ b/app/models/course/assessment/answer/multiple_response.rb
@@ -1,8 +1,7 @@
 class Course::Assessment::Answer::MultipleResponse < ActiveRecord::Base
   acts_as :answer, class_name: Course::Assessment::Answer.name, inverse_of: :actable
 
-  has_many :options, class_name: Course::Assessment::Answer::MultipleResponseOption.name,
-                     dependent: :destroy, foreign_key: :answer_id, inverse_of: :answer
-
-  accepts_nested_attributes_for :options
+  has_many :answer_options, class_name: Course::Assessment::Answer::MultipleResponseOption.name,
+                            dependent: :destroy, foreign_key: :answer_id, inverse_of: :answer
+  has_many :options, through: :answer_options
 end

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -5,4 +5,17 @@ class Course::Assessment::Question < ActiveRecord::Base
   has_and_belongs_to_many :tags
 
   delegate :to_partial_path, to: :actable
+
+  # Attempts the given question in the submission. This builds a new answer for the current
+  # question.
+  #
+  # @param [Course::Assessment::Submission] submission The submission which the answer should
+  #   belong to.
+  # @return [Course::Assessment::Answer] The answer corresponding to the question. It is required
+  #   that the {Course::Assessment::Answer#question} property be the same as +self+. The result
+  #   should not be persisted.
+  def attempt(submission)
+    return actable.attempt(submission) if actable
+    fail NotImplementedError, 'Questions must implement the #attempt method for submissions.'
+  end
 end

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -7,4 +7,8 @@ class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
                      dependent: :destroy, foreign_key: :question_id, inverse_of: :question
 
   accepts_nested_attributes_for :options
+
+  def attempt(submission)
+    submission.multiple_response_answers.build(submission: submission, question: question).answer
+  end
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -3,12 +3,12 @@ class Course::Assessment::Submission < ActiveRecord::Base
   acts_as_experience_points_record
 
   workflow do
-    state :created do
+    state :attempting do
       event :finalize, transitions_to: :submitted
     end
     state :submitted do
-      event :unsubmit, transitions_to: :created
-      event :submit, transitions_to: :graded
+      event :unsubmit, transitions_to: :attempting
+      event :grade, transitions_to: :graded
     end
     state :graded
   end
@@ -19,5 +19,5 @@ class Course::Assessment::Submission < ActiveRecord::Base
   #   The answers associated with this submission. There can be more than one answer per submission,
   #   this is because every answer is saved over time. Use the {.latest} scope of the answers if
   #   only the latest answer for each question is desired.
-  has_many :answers
+  has_many :answers, inverse_of: :submission
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -20,4 +20,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
   #   this is because every answer is saved over time. Use the {.latest} scope of the answers if
   #   only the latest answer for each question is desired.
   has_many :answers, inverse_of: :submission
+  has_many :multiple_response_answers,
+           through: :answers, source: :actable,
+           source_type: Course::Assessment::Answer::MultipleResponse.name
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -19,8 +19,12 @@ class Course::Assessment::Submission < ActiveRecord::Base
   #   The answers associated with this submission. There can be more than one answer per submission,
   #   this is because every answer is saved over time. Use the {.latest} scope of the answers if
   #   only the latest answer for each question is desired.
-  has_many :answers, inverse_of: :submission
+  has_many :answers, class_name: Course::Assessment::Answer.name, inverse_of: :submission do
+    include Course::Assessment::Submission::AnswersConcern
+  end
   has_many :multiple_response_answers,
            through: :answers, source: :actable,
            source_type: Course::Assessment::Answer::MultipleResponse.name
+
+  accepts_nested_attributes_for :answers
 end

--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
@@ -1,0 +1,5 @@
+- question = multiple_response.question.specific
+h3 = question.title
+= sanitize(question.description)
+= f.association :options, as: :check_boxes, collection: question.options,
+                          label_method: :option, label: false

--- a/app/views/course/assessment/submissions/edit.html.slim
+++ b/app/views/course/assessment/submissions/edit.html.slim
@@ -1,3 +1,9 @@
+= page_header
+
 = simple_form_for [current_course, @assessment, @submission] do |f|
-  = f.hidden_field :updated_at
+  - @answers.each do |answer|
+    = f.simple_fields_for :answers, answer do |base_answer_form|
+      = base_answer_form.simple_fields_for :actable do |specific_answer_form|
+        = render partial: answer.specific, locals: { f: specific_answer_form }
+  = f.input :updated_at, type: :hidden
   = f.button :submit

--- a/app/views/course/assessment/submissions/edit.html.slim
+++ b/app/views/course/assessment/submissions/edit.html.slim
@@ -5,5 +5,4 @@
     = f.simple_fields_for :answers, answer do |base_answer_form|
       = base_answer_form.simple_fields_for :actable do |specific_answer_form|
         = render partial: answer.specific, locals: { f: specific_answer_form }
-  = f.input :updated_at, type: :hidden
   = f.button :submit

--- a/config/locales/en/activerecord/course/assessment/answer.yml
+++ b/config/locales/en/activerecord/course/assessment/answer.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/answer:
+          attributes:
+            question:
+              consistent_assessment: 'must belong to the same assessment'

--- a/db/migrate/20150803080715_add_assessment_answer_workflow_state.rb
+++ b/db/migrate/20150803080715_add_assessment_answer_workflow_state.rb
@@ -1,0 +1,5 @@
+class AddAssessmentAnswerWorkflowState < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_answers, :workflow_state, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -171,9 +171,10 @@ ActiveRecord::Schema.define(version: 20150812024950) do
 
   create_table "course_assessment_answers", force: :cascade do |t|
     t.integer "actable_id"
-    t.string  "actable_type",  limit: 255, index: {name: "index_course_assessment_answers_actable", with: ["actable_id"], unique: true}
-    t.integer "submission_id", null: false, index: {name: "fk__course_assessment_answers_submission_id"}, foreign_key: {references: "course_assessment_submissions", name: "fk_course_assessment_answers_submission_id", on_update: :no_action, on_delete: :no_action}
-    t.integer "question_id",   null: false, index: {name: "fk__course_assessment_answers_question_id"}, foreign_key: {references: "course_assessment_questions", name: "fk_course_assessment_answers_question_id", on_update: :no_action, on_delete: :no_action}
+    t.string  "actable_type",   limit: 255, index: {name: "index_course_assessment_answers_actable", with: ["actable_id"], unique: true}
+    t.integer "submission_id",  null: false, index: {name: "fk__course_assessment_answers_submission_id"}, foreign_key: {references: "course_assessment_submissions", name: "fk_course_assessment_answers_submission_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "question_id",    null: false, index: {name: "fk__course_assessment_answers_question_id"}, foreign_key: {references: "course_assessment_questions", name: "fk_course_assessment_answers_question_id", on_update: :no_action, on_delete: :no_action}
+    t.string  "workflow_state", limit: 255, null: false
   end
 
   create_table "course_assessment_tag_groups", force: :cascade do |t|

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment::SubmissionsController do
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let!(:course) { create(:course, creator: user) }
-    let(:assessment) { create(:assessment, course: course) }
+    let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
     let!(:immutable_submission) do
       create(:submission, assessment: assessment, user: user).tap do |stub|
         allow(stub).to receive(:save).and_return(false)

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:course_assessment_assessment, :with_mcq_question, course: course) }
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Student' do
+      let(:user) { create(:course_user, :approved, course: course).user }
+      let(:submission) do
+        submission = create(:course_assessment_submission, assessment: assessment, user: user)
+        assessment.questions.attempt(submission)
+        submission
+      end
+      let(:correct_option) { assessment.questions.first.options.find(&:correct?).option }
+
+      scenario 'I can save my submission' do
+        submission
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        check correct_option
+
+        click_button 'submit'
+        expect(current_path).to eq(\
+          edit_course_assessment_submission_path(course, assessment, submission))
+
+        expect(page).to have_checked_field(correct_option)
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/answer/multiple_response_spec.rb
+++ b/spec/models/course/assessment/answer/multiple_response_spec.rb
@@ -2,10 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Course::Assessment::Answer::MultipleResponse do
   it { is_expected.to act_as(:answer) }
-  it 'has many options' do
-    expect(subject).to have_many(:options).
+  it 'has many answer_options' do
+    expect(subject).to have_many(:answer_options).
       class_name(Course::Assessment::Answer::MultipleResponseOption.name).
       dependent(:destroy)
   end
-  it { is_expected.to accept_nested_attributes_for(:options) }
+  it 'has many options' do
+    expect(subject).to have_many(:options).
+      class_name(Course::Assessment::Question::MultipleResponseOption.name)
+  end
 end

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Course::Assessment::Answer do
   it { is_expected.to be_actable }
   it { is_expected.to belong_to(:submission) }
   it { is_expected.to belong_to(:question) }
+  it { is_expected.to accept_nested_attributes_for(:actable) }
 
   let(:instance) { create(:instance) }
   with_tenant(:instance) do

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -4,4 +4,22 @@ RSpec.describe Course::Assessment::Answer do
   it { is_expected.to be_actable }
   it { is_expected.to belong_to(:submission) }
   it { is_expected.to belong_to(:question) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe 'validations' do
+      subject { build_stubbed(:course_assessment_answer) }
+
+      describe '#question' do
+        it 'validates that the assessment is consistent' do
+          subject.question = build_stubbed(:course_assessment_question)
+          expect(subject.question.assessment).not_to eq(subject.submission.assessment)
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:question]).to include(
+            I18n.t('activerecord.errors.models.course/assessment/answer.attributes.question'\
+              '.consistent_assessment'))
+        end
+      end
+    end
+  end
 end

--- a/spec/models/course/assessment/question/multiple_response_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_spec.rb
@@ -8,4 +8,22 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
       dependent(:destroy)
   end
   it { is_expected.to accept_nested_attributes_for(:options) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '#attempt' do
+      subject { build_stubbed(:course_assessment_question_multiple_response) }
+      let(:assessment) { subject.assessment }
+      let(:submission) { build_stubbed(:course_assessment_submission, assessment: assessment) }
+
+      it 'returns an Answer' do
+        expect(subject.attempt(submission)).to be_a(Course::Assessment::Answer)
+      end
+
+      it 'associates the answer with the submission' do
+        answer = subject.attempt(submission)
+        expect(submission.multiple_response_answers).to include(answer.actable)
+      end
+    end
+  end
 end

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -4,4 +4,31 @@ RSpec.describe Course::Assessment::Question do
   it { is_expected.to be_actable }
   it { is_expected.to belong_to(:assessment) }
   it { is_expected.to have_and_belong_to_many(:tags) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '#attempt' do
+      subject { build_stubbed(:course_assessment_question) }
+      it 'fails' do
+        expect { subject.attempt(nil) }.to raise_error(NotImplementedError)
+      end
+
+      context 'when the question is polymorphic' do
+        class self::TestPolymorphicQuestion < ActiveRecord::Base
+          acts_as :question, class_name: Course::Assessment::Question.name, inverse_of: :actable
+
+          def self.table_name
+            'course_assessment_questions'
+          end
+        end
+        let(:question) { self.class::TestPolymorphicQuestion.new }
+        subject { question.question }
+
+        it "calls the polymorphic object's methods" do
+          expect(question).to receive(:attempt).and_return([])
+          subject.attempt(nil)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -3,4 +3,5 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Submission do
   it { is_expected.to belong_to(:assessment) }
   it { is_expected.to have_many(:answers) }
+  it { is_expected.to accept_nested_attributes_for(:answers) }
 end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -6,4 +6,57 @@ RSpec.describe Course::Assessment do
   it { is_expected.to have_many(:questions).dependent(:destroy) }
   it { is_expected.to have_many(:multiple_response_questions).through(:questions) }
   it { is_expected.to have_many(:submissions).dependent(:destroy) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '.questions' do
+      describe '#attempt' do
+        let(:assessment) do
+          assessment = build(:assessment)
+          create_list(:course_assessment_question_multiple_response, 3, assessment: assessment)
+          assessment
+        end
+        let(:submission) { create(:course_assessment_submission, assessment: assessment) }
+        let(:answers) { assessment.questions.attempt(submission) }
+
+        context 'when some questions are being attempted' do
+          before do
+            assessment.questions.limit(1).attempt(submission).tap do |answers|
+              answers.each(&:save)
+            end
+          end
+
+          it 'instantiates new answers' do
+            expect(answers.first.persisted?).to be(true)
+            expect(answers.drop(1).any?(&:persisted?)).to be(false)
+          end
+        end
+
+        context 'when all questions are being attempted' do
+          before do
+            assessment.questions.attempt(submission).tap do |answers|
+              answers.each(&:save)
+            end
+          end
+
+          it 'reuses all existing answers' do
+            expect(answers.all?(&:persisted?)).to be(true)
+          end
+        end
+
+        context 'when some questions have been submitted' do
+          before do
+            assessment.questions.limit(1).attempt(submission).tap do |answers|
+              answers.each(&:save!)
+              answers.each(&:submit!)
+            end
+          end
+
+          it 'creates a new answer' do
+            expect(answers.all?(&:persisted?)).to be(false)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Depends on #507.

This implements a student attempting an assessment which only contains MRQ questions. The student can save his answers in his submission, and this also implements checks to ensure students cannot attempt an empty assessment.