### PR TITLE
Implement defining skills

### DIFF
--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -21,7 +21,17 @@ class Course::AssessmentsComponent < SimpleDelegator
   end
 
   def admin_sidebar_items
-    []
+    return [] unless can?(:manage, Course::Assessment::Skill.new(course: current_course))
+
+    [
+      {
+        key: :assessments_skills,
+        title: t('course.assessment.skills.sidebar_title'),
+        type: :admin,
+        weight: 3,
+        path: course_assessments_skills_path(current_course)
+      }
+    ]
   end
 
   def admin_settings_items

--- a/app/controllers/course/assessment/skills_controller.rb
+++ b/app/controllers/course/assessment/skills_controller.rb
@@ -2,12 +2,53 @@
 class Course::Assessment::SkillsController < Course::ComponentController
   load_and_authorize_resource :skill, class: Course::Assessment::Skill.name, through: :course,
                                       through_association: :assessment_skills
-  load_and_authorize_resource :skill_branch, class: Course::Assessment::SkillBranch.name,
-                                             parent: false, through: :course,
-                                             through_association: :assessment_skill_branches,
-                                             only: :index
+  before_action :load_skill_branches
   add_breadcrumb :index, :course_assessments_skills_path
 
   def index
+  end
+
+  def new
+  end
+
+  def create
+    if @skill.save
+      redirect_to course_assessments_skills_path(current_course),
+                  success: t('.success', title: @skill.title)
+    else
+      render 'new'
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @skill.update_attributes(skill_params)
+      redirect_to course_assessments_skills_path(current_course),
+                  success: t('.success', title: @skill.title)
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    if @skill.destroy
+      redirect_to course_assessments_skills_path(current_course),
+                  success: t('.success', skill: @skill.title)
+    else
+      redirect_to course_assessments_skills_path(current_course),
+                  danger: t('.failure', error: @skill.errors.full_messages.to_sentence)
+    end
+  end
+
+  private
+
+  def skill_params
+    params.require(:skill).permit(:title, :description, :skill_branch_id)
+  end
+
+  def load_skill_branches
+    @skill_branches = current_course.assessment_skill_branches.accessible_by(current_ability)
   end
 end

--- a/app/controllers/course/assessment/skills_controller.rb
+++ b/app/controllers/course/assessment/skills_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class Course::Assessment::SkillsController < Course::ComponentController
+  load_and_authorize_resource :skill, class: Course::Assessment::Skill.name, through: :course,
+                                      through_association: :assessment_skills
+  load_and_authorize_resource :skill_branch, class: Course::Assessment::SkillBranch.name,
+                                             parent: false, through: :course,
+                                             through_association: :assessment_skill_branches,
+                                             only: :index
+  add_breadcrumb :index, :course_assessments_skills_path
+
+  def index
+  end
+end

--- a/app/models/components/course/assessments_ability_component.rb
+++ b/app/models/components/course/assessments_ability_component.rb
@@ -4,4 +4,5 @@ module Course::AssessmentsAbilityComponent
   extend ActiveSupport::Concern
 
   include Course::Assessment::AssessmentAbility
+  include Course::Assessment::SkillAbility
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -32,6 +32,10 @@ class Course < ActiveRecord::Base
   has_many :assessment_categories, class_name: Course::Assessment::Category.name,
                                    dependent: :destroy, inverse_of: :course
   has_many :assessments, through: :assessment_categories
+  has_many :assessment_skills, class_name: Course::Assessment::Skill.name,
+                               dependent: :destroy
+  has_many :assessment_skill_branches, class_name: Course::Assessment::SkillBranch.name,
+                                       dependent: :destroy
   has_many :assessment_programming_evaluations,
            class_name: Course::Assessment::ProgrammingEvaluation.name, dependent: :destroy,
            inverse_of: :course

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -3,7 +3,7 @@ class Course::Assessment::Question < ActiveRecord::Base
   actable
 
   belongs_to :assessment, inverse_of: :questions
-  has_and_belongs_to_many :tags
+  has_and_belongs_to_many :skills
 
   default_scope { order(weight: :asc) }
 

--- a/app/models/course/assessment/skill.rb
+++ b/app/models/course/assessment/skill.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Course::Assessment::Skill < ActiveRecord::Base
+  belongs_to :course, inverse_of: :assessment_skills
   belongs_to :skill_branch, class_name: Course::Assessment::SkillBranch.name, inverse_of: :skills
   has_and_belongs_to_many :questions, class_name: Course::Assessment::Question.name
 end

