### PR TITLE
Prevent links for being escaped in new user registration page

### DIFF
--- a/app/views/user/registrations/new.html.slim
+++ b/app/views/user/registrations/new.html.slim
@@ -1,6 +1,6 @@
 = page_header
 
-= simple_format(t('.already_registered',
+= simple_format(t('.already_registered_html',
                   sign_in: link_to(t('layout.navbar.sign_in'), new_user_session_path)))
 
 = simple_form_for resource, as: resource_name, url: registration_path(resource_name) do |f|

--- a/config/locales/en/user/registrations.yml
+++ b/config/locales/en/user/registrations.yml
@@ -3,7 +3,7 @@ en:
     registrations:
       new:
         header: :'layout.navbar.register'
-        already_registered: >
+        already_registered_html: >
           Already registered? If you have an existing Coursemology account, you can %{sign_in}.
         password_hint: "#{length} characters minimum"
         sign_up: :'user.registrations.new.header'


### PR DESCRIPTION
Before:
![screen shot 2015-11-25 at 4 18 00 pm](https://cloud.githubusercontent.com/assets/6252919/11391793/3193405e-9390-11e5-8186-cd5e35099e91.png)

After:
![screen shot 2015-11-25 at 4 18 27 pm](https://cloud.githubusercontent.com/assets/6252919/11391794/319b0fd2-9390-11e5-80bb-ee8ba338868a.png)
