### PR TITLE
Implement leaderboard controller and settings

### DIFF
--- a/app/controllers/components/course/leaderboard_component.rb
+++ b/app/controllers/components/course/leaderboard_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class Course::LeaderboardComponent < SimpleDelegator
+  include Course::ControllerComponentHost::Component
+
+  def sidebar_items
+    main_sidebar_items + settings_sidebar_items
+  end
+
+  def settings
+    @settings ||= Course::LeaderboardSettings.new(current_course.settings(:leaderboard))
+  end
+
+  private
+
+  def main_sidebar_items
+    [
+      {
+        key: :leaderboard,
+        title: settings.title || t('course.leaderboard.sidebar_title'),
+        weight: 1,
+        path: course_leaderboard_path(current_course)
+      }
+    ]
+  end
+
+  def settings_sidebar_items
+    [
+      {
+        title: settings.title || t('course.leaderboard.title'),
+        type: :settings,
+        weight: 4,
+        path: course_admin_leaderboard_path(current_course)
+      }
+    ]
+  end
+end

--- a/app/controllers/course/admin/leaderboard_settings_controller.rb
+++ b/app/controllers/course/admin/leaderboard_settings_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class Course::Admin::LeaderboardSettingsController < Course::Admin::Controller
+  add_breadcrumb :edit, :course_admin_leaderboard_path
+  before_action :load_settings
+
+  def edit #:nodoc:
+  end
+
+  def update #:nodoc:
+    if @settings.update(leaderboard_settings_params) && current_course.save
+      redirect_to course_admin_leaderboard_path(current_course), success: t('.success')
+    else
+      render 'edit'
+    end
+  end
+
+  private
+
+  def leaderboard_settings_params #:nodoc:
+    params.require(:leaderboard_settings).permit(:title, :display_user_count)
+  end
+
+  # Load our settings adapter to handle leaderboard settings
+  def load_settings
+    @settings ||= Course::LeaderboardSettings.new(current_course.settings(:leaderboard))
+  end
+end

--- a/app/controllers/course/leaderboards_controller.rb
+++ b/app/controllers/course/leaderboards_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+class Course::LeaderboardsController < Course::ComponentController
+  before_action :check_component
+  before_action :load_settings
+  before_action :add_leaderboard_breadcrumb
+
+  def show #:nodoc:
+  end
+
+  private
+
+  # Ensure that the component is enabled.
+  #
+  # @raise [Coursemology::ComponentNotFoundError] When the component is disabled.
+  def check_component
+    raise ComponentNotFoundError unless component
+  end
+
+  # Load current component's settings
+  def load_settings
+    @leaderboard_settings = component.settings
+  end
+
+  def add_leaderboard_breadcrumb
+    add_breadcrumb @leaderboard_settings.title || :index, :course_leaderboard_path
+  end
+
+  # @return [Course::LeaderboardComponent] The leaderboard component.
+  # @return [nil] If leaderboard component is disabled.
+  def component
+    current_component_host[:course_leaderboard_component]
+  end
+end

--- a/app/models/course/leaderboard_settings.rb
+++ b/app/models/course/leaderboard_settings.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+class Course::LeaderboardSettings
+  include ActiveModel::Model
+  include ActiveModel::Conversion
+  include ActiveModel::Validations
+
+  validates :display_user_count, numericality: { greater_than_or_equal_to: 0 }
+
+  # Initialises the settings adapter
+  #
+  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
+  def initialize(settings)
+    @settings = settings
+  end
+
+  # Returns the title of leaderboard component
+  #
+  # @return [String] The custom or default title of leaderboard component
+  def title
+    @settings.title
+  end
+
+  # Sets the title of leaderboard component
+  #
+  # @param [String] title The new title
+  def title=(title)
+    title = nil unless title.present?
+    @settings.title = title
+  end
+
+  # Returns the number of users to be displayed on the leaderboard
+  #
+  # @return [Integer] The number of users to be displayed
+  def display_user_count
+    @settings.display_user_count || 30
+  end
+
+  # Returns the number of users to be displayed on the leaderboard
+  #
+  # @param [Integer] count The number of users to be displayed
+  def display_user_count=(count)
+    @settings.display_user_count = count
+  end
+
+  # Update settings with the hash attributes
+  #
+  # @param [Hash] attributes The hash who stores the new settings
+  def update(attributes)
+    attributes.each { |k, v| send("#{k}=", v) }
+    valid?
+  end
+
+  def persisted? #:nodoc:
+    true
+  end
+end

--- a/app/views/course/admin/leaderboard_settings/edit.html.slim
+++ b/app/views/course/admin/leaderboard_settings/edit.html.slim
@@ -1,0 +1,5 @@
+= simple_form_for @settings, url: course_admin_leaderboard_path(current_course) do |f|
+  = f.error_notification
+  = f.input :title, as: :string, placeholder: t('.title_placeholder')
+  = f.input :display_user_count, as: :integer
+  = f.button :submit

--- a/app/views/course/leaderboards/show.html.slim
+++ b/app/views/course/leaderboards/show.html.slim
@@ -1,0 +1,1 @@
+p To be implemented later

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -28,6 +28,8 @@ en:
           edit: :'course.material.sidebar_title'
         forum_settings:
           edit: :'course.forum.forums.sidebar_title'
