### PR TITLE
 ActiveRecord::Base#wait deadlock fix, part 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 script:
   - bundle exec consistency_fail
   - bundle exec i18n-tasks health
-  - bundle exec rspec spec --format documentation
+  - bundle exec rake spec
 
 notifications:
   slack:

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -83,7 +83,7 @@ class Course::Assessment::Answer < ActiveRecord::Base
   #
   # @return [Course::Assessment::Answer::AutoGrading]
   def ensure_auto_grading!
-    ActiveRecord::Base.transaction do
+    ActiveRecord::Base.transaction(requires_new: true) do
       auto_grading || create_auto_grading!
     end
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -22,7 +22,7 @@ class Course::Discussion::Topic < ActiveRecord::Base
   # @param [User] user The user who needs to subscribe to this topic
   def ensure_subscribed_by(user)
     return true if self.subscribed_by?(user)
-    ActiveRecord::Base.transaction do
+    ActiveRecord::Base.transaction(requires_new: true) do
       subscriptions.build(user: user).save!
     end
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e


### PR DESCRIPTION
Ensure that even if we are in a transaction, a new one is created.

This properly implements #732.