### PR TITLE
Move the `display: none` declaration to the toolbar element.

### DIFF
--- a/app/assets/stylesheets/course/assessment/submission/answer/_discussion_post.scss
+++ b/app/assets/stylesheets/course/assessment/submission/answer/_discussion_post.scss
@@ -17,11 +17,6 @@
       color: $text-muted;
       font-size: $font-size-small;
     }
-
-    .toolbar {
-      // Hide the toolbars by default, they need script to function.
-      display: none;
-    }
   }
 
   .replies {

--- a/app/views/course/assessment/answer/_comment.html.slim
+++ b/app/views/course/assessment/answer/_comment.html.slim
@@ -1,5 +1,6 @@
 = div_for(comment, 'data-post-id' => comment.id) do
-  div.toolbar.pull-right
+  / Hide toolbar; only JavaScript-enabled clients will show this div.
+  div.toolbar.pull-right style='display: none'
     - if can?(:destroy, comment)
       = link_to('#', class: ['delete']) do
         = fa_icon 'trash'.freeze

--- a/app/views/course/assessment/answer/programming/_annotation_post.html.slim
+++ b/app/views/course/assessment/answer/programming/_annotation_post.html.slim
@@ -1,5 +1,6 @@
 = div_for(annotation_post, 'data-post-id' => annotation_post.id) do
-  div.toolbar.pull-right
+  / Hide toolbar; only JavaScript-enabled clients will show this div.
+  div.toolbar.pull-right style='display: none'
     => link_to('#', class: ['reply']) do
       = fa_icon 'reply'.freeze
     - if can?(:destroy, annotation_post)


### PR DESCRIPTION
This guarantees that the element is hidden on non-JavaScript browsers, and that it is shown in JavaScript-enabled browsers.

If this is not done, it is possible that the CSS loads after the script, and $.show will not set a `display: block` on the toolbar div. When the CSS does load, the toolbar will be hidden.