### PR TITLE
Speed up course user badge

### DIFF
--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -27,7 +27,8 @@ class Course::Controller < ApplicationController
   #   course.
   # @return [nil] If there is no user session, or no course is loaded.
   def current_course_user
-    @current_course_user ||= @course.course_users.find_by(user: current_user)
+    @current_course_user ||= @course.course_users.with_course_statistics.
+                             find_by(user: current_user)
   end
   helper_method :current_course_user
 

--- a/app/models/concerns/course_user/level_progress_concern.rb
+++ b/app/models/concerns/course_user/level_progress_concern.rb
@@ -8,7 +8,7 @@ module CourseUser::LevelProgressConcern
   #
   # @return [Course::Level] Level of CourseUser.
   def current_level
-    course.level_for(experience_points)
+    @current_level ||= course.level_for(experience_points)
   end
 
   # Computes the percentage (a fixnum ranging from 0-100) of the CourseUser's EXP progress

--- a/app/models/course/level.rb
+++ b/app/models/course/level.rb
@@ -47,7 +47,7 @@ class Course::Level < ActiveRecord::Base
   # @return [Course::Level] For levels with next level in the course.
   # @return [nil] If current level is the highest in the course.
   def next
-    @next if defined? @next
+    return @next if defined? @next
     @next = course.levels.find_nth(level_number + 1, 0)
   end
 

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -61,6 +61,8 @@ class CourseUser < ActiveRecord::Base
   scope :instructors, -> { staff }
   scope :students, -> { where(role: roles[:student]) }
 
+  scope :with_course_statistics, -> { all.calculated(:experience_points, :achievement_count) }
+
   include CourseUser::LevelProgressConcern
 
   # Test whether the current scope includes the current user.


### PR DESCRIPTION
Some fixes to speed up course user badge - currently rendering the `course_user_badge` takes 30% when loading in the default course page (`http://coursemology/courses/1`). 

This reduces the load time by around 40%, so now it takes up less than 20% of total page load time (~16-18%). Most of the reduction came from memoization, as there were repeated similar SQL calls.

I'm still thinking about whether we can reduce the number of SQL calls, but I can't come up with any yet. Next steps to make it faster would be to explore caching. 