### PR TITLE
Lock evaluations before assigning them to evaluators.

### DIFF
--- a/app/models/course/assessment/programming_evaluation.rb
+++ b/app/models/course/assessment/programming_evaluation.rb
@@ -63,6 +63,13 @@ class Course::Assessment::ProgrammingEvaluation < ActiveRecord::Base
   #   completed or errored.
   scope :finished, -> { where { (status == 'completed') | (status == 'errored') } }
 
+  # Checks if the given task is still pending assignment to an evaluator.
+  #
+  # @return [Boolean]
+  def pending?
+    submitted? || (assigned? && assigned_at < Time.zone.now - TIMEOUT)
+  end
+
   # Checks if the given task is finished
   #
   # @return [Boolean]

--- a/spec/controllers/course/assessment/programming_evaluations_controller_spec.rb
+++ b/spec/controllers/course/assessment/programming_evaluations_controller_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationsController do
     let(:user) { create(:user, :auto_grader) }
     let(:course) { create(:course, creator: user) }
     let(:evaluation) do
-      create(:course_assessment_programming_evaluation, :assigned, course: course)
+      create(:course_assessment_programming_evaluation, *evaluation_traits, course: course)
     end
+    let(:evaluation_traits) { nil }
     let(:immutable_evaluation) do
       create(:course_assessment_programming_evaluation, course: course).tap do |stub|
         allow(stub).to receive(:save).and_return(false)
@@ -36,6 +37,7 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationsController do
     end
 
     describe '#update_result' do
+      let(:evaluation_traits) { [:assigned] }
       let(:request) do
         put :update_result, format: :json, course_id: course, programming_evaluation_id: evaluation,
                             programming_evaluation: evaluation.attributes.slice('stdout', 'stderr',
@@ -50,6 +52,65 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationsController do
         end
 
         it { is_expected.to respond_with(400) }
+      end
+    end
+
+    describe '#load_and_authorize_pending_programming_evaluation' do
+      subject { controller.send(:load_and_authorize_pending_programming_evaluation) {} }
+
+      context 'when the allocated programming evaluation was assigned to another thread' do
+        before do
+          count = 0
+          wrapper = proc do |method, *args|
+            count += 1
+            raise IllegalStateError if count == 1
+            method.call(*args)
+          end
+
+          expect(controller).to receive(:find_pending_programming_evaluation).exactly(:twice).
+            and_wrap_original(&wrapper)
+        end
+
+        it 'retries the allocation' do
+          subject
+          expect(controller.instance_variable_get(:@programming_evaluations)).to be_a(Array)
+        end
+      end
+    end
+
+    describe '#find_pending_programming_evaluation' do
+      subject { controller.send(:find_pending_programming_evaluation) }
+
+      before do
+        allow(Course::Assessment::ProgrammingEvaluation).to \
+          receive_message_chain(:accessible_by, :with_language, :pending, :take).
+          and_return(evaluation)
+      end
+
+      context 'when no evaluations are pending' do
+        let(:evaluation) { nil }
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+
+      context 'when an evaluation is pending' do
+        it 'returns the evaluation' do
+          evaluation
+          expect(subject).to eq(evaluation)
+        end
+      end
+
+      context 'when the evaluation is changed by another thread' do
+        it 'raises an IllegalStateError' do
+          expect(evaluation).to receive(:lock!).and_wrap_original do |method, *args|
+            evaluation.assign!(user)
+            evaluation.save
+            method.call(*args)
+          end
+
+          expect { subject }.to raise_error(IllegalStateError)
+        end
       end
     end
   end


### PR DESCRIPTION
This reduces the number of jobs assigned to multiple evaluators.