### PR TITLE
Decorate the deepest container in the layout hierarchy with the page class.

### DIFF
--- a/app/helpers/application_theming_helper.rb
+++ b/app/helpers/application_theming_helper.rb
@@ -3,4 +3,12 @@ module ApplicationThemingHelper
   def application_resources
     include_jquery
   end
+
+  def page_class
+    return nil if content_for?(:page_class_specified)
+
+    page_class = super
+    content_for(:page_class_specified) { page_class }
+    page_class
+  end
 end

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -18,5 +18,5 @@
             h5 = t('.administration')
             = sidebar_items(admin_sidebar_items)
 
-    div.col-lg-10.col-md-9.col-sm-8
+    div.col-lg-10.col-md-9.col-sm-8 class=page_class
       = yield

--- a/app/views/layouts/course_admin.html.slim
+++ b/app/views/layouts/course_admin.html.slim
@@ -3,4 +3,5 @@
   = tabs do
     - controller.sidebar_items(type: :settings).each do |item|
       = nav_to(item[:title], item[:path])
-  = yield
+  div class=page_class
+    = yield

--- a/app/views/layouts/system_admin.html.slim
+++ b/app/views/layouts/system_admin.html.slim
@@ -12,5 +12,5 @@
             = link_to(t('system.admin.navbar.instances'), admin_instances_path)
           li
             = link_to(t('system.admin.navbar.courses'), admin_courses_path)
-      div.col-lg-10.col.md-9.col-sm-8
+      div.col-lg-10.col.md-9.col-sm-8 class=page_class
         = yield

--- a/app/views/layouts/system_admin_instance.html.slim
+++ b/app/views/layouts/system_admin_instance.html.slim
@@ -12,5 +12,5 @@
             = link_to(t('system.admin.instance.navbar.announcements'), admin_instance_announcements_path)
           li
             = link_to(t('system.admin.instance.navbar.components'), admin_instance_components_path)
-      div.col-lg-10.col.md-9.col-sm-8
+      div.col-lg-10.col.md-9.col-sm-8 class=page_class
         = yield

--- a/app/views/layouts/user_admin.html.slim
+++ b/app/views/layouts/user_admin.html.slim
@@ -10,5 +10,5 @@
             = link_to(t('user.admin.navbar.emails'), user_emails_path)
           li
             = link_to(t('user.admin.navbar.account_settings'), edit_user_registration_path)
-      div.col-lg-10.col.md-9.col-sm-8
+      div.col-lg-10.col.md-9.col-sm-8 class=page_class
         = yield

--- a/spec/fixtures/helpers/application_theming_helper/layouts/page_class.html.erb
+++ b/spec/fixtures/helpers/application_theming_helper/layouts/page_class.html.erb
@@ -1,0 +1,3 @@
+<div class="<%= page_class %>" id="root">
+  <%= yield %>
+</div>

--- a/spec/fixtures/helpers/application_theming_helper/layouts/page_class_nested.html.erb
+++ b/spec/fixtures/helpers/application_theming_helper/layouts/page_class_nested.html.erb
@@ -1,0 +1,3 @@
+<div class="<%= page_class %>" id="nested">
+  <%= yield %>
+</div>

--- a/spec/fixtures/helpers/application_theming_helper/page_class_nested_inside.html.erb
+++ b/spec/fixtures/helpers/application_theming_helper/page_class_nested_inside.html.erb
@@ -1,0 +1,4 @@
+<%= render within_layout: 'page_class_nested' do %>
+  <div class="<%= page_class %>" id="nested-inside">
+  </div>
+<% end %>

--- a/spec/helpers/application_theming_helper_spec.rb
+++ b/spec/helpers/application_theming_helper_spec.rb
@@ -13,4 +13,41 @@ RSpec.describe ApplicationThemingHelper, type: :helper do
       })
     end
   end
+
+  describe '#page_class' do
+    subject { helper.page_class }
+
+    context 'when it has never been called before' do
+      it 'returns the page class' do
+        expect(subject).not_to be_blank
+      end
+    end
+
+    context 'when it has been called before' do
+      before { helper.page_class }
+      it { is_expected.to be_blank }
+    end
+
+    describe 'nested layouts' do
+      let(:views_directory) do
+        path = Pathname.new("#{__dir__}/../fixtures/helpers/application_theming_helper")
+        path.realpath
+      end
+
+      before { controller.prepend_view_path(views_directory) }
+      subject { render template: 'page_class_nested_inside', layout: 'layouts/page_class' }
+
+      it 'does not label the root container with the page class' do
+        expect(subject).not_to have_tag('div.action-view-test-case-test#root')
+      end
+
+      it 'does not label the nested layout container with the page class' do
+        expect(subject).not_to have_tag('div.action-view-test-case-test#nested')
+      end
+
+      it 'labels the deepest-nested container with the page class' do
+        expect(subject).to have_tag('div.action-view-test-case-test#nested-inside')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This prevents elements of outer layouts from being affected by the page being rendered.

@weiqingtoh this should fix the CSS for the user invitations page affecting the EXP bar.