### PR TITLE
Default the test ActiveJob queue adapter to background_thread

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,22 @@ In Rails, controller specs will always execute the `rescue_from` handlers. In ou
 disable that by default; to execute controllers with the handlers enabled, declare `run_rescue`
 within the example group.
 
+In development mode and when running specs, ActiveJob jobs are run with the `:background_thread`
+queue adapter (see `lib/autoload/active_job/queue_adapters`). This is to ensure consistency with
+production (where we will be using a separate jobs server): running jobs inline might cause
+database conenctions within the job to remain within a transaction.
+
+Therefore, specs have a group helper `with_active_job_queue_adapter`, which takes the queue
+adapter to use for that group of examples. The only adapters which should be used is:
+
+ - `:test` when counting the number of enqueued jobs.
+ - `:background_thread` when running job specs. `spec/support/active_job.rb` automatically sets
+   the default queue adapter to be `:test` when running job specs.
+
+There is no longer a need to explicitly set the `:inline` adapter for delayed delivery of mail.
+When running specs, all deferred mail deliveries are converted to immediate deliveries to keep
+track of the number of pending mail deliveries.
+
 Trackable Jobs can be waited -- use the `TrackableJob#wait` method.
 
 ## Developer Tools

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # We will assume that we are running on localhost
   config.action_mailer.default_url_options = { host: 'localhost' }
 
+  # Use the threaded background job adapter for replicating the production environment.
+  config.active_job.queue_adapter = :background_thread
+
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -110,6 +110,8 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
         # Auto grade where possible. There's one MRQ so it should be gradable.
         click_link I18n.t('course.assessment.submissions.edit.auto_grade')
+        wait_for_job
+
         expect(submission.answers.map(&:reload).any?(&:graded?)).to be(true)
 
         submission_maximum_grade = 0

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -88,6 +88,8 @@ RSpec.feature 'Course: Material: Folders: Management' do
         visit course_material_folder_path(course, parent_folder)
         find_link(nil, href: download_course_material_folder_path(course, parent_folder)).click
 
+        wait_for_job
+
         expect(page.response_headers['Content-Type']).to eq('application/zip')
       end
 

--- a/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
@@ -18,14 +18,13 @@ RSpec.describe Course::Assessment::Submission::AutoGradingJob do
         subject.perform_now(submission)
         expect(submission.answers.map(&:reload).all?(&:graded?)).to be(true)
       end
-    end
 
-    with_active_job_queue_adapter(:inline) do
       context 'when the job is complete' do
         it 'redirects to the submission edit page' do
           singleton_class.class_eval { include Rails.application.routes.url_helpers }
           job = subject.perform_later(submission).tap(&:wait).job.tap(&:reload)
 
+          expect(job).to be_completed
           expect(job.redirect_to).to \
             eq(edit_course_assessment_submission_path(submission.assessment.course,
                                                       submission.assessment, submission))

--- a/spec/libraries/trackable_job_spec.rb
+++ b/spec/libraries/trackable_job_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe TrackableJob do
     subject { self.class::NoOpJob.perform_later }
 
     it 'fails with NotImplementedError' do
-      expect { subject.perform_tracked }.to raise_error(NotImplementedError)
+      expect { subject.send(:perform_tracked) }.to raise_error(NotImplementedError)
     end
   end
 

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Course::Assessment::Answer do
         let(:answer_traits) { :graded }
         it 'allows re-grading' do
           new_grade = subject.grade = 1
-          subject.auto_grade!
+          subject.auto_grade!.wait
           subject.reload
 
           expect(subject.grade).not_to eq(new_grade)

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -20,6 +20,19 @@ module ActiveJob::TestGroupHelpers
   end
 end
 
+# Since message deliveries use the test delivery engine, all deferred deliver calls must be
+# converted to +deliver_now+ to prevent a dependency on the ActiveJob queue adapter.
+module ActionMailer::MessageDelivery::TestDeliveryHelpers
+  def deliver_later(_ = {})
+    deliver_now
+  end
+
+  def deliver_later!(_ = {})
+    deliver_now!
+  end
+end
+ActionMailer::MessageDelivery.prepend(ActionMailer::MessageDelivery::TestDeliveryHelpers)
+
 RSpec.configure do |config|
   config.extend ActiveJob::TestGroupHelpers
   config.around(:each, type: :job,


### PR DESCRIPTION
This is to ensure consistency in specs. See changes in CONTRIBUTING.md for explanation.