### PR TITLE
ActiveRecord::Base#wait deadlock fix, part 4

### DIFF
--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -8,15 +8,94 @@
 #
 #   Rails.application.config.active_job.queue_adapter = :background_thread
 class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapters::InlineAdapter
+  # The ActiveSupport::Notification instrumentation event when the pool grows.
+  GROW_EVENT = 'grow.background_thread_adapter.active_job'
+
+  # The ActiveSupport::Notification instrumentation event when the pool shrinks.
+  SHRINK_EVENT = 'shrink.background_thread_adapter.active_job'
+
+  # The maximum number of threads to maintain in the thread pool.
+  MAX_THREAD_POOL_SIZE = 3
+
+  @pending_jobs = []
+  @thread_pool = []
+  @thread_pool_mutex = Mutex.new
+
+  def self.enqueue(job) #:nodoc:
+    with_thread_pool { @pending_jobs << job }
+    ensure_threads
+  end
+
   class << self
-    def enqueue(job) #:nodoc:
-      thread = Thread.new do
+    private
+
+    def with_thread_pool(&block)
+      @thread_pool_mutex.synchronize(&block)
+    end
+
+    def ensure_threads
+      with_thread_pool do
+        return if @thread_pool.size >= MAX_THREAD_POOL_SIZE
+        return if @pending_jobs.size < @thread_pool.size
+
+        ActiveSupport::Notifications.instrument(GROW_EVENT) do |payload|
+          @thread_pool << new_thread
+          payload[:thread] = @thread_pool.last
+          payload[:pool_size] = @thread_pool.size
+        end
+      end
+    end
+
+    def remove_thread_from_pool(thread_to_remove)
+      with_thread_pool do
+        ActiveSupport::Notifications.instrument(SHRINK_EVENT) do |payload|
+          @thread_pool.delete(thread_to_remove)
+          payload[:thread] = thread_to_remove
+          payload[:pool_size] = @thread_pool.size
+        end
+      end
+    end
+
+    def new_thread
+      thread = Thread.new(&method(:thread_main))
+      thread.abort_on_exception = true
+      thread
+    end
+
+    def thread_main
+      job = nil
+      loop do
+        with_thread_pool { job = @pending_jobs.shift }
+        return unless job
+
         ActiveRecord::Base.connection_pool.with_connection do
           ActiveJob::Base.execute(job.serialize)
         end
       end
-
-      thread.abort_on_exception = true
+    ensure
+      remove_thread_from_pool(Thread.current)
     end
   end
+
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def grow(event)
+      message = "[Background Thread] New thread: #{event.payload[:thread].object_id}, "\
+                "pool size: #{event.payload[:pool_size]}"
+      info(message)
+    end
+
+    def shrink(event)
+      message = "[Background Thread] Stopping thread: #{event.payload[:thread].object_id}, "\
+                "pool size: #{event.payload[:pool_size]}"
+      info(message)
+    end
+
+    private
+
+    def logger
+      ActiveJob::Base.logger
+    end
+  end
+
+  LogSubscriber.attach_to(:'background_thread_adapter.active_job')
 end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -52,12 +52,14 @@ RSpec.describe Course::Assessment::Submission do
     end
 
     describe '#grade' do
-      let(:assessment_traits) { [:with_all_question_types] }
-      let(:submission1_traits) { :submitted }
-      let(:submission) { submission1 }
+      with_active_job_queue_adapter(:test) do
+        let(:assessment_traits) { [:with_all_question_types] }
+        let(:submission1_traits) { :submitted }
+        let(:submission) { submission1 }
 
-      it 'sums the grade of all answers' do
-        expect(submission.grade).to eq(submission.answers.map(&:grade).reduce(0, :+))
+        it 'sums the grade of all answers' do
+          expect(submission.grade).to eq(submission.answers.map(&:grade).reduce(0, :+))
+        end
       end
     end
 
@@ -96,43 +98,45 @@ RSpec.describe Course::Assessment::Submission do
     end
 
     describe '#publish!' do
-      let(:assessment_traits) { [:with_all_question_types] }
-      let(:submission) { submission1 }
-      let(:submission1_traits) { :submitted }
-
-      it 'propagates the graded state to its answers' do
-        expect(submission.answers.all?(&:submitted?)).to be(true)
-        submission.publish!
-        expect(submission.answers.all?(&:graded?)).to be(true)
-      end
-
-      context 'when some of the answers are already graded' do
-        before do
-          submission.answers.sample.tap do |answer|
-            answer.publish!
-            answer.save!
-          end
-
-          expect(submission.answers.any?(&:graded?)).to be(true)
-        end
+      with_active_job_queue_adapter(:test) do
+        let(:assessment_traits) { [:with_all_question_types] }
+        let(:submission) { submission1 }
+        let(:submission1_traits) { :submitted }
 
         it 'propagates the graded state to its answers' do
+          expect(submission.answers.all?(&:submitted?)).to be(true)
           submission.publish!
           expect(submission.answers.all?(&:graded?)).to be(true)
+        end
+
+        context 'when some of the answers are already graded' do
+          before do
+            submission.answers.sample.tap do |answer|
+              answer.publish!
+              answer.save!
+            end
+
+            expect(submission.answers.any?(&:graded?)).to be(true)
+          end
+
+          it 'propagates the graded state to its answers' do
+            submission.publish!
+            expect(submission.answers.all?(&:graded?)).to be(true)
+          end
         end
       end
     end
 
     describe '#auto_grade!' do
-      let(:assessment_traits) { [:with_all_question_types] }
-      let(:submission1_traits) { :submitted }
-      let(:submission) { submission1 }
-
-      it 'returns an ActiveJob' do
-        expect(submission.auto_grade!).to be_a(ActiveJob::Base)
-      end
-
       with_active_job_queue_adapter(:test) do
+        let(:assessment_traits) { [:with_all_question_types] }
+        let(:submission1_traits) { :submitted }
+        let(:submission) { submission1 }
+
+        it 'returns an ActiveJob' do
+          expect(submission.auto_grade!).to be_a(ActiveJob::Base)
+        end
+
         it 'queues the job' do
           submission
           expect { submission.auto_grade! }.to \


### PR DESCRIPTION
I've changed the Background Thread ActiveJob queue adapter to use a thread pool to restrict the number of database connections we check out at any one time.

The ActiveJob logs can be redirected to STDOUT on Travis to debug deadlocks/exhaustion.