### PR TITLE
Implement saving/submitting answers in guided submission

### DIFF
--- a/app/jobs/course/assessment/answer/auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/auto_grading_job.rb
@@ -6,12 +6,16 @@ class Course::Assessment::Answer::AutoGradingJob < ApplicationJob
 
   # Performs the auto grading.
   #
+  # @param [String|nil] redirect_to_path The path to be redirected after auto grading job was
+  #   finished.
   # @param [Course::Assessment::Answer::AutoGrading] auto_grading The object to store the grading
   #   results into.
-  def perform_tracked(auto_grading)
+  def perform_tracked(auto_grading, redirect_to_path = nil)
     instance = Course.unscoped { auto_grading.answer.question.assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
       Course::Assessment::Answer::AutoGradingService.grade(auto_grading)
     end
+
+    redirect_to redirect_to_path
   end
 end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -33,15 +33,18 @@ class Course::Assessment::Answer < ActiveRecord::Base
 
   # Creates an Auto Grading job for this answer. This saves the answer if there are pending changes.
   #
+  # @param [String|nil] redirect_to_path The path to be redirected after auto grading job was
+  #   finished.
   # @return [Course::Assessment::Answer::AutoGradingJob] The job instance.
   # @raise [ArgumentError] When the question cannot be auto graded.
   # @raise [IllegalStateError] When the answer has not been submitted.
-  def auto_grade!
+  def auto_grade!(redirect_to_path = nil)
     raise ArgumentError unless question.auto_gradable?
     raise IllegalStateError if attempting?
 
     ensure_auto_grading!
-    Course::Assessment::Answer::AutoGradingJob.perform_later(auto_grading).tap do |job|
+    Course::Assessment::Answer::AutoGradingJob.
+      perform_later(auto_grading, redirect_to_path).tap do |job|
       auto_grading.job_id = job.job_id
       save!
     end

--- a/app/services/course/assessment/submission/update_guided_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_guided_assessment_service.rb
@@ -2,14 +2,40 @@
 class Course::Assessment::Submission::UpdateGuidedAssessmentService <
   Course::Assessment::Submission::UpdateService
 
+  def update
+    if params[:attempting_answer_id]
+      submit_answer
+    else
+      super
+    end
+  end
+
   private
 
-  def questions_to_attempt
-    @questions_to_attempt ||= @submission.assessment.questions.
-                              step(@submission, step_param.to_i - 1)
+  def answer_id_param
+    params.permit(:attempting_answer_id)[:attempting_answer_id]
   end
 
   def step_param
     params.permit(:step)[:step]
+  end
+
+  def submit_answer
+    if @submission.update_attributes(update_params)
+      answer = @submission.answers.find(answer_id_param)
+      answer.finalise!
+      redirect_path = edit_course_assessment_submission_path(current_course, @assessment,
+                                                             @submission, step: step_param)
+      job = answer.auto_grade!(redirect_path)
+
+      redirect_to job_path(job.job)
+    else
+      render 'edit'
+    end
+  end
+
+  def questions_to_attempt
+    @questions_to_attempt ||= @submission.assessment.questions.
+                              step(@submission, step_param.to_i - 1)
   end
 end

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -1,21 +1,8 @@
 = base_answer_form.simple_fields_for :actable do |specific_answer_form|
   = render partial: specific_answer_form.object.specific, locals: { f: specific_answer_form }
 
-h3 = t('.comments')
-div.comments
+= render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
+         locals: { base_answer_form: base_answer_form, answer: answer }
 
-- if !answer.attempting? && can?(:grade, @submission)
-  div.panel.panel-default
-    div.panel-heading = t('.grading')
-    div.panel-body
-      div.form-group.submission_answers_grade.row
-        div.col-lg-3.col-md-6.col-sm-6.col-xs-6
-          = base_answer_form.input_field :grade, class: ['form-control', 'grade']
-        div.col-lg-3.col-md-6.col-sm-6.col-xs-6
-          = t('.maximum_grade', maximum_grade: answer.question.maximum_grade)
-- elsif answer.graded?
-    div.panel.panel-default
-      div.panel-heading = t('.grading')
-      div.panel-body
-        div.form-group.submission_answers_grade
-          = t('.grade', grade: answer.grade, maximum_grade: answer.question.maximum_grade)
+= render partial: 'course/assessment/answer/grading',
+         locals: { base_answer_form: base_answer_form, answer: answer }

--- a/app/views/course/assessment/answer/_grading.slim
+++ b/app/views/course/assessment/answer/_grading.slim
@@ -1,0 +1,15 @@
+- if !answer.attempting? && can?(:grade, @submission)
+  div.panel.panel-default
+    div.panel-heading = t('.grading')
+    div.panel-body
+      div.form-group.submission_answers_grade.row
+        div.col-lg-3.col-md-6.col-sm-6.col-xs-6
+          = base_answer_form.input_field :grade, class: ['form-control', 'grade']
+        div.col-lg-3.col-md-6.col-sm-6.col-xs-6
+          = t('.maximum_grade', maximum_grade: answer.question.maximum_grade)
+- elsif answer.graded?
+    div.panel.panel-default
+      div.panel-heading = t('.grading')
+      div.panel-body
+        div.form-group.submission_answers_grade
+          = t('.grade', grade: answer.grade, maximum_grade: answer.question.maximum_grade)

--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -1,0 +1,2 @@
+- if answer.attempting?
+  = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id'

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -1,0 +1,2 @@
+h3 = t('.comments')
+div.comments

--- a/app/views/course/assessment/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submissions/_guided.html.slim
@@ -3,3 +3,13 @@ nav
     - (1..@assessment.questions.length).each do |i|
       li class="#{nav_class(i)}"
         = link_to i, [:edit, current_course, @assessment, @submission, step: i], class: ['btn', 'btn-default']
+
+= simple_form_for [current_course, @assessment, @submission] do |f|
+  = f.error_notification
+  = f.simple_fields_for :answers, @submission.answers.where(question: @questions_to_attempt).last do |base_answer_form|
+    = content_tag_for(:div, base_answer_form.object) do
+      = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
+               locals: { base_answer_form: base_answer_form }
+
+      - if base_answer_form.object.attempting?
+        = f.button :submit, t('common.save')

--- a/app/views/course/assessment/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submissions/_guided.html.slim
@@ -6,10 +6,10 @@ nav
 
 = simple_form_for [current_course, @assessment, @submission] do |f|
   = f.error_notification
+  = hidden_field_tag :step, current_step
   = f.simple_fields_for :answers, @submission.answers.where(question: @questions_to_attempt).last do |base_answer_form|
     = content_tag_for(:div, base_answer_form.object) do
       = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
                locals: { base_answer_form: base_answer_form }
-
       - if base_answer_form.object.attempting?
         = f.button :submit, t('common.save')

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -11,6 +11,7 @@ en:
     draft: 'Draft'
     save: 'Save'
     search: 'Search'
+    submit: 'Submit'
   helpers:
     submit:
       condition_level:

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -2,8 +2,9 @@ en:
   course:
     assessment:
       answer:
-        answer:
+        worksheet:
           comments: 'Comments'
+        grading:
           grading: 'Grading'
           maximum_grade: '/ %{maximum_grade}'
           grade: 'Grade: %{grade} / %{maximum_grade}'

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -64,5 +64,30 @@ RSpec.describe Course::Assessment::SubmissionsController do
         expect(controller.instance_variable_get(:@questions_to_attempt)).to be_present
       end
     end
+
+    context 'when the assessment is guided' do
+      let(:assessment) { create(:assessment, :guided, :with_mcq_question, course: course) }
+      let!(:answer) do
+        answer = assessment.questions.first.attempt(immutable_submission)
+        answer.save
+        answer
+      end
+
+      describe '#submit_answer' do
+        subject do
+          put :update, course_id: course, assessment_id: assessment, id: immutable_submission,
+                       attempting_answer_id: answer.id, submission: { title: '' }
+        end
+
+        context 'when update fails' do
+          before do
+            controller.instance_variable_set(:@submission, immutable_submission)
+            subject
+          end
+
+          it { is_expected.to render_template('edit') }
+        end
+      end
+    end
   end
 end

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         # TODO: Add more asserts once questions are displayed in guided assessment.
       end
+
+      scenario 'I can submit an answer for auto grading' do
+        assessment = create(:assessment, :with_mcq_question, :guided, course: course)
+        submission = create(:course_assessment_submission, assessment: assessment, user: student)
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+        check 'true'
+        click_button 'save'
+        expect(page).to have_selector('div.alert-success',
+                                      text: 'course.assessment.submissions.update.success')
+
+        click_button 'submit'
+        wait_for_job
+
+        expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grading')
+        expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grade')
+      end
     end
   end
 end


### PR DESCRIPTION
Follow up #727, Depends on #740 

## Changes in this PR
Implement the view of guided (training) submission
Implement auto grading current answer

## Discussion
For submitting answers independently (without submitting the whole submission), I've considered using hidden field with workflow_state value as submitted. But that does not work for worksheet submission, as all the answers in the page will be submitted and graded.

So what I do is to provide a submit button for each answer, with the id of answer, so that the controller knows which answer is asking for auto grading. And this works for both guided and worksheet submission.
