### PR TITLE
Ensure that only one copy of the stylesheet is included.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,14 @@ override them in the theme directory.
 A sample theme (for [coursemology.org](http://coursemology.org)) can be found in the
 [coursemology-theme project](https://github.com/Coursemology/coursemology-theme).
 
+## Sprockets Pipeline
+Because we use Sass' `@import` directive, which does not ensure a file is included exactly once 
+(see sass/sass#139), we have a custom workaround by using an ERB template. This will properly 
+pick up changes made to scss files, but adding new files would require clearing the asset cache.
+
+Run `rake assets:clobber` (in production) and `rm -rf tmp/cache` (in development) to clear the 
+cache.
+
 ## Libraries
 The `lib` directory is not autoloaded, as described in this [blog post](http://hakunin.com/rails3-load-paths#if-you-add-code-in-your-lib-directory). However, the `lib/autoload`
 directory is. Place libraries which will be autoloaded in that directory instead.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,0 @@
-@import 'layout';
-@import 'variables';
-@import 'mixins/*';
-
-@import '**/*';

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -1,0 +1,26 @@
+@import 'layout';
+@import 'variables';
+@import 'mixins/*';
+
+<%
+# Import the rest of the files; @import '**/*' will include application.scss multiple times.
+# This is not perfect because every time a new file is added all assets need to be cleaned for the
+# new set of assets to be generated.
+#
+# TODO: Use compass-import-once after Compass/compass#1951 is fixed
+# TODO: Revert to @import '**/*' after sass/sass#139 is fixed in sass-4.0.
+exclude_imports =  ['layout', 'mixins', 'application.scss']
+imports = Dir["#{__dir__}/*"]
+imports.reject! do |path|
+  basename = File.basename(path, '.*')
+  basename.start_with?('_') || exclude_imports.include?(basename)
+end
+imports.map! do |path|
+  file_path = File.file?(path)
+  path = path[(__dir__.length + 1)..-1]
+  file_path ? path : "#{path}/**/*"
+end
+
+imports.each do |file| %>
+@import '<%= file %>';
+<% end %>

--- a/app/themes/default/assets/stylesheets/default/all.scss
+++ b/app/themes/default/assets/stylesheets/default/all.scss
@@ -1,7 +1,0 @@
-// This is a manifest file that'll automatically include all the stylesheets available in this
-// directory and any sub-directories. You're free to add application-wide styles to this file and
-// they'll appear at the top of the compiled file, but it's generally better to create a new file
-// per style scope.
-//
-@import 'default/layout';
-@import '**/*';

--- a/app/themes/default/assets/stylesheets/default/all.scss.erb
+++ b/app/themes/default/assets/stylesheets/default/all.scss.erb
@@ -1,0 +1,29 @@
+// This is a manifest file that'll automatically include all the stylesheets available in this
+// directory and any sub-directories. You're free to add application-wide styles to this file and
+// they'll appear at the top of the compiled file, but it's generally better to create a new file
+// per style scope.
+//
+@import 'default/layout';
+<%
+# Import the rest of the files; @import '**/*' will include application.scss multiple times.
+# This is not perfect because every time a new file is added all assets need to be cleaned for the
+# new set of assets to be generated.
+# This is taken from app/assets/stylesheets/application.css.erb
+#
+# TODO: Use compass-import-once after Compass/compass#1951 is fixed
+# TODO: Revert to @import '**/*' after sass/sass#139 is fixed in sass-4.0.
+exclude_imports =  ['layout', 'all.scss']
+imports = Dir["#{__dir__}/*"]
+imports.reject! do |path|
+  basename = File.basename(path, '.*')
+  basename.start_with?('_') || exclude_imports.include?(basename)
+end
+imports.map! do |path|
+  file_path = File.file?(path)
+  path = path[(__dir__.length + 1)..-1]
+  file_path ? path : "#{path}/**/*"
+end
+
+imports.each do |file| %>
+@import '<%= file %>';
+<% end %>


### PR DESCRIPTION
@import will import a file as many times as required, see sass/sass#139.

This approach mostly works, except that when a new .scss file is created, the entire asset cache must be cleared before the new file is picked up.