### PR TITLE
Normalise discussion reply behaviour

### DIFF
--- a/app/controllers/course/forum/posts_controller.rb
+++ b/app/controllers/course/forum/posts_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-class Course::Forum::PostsController < Course::Forum::Controller
+class Course::Forum::PostsController < Course::Forum::ComponentController
   before_action :load_topic
   authorize_resource :topic
+  before_action :add_topic_breadcrumb
 
   include Course::Discussion::PostsConcern
 
@@ -54,5 +55,9 @@ class Course::Forum::PostsController < Course::Forum::Controller
 
   def load_topic
     @topic ||= @forum.topics.friendly.find(topic_id_param)
+  end
+
+  def add_topic_breadcrumb
+    add_breadcrumb @topic.title, course_forum_topic_path(current_course, @forum, @topic)
   end
 end

--- a/app/controllers/course/forum/topics_controller.rb
+++ b/app/controllers/course/forum/topics_controller.rb
@@ -11,7 +11,7 @@ class Course::Forum::TopicsController < Course::Forum::ComponentController
 
   def show
     @topic.viewed_by(current_user)
-    @reply_post = @topic.posts.last.children.build
+    @reply_post = @topic.posts.build
   end
 
   def new

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -11,8 +11,7 @@ module Course::Assessment::Submission::SubmissionsHelper
     new_post = topic.posts.find(&:new_record?)
     return new_post if new_post
 
-    parent_collection = topic.posts.last ? topic.posts.last.children : topic.posts
-    parent_collection.build
+    topic.posts.build
   end
 
   # Return the CSS class of the explanation based on the correctness of the answer.

--- a/app/models/concerns/course/discussion/topic/posts_concern.rb
+++ b/app/models/concerns/course/discussion/topic/posts_concern.rb
@@ -1,4 +1,13 @@
 module Course::Discussion::Topic::PostsConcern
+  # Builds a new post in this topic.
+  #
+  # This defaults to set the new post to be a child of the latest post, ordered topologically.
+  def build(attributes = {}, &block)
+    attributes[:parent] ||= ordered_topologically.last unless attributes.key?(:parent_id)
+
+    super
+  end
+
   # Reloads the association.
   def reload
     remove_instance_variable(:@ordered_topologically) if defined?(@ordered_topologically)

--- a/app/models/concerns/course/discussion/topic/posts_concern.rb
+++ b/app/models/concerns/course/discussion/topic/posts_concern.rb
@@ -1,0 +1,14 @@
+module Course::Discussion::Topic::PostsConcern
+  # Reloads the association.
+  def reload
+    remove_instance_variable(:@ordered_topologically) if defined?(@ordered_topologically)
+    super
+  end
+
+  # Retrieves the topological ordering of the posts associated with this topic.
+  #
+  # Call +reload+ to reset the ordering.
+  def ordered_topologically
+    @ordered_topologically ||= super
+  end
+end

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -2,7 +2,9 @@
 class Course::Discussion::Topic < ActiveRecord::Base
   actable
 
-  has_many :posts, dependent: :destroy, inverse_of: :topic
+  has_many :posts, dependent: :destroy, inverse_of: :topic do
+    include Course::Discussion::Topic::PostsConcern
+  end
   has_many :subscriptions, dependent: :destroy, inverse_of: :topic
 
   accepts_nested_attributes_for :posts

--- a/app/views/course/forum/posts/_form.html.slim
+++ b/app/views/course/forum/posts/_form.html.slim
@@ -3,4 +3,6 @@
   = f.input :title
   = f.input :text
 
+  = f.hidden_field :parent_id
+
   = f.button :submit

--- a/app/views/course/forum/posts/_reply_form.html.slim
+++ b/app/views/course/forum/posts/_reply_form.html.slim
@@ -1,8 +1,0 @@
-= simple_form_for @reply_post, url: course_forum_topic_posts_path(current_course, @forum, @topic) do |f|
-  = f.error_notification
-  = f.input :title
-  = f.input :text
-
-  = f.hidden_field :parent_id, value: @post.id
-
-  = f.button :submit

--- a/app/views/course/forum/posts/edit.html.slim
+++ b/app/views/course/forum/posts/edit.html.slim
@@ -1,3 +1,5 @@
 = page_header
 
-= render 'form', url: course_forum_topic_post_path(current_course, @forum, @topic, @post), post: @post
+= render partial: 'form',
+         locals: { url: course_forum_topic_post_path(current_course, @forum, @topic, @post),
+                   post: @post }

