### PR TITLE
Restrict active submissions to one per assessment

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -5,6 +5,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   authorize_resource :assessment, class: Course::Assessment.name
 
   def index
+    @assessments = @assessments.with_submissions_by(current_user)
   end
 
   def show

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -12,7 +12,20 @@ class Course::Assessment < ActiveRecord::Base
   has_many :multiple_response_questions,
            through: :questions, source: :actable,
            source_type: Course::Assessment::Question::MultipleResponse.name
-  has_many :submissions, dependent: :destroy
+  has_many :submissions, inverse_of: :assessment, dependent: :destroy
+
+  # @!method with_submissions_by(creator)
+  #   Includes the submissions by the provided user.
+  #   @param [User] user The user to preload submissions for.
+  scope :with_submissions_by, (lambda do |user|
+    submissions = Course::Assessment::Submission.by_user(user).
+                  where(assessment: pluck(:id)).ordered_by_date
+
+    all.to_a.tap do |result|
+      preloader = ActiveRecord::Associations::Preloader::ManualPreloader.new
+      preloader.preload(result, :submissions, submissions)
+    end
+  end)
 
   def self.use_relative_model_naming?
     true

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -27,4 +27,17 @@ class Course::Assessment::Submission < ActiveRecord::Base
            source_type: Course::Assessment::Answer::MultipleResponse.name
 
   accepts_nested_attributes_for :answers
+
+  # @!method self.by_user(user)
+  #   Finds all the submissions by the given user.
+  #   @param [User] user The user to filter submissions by
+  scope :by_user, (lambda do |user|
+    joins { experience_points_record.course_user }.
+      where { experience_points_record.course_user.user == user }
+  end)
+
+  # @!method self.ordered_by_date
+  #   Orders the submissions by date of creation. This defaults to reverse chronological order
+  #   (newest submission first).
+  scope :ordered_by_date, ->(direction = :desc) { order(created_at: direction) }
 end

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -12,5 +12,10 @@
   td = format_datetime(assessment.start_at)
   td = format_datetime(assessment.end_at)
   td
-    = button_to(t('.attempt'), course_assessment_submissions_path(current_course, assessment),
-                class: ['btn-info'])
+    - attempting_submission = assessment.submissions.find(&:attempting?)
+    - if attempting_submission
+      = link_to(t('.attempt'), edit_course_assessment_submission_path(current_course,
+          assessment, attempting_submission), class: ['btn', 'btn-info'])
+    - else
+      = button_to(t('.attempt'), course_assessment_submissions_path(current_course, assessment),
+                  class: ['btn-info'])

--- a/lib/autoload/active_record/associations/preloader/manual_association_preloader.rb
+++ b/lib/autoload/active_record/associations/preloader/manual_association_preloader.rb
@@ -1,0 +1,20 @@
+module ActiveRecord::Associations::Preloader::ManualAssociationPreloader
+  def initialize(klass, owners, reflection, records)
+    super(klass, owners, reflection, nil)
+
+    @records_by_owner = records.each_with_object({}) do |record, h|
+      owner_id = record[association_key_name]
+      owner_id = owner_id.to_s if key_conversion_required?
+      records = (h[owner_id] ||= [])
+      records << record
+    end
+  end
+
+  def scope
+    fail NotImplementedError
+  end
+
+  def records_for(ids)
+    ids.flat_map { |id| @records_by_owner[id] }.tap(&:compact!)
+  end
+end

--- a/lib/autoload/active_record/associations/preloader/manual_has_many.rb
+++ b/lib/autoload/active_record/associations/preloader/manual_has_many.rb
@@ -1,0 +1,5 @@
+class ActiveRecord::Associations::Preloader
+  class ManualHasMany < HasMany
+    prepend ManualAssociationPreloader
+  end
+end

--- a/lib/autoload/active_record/associations/preloader/manual_preloader.rb
+++ b/lib/autoload/active_record/associations/preloader/manual_preloader.rb
@@ -1,0 +1,22 @@
+class ActiveRecord::Associations::Preloader
+  # A manual preloader, inspired by
+  # https://mrbrdo.wordpress.com/2013/09/25/manually-preloading-associations-in-rails
+  class ManualPreloader < ActiveRecord::Associations::Preloader
+    # Preloads the given owners by specifying the children for the given association.
+    def preload(owners, associations, children)
+      super
+    end
+
+    def preloader_for(reflection, owners, rhs_klass)
+      preloader_class = super
+      case preloader_class.name
+      when HasMany.name
+        ActiveRecord::Associations::Preloader::ManualHasMany
+      when NullPreloader.name, AlreadyLoaded.name
+        preloader_class
+      else
+        fail NotImplementedError
+      end
+    end
+  end
+end

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -3,6 +3,5 @@ FactoryGirl.define do
                                          parent: :course_experience_points_record,
                                          aliases: [:submission] do
     assessment { build(:assessment, course: course) }
-    # workflow_state 'created'
   end
 end

--- a/spec/features/course/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment_attempt_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe 'Course: Assessments: Attempt' do
         expect(current_path).to eq(\
           edit_course_assessment_submission_path(course, assessment, submission))
       end
+
+      scenario 'I can continue my attempt' do
+        submission
+        visit course_assessments_path(course)
+
+        submission_path = edit_course_assessment_submission_path(course, assessment, submission)
+        expect(page).to have_link(I18n.t('course.assessment.assessments.assessment.attempt'),
+                                  href: submission_path)
+      end
     end
   end
 end

--- a/spec/libraries/legacy_spec.rb
+++ b/spec/libraries/legacy_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Extension: Legacy', type: :model do
   describe 'maximum string column length' do
