### PR TITLE
Memoise the course controller component host

### DIFF
--- a/app/controllers/course/component_controller.rb
+++ b/app/controllers/course/component_controller.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 class Course::ComponentController < Course::Controller
   layout 'course'
+
+  before_action :load_current_component_host
+
+  private
+
+  # Forces the current component host to be loaded. This is used in the Course layout to decide
+  # which navbar items to display, so count it under the Controller's execution time instead.
+  def load_current_component_host
+    current_component_host
+  end
 end

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -41,6 +41,7 @@ class Course::Controller < ApplicationController
       Course::ControllerComponentHost.new(current_tenant.settings(:components),
                                           current_course.settings(:components), self)
   end
+  helper_method :current_component_host
 
   private
 

--- a/app/views/course/admin/component_settings/edit.html.slim
+++ b/app/views/course/admin/component_settings/edit.html.slim
@@ -5,7 +5,7 @@
       th = t('.name')
       th = t('.enabled')
     tbody
-      - instance_components = controller.current_component_host.instance_enabled_components
+      - instance_components = current_component_host.instance_enabled_components
       - collection = instance_components.map { |c| [c.name, c.key.to_s] }
       = f.collection_check_boxes :enabled_component_ids, collection, :last, :first do |f|
         tr

--- a/app/views/layouts/_course_user_badge.html.slim
+++ b/app/views/layouts/_course_user_badge.html.slim
@@ -6,12 +6,12 @@ div#course-user-badge
       = t('.progress', current: course_user.experience_points,
                        next: course_user.next_level_threshold)
   div.col-xs-6#course-user-achievements
-    - unless controller.current_component_host[:course_achievements_component].nil?
+    - unless current_component_host[:course_achievements_component].nil?
       = link_to course_achievements_path(course_user.course) do
         h5 = t('.achievements')
         p = course_user.achievement_count
   div.col-xs-6#course-user-level
-    - unless controller.current_component_host[:course_levels_component].nil?
+    - unless current_component_host[:course_levels_component].nil?
       = link_to_course_user(course_user) do
         h5 = t('.levels')
         p = course_user.level_number

--- a/spec/components/course/controller_component_host_spec.rb
+++ b/spec/components/course/controller_component_host_spec.rb
@@ -62,11 +62,22 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
       end
     end
 
+    describe '#initialize' do
+      it 'instantiates all enabled components' do
+        expect(self.class::DummyCourseModule).to receive(:new).and_call_original
+        component_host
+      end
+    end
+
     describe '#components' do
       subject { component_host.components }
 
       it 'includes instances of every enabled component' do
         expect(subject.map(&:class)).to contain_exactly(*component_host.enabled_components)
+      end
+
+      it 'memoises its result' do
+        expect(component_host.components).to be(subject)
       end
     end
 
@@ -96,6 +107,10 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
 
     describe '#enabled_components' do
       subject { component_host.enabled_components }
+
+      it 'memoises its result' do
+        expect(component_host.enabled_components).to be(subject)
+      end
 
       context 'without preferences' do
         it 'returns the default enabled components' do
@@ -136,6 +151,10 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
 
     describe '#disabled_components' do
       subject { component_host.disabled_components }
+
+      it 'memoises its result' do
+        expect(component_host.disabled_components).to be(subject)
+      end
 
       context 'without preferences' do
         it 'returns empty' do


### PR DESCRIPTION
This moves the execution cost to the controller instead of the views, which is where the component host should be instantiated. Also memoise the results so that there is no unnecessary computation (like accessing and computing the enabled set of components, which can be expensive)

All courses should also have the current component host instantiated so that components can modify controller behaviour.