### PR TITLE
Change the store path of attachments

### DIFF
--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -9,7 +9,7 @@ class FileUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    'uploads/'
+    "uploads/attachments/#{partition_name(model.name)}"
   end
 
   def filename
@@ -48,4 +48,12 @@ class FileUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
+
+  private
+
+  # Returns the name of the model in a split path form.
+  # e.g. returns 'ab/cd/ef' for name 'abcdef'.
+  def partition_name(name)
+    name.scan(/.{2}/).first(3).join('/')
+  end
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -82,4 +82,12 @@ RSpec.describe Attachment do
       end
     end
   end
+
+  describe '#path' do
+    it 'returns a path based on the split form of the name' do
+      attachment = create(:attachment, name: 'abcdef' + SecureRandom.hex(32))
+      expect(attachment.path).
+        to start_with(File.join(Rails.public_path, '/uploads/attachments/ab/cd/ef'))
+    end
+  end
 end


### PR DESCRIPTION
Store path is base on hash name, so that it won't result in too many files in a single folder.