### PR TITLE
Speed up tests and improve correctness

### DIFF
--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -3,7 +3,7 @@ class System::Admin::InstancesController < System::Admin::Controller
   add_breadcrumb :index, :admin_instances_path
 
   def index #:nodoc:
-    @instances = @instances.with_course_count.with_user_count
+    @instances = @instances.with_course_count.with_user_count.order_by_id.page(params[:page])
   end
 
   def new #:nodoc:

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -52,6 +52,10 @@ class Instance < ActiveRecord::Base
   #   @note You are scoped by the current tenant, you might not see all.
   has_many :courses, dependent: :destroy
 
+  # @!method self.order_by_id(direction = :asc)
+  #   Orders the instances by ID.
+  scope :order_by_id, ->(direction = :asc) { order(id: direction) }
+
   # @!method self.with_course_count
   #   Augments all returned records with the number of courses in that instance.
   scope :with_course_count, (lambda do

--- a/app/views/system/admin/instances/index.html.slim
+++ b/app/views/system/admin/instances/index.html.slim
@@ -10,3 +10,5 @@ table.table.table-middle-align.table-hover
 
   tbody
     = render @instances
+
+= paginate @instances

--- a/spec/factories/omniauth_providers.rb
+++ b/spec/factories/omniauth_providers.rb
@@ -1,16 +1,24 @@
 FactoryGirl.define do
   factory :omniauth_provider, class: OmniAuth::AuthHash.name do
+    transient do
+      name { generate(:name) }
+      email { generate(:email) }
+    end
     provider 'default'
     sequence(:uid) { |n| SecureRandom.random_number(2**48) + n }
     info do
-      {
-        name: generate(:name),
-        email: generate(:email)
-      }
+      {}.tap do |result|
+        result[:name] = name if name
+        result[:email] = email if email
+      end
     end
   end
 
   factory :omniauth_facebook, parent: :omniauth_provider do
     provider 'facebook'
+
+    trait :without_email do
+      email nil
+    end
   end
 end

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Course: Administration: Administration', type: :feature do
+RSpec.feature 'Course: Administration: Administration' do
   subject { page }
 
   let(:instance) { create(:instance) }
@@ -9,39 +9,25 @@ RSpec.describe 'Course: Administration: Administration', type: :feature do
     let!(:user) { create(:administrator) }
     before { login_as(user, scope: :user) }
 
-    describe 'index' do
-      let!(:course) { create(:course) }
-      before { visit course_admin_path(course) }
+    context 'As an administrator' do
+      let(:course) { create(:course) }
+      scenario 'I can change the course attributes' do
+        visit course_admin_path(course)
 
-      context 'with valid information' do
-        let(:new_title) { 'New Title' }
-        let(:new_description) { 'New Description' }
+        fill_in 'course_title', with: ''
+        click_button I18n.t('helpers.submit.course.update')
+        expect(course.reload.title).not_to eq('')
+        expect(page).to have_selector('div.has-error')
 
-        before do
-          fill_in 'course_title',          with: new_title
-          fill_in 'course_description',    with: new_description
-          click_button I18n.t('helpers.submit.course.update')
-        end
+        new_title = 'New Title'
+        new_description = 'New Description'
+        fill_in 'course_title',          with: new_title
+        fill_in 'course_description',    with: new_description
+        click_button I18n.t('helpers.submit.course.update')
 
-        it 'changes the attributes' do
-          expect(course.reload.title).to eq(new_title)
-          expect(course.reload.description).to eq(new_description)
-        end
-      end
-
-      context 'with empty title' do
-        before do
-          fill_in 'course_title', with: ''
-          click_button I18n.t('helpers.submit.course.update')
-        end
-
-        it 'does not change title' do
-          expect(course.reload.title).not_to eq('')
-        end
-
-        it 'shows the error' do
-          expect(page).to have_css('div.has-error')
-        end
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(course.reload.title).to eq(new_title)
+        expect(course.reload.description).to eq(new_description)
       end
     end
   end

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Course: Announcements', type: :feature do
-  subject { page }
-
+RSpec.feature 'Course: Announcements' do
   let!(:instance) { create(:instance) }
 
   with_tenant(:instance) do
@@ -13,155 +11,74 @@ RSpec.describe 'Course: Announcements', type: :feature do
       login_as(user, scope: :user)
     end
 
-    describe 'announcement creation' do
-      before { visit new_course_announcement_path(course) }
+    context 'As an administrator' do
+      scenario 'I can create new announcements' do
+        visit new_course_announcement_path(course)
+        click_button I18n.t('helpers.submit.announcement.create')
+        expect(page).to have_button(I18n.t('helpers.submit.announcement.create'))
+        expect(page).to have_css('div.has-error')
 
-      context 'with invalid information' do
-        before { click_button I18n.t('helpers.submit.announcement.create') }
+        announcement = build_stubbed(:course_announcement, course: course)
+        fill_in 'announcement_title',    with: announcement.title
+        fill_in 'announcement_content',  with: announcement.content
+        expect do
+          click_button I18n.t('helpers.submit.announcement.create')
+        end.to change(course.announcements, :count).by(1)
 
-        it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.announcement.create'))
-        end
-
-        it 'shows errors' do
-          expect(page).to have_css('div.has-error')
-        end
+        expect(page).to have_selector('div.alert.alert-success',
+                                      text: I18n.t('course.announcements.create.success'))
+        expect(current_path).to eq(course_announcements_path(course))
       end
 
-      context 'with valid information' do
-        let(:announcement) { build(:course_announcement, course: course) }
-        subject { click_button I18n.t('helpers.submit.announcement.create') }
+      scenario 'I can edit announcments' do
+        announcement = create(:course_announcement, course: course)
+        visit edit_course_announcement_path(course, announcement)
 
-        before do
-          fill_in 'announcement_title',    with: announcement.title
-          fill_in 'announcement_content',  with: announcement.content
-        end
+        expect(page).to have_field('announcement_title', with: announcement.title)
+        expect(page).to have_field('announcement_content', with: announcement.content)
+        expect(page).to have_field('announcement[start_at]', with: announcement.start_at)
+        expect(page).to have_field('announcement[end_at]', with: announcement.end_at)
 
-        it 'creates an announcement' do
-          expect { subject }.to change(course.announcements, :count).by(1)
-        end
+        fill_in 'announcement_title', with: ''
+        click_button I18n.t('helpers.submit.announcement.update')
+        expect(page).to have_button('helpers.submit.announcement.update')
+        expect(page).to have_css('div.has-error')
 
-        context 'after creation' do
-          before { subject }
+        new_title = 'New Title'
+        new_content = 'New content'
+        fill_in 'announcement_title',        with: new_title
+        fill_in 'announcement_content',      with: new_content
+        click_button I18n.t('helpers.submit.announcement.update')
 
-          it 'shows the success message' do
-            expect(page).to have_selector('div',
-                                          text: I18n.t('course.announcements.create.success'))
-          end
-
-          it 'redirects the user to the index page' do
-            expect(current_path).to eq(course_announcements_path(course))
-          end
-        end
-      end
-    end
-
-    describe 'announcement editing' do
-      let!(:announcement) { create(:course_announcement, course: course) }
-
-      before { visit edit_course_announcement_path(course, announcement) }
-
-      context 'page rendering' do
-        it { is_expected.to have_field('announcement_title', with: announcement.title) }
-        it { is_expected.to have_field('announcement_content', with: announcement.content) }
-        it do
-          is_expected.to have_field('announcement[start_at]',
-                                    with: announcement.start_at)
-        end
-        it do
-          is_expected.to have_field('announcement[end_at]', with: announcement.end_at)
-          click_button I18n.t('helpers.submit.announcement.update')
-        end
+        expect(current_path).to eq course_announcements_path(course)
+        expect(page).to have_selector('div.alert.alert-success',
+                                      text: I18n.t('course.announcements.update.success'))
+        expect(announcement.reload.title).to eq(new_title)
+        expect(announcement.reload.content).to eq(new_content)
       end
 
-      context 'with invalid information' do
-        before do
-          fill_in 'announcement_title', with: ''
-          click_button I18n.t('helpers.submit.announcement.update')
-        end
-
-        it 'stays on the same page' do
-          expect(page).to have_button('helpers.submit.announcement.update')
-        end
-
-        it 'shows errors' do
-          expect(page).to have_css('div.has-error')
-        end
-      end
-
-      context 'with valid information' do
-        let(:new_title)  { 'New Title' }
-        let(:new_content) { 'New content' }
-
-        before do
-          fill_in 'announcement_title',        with: new_title
-          fill_in 'announcement_content',      with: new_content
-          click_button I18n.t('helpers.submit.announcement.update')
-        end
-
-        it 'redirects the user to index page' do
-          expect(current_path).to eq course_announcements_path(course)
-        end
-
-        it 'shows the success message' do
-          expect(page).to have_selector('div',
-                                        text: I18n.t('course.announcements.update.success'))
-        end
-
-        it 'changes the attributes' do
-          expect(announcement.reload.title).to eq(new_title)
-          expect(announcement.reload.content).to eq(new_content)
-        end
-      end
-    end
-
-    describe 'index' do
-      let!(:announcements) do
-        create_list(:course_announcement, 10, course: course)
-      end
-
-      before do
+      scenario 'I can see all existing announcements' do
+        announcements = create_list(:course_announcement, 10, course: course)
         visit course_announcements_path(course)
-      end
+        expect(page).to have_link(nil, href: new_course_announcement_path(course))
 
-      context 'management buttons' do
-        it { is_expected.to have_link(nil, href: new_course_announcement_path(course)) }
-      end
-
-      it 'shows all announcements' do
         announcements.each do |announcement|
-          expect(page).to have_selector('div', text: announcement.title)
-          expect(page).to have_selector('div', text: announcement.content)
-        end
-      end
-
-      it 'shows all management buttons' do
-        announcements.each do |announcement|
+          expect(page).to have_content_tag_for(announcement)
           expect(page).to have_link(nil, href: edit_course_announcement_path(course, announcement))
           expect(page).to have_link(nil, href: course_announcement_path(course, announcement))
         end
       end
-    end
 
-    describe 'announcement destruction' do
-      let!(:announcement) { create(:course_announcement, course: course) }
-      let(:announcement_path) { course_announcement_path(course, announcement) }
+      scenario 'I can delete an existing announcement' do
+        announcement = create(:course_announcement, course: course)
+        visit course_announcements_path(course)
 
-      before { visit course_announcements_path(course) }
-
-      it 'deletes the announcement' do
         expect do
-          find_link(nil, href: announcement_path).click
+          find_link(nil, href: course_announcement_path(course, announcement)).click
         end.to change(course.announcements, :count).by(-1)
-      end
-
-      context 'after announcement deleted' do
-        before { find_link(nil, href: announcement_path).click }
-
-        it 'shows the success message' do
-          expect(page).to have_selector('div',
-                                        text: I18n.t('course.announcements.destroy.success'))
-        end
+        expect(current_path).to eq(course_announcements_path(course))
+        expect(page).to have_selector('div.alert.alert-success',
+                                      text: I18n.t('course.announcements.destroy.success'))
       end
     end
   end

--- a/spec/features/global_announcements_spec.rb
+++ b/spec/features/global_announcements_spec.rb
@@ -17,9 +17,9 @@ RSpec.feature 'Global announcements' do
 
       scenario 'I should not see any announcements if there are none' do
         visit announcements_path
-        it { is_expected.not_to have_selector('div.global-announcement') }
-        it { is_expected.not_to have_selector('div.instance-announcement') }
-        it { is_expected.not_to have_selector('div.system-announcement') }
+        expect(page).not_to have_selector('div.global-announcement')
+        expect(page).not_to have_selector('div.instance-announcement')
+        expect(page).not_to have_selector('div.system-announcement')
       end
 
       scenario 'I should see instance announcements' do
@@ -30,7 +30,7 @@ RSpec.feature 'Global announcements' do
           with_tag('div.panel-heading', text: format('×%s', announcement.title))
           with_tag('div.panel-body', text: announcement.content)
         end
-        it { is_expected.to have_selector('div.instance-announcement') }
+        expect(page).to have_content_tag_for(announcement)
       end
 
       scenario 'I should see system announcements' do
@@ -41,18 +41,17 @@ RSpec.feature 'Global announcements' do
           with_tag('div.panel-heading', text: format('×%s', announcement.title))
           with_tag('div.panel-body', text: announcement.content)
         end
-        it { is_expected.to have_selector('div.system-announcement') }
+        expect(page).to have_content_tag_for(announcement)
       end
 
       scenario 'I should see both types of announcements' do
-        announcements = (-3..0).map do |i|
+        announcements = (-3..0).flat_map do |i|
           now = Time.zone.now
           [
             create(:instance_announcement, end_at: now - i.seconds, instance: instance),
             create(:system_announcement, start_at: now - i.seconds)
           ]
         end
-        announcements.flatten!
 
         visit announcements_path
 
@@ -66,9 +65,11 @@ RSpec.feature 'Global announcements' do
                    text: I18n.t('announcements.global_announcements.more_announcements'))
         end
 
