### PR TITLE
Refactor Course::Level

### DIFF
--- a/app/controllers/course/levels_controller.rb
+++ b/app/controllers/course/levels_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class Course::LevelsController < Course::ComponentController
-  before_action :load_levels, only: [:index]
   load_and_authorize_resource :level, through: :course, class: Course::Level.name
   add_breadcrumb :index, :course_levels_path
 
   def index #:nodoc:
+    @levels = @course.levels
   end
 
   def new #:nodoc:
@@ -31,12 +31,6 @@ class Course::LevelsController < Course::ComponentController
   end
 
   private
-
-  # This methods ensures that the Course::Levels are numbered
-  # for use by the controller.
-  def load_levels
-    @levels = @course.numbered_levels
-  end
 
   def level_params #:nodoc:
     params.require(:level).permit(:experience_points_threshold)

--- a/app/models/concerns/course/levels_concern.rb
+++ b/app/models/concerns/course/levels_concern.rb
@@ -2,18 +2,6 @@
 module Course::LevelsConcern
   extend ActiveSupport::Concern
 
-  # Generates the level numbers for the Course::Levels,
-  # since only the thresholds are stored in database.
-  # The entries should have been sorted during the
-  # database query.
-  #
-  # @return [Array<Course::Levels>] Array with numbered Course::Levels
-  def numbered_levels
-    levels.each_with_index.map do |level, index|
-      level.clone.tap { |l| l.level_number = index }
-    end
-  end
-
   # Returns Course::Level object corresponding to
   # the level that a course participant would have attained if
   # s/he had experience_points number of experience points.
@@ -24,10 +12,8 @@ module Course::LevelsConcern
   # @param [Fixnum] experience_points Number of Experience Points
   # @return [Course::Level] A Course::Level instance.
   def level_for(experience_points)
-    i = numbered_levels.rindex do |l|
-      l.experience_points_threshold <= experience_points
-    end
-    i ? numbered_levels[i] : numbered_levels.first
+    level = levels.reverse_order.find_by('experience_points_threshold <= ?', experience_points)
+    level ? level : levels.first
   end
 
   # Test if the course has a default level.

--- a/app/models/course/level.rb
+++ b/app/models/course/level.rb
@@ -4,9 +4,29 @@ class Course::Level < ActiveRecord::Base
   validates :experience_points_threshold, numericality: { greater_than_or_equal_to: 0 }
 
   belongs_to :course, inverse_of: :levels
-  default_scope { order(:experience_points_threshold) }
-  attr_writer :level_number
 
+  # By default, levels should be returned with their level_number,
+  # and arranged in ascending order by experience points threshold.
+  default_scope { all.calculated(:level_number).order(:experience_points_threshold) }
+
+  # Make use of RANK(), a postgres window function to generate level numbers.
+  # Since rank starts from 1 and Course::Levels start from 0, 1 is deducted from rank.
+  calculated :level_number, (lambda do
+    <<-SQL
+      SELECT cln.level_number
+      FROM (
+        SELECT id, (-1 + rank() OVER (
+                     PARTITION BY cl.course_id ORDER BY cl.experience_points_threshold ASC)
+                   ) AS level_number
+        FROM course_levels cl
+        WHERE cl.course_id = course_levels.course_id
+      ) AS cln
+      WHERE cln.id = course_levels.id
+    SQL
+  end)
+
+  # Build default level when a new course is initalised. The default level has
+  # 0 experience_points_threshold.
   def self.after_course_initialize(course)
     return if course.persisted? || course.default_level?
 
@@ -27,20 +47,7 @@ class Course::Level < ActiveRecord::Base
   # @return [Course::Level] For levels with next level in the course.
   # @return [nil] If current level is the highest in the course.
   def next
-    course.numbered_levels[level_number + 1]
-  end
-
-  # Retrieves the level number of the current level,
-  # relative to the other levels in the same course.
-  # This number is set by Course::LevelsConcern#number_levels.
-  #
-  # @return [Integer] Level Number.
-  # @raise [RuntimeError] Raises if level_number is not set.
-  def level_number
-    if @level_number
-      @level_number
-    else
-      fail IllegalStateError, "Attempted to access a Course::Level's number before computing it."
-    end
+    @next if defined? @next
+    @next = course.levels.find_nth(level_number + 1, 0)
   end
 end

--- a/spec/features/course/level_management_spec.rb
+++ b/spec/features/course/level_management_spec.rb
@@ -41,13 +41,13 @@ RSpec.feature 'Course: Levels' do
         fill_in 'level_experience_points_threshold', with: 400
 
         expect { click_button I18n.t('helpers.submit.level.create') }.
-          to change(course.levels, :count).by(1)
+          to change { course.levels.count }.by(1)
       end
 
       scenario 'I can delete a course level' do
         visit course_levels_path(course)
         expect { find_link(nil, href: course_level_path(course, levels[0])).click }.
