### PR TITLE
ActiveJob spec helpers

### DIFF
--- a/lib/autoload/trackable_job.rb
+++ b/lib/autoload/trackable_job.rb
@@ -57,9 +57,10 @@ module TrackableJob
   private
 
   def deserialize_arguments(serialized_arguments)
-    super
+    result = super
 
     @job = Job.find(job_id)
+    result
   end
 
   # Specifies that the job should redirect to the given path.

--- a/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
@@ -14,14 +14,7 @@ RSpec.describe Course::Assessment::Submission::AutoGradingJob do
         change { ActiveJob::Base.queue_adapter.enqueued_jobs.count }.by(1)
     end
 
-    context 'when using an asynchronous adapter' do
-      around(:each) do |proc|
-        old_adapter = ActiveJob::Base.queue_adapter
-        ActiveJob::Base.queue_adapter = :background_thread
-        proc.call
-        ActiveJob::Base.queue_adapter = old_adapter
-      end
-
+    with_active_job_queue_adapter(:background_thread) do
       it 'grades submissions' do
         subject.perform_now(submission)
         expect(submission).to be_graded

--- a/spec/libraries/trackable_job_spec.rb
+++ b/spec/libraries/trackable_job_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe TrackableJob do
       subject.send(:deserialize_arguments, [])
       expect(subject.job.id).to eq(subject.job_id)
     end
+
+    it 'returns the arguments' do
+      arguments = subject.arguments
+      serialized_arguments = subject.serialize['arguments']
+      expect(subject.send(:deserialize_arguments, serialized_arguments)).to eq(arguments)
+    end
   end
 
   describe '#redirect_to' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,12 +55,4 @@ RSpec.configure do |config|
 
   # Old school have_tag, with_tag(and more) matchers for rspec 3
   config.include RSpecHtmlMatchers
-
-  # TODO: Remove when upgrading to RSpec >= 3.4
-  config.around(:each, type: :job) do |example|
-    old_adapter = ActiveJob::Base.queue_adapter
-    ActiveJob::Base.queue_adapter = :test
-    example.call
-    ActiveJob::Base.queue_adapter = old_adapter
-  end
 end

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -1,0 +1,31 @@
+module ActiveJob::TestGroupHelpers
+  def self.with_active_job_queue_adapter_method(adapter = :test)
+    proc { |example| ActiveJob::TestGroupHelpers.with_active_job_queue_adapter(example, adapter) }
+  end
+
+  def self.with_active_job_queue_adapter(example, adapter)
+    old_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = adapter
+    example.call
+  ensure
+    ActiveJob::Base.queue_adapter = old_adapter
+  end
+
+  def with_active_job_queue_adapter(adapter, &proc)
+    context "with #{adapter} ActiveJob queue adapter" do |*params|
+      around(:each, &ActiveJob::TestGroupHelpers.with_active_job_queue_adapter_method(adapter))
+
+      module_exec(*params, &proc)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.extend ActiveJob::TestGroupHelpers
+
+  # TODO: Remove when upgrading to RSpec >= 3.4
+  config.around(:each, type: :job,
+                &ActiveJob::TestGroupHelpers.with_active_job_queue_adapter_method)
+
+  config.backtrace_exclusion_patterns << /\/spec\/support\/active_job\.rb/
+end


### PR DESCRIPTION
Allows switching active job queue adapters for a spec.