-        announcements.each do |s|
-          type_selector = s.is_a?(System::Announcement) ? 'system' : 'instance'
-          it { is_expected.to have_selector("div##{type_selector}_announcement_#{s.id}") }
+        announcements.select(&:currently_active?).each do |s|
+          expect(page).to have_content_tag_for(s)
+        end
+        announcements.reject(&:currently_active?).each do |s|
+          expect(page).not_to have_content_tag_for(s)
         end
       end
     end

--- a/spec/features/system/admin/instance/instance_announcement_management_spec.rb
+++ b/spec/features/system/admin/instance/instance_announcement_management_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'System: Administration: InstanceAnnouncements', type: :feature do
+RSpec.feature 'System: Administration: Instance Announcements' do
   subject { page }
 
   let!(:instance) { create(:instance) }
@@ -12,154 +12,75 @@ RSpec.describe 'System: Administration: InstanceAnnouncements', type: :feature d
       login_as(user, scope: :user)
     end
 
-    describe 'announcement creation' do
-      before { visit new_admin_instance_announcement_path }
+    context 'As a system administrator' do
+      scenario 'I can create instance announcements' do
+        visit new_admin_instance_announcement_path
 
-      context 'with invalid information' do
-        before do
+        click_button I18n.t('helpers.submit.announcement.create')
+        expect(page).to have_button(I18n.t('helpers.submit.announcement.create'))
+        expect(page).to have_css('div.has-error')
+
+        announcement = build_stubbed(:instance_announcement, instance: instance)
+        fill_in 'announcement[title]',    with: announcement.title
+        fill_in 'announcement[content]',  with: announcement.content
+        fill_in 'announcement[start_at]', with: announcement.start_at
+        fill_in 'announcement[end_at]',   with: announcement.end_at
+        expect do
           click_button I18n.t('helpers.submit.announcement.create')
