### PR TITLE
Implement association modification behaviours for has_one_attachment

### DIFF
--- a/lib/extensions/attachable/active_record/base.rb
+++ b/lib/extensions/attachable/active_record/base.rb
@@ -44,9 +44,14 @@ module Extensions::Attachable::ActiveRecord::Base
     end
 
     def file=(file)
-      build_attachment if !attachment || attachment.new_record?
-      attachment.file_upload = file
-      attribute_will_change!('attachment'.freeze) if attachment.changed?
+      if file
+        build_attachment if !attachment || attachment.new_record?
+        attachment.file_upload = file
+        attribute_will_change!('attachment'.freeze) if attachment.changed?
+      else
+        attribute_will_change!('attachment'.freeze) if attachment
+        attachments.clear
+      end
     end
   end
 end

--- a/lib/extensions/attachable/active_record/base.rb
+++ b/lib/extensions/attachable/active_record/base.rb
@@ -30,16 +30,23 @@ module Extensions::Attachable::ActiveRecord::Base
     def attachment=(attachment)
       attachments.clear
       attachments << attachment
+      attribute_will_change!('attachment'.freeze)
     end
 
     def build_attachment(attributes = {})
       attachments.clear
       attachments.build(attributes)
+      attribute_will_change!('attachment'.freeze)
+    end
+
+    def attachment_changed?
+      changed.include?('attachment'.freeze)
     end
 
     def file=(file)
       build_attachment if !attachment || attachment.new_record?
       attachment.file_upload = file
+      attribute_will_change!('attachment'.freeze) if attachment.changed?
     end
   end
 end

--- a/spec/libraries/acts_as_attachable_spec.rb
+++ b/spec/libraries/acts_as_attachable_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe 'Extension: Acts as Attachable' do
 
     let(:files) { [File.open(File.join(Rails.root, '/spec/fixtures/files/text.txt'))] }
     let(:attachable) { self.class::SampleModelMultiple.new }
-    describe 'files=' do
+
+    describe '#files=' do
       it 'creates attachments from files' do
         attachable.files = files
         expect(attachable.attachments).to be_present
@@ -35,10 +36,23 @@ RSpec.describe 'Extension: Acts as Attachable' do
 
     let(:file) { File.open(File.join(Rails.root, '/spec/fixtures/files/text.txt')) }
     let(:attachable) { self.class::SampleModelSingular.new }
-    describe 'file=' do
+
+    describe '#attachment_changed?' do
+      context 'when the record is clean' do
+        it 'returns false' do
+          expect(attachable.attachment_changed?).to be(false)
+        end
+      end
+    end
+
+    describe '#file=' do
+      before { attachable.file = file }
       it 'creates an attachment from file' do
-        attachable.file = file
         expect(attachable.attachment).to be_present
+      end
+
+      it 'marks attachment as modified' do
+        expect(attachable.attachment_changed?).to be(true)
       end
     end
   end

--- a/spec/libraries/acts_as_attachable_spec.rb
+++ b/spec/libraries/acts_as_attachable_spec.rb
@@ -46,13 +46,43 @@ RSpec.describe 'Extension: Acts as Attachable' do
     end
 
     describe '#file=' do
-      before { attachable.file = file }
-      it 'creates an attachment from file' do
-        expect(attachable.attachment).to be_present
+      context 'when a file is specified' do
+        before { attachable.file = file }
+        it 'creates an attachment from file' do
+          expect(attachable.attachment).to be_present
+        end
+
+        it 'marks attachment as modified' do
+          expect(attachable.attachment_changed?).to be(true)
+        end
       end
 
-      it 'marks attachment as modified' do
-        expect(attachable.attachment_changed?).to be(true)
+      context 'when nil is specified' do
+        context 'when a file existed' do
+          before do
+            attachable.file = file
+            attachable.file = nil
+          end
+
+          it 'removes the attachment' do
+            expect(attachable.attachment).to be_nil
+          end
+
+          it 'marks attachment as modified' do
+            expect(attachable.attachment_changed?).to be(true)
+          end
+        end
+
+        context 'when a file was never specified' do
+          before { attachable.file = nil }
+          it 'does not have an attachment' do
+            expect(attachable.attachment).to be_nil
+          end
+
+          it 'does not change the attachment' do
+            expect(attachable.attachment_changed?).to be(false)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Implements:
 - `attachment_changed?`
 - proper behaviour when assigning nil