### PR TITLE
Deferred package commit

### DIFF
--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -28,12 +28,7 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
   def perform_import(question, attachment)
-    Tempfile.create('programming-import', binmode: true) do |temporary_file|
-      temporary_file.write(attachment.file_upload.read)
-      temporary_file.seek(0)
-      Course::Assessment::Question::ProgrammingImportService.import(question, temporary_file)
-    end
-
+    Course::Assessment::Question::ProgrammingImportService.import(question, attachment)
   ensure
     redirect_to edit_course_assessment_question_programming_path(question.assessment.course,
                                                                  question.assessment, question)

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -5,7 +5,7 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
 
   acts_as :question, class_name: Course::Assessment::Question.name
 
-  after_save :process_new_package, if: :attachment_changed?
+  before_save :process_new_package, if: :attachment_changed?
 
   validates :memory_limit, :time_limit, numericality: { greater_then: 0 }, allow_nil: true
 
@@ -40,11 +40,27 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
   end
 
   # Queues the new question package for processing.
+  #
+  # We restore the original package, but capture the new package into a local for processing by
+  # the import job.
   def process_new_package
+    return remove_old_package if attachment.nil?
+
+    new_attachment = attachment
+    restore_attribute!(:attachment)
+
     execute_after_commit do
+      new_attachment.save!
       import_job =
-        Course::Assessment::Question::ProgrammingImportJob.perform_later(self, attachment)
+        Course::Assessment::Question::ProgrammingImportJob.perform_later(self, new_attachment)
       update(import_job_id: import_job.job_id)
     end
+  end
+
+  # Removes the template files and test cases from the old package.
+  def remove_old_package
+    template_files.clear
+    test_cases.clear
+    self.import_job = nil
   end
 end

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -6,30 +6,11 @@ class Course::Assessment::Question::ProgrammingImportService
   class << self
     # Imports the programming package into the question.
     #
-    # @raise [InvalidDataError] When the package is not a valid package.
-    # @raise [Course::Assessment::ProgrammingEvaluationService::Error] When there was an error
-    #   evaluating the package.
-    #
-    # @overload import(question, package)
-    #   @param [Course::Assessment::Question::Programming] question The programming question for
-    #     import.
-    #   @param [Course::Assessment::ProgrammingPackage] package The package containing the
-    #     tests and template files.
-    #
-    # @overload import(question, package_path)
-    #   @param [Course::Assessment::Question::Programming] question The programming question for
-    #     import.
-    #   @param [String] package_path The path to the package containing the tests and template
-    # files.
-    #
-    # @overload import(question, package_stream)
-    #   @param [Course::Assessment::Question::Programming] question The programming question for
-    #     import.
-    #   @param [IO] package_stream An I/O object containing the package.
-    def import(question, package)
-      package = Course::Assessment::ProgrammingPackage.new(package) unless \
-        package.is_a?(Course::Assessment::ProgrammingPackage)
-      new(question, package).send(:import)
+    # @param [Course::Assessment::Question::Programming] question The programming question for
+    #   import.
+    # @param [Attachment] attachment The attachment containing the package to import.
+    def import(question, attachment)
+      new(question, attachment).send(:import)
     end
   end
 
@@ -38,19 +19,47 @@ class Course::Assessment::Question::ProgrammingImportService
   # Creates a new service import object.
   #
   # @param [Course::Assessment::Question::Programming] question The programming question for import.
-  # @param [Course::Assessment::ProgrammingPackage] package The package containing the tests and
-  #   template files.
-  def initialize(question, package)
+  # @param [Attachment] attachment The attachment containing the tests and files.
+  def initialize(question, attachment)
     @question = question
-    @package = package
+    @attachment = attachment
   end
 
   # Imports the templates and tests found in the package.
   def import
-    fail InvalidDataError unless @package.valid?
+    with_attachment(@attachment) do |temporary_file|
+      begin
+        package = Course::Assessment::ProgrammingPackage.new(temporary_file)
+        import_from_package(package)
+      ensure
+        next unless package
+        temporary_file.close
+        package.close
+      end
+    end
+  end
 
-    template_import_thread = Thread.new { import_template_files }
-    evaluation_result = evaluate_package
+  # Copies the attachment to disk, yielding a File stream to a block.
+  #
+  # @param [Attachment] attachment The attachment to copy its contents from.
+  # @yield [file] The file with the contents of the attachment.
+  def with_attachment(attachment)
+    Tempfile.create('programming-import', binmode: true) do |temporary_file|
+      temporary_file.write(attachment.file_upload.read)
+      temporary_file.seek(0)
+
+      yield temporary_file
+    end
+  end
+
+  # Imports the templates and tests from the given package.
+  #
+  # @param [Course::Assessment::ProgrammingPackage] package The package to import.
+  def import_from_package(package)
+    fail InvalidDataError unless package.valid?
+
+    template_import_thread = Thread.new { import_template_files(package) }
+    evaluation_result = evaluate_package(package)
     template_import_thread.join
 
     fail evaluation_result if evaluation_result.error?
