### PR TITLE
Implement discussion topic threading

### DIFF
--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -29,8 +29,7 @@ module Course::Discussion::PostsConcern
 
   # Render a new post in a separate page
   def reply
-    @reply_post = @discussion_topic.posts.build(title: t('course.discussion.posts.reply_title',
-                                                         title: @post.title))
+    @reply_post = @post.children.build
   end
 
   protected

--- a/app/controllers/course/forum/topics_controller.rb
+++ b/app/controllers/course/forum/topics_controller.rb
@@ -10,9 +10,8 @@ class Course::Forum::TopicsController < Course::Forum::ComponentController
   before_action :add_topic_breadcrumb
 
   def show
-    @posts = @topic.posts.ordered_by_created_at
     @topic.viewed_by(current_user)
-    @reply_post = @posts.last.children.build
+    @reply_post = @topic.posts.last.children.build
   end
 
   def new

--- a/app/controllers/course/forum/topics_controller.rb
+++ b/app/controllers/course/forum/topics_controller.rb
@@ -12,8 +12,7 @@ class Course::Forum::TopicsController < Course::Forum::ComponentController
   def show
     @posts = @topic.posts.ordered_by_created_at
     @topic.viewed_by(current_user)
-    @reply_post = @topic.posts.build(title: t('course.discussion.posts.reply_title',
-                                              title: @topic.title))
+    @reply_post = @posts.last.children.build
   end
 
   def new

--- a/app/models/concerns/course/discussion/post/ordering_concern.rb
+++ b/app/models/concerns/course/discussion/post/ordering_concern.rb
@@ -1,0 +1,44 @@
+module Course::Discussion::Post::OrderingConcern
+  extend ActiveSupport::Concern
+
+  # Sorts all posts in a collection in topographical order.
+  #
+  # By convention, each post is represented by an array. The first element is the post itself,
+  # the second is the children of the array.
+  class PostSort
+    include Enumerable
+    delegate :each, to: :@sorted
+
+    # Constructor.
+    #
+    # @param [Array<Course::Discussion::Post>] posts The posts to sort.
+    def initialize(posts)
+      @posts = posts
+      @sorted = sort(nil)
+    end
+
+    private
+
+    def sort(post)
+      children_posts = @posts.select { |child_post| child_post.parent == post }
+      children_posts.map do |child_post|
+        [child_post].push(sort(child_post))
+      end
+    end
+  end
+
+  module ScopeMethods
+    # Returns a set of recursive arrays indicating the parent-child relationships of posts.
+    #
+    # @return [Enumerable]
+    def ordered_topologically
+      PostSort.new(self)
+    end
+  end
+
+  included do
+    scope :ordered_topologically, (lambda do
+      ScopeMethods.instance_method(:ordered_topologically).bind(current_scope).call
+    end)
+  end
+end

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Discussion::Post < ActiveRecord::Base
+  include Course::Discussion::Post::OrderingConcern
+
   acts_as_forest order: :created_at
 
   after_initialize :set_topic, if: :new_record?

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -3,6 +3,9 @@ class Course::Discussion::Post < ActiveRecord::Base
   acts_as_forest order: :created_at
 
   after_initialize :set_topic, if: :new_record?
+  after_initialize :set_title, if: :new_record?
+  before_validation :set_title
+
   validate :parent_topic_consistency
 
   belongs_to :topic, inverse_of: :posts
@@ -13,6 +16,12 @@ class Course::Discussion::Post < ActiveRecord::Base
 
   def set_topic
     self.topic ||= parent.topic if parent
+  end
+
+  def set_title
+    return unless parent
+
+    self.title ||= self.class.human_attribute_name('title_reply_template', title: parent.title)
   end
 
   def parent_topic_consistency

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -7,6 +7,10 @@ class Course::Discussion::Topic < ActiveRecord::Base
 
   accepts_nested_attributes_for :posts
 
+  def to_partial_path
+    'course/discussion/topic'.freeze
+  end
+
   # Return if a user has subscribed to this topic
   #
   # @param [User] user The user to check

