### PR TITLE
Move image_optim to the assets bundle group.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,12 +129,16 @@ group :ci do
   gem 'codeclimate-test-reporter'
 end
 
+# This is used only when producing Production assets. Deals with things like minifying JavaScript
+# source files/image assets.
+group :assets do
+  # Compress image assets
+  gem 'image_optim'
+end
+
 group :production do
   # Puma will be our app server
   gem 'puma'
-
-  # Compress image assets
-  gem 'image_optim'
 end
 
 # Multitenancy


### PR DESCRIPTION
This is so that production builds do not need all the optimisation tools installed on the machine.

To use this: RAILS_GROUPS=assets when precompiling assets.

@fonglh can you check that it works as advertised? Because if it does not use the assets group it just means the image assets won't be squished.