### PR TITLE
Allow models to declare that they can be duplicated

### DIFF
--- a/lib/extensions/duplicable.rb
+++ b/lib/extensions/duplicable.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+module Extensions::Duplicable; end

--- a/lib/extensions/duplicable/active_record.rb
+++ b/lib/extensions/duplicable/active_record.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+module Extensions::Duplicable::ActiveRecord; end

--- a/lib/extensions/duplicable/active_record/base.rb
+++ b/lib/extensions/duplicable/active_record/base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Extensions::Duplicable::ActiveRecord::Base
+  module ClassMethods
+    # This function should be declared in model, to make it duplicable.
+    def acts_as_duplicable
+      include ActsAsDuplicable
+    end
+  end
+
+  module ActsAsDuplicable
+    # Overridden by the model to duplicate its children.
+    #
+    # @param _duplicator [Duplicator] Duplicator object for checking if objects
+    #   have been duplicated.
+    # @param _other [Object] Source object whose children are to be duplicated.
+    def initialize_duplicate(_duplicator, _other)
+      raise NotImplementedError, 'Implement your own initialize_duplicate method for this model.'
+    end
+  end
+end

--- a/spec/libraries/acts_as_duplicable_spec.rb
+++ b/spec/libraries/acts_as_duplicable_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Extension: Acts as Duplicable' do
+  class self::SampleModelDuplicable < ActiveRecord::Base
+    def self.columns
+      []
+    end
+
+    acts_as_duplicable
+  end
+
+  describe self::SampleModelDuplicable, type: :model do
+    it { is_expected.to respond_to(:initialize_duplicate) }
+
+    it 'raises an exception when initialize_duplicate is called' do
+      expect { subject.initialize_duplicate(nil, nil) }.
+        to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
Models which call `acts_as_duplicable` will have to override `initialize_duplicate` with their own implementation which duplicates their child objects.

Future PRs will add the UI and a sample implementation.