### PR TITLE
Refactor course#level_for to reduce SQL calls in leaderboard

### DIFF
--- a/app/controllers/course/leaderboards_controller.rb
+++ b/app/controllers/course/leaderboards_controller.rb
@@ -5,6 +5,7 @@ class Course::LeaderboardsController < Course::ComponentController
   before_action :add_leaderboard_breadcrumb
 
   def show #:nodoc:
+    preload_course_levels
     load_course_users
   end
 
@@ -20,6 +21,11 @@ class Course::LeaderboardsController < Course::ComponentController
   # Load current component's settings
   def load_settings
     @leaderboard_settings = component.settings
+  end
+
+  # Preload course.levels to reduce SQL calls in leaderboard view. See course#level_for.
+  def preload_course_levels
+    @course.levels.to_a
   end
 
   # Load approved students from current course with course statistics.

--- a/app/models/concerns/course/levels_concern.rb
+++ b/app/models/concerns/course/levels_concern.rb
@@ -2,23 +2,27 @@
 module Course::LevelsConcern
   extend ActiveSupport::Concern
 
-  # Returns Course::Level object corresponding to
-  # the level that a course participant would have attained if
-  # s/he had experience_points number of experience points.
+  # Returns the Course::Level object corresponding to the experience points provided.
+  # To use ruby to obtain the required level, ensure that course.levels is already loaded.
+  # Otherwise, an SQL call is fired for each method call.
   #
-  # If experience_points <= 0, the level is assumed to be the
-  # default level (the 0th level) with 0 experience_points threshold.
+  # If experience_points <= 0, the level is assumed to be the default level
+  # (the 0th level) with 0 experience_points threshold.
   #
   # @param [Fixnum] experience_points Number of Experience Points
   # @return [Course::Level] A Course::Level instance.
   def level_for(experience_points)
-    return levels.first if experience_points < 0
-    levels.reverse_order.find_by('experience_points_threshold <= ?', experience_points)
+    return first if experience_points < 0
+    if loaded?
+      reverse.find { |level| level.experience_points_threshold <= experience_points }
+    else
+      reverse_order.find_by('experience_points_threshold <= ?', experience_points)
+    end
   end
 
   # Test if the course has a default level.
   # @return [Boolean] True if there is a default level, otherwise false.
   def default_level?
-    levels.any?(&:default_level?)
+    any?(&:default_level?)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class Course < ActiveRecord::Base
-  include Course::LevelsConcern
   include Course::LessonPlanConcern
   include Course::SearchConcern
 
@@ -39,7 +38,9 @@ class Course < ActiveRecord::Base
   has_many :assessment_programming_evaluations,
            class_name: Course::Assessment::ProgrammingEvaluation.name, dependent: :destroy,
            inverse_of: :course
-  has_many :levels, dependent: :destroy, inverse_of: :course
+  has_many :levels, dependent: :destroy, inverse_of: :course do
+    include Course::LevelsConcern
+  end
   has_many :groups, dependent: :destroy, class_name: Course::Group.name
   has_many :lesson_plan_items, class_name: Course::LessonPlan::Item.name, dependent: :destroy
   has_many :lesson_plan_milestones, class_name: Course::LessonPlan::Milestone.name,
@@ -67,6 +68,8 @@ class Course < ActiveRecord::Base
   delegate :instructors, to: :course_users
   delegate :managers, to: :course_users
   delegate :user?, to: :course_users
+  delegate :level_for, to: :levels
+  delegate :default_level?, to: :levels
 
   def self.use_relative_model_naming?
     true

--- a/app/views/course/leaderboards/show.html.slim
+++ b/app/views/course/leaderboards/show.html.slim
@@ -18,7 +18,6 @@ div.col-sm-12.col-md-6
               = link_to_course_user(course_user) do
                 = format_inline_text(course_user.name)
             div
-              / TODO: Refactor to reduce SQL calls. Refer to Coursemology/coursemology2#987
               = t('.level', level_number: course_user.level_number)
 
 div.col-sm-12.col-md-6


### PR DESCRIPTION
Method now uses ruby instead of SQL, this reduces the number of SQL calls required for leaderboard.

Fixes #987.