### PR TITLE
Refactor & add more specs to assessment 

### DIFF
--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -4,5 +4,5 @@
   = base_answer_form.button :button, t('.reattempt'), value: answer.question.id, name: 'attempting_question_id'
 - elsif !guided_current_question.last_question?
   = link_to t('.continue'),
-    edit_course_assessment_submission_path(current_course, @assessment, @submission, step: current_step + 1),
+    edit_course_assessment_submission_path(current_course, @assessment, @submission, step: guided_current_step + 1),
     class: ['btn', 'btn-success']

--- a/spec/factories/course_assessment_questions.rb
+++ b/spec/factories/course_assessment_questions.rb
@@ -2,7 +2,7 @@
 FactoryGirl.define do
   factory :course_assessment_question, class: Course::Assessment::Question do
     assessment
-    title 'This awesome question'
+    sequence(:title) { |n| "The awesome question #{n}" }
     description 'Look at this awesome question'
     maximum_grade 2
     sequence(:weight)

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -55,15 +55,6 @@ RSpec.describe 'Course: Assessments: Attempt' do
         end
       end
 
-      scenario 'I can save submissions' do
-        submission
-        visit edit_course_assessment_submission_path(course, assessment, submission)
-
-        click_button I18n.t('common.save')
-        expect(current_path).to eq(\
-          edit_course_assessment_submission_path(course, assessment, submission))
-      end
-
       scenario 'I can continue my attempt' do
         submission
         visit course_assessments_path(course)
@@ -71,16 +62,6 @@ RSpec.describe 'Course: Assessments: Attempt' do
         submission_path = edit_course_assessment_submission_path(course, assessment, submission)
         expect(page).to have_link(I18n.t('course.assessment.assessments.assessment.attempt'),
                                   href: submission_path)
-      end
-
-      scenario 'I can finalise my attempt' do
-        submission
-        visit edit_course_assessment_submission_path(course, assessment, submission)
-
-        click_button I18n.t('course.assessment.submission.submissions.worksheet.finalise')
-        expect(current_path).to eq(\
-          edit_course_assessment_submission_path(course, assessment, submission))
-        expect(submission.reload.submitted?).to be(true)
       end
 
       scenario 'I can view my submission grade' do
@@ -95,19 +76,6 @@ RSpec.describe 'Course: Assessments: Attempt' do
           within find(content_tag_selector(answer)) do
             expect(page).to have_selector('.submission_answers_grade')
           end
-        end
-      end
-
-      scenario 'I can attempt a guided assessment' do
-        assessment = create(:assessment, :with_all_question_types, :guided, course: course)
-        submission = create(:course_assessment_submission, assessment: assessment, user: student)
-        visit edit_course_assessment_submission_path(course, assessment, submission)
-
-        expect(page).to have_selector('h1', text: assessment.title)
-        1..assessment.questions.length do |step|
-          path = edit_course_assessment_submission_path(course, assessment, submission,
-                                                        step: step)
-          expect(page).to have_link(step, href: path)
         end
       end
     end

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:assessment, :guided, :with_all_question_types, course: course) }
+    let(:assessment) { create(:assessment, :guided, course: course) }
+    let(:mcq_questions) do
+      create_list(:course_assessment_question_multiple_response, 2, assessment: assessment)
+    end
     before { login_as(user, scope: :user) }
 
     let(:student) { create(:course_user, :approved, course: course).user }
@@ -17,7 +20,24 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
     context 'As a Course Student' do
       let(:user) { student }
 
+      scenario 'I can save my submission' do
+        mcq_questions
+
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        option = assessment.questions.first.actable.options.first.option
+        check option
+        click_button I18n.t('common.save')
+
+        expect(page).to have_selector('div.alert-success',
+                                      text: 'course.assessment.submission.submissions.update.'\
+                                            'success')
+        expect(page).to have_checked_field(option)
+      end
+
       scenario 'I can navigate between questions' do
+        mcq_questions
+
         # Add a correct answer to the first question
         answer = assessment.questions.first.attempt(submission)
         answer.correct = true
