### PR TITLE
Do not display categories that are being created.

### DIFF
--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -8,7 +8,7 @@ class Course::AssessmentsComponent < SimpleDelegator
   private
 
   def main_sidebar_items
-    current_course.assessment_categories.map do |category|
+    current_course.assessment_categories.select(&:persisted?).map do |category|
       {
         key: :assessments,
         title: category.title,

--- a/spec/controllers/course/assessment/assessments_component_spec.rb
+++ b/spec/controllers/course/assessment/assessments_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Course::AssessmentsComponent do
+  controller(Course::Controller) {}
+  subject do
+    controller.instance_variable_set(:@course, course)
+    Course::AssessmentsComponent.new(controller)
+  end
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:course) { build(:course, instance: instance) }
+
+    describe '#main_sidebar_items' do
+      context 'when the user is defining a new category' do
+        let(:new_category_title) { 'new category' }
+        let!(:new_category) { course.assessment_categories.build(title: new_category_title) }
+
+        it 'excludes the category from the list' do
+          expect(subject.send(:main_sidebar_items).map(&:title)).not_to include(new_category_title)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ensures that when the user is defining a new category, no blank items appear in the sidebar.