### PR TITLE
Fix syntax highlighting for themes

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -8,7 +8,12 @@
     $('textarea.code', element).ace();
   }
 
-  initializeComponents(document);
+  // Queue component initialisation until the script has completely loaded.
+  //
+  // This prevents missing definitions for things like Ace themes, which are loaded after the
+  // application script.
+  setTimeout(function() { initializeComponents(document); }, 0);
+
   $(document).on('DOMNodeInserted', function(e) {
     initializeComponents(e.target);
   });

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -7,7 +7,6 @@
 @import 'nprogress';
 @import 'nprogress-bootstrap';
 @import 'font-awesome';
-@import 'pygments-css/github';
 
 body {
   padding-top: $navbar-height + $navbar-margin-bottom;

--- a/app/helpers/application_theming_helper.rb
+++ b/app/helpers/application_theming_helper.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 module ApplicationThemingHelper
   def application_resources
-    jquery = include_jquery
-    scripts = javascript_include_tag 'application', defer: true, 'data-turbolinks-track' => true
-
-    "#{jquery}\n#{scripts}\n".html_safe
+    include_jquery
   end
 end

--- a/app/themes/default/assets/javascripts/default/all.js
+++ b/app/themes/default/assets/javascripts/default/all.js
@@ -4,4 +4,5 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
+//= require ace/theme-github
 //= require_tree .

--- a/app/themes/default/assets/javascripts/default/all.js
+++ b/app/themes/default/assets/javascripts/default/all.js
@@ -4,5 +4,6 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
+//= require application
 //= require ace/theme-github
 //= require_tree .

--- a/app/themes/default/assets/stylesheets/default/layout.scss
+++ b/app/themes/default/assets/stylesheets/default/layout.scss
@@ -1,1 +1,2 @@
 @import 'application';
+@import 'pygments-css/github';

--- a/spec/helpers/application_theming_helper_spec.rb
+++ b/spec/helpers/application_theming_helper_spec.rb
@@ -7,12 +7,6 @@ RSpec.describe ApplicationThemingHelper, type: :helper do
 
     it { is_expected.to be_html_safe }
 
-    it 'has application.js' do
-      expect(subject).to have_tag('script', with: {
-        :'src^' => '/assets/application-'
-      })
-    end
-
     it 'has jquery' do
       expect(subject).to have_tag('script', with: {
         :'src^' => '/assets/jquery-'


### PR DESCRIPTION
Move the theme stylesheet/JavaScript import out of the layout files.

Each theme would need to import its own Rouge stylesheet and Ace theme as part of their theme stylesheet and JavaScript.