### PR TITLE
Implement has_many inverse_through

### DIFF
--- a/lib/extensions/has_many_inverse_through.rb
+++ b/lib/extensions/has_many_inverse_through.rb
@@ -1,0 +1,8 @@
+# This adds primitive support for +:inverse_of+ in +has_many through:+ associations. This is
+# useful for when a join association is polymorphic and cannot be be explicitly set on every join.
+# This allows a record on the other end of the association chain to be added with the join
+# record, and no duplicate join record would be created.
+#
+# @example has_many through, when products has_one polymorphic product
+#   has_many :pens, through: :products, source_type: Pen.name, inverse_through: :product
+module Extensions::HasManyInverseThrough; end

--- a/lib/extensions/has_many_inverse_through/active_record.rb
+++ b/lib/extensions/has_many_inverse_through/active_record.rb
@@ -1,0 +1,1 @@
+module Extensions::HasManyInverseThrough::ActiveRecord; end

--- a/lib/extensions/has_many_inverse_through/active_record/associations.rb
+++ b/lib/extensions/has_many_inverse_through/active_record/associations.rb
@@ -1,0 +1,1 @@
+module Extensions::HasManyInverseThrough::ActiveRecord::Associations; end

--- a/lib/extensions/has_many_inverse_through/active_record/associations/builder.rb
+++ b/lib/extensions/has_many_inverse_through/active_record/associations/builder.rb
@@ -1,0 +1,1 @@
+module Extensions::HasManyInverseThrough::ActiveRecord::Associations::Builder; end

--- a/lib/extensions/has_many_inverse_through/active_record/associations/builder/has_many.rb
+++ b/lib/extensions/has_many_inverse_through/active_record/associations/builder/has_many.rb
@@ -1,0 +1,7 @@
+module Extensions::HasManyInverseThrough::ActiveRecord::Associations::Builder::HasMany
+  module PrependMethods
+    def valid_options
+      [:inverse_through] + super
+    end
+  end
+end

--- a/lib/extensions/has_many_inverse_through/active_record/associations/has_many_through_association.rb
+++ b/lib/extensions/has_many_inverse_through/active_record/associations/has_many_through_association.rb
@@ -1,0 +1,9 @@
+module Extensions::HasManyInverseThrough::ActiveRecord::Associations::HasManyThroughAssociation
+  module PrependMethods
+    def build_through_record(record)
+      association = reflection.inverse_through
+      through_record = record.public_send(association.name) if association
+      through_record || super
+    end
+  end
+end

--- a/lib/extensions/has_many_inverse_through/active_record/reflection.rb
+++ b/lib/extensions/has_many_inverse_through/active_record/reflection.rb
@@ -1,0 +1,1 @@
+module Extensions::HasManyInverseThrough::ActiveRecord::Reflection; end

--- a/lib/extensions/has_many_inverse_through/active_record/reflection/through_reflection.rb
+++ b/lib/extensions/has_many_inverse_through/active_record/reflection/through_reflection.rb
@@ -1,0 +1,20 @@
+module Extensions::HasManyInverseThrough::ActiveRecord::Reflection::ThroughReflection
+  module PrependMethods
+    def self.prepended(module_)
+      module_.class_eval do
+        attr_accessor :inverse_through_name
+      end
+    end
+
+    def initialize(delegate_reflection)
+      super
+      @inverse_through_name = delegate_reflection.options[:inverse_through]
+    end
+  end
+
+  def inverse_through
+    return unless inverse_through_name
+
+    @inverse_through ||= klass._reflect_on_association(inverse_through_name)
+  end
+end

--- a/spec/libraries/has_many_inverse_through_spec.rb
+++ b/spec/libraries/has_many_inverse_through_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Extensions: has_many inverse_through', type: :model do
+  temporary_table(:stores) do
+  end
+
+  temporary_table(:products) do |t|
+    t.references :store
+    t.references :product, polymorphic: true
+  end
+
+  temporary_table(:pens) do
+  end
+
+  class self::Store < ActiveRecord::Base
+    has_many :products, inverse_of: :store
+    has_many :pens, through: :products, inverse_through: :product,
+                    source: :product, source_type: 'Pen'
+  end
+
+  class self::Product < ActiveRecord::Base
+    belongs_to :store, inverse_of: :products
+    belongs_to :product, polymorphic: true
+  end
+
+  class self::Pen < ActiveRecord::Base
+    has_one :product, inverse_of: :product, as: :product
+    has_one :store, through: :product
+  end
+
+  with_temporary_table(:stores, :products, :pens) do
+    context 'when constructing a new pen' do
+      it 'recycles the join record' do
+        store = self.class::Store.new
+        store.pens.build(product: self.class::Product.new(store: store))
+
+        store.save
+        expect(store.products.length).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is because polymorphic associations cannot have an inverse, so specify the inverse when explicitly building the concrete join association.