### PR TITLE
Fixed styling for achievement#show page

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -36,6 +36,7 @@ $picture-large: 140px !default;
 
 //## Variables for icons or logos used in Coursemology.
 $course-achievement-form-badge:   $picture-small !default;
+$course-achievement-user-profile: $picture-small !default;
 $course-user-listing-picture: $picture-small !default;
 $course-user-profile-picture: $picture-large !default;
 

--- a/app/assets/stylesheets/course/achievement.scss
+++ b/app/assets/stylesheets/course/achievement.scss
@@ -2,7 +2,7 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.course-achievements {
+.course-achievement-achievements {
   .achievement-list,
   .achievement-form {
     .image > img {
@@ -23,6 +23,11 @@
 
   &.show {
     .course-user-achievement {
+      .image > img {
+        height: $course-achievement-user-profile;
+        width: $course-achievement-user-profile;
+      }
+
       text-align: center;
     }
   }

--- a/app/views/course/achievement/achievements/_achievement.html.slim
+++ b/app/views/course/achievement/achievements/_achievement.html.slim
@@ -25,8 +25,8 @@
   td
     div.btn-group
       - if can?(:manage, achievement)
-        = link_to(t('.award_button'),
-                  course_achievement_course_users_path(current_course, achievement),
-                  class: ['btn', 'btn-info'])
+        = link_to course_achievement_course_users_path(current_course, achievement),
+                  class: ['btn', 'btn-info'], title: t('.award_button') do
+          = fa_icon 'trophy'
       = edit_button([current_course, achievement]) if can?(:edit, achievement)
       = delete_button([current_course, achievement]) if can?(:delete, achievement)

--- a/app/views/course/achievement/achievements/show.html.slim
+++ b/app/views/course/achievement/achievements/show.html.slim
@@ -11,5 +11,5 @@ div.user-achievements
       div.col-xs-4.col-sm-3.col-md-2.col-lg-1
         = div_for(course_user, class: ['course-user-achievement']) do
           = link_to_course_user(course_user) do
-            = display_user_image(course_user.user)
-            = display_course_user(course_user)
+            div = display_user_image(course_user.user)
+            div = display_course_user(course_user)


### PR DESCRIPTION
This PR does two things: 

First is a bug arising from #898 - I realised that the styling for achievements was not applied and realised that this was linked to refactoring the course achievement controller into the `Course::Achievement` namespace. 

This PR fixes that broken link, and specifies the height and width for the profile picture of `course_users` who have obtained that achievement.

Second, to fix #915. I've changed award achievement into an icon instead, and added the necessary tooltip. 