### PR TITLE
Allow client code to specify callbacks to update attachments after content changed

### DIFF
--- a/app/models/course/announcement.rb
+++ b/app/models/course/announcement.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::Announcement < ActiveRecord::Base
   acts_as_readable on: :updated_at
-  has_many_attachments
+  has_many_attachments on: :content
 
   after_initialize :set_defaults, if: :new_record?
   after_create :mark_as_read_by_creator

--- a/spec/models/course/announcement_spec.rb
+++ b/spec/models/course/announcement_spec.rb
@@ -64,5 +64,31 @@ RSpec.describe Course::Announcement, type: :model do
         end
       end
     end
+
+    describe '#has_many_attachments' do
+      # Announcement with image_tag in content.
+      let(:announcement) do
+        announcement = create(:course_announcement)
+        attachment = create(:attachment_reference, attachable: announcement)
+        content = "<img alt='Icon' src='/attachments/#{attachment.id}' />"
+        announcement.update_attributes(content: content)
+        announcement
+      end
+
+      it 'has an attachment_reference' do
+        expect(announcement.attachment_references.count).to eq(1)
+      end
+
+      context 'when image is removed from content' do
+        before do
+          announcement.content = ''
+          announcement.save
+        end
+
+        it 'removes the attachment_references' do
+          expect(announcement.attachment_references.count).to eq(0)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This implements #1025 

Added a option to the attachable api #has_many_attachments to specify the column associated with the attachments.

e.g. If client code says `has_many_attachments  on: :content`, the attachment_references will change after content changing. So that if images was removed from content, attachment_reference will also be removed. 

@lowjoel Let me know if this design makes sense to you.