### PR TITLE
Fix to display progress bar helper

### DIFF
--- a/app/helpers/application_widgets_helper.rb
+++ b/app/helpers/application_widgets_helper.rb
@@ -90,15 +90,18 @@ module ApplicationWidgetsHelper
   # Display a progress_bar with the given percentage and styling. The percentage is assumed to
   # be a number ranging from 0-100. In addition, a block can be passed to add custom text.
   #
+  # ActionView::Helpers::CaptureHelper#capture is used to ensure the block is rendered in the
+  # original view_context, rather than within the view_context of the progress bar layout.
+  #
   # @param [Fixnum] percentage The percentage to be displayed on the progress bar.
   # @param [Array<String>] classes An array of classes to apply to the progress bar.
   # @yield The HTML text which will be passed to the partial as text to be shown in the bar.
   # @return [String] HTML string to render the progress bar.
-  def display_progress_bar(percentage, classes = ['progress-bar-info'])
-    render layout: 'layouts/progress_bar', locals: { percentage: percentage,
-                                                     progress_bar_classes: classes } do
-      yield if block_given?
-    end
+  def display_progress_bar(percentage, classes = ['progress-bar-info'], &block)
+    text_in_block = capture(&block) if block_given?
+    render partial: 'layouts/progress_bar', locals: { percentage: percentage,
+                                                      progress_bar_classes: classes,
+                                                      progress_bar_text: text_in_block }
   end
 
   private

--- a/app/views/course/users/invitations.html.slim
+++ b/app/views/course/users/invitations.html.slim
@@ -5,7 +5,7 @@
 
 - accepted_course_users = @course_users.each.select { |user| !user.invited? }.size
 - progress = accepted_course_users * 100 / [@course_users.length, 1].max
-= display_progress_bar progress, [] do
+= display_progress_bar(progress, []) do
   = t('.progress', accepted: accepted_course_users, total: @course_users.size)
 
 = simple_format t('.manual_acceptance')

--- a/app/views/layouts/_course_user_badge.html.slim
+++ b/app/views/layouts/_course_user_badge.html.slim
@@ -3,8 +3,8 @@ div#course-user-badge
     - progress_bar_classes = ['progress-bar-info', 'progress-bar-striped',
                               'course-user-experience-points']
     = display_progress_bar(course_user.level_progress_percentage, progress_bar_classes) do
-      = t('layouts.course_user_badge.progress', current: course_user.experience_points,
-                                                next: course_user.next_level_threshold)
+      = t('.progress', current: course_user.experience_points,
+                       next: course_user.next_level_threshold)
   div.col-xs-6#course-user-achievements
     - unless controller.current_component_host[:course_achievements_component].nil?
       = link_to course_achievements_path(course_user.course) do

--- a/app/views/layouts/_progress_bar.html.slim
+++ b/app/views/layouts/_progress_bar.html.slim
@@ -2,4 +2,4 @@ div.progress
   div.progress-bar [ class=progress_bar_classes role='progressbar' aria-valuenow="#{percentage}"
                      aria-valuemin='0' aria-valuemax='100' style="width: #{percentage}%" ]
     span.sr-only #{percentage}% Complete
-    = yield
+    = progress_bar_text

--- a/spec/helpers/application_widgets_helper_spec.rb
+++ b/spec/helpers/application_widgets_helper_spec.rb
@@ -208,6 +208,12 @@ RSpec.describe ApplicationWidgetsHelper, type: :helper do
         it 'appends the text within the progress bar' do
           expect(helper.send(:display_progress_bar, 50) { '30%' }).to include('30%')
         end
+
+        it 'renders the block in the context of the helper' do
+          message = 'foo'
+          helper.define_singleton_method(:some_method) { message }
+          expect(helper.send(:display_progress_bar, 50) { helper.some_method }).to include(message)
+        end
       end
     end
   end


### PR DESCRIPTION
### Problem
This PR is for discussion only, not to be merged. This originates from #786 to fix progress bar helper. 

Problem is because `render layout:...` is used in the helper method, what happens is that `I18N` translations refer to `layouts.progress_bar.xxx` rather than the source location (where `display_progress_bar` is called). 

### Solution & Discussion
I've found 1 fix, which is to use [capture](http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-capture) (this captures the block output). 

This fix solves the issue, but I'm not sure how to test it - ie. variables that are sent into the block of `display_progress_bar` are scoped to the source, rather than rendering within the progress bar layout/partial itself. 

There are other solutions, instance_eval or manual concat of the markup (which many other view helpers use). 

Any suggestions? 