### PR TITLE
Allow users to request new confirmation emails

### DIFF
--- a/app/controllers/user/emails_controller.rb
+++ b/app/controllers/user/emails_controller.rb
@@ -32,6 +32,15 @@ class User::EmailsController < ApplicationController
     end
   end
 
+  def send_confirmation
+    if @email.confirmed?
+      redirect_to user_emails_path, warning: t('.already_confirmed', email: @email.email)
+    else
+      @email.send_confirmation_instructions
+      redirect_to user_emails_path, success: t('.success', email: @email.email)
+    end
+  end
+
   private
 
   def email_params

--- a/app/views/user/emails/_email.html.slim
+++ b/app/views/user/emails/_email.html.slim
@@ -11,8 +11,11 @@
         = t('.primary')
 
   td
-    - unless email.primary?
+    - if !email.confirmed?
+      = link_to t('.resend_confirmation'), send_confirmation_user_email_path(email),
+                method: :post, class: ['btn', 'btn-default']
+    - elsif !email.primary?
       = link_to t('.set_primary'), set_primary_user_email_path(email) ,
                 method: :post, class: ['btn', 'btn-default']
 
-    = delete_button(email) if @emails.count > 1
+  td = delete_button(email) if @emails.length > 1

--- a/config/locales/en/user/emails.yml
+++ b/config/locales/en/user/emails.yml
@@ -12,7 +12,11 @@ en:
         success: 'Email was deleted successfully'
       set_primary:
         success: 'Primary email was updated successfully'
+      send_confirmation:
+        already_confirmed: '%{email} was already confirmed.'
+        success: 'A message with a confirmation link has been sent to %{email}. Please follow the link to confirm the email_address.'
       email:
         set_primary: 'Set Primary'
         unconfirmed: 'Unconfirmed'
         primary: 'Primary'
+        resend_confirmation: 'Resend confirmation email'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
   namespace :user do
     resources :emails, only: [:index, :create, :destroy] do
       post 'set_primary', on: :member
+      post 'send_confirmation', on: :member
     end
     resource :profile, only: [:edit, :update]
   end

--- a/spec/controllers/user/emails_controller_spec.rb
+++ b/spec/controllers/user/emails_controller_spec.rb
@@ -52,5 +52,34 @@ RSpec.describe User::EmailsController, type: :controller do
         it { is_expected.to redirect_to(user_emails_path) }
       end
     end
+
+    describe '#send_confirmation' do
+      let!(:email) { create(:user_email, email_traits, user: user, primary: false) }
+      subject { post :send_confirmation, id: email }
+
+      context 'when the email is already confirmed' do
+        let(:email_traits) { :confirmed }
+
+        it 'does not send any confirmations' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+
+        it 'sets an error message' do
+          subject
+
+          expect(flash[:warning]).to eq(I18n.t('user.emails.send_confirmation.already_confirmed'))
+        end
+      end
+
+      context 'when the email is not confirmed' do
+        let(:email_traits) { :unconfirmed }
+
+        it 'sends out a confirmation email' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
+
+        it { is_expected.to redirect_to(user_emails_path) }
+      end
+    end
   end
 end

--- a/spec/features/user/email_management_spec.rb
+++ b/spec/features/user/email_management_spec.rb
@@ -56,5 +56,11 @@ RSpec.feature 'User: Emails' do
       find_link(nil, href: set_primary_user_email_path(email_to_be_set_as_primary)).click
       expect(email_to_be_set_as_primary.reload).to be_primary
     end
+
+    scenario 'I can request a new confirmation email' do
+      find_link(nil, href: send_confirmation_user_email_path(unconfirmed_email)).click
+      expect(page).to have_selector('div.alert.alert-success',
+                                    text: I18n.t('user.emails.send_confirmation.success'))
+    end
   end
 end


### PR DESCRIPTION
Depends on #817 

Allows user to request to resend confirmation emails in the email management:
![screen shot 2016-02-17 at 3 53 41 pm](https://cloud.githubusercontent.com/assets/4983239/13103150/c65fb6be-d58e-11e5-806e-45a938481d03.png)

This is a subtask of #594