### PR TITLE
Allow devise to support multiple emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,7 @@ gem 'http_accept_language'
 # User authentication
 gem 'devise'
 gem 'devise_masquerade'
+gem 'devise-multi_email'
 gem 'omniauth'
 gem 'omniauth-facebook'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    devise-multi_email (1.0.2)
+      devise
     devise_masquerade (0.1.7)
       devise (>= 2.1.0)
       railties (>= 3.0)
@@ -519,6 +521,7 @@ DEPENDENCIES
   consistency_fail
   coveralls
   devise
+  devise-multi_email
   devise_masquerade
   edge
   factory_girl_rails

--- a/app/models/concerns/user_authentication_concern.rb
+++ b/app/models/concerns/user_authentication_concern.rb
@@ -5,7 +5,7 @@ module UserAuthenticationConcern
   included do
     # Include default devise modules. Others available are:
     # :validatable, :confirmable, :lockable, :timeoutable and :omniauthable
-    devise :multi_email_authenticatable, :registerable,
+    devise :multi_email_authenticatable, :multi_email_confirmable, :registerable,
            :recoverable, :rememberable, :trackable, :masqueradable
 
     before_sign_in :create_instance_user

--- a/app/models/concerns/user_authentication_concern.rb
+++ b/app/models/concerns/user_authentication_concern.rb
@@ -5,32 +5,16 @@ module UserAuthenticationConcern
   included do
     # Include default devise modules. Others available are:
     # :validatable, :confirmable, :lockable, :timeoutable and :omniauthable
-    devise :multi_email_authenticatable, :multi_email_confirmable, :registerable,
-           :recoverable, :rememberable, :trackable, :masqueradable
+    devise :multi_email_authenticatable, :multi_email_confirmable, :multi_email_validatable,
+           :registerable, :recoverable, :rememberable, :trackable, :masqueradable
 
     before_sign_in :create_instance_user
     after_create :create_instance_user
-
-    validates :email, presence: true, if: :email_required?
-    validates :password, presence: true, if: :password_required?
-    validates :password, confirmation: true, if: :password_required?
-    validates :password, length: { within: Devise.password_length, allow_blank: true }
 
     include UserOmniauthConcern
   end
 
   private
-
-  # Checks whether a password is needed or not. For validations only.
-  # Passwords are always required if it's a new record, or if the password or confirmation are
-  # being set somewhere.
-  def password_required?
-    !persisted? || !password.nil? || !password_confirmation.nil?
-  end
-
-  def email_required?
-    true
-  end
 
   def create_instance_user
     instance_users.create if persisted? && instance_users.empty?

--- a/app/models/concerns/user_omniauth_concern.rb
+++ b/app/models/concerns/user_omniauth_concern.rb
@@ -33,6 +33,7 @@ module UserOmniauthConcern
       User.create do |user|
         user.assign_attributes(name: auth.info.name, email: auth.info.email,
                                password: Devise.friendly_token[0, 20])
+        user.skip_confirmation! if user.email
         user.link_with_omniauth(auth)
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,8 +23,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  after_validation :propagate_user_email_errors
-
   has_many :emails, -> { order('primary' => :desc) }, class_name: User::Email.name,
                                                       inverse_of: :user, dependent: :destroy
   # This order need to be preserved, so that :emails association can be detected by
@@ -78,17 +76,6 @@ class User < ActiveRecord::Base
   end
 
   private
-
-  # Propagates the error from the +user_emails+ association to the main object
-  #
-  # @return [void]
-  def propagate_user_email_errors
-    return if (email_errors = errors.delete(:'emails.email')).nil?
-
-    email_errors.each do |error|
-      errors.add(:email, error)
-    end
-  end
 
   # Gets the default email address record.
   #

--- a/app/models/user/email.rb
+++ b/app/models/user/email.rb
@@ -5,8 +5,6 @@ class User::Email < ActiveRecord::Base
   schema_validations except: :primary
   validates :primary, inclusion: [true, false]
   validates :primary, uniqueness: { scope: [:user_id], conditions: -> { where(primary: true) } }
