### PR TITLE
Update edge

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       json
       thread
       thread_safe
-    edge (0.4.2)
+    edge (0.4.3)
       activerecord (>= 4.0.0)
     erubis (2.7.0)
     execjs (2.6.0)

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -1,9 +1,8 @@
 class Course::Material::Folder < ActiveRecord::Base
-  acts_as_forest order: :name
+  acts_as_forest order: :name, dependent: :destroy
   include Course::ModelComponentHost::Component
 
   after_initialize :set_defaults, if: :new_record?
-  before_destroy :destroy_children
 
   has_many :materials, inverse_of: :folder, dependent: :destroy, foreign_key: :folder_id,
                        class_name: Course::Material.name, autosave: true
@@ -27,9 +26,5 @@ class Course::Material::Folder < ActiveRecord::Base
 
   def set_defaults
     self.start_at ||= Time.zone.now
-  end
-
-  def destroy_children
-    children.destroy_all
   end
 end

--- a/spec/models/course/material/folder_spec.rb
+++ b/spec/models/course/material/folder_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Course::Material::Folder, type: :model do
   it { is_expected.to have_many(:materials).autosave(true) }
+  it { is_expected.to have_many(:children).dependent(:destroy) }
 
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do


### PR DESCRIPTION
The latest version of `edge` supports dependent: :destroy option now.