### PR TITLE
Remove error when no users are specified to user_invitations#create

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -18,10 +18,13 @@ class Course::UserInvitationsController < Course::ComponentController
   private
 
   def course_user_invitation_params # :nodoc:
-    invitations_attributes = { course_user: [:name], user_email: [:email] }
-    @invite_params ||= params.require(:course).
-                       permit(:invitations_file, :registration_key,
-                              invitations_attributes: invitations_attributes)
+    @course_user_invitation_params ||= begin
+      params[:course] = { invitations_attributes: {} } unless params.key?(:course)
+
+      invitations_attributes = { course_user: [:name], user_email: [:email] }
+      params.require(:course).permit(:invitations_file, :registration_key,
+                                     invitations_attributes: invitations_attributes)
+    end
   end
 
   # Determines the parameters to be passed to the invitation service object.

--- a/spec/controllers/course/user_invitations_controller_spec.rb
+++ b/spec/controllers/course/user_invitations_controller_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe Course::UserInvitationsController, type: :controller do
             expect(controller.current_course.errors[:invitations_file].length).not_to eq(0)
           end
         end
+
+        context 'when no users are manually specified for invitations' do
+          subject { post :create, course_id: course }
+          it { is_expected.to redirect_to(course_users_invitations_path(course)) }
+        end
       end
 
       context 'when a student visits the page' do


### PR DESCRIPTION
Fixes #919 - Source if when no users are specified for invitation, the params are missing. 

The PR fixes this at the controller level, but I'm not sure if this is the best way to handle it. Other ways include doing front end validations, or raising an exception in the controller (and then rescuing it).