### PR TITLE
Implement badges for achievements in Controller and Views

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -13,3 +13,15 @@ $gray-dark:              lighten($gray-base, 20%) !default;   // #333
 $gray:                   lighten($gray-base, 33.5%) !default; // #555
 $gray-light:             lighten($gray-base, 46.7%) !default; // #777
 $gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
+
+//== Icons and Logos
+//
+//## Common sizes to be used across Coursemology.
+
+$picture-thumb: 25px !default;
+$picture-small: 75px !default;
+$picture-medium: 100px !default;
+
+$course-achievement-badge-thumb:   $picture-thumb !default;
+$course-achievement-badge-small:   $picture-small !default;
+$course-achievement-badge-medium:  $picture-medium !default;

--- a/app/assets/stylesheets/course/achievement.scss
+++ b/app/assets/stylesheets/course/achievement.scss
@@ -1,3 +1,13 @@
 // Place all the styles related to the course/achievement controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.course-achievements {
+  .achievement-list,
+  .achievement-form {
+    .image > img {
+      height: $course-achievement-badge-small;
+      width: $course-achievement-badge-small;
+    }
+  }
+}

--- a/app/controllers/course/achievements_controller.rb
+++ b/app/controllers/course/achievements_controller.rb
@@ -43,6 +43,6 @@ class Course::AchievementsController < Course::ComponentController
   private
 
   def achievement_params #:nodoc:
-    params.require(:achievement).permit(:title, :description, :weight, :draft)
+    params.require(:achievement).permit(:title, :description, :weight, :draft, :badge)
   end
 end

--- a/app/views/course/achievements/_achievement.html.slim
+++ b/app/views/course/achievements/_achievement.html.slim
@@ -1,6 +1,7 @@
 = content_tag_for(:tr, achievement, class: draft_class(achievement)) do
   td
-    img.achievement-icon
+    = display_achievement_badge(achievement)
+
   th
     = link_to format_inline_text(achievement.title),
               course_achievement_path(current_course, achievement)

--- a/app/views/course/achievements/_form.html.slim
+++ b/app/views/course/achievements/_form.html.slim
@@ -5,6 +5,10 @@
 
   = f.input :description
 
+  = f.label t('.badge')
+  div.achievement-form = display_achievement_badge(@achievement)
+  = f.file_field :badge
+
   = f.input :draft
 
   - if @achievement.persisted?

--- a/app/views/course/achievements/index.html.slim
+++ b/app/views/course/achievements/index.html.slim
@@ -3,7 +3,7 @@
 table.table.achievement-list.table-hover
   thead
     tr
-      th
+      th = t('.badge')
       th = t('.title')
       th = t('.description')
       th = t('.requirements')

--- a/config/locales/en/course/achievements.yml
+++ b/config/locales/en/course/achievements.yml
@@ -7,6 +7,7 @@ en:
         header: 'Achievements'
         description: 'Description'
         requirements: 'Requirements'
+        badge: 'Badge'
       new:
         header: 'New Achievement'
       create:
@@ -18,3 +19,5 @@ en:
       destroy:
         success: 'Achievement %{title} was deleted.'
         failure: 'Failed to delete achievement: %{error}'
+      form:
+        badge: :'course.achievements.index.badge'

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -24,11 +24,13 @@ RSpec.feature 'Course: Achievements' do
         achievement = build(:course_achievement, course: course)
         fill_in 'achievement_title', with: achievement.title
         fill_in 'achievement_description', with: achievement.description
+        attach_file :achievement_badge, File.join(Rails.root, '/spec/fixtures/files/picture.jpg')
         expect do
           click_button I18n.t('helpers.submit.achievement.create')
         end.to change(course.achievements, :count).by(1)
         expect(page).to have_selector('div', text: I18n.t('course.achievements.create.success'))
         expect(current_path).to eq(course_achievements_path(course))
+        expect(page).to have_content(achievement.badge.medium.url)
       end
 
       scenario 'I can delete an achievement' do
@@ -62,9 +64,11 @@ RSpec.feature 'Course: Achievements' do
         new_description = 'New description'
         fill_in 'achievement_title', with: new_title
         fill_in 'achievement_description', with: new_description
+        attach_file :achievement_badge, File.join(Rails.root, '/spec/fixtures/files/picture.jpg')
         click_button I18n.t('helpers.submit.achievement.update')
         expect(current_path).to eq course_achievements_path(course)
         expect(page).to have_selector('div', I18n.t('course.achievements.update.success'))
+        expect(page).to have_content(achievement.badge.medium.url)
         expect(achievement.reload.title).to eq(new_title)
         expect(achievement.reload.description).to eq(new_description)
       end


### PR DESCRIPTION
Continue from #748 - to implement badge for controller and views. 

Support uploading and viewing of Achievement badges. This will complete part of #617, #624.