### PR TITLE
Use checks and crosses to indicate test cases' passing status.

### DIFF
--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -25,7 +25,10 @@ table.table.table-striped.table-hover
         td = format_html(test_case.description)
         td = format_html(test_case.hint) if !test_case_result || !test_case_result.passed?
         td
-          = fa_icon 'check'.freeze if test_case_result && test_case_result.passed?
+          - if test_case_result && test_case_result.passed?
+            = fa_icon 'check'.freeze
+          - else
+            = fa_icon 'times'.freeze
   - if can?(:grade, answer.answer)
     tbody
       tr
@@ -38,7 +41,10 @@ table.table.table-striped.table-hover
           td
           td
             - test_case_result = answer_test_results_hash[test_case]
-            = fa_icon 'check'.freeze if test_case_result && test_case_result.passed?
+            - if test_case_result && test_case_result.passed?
+              = fa_icon 'check'.freeze
+            - else
+              = fa_icon 'times'.freeze
 
 - failed_private_test_cases = private_test_cases. \
     select { |t| !answer_test_results_hash[t] || !answer_test_results_hash[t].passed? }


### PR DESCRIPTION
This is clearer than having nothing display.