### PR TITLE
Fix random duplicate records when running the auto grading service specs

### DIFF
--- a/spec/factories/course_assessment_answers.rb
+++ b/spec/factories/course_assessment_answers.rb
@@ -8,7 +8,10 @@ FactoryGirl.define do
     end
 
     submission do
-      build(:course_assessment_submission, *submission_traits, assessment: question.assessment)
+      traits = *submission_traits
+      options = traits.extract_options!
+      options[:assessment] = question.assessment
+      build(:course_assessment_submission, *traits, options)
     end
     question { build(:course_assessment_question, assessment: assessment) }
 

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
                                          aliases: [:submission] do
     transient do
       grader { User.stamper }
+      auto_grade true # Used only with any of the submitted or finalised traits.
     end
     assessment { build(:assessment, course: course) }
 
@@ -16,8 +17,9 @@ FactoryGirl.define do
 
     trait :submitted do
       attempting
-      after(:build) do |submission| # rubocop:disable Style/SymbolProc
+      after(:build) do |submission, evaluator| # rubocop:disable Style/SymbolProc
         submission.finalise!
+        answer.send(:clear_attribute_changes, :workflow_state) unless evaluator.auto_grade
       end
     end
 

--- a/spec/services/course/assessment/answer/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/auto_grading_service_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Answer::AutoGradingService do
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
-    let(:answer) { create(:course_assessment_answer_multiple_response, :submitted).answer }
+    let(:answer) do
+      create(:course_assessment_answer_multiple_response, :submitted,
+             submission_traits: [{ auto_grade: false }]).answer
+    end
     let(:auto_grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
 
     describe '.grade' do

--- a/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
@@ -5,11 +5,15 @@ RSpec.describe Course::Assessment::Answer::MultipleResponseAutoGradingService do
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
     let(:answer) do
-      create(:course_assessment_answer_multiple_response, :submitted, *answer_traits,
-             question_traits: question_traits).answer
+      arguments = *answer_traits
+      options = arguments.extract_options!
+      options[:question_traits] = question_traits
+      options[:submission_traits] = submission_traits
+      create(:course_assessment_answer_multiple_response, :submitted, *arguments, options).answer
     end
     let(:question) { answer.question.actable }
     let(:question_traits) { nil }
+    let(:submission_traits) { [{ auto_grade: false }] }
     let(:answer_traits) { nil }
     let(:grading) do
       create(:course_assessment_answer_auto_grading, answer: answer)

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
         arguments = *answer_traits
         options = arguments.extract_options!
         options[:question_traits] = question_traits
+        options[:submission_traits] = submission_traits
         create(:course_assessment_answer_programming, :submitted, *arguments, options).answer
       end
-      let(:answer_traits) { [{ file_count: 1 }] }
       let(:question) { answer.question.actable }
       let(:question_traits) do
         [{
@@ -31,6 +31,8 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
       let(:question_test_report_path) do
         File.join(Rails.root, 'spec/fixtures/course/programming_single_test_suite_report.xml')
       end
+      let(:submission_traits) { [{ auto_grade: false }] }
+      let(:answer_traits) { [{ file_count: 1 }] }
       let(:grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
 
       before do

--- a/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
@@ -5,11 +5,15 @@ RSpec.describe Course::Assessment::Answer::TextResponseAutoGradingService do
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
     let(:answer) do
-      create(:course_assessment_answer_text_response, :submitted, *answer_traits,
-             question_traits: question_traits).answer
+      arguments = *answer_traits
+      options = arguments.extract_options!
+      options[:question_traits] = question_traits
+      options[:submission_traits] = submission_traits
+      create(:course_assessment_answer_text_response, :submitted, *arguments, options).answer
     end
     let(:question) { answer.question.actable }
     let(:question_traits) { nil }
+    let(:submission_traits) { [{ auto_grade: false }] }
     let(:answer_traits) { nil }
     let(:grading) do
       create(:course_assessment_answer_auto_grading, answer: answer)


### PR DESCRIPTION
This was caused by submissions creating auto grading objects when grading the submissions. These specs however need to create their own gradings to test the grading service.

cc: @weiqingtoh 