### PR TITLE
Polish Auto Grading

### DIFF
--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -38,8 +38,9 @@ class Course::Assessment::Answer < ActiveRecord::Base
     self.class.transaction do
       save!
       create_auto_grading!
-      Course::Assessment::Answer::AutoGradingJob.perform_later(auto_grading).tap do |job|
+      Course::Assessment::Answer::AutoGradingJob.new(auto_grading).tap do |job|
         auto_grading.update_attributes!(job_id: job.job_id)
+        job.enqueue
       end
     end
   end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -32,8 +32,10 @@ class Course::Assessment::Answer < ActiveRecord::Base
   #
   # @return [Course::Assessment::Answer::AutoGradingJob] The job instance.
   # @raise [ArgumentError] When the question cannot be auto graded.
+  # @raise [IllegalStateError] When the answer has not been submitted.
   def auto_grade!
     fail ArgumentError unless question.auto_gradable?
+    fail IllegalStateError if attempting?
 
     self.class.transaction do
       save!


### PR DESCRIPTION
Small changes to polish the MRQ auto grading
 - race condition between the job creation and execution
 - grade answer multiple times
 - do not allow grading an unsubmitted answer