--- a/app/models/course/assessment/skill.rb
+++ b/app/models/course/assessment/skill.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class Course::Assessment::Skill < ActiveRecord::Base
+  belongs_to :skill_branch, class_name: Course::Assessment::SkillBranch.name, inverse_of: :skills
+  has_and_belongs_to_many :questions, class_name: Course::Assessment::Question.name
+end

--- a/app/models/course/assessment/skill.rb
+++ b/app/models/course/assessment/skill.rb
@@ -3,4 +3,14 @@ class Course::Assessment::Skill < ActiveRecord::Base
   belongs_to :course, inverse_of: :assessment_skills
   belongs_to :skill_branch, class_name: Course::Assessment::SkillBranch.name, inverse_of: :skills
   has_and_belongs_to_many :questions, class_name: Course::Assessment::Question.name
+
+  validate :validate_consistent_course
+
+  private
+
+  def validate_consistent_course
+    return unless skill_branch
+
+    errors.add(:course, :consistent_course) if course != skill_branch.course
+  end
 end

--- a/app/models/course/assessment/skill_ability.rb
+++ b/app/models/course/assessment/skill_ability.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Course::Assessment::SkillAbility
+  def define_permissions
+    if user
+      allow_staff_manage_skills
+      allow_staff_manage_skill_branches
+    end
+
+    super
+  end
+
+  private
+
+  def allow_staff_manage_skills
+    can :manage, Course::Assessment::Skill, course_staff_hash
+  end
+
+  def allow_staff_manage_skill_branches
+    can :manage, Course::Assessment::SkillBranch, course_staff_hash
+  end
+end

--- a/app/models/course/assessment/skill_branch.rb
+++ b/app/models/course/assessment/skill_branch.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 class Course::Assessment::SkillBranch < ActiveRecord::Base
+  belongs_to :course, inverse_of: :assessment_skill_branches
   has_many :skills, inverse_of: :skill_branch
 end

--- a/app/models/course/assessment/skill_branch.rb
+++ b/app/models/course/assessment/skill_branch.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class Course::Assessment::SkillBranch < ActiveRecord::Base
+  has_many :skills, inverse_of: :skill_branch
+end

--- a/app/models/course/assessment/tag.rb
+++ b/app/models/course/assessment/tag.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-class Course::Assessment::Tag < ActiveRecord::Base
-  belongs_to :tag_group, class_name: Course::Assessment::TagGroup.name, inverse_of: :tags
-  has_and_belongs_to_many :questions, class_name: Course::Assessment::Question.name
-end

--- a/app/models/course/assessment/tag_group.rb
+++ b/app/models/course/assessment/tag_group.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-class Course::Assessment::TagGroup < ActiveRecord::Base
-  has_many :tags, inverse_of: :tag_group
-end

--- a/app/views/course/assessment/skills/_form.html.slim
+++ b/app/views/course/assessment/skills/_form.html.slim
@@ -1,0 +1,7 @@
+= simple_form_for([current_course, :assessments, @skill]) do |f|
+  = f.error_notification
+  = f.input :title
+  = f.input :description
+  = f.association :skill_branch, collection: @skill_branches
+
+  = f.button :submit

--- a/app/views/course/assessment/skills/_skill.html.slim
+++ b/app/views/course/assessment/skills/_skill.html.slim
@@ -1,0 +1,7 @@
+= content_tag_for(:tr, skill) do
+  th = skill.title
+  td = skill.description
+  td
+    div.btn-group
+      = edit_button([current_course, :assessments, skill]) if can?(:update, skill)
+      = delete_button([current_course, :assessments, skill]) if can?(:destroy, skill)

--- a/app/views/course/assessment/skills/_skill_branch.html.slim
+++ b/app/views/course/assessment/skills/_skill_branch.html.slim
@@ -1,0 +1,13 @@
+tbody
+  - if skill_branch
+    = content_tag_for(:tr, skill_branch) do
+      td = skill_branch.title
+      td = skill_branch.description
+      td
+        = delete_button([current_course, skill_branch]) if can?(:destroy, skill_branch)
+  - else
+    tr
+      th colspan=3
+        = t('.uncategorised')
+
+  = render partial: 'skill', collection: skills[skill_branch]

