### PR TITLE
Remove unconfirmed course_users from course user listing and achievement award

### DIFF
--- a/app/controllers/course/users_controller.rb
+++ b/app/controllers/course/users_controller.rb
@@ -19,7 +19,7 @@ class Course::UsersController < Course::ComponentController
     course_users = current_course.course_users
     case params[:action]
     when 'index'
-      @course_users ||= course_users.students.includes(:user)
+      @course_users ||= course_users.with_approved_state.students.includes(:user)
     else
       return if super
       @course_user ||= course_users.includes(:user).find(params[:id])

--- a/app/views/course/achievement/course_users/_course_users_form.html.slim
+++ b/app/views/course/achievement/course_users/_course_users_form.html.slim
@@ -14,7 +14,7 @@
         label for='toggle-all-achievements'
           = t('.enabled')
     tbody
-      - collection = course.course_users.students
+      - collection = course.course_users.with_approved_state.students
       = f.collection_check_boxes :course_user_ids, collection, :id, :name do |f|
         tr
           th = link_to_course_user(f.object)

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -75,13 +75,16 @@ RSpec.feature 'Course: Achievements' do
         expect(achievement.reload.description).to eq(new_description)
       end
 
-      scenario 'I can award an achievement to a student' do
+      scenario 'I can award an achievement to a confirmed student' do
         achievement = create(:course_achievement, course: course)
-        student = create(:course_student, course: course)
+        student = create(:course_student, :approved, course: course)
         course_user_id = "achievement_course_user_ids_#{student.id}"
+        unregistered_user = create(:course_user, course: course)
+        unregistered_user_id = "achievement_course_user_ids_#{unregistered_user.id}"
 
         visit course_achievement_course_users_path(course, achievement)
         expect(page).to have_unchecked_field(course_user_id)
+        expect(page).not_to have_field(unregistered_user_id)
         check course_user_id
 
         expect do

--- a/spec/features/course/user_listing_spec.rb
+++ b/spec/features/course/user_listing_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Courses: Course User Listing' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let!(:course_student_list) { create_list(:course_student, 5, :approved, course: course) }
+    let!(:unregistered_user) { create(:course_user, course: course) }
     let!(:course_teaching_assistant) do
       create(:course_teaching_assistant, :approved, course: course)
     end
@@ -15,13 +16,16 @@ RSpec.feature 'Courses: Course User Listing' do
       let(:student) { create(:course_student, :approved, course: course) }
       before { login_as(student.user, scope: :user) }
 
-      scenario 'I can view all student in my course' do
+      scenario 'I can view all confirmed students in my course' do
         visit course_users_path(course)
 
         course_student_list.each do |student|
           expect(page).to have_content_tag_for(student)
           expect(page).to have_link(nil, href: course_user_path(course, student))
         end
+
+        # Page should not display unconfirmed users and teaching assistants
+        expect(page).not_to have_content_tag_for(unregistered_user)
         expect(page).not_to have_content_tag_for(course_teaching_assistant)
       end
     end


### PR DESCRIPTION
Resolves part of #920 , also linked to Rollbar 76. 
