### PR TITLE
Do not create extra courses when running every course management example.

### DIFF
--- a/spec/features/system/admin/course_management_spec.rb
+++ b/spec/features/system/admin/course_management_spec.rb
@@ -26,20 +26,18 @@ RSpec.feature 'System: Administration: Courses' do
         end
       end
 
-      let!(:course_to_delete) do
-        create(:course, title: Course.unscoped.ordered_by_title.first.title)
-      end
       scenario 'I can delete a course' do
+        course_to_delete = create(:course, title: Course.unscoped.ordered_by_title.first.title)
         visit admin_courses_path
 
         find_link(nil, href: admin_course_path(course_to_delete)).click
         expect(page).to have_selector('div', text: I18n.t('system.admin.courses.destroy.success'))
       end
 
-      let!(:course_to_search) { create(:course) }
       scenario 'I can search courses' do
-        visit admin_courses_path
+        course_to_search = create(:course)
 
+        visit admin_courses_path
         fill_in 'search', with: course_to_search.title
         click_button 'layouts.search_form.search_button'
 


### PR DESCRIPTION
This prevents extra courses from accumulating and causing the test to fail nondeterministically.

Helps with #420.