### PR TITLE
Override send_devise_notification.

### DIFF
--- a/app/models/concerns/user_authentication_concern.rb
+++ b/app/models/concerns/user_authentication_concern.rb
@@ -44,5 +44,11 @@ module UserAuthenticationConcern
     def password_required?
       system? ? false : super
     end
+
+    # This sends Devise emails through the existing queue.
+    # See https://github.com/plataformatec/devise#activejob-integration
+    def send_devise_notification(notification, *args)
+      devise_mailer.send(notification, self, *args).deliver_later
+    end
   end
 end


### PR DESCRIPTION
This makes it use the existing queue setup for ActiveJob to deliver
ActionMailer messages in the background.