### PR TITLE
Remove links in link_to_user for unconfirmed course users

### DIFF
--- a/app/helpers/course/controller_helper.rb
+++ b/app/helpers/course/controller_helper.rb
@@ -9,7 +9,7 @@ module Course::ControllerHelper
     user.name
   end
 
-  # Links to the given +CourseUser+.
+  # Links to the given +CourseUser+. If the +CourseUser+ is unconfirmed, no link will be provided.
   #
   # @param [CourseUser] user The User to display.
   # @param [Hash] options The options to pass to +link_to+
@@ -19,13 +19,12 @@ module Course::ControllerHelper
   # @return [String] The user-visible string, including embedded HTML which will display the
   #   string within a link to bring to the User page.
   def link_to_course_user(user, options = {})
-    link_path = course_user_path(user.course, user)
-    link_to(link_path, options) do
-      if block_given?
-        yield(user)
-      else
-        display_course_user(user)
-      end
+    link_text = capture { block_given? ? yield(user) : display_course_user(user) }
+    if user.approved?
+      link_path = course_user_path(user.course, user)
+      link_to(link_text, link_path, options)
+    else
+      content_tag('span', link_text)
     end
   end
 

--- a/spec/helpers/course/controller_helper_spec.rb
+++ b/spec/helpers/course/controller_helper_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Course::ControllerHelper do
     end
 
     describe '#link_to_course_user' do
-      let(:user) { create(:course_user, course: course) }
+      let(:user) { create(:course_user, :approved, course: course) }
       subject { helper.link_to_course_user(user) }
 
       it { is_expected.to have_tag('a') }
@@ -46,13 +46,23 @@ RSpec.describe Course::ControllerHelper do
 
         it { is_expected.to include('Test') }
       end
+
+      context 'when a CourseUser is unconfirmed' do
+        let(:unconfirmed_user) { create(:course_user, course: course) }
+        subject { helper.link_to_course_user(unconfirmed_user) }
+
+        it 'does not create a link to the course user profile' do
+          expect(subject).to have_tag('span')
+          expect(subject).not_to have_link(course_user_path(course, unconfirmed_user))
+        end
+      end
     end
 
     describe '#link_to_user' do
       subject { helper.link_to_user(user) }
 
       context 'when a CourseUser is given' do
-        let(:user) { create(:course_user) }
+        let(:user) { create(:course_user, :approved) }
 
         it { is_expected.to eq(helper.link_to_course_user(user)) }
       end


### PR DESCRIPTION
Related to #920 , also part of Rollbar 76