### PR TITLE
Attachment API cleanup

### DIFF
--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -3,7 +3,7 @@ class Course::Material::MaterialsController < Course::Material::Controller
   load_and_authorize_resource :material, through: :folder, class: Course::Material.name
 
   def show
-    redirect_to @material.attachment.file_upload.url
+    redirect_to @material.attachment.url
   end
 
   def edit

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,6 +1,62 @@
 # frozen_string_literal: true
 class Attachment < ActiveRecord::Base
+  TEMPORARY_FILE_PREFIX = 'attachment'.freeze
+
   mount_uploader :file_upload, FileUploader
 
   belongs_to :attachable, polymorphic: true
+
+  # Opens the attachment for reading as a stream. The options are the same as those taken by
+  # +IO.new+
+  #
+  # This is read-only, because the attachment might not be stored on local disk.
+  #
+  # @option opt [Boolean] :binmode If this value is a truth value, the same as 'b'.
+  # @option opt [Boolean] :textmode If this value is a truth value, the same as 't'.
+  # @param [Proc] block The block to run with a reference to the stream.
+  # @yieldparam [IO] stream The stream to read the attachment with.
+  #
+  # @return [Tempfile] When no block is provided.
+  # @return The result of the block when a block is provided.
+  def open(opt = {}, &block)
+    return open_with_block(opt, block) if block
+
+    open_without_block(opt)
+  end
+
+  private
+
+  # Opens the attachment for reading as a block.
+  #
+  # @param opt [Hash] The options for opening the stream with.
+  # @param block [Proc] The block to receive the stream with.
+  def open_with_block(opt, block)
+    Tempfile.create(TEMPORARY_FILE_PREFIX, opt) do |temporary_file|
+      temporary_file.write(contents)
+      temporary_file.seek(0)
+
+      block.call(temporary_file)
+    end
+  end
+
+  # Opens the attachment for reading.
+  #
+  # @param opt [Hash] The options for opening the stream with.
+  # @return [Tempfile] The temporary file opened.
+  def open_without_block(opt)
+    file = Tempfile.new(TEMPORARY_FILE_PREFIX, Dir.tmpdir, opt)
+    file.write(contents)
+    file.seek(0)
+    file
+  rescue
+    file.close! if file
+    raise
+  end
+
+  # Retrieves the contents of the attachment.
+  #
+  # @return [String] The contents of the attachment.
+  def contents
+    file_upload.read
+  end
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -6,6 +6,13 @@ class Attachment < ActiveRecord::Base
 
   belongs_to :attachable, polymorphic: true
 
+  # @!attribute [r] url
+  #   The URL to the attachment contents.
+  #
+  # @!attribute [r] path
+  #   The path to the attachment contents.
+  delegate :url, :path, to: :file_upload
+
   # Opens the attachment for reading as a stream. The options are the same as those taken by
   # +IO.new+
   #

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -27,7 +27,7 @@ class Course::Assessment::Question::ProgrammingImportService
 
   # Imports the templates and tests found in the package.
   def import
-    with_attachment(@attachment) do |temporary_file|
+    @attachment.open(binmode: true) do |temporary_file|
       begin
         package = Course::Assessment::ProgrammingPackage.new(temporary_file)
         import_from_package(package)
@@ -36,19 +36,6 @@ class Course::Assessment::Question::ProgrammingImportService
         temporary_file.close
         package.close
       end
-    end
-  end
-
-  # Copies the attachment to disk, yielding a File stream to a block.
-  #
-  # @param [Attachment] attachment The attachment to copy its contents from.
-  # @yield [file] The file with the contents of the attachment.
-  def with_attachment(attachment)
-    Tempfile.create('programming-import', binmode: true) do |temporary_file|
-      temporary_file.write(attachment.file_upload.read)
-      temporary_file.seek(0)
-
-      yield temporary_file
     end
   end
 

--- a/app/services/course/material/zip_download_service.rb
+++ b/app/services/course/material/zip_download_service.rb
@@ -45,10 +45,12 @@ class Course::Material::ZipDownloadService
   # Downloads the material and store it in the given directory.
   def download_material(material, folder, dir)
     file_path = Pathname.new(dir) + material.path.relative_path_from(folder.path)
-
     file_path.dirname.mkpath
-    file = File.open(file_path, 'wb')
-    file << material.attachment.file_upload.read
-    file.close
+
+    File.open(file_path, 'wb') do |file|
+      material.attachment.open(binmode: true) do |attachment_stream|
+        FileUtils.copy_stream(attachment_stream, file)
+      end
+    end
   end
 end

--- a/app/views/layouts/_materials.html.slim
+++ b/app/views/layouts/_materials.html.slim
@@ -1,6 +1,6 @@
 - if folder.materials.any?
   - folder.materials.includes(:attachments).each do |material|
     div
