### PR TITLE
Add links to the instances

### DIFF
--- a/app/views/system/admin/instances/_instance.html.slim
+++ b/app/views/system/admin/instances/_instance.html.slim
@@ -1,7 +1,8 @@
 = content_tag_for(:tr, instance)
   th
     a
-      = link_to format_inline_text(instance.name), admin_instance_path(instance)
+      = link_to format_inline_text(instance.name), \
+                admin_instance_admin_url(host: instance.host, port: nil)
 
   td = instance.host
 

--- a/spec/features/system/admin/instance_management_spec.rb
+++ b/spec/features/system/admin/instance_management_spec.rb
@@ -58,6 +58,8 @@ RSpec.feature 'System: Administration: Instances' do
 
         instances.each do |instance|
           expect(page).to have_content_tag_for(instance)
+          expect(page).
+            to have_link(nil, href: admin_instance_admin_url(host: instance.host, port: nil))
         end
       end
 


### PR DESCRIPTION
#948 

In instance management, the link will redirect user to the specific instance and further manage the instance there.