### PR TITLE
Display explanations

### DIFF
--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -13,4 +13,11 @@ module Course::Assessment::Submission::SubmissionsHelper
     parent_collection = topic.posts.last ? topic.posts.last.children : topic.posts
     parent_collection.build
   end
+
+  # Return the CSS class of the explanation based on the correctness of the answer.
+  #
+  # @return [String]
+  def explanation_panel_class(answer)
+    answer.correct ? 'panel-success' : 'panel-danger'
+  end
 end

--- a/app/views/course/assessment/answer/_explanation.html.slim
+++ b/app/views/course/assessment/answer/_explanation.html.slim
@@ -1,0 +1,5 @@
+div.panel class="#{explanation_panel_class(answer)}"
+  div.panel-heading = answer.correct? ? t('.correct') : t('.wrong')
+  div.panel-body
+    - answer.auto_grading.result['messages'].each do |explanation|
+      div = format_html(explanation)

--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
@@ -8,5 +8,5 @@ h2 = format_inline_text(question.title)
                           label_method: :option, label: false, disabled: readonly
 
 - if f.object.auto_grading && f.object.auto_grading.result
-  div
-    = format_html(f.object.auto_grading.result['messages'])
+  = render partial: 'course/assessment/answer/explanation',
+           locals: { answer: f.object }

--- a/app/views/course/assessment/answer/programming/_programming.html.slim
+++ b/app/views/course/assessment/answer/programming/_programming.html.slim
@@ -9,6 +9,5 @@ div.files
   = f.simple_fields_for :files do |files_form|
     = render file_fields_path, f: files_form
 
-- if can?(:grade, programming.answer)
-  = render partial: 'course/assessment/answer/programming/test_cases',
-           locals: { question: question, answer: programming }
+= render partial: 'course/assessment/answer/programming/test_cases',
+         locals: { question: question, answer: programming }

--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -10,31 +10,38 @@ h3 = t('.test_cases')
 table.table.table-striped.table-hover
   thead
     tr
-      th = t('.identifier')
-      th = t('.description')
-      th = t('.hint')
+      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier)
+      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:description)
+      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:hint)
       th = t('.passed')
   tbody
     tr
       th colspan=4
         = t('.public')
     - public_test_cases.each do |test_case|
+      - test_case_result = answer_test_results_hash[test_case]
       = content_tag_for(:tr, test_case) do
-        th = test_case.identifier
-        td = test_case.description
-        td = test_case.hint
+        th = format_html(test_case.identifier)
+        td = format_html(test_case.description)
+        td = format_html(test_case.hint) if !test_case_result || !test_case_result.passed?
         td
-          - test_case_result = answer_test_results_hash[test_case]
           = fa_icon('check') if test_case_result && test_case_result.passed?
-  tbody
-    tr
-      th colspan=4
-        = t('.private')
-    - private_test_cases.each do |test_case|
-      = content_tag_for(:tr, test_case) do
-        th = test_case.identifier
-        td = test_case.description
-        td
-        td
-          - test_case_result = answer_test_results_hash[test_case]
-          = fa_icon('check') if test_case_result && test_case_result.passed?
+  - if can?(:grade, answer.answer)
+    tbody
+      tr
+        th colspan=4
+          = t('.private')
+      - private_test_cases.each do |test_case|
+        = content_tag_for(:tr, test_case) do
+          th = format_html(test_case.identifier)
+          td = format_html(test_case.description)
+          td
+          td
+            - test_case_result = answer_test_results_hash[test_case]
+            = fa_icon('check') if test_case_result && test_case_result.passed?
+
+- failed_private_test_cases = private_test_cases.select { |t| !test_case_result || !test_case_result.passed? }
+- if !failed_private_test_cases.empty? && answer.submission.attempting?
+    div.panel.panel-danger
+      div.panel-heading = t('.failed_message')
+      div.panel-body = format_html(failed_private_test_cases.map(&:hint).compact.first)

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -4,6 +4,10 @@ h2 = format_inline_text(question.title)
 - readonly = cannot?(:update, text_response.answer)
 = f.input :answer_text, label: false, readonly: readonly
 
+- if f.object.auto_grading && f.object.auto_grading.result
+  = render partial: 'course/assessment/answer/explanation',
+           locals: { answer: f.object }
+
 - if can?(:grade, text_response.answer)
   = render partial: 'course/assessment/answer/text_responses/solution',
     locals: { question: question }

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -11,3 +11,6 @@ en:
           grading: 'Grading'
           maximum_grade: '/ %{maximum_grade}'
           grade: 'Grade: %{grade} / %{maximum_grade}'
+        explanation:
+          correct: 'Correct!'
+          wrong: 'Wrong!'

--- a/config/locales/en/course/assessment/answer/programming.yml
+++ b/config/locales/en/course/assessment/answer/programming.yml
@@ -8,10 +8,8 @@ en:
           file_fields:
             delete: 'Delete file'
           test_cases:
-            identifier: :'course.assessment.question.programming.form_test_cases.identifier'
-            description: :'course.assessment.question.programming.form_test_cases.description'
-            hint: :'course.assessment.question.programming.form_test_cases.hint'
             passed: 'Passed'
             private: :'course.assessment.question.programming.form_test_cases.private'
             public: :'course.assessment.question.programming.form_test_cases.public'
             test_cases: :'course.assessment.question.programming.form_test_cases.test_cases'
+            failed_message: 'You have failed to pass one or more private test cases.'

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
           expect(all('.correct').length).to eq(options.to_a.count(&:correct?))
         end
       end
+
+      scenario 'I can view the auto grading results' do
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+        click_link I18n.t('course.assessment.submission.submissions.worksheet.auto_grade')
+        wait_for_job
+
+        expect(page).
+          to have_selector('div', text: I18n.t('course.assessment.answer.explanation.wrong'))
+      end
     end
   end
 end

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
 
       scenario 'I can view the grading scheme' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
+        click_link I18n.t('course.assessment.submission.submissions.worksheet.auto_grade')
+        wait_for_job
+
+        expect(page).
+          to have_selector('div', text: I18n.t('course.assessment.answer.explanation.wrong'))
 
         within find(content_tag_selector(submission.answers.first)) do
           assessment.questions.first.actable.solutions.each do |solution|


### PR DESCRIPTION
Depends on #838 

Implements displaying explanations for MRQ and TRQ questions.

@lowjoel For programming question ( Or even for all type of questions) I think the explanation can be merged with the displaying of test cases ?  Because we probably wants to display them based on whether the student passed the test case or not. What do you think ?  