### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ educators to increase student engagement and make learning fun.
 1. Ruby (>= 2.1.0)
 2. Ruby on Rails
 3. PostgreSQL
+4. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick))
+work)
 
 Coursemology uses [Ruby on Rails](http://rubyonrails.org/). This
 [guide](https://gorails.com/setup/) written by the awesome people at


### PR DESCRIPTION
So I tried deploying Coursemology today - Readme works just fine except for this small dependency!

For OS X,I've also found installing phantomjs to be a pain - brew doesn't sit well with the latest version of phantomjs (v2.0) and El Capitan, so for I've had to use `npm` instead to install v1.9.8. Should I add that to the contributing page? Not sure if it should be in since it is an OS specific issue.