### PR TITLE
Submission services fixes

### DIFF
--- a/app/controllers/concerns/course/assessment/submission_controller_service_concern.rb
+++ b/app/controllers/concerns/course/assessment/submission_controller_service_concern.rb
@@ -10,15 +10,15 @@ module Course::Assessment::SubmissionControllerServiceConcern
   def service_class
     case @assessment.display_mode
     when 'guided'
-      Course::Assessment::Submission::GuidedService
+      Course::Assessment::Submission::UpdateGuidedAssessmentService
     when 'worksheet'
-      Course::Assessment::Submission::WorksheetService
+      Course::Assessment::Submission::UpdateWorksheetAssessmentService
     end
   end
 
   # Instantiate a service based on the assessment display mode.
   #
-  # @return [Course::Assessment::SubmissionService] The service instance.
+  # @return [Course::Assessment::Submission::UpdateService] The service instance.
   def service
     service_class.new(self, assessment: @assessment, submission: @submission)
   end
@@ -26,7 +26,7 @@ module Course::Assessment::SubmissionControllerServiceConcern
   # Extract the defined instance variables from the service, so that views can access them.
   # Call this method at the end of the action if there are any instance variables defined in the
   # action.
-  # @param [Course::Assessment::SubmissionService] service the service instance.
+  # @param [Course::Assessment::UpdateService] service the service instance.
   def extract_instance_variables(service)
     service.instance_variables.each do |name|
       value = service.instance_variable_get(name)

--- a/app/controllers/concerns/course/assessment/submission_controller_service_concern.rb
+++ b/app/controllers/concerns/course/assessment/submission_controller_service_concern.rb
@@ -20,7 +20,7 @@ module Course::Assessment::SubmissionControllerServiceConcern
   #
   # @return [Course::Assessment::Submission::UpdateService] The service instance.
   def service
-    service_class.new(self, assessment: @assessment, submission: @submission)
+    @service ||= service_class.new(self, assessment: @assessment, submission: @submission)
   end
 
   # Extract the defined instance variables from the service, so that views can access them.

--- a/app/services/course/assessment/submission/update_guided_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_guided_assessment_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-class Course::Assessment::Submission::GuidedService < Course::Assessment::SubmissionService
+class Course::Assessment::Submission::UpdateGuidedAssessmentService <
+  Course::Assessment::Submission::UpdateService
+
   private
 
   def questions_to_attempt

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course::Assessment::SubmissionService < SimpleDelegator
+class Course::Assessment::Submission::UpdateService < SimpleDelegator
   def update
     if @submission.update_attributes(update_params)
       redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission),

--- a/app/services/course/assessment/submission/update_worksheet_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_worksheet_assessment_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-class Course::Assessment::Submission::WorksheetService < Course::Assessment::SubmissionService
+class Course::Assessment::Submission::UpdateWorksheetAssessmentService <
+  Course::Assessment::Submission::UpdateService
+
   private
 
   def questions_to_attempt

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -52,5 +52,17 @@ RSpec.describe Course::Assessment::SubmissionsController do
         it { is_expected.to render_template('edit') }
       end
     end
+
+    describe '#extract_instance_variables' do
+      subject do
+        get :edit, course_id: course, assessment_id: assessment, id: immutable_submission
+      end
+
+      it 'extracts instance variables from services' do
+        subject
+
+        expect(controller.instance_variable_get(:@questions_to_attempt)).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
- Proper naming, using verbs in service names.
- Memorize service object so that the instance variables defined in the action will be preserved