### PR TITLE
Config storage in configuration files and remove declarations from model

### DIFF
--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -5,9 +5,6 @@ class FileUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   # include CarrierWave::MiniMagick
 
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
   before :cache, :save_original_filename
 
   # Override the directory where uploaded files will be stored.

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,10 +5,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,0 +1,3 @@
+CarrierWave.configure do |config|
+  config.storage = :file
+end

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -6,10 +6,6 @@ module CarrierWave::TestGroupHelpers
   end
 
   module DirectoryOverrides
-    def self.prepended(class_)
-      class_.storage :file
-    end
-
     UPLOADS_DIR = Rails.application.config.x.temp_folder.join('spec/uploads')
 
     def cache_dir


### PR DESCRIPTION
`storage` is removed from models and use config file instead.
( We cannot declare `storage :fog` and override this in test, an exception will be raised when the Uploader is loaded )

@fonglh Need your help to create an AWS bucket and config the required environment variables. 