### PR TITLE
Persist workflow changes only after saving

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,9 @@ Declare model attributes in the following order:
 This allows models to be inherited. See the section on _Inherited Callback Queues_ from
 [`ActiveRecord::Callbacks`](http://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html#module-ActiveRecord::Callbacks-label-Inheritable+callback+queues).
 
+Take note that workflows do *not* persist their state, `save` needs to be called on the record.
+See `lib/extensions/deferred_workflow_state_persistence`.
+
 ## Views
 The same code style for Ruby code applies to all views (e.g. single quotes unless interpolations
 are used.) There is no linting for views at this point, but that might change in future.

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -31,13 +31,13 @@ class Course::Assessment::Answer < ActiveRecord::Base
   protected
 
   def finalise
-    update_attribute(:grade, 0)
-    touch(:submitted_at)
+    self.grade = 0
+    self.submitted_at = Time.zone.now
   end
 
   def publish
-    update_attribute(:grader_id, User.stamper.id)
-    touch(:graded_at)
+    self.grader = User.stamper
+    self.graded_at = Time.zone.now
   end
 
   private

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -15,8 +15,9 @@ class Course::Assessment::Answer < ActiveRecord::Base
 
   validate :validate_consistent_assessment
   validate :validate_assessment_state, if: :attempting?
-  validates :submitted_at, :grade, :grader, :graded_at, presence: true, unless: :attempting?
+  validates :submitted_at, :grade, presence: true, unless: :attempting?
   validates :submitted_at, :grade, :grader, :graded_at, absence: true, if: :attempting?
+  validates :grader, :graded_at, presence: true, if: :graded?
   validate :validate_consistent_grade, unless: :attempting?
 
   belongs_to :submission, inverse_of: :answers

--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -77,6 +77,9 @@ module Extensions
       require "#{__dir__}/#{module_.name.underscore}/#{path}"
 
       class_to_extend = module_name(path).constantize
+      warn "Class does not match: expected #{module_name(path)}, got #{class_to_extend}. Maybe "\
+        "#{module_name(path)} has not been defined?" if module_name(path) != class_to_extend.name
+
       module_to_include = "#{module_.name}::#{class_to_extend}".constantize
       extend_class(class_to_extend, module_to_include)
     end

--- a/lib/extensions/deferred_workflow_state_persistence.rb
+++ b/lib/extensions/deferred_workflow_state_persistence.rb
@@ -1,0 +1,1 @@
+module Extensions::DeferredWorkflowStatePersistence; end

--- a/lib/extensions/deferred_workflow_state_persistence/active_record.rb
+++ b/lib/extensions/deferred_workflow_state_persistence/active_record.rb
@@ -1,0 +1,1 @@
+module Extensions::DeferredWorkflowStatePersistence::ActiveRecord; end

--- a/lib/extensions/deferred_workflow_state_persistence/active_record/base.rb
+++ b/lib/extensions/deferred_workflow_state_persistence/active_record/base.rb
@@ -1,0 +1,7 @@
+module Extensions::DeferredWorkflowStatePersistence::ActiveRecord::Base
+  module ClassMethods
+    def workflow_adapter
+      Extensions::DeferredWorkflowStatePersistence::Workflow::Adapter::DeferredActiveRecord
+    end
+  end
+end

--- a/lib/extensions/deferred_workflow_state_persistence/workflow.rb
+++ b/lib/extensions/deferred_workflow_state_persistence/workflow.rb
@@ -1,0 +1,16 @@
+module Extensions::DeferredWorkflowStatePersistence::Workflow; end
+module Extensions::DeferredWorkflowStatePersistence::Workflow::Adapter; end
+module Extensions::DeferredWorkflowStatePersistence::Workflow::Adapter::DeferredActiveRecord
+  extend ActiveSupport::Concern
+  included do
+    include Workflow::Adapter::ActiveRecord
+    include InstanceMethods
+  end
+
+  module InstanceMethods
+    def persist_workflow_state(new_value)
+      write_attribute(self.class.workflow_column, new_value)
+      true
+    end
+  end
+end

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         submission.assessment.questions.attempt(submission).each(&:save!)
         submission.finalise!
         submission.publish!
+        submission.save!
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
         submission.answers.each do |answer|
@@ -103,6 +104,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
       scenario "I can grade the student's work" do
         assessment.questions.attempt(submission).each(&:save!)
         submission.finalise!
+        submission.save!
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
         submission_maximum_grade = 0

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -80,16 +80,6 @@ RSpec.describe Course::Assessment::Answer do
             expect(subject).not_to be_valid
             expect(subject.errors[:grade]).not_to be_empty
           end
-        end
-      end
-
-      describe '#grader' do
-        context 'when the answer is being attempted' do
-          it 'cannot have a grade' do
-            subject.grader = build(:user)
-            expect(subject).not_to be_valid
-            expect(subject.errors[:grader]).not_to be_empty
-          end
 
           it 'must be less than or equal to the question maximum grade' do
             subject.grade = subject.question.maximum_grade + 1
@@ -97,11 +87,12 @@ RSpec.describe Course::Assessment::Answer do
             expect(subject.errors[:grade]).not_to be_empty
           end
         end
+      end
 
-        context 'when the answer is submitted' do
-          let(:workflow_state) { 'submitted' }
-
-          it 'must have a grade' do
+      describe '#grader' do
+        context 'when the answer is being attempted' do
+          it 'cannot have a grader' do
+            subject.grader = build(:user)
             expect(subject).not_to be_valid
             expect(subject.errors[:grader]).not_to be_empty
           end
@@ -110,7 +101,7 @@ RSpec.describe Course::Assessment::Answer do
         context 'when the answer is graded' do
           let(:workflow_state) { 'graded' }
 
-          it 'must have a grade' do
+          it 'must have a grader' do
             expect(subject).not_to be_valid
             expect(subject.errors[:grader]).not_to be_empty
           end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Course::Assessment do
         context 'when some questions have been submitted' do
           before do
             assessment.questions.limit(1).attempt(submission).tap do |answers|
-              answers.each(&:save!)
               answers.each(&:finalise!)
+              answers.each(&:save!)
             end
           end
 

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -83,7 +83,9 @@ RSpec.describe CourseUser, type: :model do
     describe '.approved' do
       before do
         student.approve!
+        student.save!
         teaching_assistant.approve!
+        teaching_assistant.save!
       end
 
       it 'returns all approved course users' do
@@ -110,7 +112,7 @@ RSpec.describe CourseUser, type: :model do
     end
 
     describe '#approve!' do
-      subject { student.tap(&:approve!) }
+      subject { student.tap(&:approve!).tap(&:save!) }
       it 'increases approved course users\' count' do
         expect { subject }.to change(CourseUser.with_approved_state, :count).by(1)
       end


### PR DESCRIPTION
So we can use build() to create workflow-based objects. Also a bit closer to ActiveRecord behaviour.