### PR TITLE
Comment pool model methods

### DIFF
--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -33,6 +33,13 @@ class Course::Assessment::Answer < ActiveRecord::Base
   accepts_nested_attributes_for :actable
   accepts_nested_attributes_for :discussion_topic
 
+  # Get all discussion topic ids of type `Course::Assessment::Answer` in the given course.
+  scope :from_course, (lambda do |course_id|
+    joins { question.assessment.tab.category }.
+      where { question.assessment.tab.category.course_id == course_id }.
+      joins { discussion_topic }.select { discussion_topic.id }
+  end)
+
   # Creates an Auto Grading job for this answer. This saves the answer if there are pending changes.
   #
   # @param [String|nil] redirect_to_path The path to be redirected after auto grading job was

--- a/app/models/course/assessment/answer/programming_file_annotation.rb
+++ b/app/models/course/assessment/answer/programming_file_annotation.rb
@@ -4,4 +4,12 @@ class Course::Assessment::Answer::ProgrammingFileAnnotation < ActiveRecord::Base
 
   belongs_to :file, class_name: Course::Assessment::Answer::ProgrammingFile.name,
                     inverse_of: :annotations
+
+  # Get all discussion topic ids of type `Course::Assessment::Answer::ProgrammingFileAnnotation` in
+  # the given course.
+  scope :from_course, (lambda do |course_id|
+    joins { file.answer.answer.question.assessment.tab.category }.
+      where { file.answer.answer.question.assessment.tab.category.course_id == course_id }.
+      joins { discussion_topic }.select { discussion_topic.id }
+  end)
 end

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -9,6 +9,14 @@ class Course::Discussion::Topic < ActiveRecord::Base
 
   accepts_nested_attributes_for :posts
 
+  # Get all
+  scope :from_course, (lambda do |course_id|
+    joins { posts }.where do
+      id >> Course::Assessment::Answer::ProgrammingFileAnnotation.from_course(course_id) |
+        id >> Course::Assessment::Answer.from_course(course_id)
+    end
+  end)
+
   def to_partial_path
     'course/discussion/topic'.freeze
   end

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -83,5 +83,20 @@ RSpec.describe Course::Discussion::Topic, type: :model do
         end
       end
     end
+
+    describe '.with_course' do
+      let!(:topic) do
+        topic = build(:course_assessment_answer).discussion_topic
+        create(:course_discussion_post, topic: topic)
+        topic
+      end
+
+      subject do
+        Course::Discussion::Topic.
+          from_course(topic.actable.question.assessment.tab.category.course_id)
+      end
+
+      it { is_expected.to contain_exactly(topic) }
+    end
   end
 end


### PR DESCRIPTION
https://github.com/Coursemology/coursemology2/issues/616

These are the model methods to get all discussions of answers and annotations in current course.

@lowjoel I actually think we should add a course_id to course_discussion_topic, so that I don't need to do the complex joins and also much better performance, but the downside is that there are duplications. any thoughts ? 