### PR TITLE
Allow importing programming question packages

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -9,8 +9,12 @@ class Course::Assessment::Question::ProgrammingController < \
 
   def create
     if @programming_question.save
-      redirect_to course_assessment_path(current_course, @assessment),
-                  success: t('.success')
+      if @programming_question.import_job
+        redirect_to job_path(@programming_question.import_job)
+      else
+        redirect_to course_assessment_path(current_course, @assessment),
+                    success: t('.success')
+      end
     else
       render 'new'
     end
@@ -21,8 +25,12 @@ class Course::Assessment::Question::ProgrammingController < \
 
   def update
     if @programming_question.update_attributes(programming_question_params)
-      redirect_to course_assessment_path(current_course, @assessment),
-                  success: t('.success')
+      if @programming_question.import_job
+        redirect_to job_path(@programming_question.import_job)
+      else
+        redirect_to course_assessment_path(current_course, @assessment),
+                    success: t('.success')
+      end
     else
       render 'edit'
     end
@@ -43,6 +51,7 @@ class Course::Assessment::Question::ProgrammingController < \
 
   def programming_question_params
     params.require(:question_programming).permit(
-      :title, :description, :maximum_grade, :language_id, :memory_limit, :time_limit)
+      :title, :description, :maximum_grade, :language_id, :memory_limit, :time_limit,
+      *attachment_params)
   end
 end

--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -1,0 +1,40 @@
+class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
+  include TrackableJob
+  include Rails.application.routes.url_helpers
+
+  protected
+
+  # Performs the import of the package contents into the question.
+  #
+  # @param [Course::Assessment::Question::Programming] question The programming question to
+  #   import the package to.
+  # @param [Attachment] attachment The attachment containing the package.
+  def perform_tracked(question, attachment)
+    instance = nil
+    Course.unscoped do
+      instance = question.assessment.course.instance
+    end
+    ActsAsTenant.with_tenant(instance) do
+      perform_import(question, attachment)
+    end
+  end
+
+  private
+
+  # Copies the package from storage and imports the question.
+  #
+  # @param [Course::Assessment::Question::Programming] question The programming question to
+  #   import the package to.
+  # @param [Attachment] attachment The attachment containing the package.
+  def perform_import(question, attachment)
+    Tempfile.create('programming-import', encoding: 'ascii-8bit', binmode: true) do |temporary_file|
+      temporary_file.write(attachment.file_upload.read)
+      temporary_file.seek(0)
+      Course::Assessment::Question::ProgrammingImportService.import(question, temporary_file)
+    end
+
+  ensure
+    redirect_to edit_course_assessment_question_programming_path(question.assessment.course,
+                                                                 question.assessment, question)
+  end
+end

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -5,15 +5,22 @@ class Course::Assessment::Question::ProgrammingImportService
   class << self
     # Imports the programming package into the question.
     #
-    # @param [Course::Assessment::Question::Programming] question The programming question for
-    #   import.
-    # @param [Course::Assessment::ProgrammingPackage] package The package containing the
-    #   tests and template files.
-    #
     # @overload import(question, package)
     #   @param [Course::Assessment::Question::Programming] question The programming question for
     #     import.
-    #   @param [String] package The path to the package containing the tests and template files.
+    #   @param [Course::Assessment::ProgrammingPackage] package The package containing the
+    #     tests and template files.
+    #
+    # @overload import(question, package_path)
+    #   @param [Course::Assessment::Question::Programming] question The programming question for
+    #     import.
+    #   @param [String] package_path The path to the package containing the tests and template
+    # files.
+    #
+    # @overload import(question, package_stream)
+    #   @param [Course::Assessment::Question::Programming] question The programming question for
+    #     import.
+    #   @param [IO] package_stream An I/O object containing the package.
     def import(question, package)
       package = Course::Assessment::ProgrammingPackage.new(package) unless \
         package.is_a?(Course::Assessment::ProgrammingPackage)
@@ -35,12 +42,11 @@ class Course::Assessment::Question::ProgrammingImportService
 
   # Imports the templates and tests found in the package.
   def import
-    template_files = nil
-    template_import_thread = Thread.new { template_files = import_template_files }
+    template_import_thread = Thread.new { import_template_files }
     evaluation_result = evaluate_package
     template_import_thread.join
 
-    save(template_files, evaluation_result)
+    save(template_import_thread.value, evaluation_result)
   end
 
   # Extracts the templates from the package.

--- a/app/views/course/assessment/question/programming/_form.html.slim
+++ b/app/views/course/assessment/question/programming/_form.html.slim
@@ -5,8 +5,13 @@
   = f.association :language
   = f.input :memory_limit
   = f.input :time_limit
+  = f.label :template_package
+  = f.attachment
 
   h2 = t('.template')
+  ul
+    - f.object.template_files.each do |template|
+      li = template.filename
 
   h2 = t('.test_cases.test_cases')
   table.table.table-striped.table-hover