-        end
+        end.to change { Instance::Announcement.count }.by(1)
 
-        it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.announcement.create'))
-        end
-
-        it 'shows errors' do
-          expect(page).to have_css('div.has-error')
-        end
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(current_path).to eq(admin_instance_announcements_path)
       end
 
-      context 'with valid information' do
-        let(:announcement) { build(:instance_announcement, instance: instance) }
+      scenario 'I can edit instance announcements' do
+        announcement = create(:instance_announcement, instance: instance)
+        visit edit_admin_instance_announcement_path(announcement)
 
-        before do
-          fill_in 'announcement[title]',    with: announcement.title
-          fill_in 'announcement[content]',  with: announcement.content
-          fill_in 'announcement[start_at]', with: announcement.start_at
-          fill_in 'announcement[end_at]',   with: announcement.end_at
-        end
+        expect(page).to have_field('announcement[title]', with: announcement.title)
+        expect(page).to have_field('announcement[content]', with: announcement.content)
+        expect(page).to have_field('announcement[start_at]', with: announcement.start_at)
+        expect(page).to have_field('announcement[end_at]', with: announcement.end_at)
 
-        it 'creates an announcement' do
-          expect { click_button I18n.t('helpers.submit.announcement.create') }.to change(
-            Instance::Announcement, :count).by(1)
-        end
+        fill_in 'announcement[title]', with: ''
+        click_button I18n.t('helpers.submit.announcement.update')
+        expect(announcement.reload.title).not_to be_empty
+        expect(page).to have_button(I18n.t('helpers.submit.announcement.update'))
+        expect(page).to have_css('div.has-error')
 
