### PR TITLE
Improve Experience Points History view

### DIFF
--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -9,7 +9,7 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
 
   def index # :nodoc:
     @experience_points_records =
-      @experience_points_records.active.includes(creator: :course_users)
+      @experience_points_records.active.includes(:updater)
   end
 
   def destroy # :nodoc:

--- a/app/models/concerns/course/assessment/submission/experience_points_display_concern.rb
+++ b/app/models/concerns/course/assessment/submission/experience_points_display_concern.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Course::Assessment::Submission::ExperiencePointsDisplayConcern
+  extend ActiveSupport::Concern
+
+  # The reason to be displayed for the submission's experience point award.
+  #
+  # @return [String] The reason which will be displayed
+  def experience_points_display_reason
+    assessment.title
+  end
+end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 class Course::Assessment::Submission < ActiveRecord::Base
   include Workflow
+
   acts_as_experience_points_record
+  include Course::Assessment::Submission::ExperiencePointsDisplayConcern
 
   after_save :auto_grade_submission, if: :submitted?
 

--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -23,4 +23,11 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
   def manually_awarded?
     actable_type.nil? && actable.nil?
   end
+
+  # The string to be displayed under the 'reason' column in the experience points history page.
+  #
+  # @return [String] The formatted reason for the award
+  def reason
+    manually_awarded? ? super : specific.experience_points_display_reason
+  end
 end

--- a/app/views/course/experience_points_records/_experience_points_record.html.slim
+++ b/app/views/course/experience_points_records/_experience_points_record.html.slim
@@ -2,6 +2,7 @@
   td = experience_points_record.points_awarded
   td = format_inline_text(experience_points_record.reason)
   td = link_to_user(experience_points_record.creator)
+  td = experience_points_record.updated_at
   td
     - if experience_points_record.manually_awarded? && can?(:destroy, experience_points_record)
       = delete_button(course_user_experience_points_record_path(current_course,

--- a/app/views/course/experience_points_records/_experience_points_record.html.slim
+++ b/app/views/course/experience_points_records/_experience_points_record.html.slim
@@ -1,7 +1,7 @@
 = content_tag_for(:tr, experience_points_record)
   td = experience_points_record.points_awarded
   td = format_inline_text(experience_points_record.reason)
-  td = link_to_user(experience_points_record.creator)
+  td = link_to_user(experience_points_record.updater)
   td = experience_points_record.updated_at
   td
     - if experience_points_record.manually_awarded? && can?(:destroy, experience_points_record)

--- a/app/views/course/experience_points_records/index.html.slim
+++ b/app/views/course/experience_points_records/index.html.slim
@@ -6,6 +6,7 @@ table.table.levels-list.table-hover
       th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
       th = Course::ExperiencePointsRecord.human_attribute_name(:reason)
       th = Course::ExperiencePointsRecord.human_attribute_name(:awarder)
+      th = Course::ExperiencePointsRecord.human_attribute_name(:updated_at)
       th
   tbody
     = render @experience_points_records

--- a/app/views/course/experience_points_records/index.html.slim
+++ b/app/views/course/experience_points_records/index.html.slim
@@ -5,7 +5,7 @@ table.table.levels-list.table-hover
     tr
       th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
       th = Course::ExperiencePointsRecord.human_attribute_name(:reason)
-      th = Course::ExperiencePointsRecord.human_attribute_name(:awarder)
+      th = Course::ExperiencePointsRecord.human_attribute_name(:updater)
       th = Course::ExperiencePointsRecord.human_attribute_name(:updated_at)
       th
   tbody

--- a/lib/extensions/acts_as_helpers/active_record/base.rb
+++ b/lib/extensions/acts_as_helpers/active_record/base.rb
@@ -18,5 +18,15 @@ module Extensions::ActsAsHelpers::ActiveRecord::Base
     def manually_awarded?
       false
     end
+
+    # The description to be displayed in the 'reason' column for the experience points record on
+    # the experience points history page.
+    # This method is meant to be overridden by each class that acts as an experience points record.
+    #
+    # @return [String] Reason which will be displayed
+    def experience_points_display_reason
+      raise NotImplementedError,
+            'Experience points awarding items need to implement a points_display_reason method'
+    end
   end
 end

--- a/spec/factories/course_experience_points_records.rb
+++ b/spec/factories/course_experience_points_records.rb
@@ -13,13 +13,6 @@ FactoryGirl.define do
     points_awarded { rand(1..20) * 100 }
     reason { 'Reason for manually-awarded experience points' if manually_awarded? }
 
-    trait :automatically_awarded do
-      after(:build) do |record|
-        record.actable = record
-        record.reason = nil
-      end
-    end
-
     trait :inactive do
       points_awarded nil
     end

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -7,12 +7,10 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_student) { create(:course_student, :approved, course: course) }
+    let(:record) { create(:submission, course_user: course_student).acting_as }
     let(:manual_record) { create(:course_experience_points_record, course_user: course_student) }
     let(:inactive_record) do
       create(:course_experience_points_record, :inactive, course_user: course_student)
-    end
-    let(:record) do
-      create(:course_experience_points_record, :automatically_awarded, course_user: course_student)
     end
     let(:records) { [record, manual_record, inactive_record] }
 

--- a/spec/libraries/acts_as_exp_record_spec.rb
+++ b/spec/libraries/acts_as_exp_record_spec.rb
@@ -16,4 +16,5 @@ RSpec.describe 'Extension: Acts as Experience Points Record' do
   it { is_expected.to respond_to(:course_user) }
   it { is_expected.to respond_to(:acting_as) }
   it { expect(subject.acting_as).to respond_to(:specific) }
+  it { expect { subject.experience_points_display_reason }.to raise_error(NotImplementedError) }
 end


### PR DESCRIPTION
- Add the last updated time of experience points records
- Since we display the "updated at" column, show the updater instead of creator so that it is consistent
- Use assessment titles as the experience points award reason for submissions

Future PRs:
- Allow users to click on the reason and view the points awarding item