### PR TITLE
Switch to the documentation formatter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 script:
   - bundle exec consistency_fail
   - bundle exec i18n-tasks health
-  - bundle exec rake spec
+  - bundle exec rspec spec --format documentation
 
 notifications:
   slack:


### PR DESCRIPTION
We would want to isolate every single possible deadlock/race, so this helps debugging.