### PR TITLE
Add views for leaderboard

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -38,6 +38,8 @@ $picture-large: 140px !default;
 $course-achievement-form-badge:   $picture-small !default;
 $course-achievement-user-profile: $picture-small !default;
 $course-user-achievement-badge: $picture-medium !default;
+$course-leaderboard-user-picture: $picture-small !default;
+$course-leaderboard-achievement-badge: $picture-thumb !default;
 $course-user-listing-picture: $picture-small !default;
 $course-user-profile-picture: $picture-large !default;
 

--- a/app/assets/stylesheets/course/leaderboard.scss
+++ b/app/assets/stylesheets/course/leaderboard.scss
@@ -1,0 +1,43 @@
+.course-leaderboards {
+  &.show {
+    .leaderboard-header {
+      margin-bottom: 1em;
+      text-align: center;
+    }
+
+    .leaderboard-level,
+    .leaderboard-achievement {
+      .user-picture {
+        text-align: center;
+        width: 20%;
+
+        .image > img {
+          height: $course-leaderboard-user-picture;
+          width: $course-leaderboard-user-picture;
+        }
+      }
+
+      .rank {
+        padding-right: 2em;
+        text-align: right;
+        vertical-align: middle;
+        width: 15%;
+      }
+
+      .user-profile {
+        text-align: left;
+        vertical-align: middle;
+        width: 65%;
+      }
+    }
+
+    .leaderboard-achievement {
+      .user-profile {
+        .image > img {
+          height: $course-leaderboard-achievement-badge;
+          width: $course-leaderboard-achievement-badge;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/course/leaderboards_controller.rb
+++ b/app/controllers/course/leaderboards_controller.rb
@@ -3,6 +3,7 @@ class Course::LeaderboardsController < Course::ComponentController
   before_action :check_component
   before_action :load_settings
   before_action :add_leaderboard_breadcrumb
+  helper Course::Achievement::ControllerHelper.name.sub(/Helper$/, '')
 
   def show #:nodoc:
     load_course_users

--- a/app/controllers/course/leaderboards_controller.rb
+++ b/app/controllers/course/leaderboards_controller.rb
@@ -5,6 +5,7 @@ class Course::LeaderboardsController < Course::ComponentController
   before_action :add_leaderboard_breadcrumb
 
   def show #:nodoc:
+    load_course_users
   end
 
   private
@@ -19,6 +20,11 @@ class Course::LeaderboardsController < Course::ComponentController
   # Load current component's settings
   def load_settings
     @leaderboard_settings = component.settings
+  end
+
+  # Load approved students from current course with course statistics.
+  def load_course_users
+    @course_users = @course.course_users.students.with_approved_state.includes(:user)
   end
 
   def add_leaderboard_breadcrumb

--- a/app/helpers/course/leaderboards_helper.rb
+++ b/app/helpers/course/leaderboards_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module Course::LeaderboardsHelper
+  # @return [Fixnum] Number of users to be displayed, based on leaderboard settings.
+  def display_user_count
+    @display_user_count ||= @leaderboard_settings.display_user_count
+  end
+end

--- a/app/models/concerns/course_user/achievements_concern.rb
+++ b/app/models/concerns/course_user/achievements_concern.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module CourseUser::AchievementsConcern
+  # Order achievements based on when each course_user obtained the achievement.
+  def ordered_by_date_obtained
+    order { course_user_achievements.obtained_at.desc }
+  end
+end

--- a/app/views/course/leaderboards/show.html.slim
+++ b/app/views/course/leaderboards/show.html.slim
@@ -1,1 +1,45 @@
-p To be implemented later
+= page_header
+
+div.col-sm-12.col-md-6
+  div.leaderboard-header
+    h4 = t('.level_header')
+  table.table.leaderboard-level
+    tbody
+      - course_users_points = @course_users.ordered_by_experience_points.take(display_user_count)
+      - course_users_points.each.with_index(1) do |course_user, index|
+        = content_tag_for(:tr, course_user, class: ['course-user'])
+          td.rank
+            h3 = index
+          td.user-picture
+            = link_to_course_user(course_user) do
+              = display_user_image(course_user.user)
+          td.user-profile
+            div
+              = link_to_course_user(course_user) do
+                = format_inline_text(course_user.name)
+            div
+              / TODO: Refactor to reduce SQL calls. Refer to Coursemology/coursemology2#987
+              = t('.level', level_number: course_user.level_number)
+
+div.col-sm-12.col-md-6
+  div.leaderboard-header
+    h4 = t('.achievement_count_header')
+  table.table.leaderboard-achievement
+    tbody
+      - course_users_count = @course_users.ordered_by_achievement_count.take(display_user_count)
+      - course_users_count.each.with_index(1) do |course_user, index|
+        = content_tag_for(:tr, course_user, class: ['course-user'])
+          td.rank
+            h3 = index
+          td.user-picture
+            = link_to_course_user(course_user) do
+              = display_user_image(course_user.user)
+          td.user-profile
+            div
+              = link_to_course_user(course_user) do
+                = format_inline_text(course_user.name)
+            div
+              - course_user.achievements.ordered_by_date_obtained.take(5).each do |achievement|
+                = content_tag_for(:span, achievement) do
+                  = link_to course_achievement_path(current_course, achievement) do
+                    = display_achievement_badge(achievement)

--- a/config/locales/en/course/leaderboard.yml
+++ b/config/locales/en/course/leaderboard.yml
@@ -5,3 +5,10 @@ en:
       title: :'course.leaderboard.index.header'
       index:
         header: 'Leaderboard'
+    # TODO: Refactor to singular controller
+    leaderboards:
+      show:
+        header: 'Leaderboard'
+        level_header: 'By Level'
+        level: 'Level %{level_number}'
+        achievement_count_header: 'By Achievement Count'

--- a/spec/features/course/leaderboard_viewing_spec.rb
+++ b/spec/features/course/leaderboard_viewing_spec.rb
@@ -10,9 +10,41 @@ RSpec.describe 'Course: Leaderboard: View' do
     end
 
     context 'As a student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
-      scenario 'I can view the leaderboard' do
+      let(:students) { create_list(:course_student, 2, :approved, course: course) }
+      let(:user) { students[0].user }
+
+      scenario 'I can view the leaderboard sorted by level' do
+        create(:course_experience_points_record, points_awarded: 200, course_user: students[0])
         visit course_leaderboard_path(course)
+
+        within find('.leaderboard-level') do
+          sorted_course_users = course.course_users.students.ordered_by_experience_points
+
+          sorted_course_users.each.with_index(1) do |student, index|
+            within find(content_tag_selector(student)) do
+              expect(page).to have_text(index)
+              expect(page).to have_text(I18n.t('course.leaderboards.show.level'))
+            end
+          end
+        end
+      end
+
+      scenario 'I can view the leaderboard sorted by achievement count' do
+        create(:course_user_achievement, course_user: students[0])
+        visit course_leaderboard_path(course)
+
+        within find('.leaderboard-achievement') do
+          sorted_course_users = course.course_users.students.ordered_by_achievement_count
+
+          sorted_course_users.each.with_index(1) do |student, index|
+            within find(content_tag_selector(student)) do
+              expect(page).to have_text(index)
+              student.achievements.ordered_by_date_obtained.take(5).each do |achievement|
+                expect(page).to have_content_tag_for(achievement)
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Sorry if this is a big PR, but it seemed to all fit into big piece under leaderboard view. 

Quick summary: 
- Scope to load course_users, sorted by experience points
- Scope to load course_users, sorted by achievement count, as well as date when achievement_count is obtained. 
- Views to display leaderboard.
- Addition of level helper method to reduce SQL calls when loading leaderboard. 

This completes #634 