### PR TITLE
Experience Points Disbursement feature

### DIFF
--- a/app/controllers/components/course/points_disbursement_component.rb
+++ b/app/controllers/components/course/points_disbursement_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class Course::PointsDisbursementComponent < SimpleDelegator
+  include Course::ControllerComponentHost::Component
+
+  def sidebar_items
+    return [] unless can_create_experience_points_record?
+
+    [
+      {
+        title: t('course.experience_points_disbursement.sidebar_title'),
+        type: :admin,
+        weight: 2,
+        path: disburse_experience_points_course_users_path(current_course)
+      }
+    ]
+  end
+
+  private
+
+  def can_create_experience_points_record?
+    can?(:create, Course::ExperiencePointsRecord.
+                    new(course_user: CourseUser.new(course: current_course)))
+  end
+end

--- a/app/controllers/course/experience_points_disbursement_controller.rb
+++ b/app/controllers/course/experience_points_disbursement_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+class Course::ExperiencePointsDisbursementController < Course::ComponentController
+  include Course::UsersBreadcrumbConcern
+  load_resource :experience_points_disbursement, class: Course::ExperiencePointsDisbursement.name
+
+  def new # :nodoc:
+    @experience_points_disbursement.build(current_course)
+    authorize_resource
+  end
+
+  def create # :nodoc:
+    @experience_points_disbursement.course = Course.find(params[:course_id])
+    authorize_resource
+    if @experience_points_disbursement.save
+      recipient_count = @experience_points_disbursement.experience_points_records.length
+      redirect_to disburse_experience_points_course_users_path(current_course),
+                  success: t('.success', count: recipient_count)
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def experience_points_disbursement_params # :nodoc:
+    params.
+      require(:experience_points_disbursement).
+      permit(:reason, experience_points_records_attributes: [:points_awarded, :course_user_id])
+  end
+
+  # Authorizes each newly-built experience points record.
+  # Each record has to be checked otherwise it might be possible for a course staff
+  # to award experience points to a student from a different course. Only checking the records
+  # is also insufficient since access will not be denied if there are no records to authroize.
+  def authorize_resource
+    authorize!(:disburse, @experience_points_disbursement)
+    @experience_points_disbursement.experience_points_records.each do |record|
+      authorize!(:create, record)
+    end
+  end
+end

--- a/app/models/components/course/experience_points_disbursement_ability_component.rb
+++ b/app/models/components/course/experience_points_disbursement_ability_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Course::ExperiencePointsDisbursementAbilityComponent
+  include AbilityHost::Component
+
+  def define_permissions
+    allow_staff_disburse_experience_points if user
+
+    super
+  end
+
+  private
+
+  def allow_staff_disburse_experience_points
+    can :disburse, Course::ExperiencePointsDisbursement, course_staff_hash
+  end
+end

--- a/app/models/course/experience_points_disbursement.rb
+++ b/app/models/course/experience_points_disbursement.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+class Course::ExperiencePointsDisbursement
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  # @!attribute [rw] reason
+  #   This reason for the disbursement.
+  #   This will become the reason for each experience points record awarded.
+  #   @return [String]
+  attr_accessor :reason
+
+  # @!attribute [rw] course
+  #   The course that this disbursement is for.
+  #   @return [Course]
+  attr_accessor :course
+
+  # @!attribute [r] experience_points_records
+  #   Experience points records that will potentially be created.
+  #   @return [Array<Course::ExperiencePointsRecords>]
+  attr_reader :experience_points_records
+
+  validates :reason, presence: true
+
+  # Given a course, builds an empty experience points record for each of its approved students.
+  #
+  # @return [Array<Course::ExperiencePointsRecords>] The newly built experience points records
+  def build(current_course)
+    @course = current_course
+    @experience_points_records = course.course_users.students.with_approved_state.map do |student|
+      student.experience_points_records.build
+    end
+  end
+
+  # Processes the experience points records attributes hash, instantiating new experience points
+  # records for attributes hashes that represents a valid award.
+  #
+  # @param [Hash] attributes Experience points records attributes hash
+  # @return [Hash] Experience points records attributes hash
+  def experience_points_records_attributes=(attributes)
+    valid_attributes = attributes.values.select(&method(:valid_points_record_attributes?))
+    @experience_points_records = valid_attributes.map do |hash|
+      hash[:reason] = reason
+      Course::ExperiencePointsRecord.new(hash)
+    end
+    attributes
+  end
+
+  # Saves the newly built experience points records.
+  #
+  # @return [Boolean] True if bulk saving was successful
+  def save
+    Course::ExperiencePointsRecord.transaction { @experience_points_records.map(&:save!).all? }
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
+  private
+
+  # Checks whether an attributes hash represents a valid experience points award.
+  #
+  # @param [Hash] attributes Experience points record attributes hash
+  # @return [Boolean] True if hash represents a valid points award
+  def valid_points_record_attributes?(attibutes)
+    attibutes[:course_user_id].present? &&
+      attibutes[:points_awarded].present? &&
+      attibutes[:points_awarded].to_i != 0
+  end
+end