-        context 'after creation' do
-          before { click_button I18n.t('helpers.submit.announcement.create') }
+        new_title = 'New Title'
+        new_content = 'New content'
 
-          it 'shows the success message' do
-            expect(page).
-              to have_selector('div',
-                               text: I18n.t('system.admin.instance.announcements.create.success'))
-          end
+        fill_in 'announcement[title]',        with: new_title
+        fill_in 'announcement[content]',      with: new_content
+        click_button I18n.t('helpers.submit.announcement.update')
 
-          it 'redirects the user to the index page' do
-            expect(current_path).to eq(admin_instance_announcements_path)
-          end
-        end
-      end
-    end
-
-    describe 'announcement editing' do
-      let!(:announcement) { create(:instance_announcement, instance: instance) }
-
-      before { visit edit_admin_instance_announcement_path(announcement) }
-
-      context 'page rendering' do
-        it { is_expected.to have_field('announcement[title]', with: announcement.title) }
-
-        it do
-          is_expected.to have_field('announcement[content]', with: announcement.content)
-        end
-
-        it do
-          is_expected.to have_field('announcement[start_at]',
-                                    with: announcement.start_at)
-        end
-
-        it do
-          is_expected.to have_field('announcement[end_at]', with: announcement.end_at)
-        end
+        expect(current_path).to eq admin_instance_announcements_path
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(announcement.reload.title).to eq(new_title)
+        expect(announcement.reload.content).to eq(new_content)
       end
 
