### PR TITLE
Define the API to unlock or lock the conditional for a given course user

### DIFF
--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -16,4 +16,10 @@ class Course::Achievement < ActiveRecord::Base
   def set_defaults
     self.weight ||= 10
   end
+
+  def permitted_for!(_course_user)
+  end
+
+  def precluded_for!(_course_user)
+  end
 end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -72,6 +72,12 @@ class Course::Assessment < ActiveRecord::Base
     'course/assessment/assessments/assessment'.freeze
   end
 
+  def permitted_for!(_course_user)
+  end
+
+  def precluded_for!(_course_user)
+  end
+
   private
 
   # Sets the course of the lesson plan item to be the same as the one for the assessment.

--- a/lib/extensions/conditional/active_record/base.rb
+++ b/lib/extensions/conditional/active_record/base.rb
@@ -32,6 +32,20 @@ module Extensions::Conditional::ActiveRecord::Base
     def conditions_satisfied_by?(course_user)
       conditions.all? { |condition| condition.satisfied_by?(course_user) }
     end
+
+    # Permit the conditional for the given course user.
+    #
+    # @param [CourseUser] _course_user The course user in which the conditional is to unlock for
+    def permitted_for!(_course_user)
+      raise NotImplementedError, 'Subclasses must implement a permitted_for! method.'
+    end
+
+    # Preclude the conditional for the given course user.
+    #
+    # @param [CourseUser] _course_user The course user in which the conditional is to lock for
+    def precluded_for!(_course_user)
+      raise NotImplementedError, 'Subclasses must implement a precluded_for! method.'
+    end
   end
 
   module ConditionInstanceMethods
@@ -44,13 +58,13 @@ module Extensions::Conditional::ActiveRecord::Base
     # A human-readable name for each condition; usually just wraps a title
     # or name field. Meant to be used in a polymorphic manner for views.
     def title
-      raise NotImplementedError
+      raise NotImplementedError, 'Subclasses must implement a title method.'
     end
 
     # @return [Object] Conditional object that the condition depends on to check if it is
     #   satisfiable
     def dependent_object
-      raise NotImplementedError
+      raise NotImplementedError, 'Subclasses must implement a dependent_object method.'
     end
 
     # Checks if the condition is satisfied by the user.
@@ -58,7 +72,7 @@ module Extensions::Conditional::ActiveRecord::Base
     # @param [CourseUser] _user The user that the condition is being checked on
     # @return [Boolean] true if the condition is met and false otherwise
     def satisfied_by?(_user)
-      raise NotImplementedError
+      raise NotImplementedError, 'Subclasses must implement a satisfied_by? method.'
     end
 
     private
@@ -86,7 +100,7 @@ module Extensions::Conditional::ActiveRecord::Base
   module ConditionClassMethods
     # Class that the condition depends on.
     def dependent_class
-      raise NotImplementedError
+      raise NotImplementedError, 'Subclasses must implement a dependent_class method.'
     end
 
     # Evaluate and update the satisfied conditionals for the given course user.

--- a/spec/libraries/acts_as_conditional_spec.rb
+++ b/spec/libraries/acts_as_conditional_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe 'Extension: Acts as Conditional', type: :model do
 
     it { is_expected.to have_many(:conditions).inverse_of(:conditional) }
 
+    it 'implements #permitted_for!' do
+      expect(subject).to respond_to(:permitted_for!)
+      expect { subject.permitted_for!(double) }.to raise_error(NotImplementedError)
+    end
+
+    it 'implements #precluded_for!' do
+      expect(subject).to respond_to(:precluded_for!)
+      expect { subject.precluded_for!(double) }.to raise_error(NotImplementedError)
+    end
+
     describe '#specific_conditions' do
       it 'is of the specific condition type' do
         condition = instance_double(Course::Condition)

--- a/spec/models/course/achievement_spec.rb
+++ b/spec/models/course/achievement_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Course::Achievement, type: :model do
         expect(weights.length).to be > 1
         expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
       end
+
+      it 'implements #permitted_for!' do
+        expect(subject).to respond_to(:permitted_for!)
+        expect { subject.permitted_for!(double) }.to_not raise_error
+      end
+
+      it 'implements #precluded_for!' do
+        expect(subject).to respond_to(:precluded_for!)
+        expect { subject.precluded_for!(double) }.to_not raise_error
+      end
     end
   end
 end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Course::Assessment do
     let(:assessment) { create(:assessment, *assessment_traits, course: course) }
     let(:assessment_traits) { [] }
 
+    it 'implements #permitted_for!' do
+      expect(subject).to respond_to(:permitted_for!)
+      expect { subject.permitted_for!(double) }.to_not raise_error
+    end
+
+    it 'implements #precluded_for!' do
+      expect(subject).to respond_to(:precluded_for!)
+      expect { subject.precluded_for!(double) }.to_not raise_error
+    end
+
     describe 'validations' do
       context 'when it is not a draft' do
         context 'when it has no questions' do


### PR DESCRIPTION
API to lock or unlock the conditional object for a given course user. Conditional object that requires additional logic could override these methods. E.g. Achievement

These method will be called during the process of traversing the satisfiability graph to update the state of the conditionals for the given course user.