-    class ExtensionLegacyStringColumnLength < ActiveRecord::Base
+    class self::ExtensionLegacyStringColumnLength < ActiveRecord::Base
     end
 
     temporary_table(:extension_legacy_string_column_lengths) do |t|
@@ -10,7 +10,7 @@ RSpec.describe 'Extension: Legacy', type: :model do
     end
     with_temporary_table(:extension_legacy_string_column_lengths) do
       it 'imposes a limit of 255 characters' do
-        test = ExtensionLegacyStringColumnLength.new(test: '6' * 256)
+        test = self.class::ExtensionLegacyStringColumnLength.new(test: '6' * 256)
         expect(test.valid?).to be_falsey
         expect(test.errors[:test].find { |e| e =~ /too long/i }).not_to be_nil
       end

--- a/spec/libraries/manual_eager_load_spec.rb
+++ b/spec/libraries/manual_eager_load_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe 'Extension: Manual Eager Load', type: :model do
+  class self::SourceItem < ActiveRecord::Base
+    has_many :referenced_items, inverse_of: :source_item
+    has_one :singular_item, inverse_of: :source_item
+  end
+  class self::ReferencedItem < ActiveRecord::Base
+    belongs_to :source_item, inverse_of: :referenced_items
+  end
+  class self::SingularItem < ActiveRecord::Base
+    self.table_name = 'referenced_items'
+    belongs_to :source_item, inverse_of: :referenced_items
+  end
+
+  temporary_table(:source_items) do |t|
+    t.string :test
+  end
+  temporary_table(:referenced_items) do |t|
+    t.references :source_item, foreign_key: nil
+  end
+  with_temporary_table(:source_items) do
+    with_temporary_table(:referenced_items) do
+      let(:preloader) { ActiveRecord::Associations::Preloader::ManualPreloader.new }
+      let(:source) { self.class::SourceItem.create }
+      let(:referenced1) { self.class::ReferencedItem.create(source_item: source) }
+      let(:referenced2) { self.class::ReferencedItem.create(source_item: source) }
+      let(:referenced3) { self.class::ReferencedItem.create(source_item: source) }
+
+      context 'when eager loading a has_one relation' do
+        before do
+          referenced1
+
+          source.reload
+        end
+
+        it 'fails with NotImplementedError' do
+          expect { preloader.preload(source, :singular_item, []) }.
+            to raise_error(NotImplementedError)
+        end
+      end
+
+      context 'when eager loading a has_many relation' do
+        before do
+          referenced1
+          referenced2
+          referenced3
+
+          source.reload
+          preloader.preload(source, :referenced_items, eager_load_items)
+        end
+
+        let(:eager_load_items) { [referenced1, referenced3] }
+        it 'marks the association as loaded' do
+          expect(source.referenced_items.loaded?).to be(true)
+        end
+
+        it 'preserves the order of the items' do
+          expect(source.referenced_items.to_a).to eq(eager_load_items)
+        end
+
+        it 'sets the inverse for the eager loaded items' do
+          expect(eager_load_items.all? do |referenced|
+            referenced.association(:source_item).loaded?
+          end).to be(true)
+          expect(eager_load_items.map(&:source_item).all? do |source_item|
+            source.object_id == source_item.object_id
+          end).to be(true)
+        end
+      end
+
+      context 'when the association has already been loaded' do
+        before do
+          source.association(:referenced_items).loaded!
+          source.referenced_items << referenced1
+          preloader.preload(source, :referenced_items, [referenced2])
+        end
+
+        it 'does not change the target' do
+          expect(source.referenced_items.loaded?).to be(true)
+          expect(source.referenced_items).to contain_exactly(referenced1)
+        end
+      end
+    end
+
+    describe ActiveRecord::Associations::Preloader::ManualAssociationPreloader do
+      class self::DummyPreloader
+        include ActiveRecord::Associations::Preloader::ManualAssociationPreloader
+
+        def initialize
+        end
+      end
+
+      subject { self.class::DummyPreloader.new }
+
+      describe '#scope' do
+        it 'raises when scope is called' do
+          expect { subject.scope }.to raise_error(NotImplementedError)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -4,4 +4,41 @@ RSpec.describe Course::Assessment::Submission do
   it { is_expected.to belong_to(:assessment) }
   it { is_expected.to have_many(:answers) }
   it { is_expected.to accept_nested_attributes_for(:answers) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:assessment, course: course) }
+
+    let(:user1) { create(:user) }
+    let(:submission1) { create(:submission, assessment: assessment, user: user1) }
+    let(:user2) { create(:user) }
+    let(:submission2) { create(:submission, assessment: assessment, user: user2) }
+
+    describe '.with_creator' do
+      before do
+        submission1
+        submission2
+      end
+
+      it "only returns the selected user's submissions" do
+        expect(assessment.submissions.by_user(user1).empty?).to be(false)
+        expect(assessment.submissions.by_user(user1).
+          all? { |submission| submission.course_user.user == user1 }).to be(true)
+      end
+    end
+
+    describe '.ordered_by_date' do
+      before do
+        submission1
+        submission2
+      end
+
+      it 'returns the submissions in the specified order' do
+        expect(assessment.submissions.ordered_by_date.length).to be >= 2
+        expect(assessment.submissions.ordered_by_date.each_cons(2).
+          all? { |a, b| a.created_at >= b.created_at }).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
 1. Implement manually preloading associations
 2. Implement scopes for querying assessments
 3. Changed the controller to use those scopes

This is ugly, but I can't find a cleaner way. Rails does not allow us to specify conditions on the JOIN which are parameterised and supports eager loading.