### PR TITLE
 ActiveRecord::Base#wait deadlock fix, part 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'validates_hostname'
 gem 'workflow'
 # Add creator_id and updater_id attributes to models
 gem 'activerecord-userstamp', '>= 3.0.2'
+# Allow actions to be deferred until after a record is committed.
+gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
 gem 'calculated_attributes', '>= 0.1.3'
 # Squeel as an SQL-like DSL

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    after_commit_action (1.0.1)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     anbt-sql-formatter (0.0.3)
     arel (6.0.3)
     ast (2.2.0)
@@ -514,6 +517,7 @@ DEPENDENCIES
   active_record-acts_as!
   activerecord-userstamp (>= 3.0.2)
   acts_as_tenant!
+  after_commit_action
   autoprefixer-rails
   bootstrap-sass
   bootstrap-sass-extras!

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -115,6 +115,8 @@ class Course::Assessment::Submission < ActiveRecord::Base
   def auto_grade_submission
     return unless workflow_state_changed?
 
-    auto_grade!
+    execute_after_commit do
+      auto_grade!
+    end
   end
 end

--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -10,11 +10,13 @@
 class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapters::InlineAdapter
   class << self
     def enqueue(job) #:nodoc:
-      Thread.new do
+      thread = Thread.new do
         ActiveRecord::Base.connection_pool.with_connection do
           ActiveJob::Base.execute(job.serialize)
         end
       end
+
+      thread.abort_on_exception = true
     end
   end
 end

--- a/lib/extensions/after_commit_action.rb
+++ b/lib/extensions/after_commit_action.rb
@@ -1,0 +1,4 @@
+module Extensions::AfterCommitAction; end
+ActiveRecord::Base.class_eval do
+  include AfterCommitAction
+end

--- a/spec/libraries/trackable_job_spec.rb
+++ b/spec/libraries/trackable_job_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe TrackableJob do
     it 'is persisted to the database' do
       expect(TrackableJob::Job.find(subject.job_id)).to eq(subject.job)
     end
+
+    it 'only creates one job' do
+      expect { subject }.to change { TrackableJob::Job.count }.by(1)
+    end
   end
 
   context 'when the job is completed' do

--- a/spec/libraries/trackable_job_spec.rb
+++ b/spec/libraries/trackable_job_spec.rb
@@ -118,10 +118,12 @@ RSpec.describe TrackableJob do
   end
 
   describe '#perform_tracked' do
-    subject { self.class::NoOpJob.perform_later }
+    with_active_job_queue_adapter(:inline) do
+      subject { self.class::NoOpJob.perform_later }
 
-    it 'fails with NotImplementedError' do
-      expect { subject.send(:perform_tracked) }.to raise_error(NotImplementedError)
+      it 'fails with NotImplementedError' do
+        expect { subject.send(:perform_tracked) }.to raise_error(NotImplementedError)
+      end
     end
   end
 


### PR DESCRIPTION
I've identified two more contributing factors, in addition to those in #721:
 - Exceptions in threads are swallowed by default, see Thread#abort_on_exception; this can cause jobs to die without anyone knowing, especially if the job was not instantiated in the thread yet
 - We spawn jobs within a transaction; this is a problem because the transaction creates the job (in the Jobs table), but the job can start and look for itself in the jobs table *before the transaction is committed*. This causes some jobs to fail without warning, see point 1.

I've also reduced the number of spurious jobs in the jobs table by only committing the job to the table when the job is enqueued, that should reduce the number of blank jobs in the jobs table. This helps debugging.