### PR TITLE
Admin instance management

### DIFF
--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -29,6 +29,12 @@ class System::Admin::InstancesController < System::Admin::Controller
   end
 
   def destroy #:nodoc:
+    if @instance.destroy
+      redirect_to admin_instances_path, success: t('.success', instance: @instance.name)
+    else
+      redirect_to admin_instances_path,
+                  danger: t('.failure', error: @instance.errors.full_messages.to_sentence)
+    end
   end
 
   private

--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -3,7 +3,7 @@ class System::Admin::InstancesController < System::Admin::Controller
   add_breadcrumb :index, :admin_instances_path
 
   def index #:nodoc:
-    @instances = @instances.with_course_count.with_user_count.order_by_id.page(page_param)
+    @instances = Instance.order_by_id.page(page_param).calculated(:course_count, :user_count)
   end
 
   def new #:nodoc:

--- a/app/models/components/system/admin/system_admin_ability_component.rb
+++ b/app/models/components/system/admin/system_admin_ability_component.rb
@@ -1,0 +1,17 @@
+module System::Admin::SystemAdminAbilityComponent
+  include AbilityHost::Component
+
+  def define_permissions
+    if user
+      do_not_allow_system_admin_manage_default_instance
+    end
+
+    super
+  end
+
+  private
+
+  def do_not_allow_system_admin_manage_default_instance
+    cannot :manage, Instance, host: Instance::DEFAULT_HOST_NAME
+  end
+end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -56,22 +56,18 @@ class Instance < ActiveRecord::Base
   #   Orders the instances by ID.
   scope :order_by_id, ->(direction = :asc) { order(id: direction) }
 
-  # @!method self.with_course_count
-  #   Augments all returned records with the number of courses in that instance.
-  scope :with_course_count, (lambda do
-    joins { courses.outer }.
-      select { 'instances.*' }.
-      select { count(courses.id).as(course_count) }.
-      group { instances.id }
+  # @!attribute [r] course_count
+  #   The number of courses in the instance.
+  calculated :course_count, (lambda do
+    Course.unscoped.where { courses.instance_id == instances.id }.
+      select { count('*') }
   end)
 
-  # @!method self.with_user_count
-  #   Augments all returned records with the number of users in that instance.
-  scope :with_user_count, (lambda do
-    joins { instance_users.outer }.
-      select { 'instances.*' }.
-      select { count(instance_users.id).as(user_count) }.
-      group { instances.id }
+  # @!attribute [r] user_count
+  #   The number of users in the instance.
+  calculated :user_count, (lambda do
+    InstanceUser.unscoped.where { instance_users.instance_id == instances.id }.
+      select { count('*') }
   end)
 
   def self.use_relative_model_naming?

--- a/app/views/system/admin/instances/_instance.html.slim
+++ b/app/views/system/admin/instances/_instance.html.slim
@@ -8,3 +8,7 @@
   td = instance.user_count
 
   td = instance.course_count
+
+  td
+    = edit_button([:admin, instance]) if can?(:edit, instance)
+    = delete_button([:admin, instance]) if can?(:delete, instance)

--- a/config/locales/en/system/admin/instances.yml
+++ b/config/locales/en/system/admin/instances.yml
@@ -11,8 +11,11 @@ en:
         new:
           header: 'New Instance'
         create:
-          success: 'Instance has been successfully created'
+          success: 'Instance has been successfully created.'
         edit:
           header: 'Edit Instance'
         update:
-          success: 'Instance has been successfully updated'
+          success: 'Instance has been successfully updated.'
+        destroy:
+          success: '%{instance} was destroyed.'
+          failure: 'Failed to delete instance: %{error}'

--- a/spec/controllers/system/admin/instances_controller_spec.rb
+++ b/spec/controllers/system/admin/instances_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe System::Admin::InstancesController do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:admin) { create(:administrator) }
+    before { sign_in(admin) }
+
+    describe '#destroy' do
+      let!(:instance_to_delete) { create(:instance) }
+      let!(:instance_stub) do
+        stub = build_stubbed(:instance)
+        allow(stub).to receive(:destroy).and_return(false)
+        stub
+      end
+
+      subject { delete :destroy, id: instance_to_delete }
+
+      it { is_expected.to redirect_to(admin_instances_path) }
+
+      it 'sets an success flash message' do
+        subject
+        expect(flash[:success]).to eq(I18n.t('system.admin.instances.destroy.success'))
+      end
+
+      context 'when the instance cannot be destroyed' do
+        before do
+          controller.instance_variable_set(:@instance, instance_stub)
+          subject
+        end
+
+        it { is_expected.to redirect_to(admin_instances_path) }
+
+        it 'sets an error flash message' do
+          expect(flash[:danger]).to eq(I18n.t('system.admin.instances.destroy.failure'))
+        end
+      end
+    end
+  end
+end

--- a/spec/features/system/admin/instance_management_spec.rb
+++ b/spec/features/system/admin/instance_management_spec.rb
@@ -59,6 +59,15 @@ RSpec.feature 'System: Administration: Instances' do
           expect(page).to have_content_tag_for(instance)
         end
       end
+
+      scenario 'I can destroy an instance' do
+        instance = create(:instance)
+        last_page = Instance.page.total_pages
+        visit admin_instances_path(page: last_page)
+
+        find_link(nil, href: admin_instance_path(instance)).click
+        expect(Instance.find_by(id: instance.id)).to be_nil
+      end
     end
   end
 end

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -80,19 +80,39 @@ RSpec.describe Instance do
 
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
-    describe '.with_course_count' do
+    describe '.course_count' do
       let!(:courses) { create_list(:course, 2, instance: instance) }
+      subject { Instance.where(id: instance.id).calculated(:course_count).first }
 
       it 'shows the correct count' do
-        expect(Instance.with_course_count.find(instance.id).course_count).to eq(courses.size)
+        expect(subject.course_count).to eq(courses.size)
+      end
+
+      context 'when viewing from another instance' do
+        let(:new_instance) { create(:instance) }
+        it 'shows the correct count' do
+          ActsAsTenant.with_tenant(new_instance) do
+            expect(subject.course_count).to eq(courses.size)
+          end
+        end
       end
     end
 
-    describe '.with_user_count' do
+    describe '.user_count' do
       let!(:users) { create_list(:instance_user, 3, instance: instance) }
+      subject { Instance.where(id: instance.id).calculated(:user_count).first }
 
       it 'shows the correct count' do
-        expect(Instance.with_user_count.find(instance.id).user_count).to eq(users.size)
+        expect(subject.user_count).to eq(users.size)
+      end
+
+      context 'when viewing from another instance' do
+        let(:new_instance) { create(:instance) }
+        it 'shows the correct count' do
+          ActsAsTenant.with_tenant(new_instance) do
+            expect(subject.user_count).to eq(users.size)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Changes:
- `. with_course_count` and `. with_course_count` were not working well when accessing from another instance. Changed to use calculate attributes.
- Default instance is not manageable now.
- Implement missing destroy instance.
