### PR TITLE
Mail using background jobs

### DIFF
--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -29,7 +29,7 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
 
   def self.enqueue(job) #:nodoc:
     ActiveSupport::Notifications.instrument(ENQUEUE_EVENT, job: job, caller: caller) do |payload|
-      with_thread_pool { @pending_jobs << job }
+      with_thread_pool { @pending_jobs << job.serialize }
       ensure_threads
 
       payload.reverse_merge!(notification_statistics)
@@ -151,7 +151,7 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
     # also maintain the current number of jobs running.
     def thread_run_job(job)
       ActiveRecord::Base.connection_pool.with_connection do
-        ActiveJob::Base.execute(job.serialize)
+        ActiveJob::Base.execute(job)
       end
     ensure
       thread_finish_job(job)

--- a/spec/controllers/user/emails_controller_spec.rb
+++ b/spec/controllers/user/emails_controller_spec.rb
@@ -74,8 +74,10 @@ RSpec.describe User::EmailsController, type: :controller do
       context 'when the email is not confirmed' do
         let(:email_traits) { :unconfirmed }
 
-        it 'sends out a confirmation email' do
-          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        with_active_job_queue_adapter(:test) do
+          it 'sends out a confirmation email' do
+            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          end
         end
 
         it { is_expected.to redirect_to(user_emails_path) }

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Course::UserInvitationService, type: :service do
       end
     end
 
-    let(:course) { build(:course) }
-    let(:user) { build(:user) }
+    let(:course) { create(:course) }
+    let(:user) { create(:user) }
     let(:stubbed_user_invitation_service) do
       Course::UserInvitationService.new(user, course).tap do |result|
         result.define_singleton_method(:invite_users) do |users|
@@ -92,9 +92,11 @@ RSpec.describe Course::UserInvitationService, type: :service do
           verify_users
         end
 
-        it 'sends an email to everyone' do
-          expect { invite }.to change { ActionMailer::Base.deliveries.count }.
-            by(user_form_attributes.length)
+        with_active_job_queue_adapter(:test) do
+          it 'sends an email to everyone' do
+            expect { invite }.to change { ActionMailer::Base.deliveries.count }.
+              by(user_form_attributes.length)
+          end
         end
       end
 
@@ -107,12 +109,14 @@ RSpec.describe Course::UserInvitationService, type: :service do
           verify_users
         end
 
-        it 'sends an email to everyone' do
-          expect do
-            subject.invite(temp_csv_from_attributes(user_attributes.map do |attributes|
-              OpenStruct.new(attributes)
-            end))
-          end.to change { ActionMailer::Base.deliveries.count }.by(user_attributes.length)
+        with_active_job_queue_adapter(:test) do
+          it 'sends an email to everyone' do
+            expect do
+              subject.invite(temp_csv_from_attributes(user_attributes.map do |attributes|
+                OpenStruct.new(attributes)
+              end))
+            end.to change { ActionMailer::Base.deliveries.count }.by(user_attributes.length)
+          end
         end
       end
 

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -34,15 +34,18 @@ module ActiveJob::TestGroupHelpers
   end
 end
 
-# Since message deliveries use the test delivery engine, all deferred deliver calls must be
-# converted to +deliver_now+ to prevent a dependency on the ActiveJob queue adapter.
+# Since message deliveries use the test delivery engine, all deferred deliver calls must also call
+# +deliver_now+ so that the +ActionMailer::Base.deliveries.count+ attribute will also be
+# incremented.
 module ActionMailer::MessageDelivery::TestDeliveryHelpers
   def deliver_later(_ = {})
     deliver_now
+    super
   end
 
   def deliver_later!(_ = {})
     deliver_now!
+    super
   end
 end
 ActionMailer::MessageDelivery.prepend(ActionMailer::MessageDelivery::TestDeliveryHelpers)


### PR DESCRIPTION
 - Synchronise both the ActionMailer count and ActiveJob counts. Mail specs need to set the job adapter to :test to ensure that the number of mail sent aren't double counted.
 - Serialize a job the moment it is enqueued, similar to the Sidekiq adapter.

Needed by #976. @fonglh 