### PR TITLE
Some minor fixes to controllers and breadcrumbs

### DIFF
--- a/app/controllers/course/achievement/controller.rb
+++ b/app/controllers/course/achievement/controller.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 class Course::Achievement::Controller < Course::ComponentController
+  before_action :check_component
   load_and_authorize_resource :achievement, through: :course, class: Course::Achievement.name
   add_breadcrumb :index, :course_achievements_path
 
   helper name
+
+  private
+
+  # Ensure that the component is enabled.
+  #
+  # @raise [Coursemology::ComponentNotFoundError] When the component is disabled.
+  def check_component
+    raise ComponentNotFoundError unless component
+  end
+
+  # @return [Course::AchievementsComponent] The forum component.
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_achievements_component]
+  end
 end

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -85,9 +85,9 @@ en:
       lesson_plan:
         items:
           index: :'course.lesson_plan.items.index.header'
-        milestones: :'breadcrumbs.course.lesson_plan.items'
-      events:
-        index: :'breadcrumbs.course.lesson_plan_items'
+        milestones: :'breadcrumbs.course.lesson_plan.items.index'
+        events:
+          index: :'breadcrumbs.course.lesson_plan.items.index'
       material:
         folders:
           new_subfolder: :'course.material.folders.new_subfolder.header'

--- a/spec/controllers/course/achievement/achievements_controller_spec.rb
+++ b/spec/controllers/course/achievement/achievements_controller_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Course::Achievement::AchievementsController, type: :controller do
 
     before { sign_in(user) }
 
+    describe '#index' do
+      before do
+        allow(controller).to receive_message_chain('current_component_host.[]').and_return(nil)
+      end
+      subject { get :index, course_id: course }
+      it 'raises an component not found error' do
+        expect { subject }.to raise_error(ComponentNotFoundError)
+      end
+    end
+
     describe '#destroy' do
       subject { delete :destroy, course_id: course, id: achievement_stub }
 

--- a/spec/controllers/course/leaderboards_controller_spec.rb
+++ b/spec/controllers/course/leaderboards_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::LeaderboardsController, type: :controller do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:administrator) }
+    let!(:course) { create(:course) }
+
+    before { sign_in(user) }
+
+    describe '#show' do
+      before do
+        allow(controller).to receive_message_chain('current_component_host.[]').and_return(nil)
+      end
+      subject { get :show, course_id: course }
+      it 'raises an component not found error' do
+        expect { subject }.to raise_error(ComponentNotFoundError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Noticed lesson plan breadcrumbs were off, so this PR fixes that.
- Achievements controller did not check whether component is disabled, so I added it. Controller specs are added for Achievements and Leaderboard as well.

For 2, there is one question - which components do we want to allow to disable? Some of them definitely cannot be disabled, eg. Course::CoursesComponent, but components such as levels are sort of a grey area? 

Once we decide, I can do the edits. 

