### PR TITLE
Add 'levels#next_level_threshold`

### DIFF
--- a/app/models/course/level.rb
+++ b/app/models/course/level.rb
@@ -50,4 +50,13 @@ class Course::Level < ActiveRecord::Base
     @next if defined? @next
     @next = course.levels.find_nth(level_number + 1, 0)
   end
+
+  # Returns the experience_points_threshold of the next level. If current level is highest
+  # the current experience_points_threshold will be returned.
+  #
+  # @return [Fixnum] The experience_points_threshold of the next level, or threshold of current
+  # level if current level is the highest.
+  def next_level_threshold
+    self.next ? self.next.experience_points_threshold : experience_points_threshold
+  end
 end

--- a/spec/models/course/level_spec.rb
+++ b/spec/models/course/level_spec.rb
@@ -95,5 +95,25 @@ RSpec.describe Course::Level, type: :model do
         end
       end
     end
+
+    describe '#next_level_threshold' do
+      before { course.levels.concat(create_list(:course_level, 5, course: course)) }
+
+      context 'when current level is not the highest' do
+        it "returns the next level's threshold" do
+          course.levels.each_cons(2) do |current_level, next_level|
+            expect(current_level.next_level_threshold).
+              to eq(next_level.experience_points_threshold)
+          end
+        end
+      end
+
+      context 'when current level is the highest' do
+        it "returns the current level's threshold" do
+          expect(course.levels.last.next_level_threshold).
+            to eq(course.levels.last.experience_points_threshold)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Dependent on #724, small part of #632

Eventually this will be used for CourseUser badge display in the form `{current_exp} / {next_level_exp}`. 
Would rather prefer having this method housed in models rather than dealing with it in the views/helpers. 