### PR TITLE
Fixed assessment submission page crash when end time is nil

### DIFF
--- a/app/views/course/assessment/submissions/edit.html.slim
+++ b/app/views/course/assessment/submissions/edit.html.slim
@@ -28,7 +28,7 @@
               td = @submission.points_awarded
             tr
               th = t('.due_at')
-              td = format_datetime(@assessment.end_at)
+              td = format_datetime(@assessment.end_at) if @assessment.end_at
             tr
               th = @submission.class.human_attribute_name(:submitted_at)
               td = format_datetime(@submission.submitted_at)

--- a/spec/factories/course_lesson_plan_items.rb
+++ b/spec/factories/course_lesson_plan_items.rb
@@ -5,8 +5,16 @@ FactoryGirl.define do
     time_bonus_exp    { rand(1..10) * 100 }
     extra_bonus_exp   { rand(1..10) * 100 }
     start_at { 1.day.ago }
-    bonus_end_at { 2.days.from_now }
-    end_at { 3.days.from_now }
+    bonus_end_at { nil }
+    end_at { nil }
     sequence(:title) { |n| "Example Lesson Plan Item #{n}" }
+
+    trait :with_bonus_end_time do
+      bonus_end_at { 2.days.from_now }
+    end
+
+    trait :with_end_time do
+      end_at { 3.days.from_now }
+    end
   end
 end


### PR DESCRIPTION
- When student submits an assessment without an end_time (which is not necessary), the subsequent page will crash.
- Commit fixes bug and adds the necessary specs.

Not sure if we can find a better name for the variable in the spec >_< this was the cleanest I could think of. 