-      context 'with invalid information' do
-        before do
-          fill_in 'announcement[title]', with: ''
-          click_button I18n.t('helpers.submit.announcement.update')
-        end
+      scenario 'I can see all instance announcements' do
+        announcements = create_list(:instance_announcement, 2, instance: instance)
+        visit admin_instance_announcements_path(page: Instance::Announcement.page.total_pages)
 
-        it 'stays on the same page' do
-          expect(page).to have_button(I18n.t('helpers.submit.announcement.update'))
-        end
-
-        it 'shows errors' do
-          expect(page).to have_css('div.has-error')
-        end
-      end
-
-      context 'with valid information' do
-        let(:new_title)  { 'New Title' }
-        let(:new_content) { 'New content' }
-
-        before do
-          fill_in 'announcement[title]',        with: new_title
-          fill_in 'announcement[content]',      with: new_content
-          click_button I18n.t('helpers.submit.announcement.update')
-        end
-
-        it 'redirects the user to index page' do
-          expect(current_path).to eq admin_instance_announcements_path
-        end
-
-        it 'shows the success message' do
-          expect(page).
-            to have_selector('div',
-                             text: I18n.t('system.admin.instance.announcements.update.success'))
-        end
-
-        it 'changes the attributes' do
-          expect(announcement.reload.title).to eq(new_title)
-          expect(announcement.reload.content).to eq(new_content)
-        end
-      end
-    end
-
-    describe 'index' do
-      let!(:announcements) do
-        create_list(:instance_announcement, 10, instance: instance)
-      end
-
-      before do
-        visit admin_instance_announcements_path
-      end
-
-      context 'management buttons' do
-        it { is_expected.to have_link(nil, href: new_admin_instance_announcement_path) }
-      end
-
-      it 'shows all announcements' do
+        expect(page).to have_link(nil, href: new_admin_instance_announcement_path)
         announcements.each do |announcement|
