### PR TITLE
Make emails confirmable

### DIFF
--- a/app/models/concerns/user_authentication_concern.rb
+++ b/app/models/concerns/user_authentication_concern.rb
@@ -18,6 +18,7 @@ module UserAuthenticationConcern
 
     extend ReplacementClassMethods
     include UserOmniauthConcern
+    include UserConfirmableConcern
   end
 
   private

--- a/app/models/concerns/user_confirmable_concern.rb
+++ b/app/models/concerns/user_confirmable_concern.rb
@@ -1,0 +1,34 @@
+module UserConfirmableConcern
+  extend ActiveSupport::Concern
+
+  module ReplacementInstanceMethods
+    private
+
+    # Overrides Devise::Models::Confirmable#confirmation_required?
+    # This is for disabling the email confirmation logic in User model.
+    # User::Email is supposed to handle all the confirmation stuffs.
+    def confirmation_required?
+      false
+    end
+
+    # Overrides Devise::Models::Confirmable#reconfirmation_required?
+    # This is for disabling the email confirmation logic in User model.
+    # User::Email is supposed to handle all the confirmation stuffs.
+    def reconfirmation_required?
+      false
+    end
+
+    # Overrides Devise::Models::Confirmable#postpone_email_change?
+    # This is for disabling the email confirmation logic in User model.
+    # User::Email is supposed to handle all the confirmation stuffs.
+    def postpone_email_change?
+      false
+    end
+  end
+
+  included do
+    devise :confirmable
+
+    include ReplacementInstanceMethods
+  end
+end

--- a/app/models/user/email.rb
+++ b/app/models/user/email.rb
@@ -1,6 +1,7 @@
 # Represents an email address belonging to a user.
 class User::Email < ActiveRecord::Base
   after_destroy :set_new_user_primary_email, if: :primary?
+  devise :confirmable
 
   schema_validations except: :primary
   validates :primary, inclusion: [true, false]
@@ -19,6 +20,10 @@ class User::Email < ActiveRecord::Base
       fail ActiveRecord::Rollback unless update_attributes(primary: true)
       true
     end
+  end
+
+  def devise_scope
+    :user
   end
 
   private

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -160,6 +160,7 @@ class Course::UserInvitationService
                                                        creator: @current_user,
                                                        updater: @current_user)
       user_email = user_email_map[user[:email]] || User::Email.new(email: user[:email])
+      user_email.confirmed_at = Time.zone.now
       course_user.build_invitation(user_email: user_email, creator: @current_user,
                                    updater: @current_user)
     end

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -1,0 +1,5 @@
+p = t('.welcome', email: @email)
+
+p = t('.instruction')
+
+p = link_to t('.link_title'), confirmation_url(@resource.user, confirmation_token: @token)

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -19,6 +19,9 @@ en:
     mailer:
       confirmation_instructions:
         subject: 'Confirmation instructions'
+        welcome: 'Welcome %{email} !'
+        instruction: 'You can confirm your email through the link below:'
+        link_title: 'Confirm my email'
       reset_password_instructions:
         subject: 'Reset password instructions'
       unlock_instructions:

--- a/spec/factories/user_emails.rb
+++ b/spec/factories/user_emails.rb
@@ -7,9 +7,14 @@ FactoryGirl.define do
   factory :user_email, class: User::Email.name do
     primary true
     email
+    confirmed_at { Time.zone.now }
 
     after(:build) do |user_email|
       user_email.user ||= build(:user, emails: [user_email], emails_count: 0)
+    end
+
+    trait :unconfirmed do
+      confirmed_at nil
     end
   end
 end

--- a/spec/models/user/email_spec.rb
+++ b/spec/models/user/email_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe User::Email, type: :model do
 
   with_tenant(:instance) do
     let(:email) { build(:user_email) }
+
+    describe 'send_confirmation_instructions' do
+      it 'sends the confirmation instructions' do
+        email = create(:user_email)
+
+        expect { email.send_confirmation_instructions }.
+          to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+
     it 'rejects invalid email addresses' do
       email.email = 'wrong'
       expect(email.valid?).to eq(false)


### PR DESCRIPTION
Add an extension to support `email.send_confirmation_instructions`
Declare confirmable in User and forward the logic to User::Email