### PR TITLE
[Pending Discussion] Add survey models for course - models, factories, migration, specs.

### DIFF
--- a/app/models/concerns/course/survey/response/experience_points_display_concern.rb
+++ b/app/models/concerns/course/survey/response/experience_points_display_concern.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Course::Survey::Response::ExperiencePointsDisplayConcern
+  extend ActiveSupport::Concern
+
+  # The reason to be displayed for the response's experience point award.
+  #
+  # @return [String] The reason which will be displayed
+  def experience_points_display_reason
+    survey.title
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -48,6 +48,7 @@ class Course < ActiveRecord::Base
   has_many :lesson_plan_events, through: :lesson_plan_items,
                                 source: :actable, source_type: Course::LessonPlan::Event.name
   has_many :forums, dependent: :destroy
+  has_many :surveys, through: :lesson_plan_items, source: :actable, source_type: Course::Survey.name
 
   accepts_nested_attributes_for :invitations, :assessment_categories
 

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class Course::Survey < ActiveRecord::Base
+  acts_as_lesson_plan_item
+
+  has_many :questions, inverse_of: :survey, dependent: :destroy
+  has_many :responses, inverse_of: :survey, dependent: :destroy
+end

--- a/app/models/course/survey/answer.rb
+++ b/app/models/course/survey/answer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class Course::Survey::Answer < ActiveRecord::Base
+  actable
+
+  belongs_to :response, inverse_of: :answers
+  belongs_to :question, inverse_of: nil
+end

--- a/app/models/course/survey/answer/text_response.rb
+++ b/app/models/course/survey/answer/text_response.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class Course::Survey::Answer::TextResponse < ActiveRecord::Base
+  acts_as :answer, class_name: Course::Survey::Answer.name
+end

--- a/app/models/course/survey/question.rb
+++ b/app/models/course/survey/question.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Course::Survey::Question < ActiveRecord::Base
+  actable
+
+  belongs_to :survey, inverse_of: :questions
+end

--- a/app/models/course/survey/question/text_response.rb
+++ b/app/models/course/survey/question/text_response.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class Course::Survey::Question::TextResponse < ActiveRecord::Base
+  acts_as :question, class_name: Course::Survey::Question.name
+end

--- a/app/models/course/survey/response.rb
+++ b/app/models/course/survey/response.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Course::Survey::Response < ActiveRecord::Base
+  acts_as_experience_points_record
+  include Course::Survey::Response::ExperiencePointsDisplayConcern
+
+  belongs_to :survey, inverse_of: :responses
+  has_many :answers, inverse_of: :response
+end

