### PR TITLE
Test report parsing improvements

### DIFF
--- a/lib/autoload/course/assessment/programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/programming_test_case_report.rb
@@ -90,7 +90,8 @@ class Course::Assessment::ProgrammingTestCaseReport
     #
     # @return [String]
     def identifier
-      "#{@test_suite.identifier}/#{name.underscore}"
+      class_name = self.class_name ? self.class_name + '/' : ''
+      "#{@test_suite.identifier}/#{class_name}#{name.underscore}"
     end
 
     # Checks if the test case was skipped.

--- a/lib/autoload/course/assessment/programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/programming_test_case_report.rb
@@ -94,6 +94,13 @@ class Course::Assessment::ProgrammingTestCaseReport
       "#{@test_suite.identifier}/#{class_name}#{name.underscore}"
     end
 
+    # Checks if the test case encountered an error.
+    #
+    # @return [Boolean]
+    def errored?
+      !@test_case.search('./error').empty?
+    end
+
     # Checks if the test case was skipped.
     #
     # @return [Boolean]
@@ -112,7 +119,7 @@ class Course::Assessment::ProgrammingTestCaseReport
     #
     # @return [Boolean]
     def passed?
-      !failed? && !skipped?
+      !failed? && !skipped? && !errored?
     end
   end
 

--- a/spec/libraries/course/assessment/programming_test_case_report_spec.rb
+++ b/spec/libraries/course/assessment/programming_test_case_report_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
       end
 
       describe '#identifier' do
-        it 'generates an identifer for the test suite' do
+        it 'generates an identifier for the test suite' do
           expect(subject.identifier).to eq(subject.name)
         end
       end
@@ -69,9 +69,21 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
       end
 
       describe '#identifier' do
-        it 'generates an identifer for the test suite' do
+        it 'generates an identifier for the test suite' do
           expect(subject.identifier).to include(subject.test_suite.name)
           expect(subject.identifier).to include(subject.name)
+        end
+
+        context 'when the test case as a class name' do
+          it 'uses the class name as part of the identifier' do
+            expect(subject.identifier).to include(subject.class_name)
+          end
+        end
+
+        context 'when the test case does not have a class name' do
+          it 'still generates an identifier' do
+            expect(subject.identifier).not_to be_nil
+          end
         end
       end
 

--- a/spec/libraries/course/assessment/programming_test_case_report_spec.rb
+++ b/spec/libraries/course/assessment/programming_test_case_report_spec.rb
@@ -96,11 +96,13 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
       context 'when the test case failed' do
         subject { test_cases.first }
         it { is_expected.to be_failed }
+        it { is_expected.not_to be_passed }
       end
 
       context 'when the test case was skipped' do
         subject { test_cases.second }
         it { is_expected.to be_skipped }
+        it { is_expected.not_to be_passed }
       end
 
       context 'when the test case passed' do
@@ -129,6 +131,16 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
     describe '#test_cases' do
       it 'returns all the test cases in the report' do
         expect(subject.test_cases.length).to eq(3)
+      end
+    end
+
+    describe Course::Assessment::ProgrammingTestCaseReport::TestCase do
+      let(:test_cases) { parsed_report.test_suites.first.test_cases }
+
+      context 'when the test case errored' do
+        subject { test_cases.first }
+        it { is_expected.to be_errored }
+        it { is_expected.not_to be_passed }
       end
     end
   end


### PR DESCRIPTION
 - Include the test case's class name in its identifier if one is present. This helps disambiguate test cases with the same name.
 - Properly check if a test case errored. Now test cases can be:
    - failed
    - skipped
    - errored