### PR TITLE
Use strong parameters to ensure that we retrieve only a scalar for the page parameter.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
   include ApplicationThemingConcern
   include ApplicationUserConcern
   include ApplicationAnnouncementsConcern
+  include ApplicationPaginationConcern
 
   rescue_from IllegalStateError, with: :handle_illegal_state_error
 

--- a/app/controllers/concerns/application_pagination_concern.rb
+++ b/app/controllers/concerns/application_pagination_concern.rb
@@ -1,0 +1,12 @@
+module ApplicationPaginationConcern
+  extend ActiveSupport::Concern
+
+  protected
+
+  # Retrieves the page number from the GET URL.
+  #
+  # @return [Fixnum|nil] The page number requested, or +nil+ if none was specified.
+  def page_param
+    params.permit(:page)[:page]
+  end
+end

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -6,7 +6,7 @@ class Course::AnnouncementsController < Course::ComponentController
 
   def index #:nodoc:
     @announcements = @announcements.includes(:creator).sorted_by_sticky.sorted_by_date
-    @announcements = @announcements.page(params[:page])
+    @announcements = @announcements.page(page_param)
     unread = @announcements.unread_by(current_user)
     Course::Announcement.mark_array_as_read(unread, current_user)
   end

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -2,7 +2,7 @@ class Course::CoursesController < Course::Controller
   include Course::ActivityFeedsConcern
 
   def index # :nodoc:
-    @courses = @courses.page(params[:page])
+    @courses = @courses.page(page_param)
   end
 
   def show # :nodoc:

--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -8,7 +8,7 @@ class Course::Forum::ForumsController < Course::Forum::Controller
 
   def show
     @topics = @forum.topics.accessible_by(current_ability).order(created_at: :desc).
-              with_topic_statistics.includes(:creator).page(params[:page]).with_latest_post
+              with_topic_statistics.includes(:creator).page(page_param).with_latest_post
   end
 
   def new

--- a/app/controllers/system/admin/announcements_controller.rb
+++ b/app/controllers/system/admin/announcements_controller.rb
@@ -3,7 +3,7 @@ class System::Admin::AnnouncementsController < System::Admin::Controller
   add_breadcrumb :index, :admin_announcements_path
 
   def index
-    @announcements = @announcements.includes(:creator).ordered_by_date.page(params[:page])
+    @announcements = @announcements.includes(:creator).ordered_by_date.page(page_param)
   end
 
   def new

--- a/app/controllers/system/admin/courses_controller.rb
+++ b/app/controllers/system/admin/courses_controller.rb
@@ -3,7 +3,7 @@ class System::Admin::CoursesController < System::Admin::Controller
   add_breadcrumb :index, :admin_courses_path
 
   def index
-    @courses = Course.ordered_by_title.page(params[:page]).includes(:instance).
+    @courses = Course.ordered_by_title.page(page_param).includes(:instance).
                search(params[:search]).with_owners
   end
 

--- a/app/controllers/system/admin/courses_controller.rb
+++ b/app/controllers/system/admin/courses_controller.rb
@@ -4,7 +4,7 @@ class System::Admin::CoursesController < System::Admin::Controller
 
   def index
     @courses = Course.ordered_by_title.page(page_param).includes(:instance).
-               search(params[:search]).with_owners
+               search(search_param).with_owners
   end
 
   def destroy
@@ -24,5 +24,9 @@ class System::Admin::CoursesController < System::Admin::Controller
     Course.unscoped do
       yield
     end
+  end
+
+  def search_param
+    params.permit(:search)[:search]
   end
 end

--- a/app/controllers/system/admin/instance/announcements_controller.rb
+++ b/app/controllers/system/admin/instance/announcements_controller.rb
@@ -4,7 +4,7 @@ class System::Admin::Instance::AnnouncementsController < System::Admin::Instance
   add_breadcrumb :index, :admin_instance_announcements_path
 
   def index
-    @announcements = @announcements.includes(:creator).page(params[:page])
+    @announcements = @announcements.includes(:creator).page(page_param)
   end
 
   def new

--- a/app/controllers/system/admin/instance/courses_controller.rb
+++ b/app/controllers/system/admin/instance/courses_controller.rb
@@ -5,7 +5,7 @@ class System::Admin::Instance::CoursesController < System::Admin::Instance::Cont
 
   def index
     @courses = @instance.courses.ordered_by_title.page(page_param).
-               search(params[:search]).with_owners
+               search(search_param).with_owners
   end
 
   def destroy
@@ -15,5 +15,11 @@ class System::Admin::Instance::CoursesController < System::Admin::Instance::Cont
       redirect_to admin_instance_courses_path,
                   danger: t('.failure', error: @course.errors.full_messages.to_sentence)
     end
+  end
+
+  private
+
+  def search_param
+    params.permit(:search)[:search]
   end
 end

--- a/app/controllers/system/admin/instance/courses_controller.rb
+++ b/app/controllers/system/admin/instance/courses_controller.rb
@@ -4,7 +4,7 @@ class System::Admin::Instance::CoursesController < System::Admin::Instance::Cont
   add_breadcrumb :index, :admin_instance_courses_path
 
   def index
-    @courses = @instance.courses.ordered_by_title.page(params[:page]).
+    @courses = @instance.courses.ordered_by_title.page(page_param).
                search(params[:search]).with_owners
   end
 

--- a/app/controllers/system/admin/instance/users_controller.rb
+++ b/app/controllers/system/admin/instance/users_controller.rb
@@ -5,7 +5,7 @@ class System::Admin::Instance::UsersController < System::Admin::Instance::Contro
 
   def index
     @instance_users = @instance.instance_users.includes(user: [:emails, :courses]).
-                      ordered_by_username.page(params[:page])
+                      ordered_by_username.page(page_param)
   end
 
   def update

--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -3,7 +3,7 @@ class System::Admin::InstancesController < System::Admin::Controller
   add_breadcrumb :index, :admin_instances_path
 
   def index #:nodoc:
-    @instances = @instances.with_course_count.with_user_count.order_by_id.page(params[:page])
+    @instances = @instances.with_course_count.with_user_count.order_by_id.page(page_param)
   end
 
   def new #:nodoc:

--- a/app/controllers/system/admin/users_controller.rb
+++ b/app/controllers/system/admin/users_controller.rb
@@ -3,7 +3,7 @@ class System::Admin::UsersController < System::Admin::Controller
   add_breadcrumb :index, :admin_users_path
 
   def index
-    @users = @users.ordered_by_name.includes(:emails).page(params[:page])
+    @users = @users.ordered_by_name.includes(:emails).page(page_param)
   end
 
   def update


### PR DESCRIPTION
Fixes #572.