-          to change(course.levels, :count).by(-1)
+          to change { course.levels.count }.by(-1)
       end
     end
 

--- a/spec/models/course/level_spec.rb
+++ b/spec/models/course/level_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe Course::Level, type: :model do
       end
     end
 
-    context 'before level_number is set' do
-      it 'raises an IllegalStateError' do
-        expect { Course::Level.new.level_number }.to raise_error(IllegalStateError)
-      end
-    end
-
     describe '.after_course_initialize' do
       it 'builds one default level' do
         expect(course.levels.size).to eq(1)
@@ -47,6 +41,23 @@ RSpec.describe Course::Level, type: :model do
 
           course.save
           expect(level).to be_persisted
+        end
+      end
+    end
+
+    describe '.default_scope' do
+      before { course.levels.concat(create_list(:course_level, 5, course: course)) }
+
+      it 'orders by ascending experience_points_threshold' do
+        course.levels.each_cons(2) do |current_level, next_level|
+          expect(current_level.experience_points_threshold).
+            to be < next_level.experience_points_threshold
+        end
+      end
+
+      it 'adds level_number to each level record' do
+        course.levels.each_with_index do |level, index|
+          expect(level.level_number).to eq(index)
         end
       end
     end
@@ -68,10 +79,11 @@ RSpec.describe Course::Level, type: :model do
     end
 
     describe '.next' do
-      before { create_list(:course_level, 5, course: course) }
+      before { course.levels.concat(create_list(:course_level, 5, course: course)) }
+
       context 'when current level is not the highest' do
         it 'returns the next level' do
-          course.reload.numbered_levels.each_cons(2) do |current_level, next_level|
+          course.levels.each_cons(2) do |current_level, next_level|
             expect(current_level.next).to eq(next_level)
           end
         end
@@ -79,7 +91,7 @@ RSpec.describe Course::Level, type: :model do
 
       context 'when current level is the highest' do
         it 'returns nil' do
-          expect(course.numbered_levels.last.next).to be_nil
+          expect(course.levels.last.next).to be_nil
         end
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -71,19 +71,12 @@ RSpec.describe Course, type: :model do
 
         context 'when experience_points is a positive number' do
           it 'returns the correct level number' do
-            course.numbered_levels.each do |level|
+            course.levels.each do |level|
               experience_points = level.experience_points_threshold
               expect(course.level_for(experience_points)).to eq(level)
               expect(course.level_for(experience_points + 1)).to eq(level)
             end
           end
-        end
-      end
-
-      describe '#numbered_levels' do
-        it 'numbers levels' do
-          numbering = course.numbered_levels.map(&:level_number)
-          expect(numbering).to eq((0..(course.levels.count - 1)).to_a)
         end
       end
     end


### PR DESCRIPTION
### Overall Idea

Trying to fix #710 - there are a few moving parts here. 

Mainly, I'm shifting most of `Course#numbered_levels`'s logic of adding level numbers into the SQL call using postgres rank()  window function. 

I wasn't too sure if adding it did make it more efficient, so I tried to benchmark it using `Benchmark.measure`. The console output is in the [public gist here](https://gist.github.com/weiqingtoh/04ece9f452a6d27cf84f), and I'll summarise the time in the PR.

I tried benchmarking by querying levels on two courses, `Course.first` has approximately 1.3k levels (just in case someone actually decides to do something like that), while `Course.second` has approximately 30 levels (more suitable for our own use case). 

### Change of `Course#numbered_levels`

- Added default scope to include postgres window function rank to calculate level_number
- Remove Course#numbered_levels, and changed all instances where method is used to Course.levels

| Course | Course.levels (new) | Course.numbered_levels (old) |
| :--- | :---: | :---: |
| First | 0.003011 | 0.036961 |
| Second | 0.003024 | 0.020893 |
* Definitely going with Postgres window functions. 
* Onc caveat of the particular implementation is that having custom select attributes breaks some of ActiveRecord's methods such as count, and a workaround has been documented in the code. 

### Speed up `Course#level_for`

- Refactored Course#level_for, speed up query.
`Level_for` calculated the current level given the experience points. There were two options: i) use SQL to calculate current level through ActiveRecord, or ii) use ruby to do it. 


| Course | Course.level_for (SQL) | Course.level_for (Ruby) |
| :--- | :---: | :---: |
| First | 0.025018 | 0.030411 |
| Second | 0.028808 | 0.029139 |
*Benchmark was done by finding the current level of 1526 experience points.
* Preference to use Activerecord / SQL to do this.

### Memoise Level#next
As discussed in #708 - had to check if `@next` is defined, as `Level.next` might be `nil`, rendering the `||=` operator useless. 
