### PR TITLE
Hide the empty linked folders

### DIFF
--- a/app/controllers/course/material/folders_controller.rb
+++ b/app/controllers/course/material/folders_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Course::Material::FoldersController < Course::Material::Controller
   def show
+    @subfolders = @folder.children.with_content_statistics.accessible_by(current_ability).
+                  includes(:owner).without_empty_linked_folder
   end
 
   def edit

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -30,6 +30,16 @@ class Course::Material::Folder < ActiveRecord::Base
       where { children.parent_id == course_material_folders.id }
   end)
 
+  # Filter out the empty linked folders (i.e. Folder with an owner).
+  def self.without_empty_linked_folder
+    select do |folder|
+      folder.owner.nil? ||
+        folder.owner && folder.material_count != 0 && folder.children_count != 0
+    end
+  end
+
+  scope :with_content_statistics, ->() { all.calculated(:material_count, :children_count) }
+
   def files_attributes=(files)
     files.each do |file|
       materials.build(name: Pathname.normalize_filename(file.original_filename), file: file)

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -15,6 +15,21 @@ class Course::Material::Folder < ActiveRecord::Base
   validate :validate_name_is_unique_among_materials
   validates_with FilenameValidator
 
+  # @!attribute [r] material_count
+  #   Returns the number of files in current folder.
+  calculated :material_count, (lambda do
+    Course::Material.select { count('*') }.
+      where { course_materials.folder_id == course_material_folders.id }
+  end)
+
+  # @!attribute [r] children_count
+  #   Returns the number of subfolders in current folder.
+  calculated :children_count, (lambda do
+    select { count('*') }.
+      from('course_material_folders children').
+      where { children.parent_id == course_material_folders.id }
+  end)
+
   def files_attributes=(files)
     files.each do |file|
       materials.build(name: Pathname.normalize_filename(file.original_filename), file: file)

--- a/app/views/course/material/folders/show.html.slim
+++ b/app/views/course/material/folders/show.html.slim
@@ -13,5 +13,5 @@ table.table.table-hover
         td colspan="100%"
           = link_to '...', course_material_folder_path(current_course, @folder.parent)
 
-    = render @folder.children.accessible_by(current_ability).preload(:owner)
+    = render @subfolders
     = render partial: 'material', collection: @folder.materials

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -25,6 +25,12 @@ RSpec.feature 'Course: Material: Folders: Management' do
           expect(page).to have_link(nil, href: edit_course_material_folder_path(course, subfolder))
           expect(page).to have_link(nil, href: course_material_folder_path(course, subfolder))
         end
+
+        empty_linked_folders = parent_folder.children.
+                               select { |f| f.owner && !f.materials.empty? && !f.children.empty? }
+        empty_linked_folders.each do |subfolder|
+          expect(page).not_to have_content_tag_for(subfolder)
+        end
       end
 
       scenario 'I can create a subfolder' do
@@ -45,7 +51,7 @@ RSpec.feature 'Course: Material: Folders: Management' do
         fill_in 'material_folder_name', with: new_folder.name
         click_button 'submit'
 
-        expect(page).to have_content_tag_for(parent_folder.children.last)
+        expect(page).to have_content_tag_for(parent_folder.children.find_by(name: new_folder.name))
       end
 
       scenario 'I can edit a subfolder' do

--- a/spec/models/course/material/folder_spec.rb
+++ b/spec/models/course/material/folder_spec.rb
@@ -70,5 +70,25 @@ RSpec.describe Course::Material::Folder, type: :model do
         expect(folder.send(:next_valid_name)).to eq(common_name + ' (1)')
       end
     end
+
+    describe '#material_count' do
+      let(:folder) { create(:folder) }
+      let(:count) { Random.rand(3) }
+
+      it 'returns the number of materials in the folder' do
+        create_list(:material, count, folder: folder)
+        expect(folder.material_count).to eq(count)
+      end
+    end
+
+    describe '#children_count' do
+      let(:folder) { create(:folder) }
+      let(:count) { Random.rand(3) }
+
+      it 'returns the number of subfolders in the folder' do
+        create_list(:folder, count, parent: folder)
+        expect(folder.children_count).to eq(count)
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes #962 

- Implement calculating material count and subfolder count
- Filter out those empty folder with owners