### PR TITLE
Add course logos to Coursemology pages

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -35,3 +35,4 @@ $course-achievement-form-badge:   $picture-small !default;
 
 $course-admin-form-logo: $picture-small !default;
 $course-layout-sidebar-logo: $picture-medium !default;
+$course-course-listing-logo: $picture-medium !default;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -34,3 +34,4 @@ $picture-medium: 100px !default;
 $course-achievement-form-badge:   $picture-small !default;
 
 $course-admin-form-logo: $picture-small !default;
+$course-layout-sidebar-logo: $picture-medium !default;

--- a/app/assets/stylesheets/course/courses.scss
+++ b/app/assets/stylesheets/course/courses.scss
@@ -8,4 +8,14 @@
       @extend .col-md-4;
     }
   }
+
+  &.index {
+    .thumbnail {
+      .image > img {
+        height: $course-course-listing-logo;
+        margin-top: 1em;
+        width: $course-course-listing-logo;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -19,4 +19,15 @@
       }
     }
   }
+
+  #course-sidebar-logo {
+    .image > img {
+      height: $course-layout-sidebar-logo;
+      width: $course-layout-sidebar-logo;
+    }
+  }
+
+  .user {
+    margin: 0.5em 0;
+  }
 }

--- a/app/views/course/courses/_course.html.slim
+++ b/app/views/course/courses/_course.html.slim
@@ -1,6 +1,9 @@
 = div_for(course, class: ['col-sm-6', 'col-md-4', 'col-lg-3']) do
   = link_to course_path(course) do
-    div.thumbnail
+    div.thumbnail.text-center
+      div.course-logo
+        = display_course_logo(course)
       div.caption
-        h2 = format_inline_text(course.title)
-        = format_html(course.description)
+        / TODO: Truncate text when text truncator is implemented for HTML pipeline
+        h3 = format_inline_text(course.title)
+        p = format_html(course.description)

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -4,6 +4,9 @@
   div.row.course-layout
     div.col-lg-2.col-md-3.col-sm-4
       div.row
+        div.hidden-xs.text-center#course-sidebar-logo
+          = link_to course_path(current_course) do
+            = display_course_logo(current_course)
         div.col-xs-12.user
           = display_user_image(current_user)
           = link_to_user(current_course_user || current_user)


### PR DESCRIPTION
Added Course logo to:
 - Top of course layout sidebar
 - Course listing / index page (which shows all courses)

### Issues
Not too sure whether we will be fixing styling later on, but for now it looks ... barely passable. 

For the course listing page, I've added `text-overflow: ellipsis` for now. This is because long course titles and/or descriptions makes the markup really ugly (due to different heights of each thumbnail): 

<img width="1089" alt="screen shot 2016-02-17 at 6 49 07 pm" src="https://cloud.githubusercontent.com/assets/4353853/13107178/580a7096-d5a7-11e5-9ccf-fc12c843b3c9.png">

As a result, some descriptions and titles are truncated. We will need to revisit this issue later on to see how to solve it - either some javascript or CSS to ensure the same height, or using bootstrap's [`clearfix`](http://getbootstrap.com/css/#grid-responsive-resets); or moving away from grids. 

### Screenshots
After implementation, this is how it looks:

<img width="978" alt="screen shot 2016-02-17 at 6 41 49 pm" src="https://cloud.githubusercontent.com/assets/4353853/13107211/7328968c-d5a7-11e5-82fd-ffa474ce12ad.png">

<img width="1468" alt="screen shot 2016-02-17 at 6 41 32 pm" src="https://cloud.githubusercontent.com/assets/4353853/13107210/73279cdc-d5a7-11e5-8219-0b376f65da22.png">

<img width="1177" alt="screen shot 2016-02-17 at 7 03 27 pm" src="https://cloud.githubusercontent.com/assets/4353853/13107556/3d752cf6-d5a9-11e5-9f43-bf55b6631934.png">