-      = link_to material.attachment.file_upload.url do
+      = link_to material.attachment.url do
           => fa_icon 'file-o'.freeze
           = format_inline_text(material.name)

--- a/lib/extensions/attachable/active_record/base.rb
+++ b/lib/extensions/attachable/active_record/base.rb
@@ -3,8 +3,8 @@ module Extensions::Attachable::ActiveRecord::Base
   module ClassMethods
     # This function should be declared in model, to it have attachments.
     def has_many_attachments # rubocop:disable Style/PredicateName
-      has_many :attachments, as: :attachable, inverse_of: :attachable,
-                             dependent: :destroy, autosave: true
+      has_many :attachments, as: :attachable, class_name: "::#{Attachment.name}",
+                             inverse_of: :attachable, dependent: :destroy, autosave: true
 
       define_method(:files=) do |files|
         files.each do |file|
@@ -18,8 +18,8 @@ module Extensions::Attachable::ActiveRecord::Base
 
       validates :attachments, length: { maximum: 1 }
 
-      has_many :attachments, as: :attachable, inverse_of: :attachable,
-                             dependent: :destroy, autosave: true
+      has_many :attachments, as: :attachable, class_name: "::#{Attachment.name}",
+                             inverse_of: :attachable, dependent: :destroy, autosave: true
     end
   end
 

--- a/spec/controllers/course/material/materials_controller_spec.rb
+++ b/spec/controllers/course/material/materials_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
       let(:material) { create(:material, folder: folder) }
       subject { get :show, course_id: course, folder_id: folder, id: material }
 
-      it { is_expected.to redirect_to(material.attachment.file_upload.url) }
+      it { is_expected.to redirect_to(material.attachment.url) }
     end
 
     describe '#update' do
@@ -33,9 +33,9 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
 
       context 'when a different file is given' do
         it 'changes the file' do
-          old_file_url = material_stub.attachment.file_upload.url
+          old_file_url = material_stub.attachment.url
           subject
-          expect(material_stub.reload.attachment.file_upload.url).not_to eq(old_file_url)
+          expect(material_stub.reload.attachment.url).not_to eq(old_file_url)
         end
       end
     end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Attachment do
+  let(:file_path) { File.join(Rails.root, '/spec/fixtures/files/text.txt') }
+  subject { build(:attachment, file: file_path) }
+
+  it { is_expected.to belong_to(:attachable) }
+  it { is_expected.to respond_to(:url) }
+  it { is_expected.to respond_to(:path) }
+
+  describe '#open' do
+    context 'when a block is provided' do
+      it 'yields a stream' do
+        subject.open do |file|
+          expect(file).to be_a(IO)
+        end
+      end
+
+      it 'contains the contents of the file' do
+        subject.open do |file|
+          File.open(file_path) do |template_file|
+            expect(FileUtils.compare_stream(template_file, file)).to be(true)
+          end
+        end
+      end
+    end
+
+    context 'when no block is given' do
+      let(:file) { subject.open }
+      after { file.close }
+      it 'returns a stream' do
+        expect(file).to be_a(Tempfile).or be_a(IO).or be_a(StringIO)
+      end
+
+      it 'contains the contents of the file' do
+        File.open(file_path) do |template_file|
+          expect(FileUtils.compare_stream(template_file, file)).to be(true)
+        end
+      end
+    end
+  end
+
+  describe '#open_without_block' do
+    let(:file) { subject.open }
+
+    it 'closes the file when an error occurs' do
+      tempfile = nil
+      expect(Tempfile).to receive(:new).and_wrap_original do |method, *args|
+        tempfile = method.call(*args)
+        tempfile.define_singleton_method(:seek) do |*|
+          fail IOError
+        end
+        tempfile
+      end.at_least(:once)
+
+      expect { file }.to raise_error(IOError)
+      expect(tempfile).to be_closed
+    end
+  end
+end

--- a/spec/services/course/material/zip_download_service_spec.rb
+++ b/spec/services/course/material/zip_download_service_spec.rb
@@ -39,21 +39,21 @@ RSpec.describe Course::Material::ZipDownloadService do
           expect(
             FileUtils.compare_file(
               material_a_path,
-              material_a.attachment.file_upload.path
+              material_a.attachment.path
             )
           ).to be_truthy
 
           expect(
             FileUtils.compare_file(
               material_b_path,
-              material_b.attachment.file_upload.path
+              material_b.attachment.path
             )
           ).to be_truthy
 
           expect(
             FileUtils.compare_file(
               material_d_path,
-              material_d.attachment.file_upload.path
+              material_d.attachment.path
             )
           ).to be_truthy
         end


### PR DESCRIPTION
Prevent two code smells:

 - Directly accessing the file_upload uploader in attachments
 - Directly accessing the file content of the uploaded file as a string. It is now exposed as a stream.