--- a/db/migrate/20160426093832_create_survey_tables.rb
+++ b/db/migrate/20160426093832_create_survey_tables.rb
@@ -1,0 +1,39 @@
+class CreateSurveyTables < ActiveRecord::Migration
+  def change
+    create_table :course_surveys do |t|
+      t.userstamps null: false, foreign_key: { references: :users }
+      t.timestamps null: false
+    end
+
+    create_table :course_survey_questions do |t|
+      t.actable index: { unique: true, name: :index_course_survey_questions_actable }
+      t.references :survey, null: false, foreign_key: { references: :course_surveys }
+      t.text :description, null: false
+
+      t.userstamps null: false, foreign_key: { references: :users }
+      t.timestamps null: false
+    end
+
+    create_table :course_survey_question_text_responses do |t|
+    end
+
+    create_table :course_survey_responses do |t|
+      t.references :survey, null: false, foreign_key: { references: :course_surveys }
+
+      t.userstamps null: false, foreign_key: { references: :users }
+      t.timestamps null: false
+    end
+
+    create_table :course_survey_answers do |t|
+      t.actable index: { unique: true, name: :index_course_survey_answers_actable }
+      t.references :question, null: false, foreign_key: { references: :course_survey_questions }
+      t.references :response, null: false, foreign_key: { references: :course_survey_responses }
+
+      t.userstamps null: false, foreign_key: { references: :users }
+      t.timestamps null: false
+    end
+
+    create_table :course_survey_answer_text_responses do |t|
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160420005403) do
+ActiveRecord::Schema.define(version: 20160426093832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -544,6 +544,49 @@ ActiveRecord::Schema.define(version: 20160420005403) do
     t.integer  "notification_type", default: 0, null: false
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+  end
+
+  create_table "course_surveys", force: :cascade do |t|
+    t.integer  "creator_id", null: false, index: {name: "fk__course_surveys_creator_id"}, foreign_key: {references: "users", name: "fk_course_surveys_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id", null: false, index: {name: "fk__course_surveys_updater_id"}, foreign_key: {references: "users", name: "fk_course_surveys_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "course_survey_questions", force: :cascade do |t|
+    t.integer  "actable_id"
+    t.string   "actable_type", limit: 255, index: {name: "index_course_survey_questions_actable", with: ["actable_id"], unique: true}
+    t.integer  "survey_id",    null: false, index: {name: "fk__course_survey_questions_survey_id"}, foreign_key: {references: "course_surveys", name: "fk_course_survey_questions_survey_id", on_update: :no_action, on_delete: :no_action}
+    t.text     "description",  null: false
+    t.integer  "creator_id",   null: false, index: {name: "fk__course_survey_questions_creator_id"}, foreign_key: {references: "users", name: "fk_course_survey_questions_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",   null: false, index: {name: "fk__course_survey_questions_updater_id"}, foreign_key: {references: "users", name: "fk_course_survey_questions_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  create_table "course_survey_question_text_responses", force: :cascade do |t|
+  end
+
+  create_table "course_survey_responses", force: :cascade do |t|
+    t.integer  "survey_id",  null: false, index: {name: "fk__course_survey_responses_survey_id"}, foreign_key: {references: "course_surveys", name: "fk_course_survey_responses_survey_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "creator_id", null: false, index: {name: "fk__course_survey_responses_creator_id"}, foreign_key: {references: "users", name: "fk_course_survey_responses_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id", null: false, index: {name: "fk__course_survey_responses_updater_id"}, foreign_key: {references: "users", name: "fk_course_survey_responses_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "course_survey_answers", force: :cascade do |t|
+    t.integer  "actable_id"
+    t.string   "actable_type", limit: 255, index: {name: "index_course_survey_answers_actable", with: ["actable_id"], unique: true}
+    t.integer  "question_id",  null: false, index: {name: "fk__course_survey_answers_question_id"}, foreign_key: {references: "course_survey_questions", name: "fk_course_survey_answers_question_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "response_id",  null: false, index: {name: "fk__course_survey_answers_response_id"}, foreign_key: {references: "course_survey_responses", name: "fk_course_survey_answers_response_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "creator_id",   null: false, index: {name: "fk__course_survey_answers_creator_id"}, foreign_key: {references: "users", name: "fk_course_survey_answers_creator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "updater_id",   null: false, index: {name: "fk__course_survey_answers_updater_id"}, foreign_key: {references: "users", name: "fk_course_survey_answers_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  create_table "course_survey_answer_text_responses", force: :cascade do |t|
   end
 
   create_table "course_user_achievements", force: :cascade do |t|

--- a/spec/factories/course_survey_answer_text_responses.rb
+++ b/spec/factories/course_survey_answer_text_responses.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_survey_answer_text_response, class: Course::Survey::Answer::TextResponse.name,
+                                               parent: :course_survey_answer do
+  end
+end

--- a/spec/factories/course_survey_answers.rb
+++ b/spec/factories/course_survey_answers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_survey_answer, class: Course::Survey::Answer.name do
+    transient do
+      response
+    end
+
+    association :question, factory: :course_survey_question
+  end
+end

--- a/spec/factories/course_survey_question_text_responses.rb
+++ b/spec/factories/course_survey_question_text_responses.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_survey_question_text_response, class: Course::Survey::Question::TextResponse.name,
+                                                 parent: :course_survey_question do
+  end
+end

--- a/spec/factories/course_survey_questions.rb
+++ b/spec/factories/course_survey_questions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  sequence(:course_survey_question_name) { |n| "Survey Question #{n}" }
+  factory :course_survey_question, class: Course::Survey::Question.name do
+    survey
+    description { generate(:course_survey_question_name) }
+  end
+end

--- a/spec/factories/course_survey_responses.rb
+++ b/spec/factories/course_survey_responses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_survey_response, class: Course::Survey::Response.name, aliases: [:response],
+                                   parent: :course_experience_points_record do
+    survey { build(:survey, course: course) }
+  end
+end

--- a/spec/factories/course_surveys.rb
+++ b/spec/factories/course_surveys.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  sequence(:course_survey_name) { |n| "Survey #{n}" }
+  factory :course_survey, class: Course::Survey.name, aliases: [:survey],
+                          parent: :course_lesson_plan_item do
+    title { generate(:course_survey_name) }
+  end
+end

--- a/spec/models/course/survey/answer/text_response_answer_spec.rb
+++ b/spec/models/course/survey/answer/text_response_answer_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::Answer::TextResponse, type: :model do
+  it { is_expected.to act_as(Course::Survey::Answer) }
+end

--- a/spec/models/course/survey/answer_spec.rb
+++ b/spec/models/course/survey/answer_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::Answer do
+  it { is_expected.to belong_to(:response).inverse_of(:answers) }
+  it { is_expected.to belong_to(:question) }
+end

--- a/spec/models/course/survey/question/text_response_spec.rb
+++ b/spec/models/course/survey/question/text_response_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::Question::TextResponse, type: :model do
+  it { is_expected.to act_as(Course::Survey::Question) }
+end

--- a/spec/models/course/survey/question_spec.rb
+++ b/spec/models/course/survey/question_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::Question do
+  it { is_expected.to be_actable }
+  it { is_expected.to belong_to(:survey).inverse_of(:questions) }
+end

--- a/spec/models/course/survey/response_spec.rb
+++ b/spec/models/course/survey/response_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::Response do
+  it { is_expected.to act_as(Course::ExperiencePointsRecord) }
+  it { is_expected.to belong_to(:survey).inverse_of(:responses) }
+  it { is_expected.to have_many(:answers).inverse_of(:response) }
+end

--- a/spec/models/course/survey_spec.rb
+++ b/spec/models/course/survey_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey, type: :model do
+  it { is_expected.to act_as(Course::LessonPlan::Item) }
+  it { is_expected.to have_many(:questions).inverse_of(:survey).dependent(:destroy) }
+  it { is_expected.to have_many(:responses).inverse_of(:survey).dependent(:destroy) }
+end


### PR DESCRIPTION
This PR implements Models for survey in course. 

Added factories in here so that we are able to create objects if needed. Not too sure if they are all correctly specified though. 

Related to #1020 