### PR TITLE
Add experience points history

### DIFF
--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Course::ExperiencePointsRecordsController < Course::ComponentController
+  load_resource :course_user, through: :course
+  load_and_authorize_resource :experience_points_record, through: :course_user,
+                                                         class: Course::ExperiencePointsRecord.name
+
+  def index # :nodoc:
+    @experience_points_records =
+      @experience_points_records.active.includes(creator: :course_users)
+  end
+end

--- a/app/views/course/experience_points_records/_experience_points_record.html.slim
+++ b/app/views/course/experience_points_records/_experience_points_record.html.slim
@@ -1,0 +1,4 @@
+= content_tag_for(:tr, experience_points_record)
+  td = experience_points_record.points_awarded
+  td = format_inline_text(experience_points_record.reason)
+  td = link_to_user(experience_points_record.creator)

--- a/app/views/course/experience_points_records/index.html.slim
+++ b/app/views/course/experience_points_records/index.html.slim
@@ -1,0 +1,10 @@
+= page_header t('.header', name: display_course_user(@course_user))
+
+table.table.levels-list.table-hover
+  thead
+    tr
+      th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
+      th = Course::ExperiencePointsRecord.human_attribute_name(:reason)
+      th = Course::ExperiencePointsRecord.human_attribute_name(:awarder)
+  tbody
+    = render @experience_points_records

--- a/config/locales/en/course/experience_points_records.yml
+++ b/config/locales/en/course/experience_points_records.yml
@@ -1,0 +1,5 @@
+en:
+  course:
+    experience_points_records:
+      index:
+        header: 'Experience Points History for %{name}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,6 +215,10 @@ Rails.application.routes.draw do
           resources :materials, path: 'files'
         end
       end
+
+      resources :course_users, only: [] do
+        resources :experience_points_records, only: [:index]
+      end
     end
   end
 end

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Courses: Experience Points Records: Management' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:course_student) { create(:course_student, :approved, course: course) }
+    let!(:record) { create(:course_experience_points_record, course_user: course_student) }
+    let!(:inactive_record) do
+      create(:course_experience_points_record, :inactive, course_user: course_student)
+    end
+
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course manager' do
+      let(:user) { create(:course_manager, :approved, course: course).user }
+
+      scenario "I can view a course student's active experience points records" do
+        visit course_course_user_experience_points_records_path(course, course_student)
+
+        expect(page).to have_content_tag_for(record)
+        expect(page).not_to have_content_tag_for(inactive_record)
+      end
+    end
+
+    context 'As a Course student' do
+      let(:user) { course_student.user }
+
+      scenario 'I can view my active experience points records' do
+        visit course_course_user_experience_points_records_path(course, course_student)
+
+        expect(page).to have_content_tag_for(record)
+        expect(page).not_to have_content_tag_for(inactive_record)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a separate page from the CourseUser profile page.

In a subsequent PR:
- show the generated reason when the ExperiencePointsRecord is not a manually awarded one. 