### PR TITLE
Move subscribed_by? method from Forum::Topic to Discussion::Topic

### DIFF
--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -5,4 +5,12 @@ class Course::Discussion::Topic < ActiveRecord::Base
   has_many :subscriptions, dependent: :destroy, inverse_of: :topic
 
   accepts_nested_attributes_for :posts
+
+  # Return if a user has subscribed to this topic
+  #
+  # @param [User] user The user to check
+  # @return [Boolean] True if the user has subscribed this topic
+  def subscribed_by?(user)
+    subscriptions.where(user: user).any?
+  end
 end

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -51,14 +51,6 @@ class Course::Forum::Topic < ActiveRecord::Base
     0 # :TODO
   end
 
-  # Return if a user has subscribed to this topic
-  #
-  # @param [User] user The user to check
-  # @return [Boolean] True if the user has subscribed this topic
-  def subscribed_by?(user)
-    subscriptions.where(user: user).any?
-  end
-
   private
 
   # Try building a slug based on the following fields in

--- a/spec/factories/course_discussion_topic_subscriptions.rb
+++ b/spec/factories/course_discussion_topic_subscriptions.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :discussion_topic_subscription, class: Course::Discussion::Topic::Subscription.name do
+    association :topic, factory: :discussion_topic
+    user
+  end
+end

--- a/spec/factories/course_discussion_topics.rb
+++ b/spec/factories/course_discussion_topics.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :discussion_topic, class: Course::Discussion::Topic.name do
+    association :actable, factory: :user
+  end
+end

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -4,4 +4,28 @@ RSpec.describe Course::Discussion::Topic, type: :model do
   it { is_expected.to be_actable }
   it { is_expected.to have_many(:posts).inverse_of(:topic).dependent(:destroy) }
   it { is_expected.to have_many(:subscriptions).inverse_of(:topic).dependent(:destroy) }
+
+  let!(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '#subscribed_by?' do
+      let(:user) { create(:user) }
+      let(:another_user) { create(:user) }
+      let(:topic) { create(:forum_topic) }
+      let!(:discussion_topic_subscription) do
+        create(:discussion_topic_subscription, topic: topic.acting_as, user: user)
+      end
+
+      context 'when the user has subscribed to a topic' do
+        it 'returns true' do
+          expect(topic.subscribed_by?(user)).to eq(true)
+        end
+      end
+
+      context 'when the user has not subscribed to a topic' do
+        it 'returns false' do
+          expect(topic.subscribed_by?(another_user)).to eq(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I move this method, because this method can be used by other models which also act_as :topic.