--- a/app/views/course/assessment/skills/edit.html.slim
+++ b/app/views/course/assessment/skills/edit.html.slim
@@ -1,0 +1,4 @@
+- add_breadcrumb @skill.title
+= page_header @skill.title
+
+= render partial: 'form'

--- a/app/views/course/assessment/skills/index.html.slim
+++ b/app/views/course/assessment/skills/index.html.slim
@@ -1,0 +1,13 @@
+= page_header do
+  div.btn-group
+    - if can?(:create, Course::Assessment::Skill.new(course: current_course))
+      = new_button([current_course, :assessments, :skill])
+
+table.table.skills-list.table-hover
+  thead
+    tr
+      th = Course::Assessment::Skill.human_attribute_name(:title)
+      th = Course::Assessment::Skill.human_attribute_name(:description)
+      th
+  = render partial: 'skill_branch', collection: @skill_branches + [nil],
+           locals: { skills: @skills.group_by(&:skill_branch) }

--- a/app/views/course/assessment/skills/new.html.slim
+++ b/app/views/course/assessment/skills/new.html.slim
@@ -1,0 +1,4 @@
+- add_breadcrumb :new
+= page_header
+
+= render partial: 'form'

--- a/config/locales/en/activerecord/course/assessment/skill.yml
+++ b/config/locales/en/activerecord/course/assessment/skill.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/skill:
+          attributes:
+            course:
+              consistent_course: 'must belong to the same course'

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -70,6 +70,8 @@ en:
             new: :'course.assessment.question.text_responses.new.header'
           programming:
             new: :'course.assessment.question.programming.new.header'
+        skills:
+          index: :'course.assessment.skills.index.header'
       groups:
         index: :'course.groups.index.header'
         new: :'course.groups.new.header'

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -71,6 +71,7 @@ en:
           programming:
             new: :'course.assessment.question.programming.new.header'
         skills:
+          new: :'course.assessment.skills.new.header'
           index: :'course.assessment.skills.index.header'
       groups:
         index: :'course.groups.index.header'

--- a/config/locales/en/course/assessment/skills.yml
+++ b/config/locales/en/course/assessment/skills.yml
@@ -1,0 +1,10 @@
+en:
+  course:
+    assessment:
+      skills:
+        sidebar_title: 'Skills'
+        index:
+          header: 'Skills'
+          failure: 'Could not delete skill: %{error}'
+        skill_branch:
+          uncategorised: 'Uncategorised Skills'

--- a/config/locales/en/course/assessment/skills.yml
+++ b/config/locales/en/course/assessment/skills.yml
@@ -5,6 +5,15 @@ en:
         sidebar_title: 'Skills'
         index:
           header: 'Skills'
+        new:
+          header: 'New Skill'
+        create:
+          success: 'Skill %{title} was created.'
+        update:
+          success: 'Skill %{title} was updated.'
+        destroy:
+          success: 'Skill %{assessment} was deleted.'
+          failure: 'Could not delete skill: %{error}'
           failure: 'Could not delete skill: %{error}'
         skill_branch:
           uncategorised: 'Uncategorised Skills'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,10 @@ Rails.application.routes.draw do
             post :auto_grade, on: :member
           end
           concerns :conditional
+
+          collection do
+            resources :skills, as: :assessments_skills
+          end
         end
       end
       resources :levels, except: [:show, :edit, :update]

--- a/db/migrate/20160220081731_rename_assessment_tags_to_skills.rb
+++ b/db/migrate/20160220081731_rename_assessment_tags_to_skills.rb
@@ -1,0 +1,10 @@
+class RenameAssessmentTagsToSkills < ActiveRecord::Migration
+  def change
+    rename_table :course_assessment_tag_groups, :course_assessment_skill_branches
+    rename_table :course_assessment_tags, :course_assessment_skills
+    rename_table :course_assessment_questions_tags, :course_assessment_questions_skills
+
+    rename_column :course_assessment_skills, :tag_group_id, :skill_branch_id
+    rename_column :course_assessment_questions_skills, :tag_id, :skill_id
+  end
+end