--- a/app/views/course/discussion/_posts.html.slim
+++ b/app/views/course/discussion/_posts.html.slim
@@ -1,0 +1,7 @@
+- post_locals ||= {}
+- posts.each do |post|
+  = render partial: post_partial, locals: post_locals.reverse_merge(post: post.first)
+  div.replies
+    = render partial: 'course/discussion/posts', locals: { posts: post.second,
+                                                           post_partial: post_partial,
+                                                           post_locals: post_locals }

--- a/app/views/course/discussion/_topic.html.slim
+++ b/app/views/course/discussion/_topic.html.slim
@@ -1,0 +1,4 @@
+- posts_locals = { posts: topic.posts.ordered_topologically }
+- posts_locals[:post_partial] = post_partial if defined?(post_partial)
+- posts_locals[:post_locals] = post_locals if defined?(post_locals)
+= render partial: 'course/discussion/posts', locals: posts_locals

--- a/app/views/course/forum/topics/show.html.slim
+++ b/app/views/course/forum/topics/show.html.slim
@@ -1,8 +1,9 @@
 = page_header format_inline_text(@topic.title) do
   = render 'controls'
 
-- @posts.each do |post|
-  = render partial: 'course/forum/posts/post', locals: { post: post, show_buttons: false }
+= render partial: @topic.topic, locals: { post_partial: 'course/forum/posts/post',
+                                          post_locals: { show_buttons: false } }
+
 hr
 
 h3 = t('.post_reply')

--- a/config/locales/en/activerecord/course/discussion/post.yml
+++ b/config/locales/en/activerecord/course/discussion/post.yml
@@ -1,0 +1,11 @@
+en:
+  activerecord:
+    attributes:
+      course/discussion/post:
+        title_reply_template: 'Re: %{title}'
+    errors:
+      models:
+        course/discussion/post:
+          attributes:
+            post:
+              topic_inconsistent: 'The post and its parent post reference a different topic.'

--- a/config/locales/en/activerecord/course/discussion/post_validator.yml
+++ b/config/locales/en/activerecord/course/discussion/post_validator.yml
@@ -1,8 +1,0 @@
-en:
-  activerecord:
-    errors:
-      models:
-        course/discussion/post:
-          attributes:
-            post:
-              topic_inconsistent: 'The topic is inconsistent with its parent post'

--- a/config/locales/en/course/discussion/posts.yml
+++ b/config/locales/en/course/discussion/posts.yml
@@ -2,7 +2,6 @@ en:
   course:
     discussion:
       posts:
-        reply_title: 'Re: %{title}'
         create:
           success: 'Post was created'
           failure: 'Fail to create post: %{error}'

--- a/spec/controllers/course/forum/forums_controller_spec.rb
+++ b/spec/controllers/course/forum/forums_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Course::Forum::ForumsController, type: :controller do
     describe '#show' do
       let(:forum) { create(:forum, course: course) }
       let!(:topic) { create(:forum_topic, forum: forum) }
