### PR TITLE
ActiveRecord::Base#wait deadlock fix, part 5

### DIFF
--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -9,7 +9,20 @@ module ActiveJob::TestGroupHelpers
     ActiveJob::Base.queue_adapter = adapter
     example.call
   ensure
+    wait_for_jobs if adapter == :background_thread ||
+                     adapter == ActiveJob::QueueAdapters::BackgroundThreadAdapter
     ActiveJob::Base.queue_adapter = old_adapter
+  end
+
+  def self.ensure_jobs_completion(example)
+    example.call
+  ensure
+    wait_for_jobs if ActiveJob::Base.queue_adapter ==
+                     ActiveJob::QueueAdapters::BackgroundThreadAdapter
+  end
+
+  def self.wait_for_jobs
+    ActiveJob::QueueAdapters::BackgroundThreadAdapter.wait_for_jobs
   end
 
   def with_active_job_queue_adapter(adapter, &proc)
@@ -48,6 +61,8 @@ RSpec.configure do |config|
   config.extend ActiveJob::TestGroupHelpers
   config.around(:each, type: :job,
                 &ActiveJob::TestGroupHelpers.with_active_job_queue_adapter_method)
+  config.around(:each,
+                &ActiveJob::TestGroupHelpers.method(:ensure_jobs_completion))
   config.include TrackableJob::TestExampleHelpers, type: :feature
 
   config.backtrace_exclusion_patterns << /\/spec\/support\/active_job\.rb/


### PR DESCRIPTION
I've fixed a few possible causes of deadlocks for the specs, this should really be solid now.

 - All examples will need to wait for spawned jobs to finish before they can exit. This prevents state from spilling over from one example to the next (such as when spawning a submission job)
 - Added more sources of logging to allow better debugging of deadlocks.
 - Ensure that when we decide whether to expand the thread pool, we also consider the number of executing tasks, not just the pending tasks. If there is only one task running, and one task queued, the previous implementation will not start a new thread to run the new task. If the first task is waiting for the second, the first task will never return.