### PR TITLE
Ensure that we do not leak ActiveRecord connections.

### DIFF
--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -10,7 +10,11 @@
 class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapters::InlineAdapter
   class << self
     def enqueue(job) #:nodoc:
-      Thread.new { ActiveJob::Base.execute(job.serialize) }
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ActiveJob::Base.execute(job.serialize)
+        end
+      end
     end
   end
 end

--- a/spec/support/stubs/course/assessment/stubbed_programming_evaluation_service.rb
+++ b/spec/support/stubs/course/assessment/stubbed_programming_evaluation_service.rb
@@ -4,8 +4,10 @@ module Course::Assessment::StubbedProgrammingEvaluationService
   def wait_for_evaluation(evaluation)
     tenant = ActsAsTenant.current_tenant
     Thread.new do
-      ActsAsTenant.with_tenant(tenant) do
-        populate_mock_result(evaluation)
+      ActiveRecord::Base.connection_pool.with_connection do
+        ActsAsTenant.with_tenant(tenant) do
+          populate_mock_result(evaluation)
+        end
       end
     end
 


### PR DESCRIPTION
See https://bibwild.wordpress.com/2014/07/17/activerecord-concurrency-in-rails4-avoid-leaked-connections/