### PR TITLE
[Discussion] Implement achievement awarding logic

### DIFF
--- a/app/models/course/condition/achievement.rb
+++ b/app/models/course/condition/achievement.rb
@@ -7,6 +7,10 @@ class Course::Condition::Achievement < ActiveRecord::Base
     Course::Condition::Achievement.on_dependent_status_change(achievement)
   end
 
+  Course::UserAchievement.after_destroy do |achievement|
+    Course::Condition::Achievement.on_dependent_status_change(achievement)
+  end
+
   validate :validate_achievement_condition, if: :achievement_id_changed?
 
   belongs_to :achievement, class_name: Course::Achievement.name, inverse_of: :achievement_conditions
@@ -32,7 +36,7 @@ class Course::Condition::Achievement < ActiveRecord::Base
   end
 
   def self.on_dependent_status_change(achievement)
-    return if achievement.changes.empty?
+    return unless achievement.changes.any? || achievement.destroyed?
     achievement.execute_after_commit { evaluate_conditional_for(achievement.course_user) }
   end
 

--- a/spec/models/course/condition/achievement_spec.rb
+++ b/spec/models/course/condition/achievement_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe Course::Condition::Achievement, type: :model do
             user_achievement.save!
           end
         end
+
+        context 'when the user achievement is destroyed' do
+          it 'evaluate_conditional_for the affected course_user' do
+            user_achievement = create(:course_user_achievement, course_user: course_user)
+            expect(Course::Condition::Achievement).
+              to receive(:evaluate_conditional_for).with(course_user)
+            user_achievement.destroy!
+          end
+        end
+
+        context 'when the user achievement is destroyed through update attributes' do
+          it 'evaluate_conditional_for the affected course_user' do
+            user_achievement = create(:course_user_achievement, course_user: course_user)
+            expect(Course::Condition::Achievement).
+              to receive(:evaluate_conditional_for).with(course_user)
+            user_achievement.achievement.update_attributes(course_user_ids: [])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
@weiqingtoh Implemented the achievement awarding logic according to the following specification:

1) Achievement that has no conditions should not be automatically awarded for the course user
2) Achievement with conditions will automatically be awarded when student meets those conditions
3) When an achievement is removed from the user, dependent achievements (conditionals) will be removed as well.

To be discuss:
Following the requirements of (1-3), there is an implicit constraint that a grader could not manually award an achievement to the user when the achievement's conditions are not satisfied. Since the satisfiability graph will recognize that it is not satisfied and remove it currently. However, this can be solve by changing the precluded_for! logic to check for manually awarded achievement. What will then be the intended behavior for manually awarded achievement?