@@ -59,18 +68,20 @@ class Course::Assessment::Question::ProgrammingImportService
 
   # Extracts the templates from the package.
   #
+  # @param [Course::Assessment::ProgrammingPackage] package The package to import.
   # @return [Hash<Pathname, String>] The templates found in the package.
-  def import_template_files
-    @package.submission_files
+  def import_template_files(package)
+    package.submission_files
   end
 
   # Evaluates the package to obtain the set of tests.
   #
+  # @param [Course::Assessment::ProgrammingPackage] package The package to import.
   # @return [Course::Assessment::ProgrammingEvaluationService::Result]
-  def evaluate_package
+  def evaluate_package(package)
     Course::Assessment::ProgrammingEvaluationService.
       execute(@question.assessment.course, @question.language, @question.memory_limit,
-              @question.time_limit, @package.path)
+              @question.time_limit, package.path)
   end
 
   # Saves the templates and tests to the question.
@@ -79,6 +90,7 @@ class Course::Assessment::Question::ProgrammingImportService
   # @param [Course::Assessment::ProgrammingEvaluationService::Result] evaluation_result The
   #   result of evaluating the package.
   def save(template_files, evaluation_result)
+    @question.attachment = @attachment
     @question.template_files = build_template_file_records(template_files)
     @question.test_cases = build_test_case_records(evaluation_result.test_report)
 

--- a/spec/controllers/course/material/materials_controller_spec.rb
+++ b/spec/controllers/course/material/materials_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
         it 'changes the file' do
           old_file_url = material_stub.attachment.file_upload.url
           subject
-          expect(material_stub.attachment.reload.file_upload.url).not_to eq(old_file_url)
+          expect(material_stub.reload.attachment.file_upload.url).not_to eq(old_file_url)
         end
       end
     end

--- a/spec/libraries/course/assessment/programming_package_spec.rb
+++ b/spec/libraries/course/assessment/programming_package_spec.rb
@@ -54,13 +54,23 @@ RSpec.describe Course::Assessment::ProgrammingPackage do
   end
 
   describe '#path' do
-    it 'returns the path to the package' do
-      expect(subject.path).to eq(self.class::PACKAGE_PATH)
+    context 'when the package is not loaded' do
+      context 'when a File name is given' do
+        it 'returns the path to the package' do
+          expect(subject.path).to eq(self.class::PACKAGE_PATH)
+        end
+      end
+
+      context 'when a File is given' do
+        let(:package_path) { File.new(self.class::PACKAGE_PATH, 'rb') }
+        it 'returns the path to the File' do
+          expect(subject.path).to eq(self.class::PACKAGE_PATH)
+        end
+      end
     end
 
-    context 'when a File is given' do
-      let(:package_path) { File.new(self.class::PACKAGE_PATH, 'rb') }
-      it 'returns the path to the File' do
+    context 'when the package is loaded' do
+      it 'returns the path to the package' do
         subject.valid?
         expect(subject.path).to eq(self.class::PACKAGE_PATH)
       end

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -8,22 +8,16 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
     let(:package_path) do
       File.join(Rails.root, 'spec/fixtures/course/programming_question_template.zip')
     end
-    let(:package) { Course::Assessment::ProgrammingPackage.new(package_path) }
-    subject { Course::Assessment::Question::ProgrammingImportService.new(question, package) }
+    let(:attachment) { create(:attachment, binary: true, file: package_path) }
+    subject { Course::Assessment::Question::ProgrammingImportService.new(question, attachment) }
 
     describe '.import' do
       subject { Course::Assessment::Question::ProgrammingImportService }
-      it 'accepts package file paths' do
+      it 'accepts attachments' do
         expect(subject).to receive(:new).
-          with(question, instance_of(Course::Assessment::ProgrammingPackage)).
+          with(question, instance_of(Attachment)).
           and_call_original
-        subject.import(question, package_path)
-      end
-
-      it 'accepts package file streams' do
-        File.open(package_path, 'rb') do |file|
-          subject.import(question, file)
-        end
+        subject.import(question, attachment)
       end
 
       context 'when an invalid package is provided' do
@@ -32,7 +26,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
         end
 
         it 'raises an InvalidDataError' do
-          expect { subject.import(question, package_path) }.to raise_error(InvalidDataError)
+          expect { subject.import(question, attachment) }.to raise_error(InvalidDataError)
         end
       end
     end


### PR DESCRIPTION
When uploading a new template file, run all the tests to retrieve the specs and test cases before saving them all to the database atomically.

This prevents a bad template from messing up a working template.