### PR TITLE
Disable awarding of automatically-awarded achievements to course users

### DIFF
--- a/app/controllers/course/achievement/achievements_controller.rb
+++ b/app/controllers/course/achievement/achievements_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Achievement::AchievementsController < Course::Achievement::Controller
+  before_action :authorize_achievement!, only: [:update]
+
   def index #:nodoc:
     @achievements = @achievements.includes(:conditions)
   end
@@ -44,7 +46,13 @@ class Course::Achievement::AchievementsController < Course::Achievement::Control
   private
 
   def achievement_params #:nodoc:
-    params.require(:achievement).permit(:title, :description, :weight, :draft, :badge,
-                                        course_user_ids: [])
+    @achievement_params ||= params.require(:achievement).
+                            permit(:title, :description, :weight, :draft, :badge,
+                                   course_user_ids: [])
+  end
+
+  # Only allow awarding of manually awarded achievements.
+  def authorize_achievement!
+    authorize!(:award, @achievement) if achievement_params.include?(:course_user_ids)
   end
 end

--- a/app/controllers/course/achievement/course_users_controller.rb
+++ b/app/controllers/course/achievement/course_users_controller.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 class Course::Achievement::CourseUsersController < Course::Achievement::Controller
+  before_action :authorize_achievement!, only: [:index]
+
   def index
+  end
+
+  private
+
+  def authorize_achievement!
+    authorize!(:award, @achievement)
   end
 end

--- a/app/models/components/course/achievements_ability_component.rb
+++ b/app/models/components/course/achievements_ability_component.rb
@@ -7,6 +7,7 @@ module Course::AchievementsAbilityComponent
       allow_student_show_achievements
       allow_students_with_achievement_show_badges
       allow_staff_manage_achievements
+      do_not_allow_staff_award_automatically_awarded_achievements
     end
 
     super
@@ -21,6 +22,12 @@ module Course::AchievementsAbilityComponent
 
   def allow_staff_manage_achievements
     can :manage, Course::Achievement, course_staff_hash
+  end
+
+  def do_not_allow_staff_award_automatically_awarded_achievements
+    cannot :award, Course::Achievement do |achievement|
+      !achievement.manually_awarded?
+    end
   end
 
   def allow_students_with_achievement_show_badges

--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -17,6 +17,15 @@ class Course::Achievement < ActiveRecord::Base
     self.weight ||= 10
   end
 
+  # Returns if achievement is manually or automatically awarded.
+  #
+  # @return [Boolean] Whether the achievement is manually awarded.
+  def manually_awarded?
+    # TODO: Correct call should be conditions.empty?, but that results in an
+    # exception due to polymorphism. To investigate.
+    specific_conditions.empty?
+  end
+
   def permitted_for!(_course_user)
   end
 

--- a/app/views/course/achievement/achievements/_achievement.html.slim
+++ b/app/views/course/achievement/achievements/_achievement.html.slim
@@ -24,9 +24,13 @@
 
   td
     div.btn-group
-      - if can?(:manage, achievement)
+      - if can?(:award, achievement)
         = link_to course_achievement_course_users_path(current_course, achievement),
                   class: ['btn', 'btn-info'], title: t('.award_button') do
-          = fa_icon 'trophy'
+          = fa_icon 'trophy'.freeze
+      - else
+        = content_tag(:span, class:['btn', 'btn-info'], title: t('.disabled_award_button'),
+                             disabled: true) do
+          = fa_icon 'trophy'.freeze
       = edit_button([current_course, achievement]) if can?(:edit, achievement)
       = delete_button([current_course, achievement]) if can?(:delete, achievement)

--- a/config/locales/en/course/achievement/achievements.yml
+++ b/config/locales/en/course/achievement/achievements.yml
@@ -27,3 +27,5 @@ en:
           requirements: 'Requirements'
         achievement:
           award_button: :'course.achievement.course_users.course_users_form.header'
+          disabled_award_button: >
+            Automatically-awarded achievements cannot be manually awarded to students.

--- a/spec/controllers/course/achievement/course_users_controller_spec.rb
+++ b/spec/controllers/course/achievement/course_users_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Achievement::CourseUsersController, type: :controller do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:administrator) }
+    let!(:course) { create(:course) }
+    let!(:achievement) { create(:course_achievement, course: course) }
+
+    before { sign_in(user) }
+
+    describe '#index' do
+      subject { get :index, course_id: course, achievement_id: achievement }
+
+      context 'when the achievement is automatically awarded' do
+        before do
+          allow(achievement).to receive(:manually_awarded?).and_return(false)
+          controller.instance_variable_set(:@achievement, achievement)
+        end
+
+        it 'raises an error' do
+          expect { subject }.to raise_exception(CanCan::AccessDenied)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/achievement_ability_spec.rb
+++ b/spec/models/course/achievement_ability_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe Course::Achievement do
         expect(course.achievements.accessible_by(subject)).
           to contain_exactly(achievement, draft_achievement)
       end
+
+      context 'when the achievement is manually awarded' do
+        before { allow(achievement).to receive(:manually_awarded?).and_return(true) }
+
+        it { is_expected.to be_able_to(:award, achievement) }
+      end
+
+      context 'when the achievement is not manually awarded' do
+        before { allow(achievement).to receive(:manually_awarded?).and_return(false) }
+
+        it { is_expected.not_to be_able_to(:award, achievement) }
+      end
     end
   end
 end

--- a/spec/models/course/achievement_spec.rb
+++ b/spec/models/course/achievement_spec.rb
@@ -29,5 +29,20 @@ RSpec.describe Course::Achievement, type: :model do
         expect { subject.precluded_for!(double) }.to_not raise_error
       end
     end
+
+    describe '#manually_awarded?' do
+      let(:achievement) { create(:course_achievement) }
+      subject { achievement.manually_awarded? }
+
+      context 'when achievement has no conditions' do
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when achievement has 1 or more conditions' do
+        before { create(:course_condition_achievement, conditional: achievement) }
+
+        it { is_expected.to be_falsey }
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR:

1. Adds a model method to determine if an achievement is manually awarded;
1. Adds ability to disable awarding of automatically-awarded achievement to students; 
1.  Add authorization for `Course::Achievement::CourseUserController#index` action;
1. Modify views to disable awarding of automatically-awarded achievements. 

For point 3: Usually I see that this is implemented at the update controller action (ie. `update`), rather than on the view page (ie. `edit`). Because the awarding of achievements are done at the `achievements#update` (together with the updating of that achievement's attributes), I've added the authorization at `achievements::course_user#index` action instead. Is this correct? Or should I authorize at the `achievements#update` action itself? 

Note: For point 1, I've passed that commit on to @custode for #1017. This is done on a PR at https://github.com/coursemology-collab/coursemology2/pull/1. Depending on which PR gets merges first, the other will have to do some conflict resolution. 