--- a/lib/autoload/trackable_job.rb
+++ b/lib/autoload/trackable_job.rb
@@ -68,7 +68,11 @@ module TrackableJob
 
   def rescue_tracked(exception)
     @job.status = :errored
-    @job.error = { message: exception.to_s }
+    @job.error = {
+      class: exception.class.name,
+      message: exception.to_s,
+      backtrace: exception.backtrace
+    }
     @job.save!
   end
 

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
 
     before do
       sign_in(user)
-      return unless programming_question
       controller.instance_variable_set(:@programming_question, programming_question)
     end
 
@@ -37,16 +36,59 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
         let(:programming_question) { immutable_programming_question }
         it { is_expected.to render_template('new') }
       end
+
+      context 'when attaching a template package' do
+        include Rails.application.routes.url_helpers
+
+        let(:question_programming_attributes) do
+          attributes_for(:course_assessment_question_programming, template_package: true).
+            slice(:title, :description, :maximum_grade, :language, :memory_limit,
+                  :time_limit, :file).tap do |result|
+            result[:language_id] = result.delete(:language).id
+            result[:file] = fixture_file_upload('course/programming_question_template.zip')
+          end
+        end
+
+        it 'redirects to job progress page' do
+          subject
+          expect(subject).to redirect_to(
+            job_path(controller.instance_variable_get(:@programming_question).import_job))
+        end
+      end
     end
 
     describe '#update' do
-      let(:programming_question) { immutable_programming_question }
       subject do
         patch :update, course_id: course, assessment_id: assessment, id: programming_question,
                        question_programming: question_programming_attributes
       end
 
-      it { is_expected.to render_template('edit') }
+      context 'when the question cannot be saved' do
+        let(:programming_question) { immutable_programming_question }
+        it { is_expected.to render_template('edit') }
+      end
+
+      context 'when attaching a template package' do
+        include Rails.application.routes.url_helpers
+
+        let(:programming_question) do
+          create(:course_assessment_question_programming, assessment: assessment)
+        end
+        let(:question_programming_attributes) do
+          attributes_for(:course_assessment_question_programming, template_package: true).
+            slice(:title, :description, :maximum_grade, :language, :memory_limit,
+                  :time_limit).tap do |result|
+            result[:language_id] = result.delete(:language).id
+            result[:file] = fixture_file_upload('course/programming_question_template.zip')
+          end
+        end
+
+        it 'redirects to job progress page' do
+          subject
+          expect(subject).to redirect_to(
+            job_path(controller.instance_variable_get(:@programming_question).import_job))
+        end
+      end
     end
 
     describe '#destroy' do
@@ -55,10 +97,14 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
         post :destroy, course_id: course, assessment_id: assessment, id: programming_question
       end
 
-      it { is_expected.to redirect_to(course_assessment_path(course, assessment)) }
-      it 'sets the correct flash message' do
-        subject
-        expect(flash[:danger]).not_to be_empty
+      context 'when the question cannot be destroyed' do
+        let(:programming_question) { immutable_programming_question }
+
+        it { is_expected.to redirect_to(course_assessment_path(course, assessment)) }
+        it 'sets the correct flash message' do
+          subject
+          expect(flash[:danger]).not_to be_empty
+        end
       end
     end
   end

--- a/spec/factories/course_assessment_question_programming.rb
+++ b/spec/factories/course_assessment_question_programming.rb
@@ -3,7 +3,8 @@ FactoryGirl.define do
           class: Course::Assessment::Question::Programming,
           parent: :course_assessment_question do
     transient do
-      template_file_count 1
+      template_file_count 0
+      template_package false
     end
 
     memory_limit 32
@@ -13,6 +14,10 @@ FactoryGirl.define do
       template_file_count.downto(0).map do
         build(:course_assessment_question_programming_template_file, question: nil)
       end
+    end
+    file do
+      File.new(File.join(Rails.root, 'spec/fixtures/course/'\
+                         'programming_question_template.zip')) if template_package
     end
   end
 end

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -56,6 +56,41 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).not_to have_content_tag_for(question)
       end
+
+      scenario 'I can create a new question and upload the template package' do
+        visit new_course_assessment_question_programming_path(course, assessment)
+        question_attributes = attributes_for(:course_assessment_question_programming)
+        fill_in 'title', with: question_attributes[:title]
+        fill_in 'description', with: question_attributes[:description]
+        fill_in 'maximum_grade', with: question_attributes[:maximum_grade]
+        select question_attributes[:language].name, from: 'language'
+        fill_in 'memory_limit', with: question_attributes[:memory_limit]
+        fill_in 'time_limit', with: question_attributes[:time_limit]
+        attach_file 'question_programming[file]',
+                    File.join(ActionController::TestCase.fixture_path,
+                              'course/programming_question_template.zip')
+
+        click_button 'submit'
+        wait_for_job
+
+        expect(current_path).to \
+          start_with(course_assessment_path(course, assessment))
+      end
+
+      scenario 'I can upload a question package' do
+        question = create(:course_assessment_question_programming, assessment: assessment)
+        visit edit_course_assessment_question_programming_path(course, assessment, question)
+
+        attach_file 'question_programming[file]',
+                    File.join(ActionController::TestCase.fixture_path,
+                              'course/programming_question_template.zip')
+
+        click_button 'submit'
+        wait_for_job
+
+        expect(current_path).to \
+          start_with(course_assessment_path(course, assessment))
+      end
     end
 
     context 'As a Student' do

