### PR TITLE
Add achievement#show page and refactor achievement views

### DIFF
--- a/app/assets/stylesheets/course/achievement.scss
+++ b/app/assets/stylesheets/course/achievement.scss
@@ -20,4 +20,10 @@
       background-color: $course-achievement-locked-bg;
     }
   }
+
+  &.show {
+    .course-user-achievement {
+      text-align: center;
+    }
+  }
 }

--- a/app/controllers/course/achievements_controller.rb
+++ b/app/controllers/course/achievements_controller.rb
@@ -7,6 +7,9 @@ class Course::AchievementsController < Course::ComponentController
     @achievements = @achievements.includes(:conditions)
   end
 
+  def show #:nodoc:
+  end
+
   def new #:nodoc:
   end
 

--- a/app/views/course/achievements/_achievement.html.slim
+++ b/app/views/course/achievements/_achievement.html.slim
@@ -10,7 +10,7 @@
 
   th
     = link_to format_inline_text(achievement.title),
-              course_achievement_path(current_course, achievement)
+      course_achievement_path(current_course, achievement)
     - if achievement.draft?
       small title=achievement
         =< fa_icon(:'eye-slash')
@@ -19,7 +19,8 @@
     div.description
       = format_html(achievement.description)
 
-  td = achievement.specific_conditions.map(&:title).to_sentence
+  - if include_requirements
+    td = achievement.specific_conditions.map(&:title).to_sentence
 
   td
     div.btn-group

--- a/app/views/course/achievements/_achievements.html.slim
+++ b/app/views/course/achievements/_achievements.html.slim
@@ -1,0 +1,12 @@
+table.table.achievement-list.table-hover
+  thead
+    tr
+      th = t('.badge')
+      th = t('.title')
+      th = t('.description')
+      th = t('.requirements') if include_requirements
+      th
+  tbody
+    = render partial: 'achievement',
+             collection: achievements,
+             locals: { include_requirements: include_requirements }

--- a/app/views/course/achievements/index.html.slim
+++ b/app/views/course/achievements/index.html.slim
@@ -1,12 +1,5 @@
 = page_header do
   = new_button([current_course, :achievement]) if can?(:create, Course::Achievement.new(course: current_course))
-table.table.achievement-list.table-hover
-  thead
-    tr
-      th = t('.badge')
-      th = t('.title')
-      th = t('.description')
-      th = t('.requirements')
-      th
-  tbody
-    = render @achievements
+
+= render partial: 'achievements',
+         locals: { include_requirements: true, achievements: @achievements }

--- a/app/views/course/achievements/show.html.slim
+++ b/app/views/course/achievements/show.html.slim
@@ -1,0 +1,5 @@
+- add_breadcrumb format_inline_text(@achievement.title)
+= page_header format_inline_text(@achievement.title)
+
+= render partial: 'achievements',
+         locals: { include_requirements: false, achievements: [@achievement] }

--- a/app/views/course/achievements/show.html.slim
+++ b/app/views/course/achievements/show.html.slim
@@ -3,3 +3,13 @@
 
 = render partial: 'achievements',
          locals: { include_requirements: false, achievements: [@achievement] }
+
+div.user-achievements
+  h2 = t('.users_with_achievement')
+  div.row
+    - @achievement.course_users.includes(:user).each do |course_user|
+      div.col-xs-4.col-sm-3.col-md-2.col-lg-1
+        = div_for(course_user, class: ['course-user-achievement']) do
+          = link_to_course_user(course_user) do
+            = display_user_image(course_user.user)
+            = display_course_user(course_user)

--- a/config/locales/en/course/achievements.yml
+++ b/config/locales/en/course/achievements.yml
@@ -3,11 +3,7 @@ en:
     achievements:
       sidebar_title: :'course.achievements.index.header'
       index:
-        title: 'Title'
         header: 'Achievements'
-        description: 'Description'
-        requirements: 'Requirements'
-        badge: 'Badge'
       new:
         header: 'New Achievement'
       create:
@@ -20,4 +16,9 @@ en:
         success: 'Achievement %{title} was deleted.'
         failure: 'Failed to delete achievement: %{error}'
       form:
-        badge: :'course.achievements.index.badge'
+        badge: :'course.achievements.achievements.badge'
+      achievements:
+        badge: 'Badge'
+        title: 'Title'
+        description: 'Description'
+        requirements: 'Requirements'

--- a/config/locales/en/course/achievements.yml
+++ b/config/locales/en/course/achievements.yml
@@ -4,6 +4,8 @@ en:
       sidebar_title: :'course.achievements.index.header'
       index:
         header: 'Achievements'
+      show:
+        users_with_achievement: 'Students with this Achievement'
       new:
         header: 'New Achievement'
       create:

--- a/spec/features/course/achievement_listing_spec.rb
+++ b/spec/features/course/achievement_listing_spec.rb
@@ -31,10 +31,12 @@ RSpec.feature 'Course: Achievements' do
     end
 
     context 'As an Course Student' do
-      let!(:course_student) { create(:course_student, :approved, course: course) }
-      let!(:user) { course_student.user }
+      let!(:course_student1) { create(:course_student, :approved, course: course) }
+      let!(:course_student2) { create(:course_student, :approved, course: course) }
+      let!(:user) { course_student1.user }
       before do
-        create(:course_user_achievement, course_user: course_student, achievement: achievement1)
+        create(:course_user_achievement, course_user: course_student1, achievement: achievement1)
+        create(:course_user_achievement, course_user: course_student2, achievement: achievement2)
       end
 
       scenario 'I can view all published achievements and whether I have obtained them' do
@@ -57,6 +59,16 @@ RSpec.feature 'Course: Achievements' do
         visit course_path(course)
 
         expect(page).to have_selector('li', text: 'course.achievements.sidebar_title')
+      end
+
+      scenario 'I can view all users who have obtained an achievement' do
+        visit course_achievement_path(course, achievement1)
+        expect(page).to have_content_tag_for(course_student1)
+        expect(page).not_to have_content_tag_for(course_student2)
+
+        visit course_achievement_path(course, achievement2)
+        expect(page).to have_content_tag_for(course_student2)
+        expect(page).not_to have_content_tag_for(course_student1)
       end
     end
   end


### PR DESCRIPTION
This PR breaks up certain achievement views into partials, as there will be re-use of certain views in the manual award of achievements. Also, it implements achievement#show, which shows all the `course_users` who have obtained this particular achievement. 

Next step would be to define the abilities and controller actions for the manual award achievements.