-          expect(page).to have_selector('div', text: announcement.title)
-          expect(page).to have_selector('div', text: announcement.content)
-        end
-      end
-
-      it 'shows all management buttons' do
-        announcements.each do |announcement|
+          expect(page).to have_content_tag_for(announcement)
           expect(page).to have_link(nil, href: edit_admin_instance_announcement_path(announcement))
           expect(page).to have_link(nil, href: admin_instance_announcement_path(announcement))
         end
       end
-    end
 
-    describe 'announcement deletion' do
-      let!(:announcement) { create(:instance_announcement, instance: instance) }
-      let(:announcement_path) { admin_instance_announcement_path(announcement) }
-      before { visit admin_instance_announcements_path }
+      scenario 'I can delete announcements' do
+        announcement = create(:instance_announcement, instance: instance)
+        visit admin_instance_announcements_path(page: Instance::Announcement.page.total_pages)
 
-      it 'deletes the announcement' do
-        find_link(nil, href: announcement_path).click
-        it { is_expected.not_to have_link(nil, href: announcement_path) }
+        find_link(nil, href: admin_instance_announcement_path(announcement)).click
+        expect(instance.announcements.exists?(announcement.id)).to be(false)
+        visit admin_instance_announcements_path(page: Instance::Announcement.page.total_pages)
+        expect(page).not_to have_link(nil, href: admin_instance_announcement_path(announcement))
       end
     end
   end

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'System: Administration: Users' do
         expect(user_to_change.reload).to be_administrator
       end
 
-      let!(:user_to_delete) { create(:user, name: users.first.name) }
+      let!(:user_to_delete) { create(:user, name: '!' + users.first.name) }
       scenario 'I can delete a user' do
         visit admin_users_path
 

--- a/spec/features/user/email_management_spec.rb
+++ b/spec/features/user/email_management_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'User: Emails' do
     scenario 'I can view all my emails' do
       user.emails.each do |email|
         expect(page).to have_selector('tr td', text: email.email)
-        it { is_expected.to have_selector('tr td', text: email.email) }
       end
     end
 
@@ -23,11 +22,11 @@ RSpec.feature 'User: Emails' do
       valid_email = build(:user_email).email
       fill_in 'user_email_email', with: invalid_email
       click_button 'add'
-      it { is_expected.to have_selector('div.alert-danger') }
+      expect(page).to have_selector('div.alert-danger')
 
       fill_in 'user_email_email', with: valid_email
       click_button 'add'
-      it { is_expected.to have_selector('tr td', text: valid_email) }
+      expect(page).to have_selector('tr td', text: valid_email)
     end
 
     scenario 'I can delete a email' do
@@ -36,7 +35,7 @@ RSpec.feature 'User: Emails' do
         find_link(nil, href: user_email_path(email_to_delete)).click
       end.to change { user.emails.count }.by(-1)
 
-      it { is_expected.to have_selector('div.success') }
+      expect(page).to have_selector('div.alert.alert-success')
     end
 
     scenario 'I can set an email as primary' do

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -3,29 +3,26 @@ require 'rails_helper'
 RSpec.feature 'Users: Sign Up' do
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
-    before { visit new_user_registration_path }
+    context 'As an unregistered user' do
+      scenario 'I can register for an account' do
+        visit new_user_registration_path
 
-    context 'with invalid information' do
-      subject { click_button I18n.t('user.registrations.new.sign_up') }
-      it 'does not create a user' do
-        expect { subject }.not_to change(User, :count)
-      end
-    end
+        expect do
+          click_button I18n.t('user.registrations.new.sign_up')
+        end.not_to change(User, :count)
+        expect(page).to have_selector('div.has-error')
 
-    context 'with valid information' do
-      let(:valid_user) { build(:user) }
-      subject { click_button I18n.t('user.registrations.new.sign_up') }
+        valid_user = attributes_for(:user).reverse_merge(email: generate(:email))
+        fill_in 'user_name', with: valid_user[:name]
+        fill_in 'user_email', with: valid_user[:email]
+        fill_in 'user_password', with: valid_user[:password]
+        fill_in 'user_password_confirmation', with: valid_user[:password]
 
