### PR TITLE
Fix cyclic validation for conditions with no dependent object.

### DIFF
--- a/lib/autoload/course/conditional/user_satisfiability_graph.rb
+++ b/lib/autoload/course/conditional/user_satisfiability_graph.rb
@@ -51,6 +51,7 @@ class Course::Conditional::UserSatisfiabilityGraph
   # @param [Object] dest Conditional node as the destination
   # @return [Bool] true if the dest node is reachable from the source node
   def self.reachable?(source, dest)
+    return false unless dest
     return true if source == dest
 
     dest.specific_conditions.index { |c| reachable?(source, c.dependent_object) }.present?


### PR DESCRIPTION
Fix #986. This issue arise because level condition do not have any dependent conditional object.

Add the logic to handle the case in which destination may be nil.