### PR TITLE
Fix assessment breadcrumbs

### DIFF
--- a/app/controllers/course/assessment/controller.rb
+++ b/app/controllers/course/assessment/controller.rb
@@ -1,6 +1,6 @@
 class Course::Assessment::Controller < Course::ComponentController
   before_action :load_and_authorize_assessment
-  add_breadcrumb :index, :course_assessments_path
+  before_action :add_assessment_breadcrumbs
 
   protected
 
@@ -10,11 +10,33 @@ class Course::Assessment::Controller < Course::ComponentController
     {}
   end
 
+  def category
+    @category ||= tab.category
+  end
+
+  def tab
+    @tab ||= @assessment.tab
+  end
+
   private
 
   def load_and_authorize_assessment
     options = load_assessment_options.reverse_merge(through: :course,
                                                     class: Course::Assessment.name)
     self.class.cancan_resource_class.new(self, :assessment, options).load_and_authorize_resource
+  end
+
+  def add_assessment_breadcrumbs
+    category_path = course_assessments_path(course_id: current_course, category: category)
+    add_breadcrumb(category.title, category_path)
+
+    add_assessment_tab_breadcrumb
+  end
+
+  def add_assessment_tab_breadcrumb
+    return if category.tabs.length == 1
+
+    tab_path = course_assessments_path(course_id: current_course, category: category, tab: tab)
+    add_breadcrumb(tab.title, tab_path)
   end
 end

--- a/spec/controllers/course/assessment/assessments_controller_spec.rb
+++ b/spec/controllers/course/assessment/assessments_controller_spec.rb
@@ -69,5 +69,30 @@ RSpec.describe Course::Assessment::AssessmentsController do
         end
       end
     end
+
+    describe '#add_assessment_breadcrumbs' do
+      let(:breadcrumbs) { controller.send(:breadcrumb_names) }
+      let(:tabs) { 1 }
+      before do
+        create_list(:course_assessment_tab, tabs - 1,
+                    category: course.assessment_categories.first)
+        get :index, course_id: course.id
+      end
+
+      context 'when the category has one tab' do
+        it 'only displays the category' do
+          expect(breadcrumbs).to include(course.assessment_categories.first.title)
+          expect(breadcrumbs).not_to include(course.assessment_categories.first.tabs.first.title)
+        end
+      end
+
+      context 'when the category has more than one tab' do
+        let(:tabs) { 2 }
+        it 'also displays the tab' do
+          expect(breadcrumbs).to include(course.assessment_categories.first.title)
+          expect(breadcrumbs).to include(course.assessment_categories.first.tabs.first.title)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/course/assessment/controller_spec.rb
+++ b/spec/controllers/course/assessment/controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Controller do
+  controller(Course::Assessment::Controller) do
+    def index
+      render nothing: true
+    end
+  end
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let(:course) { create(:course, creator: user) }
+    before { sign_in(user) }
+
+    describe '#add_assessment_breadcrumbs' do
+      let(:breadcrumbs) { controller.send(:breadcrumb_names) }
+      let(:assessment) { build_stubbed(:course_assessment_assessment, course: course) }
+      let(:tabs) { 1 }
+      before do
+        create_list(:course_assessment_tab, tabs - 1,
+                    category: course.assessment_categories.first)
+        @controller.instance_variable_set(:@assessment, assessment)
+        get :index, course_id: course.id
+      end
+
+      context 'when the category has one tab' do
+        it 'only displays the category' do
+          expect(breadcrumbs).to include(assessment.tab.category.title)
+          expect(breadcrumbs).not_to include(assessment.tab.title)
+        end
+      end
+
+      context 'when the category has more than one tab' do
+        let(:tabs) { 2 }
+        it 'also displays the tab' do
+          expect(breadcrumbs).to include(assessment.tab.category.title)
+          expect(breadcrumbs).to include(assessment.tab.title)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This does not display the tab breadcrumb if the category only has one tab. This also adds the category and tab into the breadcrumbs when loading assessments for display.