@@ -25,47 +45,45 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
-        1..assessment.questions.length do |step|
-          path = edit_course_assessment_submission_path(course, assessment, submission,
-                                                        step: step)
+        (1..assessment.questions.length).each do |step|
+          path = edit_course_assessment_submission_path(course, assessment, submission, step: step)
           expect(page).to have_link(step, href: path)
         end
+        expect(page).to have_selector('h2', assessment.questions.first.title)
 
-        # TODO: Add more asserts once questions are displayed in guided assessment.
+        click_link '2'
+        expect(page).to have_selector('h2', assessment.questions.second.title)
       end
 
-      scenario 'I can submit an answer for auto grading' do
-        assessment = create(:assessment, :with_mcq_question, :guided, course: course)
-        submission = create(:course_assessment_submission, assessment: assessment, user: student)
+      scenario 'I can continue to the next question when current answer is correct' do
+        mcq_questions
+
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        check 'true'
-        click_button I18n.t('common.save')
-        expect(page).to have_selector('div.alert-success',
-                                      text: 'course.assessment.submission.submissions.update.'\
-                                            'success')
+        correct_option = mcq_questions.first.options.correct.first.option
+        check correct_option
 
         click_button I18n.t('common.submit')
         wait_for_job
-
         expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grading')
         expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grade')
+
+        click_link I18n.t('course.assessment.answer.guided.continue')
+        expect(page).to have_selector('h2', mcq_questions.second.title)
       end
 
-      scenario 'I can submit an answer for auto grading' do
-        assessment = create(:assessment, :with_mcq_question, :guided, course: course)
-        submission = create(:course_assessment_submission, assessment: assessment, user: student)
-        # Create an incorrect answer
-        create(:course_assessment_answer_multiple_response, :graded,
-               correct: false, question: assessment.questions.first, submission: submission)
+      scenario 'I can reattempt the question when current answer is not correct' do
+        mcq_questions
 
         visit edit_course_assessment_submission_path(assessment.course, assessment, submission)
 
-        expect(page).not_to have_button(I18n.t('common.save'))
-        expect(page).not_to have_button(I18n.t('common.submit'))
+        wrong_option = mcq_questions.first.options.where(correct: false).first.option
+        check wrong_option
+        click_button I18n.t('common.submit')
+        wait_for_job
 
         click_button I18n.t('course.assessment.answer.guided.reattempt')
-        expect(page).to have_button(I18n.t('common.save'))
-        expect(page).to have_button(I18n.t('common.submit'))
+        expect(page).to have_selector('h2', mcq_questions.first.title)
+        expect(page).not_to have_checked_field(wrong_option)
       end
     end
   end

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:assessment, :with_mcq_question, course: course) }
+    let(:assessment) { create(:assessment, :worksheet, :with_mcq_question, course: course) }
     before { login_as(user, scope: :user) }
 
     let(:student) { create(:course_user, :approved, course: course).user }
@@ -16,6 +16,29 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
 
     context 'As a Course Student' do
       let(:user) { student }
+
+      scenario 'I can save my submission' do
+        submission
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        option = assessment.questions.first.actable.options.first.option
+        check option
+        click_button I18n.t('common.save')
+
+        expect(current_path).to eq(\
+          edit_course_assessment_submission_path(course, assessment, submission))
+        expect(page).to have_checked_field(option)
+      end
+
+      scenario 'I can finalise my submission' do
+        submission
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        click_button I18n.t('course.assessment.submission.submissions.worksheet.finalise')
+        expect(current_path).to eq(\
+          edit_course_assessment_submission_path(course, assessment, submission))
+        expect(submission.reload).to be_submitted
+      end
 
       scenario 'I can comment on answers' do
         visit edit_course_assessment_submission_path(course, assessment, submission)


### PR DESCRIPTION
- Specs which test the common behaviour of guided and worksheet remain in `spec/features/course/assessment/assessment_attempt_spec.rb`.

- Submission type specific specs are moved to their own files.

- Refactor and add more specs to test guided submission, think it's more cleaner now.
