### PR TITLE
Trackable jobs

### DIFF
--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -1,0 +1,6 @@
+.jobs.show {
+  .spinner {
+    font-size: 500%;
+    text-align: center;
+  }
+}

--- a/app/controllers/concerns/application_components_concern.rb
+++ b/app/controllers/concerns/application_components_concern.rb
@@ -9,6 +9,6 @@ module ApplicationComponentsConcern
 
   def handle_component_not_found(exception)
     @exception = exception
-    render file: 'public/404', layout: false, status: 404
+    render file: 'public/404', layout: false, status: :not_found
   end
 end

--- a/app/controllers/concerns/application_user_concern.rb
+++ b/app/controllers/concerns/application_user_concern.rb
@@ -14,6 +14,6 @@ module ApplicationUserConcern
 
   def handle_access_denied(exception)
     @exception = exception
-    render 'pages/403', status: 403
+    render 'pages/403', status: :forbidden
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,0 +1,38 @@
+class JobsController < ApplicationController
+  before_action :load_job
+
+  def show
+    if @job.completed?
+      show_completed_job
+    elsif @job.errored?
+      show_errored_job
+    else
+      show_submitted_job
+    end
+  end
+
+  protected
+
+  def publicly_accessible?
+    true
+  end
+
+  private
+
+  def load_job
+    @job ||= TrackableJob::Job.find(params[:id])
+  end
+
+  def show_completed_job
+    redirect_to @job.redirect_to if @job.redirect_to.present?
+  end
+
+  def show_errored_job
+    if @job.redirect_to.present?
+      redirect_to @job.redirect_to
+    end
+  end
+
+  def show_submitted_job
+  end
+end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -30,9 +30,12 @@ class JobsController < ApplicationController
   def show_errored_job
     if @job.redirect_to.present?
       redirect_to @job.redirect_to
+    else
+      response.status = :internal_server_error
     end
   end
 
   def show_submitted_job
+    response.status = :accepted
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,15 @@ module ApplicationHelper
   include ApplicationSidebarHelper
   include RouteOverridesHelper
 
+  # Accesses the header tags specified for the current page
+  def header_tags(*args, &proc)
+    content_for(:header_tags, *args, &proc)
+  end
+
+  # @!method within_head_tag(&proc)
+  #   Adds the given block to the header tags which will be added to the rendered page.
+  alias_method :within_head_tag, :header_tags
+
   # Generates a page header. The title shown will be the +.header+ key in the page
   # that calls this helper.
   #

--- a/app/themes/default/views/layouts/default.html.slim
+++ b/app/themes/default/views/layouts/default.html.slim
@@ -9,6 +9,7 @@ html
     = stylesheet_link_tag 'default/all', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'default/all', defer: true, 'data-turbolinks-track' => true
     = csrf_meta_tags
+    = header_tags
 
   body
     nav.navbar.navbar-inverse.navbar-fixed-top role="navigation"

--- a/app/views/jobs/_completed.html.slim
+++ b/app/views/jobs/_completed.html.slim
@@ -1,0 +1,2 @@
+div.alert.alert-success
+  = t('.completed')

--- a/app/views/jobs/_completed.json.jbuilder
+++ b/app/views/jobs/_completed.json.jbuilder
@@ -1,0 +1,1 @@
+json.message t('.completed')

--- a/app/views/jobs/_errored.html.slim
+++ b/app/views/jobs/_errored.html.slim
@@ -1,0 +1,2 @@
+div.alert.alert-danger
+  = t('.errored')

--- a/app/views/jobs/_errored.json.jbuilder
+++ b/app/views/jobs/_errored.json.jbuilder
@@ -1,0 +1,1 @@
+json.message t('.errored')

--- a/app/views/jobs/_submitted.html.slim
+++ b/app/views/jobs/_submitted.html.slim
@@ -1,0 +1,5 @@
+= within_head_tag do
+  meta http-equiv='refresh' content='5'
+
+div.spinner
+  = fa_icon 'spinner'.freeze, class: ['fa-spin']

--- a/app/views/jobs/show.html.slim
+++ b/app/views/jobs/show.html.slim
@@ -1,0 +1,1 @@
+= render partial: @job.status

--- a/app/views/jobs/show.json.jbuilder
+++ b/app/views/jobs/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! @job.status

--- a/config/locales/en/jobs.yml
+++ b/config/locales/en/jobs.yml
@@ -1,0 +1,6 @@
+en:
+  jobs:
+    completed:
+      completed: 'The job has completed.'
+    errored:
+      errored: 'The job has encountered an error.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,8 @@ Rails.application.routes.draw do
   }
 
   resources :announcements, only: [:index]
+  resources :jobs, only: [:show]
+
   namespace :user do
     resources :emails, only: [:index, :create, :destroy] do
       post 'set_primary', on: :member

