### PR TITLE
Hide system user in users management

### DIFF
--- a/app/controllers/system/admin/users_controller.rb
+++ b/app/controllers/system/admin/users_controller.rb
@@ -3,7 +3,8 @@ class System::Admin::UsersController < System::Admin::Controller
   add_breadcrumb :index, :admin_users_path
 
   def index
-    @users = @users.ordered_by_name.includes(:emails).page(page_param).search(search_param)
+    @users = @users.human_users.ordered_by_name.includes(:emails).page(page_param).
+             search(search_param)
   end
 
   def update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,7 @@ class User < ActiveRecord::Base
   accepts_nested_attributes_for :emails
 
   scope :ordered_by_name, -> { order(:name) }
+  scope :human_users, -> { where { id != User::SYSTEM_USER_ID } }
 
   # Gets whether the current user is the system user.
   #

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'System: Administration: Users' do
 
       let!(:users) do
         create_list(:user, 2)
-        User.ordered_by_name.page(1)
+        User.human_users.ordered_by_name.page(1)
       end
       scenario 'I can view all users in the system' do
         visit admin_users_path

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -195,5 +195,13 @@ RSpec.describe User do
         expect(user.notifications.unread).to include(unread_notification)
       end
     end
+
+    describe '.human_users' do
+      subject { User.human_users }
+
+      it 'does not include the system user' do
+        expect(subject.find_by(id: User::SYSTEM_USER_ID)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This should also fix the random test failure:

```
Failure/Error: field = find('tr.user td', text: user_to_change.email)
     
     Capybara::Ambiguous:
       Ambiguous match, found 125 elements matching css "tr.user td"
```