### PR TITLE
Improve satisfiability graph to deal with additional conditional's logic

### DIFF
--- a/app/services/course/conditional/conditional_satisfiability_evaluation_service.rb
+++ b/app/services/course/conditional/conditional_satisfiability_evaluation_service.rb
@@ -13,22 +13,10 @@ class Course::Conditional::ConditionalSatisfiabilityEvaluationService
     @course_user = course_user
     @course = course_user.course
 
-    # Evaluate conditionals for the user
-    satisfied_conditionals = satisfiability_graph.evaluate(satisfied_conditions, @course_user)
-
-    # Update the user with the satisfied conditionals
-    update_conditionals(satisfied_conditionals)
+    update_conditions(satisfiability_graph.evaluate(@course_user))
   end
 
   private
-
-  # Finds all the conditions that are satisfied by the course user
-  def satisfied_conditions
-    # TODO: Invalidate and replace current cache with the newly satisfied_condition
-    Course::Condition.includes(:actable).where(course: @course).
-      select { |c| c.satisfied_by?(@course_user) }.
-      map(&:specific)
-  end
 
   # Retrieve the satisfiability graph for the given course
   def satisfiability_graph
@@ -37,9 +25,7 @@ class Course::Conditional::ConditionalSatisfiabilityEvaluationService
       Course::Condition.conditionals_for(@course))
   end
 
-  # Update the conditionals for the course user base on the given satisfied conditionals
-  def update_conditionals(conditionals)
-    # TODO: To be replace with conditional's API for adding and removing conditionals
-    conditionals
+  def update_conditions(_satisfied_conditions)
+    # Call course user API to update the cache for the satisfied conditions
   end
 end

--- a/spec/services/course/conditional/conditional_satisfiability_evaluation_service_spec.rb
+++ b/spec/services/course/conditional/conditional_satisfiability_evaluation_service_spec.rb
@@ -13,23 +13,21 @@ RSpec.describe Course::Conditional::ConditionalSatisfiabilityEvaluationService d
         create(:course_achievement, course: course, conditions: [level_condition])
       end
 
-      subject do
-        Course::Conditional::ConditionalSatisfiabilityEvaluationService.evaluate(course_user)
-      end
-
       context 'when course user satisfy the level condition' do
         it 'adds the satisfied achievement conditional to the course user' do
           allow(course_user).to receive(:level_number).and_return(2)
-          # TODO: Check that the achievement was added to the course user once conditional's API
+          # TODO: Check that the achievement was added to the course user once achievement's API
           # are added in
-          expect(subject).to contain_exactly(achievement)
+          subject.evaluate(course_user)
         end
       end
 
       context 'when course user do not satisfy the level condition' do
-        # TODO: Check that course user do not have the achievement once conditional's API are
-        # added in
-        it { is_expected.to be_empty }
+        it 'does not adds the unsatisfied achievement conditional to the course user' do
+          # TODO: Check that course user do not have the achievement once achievement's API are
+          # added in
+          subject.evaluate(course_user)
+        end
       end
     end
   end


### PR DESCRIPTION
Depends on #965.

Allow satisfiaibility graph to consider the business logic of conditionals during evaluation to properly propagate the effect of satisfied conditionals.

This dealt with the case in which conditionals have additional business logic that is not related to the dependency. E.g. Achievement with no dependency should not be automatically awarded. In the past, all conditionals that are satisfied will be propagated, which is incorrect for Achievement.

This was achieved by making use of the conditional's locking and unlocking API during evaluation rather than in the evaluation service, so that the unlocking logic will be called before further evaluation.

Test cases for the satisfiability graph are also improved to include these additional logic.