### PR TITLE
Make Devise initializer consistent with the autogenerated one for Rails 4

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,6 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # config.secret_key = 'b78e9024115bb66424c13b032a5588518fb468db3f771a0b39ef5fef8102826cbd095c10c'\
   #                     'e9d754daa82e847bcbb662d8f5d705b3dc1c3e074a20ecc175d6c3d'
-  config.secret_key = ENV['DEVISE_SECRET'] if ENV['DEVISE_SECRET']
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
For Rails 4 installs, Devise comments out `config.secret_key` when generating the initializer. See https://github.com/plataformatec/devise/blob/7df57d5081f9884849ca15e4fde179ef164a575f/lib/generators/templates/devise.rb

To prevent runtime errors about unset secret keys, set `secret_key_base` instead.