--- a/app/views/course/forum/posts/edit.html.slim
+++ b/app/views/course/forum/posts/edit.html.slim
@@ -1,4 +1,5 @@
-= page_header
+- add_breadcrumb(@post.title)
+= page_header(@post.title)
 
 = render partial: 'form',
          locals: { url: course_forum_topic_post_path(current_course, @forum, @topic, @post),

--- a/app/views/course/forum/posts/reply.html.slim
+++ b/app/views/course/forum/posts/reply.html.slim
@@ -4,4 +4,6 @@
 hr
 
 h3 = t('.reply')
-= render partial: 'reply_form'
+= render partial: 'form',
+         locals: { post: @reply_post,
+                   url: course_forum_topic_posts_path(current_course, @forum, @topic) }

--- a/app/views/course/forum/topics/show.html.slim
+++ b/app/views/course/forum/topics/show.html.slim
@@ -8,4 +8,5 @@ hr
 
 h3 = t('.post_reply')
 = render partial: 'course/forum/posts/form',
-         locals: { url: course_forum_topic_posts_path(current_course, @forum, @topic), post: @reply_post }
+         locals: { post: @reply_post,
+                   url: course_forum_topic_posts_path(current_course, @forum, @topic), }

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -41,21 +41,30 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
       end
 
       scenario 'I can comment on answers' do
+        assessment.questions.attempt(submission).each(&:save!)
+        comment_answer = submission.answers.first
+        comment_topic = comment_answer.discussion_topic
+        create_list(:course_discussion_post, 2, topic: comment_topic)
+        comment_parent_post = comment_topic.posts.ordered_topologically.last
+
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
         comment_post_text = 'test comment'
-        within find(content_tag_selector(submission.answers.first)) do
+        within find(content_tag_selector(comment_answer)) do
           find(:css, 'textarea.comment').set(comment_post_text)
         end
 
         click_button 'save'
 
-        comment_post = submission.answers.first.discussion_topic.posts.first
+        comment_post = comment_topic.posts.reload.last
         expect(comment_post.text).to eq(comment_post_text)
+        expect(comment_post.parent).to eq(comment_parent_post)
 
         submission.answers.each do |answer|
           within find(content_tag_selector(answer)) do
-            expect(page).to have_content_tag_for(comment_post)
+            answer.discussion_topic.posts.each do |post|
+              expect(page).to have_content_tag_for(post)
+            end
           end
         end
       end

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -82,7 +82,8 @@ RSpec.feature 'Course: Forum: Post: Management' do
       end
 
       scenario 'I can reply to a post' do
-        post = topic.posts.last
+        create_list(:course_discussion_post, 2, topic: topic.topic)
+        post = topic.posts.reload.sample
 
         visit course_forum_topic_path(course, forum, topic)
 
@@ -112,6 +113,22 @@ RSpec.feature 'Course: Forum: Post: Management' do
                     title: post.title))
         expect(topic.reload.posts.last.text).to eq('test')
         expect(topic.reload.posts.last.parent).to eq(post)
+      end
+
+      scenario 'I can reply to a topic' do
+        create_list(:course_discussion_post, 2, topic: topic.topic)
+        parent_post = topic.posts.reload.ordered_topologically.last
+        expect(parent_post).not_to be_nil
+        visit course_forum_topic_path(course, forum, topic)
+
+        post_content = 'test post content'
+        fill_in 'text', with: post_content
+        click_button 'submit'
+
+        new_post = topic.posts.reload.last
+        expect(new_post.text).to eq(post_content)
+        expect(new_post.parent).to eq(parent_post)
+        expect(page).to have_content_tag_for(new_post)
       end
     end
   end

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -11,6 +11,28 @@ RSpec.describe Course::Discussion::Topic, type: :model do
     let(:user) { create(:user) }
     let(:topic) { create(:forum_topic) }
 
+    describe '#posts' do
+      describe '#reload' do
+        it 'removes its memoised result' do
+          posts = topic.posts.ordered_topologically
+          topic.posts.reload
+          expect(topic.posts.ordered_topologically).not_to be(posts)
+        end
+
+        context 'before the posts are ordered' do
+          it 'can be reloaded' do
+            topic.posts.reload
+          end
+        end
+      end
+
+      describe '#ordered_topologically' do
+        it 'memoises its result' do
+          expect(topic.posts.ordered_topologically).to be(topic.posts.ordered_topologically)
+        end
+      end
+    end
+
     describe '#subscribed_by?' do
       let(:another_user) { create(:user) }
       let!(:discussion_topic_subscription) do


### PR DESCRIPTION
Replying to a topic now defaults to replying to the last post in the topological ordering. This is applied to forum posts and answer comments. Annotation comments will be handled in the next PR.

This makes the reply behaviour similar to replying to a linear conversation when no other post is explicitly being replied to.

Addresses #870.