### PR TITLE
[For Discussion] Controller Actions and Routes for Manual Award Achievements

### DIFF
--- a/app/controllers/course/user_achievements_controller.rb
+++ b/app/controllers/course/user_achievements_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class Course::UserAchievementsController < Course::ComponentController
+  load_and_authorize_resource :achievement, through: :course, parent: false,
+                              class: Course::Achievement.name
+  add_breadcrumb :index, :course_users_students_path
+  helper Course::AchievementsHelper
+
+  def index # :nodoc:
+  end
+
+  def edit # :nodoc:
+  end
+
+  def update # :nodoc:
+  end
+
+  private
+
+  def achievement_params #:nodoc:
+    params.require(:achievement).permit(course_user_attributes: [:id])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,10 +125,16 @@ Rails.application.routes.draw do
 
         get 'forums' => 'forum_settings#edit'
         patch 'forums' => 'forum_settings#update'
+
         namespace 'assessments' do
           resources :categories, only: [:new, :create, :destroy] do
             resources :tabs, only: [:new, :create, :destroy]
           end
+        end
+
+        namespace 'manual_award' do
+          resources :achievements, controller: '/course/user_achievements',
+                    only: [:index, :edit, :update]
         end
       end
 


### PR DESCRIPTION
Just want to see some feedback on whether the controller convention, and routes I have defined are okay. 

For controller: Although this is `Course::UserAchievementsController`, I'm loading `@achievements`, hence have opted to do an update on `courseuser_ids` instead. 

For routes: Part of the intention was in line with exp transations - hence I'm suggesting for the routes to be the following: 

Verb | Controller Action | Route
--- | --- | ---
GET | index | `course/:id/admin/manual_award/achievements`
GET | edit | `course/:id/admin/manual_award/achievements/:id/edit`
PATCH/PUT | update | `course/:id/admin/manual_award/achievements/:id`

Ideally after that, we can part `experience_points` under the `manual_award` namespace.

---

My plan is to PR a skeleton controller and routes first, and add in the views later on. 