### PR TITLE
Minor fixes to translation key and ordering of sidebar items

### DIFF
--- a/app/controllers/components/course/achievements_component.rb
+++ b/app/controllers/components/course/achievements_component.rb
@@ -7,7 +7,7 @@ class Course::AchievementsComponent < SimpleDelegator
       {
         key: :achievements,
         title: I18n.t('course.achievement.achievements.sidebar_title'),
-        weight: 2,
+        weight: 4,
         path: course_achievements_path(current_course),
         unread: 0
       }

--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -13,7 +13,7 @@ class Course::AssessmentsComponent < SimpleDelegator
       {
         key: :assessments,
         title: category.title,
-        weight: 3,
+        weight: 2,
         path: course_assessments_path(current_course, category: category, tab: category.tabs.first),
         unread: 0
       }

--- a/app/controllers/components/course/forums_component.rb
+++ b/app/controllers/components/course/forums_component.rb
@@ -17,7 +17,7 @@ class Course::ForumsComponent < SimpleDelegator
       {
         key: :forums,
         title: settings.title || t('course.forum.forums.sidebar_title'),
-        weight: 5,
+        weight: 9,
         path: course_forums_path(current_course),
         unread: unread_count
       }

--- a/app/controllers/components/course/leaderboard_component.rb
+++ b/app/controllers/components/course/leaderboard_component.rb
@@ -17,7 +17,7 @@ class Course::LeaderboardComponent < SimpleDelegator
       {
         key: :leaderboard,
         title: settings.title || t('course.leaderboards.sidebar_title'),
-        weight: 1,
+        weight: 5,
         path: course_leaderboard_path(current_course)
       }
     ]

--- a/app/controllers/components/course/leaderboard_component.rb
+++ b/app/controllers/components/course/leaderboard_component.rb
@@ -16,7 +16,7 @@ class Course::LeaderboardComponent < SimpleDelegator
     [
       {
         key: :leaderboard,
-        title: settings.title || t('course.leaderboard.sidebar_title'),
+        title: settings.title || t('course.leaderboards.sidebar_title'),
         weight: 1,
         path: course_leaderboard_path(current_course)
       }
@@ -26,7 +26,7 @@ class Course::LeaderboardComponent < SimpleDelegator
   def settings_sidebar_items
     [
       {
-        title: settings.title || t('course.leaderboard.title'),
+        title: settings.title || t('course.leaderboards.title'),
         type: :settings,
         weight: 4,
         path: course_admin_leaderboard_path(current_course)

--- a/app/controllers/components/course/lesson_plan_component.rb
+++ b/app/controllers/components/course/lesson_plan_component.rb
@@ -7,7 +7,7 @@ class Course::LessonPlanComponent < SimpleDelegator
       {
         key: :lesson_plan,
         title: I18n.t('course.lesson_plan.items.sidebar_title'),
-        weight: 3,
+        weight: 7,
         path: course_lesson_plan_path(current_course)
       }
     ]

--- a/app/controllers/components/course/materials_component.rb
+++ b/app/controllers/components/course/materials_component.rb
@@ -17,7 +17,7 @@ class Course::MaterialsComponent < SimpleDelegator
       {
         key: :materials,
         title: settings.title || t('course.material.sidebar_title'),
-        weight: 4,
+        weight: 8,
         path: course_material_folder_path(current_course, current_course.root_folder),
         unread: 0
       }

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -13,7 +13,7 @@ class Course::UsersComponent < SimpleDelegator
       {
         title: t('course.users.sidebar_title'),
         key: :users,
-        weight: 8,
+        weight: 6,
         path: course_users_path(current_course)
       }
     ]

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -29,7 +29,7 @@ en:
         forum_settings:
           edit: :'course.forum.forums.sidebar_title'
         leaderboard_settings:
-          edit: :'course.leaderboard.index.header'
+          edit: :'course.leaderboards.index.header'
       users:
         index: 'Users'
         students: :'course.users.students.header'
@@ -101,7 +101,7 @@ en:
           new_topic: :'course.forum.topics.new_topic.header'
           edit_topic: :'course.forum.topics.edit_topic.header'
       leaderboards:
-        index: :'course.leaderboard.title'
+        index: :'course.leaderboards.title'
       experience_points_records:
         index: 'Experience Points History'
 

--- a/config/locales/en/course/leaderboards.yml
+++ b/config/locales/en/course/leaderboards.yml
@@ -1,12 +1,10 @@
 en:
   course:
-    leaderboard:
-      sidebar_title: :'course.leaderboard.index.header'
-      title: :'course.leaderboard.index.header'
+    leaderboards:
+      sidebar_title: :'course.leaderboards.index.header'
+      title: :'course.leaderboards.index.header'
       index:
         header: 'Leaderboard'
-    # TODO: Refactor to singular controller
-    leaderboards:
       show:
         header: 'Leaderboard'
         level_header: 'By Level'

--- a/spec/features/course/admin/leaderboard_settings_spec.rb
+++ b/spec/features/course/admin/leaderboard_settings_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Course: Administration: Leaderboard' do
         click_button 'update'
         expect(page).
           to have_selector('div', text: I18n.t('course.admin.leaderboard_settings.update.success'))
-        expect(page).to have_selector('li a', text: I18n.t('course.leaderboard.sidebar_title'))
+        expect(page).to have_selector('li a', text: I18n.t('course.leaderboards.sidebar_title'))
       end
     end
   end


### PR DESCRIPTION
This PR does some minor fixes: 
- Standardise translation keys (used to be `course.leaderboards.x` and `course.leaderboard.x`) for leaderboard. 
- Shifted achievements and leaderboard components below assessments. 

This addresses part of #917

Updated default sidebar order is as follows: (Taken reference from v1)

<img width="314" alt="screen shot 2016-04-08 at 5 00 00 pm" src="https://cloud.githubusercontent.com/assets/4353853/14379280/f2213bde-fdab-11e5-94e3-aa18d8aad3f4.png">
