### PR TITLE
Explicitly ensure that all zip files are open in binary mode.

### DIFF
--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -27,7 +27,7 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
   def perform_import(question, attachment)
-    Tempfile.create('programming-import', encoding: 'ascii-8bit', binmode: true) do |temporary_file|
+    Tempfile.create('programming-import', binmode: true) do |temporary_file|
       temporary_file.write(attachment.file_upload.read)
       temporary_file.seek(0)
       Course::Assessment::Question::ProgrammingImportService.import(question, temporary_file)

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -67,7 +67,7 @@ class Course::Assessment::ProgrammingEvaluationService
   #
   # @return [Course::Assessment::ProgrammingEvaluation]
   def create_evaluation
-    File.open(@package) do
+    File.open(@package, 'rb') do
       Course::Assessment::ProgrammingEvaluation.create(
         course: @course, language: @language, memory_limit: @memory_limit,
         time_limit: @time_limit.to_i)

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,12 +1,14 @@
 FactoryGirl.define do
   factory :attachment do
     transient do
+      binary false
+      content_type 'text/plain'
       file { File.join(Rails.root, '/spec/fixtures/files/text.txt') }
     end
 
     name 'Attachment'
     file_upload do
-      Rack::Test::UploadedFile.new(file)
+      Rack::Test::UploadedFile.new(file, content_type, binary)
     end
   end
 end

--- a/spec/factories/course_assessment_programming_evaluations.rb
+++ b/spec/factories/course_assessment_programming_evaluations.rb
@@ -6,7 +6,8 @@ FactoryGirl.define do
     status :submitted
     attachment do
       build(:attachment,
-            file: File.join(Rails.root, '/spec/fixtures/course/programming_question_template.zip'))
+            file: File.join(Rails.root, '/spec/fixtures/course/programming_question_template.zip'),
+            binary: true)
     end
 
     trait :assigned do

--- a/spec/factories/course_assessment_question_programming.rb
+++ b/spec/factories/course_assessment_question_programming.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     end
     file do
       File.new(File.join(Rails.root, 'spec/fixtures/course/'\
-                         'programming_question_template.zip')) if template_package
+                         'programming_question_template.zip'), 'rb') if template_package
     end
   end
 end

--- a/spec/jobs/course/assessment/question/programming_import_job_spec.rb
+++ b/spec/jobs/course/assessment/question/programming_import_job_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportJob do
     end
     let(:attachment) do
       create(:attachment,
-             file: File.join(Rails.root, 'spec/fixtures/course/programming_question_template.zip'))
+             file: File.join(Rails.root, 'spec/fixtures/course/programming_question_template.zip'),
+             binary: true)
     end
 
     it 'can be queued' do

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Course::Assessment::Question::Programming do
             it 'queues a new import job' do
               expect(subject.import_job).to be_nil
               subject.file = File.new(File.join(Rails.root, 'spec/fixtures/course/'\
-                                                            'programming_question_template.zip'))
+                                                            'programming_question_template.zip'),
+                                      'rb')
               expect { subject.save }.to \
                 have_enqueued_job(Course::Assessment::Question::ProgrammingImportJob).exactly(:once)
             end

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
       end
 
       it 'accepts package file streams' do
-        File.open(package_path) do |file|
+        File.open(package_path, 'rb') do |file|
           subject.import(question, file)
         end
       end


### PR DESCRIPTION
This ensures Windows compatibility.