### PR TITLE
Improve discussion post ordering logic

### DIFF
--- a/app/models/concerns/course/discussion/post/ordering_concern.rb
+++ b/app/models/concerns/course/discussion/post/ordering_concern.rb
@@ -19,10 +19,10 @@ module Course::Discussion::Post::OrderingConcern
 
     private
 
-    def sort(post)
-      children_posts = @posts.select { |child_post| child_post.parent == post }
+    def sort(post_id)
+      children_posts = @posts.select { |child_post| child_post.parent_id == post_id }
       children_posts.map do |child_post|
-        [child_post].push(sort(child_post))
+        [child_post].push(sort(child_post.id))
       end
     end
   end

--- a/app/models/concerns/course/discussion/post/ordering_concern.rb
+++ b/app/models/concerns/course/discussion/post/ordering_concern.rb
@@ -1,7 +1,7 @@
 module Course::Discussion::Post::OrderingConcern
   extend ActiveSupport::Concern
 
-  # Sorts all posts in a collection in topographical order.
+  # Sorts all posts in a collection in topological order.
   #
   # By convention, each post is represented by an array. The first element is the post itself,
   # the second is the children of the array.

--- a/app/models/concerns/course/discussion/post/ordering_concern.rb
+++ b/app/models/concerns/course/discussion/post/ordering_concern.rb
@@ -17,6 +17,18 @@ module Course::Discussion::Post::OrderingConcern
       @sorted = sort(nil)
     end
 
+    # Retrieves the last post topologically -- the last post at every branch.
+    #
+    # @return [Course::Discussion::Post] The last post topologically.
+    # @return [nil] When there are no posts.
+    def last
+      current_thread = @sorted.last
+      return nil unless current_thread
+
+      current_thread = current_thread.second.last until current_thread.second.empty?
+      current_thread.first
+    end
+
     private
 
     def sort(post_id)

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -12,7 +12,9 @@ class Course::Discussion::Post < ActiveRecord::Base
 
   belongs_to :topic, inverse_of: :posts
 
-  scope :ordered_by_created_at, -> { order(created_at: :asc).includes(:creator).to_a }
+  default_scope { ordered_by_created_at.with_creator }
+  scope :ordered_by_created_at, -> { order(created_at: :asc) }
+  scope :with_creator, -> { includes(:creator) }
 
   private
 

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -34,9 +34,11 @@ class Course::Forum::Topic < ActiveRecord::Base
   # @!method self.with_latest_post
   #   Augments all returned records with the latest post.
   scope :with_latest_post, (lambda do
+    topic_ids = pluck('course_discussion_topics.id')
     ids = Course::Discussion::Post.unscope(:order).
-          select { max(id) }.group { course_discussion_posts.topic_id }
-    last_posts = Course::Discussion::Post.where(id: ids).includes(:creator)
+          select { max(id) }.group { course_discussion_posts.topic_id }.
+          where { topic_id.in(topic_ids) }
+    last_posts = Course::Discussion::Post.with_creator.where(id: ids)
 
     all.tap do |result|
       preloader = ActiveRecord::Associations::Preloader::ManualPreloader.new

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -34,7 +34,8 @@ class Course::Forum::Topic < ActiveRecord::Base
   # @!method self.with_latest_post
   #   Augments all returned records with the latest post.
   scope :with_latest_post, (lambda do
-    ids = Course::Discussion::Post.select { max(id) }.group { course_discussion_posts.topic_id }
+    ids = Course::Discussion::Post.unscope(:order).
+          select { max(id) }.group { course_discussion_posts.topic_id }
     last_posts = Course::Discussion::Post.where(id: ids).includes(:creator)
 
     all.tap do |result|

--- a/spec/models/course/discussion/post_spec.rb
+++ b/spec/models/course/discussion/post_spec.rb
@@ -44,6 +44,20 @@ RSpec.describe Course::Discussion::Post, type: :model do
                                                    [graph[:b], []]]],
                                                  [graph[:c], []])
       end
+
+      describe '#last' do
+        it 'returns the last post topologically' do
+          expect(subject.last).to eq(graph[:c])
+        end
+
+        context 'when there are no posts' do
+          subject { topic.posts.ordered_topologically }
+
+          it 'returns nil' do
+            expect(subject.last).to be_nil
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/course/discussion/post_spec.rb
+++ b/spec/models/course/discussion/post_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Course::Discussion::Post, type: :model do
       end
     end
 
-    describe '.tsort' do
+    describe '.ordered_topologically' do
       let(:topic) { create(:course_discussion_topic) }
       let(:graph) do
         # root -> a -> b
@@ -31,11 +31,11 @@ RSpec.describe Course::Discussion::Post, type: :model do
         b = create(:course_discussion_post, parent: a, topic: topic)
         c = create(:course_discussion_post, parent: root, topic: topic)
 
-        { root: root, a: a, b: b, c: c } # Already in topographical order.
+        { root: root, a: a, b: b, c: c } # Already in topological order.
       end
       subject { graph[:root].topic.posts.ordered_topologically }
 
-      it 'sorts the posts topographically' do
+      it 'sorts the posts topologically' do
         root_post = subject.to_a.first
         expect(root_post.first).to eq(graph[:root])
 

--- a/spec/models/course/discussion/post_spec.rb
+++ b/spec/models/course/discussion/post_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe Course::Discussion::Post, type: :model do
 
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
+    describe '.all' do
+      let(:topic) { create(:course_discussion_topic) }
+      let(:posts) do
+        (1..3).map do |i|
+          create(:course_discussion_post, topic: topic, created_at: Time.zone.now + i.seconds)
+        end
+      end
+
+      it 'is sorted by ascending date' do
+        created_times = posts.map(&:created_at)
+        expect(created_times.each_cons(2).all? { |current, following| current <= following })
+      end
+    end
+
     describe '.tsort' do
       let(:topic) { create(:course_discussion_topic) }
       let(:graph) do


### PR DESCRIPTION
 - Ensure that posts are minimally sorted by date
 - Ensure all posts can be loaded within one query when doing topological sorting
 - Implement retrieving the topologically last post. This is useful for deciding a default post to reply to.