### PR TITLE
Change course_groups to refer to course_user instead of user

### DIFF
--- a/app/controllers/course/groups_controller.rb
+++ b/app/controllers/course/groups_controller.rb
@@ -41,7 +41,8 @@ class Course::GroupsController < Course::ComponentController
   private
 
   def group_params #:nodoc:
-    params.require(:group).permit(:name, user_ids: [],
-                                         group_users_attributes: [:id, :user_id, :role, :_destroy])
+    params.require(:group).
+      permit(:name, course_user_ids: [],
+                    group_users_attributes: [:id, :course_user_id, :role, :_destroy])
   end
 end

--- a/app/models/components/course/groups_ability_component.rb
+++ b/app/models/components/course/groups_ability_component.rb
@@ -22,6 +22,6 @@ module Course::GroupsAbilityComponent
   end
 
   def course_group_manager_hash
-    { group_users: { user_id: user.id, role: Course::GroupUser.roles[:manager] } }
+    { group_users: { course_user: { user_id: user.id }, role: Course::GroupUser.roles[:manager] } }
   end
 end

--- a/app/models/course/group.rb
+++ b/app/models/course/group.rb
@@ -4,12 +4,13 @@ class Course::Group < ActiveRecord::Base
   before_validation :set_defaults, if: :new_record?
 
   belongs_to :course, inverse_of: :groups
-  has_many :group_users, inverse_of: :course_group, dependent: :destroy,
-                         class_name: Course::GroupUser.name, foreign_key: :course_group_id
-  has_many :users, through: :group_users
+  has_many :group_users, inverse_of: :group, dependent: :destroy,
+                         class_name: Course::GroupUser.name, foreign_key: :group_id
+  has_many :course_users, through: :group_users
 
-  accepts_nested_attributes_for :group_users, allow_destroy: true,
-                                              reject_if: -> (params) { params[:user_id].blank? }
+  accepts_nested_attributes_for :group_users,
+                                allow_destroy: true,
+                                reject_if: -> (params) { params[:course_user_id].blank? }
 
   validate :validate_new_users_are_unique
 
@@ -17,8 +18,8 @@ class Course::Group < ActiveRecord::Base
 
   # Set default values
   def set_defaults
-    group_users.build(user: creator, role: :manager,
-                      creator: creator, updater: updater) if should_create_manager?
+    group_users.build(course_user: course.course_users.find_by(user_id: creator.id),
+                      role: :manager, creator: creator, updater: updater) if should_create_manager?
   end
 
   # Checks if the current group has sufficient information to have a manager, but does not
@@ -28,7 +29,7 @@ class Course::Group < ActiveRecord::Base
   def should_create_manager?
     course && creator &&
       course.course_users.exists?(user: creator) &&
-      !group_users.exists?(user: creator)
+      !group_users.any? { |group_user| group_user.course_user.user_id == creator }
   end
 
   # Validate that the new users are unique.
@@ -38,11 +39,11 @@ class Course::Group < ActiveRecord::Base
   # new records and will raise a {RecordNotUnique} error in that circumstance.
   def validate_new_users_are_unique
     new_group_users = group_users.select(&:new_record?)
-    return if new_group_users.count == new_group_users.uniq(&:user).count
+    return if new_group_users.count == new_group_users.uniq(&:course_user).count
 
     errors.add(:group_users, :invalid)
-    (new_group_users - new_group_users.uniq(&:user)).each do |group_user|
-      group_user.errors.add(:user, :taken)
+    (new_group_users - new_group_users.uniq(&:course_user)).each do |group_user|
+      group_user.errors.add(:course_user, :taken)
     end
   end
 end

--- a/app/models/course/group_user.rb
+++ b/app/models/course/group_user.rb
@@ -4,12 +4,10 @@ class Course::GroupUser < ActiveRecord::Base
 
   enum role: { normal: 0, manager: 1 }
 
-  validate :user_and_group_in_same_course
+  validate :course_user_and_group_in_same_course
 
-  belongs_to :user, inverse_of: :course_group_users
-  belongs_to :course_group, class_name: Course::Group.name, inverse_of: :group_users
-
-  alias_method :group, :course_group
+  belongs_to :course_user, inverse_of: :group_users
+  belongs_to :group, class_name: Course::Group.name, inverse_of: :group_users
 
   private
 
@@ -18,8 +16,9 @@ class Course::GroupUser < ActiveRecord::Base
     self.role ||= :normal
   end
 
