### PR TITLE
Using labels to indicate email statuses

### DIFF
--- a/app/views/user/emails/_email.html.slim
+++ b/app/views/user/emails/_email.html.slim
@@ -6,6 +6,10 @@
       div.label.label-default
         = t('.unconfirmed')
 
+    - if email.primary?
+      div.label.label-info
+        = t('.primary')
+
   td
     - unless email.primary?
       = link_to t('.set_primary'), set_primary_user_email_path(email) ,

--- a/app/views/user/emails/_email.html.slim
+++ b/app/views/user/emails/_email.html.slim
@@ -2,6 +2,10 @@
   td
     = email.email
 
+    - if !email.confirmed?
+      div.label.label-default
+        = t('.unconfirmed')
+
   td
     - unless email.primary?
       = link_to t('.set_primary'), set_primary_user_email_path(email) ,

--- a/config/locales/en/user/emails.yml
+++ b/config/locales/en/user/emails.yml
@@ -15,3 +15,4 @@ en:
       email:
         set_primary: 'Set Primary'
         unconfirmed: 'Unconfirmed'
+        primary: 'Primary'

--- a/config/locales/en/user/emails.yml
+++ b/config/locales/en/user/emails.yml
@@ -14,3 +14,4 @@ en:
         success: 'Primary email was updated successfully'
       email:
         set_primary: 'Set Primary'
+        unconfirmed: 'Unconfirmed'

--- a/spec/factories/user_emails.rb
+++ b/spec/factories/user_emails.rb
@@ -8,10 +8,18 @@ FactoryGirl.define do
   factory :user_email, class: User::Email.name do
     primary true
     email
-    confirmed_at { Time.zone.now }
+    confirmed
 
     after(:build) do |user_email|
       user_email.user ||= build(:user, emails: [user_email], emails_count: 0)
+    end
+
+    trait :confirmed do
+      confirmed_at { Time.zone.now }
+    end
+
+    trait :unconfirmed do
+      confirmed_at nil
     end
   end
 end

--- a/spec/features/user/email_management_spec.rb
+++ b/spec/features/user/email_management_spec.rb
@@ -15,12 +15,17 @@ RSpec.feature 'User: Emails' do
     end
 
     scenario 'I can view all my emails' do
-      user.emails.each do |email|
+      user.reload.emails.each do |email|
         expect(page).to have_selector('tr td', text: email.email)
 
         unless email.confirmed?
-          expect(page).to have_selector("tr#user_email_#{unconfirmed_email.id} td",
+          expect(page).to have_selector("tr#user_email_#{email.id} td",
                                         text: I18n.t('user.emails.email.unconfirmed'))
+        end
+
+        if email.primary?
+          expect(page).to have_selector("tr#user_email_#{email.id} td",
+                                        text: I18n.t('user.emails.email.primary'))
         end
       end
     end


### PR DESCRIPTION
![screen shot 2016-02-17 at 3 33 03 pm](https://cloud.githubusercontent.com/assets/4983239/13102751/ec78bfec-d58b-11e5-8297-1f0a5c4ea3cd.png)

Adding labels for indicating primary email and unconfirmed emails.

This is a subtask of #594 

