### PR TITLE
Implement satisfiability constraint on assessment attempt.

### DIFF
--- a/spec/models/course/condition/assessment_ability_spec.rb
+++ b/spec/models/course/condition/assessment_ability_spec.rb
@@ -13,5 +13,42 @@ RSpec.describe Course::Condition::Assessment do
 
       it { is_expected.to be_able_to(:manage, condition) }
     end
+
+    context 'when the user is a Course Student' do
+      let(:user) { create(:course_student, :approved, course: course).user }
+
+      context 'when the assessment has not started' do
+        let(:unopened_assessment) { create(:assessment, :unopened, course: course) }
+
+        it { is_expected.to_not be_able_to(:attempt, unopened_assessment) }
+      end
+
+      context 'when the assessment has started' do
+        let(:assessment1) { create(:assessment, course: course) }
+        let(:assessment2) { create(:assessment, course: course) }
+        let!(:condition) do
+          create(:assessment_condition,
+                 course: course,
+                 assessment: assessment2,
+                 conditional: assessment1)
+        end
+
+        context 'when the assessment does not have any condition' do
+          it { is_expected.to be_able_to(:attempt, assessment2) }
+        end
+
+        context "when the user does not satisfied the assessment's conditions" do
+          it { is_expected.to_not be_able_to(:attempt, assessment1) }
+        end
+
+        context "when the user satisfied the assessment's conditions" do
+          it 'is able to attempt the assessment' do
+            allow(assessment1).to receive(:conditions_satisfied_by?).and_return(true)
+
+            expect(subject.can?(:attempt, assessment1)).to be_truthy
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Course user can only attempt the assessment if and only if the dependency are satisfied. On the other hand, Course staff who can manage the assessment can attempt it without satisfying the constraint.