### PR TITLE
Add `image_optim` to the list of gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,9 @@ end
 group :production do
   # Puma will be our app server
   gem 'puma'
+
+  # Compress image assets
+  gem 'image_optim'
 end
 
 # Multitenancy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
       activerecord (>= 4.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
+    exifr (1.2.4)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.6.0)
@@ -179,6 +180,7 @@ GEM
       railties (>= 3.2, < 5.1)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
+    fspath (2.1.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.3)
@@ -203,6 +205,14 @@ GEM
       parser (>= 2.2.3.0)
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
+    image_optim (0.22.1)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 2.1)
+      image_size (~> 1.3)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+    image_size (1.4.2)
+    in_threads (1.3.1)
     its-it (1.2.1)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
@@ -277,6 +287,7 @@ GEM
       websocket-driver (>= 0.2.0)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
+    progress (3.1.1)
     puma (2.16.0)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -536,6 +547,7 @@ DEPENDENCIES
   html-pipeline-rouge_filter
   http_accept_language
   i18n-tasks
+  image_optim
   jbuilder
   jquery-cdn
   jquery-rails


### PR DESCRIPTION
This compresses all image assets when running a `rake assets:precompile`.

@fonglh You'd need these binaries for deploy: https://github.com/toy/image_optim

I'm not entirely sure if this is good though. Does anyone want to benchmark?