### PR TITLE
Course user badge fixes

### DIFF
--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -1,22 +1,22 @@
-#course-user-badge {
-  #course-user-progress {
-    .progress {
-      margin-bottom: 10px;
-      margin-top: 10px;
-    }
-  }
+.course-layout {
+  #course-user-badge {
+    #course-user-progress {
+      .progress {
+        margin-bottom: 10px;
+        margin-top: 10px;
 
-  #course-user-achievements {
-    h5,
-    p {
-      text-align: center;
+        .course-user-experience-points {
+          min-width: 10em;
+        }
+      }
     }
-  }
 
-  #course-user-level {
-    h5,
-    p {
-      text-align: right;
+    #course-user-achievements,
+    #course-user-level {
+      h5,
+      p {
+        text-align: center;
+      }
     }
   }
 }

--- a/app/views/layouts/_course_user_badge.html.slim
+++ b/app/views/layouts/_course_user_badge.html.slim
@@ -1,7 +1,10 @@
 div#course-user-badge
   div.col-xs-12#course-user-progress
-    = display_progress_bar course_user.level_progress_percentage,
-      ['progress-bar-info', 'progress-bar-striped']
+    - progress_bar_classes = ['progress-bar-info', 'progress-bar-striped',
+                              'course-user-experience-points']
+    = display_progress_bar(course_user.level_progress_percentage, progress_bar_classes) do
+      = t('layouts.course_user_badge.progress', current: course_user.experience_points,
+                                                next: course_user.next_level_threshold)
   div.col-xs-6#course-user-achievements
     - unless controller.current_component_host[:course_achievements_component].nil?
       = link_to course_achievements_path(course_user.course) do
@@ -9,6 +12,6 @@ div#course-user-badge
         p = course_user.achievement_count
   div.col-xs-6#course-user-level
     - unless controller.current_component_host[:course_levels_component].nil?
-      / TODO: Link to the course_user course summary page
-      h5 = t('.levels') + ' ' + course_user.level_number.to_s
-      p #{course_user.experience_points} / #{course_user.next_level_threshold} EXP
+      = link_to_course_user(course_user) do
+        h5 = t('.levels')
+        p = course_user.level_number

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -1,13 +1,12 @@
 - layout = controller.parent_layout(of_layout: 'course') || controller.current_layout
 = render within_layout: layout do
   = render_breadcrumbs
-  div.row
+  div.row.course-layout
     div.col-lg-2.col-md-3.col-sm-4
-      div.container-fluid
-        div.row
-          div.col-xs-12.user
-            = display_user_image(current_user)
-            = link_to_user(current_user)
+      div.row
+        div.col-xs-12.user
+          = display_user_image(current_user)
+          = link_to_user(current_user)
         - if current_course_user.present? && !current_course_user.staff?
           = display_course_user_badge(current_course_user)
       nav.navbar-default role='navigation'

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -41,3 +41,4 @@ en:
     course_user_badge:
       achievements: :'course.achievements.index.header'
       levels: :'course.levels.index.level'
+      progress: '%{current} / %{next} EXP'

--- a/spec/helpers/course/controller_helper_spec.rb
+++ b/spec/helpers/course/controller_helper_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Course::ControllerHelper do
           end
 
           it "shows the course user's experience points" do
-            expect(subject).to include(user.experience_points.to_s)
+            expect(subject).to include(I18n.t('layouts.course_user_badge.progress'))
           end
 
           it "shows the course user's level number" do
@@ -95,7 +95,9 @@ RSpec.describe Course::ControllerHelper do
 
           it 'displays the progress bar with current level progress' do
             expect(helper).to receive(:display_progress_bar).
-              with(user.level_progress_percentage, ['progress-bar-info', 'progress-bar-striped'])
+              with(user.level_progress_percentage,
+                   ['progress-bar-info', 'progress-bar-striped',
+                    'course-user-experience-points'])
             subject
           end
         end


### PR DESCRIPTION
- Fixed ugly wrapping for course user badge at around 10xx pixels. 
- Linked course user badge to course-user page (to be done).
- Shifted exp progress text into progress bar. 
- Plus a small fix in one of the old locales when I implemented `display_progress_bar`. 

Before:
<img width="400" alt="screen shot 2016-02-05 at 5 25 16 pm" src="https://cloud.githubusercontent.com/assets/4353853/12941162/c02120b4-d00a-11e5-8e27-1043d951a0ca.png">

After: 
<img width="400" alt="screen shot 2016-02-10 at 3 26 20 pm" src="https://cloud.githubusercontent.com/assets/4353853/12941165/c8924944-d00a-11e5-9a29-0d547d41f191.png">