--- a/app/views/course/experience_points_disbursement/new.slim
+++ b/app/views/course/experience_points_disbursement/new.slim
@@ -1,0 +1,26 @@
+- add_breadcrumb :new
+= page_header t('.header')
+
+= simple_form_for @experience_points_disbursement,
+                  url: disburse_experience_points_course_users_path,
+                  method: :post do |f|
+  = f.error_notification
+
+  h3 = t('.reason')
+  = f.input :reason, label: false
+
+  h3 = t('.awardees')
+  table.table.table-hover
+    thead
+      tr
+        th = CourseUser.human_attribute_name(:name)
+        th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
+    tbody
+      = f.simple_fields_for :experience_points_records do |record_fields|
+        = content_tag_for(:tr, record_fields.object.course_user)
+          td = display_course_user(record_fields.object.course_user)
+          td = record_fields.input :points_awarded, label: false,
+                                   input_html: { class: 'points_awarded' }
+          = record_fields.hidden_field :course_user_id
+
+  = f.button :submit, t('.submit')

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -104,6 +104,8 @@ en:
         index: :'course.leaderboards.title'
       experience_points_records:
         index: 'Experience Points History'
+      experience_points_disbursement:
+        new: :'course.experience_points_disbursement.new.header'
 
     system:
       admin:

--- a/config/locales/en/course/experience_points_disbursement.yml
+++ b/config/locales/en/course/experience_points_disbursement.yml
@@ -1,0 +1,14 @@
+en:
+  course:
+    experience_points_disbursement:
+      sidebar_title: 'Disburse Points'
+      new:
+        header: 'Disburse Experience Points'
+        awardees: 'Recipients'
+        reason: 'Reason for Disbursement'
+        submit: 'Disburse Points'
+      create:
+        success:
+          zero: 'No experience points were disbursed.'
+          one: 'Experience points disbursed to one recipient.'
+          other: 'Experience points disbursed to %{count} recipients.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,9 @@ Rails.application.routes.draw do
         resources :experience_points_records, only: [:index, :destroy]
         get 'invite' => 'user_invitations#new', on: :collection
         post 'invite' => 'user_invitations#create', on: :collection
+        get 'disburse_experience_points' => 'experience_points_disbursement#new', on: :collection
+        post 'disburse_experience_points' => 'experience_points_disbursement#create',
+             on: :collection
       end
       post 'register' => 'user_registrations#create'
       get 'students' => 'users#students', as: :users_students

--- a/spec/controllers/course/experience_points_disbursement_controller_spec.rb
+++ b/spec/controllers/course/experience_points_disbursement_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::ExperiencePointsDisbursementController, type: :controller do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:course_student) { create(:course_student, :approved, course: course) }
+    let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+    let(:disbursement_stub) do
+      stub = Course::ExperiencePointsDisbursement.new
+      stub.instance_variable_set(:@course, course)
+      record_stub = Course::ExperiencePointsRecord.new(course_user: course_student)
+      stub.instance_variable_set(:@experience_points_records, [record_stub])
+      stub
+    end
+
+    before { sign_in(user) }
+    describe '#create' do
+      subject { post :create, course_id: course }
+
+      context 'when create fails' do
+        before do
+          controller.instance_variable_set(:@experience_points_disbursement, disbursement_stub)
+          subject
+        end
+
+        it { is_expected.to render_template('new') }
+      end
+    end
+  end
+end

--- a/spec/features/course/experience_points_disbursement_spec.rb
+++ b/spec/features/course/experience_points_disbursement_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Course: Experience Points Disbursement' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:unapproved_course_student) { create(:course_student, course: course) }
+    let(:course_students) { create_list(:course_student, 3, :approved, course: course) }
+    let(:course_teaching_assistant) do
+      create(:course_teaching_assistant, :approved, course: course)
+    end
+
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Teaching Assistant' do
+      let(:user) { course_teaching_assistant.user }
+
+      scenario 'I can disburse experience points' do
+        unapproved_course_student
+        unawarded_student, awarded_student, awarded_zero_student = course_students
+        visit disburse_experience_points_course_users_path(course)
+
+        fill_in 'experience_points_disbursement_reason', with: 'a reason'
+
+        expect(page).not_to have_content_tag_for(unapproved_course_student)
+        expect(page).to have_content_tag_for(unawarded_student)
+        within find(content_tag_selector(awarded_student)) do
+          find('input.points_awarded').set '100'
+        end
+        within find(content_tag_selector(awarded_zero_student)) do
+          find('input.points_awarded').set '00'
+        end
+
+        expect do
+          click_button I18n.t('course.experience_points_disbursement.new.submit')
+        end.to change(Course::ExperiencePointsRecord, :count).by(1)
+
+        expect(current_path).to eq(disburse_experience_points_course_users_path(course))
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Naming**
Used the name 'disbursement' as 'awarding' can sound awkward as a noun. It is also sounds ambiguous in certain contexts, e.g. when we say 'PointsAwardingController' -- the first impression might be that the controller itself awards points. 'Disbursement' also has a stronger connotation of 'giving out to many'.

Wanted to use 'award points' instead of 'disburse points' for the sidebar, page header and other user-visible places, since it is the term used in v1, other than 'giveaway', but decided to keep it consistent with the backend naming.

Are we okay with this or is this a bad idea?

**To be deferred to subsequent PRs**
- Copy points for all students
- Filter own students
- Forum points disbursement

Currently depends on #927