### PR TITLE
Allow course managers to delete their own course

### DIFF
--- a/app/controllers/course/admin/admin_controller.rb
+++ b/app/controllers/course/admin/admin_controller.rb
@@ -11,10 +11,30 @@ class Course::Admin::AdminController < Course::Admin::Controller
     end
   end
 
+  def destroy #:nodoc:
+    if current_course.destroy
+      destroy_success
+    else
+      destroy_failure
+    end
+  end
+
   private
 
   def course_setting_params #:nodoc:
     params.require(:course).
       permit(:title, :description, :status, :start_at, :end_at)
+  end
+
+  def destroy_success #:nodoc:
+    redirect_to courses_path,
+                success: t('course.admin.admin.destroy.success',
+                           title: current_course.title)
+  end
+
+  def destroy_failure #:nodoc:
+    redirect_to course_admin_path(@course),
+                danger: t('course.admin.admin.destroy.failure',
+                          error: current_course.errors.full_messages.to_sentence)
   end
 end

--- a/app/views/course/admin/admin/index.html.slim
+++ b/app/views/course/admin/admin/index.html.slim
@@ -1,14 +1,22 @@
-= simple_form_for current_course, url: course_admin_path(current_course) do |f|
-  = f.input :title, label: t('course.courses.form.title_label'),
-      placeholder: t('course.courses.form.title_placeholder')
+= div_for(current_course)
+  = simple_form_for current_course, url: course_admin_path(current_course) do |f|
+    = f.input :title, label: t('course.courses.form.title_label'),
+        placeholder: t('course.courses.form.title_placeholder')
 
-  = f.input :description, label: t('course.courses.form.description_label'),
-      placeholder: t('course.courses.form.description_placeholder')
+    = f.input :description, label: t('course.courses.form.description_label'),
+        placeholder: t('course.courses.form.description_placeholder')
 
-  = f.input :status, as: :radio_buttons, collection: Course.statuses.keys
+    = f.input :status, as: :radio_buttons, collection: Course.statuses.keys
 
-  = f.input :start_at
+    = f.input :start_at
 
-  = f.input :end_at
+    = f.input :end_at
 
-  = f.button :submit
+    = f.button :submit
+
+  div.delete-course
+    = page_header t('.delete.header')
+    div.alert.alert-danger
+      = simple_format(t('.delete.description_placeholder'))
+    = delete_button(course_admin_path(current_course)) do
+      = t('.delete.button')

--- a/app/views/layouts/course_admin.html.slim
+++ b/app/views/layouts/course_admin.html.slim
@@ -1,4 +1,5 @@
 = render within_layout: controller.parent_layout(of_layout: 'course_admin') do
+  = page_header t('.title')
   = tabs do
     - controller.sidebar_items(type: :settings).each do |item|
       = nav_to(item[:title], item[:path])

--- a/config/locales/en/course/admin/admin.yml
+++ b/config/locales/en/course/admin/admin.yml
@@ -4,6 +4,11 @@ en:
       admin:
         index:
           header: 'Settings'
+          delete:
+            header: 'Delete Course'
+            button: 'Delete My Course'
+            description_placeholder: >
+              Once you delete this course, you will not be able to access it any more.
         update:
           success: 'Course %{title} was updated.'
         destroy:

--- a/config/locales/en/course/admin/admin.yml
+++ b/config/locales/en/course/admin/admin.yml
@@ -6,3 +6,6 @@ en:
           header: 'Settings'
         update:
           success: 'Course %{title} was updated.'
+        destroy:
+          success: 'Course %{title} was deleted.'
+          failure: 'Failed to delete course: %{error}.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
       namespace :admin do
         get '/' => 'admin#index'
         patch '/' => 'admin#update'
+        delete '/' => 'admin#destroy'
 
         get 'components' => 'component_settings#edit'
         patch 'components' => 'component_settings#update'

--- a/spec/controllers/course/admin/admin_controller_spec.rb
+++ b/spec/controllers/course/admin/admin_controller_spec.rb
@@ -57,5 +57,51 @@ RSpec.describe Course::Admin::AdminController do
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
     end
+
+    describe '#destroy' do
+      subject { delete :destroy, course_id: course }
+      before { controller.instance_variable_set(:@course, course) }
+
+      context 'when the user is a Course Manager' do
+        let(:user) { create(:course_manager, :approved, course: course).user }
+
+        it 'destroys the course' do
+          subject
+          expect(controller.current_course).to be_destroyed
+        end
+
+        it { is_expected.to redirect_to(courses_path) }
+
+        it 'sets the proper flash message' do
+          subject
+          expect(flash[:success]).to eq(I18n.t('course.admin.admin.destroy.success'))
+        end
+
+        context 'when the course cannot be destroyed' do
+          before do
+            allow(course).to receive(:destroy).and_return(false)
+            subject
+          end
+
+          it { is_expected.to redirect_to(course_admin_path(course)) }
+
+          it 'sets an error flash message' do
+            expect(flash[:danger]).to eq(I18n.t('course.admin.admin.destroy.failure'))
+          end
+        end
+      end
+
+      context 'when the user is an Teaching Assistant' do
+        let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the user is a Course Student' do
+        let(:user) { create(:course_student, :approved, course: course).user }
+
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+    end
   end
 end

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -43,6 +43,14 @@ RSpec.feature 'Course: Administration: Administration' do
         expect(course.reload.title).to eq(new_title)
         expect(course.reload.description).to eq(new_description)
       end
+
+      scenario 'I can delete the course' do
+        visit course_admin_path(course)
+
+        expect { click_link(I18n.t('course.admin.admin.index.delete.button')) }.
+          to change(instance.courses, :count).by(-1)
+        expect(page).to have_selector('div', text: I18n.t('course.admin.admin.destroy.success'))
+      end
     end
 
     context 'As a Course Teaching Assistant' do

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -19,6 +19,12 @@ RSpec.feature 'Course: Administration: Administration' do
         expect(page).to have_selector('li', text: 'layouts.course_admin.title')
       end
 
+      scenario 'I can view the course settings page' do
+        visit course_admin_path(course)
+
+        expect(page).to have_selector('h1', text: 'layouts.course_admin.title')
+      end
+
       scenario 'I can change the course attributes' do
         visit course_admin_path(course)
 


### PR DESCRIPTION
Fixes #745 - allowing course managers to delete their own course in the course admin page. 

Also changed the sidebar title from Settings to Course Settings. 