### PR TITLE
Implement show attachments & let main models to support attachments

### DIFF
--- a/app/controllers/attachment_references_controller.rb
+++ b/app/controllers/attachment_references_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class AttachmentReferencesController < ApplicationController
+  load_resource :attachment_reference
+  before_action :authorize_resource
+
+  def show
+    redirect_to @attachment_reference.url
+  end
+
+  private
+
+  def authorize_resource
+    authorize!(:read, @attachment_reference.attachable)
+  end
+end

--- a/app/models/course/announcement.rb
+++ b/app/models/course/announcement.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Announcement < ActiveRecord::Base
   acts_as_readable on: :updated_at
+  has_many_attachments
 
   after_initialize :set_defaults, if: :new_record?
   after_create :mark_as_read_by_creator

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::Question < ActiveRecord::Base
   actable
+  has_many_attachments
 
   belongs_to :assessment, inverse_of: :questions
   has_and_belongs_to_many :skills

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -3,6 +3,7 @@ class Course::Discussion::Post < ActiveRecord::Base
   include Course::Discussion::Post::OrderingConcern
 
   acts_as_forest order: :created_at
+  has_many_attachments
 
   after_initialize :set_topic, if: :new_record?
   after_initialize :set_title, if: :new_record?

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::LessonPlan::Item < ActiveRecord::Base
   actable
+  has_many_attachments
 
   after_initialize :set_default_values, if: :new_record?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -241,4 +241,6 @@ Rails.application.routes.draw do
       resource :leaderboard, only: [:show]
     end
   end
+
+  resources :attachment_references, path: 'attachments', only: [:show]
 end

--- a/spec/controllers/attachment_references_controller_spec.rb
+++ b/spec/controllers/attachment_references_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AttachmentReferencesController, type: :controller do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:user) { create(:administrator) }
+    before { sign_in(user) }
+
+    describe '#show' do
+      let(:attachment_reference) { create(:attachment_reference) }
+      subject { get :show, id: attachment_reference }
+
+      it { is_expected.to redirect_to(attachment_reference.attachment.url) }
+    end
+  end
+end


### PR DESCRIPTION
- Implemented attachment_reference show,  image and files in model contents/descriptions should reference to the attachment in future, not the file in S3.

- Add `has_many_attachments` to the models that V1 has image support, this will help with the migration.
  - V1 only supports image upload in CourseAnnouncement, Assessment, Question and ForumPost.
  - I didn't add has_many_attachments to all models because some of them does not make sense, like images in achievement description, think we can add them when there is a use case. 