-      let!(:first_topic_post) { create(:post, topic: topic.acting_as) }
-      let!(:second_topic_post) { create(:post, topic: topic.acting_as) }
+      let!(:first_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
+      let!(:second_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
 
       it 'preloads the latest post for each topics of the forum' do
         get :show, course_id: course, id: forum

--- a/spec/controllers/course/forum/posts_controller_spec.rb
+++ b/spec/controllers/course/forum/posts_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::Forum::PostsController, type: :controller do
     let(:forum) { create(:forum, course: course) }
     let(:topic) { create(:forum_topic, forum: forum) }
     let!(:post_stub) do
-      stub = build_stubbed(:post, topic: topic.acting_as)
+      stub = build_stubbed(:course_discussion_post, topic: topic.acting_as)
       allow(stub).to receive(:destroy).and_return(false)
       stub
     end

--- a/spec/factories/course_discussion_posts.rb
+++ b/spec/factories/course_discussion_posts.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 FactoryGirl.define do
-  factory :post, class: Course::Discussion::Post.name do
+  factory :course_discussion_post, class: Course::Discussion::Post.name do
     creator
     updater
     parent nil
-    association :topic, factory: :discussion_topic
+    association :topic, factory: :course_discussion_topic
     sequence(:title) { |n| "post #{n}" }
     text 'This is a test post'
   end

--- a/spec/factories/course_discussion_topic_subscriptions.rb
+++ b/spec/factories/course_discussion_topic_subscriptions.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 FactoryGirl.define do
-  factory :discussion_topic_subscription, class: Course::Discussion::Topic::Subscription.name do
-    association :topic, factory: :discussion_topic
+  factory :course_discussion_topic_subscription,
+          class: Course::Discussion::Topic::Subscription.name do
+    association :topic, factory: :course_discussion_topic
     user
   end
 end

--- a/spec/factories/course_discussion_topics.rb
+++ b/spec/factories/course_discussion_topics.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 FactoryGirl.define do
-  factory :discussion_topic, class: Course::Discussion::Topic.name do
+  factory :course_discussion_topic, class: Course::Discussion::Topic.name do
     association :actable, factory: :user
   end
 end

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -39,8 +39,9 @@ RSpec.feature 'Course: Forum: Post: Management' do
         end
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
-        expect(topic.reload.posts.last.title).to eq(I18n.t('course.discussion.posts.reply_title',
-                                                           title: topic.title))
+        expect(topic.reload.posts.last.title).to \
+          eq(I18n.t('activerecord.attributes.course/discussion/post.title_reply_template',
+                    title: topic.title))
         expect(topic.reload.posts.last.text).to eq('test')
         expect(topic.reload.subscriptions.where(user: user).count).to eq(1)
       end
@@ -106,8 +107,9 @@ RSpec.feature 'Course: Forum: Post: Management' do
         end
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
-        expect(topic.reload.posts.last.title).to eq(I18n.t('course.discussion.posts.reply_title',
-                                                           title: post.title))
+        expect(topic.reload.posts.last.title).to \
+          eq(I18n.t('activerecord.attributes.course/discussion/post.title_reply_template',
+                    title: post.title))
         expect(topic.reload.posts.last.text).to eq('test')
         expect(topic.reload.posts.last.parent).to eq(post)
       end

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Course: Forum: Post: Management' do
     context 'As a Course Manager' do
       let(:user) { create(:administrator) }
       scenario 'I can see posts' do
-        posts = create_list(:post, 2, topic: topic.acting_as)
+        posts = create_list(:course_discussion_post, 2, topic: topic.acting_as)
         visit course_forum_topic_path(course, forum, topic)
         posts.each do |post|
           expect(page).to have_content_tag_for(post)
@@ -72,7 +72,7 @@ RSpec.feature 'Course: Forum: Post: Management' do
       end
 
       scenario 'I can delete a topic' do
-        post = create(:post, topic: topic.acting_as)
+        post = create(:course_discussion_post, topic: topic.acting_as)
         visit course_forum_topic_path(course, forum, topic)
 
         find_link(nil, href: course_forum_topic_post_path(course, forum, topic, post)).click

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Course::Discussion::Topic, type: :model do
     describe '#subscribed_by?' do
       let(:another_user) { create(:user) }
       let!(:discussion_topic_subscription) do
-        create(:discussion_topic_subscription, topic: topic.acting_as, user: user)
+        create(:course_discussion_topic_subscription, topic: topic.acting_as, user: user)
       end
 
       context 'when the user has subscribed to a topic' do
@@ -33,7 +33,7 @@ RSpec.describe Course::Discussion::Topic, type: :model do
     describe '#ensure_subscribed_by' do
       context 'when the user has subscribed to a topic' do
         let!(:discussion_topic_subscription) do
-          create(:discussion_topic_subscription, topic: topic.acting_as, user: user)
+          create(:course_discussion_topic_subscription, topic: topic.acting_as, user: user)
         end
 
         it 'returns true' do
@@ -49,7 +49,7 @@ RSpec.describe Course::Discussion::Topic, type: :model do
 
       context 'when record already exists' do
         let!(:discussion_topic_subscription) do
-          create(:discussion_topic_subscription, topic: topic.acting_as, user: user)
+          create(:course_discussion_topic_subscription, topic: topic.acting_as, user: user)
         end
 
         before do

--- a/spec/models/course/forum/topic_spec.rb
+++ b/spec/models/course/forum/topic_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Course::Forum::Topic, type: :model do
 
     describe '.post_count' do
       let(:topic) { create(:forum_topic, forum: forum) }
-      let!(:topic_posts) { create_list(:post, 2, topic: topic.acting_as) }
+      let!(:topic_posts) { create_list(:course_discussion_post, 2, topic: topic.acting_as) }
 
       it 'preloads the correct post count' do
         expect(forum.topics.calculated(:post_count).first.post_count).to eq(topic_posts.size + 1)
@@ -84,8 +84,8 @@ RSpec.describe Course::Forum::Topic, type: :model do
 
     describe '.with_latest_post' do
       let(:topic) { create(:forum_topic, forum: forum) }
-      let!(:first_topic_post) { create(:post, topic: topic.acting_as) }
-      let!(:second_topic_post) { create(:post, topic: topic.acting_as) }
+      let!(:first_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
+      let!(:second_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
 
       it 'preloads the latest post' do
         expect(forum.topics.with_latest_post.first.posts.first).to eq(second_topic_post)
@@ -94,7 +94,7 @@ RSpec.describe Course::Forum::Topic, type: :model do
 
     describe '.with_topic_statistics' do
       let(:topic) { create(:forum_topic, forum: forum) }
-      let!(:topic_posts) { create_list(:post, 2, topic: topic.acting_as) }
+      let!(:topic_posts) { create_list(:course_discussion_post, 2, topic: topic.acting_as) }
       let!(:topic_views) { create_list(:forum_topic_view, 2, topic: topic) }
 
       it 'preloads the correct post and view count' do

--- a/spec/models/course/forum_spec.rb
+++ b/spec/models/course/forum_spec.rb
@@ -40,8 +40,12 @@ RSpec.describe Course::Forum, type: :model do
       let(:forum) { create(:forum, course: course) }
       let(:first_topic) { create(:forum_topic, forum: forum) }
       let(:second_topic) { create(:forum_topic, forum: forum) }
-      let!(:first_topic_posts) { create_list(:post, 2, topic: first_topic.acting_as) }
-      let!(:second_topic_posts) { create_list(:post, 1, topic: second_topic.acting_as) }
+      let!(:first_topic_posts) do
+        create_list(:course_discussion_post, 2, topic: first_topic.acting_as)
+      end
+      let!(:second_topic_posts) do
+        create_list(:course_discussion_post, 1, topic: second_topic.acting_as)
+      end
 
       it 'shows the correct count' do
         expect(course.forums.calculated(:topic_post_count).first.topic_post_count).
@@ -66,8 +70,12 @@ RSpec.describe Course::Forum, type: :model do
       let(:forum) { create(:forum, course: course) }
       let(:first_topic) { create(:forum_topic, forum: forum) }
       let(:second_topic) { create(:forum_topic, forum: forum) }
-      let!(:first_topic_posts) { create_list(:post, 1, topic: first_topic.acting_as) }
-      let!(:second_topic_posts) { create_list(:post, 2, topic: second_topic.acting_as) }
+      let!(:first_topic_posts) do
+        create_list(:course_discussion_post, 1, topic: first_topic.acting_as)
+      end
+      let!(:second_topic_posts) do
+        create_list(:course_discussion_post, 2, topic: second_topic.acting_as)
+      end
       let!(:first_topic_views) { create_list(:forum_topic_view, 2, topic: first_topic) }
       let!(:second_topic_views) { create_list(:forum_topic_view, 1, topic: second_topic) }
 


### PR DESCRIPTION
 - Move the "RE: title" prefix logic to the models
 - Implement (pseudo?) topological ordering on posts
 - Implement displaying the posts indented according to their replies. This is a simple implementation which does not collapse consecutive posts without forking, nor is there a limit on indenting.