-  def user_and_group_in_same_course #:nodoc:
-    return if group.course.course_users.with_approved_state.exists?(user: user)
-    errors.add(:user, :not_enrolled)
+  # Checks if course_user and course_group belongs to the same course.
+  def course_user_and_group_in_same_course
+    return if group.course == course_user.course
+    errors.add(:course_user, :not_enrolled)
   end
 end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -41,6 +41,10 @@ class CourseUser < ActiveRecord::Base
     include CourseUser::AchievementsConcern
   end
   has_one :invitation, class_name: Course::UserInvitation.name, dependent: :destroy, validate: true
+  has_many :group_users, class_name: Course::GroupUser.name,
+                         inverse_of: :course_user, dependent: :destroy
+  has_many :groups, through: :group_users, class_name: Course::Group.name, source: :group
+
 
   # @!attribute [r] experience_points
   #   Sums the total experience points for the course user.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,8 +55,6 @@ class User < ActiveRecord::Base
   end
   has_many :course_users, dependent: :destroy
   has_many :courses, through: :course_users
-  has_many :course_group_users, dependent: :destroy, class_name: Course::GroupUser.name
-  has_many :course_groups, through: :course_group_users, class_name: Course::Group.name
 
   accepts_nested_attributes_for :emails
 

--- a/app/views/course/groups/_group.html.slim
+++ b/app/views/course/groups/_group.html.slim
@@ -1,6 +1,6 @@
 = content_tag_for(:tr, group) do
   th = format_inline_text(group.name)
-  td = group.users.normal.count
+  td = group.course_users.with_approved_state.count
   td
     = edit_button(edit_course_group_path(current_course, group))
     = delete_button(course_group_path(current_course, group))

--- a/app/views/course/groups/_group_user_fields.html.slim
+++ b/app/views/course/groups/_group_user_fields.html.slim
@@ -1,4 +1,5 @@
 = content_tag_for(:tr, f.object, class: 'nested-fields') do
-  td = f.association :user, collection: current_course.users.with_approved_state, label: false
+  td = f.association :course_user, collection: current_course.course_users.with_approved_state,
+                                   label:  false
   td = f.input :role, as: :select, label: false, collection: Course::GroupUser.roles.keys
   td = link_to_remove_association  t('.remove'), f

--- a/app/views/course/groups/new.html.slim
+++ b/app/views/course/groups/new.html.slim
@@ -3,6 +3,7 @@
 = simple_form_for [current_course, @group] do |f|
   = f.input :name
 
-  = f.association :users, collection: current_course.users.with_approved_state - [current_user]
+  = f.association :course_users, collection: current_course.course_users.with_approved_state - \
+                                             [current_course_user]
 
   = f.button :submit