--- a/spec/jobs/course/assessment/question/programming_import_job_spec.rb
+++ b/spec/jobs/course/assessment/question/programming_import_job_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::ProgrammingImportJob do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    subject { Course::Assessment::Question::ProgrammingImportJob }
+    let(:question) do
+      create(:course_assessment_question_programming, template_file_count: 0)
+    end
+    let(:attachment) do
+      create(:attachment,
+             file: File.join(Rails.root, 'spec/fixtures/course/programming_question_template.zip'))
+    end
+
+    it 'can be queued' do
+      expect { subject.perform_later(question, attachment) }.to \
+        have_enqueued_job(subject).exactly(:once)
+    end
+
+    it 'imports the templates' do
+      subject.perform_now(question, attachment)
+      expect(question.template_files).not_to be_empty
+    end
+
+    it 'imports the test cases' do
+      subject.perform_now(question, attachment)
+      expect(question.test_cases).not_to be_empty
+    end
+  end
+end

--- a/spec/libraries/course/assessment/programming_package_spec.rb
+++ b/spec/libraries/course/assessment/programming_package_spec.rb
@@ -6,9 +6,13 @@ RSpec.describe Course::Assessment::ProgrammingPackage do
   self::TEMP_PACKAGE_PATH = File.join(Rails.root, 'tmp/spec')
 
   def temp_package_path
+    temp_package_stream.tap(&:close).path
+  end
+
+  def temp_package_stream
     package_path = self.class::TEMP_PACKAGE_PATH
     Dir.mkdir(package_path) unless Dir.exist?(package_path)
-    Tempfile.create('programming_package', package_path).tap(&:close).path
+    Tempfile.create('programming_package', package_path)
   end
 
   def open_package(path)
@@ -17,6 +21,34 @@ RSpec.describe Course::Assessment::ProgrammingPackage do
 
   let(:package_path) { self.class::PACKAGE_PATH }
   subject { open_package(package_path) }
+
+  describe '#initialize' do
+    context 'when a file path is specified' do
+      it 'opens the file' do
+        expect(subject.submission_files).not_to be_empty
+      end
+    end
+
+    context 'when a file stream is specified' do
+      let(:package_stream) { temp_package_stream }
+      subject { open_package(package_stream) }
+      before do
+        IO.copy_stream(self.class::PACKAGE_PATH, package_stream)
+        package_stream.seek(0)
+      end
+
+      it 'opens the file' do
+        expect(subject.submission_files).not_to be_empty
+      end
+    end
+
+    context 'when anything else is specified' do
+      subject { open_package(3) }
+      it 'fails with ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
 
   describe '#path' do
     it 'returns the path to the package' do
@@ -48,6 +80,15 @@ RSpec.describe Course::Assessment::ProgrammingPackage do
       replacement = { Pathname.new('test.py') => 'test!' }
       expect(subject.submission_files = replacement).to eq(replacement)
       expect(subject.submission_files).to eq(replacement)
+    end
+  end
+
+  describe '#ensure_file_open!' do
+    context 'when the file cannot be opened' do
+      it 'raises an IllegalStateError' do
+        subject.instance_variable_set(:@path, nil)
+        expect { subject.submission_files }.to raise_error(IllegalStateError)
+      end
     end
   end
 end

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe Course::Assessment::Question::Programming do
 
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
+    describe 'callbacks' do
+      subject { build(:course_assessment_question_programming) }
+
+      describe 'after_save' do
+        context 'when a new package is uploaded' do
+          with_active_job_queue_adapter(:test) do
+            it 'queues a new import job' do
+              expect(subject.import_job).to be_nil
+              subject.file = File.new(File.join(Rails.root, 'spec/fixtures/course/'\
+                                                            'programming_question_template.zip'))
+              expect { subject.save }.to \
+                have_enqueued_job(Course::Assessment::Question::ProgrammingImportJob).exactly(:once)
+            end
+          end
+        end
+      end
+    end
+
     describe 'validations' do
     end
 

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
           and_call_original
         subject.import(question, package_path)
       end
+
+      it 'accepts package file streams' do
+        File.open(package_path) do |file|
+          subject.import(question, file)
+        end
+      end
     end
 
     describe '#import' do


### PR DESCRIPTION
This will trigger an import job when uploading a question, which will load the templates and test cases into the database.

After this, to complete the entire cycle would just require an evaluator set up.