+        leaderboard_settings:
+          edit: :'course.leaderboard.index.header'
       users:
         index: 'Users'
         students: :'course.users.students.header'

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -100,6 +100,8 @@ en:
         topics:
           new_topic: :'course.forum.topics.new_topic.header'
           edit_topic: :'course.forum.topics.edit_topic.header'
+      leaderboards:
+        index: :'course.leaderboard.title'
 
     system:
       admin:

--- a/config/locales/en/course/admin/leaderboard_settings.yml
+++ b/config/locales/en/course/admin/leaderboard_settings.yml
@@ -1,0 +1,8 @@
+en:
+  course:
+    admin:
+      leaderboard_settings:
+        edit:
+          title_placeholder: 'Leave blank to use default title'
+        update:
+          success: 'Leaderboard settings updated.'

--- a/config/locales/en/course/leaderboard.yml
+++ b/config/locales/en/course/leaderboard.yml
@@ -1,0 +1,6 @@
+en:
+  course:
+    leaderboard:
+      sidebar_title: :'course.leaderboard.index.header'
+      index:
+        header: 'Leaderboard'

--- a/config/locales/en/course/leaderboard.yml
+++ b/config/locales/en/course/leaderboard.yml
@@ -2,5 +2,6 @@ en:
   course:
     leaderboard:
       sidebar_title: :'course.leaderboard.index.header'
+      title: :'course.leaderboard.index.header'
       index:
         header: 'Leaderboard'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,8 @@ Rails.application.routes.draw do
       resources :course_users, only: [] do
         resources :experience_points_records, only: [:index]
       end
+
+      resource :leaderboard, only: [:show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,10 @@ Rails.application.routes.draw do
 
         get 'forums' => 'forum_settings#edit'
         patch 'forums' => 'forum_settings#update'
+
+        get 'leaderboard' => 'leaderboard_settings#edit'
+        patch 'leaderboard' => 'leaderboard_settings#update'
+
         namespace 'assessments' do
           resources :categories, only: [:new, :create, :destroy] do
             resources :tabs, only: [:new, :create, :destroy]

--- a/spec/controllers/course/admin/leaderboard_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/leaderboard_settings_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Admin::LeaderboardSettingsController, type: :controller do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let(:course) { create(:course, creator: user) }
+    before { sign_in(user) }
+
+    describe '#edit' do
+      subject { get :edit, course_id: course }
+      it { is_expected.to render_template(:edit) }
+    end
+
+    describe '#update' do
+      before do
+        allow(course).to receive(:save).and_return(false)
+        allow(controller).to receive(:current_course).and_return(course)
+      end
+      context 'when course cannot be saved' do
+        subject { patch :update, course_id: course, leaderboard_settings: { title: '' } }
+        it { is_expected.to render_template(:edit) }
+      end
+    end
+  end
+end

--- a/spec/features/course/admin/leaderboard_settings_spec.rb
+++ b/spec/features/course/admin/leaderboard_settings_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Course: Administration: Leaderboard' do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Manager' do
+      let(:user) { create(:course_manager, :approved, course: course).user }
+
+      scenario 'I can change the leaderboard display user count setting' do
+        visit course_admin_leaderboard_path(course)
+
+        invalid_display_user_count = -1
+        valid_display_user_count = 100
+
+        fill_in 'leaderboard_settings_display_user_count', with: invalid_display_user_count
+        click_button 'update'
+        expect(page).to have_css('div.has-error')
+
+        fill_in 'leaderboard_settings_display_user_count', with: valid_display_user_count
+        click_button 'update'
+        expect(page).
+          to have_selector('div', text: I18n.t('course.admin.leaderboard_settings.update.success'))
+        expect(page).to have_field('leaderboard_settings_display_user_count',
+                                   with: valid_display_user_count)
+      end
+
+      scenario 'I can change the leaderboard title' do
+        visit course_admin_leaderboard_path(course)
+
+        new_title = 'New Title'
+        empty_title = ''
+
+        fill_in 'leaderboard_settings_title', with: new_title
+        click_button 'update'
+        expect(page).
+          to have_selector('div', text: I18n.t('course.admin.leaderboard_settings.update.success'))
+        expect(page).to have_field('leaderboard_settings_title', with: new_title)
+        expect(page).to have_selector('li a', text: new_title)
+
+        fill_in 'leaderboard_settings_title', with: empty_title
+        click_button 'update'
+        expect(page).
+          to have_selector('div', text: I18n.t('course.admin.leaderboard_settings.update.success'))
+        expect(page).to have_selector('li a', text: I18n.t('course.leaderboard.sidebar_title'))
+      end
+    end
+  end
+end

--- a/spec/features/course/leaderboard_viewing_spec.rb
+++ b/spec/features/course/leaderboard_viewing_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Course: Leaderboard: View' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    before do
+      login_as(user, scope: :user)
+    end
+
+    context 'As a student' do
+      let(:user) { create(:course_student, :approved, course: course).user }
+      scenario 'I can view the leaderboard' do
+        visit course_leaderboard_path(course)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR sets up the base for implementing leaderboard:
 - Implement leaderboard settings (model, controller, views) 
 - Set up leaderboard controller (components and sidebar)

This is part 1 of #634.

Will work on implementing the leaderboard view next. 