### PR TITLE
Implement display name for components

### DIFF
--- a/app/controllers/components/course/achievements_component.rb
+++ b/app/controllers/components/course/achievements_component.rb
@@ -2,6 +2,10 @@
 class Course::AchievementsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.achievements.name')
+  end
+
   def sidebar_items
     [
       {

--- a/app/controllers/components/course/announcements_component.rb
+++ b/app/controllers/components/course/announcements_component.rb
@@ -2,6 +2,10 @@
 class Course::AnnouncementsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.announcements.name')
+  end
+
   def sidebar_items
     main_sidebar_items + settings_sidebar_items
   end

--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -2,6 +2,10 @@
 class Course::AssessmentsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.assessments.name')
+  end
+
   def sidebar_items
     main_sidebar_items + admin_sidebar_items + admin_settings_items
   end

--- a/app/controllers/components/course/controller_component_host.rb
+++ b/app/controllers/components/course/controller_component_host.rb
@@ -32,6 +32,14 @@ class Course::ControllerComponentHost
       def key
         name.underscore.tr('/', '_').to_sym
       end
+
+      # Override this to customise the display name of the component.
+      # The module name is the default display name.
+      #
+      # @return [String]
+      def display_name
+        name
+      end
     end
   end
 

--- a/app/controllers/components/course/forums_component.rb
+++ b/app/controllers/components/course/forums_component.rb
@@ -2,6 +2,10 @@
 class Course::ForumsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.forums.name')
+  end
+
   def sidebar_items
     main_sidebar_items + settings_sidebar_items
   end

--- a/app/controllers/components/course/groups_component.rb
+++ b/app/controllers/components/course/groups_component.rb
@@ -2,6 +2,10 @@
 class Course::GroupsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.groups.name')
+  end
+
   def sidebar_items
     return [] unless can_manage_group?
 

--- a/app/controllers/components/course/leaderboard_component.rb
+++ b/app/controllers/components/course/leaderboard_component.rb
@@ -2,6 +2,10 @@
 class Course::LeaderboardComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.leaderboard.name')
+  end
+
   def sidebar_items
     main_sidebar_items + settings_sidebar_items
   end

--- a/app/controllers/components/course/lesson_plan_component.rb
+++ b/app/controllers/components/course/lesson_plan_component.rb
@@ -2,6 +2,10 @@
 class Course::LessonPlanComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.lesson_plan.name')
+  end
+
   def sidebar_items
     [
       {

--- a/app/controllers/components/course/levels_component.rb
+++ b/app/controllers/components/course/levels_component.rb
@@ -2,6 +2,10 @@
 class Course::LevelsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.levels.name')
+  end
+
   def sidebar_items
     return [] unless can?(:manage, Course::Level.new(course: current_course))
 

--- a/app/controllers/components/course/materials_component.rb
+++ b/app/controllers/components/course/materials_component.rb
@@ -2,6 +2,10 @@
 class Course::MaterialsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.display_name
+    I18n.t('components.materials.name')
+  end
+
   def sidebar_items
     main_sidebar_items + settings_sidebar_items
   end

--- a/app/views/course/admin/component_settings/edit.html.slim
+++ b/app/views/course/admin/component_settings/edit.html.slim
@@ -7,7 +7,7 @@
         th = t('.enabled')
     tbody
       - instance_components = current_component_host.instance_enabled_components
-      - collection = instance_components.map { |c| [c.name, c.key.to_s] }
+      - collection = instance_components.map { |c| [c.display_name, c.key.to_s] }
       = f.collection_check_boxes :enabled_component_ids, collection, :last, :first do |f|
         tr
           th = f.label

--- a/app/views/system/admin/instance/components/edit.html.slim
+++ b/app/views/system/admin/instance/components/edit.html.slim
@@ -6,7 +6,7 @@
         th = t('.name')
         th = t('.enabled')
     tbody
-      - collection = Course::ControllerComponentHost.components.map { |c| [c.name, c.key.to_s] }
+      - collection = Course::ControllerComponentHost.components.map { |c| [c.display_name, c.key.to_s] }
       = f.collection_check_boxes :enabled_component_ids, collection, :last, :first do |f|
         tr
           th = f.label

--- a/config/locales/en/components.yml
+++ b/config/locales/en/components.yml
@@ -1,0 +1,20 @@
+en:
+  components:
+    announcements:
+      name: :'course.announcements.index.header'
+    achievements:
+      name: :'course.achievement.achievements.index.header'
+    lesson_plan:
+      name: :'course.lesson_plan.items.index.header'
+    assessments:
+      name: 'Assessments'
+    forums:
+      name: :'course.forum.forums.index.header'
+    groups:
+      name: :'course.groups.index.header'
+    levels:
+      name: :'course.levels.index.header'
+    leaderboard:
+      name: :'course.leaderboards.index.header'
+    materials:
+      name: :'course.material.sidebar_title'

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Course: Administration: Components' do
         visit course_admin_components_path(course)
 
         components.each do |component|
-          expect(page).to have_selector('th', text: component.name)
+          expect(page).to have_selector('th', text: component.display_name)
           enabled = course.reload.settings(:components, component.key).enabled
           enabled = enabled.nil? ? component.enabled_by_default? : enabled
           checkbox = find("#settings_effective_enabled_component_ids_#{component.key}")

--- a/spec/features/system/admin/components_settings_spec.rb
+++ b/spec/features/system/admin/components_settings_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'System: Administration: Components', type: :feature do
                                                    Course::ControllerComponentHost)
       enabled_components = settings.enabled_component_ids
       components.each do |component|
-        expect(page).to have_selector('th', text: component.name)
+        expect(page).to have_selector('th', text: component.display_name)
 
         checkbox = find("#settings_effective_enabled_component_ids_#{component.key}")
         if enabled_components.include?(component.key.to_s)


### PR DESCRIPTION
See #595 

Haven't add translations to Courses and Users component, think those cannot be disabled and should not be displayed in settings either( this might related to #950)

