### PR TITLE
Use the default latest versions of each specific Ruby version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ branches:
   except:
     - /^bundle-update-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}+$/
 rvm:
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  - 2.1
+  - 2.2
+  - 2.3
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
This removes the need to manually update the Travis Ruby versions when new ones are released.