### PR TITLE
Prevent invalid assessment state when there are no questions or answers.

### DIFF
--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -35,7 +35,7 @@ class Course::Assessment < ActiveRecord::Base
   #   @return [Fixnum]
   calculated :maximum_grade, (lambda do
     Course::Assessment::Question.unscope(:order).
-      select { sum(course_assessment_questions.maximum_grade) }.
+      select { coalesce(sum(course_assessment_questions.maximum_grade), 0) }.
       where { course_assessment_questions.assessment_id == course_assessments.id }
   end)
 

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -7,8 +7,11 @@ class Course::Assessment < ActiveRecord::Base
   acts_as_conditional
   has_one_folder
 
+  after_initialize :set_defaults, if: :new_record?
   before_validation :assign_folder_attributes
   before_validation :propagate_course
+
+  validate :draft_status
 
   enum display_mode: { worksheet: 0, guided: 1 }
 
@@ -70,5 +73,14 @@ class Course::Assessment < ActiveRecord::Base
   def assign_folder_attributes
     folder.assign_attributes(name: title, course: course, parent: tab.category.folder,
                              start_at: start_at)
+  end
+
+  def set_defaults
+    self.draft ||= true
+  end
+
+  def draft_status
+    return if draft
+    errors.add(:draft, :no_questions) unless questions.present?
   end
 end

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -49,7 +49,7 @@ class Course::Condition::Assessment < ActiveRecord::Base
   def graded_submissions_with_minimum_grade(user, minimum_grade)
     graded_submissions_by_user(user).joins { answers }.
       group { course_assessment_submissions.id }.
-      having { sum(answers.grade) >= minimum_grade }
+      having { coalesce(sum(answers.grade), 0) >= minimum_grade }
   end
 
   def validate_assessment_condition

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -8,7 +8,8 @@
   = f.input :start_at
   = f.input :end_at
   = f.input :bonus_end_at
-  = f.input :draft
+  - unless @assessment.new_record?
+    = f.input :draft
   = f.input :display_mode, as: :select, collection: Course::Assessment.display_modes.keys
   = f.folder
   = f.hidden_field :tab, value: @tab.id

--- a/config/locales/en/course/assessments.yml
+++ b/config/locales/en/course/assessments.yml
@@ -1,0 +1,7 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment:
+          no_questions: 'Assessment can exit draft mode only after adding questions'
+

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -182,12 +182,20 @@ RSpec.describe Course::Assessment do
     end
 
     describe '#maximum_grade' do
-      let(:assessment_traits) { [:with_all_question_types] }
+      context 'when it has questions' do
+        let(:assessment_traits) { [:with_all_question_types] }
 
-      it 'returns the maximum grade' do
-        maximum_grade = self.assessment.questions.map(&:maximum_grade).reduce(0, :+)
+        it 'returns the maximum grade' do
+          maximum_grade = self.assessment.questions.map(&:maximum_grade).reduce(0, :+)
 
-        expect(assessment.maximum_grade).to eq(maximum_grade)
+          expect(assessment.maximum_grade).to eq(maximum_grade)
+        end
+      end
+
+      context 'when it does not have any question' do
+        it 'returns 0' do
+          expect(assessment.maximum_grade).to eq(0)
+        end
       end
     end
 

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -17,6 +17,37 @@ RSpec.describe Course::Assessment do
     let(:assessment) { create(:assessment, *assessment_traits, course: course) }
     let(:assessment_traits) { [] }
 
+    describe 'validations' do
+      context 'when it is not a draft' do
+        context 'when it has no questions' do
+          subject { build(:assessment, draft: false) }
+
+          it 'adds a :no_questions error on :draft' do
+            expect(subject.valid?).to be(false)
+            expect(subject.errors[:draft]).to include(I18n.t('activerecord.errors.models.' \
+            'course/assessment.no_questions'))
+          end
+        end
+
+        context 'when it has questions' do
+          subject { build(:assessment, :with_all_question_types, draft: true) }
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'when it is a draft' do
+        context 'when it has no questions' do
+          subject { build(:assessment, draft: true) }
+          it { is_expected.to be_valid }
+        end
+
+        context 'when it has questions' do
+          subject { build(:assessment, :with_all_question_types, draft: true) }
+          it { is_expected.to be_valid }
+        end
+      end
+    end
+
     describe 'callbacks' do
       describe 'after assessment was initialized' do
         subject { build(:assessment) }

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -122,6 +122,12 @@ RSpec.describe Course::Condition::Assessment, type: :model do
                               user: course_user.user)
         end
 
+        context 'when there is no answer' do
+          it 'return false' do
+            expect(subject.satisfied_by?(course_user)).to be_falsey
+          end
+        end
+
         context 'when all graded submissions are below the minimum grade percentage' do
           it 'returns false' do
             answers = assessment.questions.attempt(submission)


### PR DESCRIPTION
1) Assessment now return 0 max grade where there is no question
2) Condition::Assessment.satisfied_by? now do not throw error when there are no answers
3) Set assessment.draft to be true by default
4) Disable the checkbox for draft when no questions were added