### PR TITLE
Implement validation for conditions to prevent cyclic dependency in satisfiability graph

### DIFF
--- a/app/models/course/condition/achievement.rb
+++ b/app/models/course/condition/achievement.rb
@@ -67,6 +67,7 @@ class Course::Condition::Achievement < ActiveRecord::Base
   def validate_achievement_condition
     validate_references_self
     validate_unique_dependency
+    validate_acyclic_dependency
   end
 
   def validate_references_self
@@ -77,5 +78,10 @@ class Course::Condition::Achievement < ActiveRecord::Base
   def validate_unique_dependency
     return unless required_achievements_for(conditional).include?(achievement)
     errors.add(:achievement, :unique_dependency)
+  end
+
+  def validate_acyclic_dependency
+    return unless cyclic?
+    errors.add(:achievement, :cyclic_dependency)
   end
 end

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -71,6 +71,7 @@ class Course::Condition::Assessment < ActiveRecord::Base
   def validate_assessment_condition
     validate_references_self
     validate_unique_dependency
+    validate_acyclic_dependency
   end
 
   def validate_references_self
@@ -81,6 +82,11 @@ class Course::Condition::Assessment < ActiveRecord::Base
   def validate_unique_dependency
     return unless required_assessments_for(conditional).include?(assessment)
     errors.add(:assessment, :unique_dependency)
+  end
+
+  def validate_acyclic_dependency
+    return unless cyclic?
+    errors.add(:assessment, :cyclic_dependency)
   end
 
   # Given a conditional object, returns all assessments that it requires.

--- a/config/locales/en/activerecord/course/condition/achievement.yml
+++ b/config/locales/en/activerecord/course/condition/achievement.yml
@@ -9,3 +9,4 @@ en:
             achievement:
               unique_dependency: 'cannot have duplicate conditions'
               references_self: 'cannot have itself as a condition'
+              cyclic_dependency: 'cannot have cyclic dependency'

--- a/config/locales/en/activerecord/course/condition/assessment.yml
+++ b/config/locales/en/activerecord/course/condition/assessment.yml
@@ -12,3 +12,4 @@ en:
             assessment:
               unique_dependency: 'cannot have duplicate conditions'
               references_self: 'cannot have itself as condition'
+              cyclic_dependency: 'cannot have cyclic dependency'

--- a/lib/autoload/course/conditional/user_satisfiability_graph.rb
+++ b/lib/autoload/course/conditional/user_satisfiability_graph.rb
@@ -20,9 +20,10 @@ class Course::Conditional::UserSatisfiabilityGraph
   # @raise [ArgumentError] When there is a cyclic dependency within the given conditionals
   def initialize(conditionals)
     @edges = EdgeSet.new
+    @nodes = conditionals
 
     begin
-      @graph = TSort.tsort(each_node(conditionals), each_child)
+      @graph = TSort.tsort(each_node, each_child)
     rescue TSort::Cyclic
       raise ArgumentError, 'Cyclic dependency detected in given conditionals'
     end
@@ -50,10 +51,21 @@ class Course::Conditional::UserSatisfiabilityGraph
     satisfied_conditionals
   end
 
+  # Return true if the destination node is reachable from the source node
+  #
+  # @param [Object] source Conditional node as the source
+  # @param [Object] dest Conditional node as the destination
+  # @return [Bool] true if the dest node is reachable from the source node
+  def self.reachable?(source, dest)
+    return true if source == dest
+
+    dest.specific_conditions.index { |c| reachable?(source, c.dependent_object) }.present?
+  end
+
   private
 
-  def each_node(conditionals)
-    conditionals.method(:each)
+  def each_node
+    @nodes.method(:each)
   end
 
   def each_child

--- a/lib/extensions/conditional/active_record/base.rb
+++ b/lib/extensions/conditional/active_record/base.rb
@@ -73,6 +73,14 @@ module Extensions::Conditional::ActiveRecord::Base
     def rebuild_satisfiability_graph(_course)
       # TODO: Replace with the job for building the satisfiability graph
     end
+
+    # @return [Boolean] true if the condition completes a cyclic path in the satifiability graph.
+    def cyclic?
+      # This condition will add an edge connecting the dependent_object to the conditional in the
+      # satisfiability graph. Thus a cyclic dependency will be created if there is an existing
+      # path from the conditional to the dependent_object.
+      Course::Conditional::UserSatisfiabilityGraph.reachable?(conditional, dependent_object)
+    end
   end
 
   module ConditionClassMethods


### PR DESCRIPTION
Depends on #924.

A new condition add an edge from the condition dependent object to the conditional object. Thus, we check for cyclic dependency by finding whether there exist a path from the conditional object to the dependent object in the current satisfiability graph.

Caching can be added in the future to cache all the reachable nodes for every node in the satisfiability graph since this is already a side product of the process in producing the satisfiability graph for the course.