-  validates :email, uniqueness: { case_sensitive: false }
-  validates :email, format: Devise.email_regexp
 
   belongs_to :user, inverse_of: :emails
 

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -160,6 +160,7 @@ class Course::UserInvitationService
                                                        creator: @current_user,
                                                        updater: @current_user)
       user_email = user_email_map[user[:email]] || User::Email.new(email: user[:email])
+      user_email.skip_confirmation!
       course_user.build_invitation(user_email: user_email, creator: @current_user,
                                    updater: @current_user)
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,9 @@ ActsAsTenant.with_tenant(Instance.default) do
   # Create the default user account.
   user = User::Email.find_by_email('test@example.org')
   unless user
-    User.create!(name: 'Administrator', email: 'test@example.org',
-                 password: 'Coursemology!', role: :administrator)
+    user = User.new(name: 'Administrator', email: 'test@example.org',
+                    password: 'Coursemology!', role: :administrator)
+    user.skip_confirmation!
+    user.save!
   end
 end

--- a/spec/factories/user_emails.rb
+++ b/spec/factories/user_emails.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
   factory :user_email, class: User::Email.name do
     primary true
     email
+    confirmed_at { Time.zone.now }
 
     after(:build) do |user_email|
       user_email.user ||= build(:user, emails: [user_email], emails_count: 0)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,70 +35,6 @@ RSpec.describe User do
       end
     end
 
-    describe '#email' do
-      context 'when the user has no email addresses' do
-        let(:user) { User.new }
-        it 'does not have a default email' do
-          expect(user.email).to eq(nil)
-        end
-      end
-
-      context 'when the user has multiple email address' do
-        context 'no email address is primary' do
-          let(:user) do
-            user = build(:user, emails_count: 4)
-            user.emails.each { |email_record| email_record.primary = false }
-            user.emails.each.take(2).each(&:mark_for_destruction)
-            user
-          end
-
-          it 'picks the first non-deleted email as the primary email' do
-            not_marked_for_destruction = user.emails.each.select do |email_record|
-              !email_record.marked_for_destruction?
-            end
-            expect(user.email).to eq(not_marked_for_destruction.first.email)
-          end
-        end
-      end
-    end
-
-    describe '#email=' do
-      context 'when the user has no email addresses' do
-        let(:user) do
-          result = build(:user, emails_count: 0)
-          result.email = generate(:email)
-          result
-        end
-        it 'creates a new User::Email' do
-          expect(user.emails.length).to_not eq(0)
-        end
-
-        it 'creates a new primary User::Email' do
-          expect(user.emails[0].primary?).to eq(true)
-        end
-
-        it 'deletes the only email address when assigning nil' do
-          user.email = nil
-          expect(user.email).to eq(nil)
-
-          remaining_emails = user.emails.reject(&:marked_for_destruction?)
-          expect(remaining_emails.length).to eq(0)
-        end
-      end
-
-      context 'when the user has multiple email addresses' do
-        let(:user) { build(:user, emails_count: 2) }
-        context 'when there is no primary email set' do
-          it 'sets the first email as primary' do
-            user.email = 'test1a@email'
-            email_record = user.send(:default_email_record)
-            expect(email_record.primary?).to eq(true)
-            expect(email_record.email).to eq('test1a@email')
-          end
-        end
-      end
-    end
-
     describe '#emails' do
       let(:user) { create(:user, emails_count: 5) }
       it 'only allows one primary email' do
@@ -111,16 +47,6 @@ RSpec.describe User do
       let(:user) { User.new }
       it 'expects to be normal role by default' do
         expect(user.normal?).to eq(true)
-      end
-    end
-
-    context 'when the user has an invalid email address' do
-      subject { build(:user, email: 'xyz@sdf') }
-
-      it 'propagates the error to the error attribute' do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:email].length).to eq(1)
-        expect(subject.errors[:email].first).to match(/invalid/)
       end
     end
 


### PR DESCRIPTION
Wrote a gem as a devise plugin to let devise support multiple emails: https://github.com/allenwq/devise-multi_email, see gem README for more details.

Multi email authenticatable, confirmable and validatable are adopted in this PR.  Existing code for devise to support multiple emails have been deleted.