### PR TITLE
Materials filename validation/normalization

### DIFF
--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -3,6 +3,7 @@ class Course::Material < ActiveRecord::Base
   belongs_to :folder, inverse_of: :materials, class_name: Course::Material::Folder.name
 
   validate :validate_name_is_unique_among_folders
+  validates_with FilenameValidator
 
   # Returns the path of the material
   #

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -11,6 +11,7 @@ class Course::Material::Folder < ActiveRecord::Base
   belongs_to :owner, polymorphic: true, inverse_of: :folder
 
   validate :validate_name_is_unique_among_materials
+  validates_with FilenameValidator
 
   def files_attributes=(files)
     files.each do |file|

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -3,6 +3,7 @@ class Course::Material::Folder < ActiveRecord::Base
   include Course::ModelComponentHost::Component
 
   after_initialize :set_defaults, if: :new_record?
+  before_validation :normalize_filename, if: :owner
   before_validation :assign_valid_name
 
   has_many :materials, inverse_of: :folder, dependent: :destroy, foreign_key: :folder_id,
@@ -15,7 +16,7 @@ class Course::Material::Folder < ActiveRecord::Base
 
   def files_attributes=(files)
     files.each do |file|
-      materials.build(name: file.original_filename, file: file)
+      materials.build(name: Pathname.normalize_filename(file.original_filename), file: file)
     end
   end
 
@@ -76,5 +77,10 @@ class Course::Material::Folder < ActiveRecord::Base
     return unless name_changed? && owner
 
     self.name = next_valid_name
+  end
+
+  # Normalize the folder name
+  def normalize_filename
+    self.name = Pathname.normalize_filename(name)
   end
 end

--- a/config/locales/en/activerecord/filename_validator.yml
+++ b/config/locales/en/activerecord/filename_validator.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      messages:
+        filename_validator:
+          invalid_characters: '%{characters} are not allowed.'
+          tailing_dots: 'tailing dots are not allowed.'
+          whitespaces: 'leading or tailing whitespaces are not allowed.'

--- a/lib/autoload/filename_validator.rb
+++ b/lib/autoload/filename_validator.rb
@@ -1,0 +1,17 @@
+class FilenameValidator < ActiveModel::Validator
+  def validate(record)
+    errors = record.errors[:name]
+    # \ : * ? " < > | are not allowed
+    if record.name =~ /[\/\\:\*\?\"<>\|]/
+      errors <<
+        I18n.t('activerecord.errors.messages.filename_validator.invalid_characters',
+               characters: '\ : * ? " < > |')
+    # Tailing dots are not allowed
+    elsif record.name =~ /\.+\z/
+      errors << I18n.t('activerecord.errors.messages.filename_validator.tailing_dots')
+    # Leading or tailing whitespaces are not allowed
+    elsif record.name =~ /(\A\s+.*)|(.*\s+\z)/
+      errors << I18n.t('activerecord.errors.messages.filename_validator.whitespaces')
+    end
+  end
+end

--- a/spec/libraries/filename_validator_spec.rb
+++ b/spec/libraries/filename_validator_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe FilenameValidator do
+  class self::FileModel < ActiveRecord::Base
+    def self.columns
+      []
+    end
+
+    attr_accessor :name
+
+    validates_with FilenameValidator
+  end
+
+  describe '#validate' do
+    subject { self.class::FileModel.new }
+
+    context 'when the filename is valid' do
+      let(:valid_filenames) { ['Name', 'File Name', 'I\'m valid'] }
+
+      it 'is valid' do
+        valid_filenames.each do |name|
+          subject.name = name
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    context 'when the filename is not valid' do
+      let(:invalid_filenames) do
+        [
+          ' name', 'name  ', 'name.', 'na/me', 'na\me',
+          'na*me', 'na|me', 'na<me', 'na>me', 'na"me'
+        ]
+      end
+
+      it 'is not valid' do
+        invalid_filenames.each do |name|
+          subject.name = name
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/libraries/materials_spec.rb
+++ b/spec/libraries/materials_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe 'Extension: Materials' do
         assessment.files_attributes = files
         expect(assessment.folder.materials).to be_present
       end
+
+      context 'when filename is not valid' do
+        let(:files) { [OpenStruct.new(original_filename: 'lol\lol.txt')] }
+
+        it 'normalizes the name' do
+          assessment.files_attributes = files
+          expect(assessment.folder.materials.first.name).to eq('lol lol.txt')
+        end
+      end
     end
   end
 

--- a/spec/models/course/assessment/category_spec.rb
+++ b/spec/models/course/assessment/category_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe Course::Assessment::Category do
         expect(subject.folder.course).to eq(subject.course)
         expect(subject.folder.parent).to eq(subject.course.root_folder)
       end
+
+      context 'when category title is not a valid filename' do
+        subject { create(:course_assessment_category, title: 'lol\lol') }
+
+        it 'creates a folder with the valid name' do
+          expect(subject.folder.name).to eq('lol lol')
+        end
+      end
     end
 
     describe 'after category title was changed' do


### PR DESCRIPTION
* Implemented a filename validator, this handles the case when user manually changed the material/folder name(in edit action).

* Normalise the material/folder name for linked folder and uploaded materials