### PR TITLE
Implement events over database records

### DIFF
--- a/lib/extensions/database_event.rb
+++ b/lib/extensions/database_event.rb
@@ -1,0 +1,1 @@
+module Extensions::DatabaseEvent; end

--- a/lib/extensions/database_event/active_record.rb
+++ b/lib/extensions/database_event/active_record.rb
@@ -1,0 +1,1 @@
+module Extensions::DatabaseEvent::ActiveRecord; end

--- a/lib/extensions/database_event/active_record/base.rb
+++ b/lib/extensions/database_event/active_record/base.rb
@@ -1,0 +1,82 @@
+module Extensions::DatabaseEvent::ActiveRecord::Base
+  module ClassMethods
+    # Waits for the given +NOTIFY+ signal, optionally until a give time, or until a specific
+    # condition is met.
+    #
+    # @param [Fixnum|nil] timeout The timeout to wait for a message. A +nil+ or zero timeout will
+    #   wait indefinitely. The timeout applies to the total time waiting for a notification, even
+    #   if the function waits multiple times.
+    # @param [Proc|nil] while_callback The callback that will be called after the +LISTEN+ statement
+    #   is sent, and is used to check to see if the library should continue waiting for a
+    #   notification. If this returns +false+, the named of the last received notification is
+    #   returned. If no notification was received yet (i.e. before the first wait), this returns
+    #   +false+.
+    # @return [String|Boolean|nil] If a +while+ callback was specified and it returned
+    #   false before the first wait, this returns false. Otherwise, this returns the notification
+    #   received, or +nil+.
+    def wait(identifier, timeout: nil, while_callback: nil, &block)
+      deadline = timeout ? Time.zone.now + timeout : nil
+      connection.execute("LISTEN #{identifier};")
+
+      return false if while_callback && while_callback.call == false
+      wait_until(deadline, while_callback, &block)
+    ensure
+      connection.execute('UNLISTEN *;')
+    end
+
+    # Signals to possible waiting consumers on this record.
+    def signal(identifier)
+      connection.execute("NOTIFY #{identifier};")
+    end
+
+    private
+
+    # Waits until the deadline, or while_callback returns false.
+    #
+    # @param [Time|nil] deadline The deadline to wait until.
+    # @param [Proc|nil] while_callback The loop will keep waiting until this returns a truthy value.
+    # @return [String|nil] +nil+ if the deadline elapsed. Otherwise, this returns the notified
+    #   event.
+    def wait_until(deadline, while_callback, &block)
+      while deadline.nil? || Time.zone.now < deadline
+        wait_timeout = deadline ? deadline - Time.zone.now : nil
+        result = connection.instance_variable_get(:@connection).
+                 wait_for_notify(wait_timeout, &block)
+        return result if while_callback.nil? || !while_callback.call
+      end
+
+      nil
+    end
+  end
+
+  # Waits for a signal on the current record. A signal can be sent by using {#signal}.
+  #
+  # @param [Fixnum|nil] timeout The timeout to wait for a message. A +nil+ or zero timeout will
+  #   wait indefinitely.
+  # @param [Proc] while_callback The callback that will be called after the +LISTEN+ statement is
+  #   sent, and is used to check to see if the library should continue waiting for a notification
+  #   event. If this returns +false+, the named of the last received notification is returned. If no
+  #   notification was received yet (i.e. before the first wait), this returns false.
+  # @return [String|Boolean|nil] If a +while+ callback was specified and it returned
+  #   false before the first wait, this returns false. Otherwise, this returns the notification
+  #   received, or +nil+.
+  def wait(timeout: nil, while_callback: nil, &block)
+    self.class.wait(notify_identifier, timeout: timeout, while_callback: while_callback, &block)
+  end
+
+  # Signals to possible waiting consumers on this record.
+  def signal
+    self.class.signal(notify_identifier)
+  end
+
+  private
+
+  # A string identifier usable with the Postgres NOTIFY command.
+  #
+  # @return [String]
+  def notify_identifier
+    to_global_id.to_s[18..-1]. # Remove gid://application/
+      tr('/:', '_'). # Remove / and :
+      underscore
+  end
+end

--- a/spec/libraries/database_event_spec.rb
+++ b/spec/libraries/database_event_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe 'Extensions: Database Event' do
+  subject { Instance.default }
+
+  self::NOTIFICATION = 'database_event_test'
+
+  def signal
+    Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do
+        ActiveRecord::Base.signal(self.class::NOTIFICATION)
+      end
+    end
+  end
+
+  describe '.wait' do
+    context 'when a timeout is specified' do
+      context 'when the timeout elapses without a signal' do
+        it 'returns nil' do
+          expect(ActiveRecord::Base.wait(self.class::NOTIFICATION, timeout: 0)).to be_nil
+        end
+      end
+    end
+
+    context 'when a timeout is not specified' do
+      it 'returns the notification event notified' do
+        signal
+        expect(ActiveRecord::Base.wait(self.class::NOTIFICATION)).to eq(self.class::NOTIFICATION)
+      end
+    end
+
+    context 'when a while_callback is specified' do
+      it 'is called' do
+        count = 0
+        callback = lambda do
+          count += 1
+          false
+        end
+
+        expect do
+          ActiveRecord::Base.wait(self.class::NOTIFICATION, while_callback: callback)
+        end.to change { count }.by(1)
+      end
+
+      context 'when the callback returns false on the first time' do
+        it 'returns false' do
+          expect(ActiveRecord::Base.wait(self.class::NOTIFICATION,
+                                         while_callback: -> { false })).to be(false)
+        end
+      end
+
+      context 'when the callback returns false on subsequent times' do
+        context 'when no notification was received' do
+          it 'returns nil' do
+            count = 0
+            callback = lambda do
+              count += 1
+              count == 1
+            end
+
+            expect(ActiveRecord::Base.wait(self.class::NOTIFICATION,
+                                           timeout: 1.second,
+                                           while_callback: callback)).to be_nil
+          end
+        end
+
+        context 'when a notification was received' do
+          it 'returns the notification' do
+            count = 0
+            callback = lambda do
+              count += 1
+              count == 1
+            end
+
+            signal
+            expect(ActiveRecord::Base.wait(self.class::NOTIFICATION,
+                                           while_callback: callback)).to \
+                                             eq(self.class::NOTIFICATION)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#wait' do
+    it 'respects the timeout' do
+      expect(subject.wait(timeout: 0)).to be_nil
+    end
+
+    it 'respects the while_callback' do
+      expect(subject.wait(while_callback: -> { false })).to be(false)
+    end
+
+    it 'automatically generates a notification identifier' do
+      expect(subject).to receive(:notify_identifier).and_call_original
+      subject.wait(timeout: 0)
+    end
+  end
+
+  describe '#signal' do
+    it 'automatically generates a notification identifier' do
+      expect(subject).to receive(:notify_identifier).and_call_original
+      subject.signal
+    end
+  end
+end


### PR DESCRIPTION
This removes polling waits which increase traffic on the database. Also, this allows us to elegantly express waiting for some event to happen in some other process.

ActiveRecord objects can signal to listeners even in other threads or processes now.