### PR TITLE
Allow staff to award points for worksheet assessments

### DIFF
--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -39,6 +39,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
     @update_params ||= begin
       params.require(:submission).permit(
         *workflow_state_params,
+        :points_awarded,
         answers_attributes: [:id] + update_answers_params
       )
     end

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -19,7 +19,7 @@ nav
     = f.button :submit, t('.finalise'), name: 'submission[finalise]', class: ['btn-danger']
 
   - unless @submission.attempting?
-    = render 'statistics'
+    = render 'statistics', f: f
 
   - if @submission.submitted? && can?(:grade, @submission)
     = link_to t('.auto_grade'),

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -14,7 +14,10 @@ div.panel.panel-default
           td = @submission.grade
         tr
           th = @submission.experience_points_record.class.human_attribute_name(:points_awarded)
-          td = @submission.points_awarded
+          - if can?(:grade, @submission)
+            td = f.input :points_awarded, label: false
+          - else
+            td = @submission.points_awarded
         tr
           th = t('.due_at')
           td = format_datetime(@assessment.end_at) if @assessment.end_at

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -7,7 +7,7 @@
                locals: { base_answer_form: base_answer_form }
 
   - unless @submission.attempting?
-    = render 'statistics'
+    = render 'statistics', f: f
 
   = f.button :submit, t('common.save')
   - if @submission.attempting? && can?(:update, @submission)

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
     let(:submission) do
       create(:course_assessment_submission, assessment: assessment, user: student)
     end
+    let(:points_awarded) { 22 }
 
     context 'As a Course Student' do
       let(:user) { student }
@@ -103,12 +104,14 @@ RSpec.describe 'Course: Assessments: Attempt' do
             submission_maximum_grade += answer.question.maximum_grade
           end
         end
+        fill_in 'submission_points_awarded', with: points_awarded
 
         click_button I18n.t('course.assessment.submission.submissions.worksheet.publish')
         expect(current_path).to eq(
           edit_course_assessment_submission_path(course, assessment, submission))
         expect(submission.reload.graded?).to be(true)
         expect(submission.grade).to eq(submission_maximum_grade)
+        expect(submission.points_awarded).to eq(points_awarded)
       end
     end
   end


### PR DESCRIPTION
Subsequent PRs:
- Ensure that guided assessments are able to award experience points (after #938 is merged)
- Add feature that recommends the number of points to award based on the grading