-      before do
-        fill_in 'user_name', with: valid_user.name
-        fill_in 'user_email', with: valid_user.email
-        fill_in 'user_password', with: valid_user.password
-        fill_in 'user_password_confirmation', with: valid_user.password
-      end
-
-      it 'creates a user' do
-        it { is_expected.to change(User, :count).by(1) }
-        it { is_expected.to change(instance.instance_users, :count).by(1) }
+        expect do
+          click_button I18n.t('user.registrations.new.sign_up')
+        end.to change(User, :count).by(1)
+        user = User::Email.find_by!(email: valid_user[:email]).user
+        expect(instance.users.exists?(user)).to be_truthy
       end
     end
   end

--- a/spec/models/generic_announcement_spec.rb
+++ b/spec/models/generic_announcement_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe GenericAnnouncement, type: :model do
       end
 
       it 'shows currently active announcements' do
-        all = GenericAnnouncement.currently_active
-        expect(all).to include(*active_system_announcements)
-        expect(all).to include(*active_instance_announcements)
+        active_announcements = active_system_announcements + active_instance_announcements
+        all = GenericAnnouncement.currently_active.where(id: active_announcements.map(&:id))
+        expect(all).to contain_exactly(*active_announcements)
       end
 
       it 'does not show inactive announcements' do
-        all = GenericAnnouncement.currently_active
-        expect(all).to_not include(*inactive_announcements)
+        active = GenericAnnouncement.currently_active.where(id: inactive_announcements.map(&:id))
+        expect(active).to be_empty
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe User, type: :model do
     describe '.new_with_session' do
       context 'when facebook data is provided' do
         let(:params) { {} }
-        let(:facebook_data) { OmniAuth.config.mock_auth[:facebook] }
+        let(:facebook_data) { build(:omniauth_facebook) }
         let(:session) { { 'devise.facebook_data' => facebook_data } }
         subject { User.new_with_session(params, session) }
 
@@ -130,11 +130,7 @@ RSpec.describe User, type: :model do
         end
 
         context 'when the user did not authorize access to his email address' do
-          let(:facebook_data) do
-            OmniAuth.config.mock_auth[:facebook].tap do |facebook|
-              facebook[:info].except(:email)
-            end
-          end
+          let(:facebook_data) { build(:omniauth_facebook, :without_email) }
           let(:email) { generate(:email) }
           let(:params) { { email: email } }
 

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -68,25 +68,23 @@ module ActsAsTenant::TestGroupHelpers
   end
 end
 
-module ActsAsTenant::TestExampleHelpers
-  module FeatureHelpers
-    [:visit, :click_button, :click_link].each do |method|
-      define_method(method) do |*args|
-        # Unset the active tenant, let the request flow through the Rack stack and allow our own
-        # code to deduce the tenant from the host name.
-        ActsAsTenant.with_tenant(nil) do
-          super(*args)
-        end
+module ActsAsTenant::CapybaraHelpers
+  module BrowserHelpers
+    # Unset the active tenant, let the request flow through the Rack stack and allow our own
+    # code to deduce the tenant from the host name.
+    def process(*)
+      ActsAsTenant.with_tenant(nil) do
+        super
       end
     end
   end
 end
+Capybara::RackTest::Browser.prepend(ActsAsTenant::CapybaraHelpers::BrowserHelpers)
 
 RSpec.configure do |config|
   config.extend ActsAsTenant::TestGroupHelpers::ModelHelpers
   config.extend ActsAsTenant::TestGroupHelpers::ControllerHelpers, type: :controller
   config.extend ActsAsTenant::TestGroupHelpers::FeatureHelpers, type: :feature
-  config.include ActsAsTenant::TestExampleHelpers::FeatureHelpers, type: :feature
 
   config.backtrace_exclusion_patterns << %r{/spec/support/acts_as_tenant\.rb}
 end


### PR DESCRIPTION
Helps with #225.

`with_tenant` enhanced to work with link clicks and form submissions. Also rewrote some specs to use the user story-style.