--- a/db/migrate/20160220092350_add_course_to_skill_and_skill_branch.rb
+++ b/db/migrate/20160220092350_add_course_to_skill_and_skill_branch.rb
@@ -1,0 +1,11 @@
+class AddCourseToSkillAndSkillBranch < ActiveRecord::Migration
+  def change
+    change_table :course_assessment_skills do |t|
+      t.references :course, null: false
+    end
+
+    change_table :course_assessment_skill_branches do |t|
+      t.references :course, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 # encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
@@ -12,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160126094510) do
+ActiveRecord::Schema.define(version: 20160220081731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -285,28 +284,28 @@ ActiveRecord::Schema.define(version: 20160126094510) do
     t.text    "explanation"
   end
 
-  create_table "course_assessment_tag_groups", force: :cascade do |t|
+  create_table "course_assessment_skill_branches", force: :cascade do |t|
     t.string   "title",       limit: 255, null: false
     t.text     "description", null: false
-    t.integer  "creator_id",  null: false, index: {name: "fk__course_assessment_tag_groups_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_tag_groups_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__course_assessment_tag_groups_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_tag_groups_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "creator_id",  null: false, index: {name: "fk__course_assessment_skill_branches_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skill_branches_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",  null: false, index: {name: "fk__course_assessment_skill_branches_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skill_branches_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
 
-  create_table "course_assessment_tags", force: :cascade do |t|
-    t.integer  "tag_group_id", index: {name: "fk__course_assessment_tags_tag_group_id"}, foreign_key: {references: "course_assessment_tag_groups", name: "fk_course_assessment_tags_tag_group_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",        limit: 255, null: false
-    t.text     "description",  null: false
-    t.integer  "creator_id",   null: false, index: {name: "fk__course_assessment_tags_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_tags_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",   null: false, index: {name: "fk__course_assessment_tags_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_tags_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+  create_table "course_assessment_skills", force: :cascade do |t|
+    t.integer  "skill_branch_id", index: {name: "fk__course_assessment_skills_skill_branch_id"}, foreign_key: {references: "course_assessment_skill_branches", name: "fk_course_assessment_skills_skill_branch_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "title",           limit: 255, null: false
+    t.text     "description",     null: false
+    t.integer  "creator_id",      null: false, index: {name: "fk__course_assessment_skills_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skills_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",      null: false, index: {name: "fk__course_assessment_skills_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skills_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
-  create_table "course_assessment_questions_tags", force: :cascade do |t|
-    t.integer "question_id", null: false, index: {name: "course_assessment_question_tags_question_index"}, foreign_key: {references: "course_assessment_questions", name: "fk_course_assessment_questions_tags_question_id", on_update: :no_action, on_delete: :no_action}
-    t.integer "tag_id",      null: false, index: {name: "course_assessment_question_tags_tag_index"}, foreign_key: {references: "course_assessment_tags", name: "fk_course_assessment_questions_tags_tag_id", on_update: :no_action, on_delete: :no_action}
+  create_table "course_assessment_questions_skills", force: :cascade do |t|
+    t.integer "question_id", null: false, index: {name: "course_assessment_question_skills_question_index"}, foreign_key: {references: "course_assessment_questions", name: "fk_course_assessment_questions_skills_question_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "skill_id",    null: false, index: {name: "course_assessment_question_skills_skill_index"}, foreign_key: {references: "course_assessment_skills", name: "fk_course_assessment_questions_skills_skill_id", on_update: :no_action, on_delete: :no_action}
   end
 
   create_table "course_condition_achievements", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160220081731) do
+ActiveRecord::Schema.define(version: 20160220092350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -285,6 +285,7 @@ ActiveRecord::Schema.define(version: 20160220081731) do
   end
 
   create_table "course_assessment_skill_branches", force: :cascade do |t|
+    t.integer  "course_id",   null: false, index: {name: "fk__course_assessment_skill_branches_course_id"}, foreign_key: {references: "courses", name: "fk_course_assessment_skill_branches_course_id", on_update: :no_action, on_delete: :no_action}
     t.string   "title",       limit: 255, null: false
     t.text     "description", null: false
     t.integer  "creator_id",  null: false, index: {name: "fk__course_assessment_skill_branches_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skill_branches_creator_id", on_update: :no_action, on_delete: :no_action}
@@ -294,6 +295,7 @@ ActiveRecord::Schema.define(version: 20160220081731) do
   end
 
   create_table "course_assessment_skills", force: :cascade do |t|
+    t.integer  "course_id",       null: false, index: {name: "fk__course_assessment_skills_course_id"}, foreign_key: {references: "courses", name: "fk_course_assessment_skills_course_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "skill_branch_id", index: {name: "fk__course_assessment_skills_skill_branch_id"}, foreign_key: {references: "course_assessment_skill_branches", name: "fk_course_assessment_skills_skill_branch_id", on_update: :no_action, on_delete: :no_action}
     t.string   "title",           limit: 255, null: false
     t.text     "description",     null: false

--- a/spec/controllers/course/assessment/skills_controller_spec.rb
+++ b/spec/controllers/course/assessment/skills_controller_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::SkillsController do
+end

--- a/spec/controllers/course/assessment/skills_controller_spec.rb
+++ b/spec/controllers/course/assessment/skills_controller_spec.rb
@@ -2,4 +2,64 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::SkillsController do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let(:course) { create(:course, creator: user) }
+    let(:immutable_skill) do
+      create(:course_assessment_skill, course: course).tap do |immutable_skill|
+        allow(immutable_skill).to receive(:save).and_return(false)
+        allow(immutable_skill).to receive(:destroy).and_return(false)
+      end
+    end
+
+    before { sign_in(user) }
+
+    describe '#create' do
+      subject { post :create, course_id: course }
+
+      context 'when create fails' do
+        before do
+          controller.instance_variable_set(:@skill, immutable_skill)
+          subject
+        end
+
+        it { is_expected.to render_template('new') }
+      end
+    end
+
+    describe '#update' do
+      subject do
+        post :update, course_id: course, id: immutable_skill, skill: { title: '' }
+      end
+
+      context 'when update fails' do
+        before do
+          controller.instance_variable_set(:@skill, immutable_skill)
+          subject
+        end
+
+        it { is_expected.to render_template('edit') }
+      end
+    end
+
+    describe '#destroy' do
+      subject do
+        delete :destroy, course_id: course, id: immutable_skill
+      end
+
+      context 'when destroy fails' do
+        before do
+          controller.instance_variable_set(:@skill, immutable_skill)
+          subject
+        end
+
+        it { is_expected.to redirect_to course_assessments_skills_path(course) }
+        it 'sets the appropriate flash message' do
+          expect(flash[:danger]).to eq(I18n.t('course.assessment.skills.destroy.failure'))
+        end
+      end
+    end
+  end
 end

--- a/spec/factories/course_assessment_skill_branches.rb
+++ b/spec/factories/course_assessment_skill_branches.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :course_assessment_skill_branch, class: Course::Assessment::SkillBranch do
+    course
+    title 'Skill Branch'
+    description 'Branch description'
+  end
+end

--- a/spec/factories/course_assessment_skills.rb
+++ b/spec/factories/course_assessment_skills.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :course_assessment_skill, class: Course::Assessment::Skill do
+    course
+    title 'Skill'
+    description 'Description'
+  end
+end

--- a/spec/features/course/assessment/skill_management_spec.rb
+++ b/spec/features/course/assessment/skill_management_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'Course: Skills' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Manager' do
+      let(:user) { create(:course_manager, :approved, course: course).user }
+
+      scenario 'I can create a skill' do
+        visit course_assessments_skills_path(course)
+        click_link(nil, href: new_course_assessments_skill_path(course))
+
+        skill_attributes = attributes_for(:course_assessment_skill)
+        fill_in 'title', with: skill_attributes[:title]
+        fill_in 'description', with: skill_attributes[:description]
+
+        click_button 'submit'
+
+        expect(current_path).to eq(course_assessments_skills_path(course))
+        expect(page).to have_content_tag_for(course.assessment_skills.first)
+
+        expect(course.assessment_skills.first.title).to eq(skill_attributes[:title])
+        expect(course.assessment_skills.first.description).to eq(skill_attributes[:description])
+      end
+
+      scenario 'I can edit a skill' do
+        skill = create(:course_assessment_skill, course: course)
+        visit course_assessments_skills_path(course)
+        within find(content_tag_selector(skill)) do
+          click_link(nil, href: edit_course_assessments_skill_path(course, skill))
+        end
+
+        new_skill_title = skill.title + ' there!'
+        fill_in 'title', with: new_skill_title
+
+        click_button 'submit'
+
+        expect(current_path).to eq(course_assessments_skills_path(course))
+        expect(page).to have_content_tag_for(skill)
+
+        expect(skill.reload.title).to eq(new_skill_title)
+      end
+
+      scenario 'I can delete a skill' do
+        skill = create(:course_assessment_skill, course: course)
+        visit course_assessments_skills_path(course)
+        within find(content_tag_selector(skill)) do
+          click_link(nil, href: course_assessments_skill_path(course, skill))
+        end
+
+        expect(current_path).to eq(course_assessments_skills_path(course))
+        expect(page).not_to have_content_tag_for(skill)
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Course::Assessment::Question do
 
   it { is_expected.to be_actable }
   it { is_expected.to belong_to(:assessment) }
-  it { is_expected.to have_and_belong_to_many(:tags) }
+  it { is_expected.to have_and_belong_to_many(:skills) }
 
   let(:instance) { create(:instance) }
   with_tenant(:instance) do

--- a/spec/models/course/assessment/skill_branch_spec.rb
+++ b/spec/models/course/assessment/skill_branch_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::SkillBranch do
+  it { is_expected.to have_many(:skills) }
+end

--- a/spec/models/course/assessment/skill_branch_spec.rb
+++ b/spec/models/course/assessment/skill_branch_spec.rb
@@ -2,5 +2,6 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::SkillBranch do
+  it { is_expected.to belong_to(:course).inverse_of(:assessment_skill_branches) }
   it { is_expected.to have_many(:skills) }
 end

--- a/spec/models/course/assessment/skill_spec.rb
+++ b/spec/models/course/assessment/skill_spec.rb
@@ -5,4 +5,25 @@ RSpec.describe Course::Assessment::Skill do
   it { is_expected.to belong_to(:course).inverse_of(:assessment_skills) }
   it { is_expected.to belong_to(:skill_branch) }
   it { is_expected.to have_and_belong_to_many(:questions) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:course) { build(:course) }
+    let(:skill_branch) { nil }
+    subject { build(:course_assessment_skill, skill_branch: skill_branch, course: course) }
+
+    describe 'validations' do
+      describe '#course' do
+        context 'when the course does not match the skill branch' do
+          let(:skill_branch) { build(:course_assessment_skill_branch) }
+          it 'adds a :consistent_course error on :course' do
+            expect(subject).not_to be_valid
+            expect(subject.errors[:course]).to include(I18n.t('activerecord.errors.models.course/'\
+                                                              'assessment/skill.attributes.course.'\
+                                                              'consistent_course'))
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/course/assessment/skill_spec.rb
+++ b/spec/models/course/assessment/skill_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Course::Assessment::Tag do
-  it { is_expected.to belong_to(:tag_group) }
+RSpec.describe Course::Assessment::Skill do
+  it { is_expected.to belong_to(:skill_branch) }
   it { is_expected.to have_and_belong_to_many(:questions) }
 end

--- a/spec/models/course/assessment/skill_spec.rb
+++ b/spec/models/course/assessment/skill_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Skill do
+  it { is_expected.to belong_to(:course).inverse_of(:assessment_skills) }
   it { is_expected.to belong_to(:skill_branch) }
   it { is_expected.to have_and_belong_to_many(:questions) }
 end

--- a/spec/models/course/assessment/tag_group_spec.rb
+++ b/spec/models/course/assessment/tag_group_spec.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-require 'rails_helper'
-
-RSpec.describe Course::Assessment::TagGroup do
-  it { is_expected.to have_many(:tags) }
-end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Course, type: :model do
     it { is_expected.to have_many(:assessment_categories).dependent(:destroy) }
     it { is_expected.to have_many(:assessment_programming_evaluations).dependent(:destroy) }
     it { is_expected.to have_many(:assessments).through(:assessment_categories) }
+    it { is_expected.to have_many(:assessment_skills).dependent(:destroy) }
+    it { is_expected.to have_many(:assessment_skill_branches).dependent(:destroy) }
     it { is_expected.to have_many(:forums).dependent(:destroy) }
     it { is_expected.to have_many(:lesson_plan_items).dependent(:destroy) }
     it { is_expected.to have_many(:lesson_plan_milestones).dependent(:destroy) }


### PR DESCRIPTION
I've renamed tags/tag groups to skills/skill branches to be unambiguous. This implements CRUD for skills.

Next PR will handle skill branches, then next PR will handle associating questions with skills.