--- a/db/migrate/20151114043545_create_jobs.rb
+++ b/db/migrate/20151114043545_create_jobs.rb
@@ -1,0 +1,10 @@
+class CreateJobs < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+    create_table :jobs, id: :uuid do |t|
+      t.integer :status, null: false, default: 0
+      t.string :redirect_to
+      t.json :error
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151101050627) do
+ActiveRecord::Schema.define(version: 20151114043545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                   limit: 255,              null: false
@@ -485,6 +486,12 @@ ActiveRecord::Schema.define(version: 20151101050627) do
     t.datetime "updated_at",  null: false
   end
   add_index "instance_users", ["instance_id", "user_id"], name: "index_instance_users_on_instance_id_and_user_id", unique: true
+
+  create_table "jobs", id: :uuid, default: nil, force: :cascade do |t|
+    t.integer "status",      default: 0, null: false
+    t.string  "redirect_to", limit: 255
+    t.json    "error"
+  end
 
   create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"

--- a/lib/autoload/trackable_job.rb
+++ b/lib/autoload/trackable_job.rb
@@ -1,0 +1,69 @@
+# This is a mix-in that allows jobs to be trackable. Trackable jobs can be queried at /jobs/<id>.
+# A client requesting HTML would see a progress bar; a client requesting JSON will get a status
+# message. When the job is complete, the trackable job can specify a path to redirect the user to.
+#
+# To use this mix-in, implement +perform_tracked+ instead of +perform+, with the same arguments.
+# If you intend to use +rescue_from+ and you wish for the job to fail, call +rescue_tracked+ with
+# the exception.
+#
+# Jobs are ephemeral; do not expect jobs to remain after a long period of time. Also since jobs
+# are uniquely identified only by ID and do not need authentication, do not leak anything
+# sensitive from the job.
+module TrackableJob
+  extend ActiveSupport::Concern
+
+  class Job < ActiveRecord::Base
+    enum status: [:submitted, :completed, :errored]
+
+    validates :redirect_to, absence: true, if: :submitted?
+    validates :error, absence: true, unless: :errored?
+  end
+
+  included do
+    rescue_from(StandardError) do |exception|
+      rescue_tracked(exception)
+    end
+  end
+
+  # @!attribute [r] job
+  #   The Job object which tracks the status of this job.
+  attr_reader :job
+
+  # Implements +initialize+, creating the job in the database.
+  def initialize(*args)
+    super
+
+    @job = Job.create!(id: job_id)
+  end
+
+  def perform(*args)
+    perform_tracked(*args)
+    @job.status = :completed
+    @job.save!
+  end
+
+  protected
+
+  def perform_tracked(*)
+    fail NotImplementedError
+  end
+
+  def rescue_tracked(exception)
+    @job.status = :errored
+    @job.error = { message: exception.to_s }
+    @job.save!
+  end
+
+  private
+
+  def deserialize_arguments(serialized_arguments)
+    super
+
+    @job = Job.find(job_id)
+  end
+
+  # Specifies that the job should redirect to the given path.
+  def redirect_to(path)
+    @job.redirect_to = path
+  end
+end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe JobsController do
+  let(:job) { create(:trackable_job, *job_traits) }
+  let(:job_traits) { nil }
+  before do
+    controller.instance_variable_set(:@job, job)
+  end
+
+  describe '#show' do
+    def self.expect_to_redirect_to_job_redirect_to
+      before { job.redirect_to = '/' }
+      it { is_expected.to redirect_to(job.redirect_to) }
+    end
+
+    subject { get 'show', id: job.id }
+
+    context 'when the job has been completed' do
+      context 'when the job has a redirect_to path' do
+        let(:job_traits) { :completed }
+        expect_to_redirect_to_job_redirect_to
+      end
+    end
+
+    context 'when the job has errored' do
+      context 'when the job has a redirect_to path' do
+        let(:job_traits) { :errored }
+        expect_to_redirect_to_job_redirect_to
+      end
+    end
+  end
+end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -9,23 +9,35 @@ RSpec.describe JobsController do
 
   describe '#show' do
     def self.expect_to_redirect_to_job_redirect_to
-      before { job.redirect_to = '/' }
-      it { is_expected.to redirect_to(job.redirect_to) }
+      let(:redirect_path) { '/' }
+      let(:job_traits) do
+        super_traits = *super()
+        super_traits + [{ redirect_to: redirect_path }]
+      end
+      it { is_expected.to redirect_to(redirect_path) }
     end
 
-    subject { get 'show', id: job.id }
+    before { get 'show', id: job.id }
+
+    context 'when the job is in progress' do
+      it { is_expected.to respond_with(:accepted) }
+    end
 
     context 'when the job has been completed' do
+      let(:job_traits) { :completed }
       context 'when the job has a redirect_to path' do
-        let(:job_traits) { :completed }
         expect_to_redirect_to_job_redirect_to
       end
     end
 
     context 'when the job has errored' do
+      let(:job_traits) { :errored }
       context 'when the job has a redirect_to path' do
-        let(:job_traits) { :errored }
         expect_to_redirect_to_job_redirect_to
+      end
+
+      context 'when the job does not have a redirec_to path' do
+        it { is_expected.to respond_with(:internal_server_error) }
       end
     end
   end

--- a/spec/factories/trackable_jobs.rb
+++ b/spec/factories/trackable_jobs.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :trackable_job, class: TrackableJob::Job do
+    id { SecureRandom.uuid }
+    trait :completed do
+      status 'completed'
+    end
+
+    trait :errored do
+      status 'errored'
+    end
+  end
+end

--- a/spec/features/jobs_query_spec.rb
+++ b/spec/features/jobs_query_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Jobs: status query' do
+  context 'As a user' do
+    let(:job) { create(:trackable_job) }
+
+    scenario 'I can query the status of a job' do
+      visit job_path(job.id)
+      expect(page).to have_selector('.fa-spinner.fa-spin')
+      expect(page).to have_selector(:xpath, '/html/head/meta[@http-equiv="refresh"][@content="5"]',
+                                    visible: false)
+
+      redirect_path = '/'
+      job.update_attributes(status: 'completed', redirect_to: redirect_path)
+      visit job_path(job.id)
+      expect(current_path).to eq(redirect_path)
+
+      job.update_attributes(status: 'errored', redirect_to: nil)
+      visit job_path(job.id)
+      expect(page).to have_selector('div.alert-danger')
+
+      job.update_attributes(status: 'errored', redirect_to: redirect_path)
+      visit job_path(job.id)
+      expect(current_path).to eq(redirect_path)
+    end
+  end
+end

--- a/spec/libraries/trackable_job_spec.rb
+++ b/spec/libraries/trackable_job_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe TrackableJob do
+  class self::NoOpJob < ActiveJob::Base
+    include TrackableJob
+  end
+
+  class self::ExampleJob < self::NoOpJob
+    protected
+
+    def perform_tracked
+    end
+  end
+
+  describe TrackableJob::Job, type: :model do
+    subject { TrackableJob::Job.new }
+
+    def self.validate_absence_of_error
+      it 'validates absence of :error' do
+        subject.error = { message: '' }
+        expect(subject.valid?).to be(false)
+        expect(subject.errors[:error]).not_to be_empty
+      end
+    end
+
+    it { is_expected.to validate_absence_of(:redirect_to) }
+    validate_absence_of_error
+
+    context 'when the job is completed' do
+      before { subject.status = :completed }
+
+      it { is_expected.not_to validate_absence_of(:redirect_to) }
+      validate_absence_of_error
+    end
+
+    context 'when the job is errored' do
+      before { subject.status = :errored }
+
+      it { is_expected.not_to validate_absence_of(:redirect_to) }
+      it 'does not validate absence of :error' do
+        subject.error = { message: '' }
+        expect(subject.valid?).to be(true)
+      end
+    end
+  end
+
+  subject { self.class::ExampleJob.perform_later }
+
+  context 'when a new job is created' do
+    it 'has a submitted state' do
+      expect(subject.job.status).to eq('submitted')
+    end
+
+    it 'is persisted to the database' do
+      expect(TrackableJob::Job.find(subject.job_id)).to eq(subject.job)
+    end
+  end
+
+  context 'when the job is completed' do
+    before { subject.perform_now }
+    it 'transitions to the completed state' do
+      expect(subject.job.status).to eq('completed')
+    end
+  end
+
+  context 'when the job has an error' do
+    before do
+      def subject.perform_tracked
+        fail
+      end
+
+      subject.perform_now
+    end
+
+    it 'transitions to the errored state' do
+      expect(subject.job.status).to eq('errored')
+    end
+
+    it 'has the error' do
+      expect(subject.job.error).to be_present
+    end
+  end
+
+  describe '#perform_tracked' do
+    subject { self.class::NoOpJob.perform_later }
+
+    it 'fails with NotImplementedError' do
+      expect { subject.perform_tracked }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#deserialize_arguments' do
+    it 'fetches the job' do
+      subject.send(:deserialize_arguments, [])
+      expect(subject.job.id).to eq(subject.job_id)
+    end
+  end
+
+  describe '#redirect_to' do
+    let(:redirect_to_path) { '/' }
+    it 'sets the #redirect_to attribute of the job' do
+      subject.send(:redirect_to, redirect_to_path)
+      expect(subject.job.redirect_to).to eq(redirect_to_path)
+    end
+  end
+end


### PR DESCRIPTION
Depends on #560. If this is merged, I'll rewrite the MRQ grader job to follow this convention.

Basically, this adds support for jobs to be tracked by clients, by the job's UUID. If it is a browser, the client will be held on a progress page until the job is done, where the client is redirected to the page of the job's choosing.