--- a/db/migrate/20160420005403_change_course_groups_from_user_to_course_user.rb
+++ b/db/migrate/20160420005403_change_course_groups_from_user_to_course_user.rb
@@ -1,0 +1,15 @@
+class ChangeCourseGroupsFromUserToCourseUser < ActiveRecord::Migration
+  def change
+    remove_index :course_group_users,
+                 column: [:user_id, :course_group_id],
+                 name: 'index_course_group_users_on_user_id_and_course_group_id'
+    remove_column :course_group_users, :user_id, :integer,
+                  null: false, foreign_key: { references: :users }
+    rename_column :course_group_users, :course_group_id, :group_id
+
+    add_column :course_group_users, :course_user_id, :integer,
+               null: false, foreign_key: { references: :course_users }
+    add_index :course_group_users, [:course_user_id, :group_id],
+              unique: true, name: 'index_course_group_users_on_course_user_id_and_course_group_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160330031839) do
+ActiveRecord::Schema.define(version: 20160420005403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -457,15 +457,15 @@ ActiveRecord::Schema.define(version: 20160330031839) do
   add_index "course_groups", ["course_id", "name"], name: "index_course_groups_on_course_id_and_name", unique: true
 
   create_table "course_group_users", force: :cascade do |t|
-    t.integer  "course_group_id", null: false, index: {name: "fk__course_group_users_course_group_id"}, foreign_key: {references: "course_groups", name: "fk_course_group_users_course_group_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "user_id",         null: false, index: {name: "fk__course_group_users_user_id"}, foreign_key: {references: "users", name: "fk_course_group_users_user_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "role",            null: false
-    t.integer  "creator_id",      null: false, index: {name: "fk__course_group_users_creator_id"}, foreign_key: {references: "users", name: "fk_course_group_users_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",      null: false, index: {name: "fk__course_group_users_updater_id"}, foreign_key: {references: "users", name: "fk_course_group_users_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.integer  "group_id",       null: false, index: {name: "fk__course_group_users_course_group_id"}, foreign_key: {references: "course_groups", name: "fk_course_group_users_course_group_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "course_user_id", null: false, index: {name: "fk__course_group_users_course_user_id"}, foreign_key: {references: "course_users", name: "fk_course_group_users_course_user_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "role",           null: false
+    t.integer  "creator_id",     null: false, index: {name: "fk__course_group_users_creator_id"}, foreign_key: {references: "users", name: "fk_course_group_users_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",     null: false, index: {name: "fk__course_group_users_updater_id"}, foreign_key: {references: "users", name: "fk_course_group_users_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
-  add_index "course_group_users", ["user_id", "course_group_id"], name: "index_course_group_users_on_user_id_and_course_group_id", unique: true
+  add_index "course_group_users", ["course_user_id", "group_id"], name: "index_course_group_users_on_course_user_id_and_course_group_id", unique: true
 
   create_table "course_lesson_plan_events", force: :cascade do |t|
     t.string  "location",   limit: 255

--- a/spec/factories/course_group_users.rb
+++ b/spec/factories/course_group_users.rb
@@ -5,8 +5,9 @@ FactoryGirl.define do
       course { build(:course) }
     end
 
-    course_group { build(:course_group, course: course) }
-    user { create(:course_user, :approved, course: course_group.course).user }
+    group { build(:course_group, course: course) }
+    course_user { build(:course_user, :approved, course: course) }
+
     role :normal
 
     factory :course_group_student

--- a/spec/features/course/group_management_spec.rb
+++ b/spec/features/course/group_management_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Courses: Groups' do
       end
 
       let!(:course_users) { create_list(:course_user, 3, :approved, course: course) }
-      let(:sample_user) { course_users.sample.user }
+      let(:sample_course_user) { course_users.sample }
       scenario 'I can create a group' do
         visit new_course_group_path(course)
 
@@ -40,12 +40,12 @@ RSpec.feature 'Courses: Groups' do
 
         fill_in 'group_name', with: 'Group name'
 
-        within '#group_user_ids' do
-          find("option[value='#{sample_user.id}']").select_option
+        within '#group_course_user_ids' do
+          find("option[value='#{sample_course_user.id}']").select_option
         end
 
         click_button 'create'
-        expect(sample_user.course_groups.count).to eq(1)
+        expect(sample_course_user.groups.count).to eq(1)
       end
 
       let(:group) { create(:course_group, course: course) }
@@ -74,7 +74,10 @@ RSpec.feature 'Courses: Groups' do
 
     context 'As a Group Manager' do
       let(:group) { create(:course_group, course: course) }
-      let(:user) { create(:course_group_manager, course: course, course_group: group).user }
+      let(:course_group_manager) do
+        create(:course_group_manager, course: course, group: group)
+      end
+      let(:user) { course_group_manager.course_user.user }
 
       scenario 'I can view the Group Sidebar item' do
         visit course_path(course)

--- a/spec/models/course/group_ability_spec.rb
+++ b/spec/models/course/group_ability_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe Course::Group do
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }
+    let(:user) { create(:user) }
     let!(:group) { create(:course_group, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let!(:course_manager) { create(:course_manager, :approved, course: course, user: user) }
 
       it { is_expected.to be_able_to(:manage, group) }
 
@@ -20,7 +21,10 @@ RSpec.describe Course::Group do
     end
 
     context 'when the user is a Group Manager' do
-      let(:user) { create(:course_group_manager, course: course, course_group: group).user }
+      let!(:course_user) { create(:course_user, course: course, user: user) }
+      let!(:course_group_manager) do
+        create(:course_group_manager, course_user: course_user, group: group)
+      end
 
       it { is_expected.to be_able_to(:manage, group.reload) }
 

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 
 RSpec.describe Course::Group, type: :model do
   it { is_expected.to belong_to(:course).inverse_of(:groups) }
-  it { is_expected.to have_many(:group_users).inverse_of(:course_group).dependent(:destroy) }
-  it { is_expected.to have_many(:users).through(:group_users) }
+  it { is_expected.to have_many(:group_users).inverse_of(:group).dependent(:destroy) }
+  it { is_expected.to have_many(:course_users).through(:group_users) }
 
   let!(:instance) { create :instance }
   with_tenant(:instance) do
     describe '#initialize' do
       let(:owner) { create(:user) }
       let(:course) { create(:course, creator: owner) }
+      let(:course_owner) { course.course_users.find_by(user: owner) }
       subject { Course::Group.new(course: course, name: 'group') }
 
       # TODO: Remove when using Rails 5.0
@@ -21,7 +22,7 @@ RSpec.describe Course::Group, type: :model do
         it 'sets the user as the owner of the group' do
           expect(subject.group_users.length).to eq(1)
           owner_group_user = subject.group_users.first
-          expect(owner_group_user.user).to eq(owner)
+          expect(owner_group_user.course_user).to eq(course_owner)
           expect(owner_group_user.role).to eq('manager')
         end
       end
@@ -32,18 +33,16 @@ RSpec.describe Course::Group, type: :model do
           subject.save!
         end
         it 'sets the user as the owner of the group' do
-          expect(subject.group_users.exists?(user: owner, role: self.class::MANAGER_ROLE)).to \
-            be_truthy
+          expect(subject.group_users.exists?(course_user: course_owner,
+                                             role: self.class::MANAGER_ROLE)).
+            to be_truthy
         end
       end
 
       context 'when multiple group_users reference a same user' do
         subject { create(:course_group, course: course) }
-        let(:user) { create(:user) }
-        let!(:group_users) do
-          create(:course_user, :approved, course: course, user: user)
-          Array.new(2) { subject.group_users.build(user: user) }
-        end
+        let(:course_user) { create(:course_user, course: course) }
+        let!(:group_users) { Array.new(2) { subject.group_users.build(course_user: course_user) } }
 
         it 'is an invalid group' do
           expect(subject.save).to be(false)
@@ -52,10 +51,11 @@ RSpec.describe Course::Group, type: :model do
 
         it 'adds errors to group users' do
           subject.valid?
-          user_with_errors = subject.group_users.select { |user| !user.errors.empty? }
+          user_with_errors = subject.group_users.select { |group_user| !group_user.errors.empty? }
           expect(user_with_errors).not_to be_empty
-          user_with_errors.each do |user|
-            expect(user.errors.messages[:user]).to include(I18n.t('errors.messages.taken'))
+          user_with_errors.each do |group_user|
+            expect(group_user.errors.messages[:course_user]).
+              to include(I18n.t('errors.messages.taken'))
           end
         end
       end

--- a/spec/models/course/group_user_spec.rb
+++ b/spec/models/course/group_user_spec.rb
@@ -2,15 +2,21 @@
 require 'rails_helper'
 
 RSpec.describe Course::GroupUser, type: :model do
-  it { is_expected.to belong_to(:user).inverse_of(:course_group_users) }
-  it { is_expected.to belong_to(:course_group).inverse_of(:group_users) }
+  it { is_expected.to belong_to(:course_user).inverse_of(:group_users) }
+  it { is_expected.to belong_to(:group).inverse_of(:group_users) }
 
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do
-    subject { build(:course_group_user) }
-
     context 'when user is not enrolled in group\'s course' do
-      before { subject.user.course_users.delete_all }
+      let(:course_group) { create(:course_group) }
+      let(:other_course_user) do
+        other_course = create(:course)
+        create(:course_user, course: other_course)
+      end
+      subject do
+        build(:course_group_user, group: course_group, course_user: other_course_user)
+      end
+
       it { is_expected.not_to be_valid }
     end
   end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe CourseUser, type: :model do
   it { is_expected.to have_one(:invitation) }
   it { is_expected.to have_many(:course_user_achievements).inverse_of(:course_user) }
   it { is_expected.to have_many(:achievements).through(:course_user_achievements) }
+  it { is_expected.to have_many(:group_users).dependent(:destroy) }
+  it { is_expected.to have_many(:groups).through(:group_users).source(:group) }
 
   let!(:instance) { create :instance }
   with_tenant(:instance) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe User do
   it { is_expected.to have_many(:identities).dependent(:destroy) }
   it { is_expected.to have_many(:course_users).dependent(:destroy) }
   it { is_expected.to have_many(:courses).through(:course_users) }
-  it { is_expected.to have_many(:course_group_users).dependent(:destroy) }
-  it { is_expected.to have_many(:course_groups).through(:course_group_users) }
 
   let!(:instance) { create(:instance) }
 


### PR DESCRIPTION
This PR changes the `course_groups` to reference to `course_user`, mostly to support functionality at the course level (eg. leaderboard). 

Generally speaking most of it was replacement of `user` with `course_user`, but I've had to wrestle with many small things which were rather painful. I'm putting this up for review first, but I'm thinking if there are any specs we can add on for edge cases introduced by this change. 

I've split it up into 2 for easier review and changes; after that I will squash into a single commit. 