### PR TITLE
Creation and validation of group managers in Course Groups

### DIFF
--- a/app/models/course/group.rb
+++ b/app/models/course/group.rb
@@ -18,8 +18,8 @@ class Course::Group < ActiveRecord::Base
 
   # Set default values
   def set_defaults
-    group_users.build(course_user: course.course_users.find_by(user_id: creator.id),
-                      role: :manager, creator: creator, updater: updater) if should_create_manager?
+    group_users.build(course_user: default_group_manager, role: :manager,
+                      creator: creator, updater: updater) if should_create_manager?
   end
 
   # Checks if the current group has sufficient information to have a manager, but does not
@@ -27,9 +27,16 @@ class Course::Group < ActiveRecord::Base
   #
   # @return [Boolean]
   def should_create_manager?
-    course && creator &&
-      course.course_users.exists?(user: creator) &&
-      !group_users.any? { |group_user| group_user.course_user.user_id == creator }
+    course && creator && group_users.managers.count == 0
+  end
+
+  # Returns the default course_user to be a group_manager.
+  # This will be the creator of the group is a course_user in the course, otherwise it
+  # the group_manager will be the course_creator.
+  #
+  # @return [CourseUser]
+  def default_group_manager
+    course.course_users.find_by(user: creator) || course.course_users.find_by(user: course.creator)
   end
 
   # Validate that the new users are unique.

--- a/app/models/course/group.rb
+++ b/app/models/course/group.rb
@@ -13,6 +13,7 @@ class Course::Group < ActiveRecord::Base
                                 reject_if: -> (params) { params[:course_user_id].blank? }
 
   validate :validate_new_users_are_unique
+  validate :validate_presence_of_group_manager, on: :update
 
   private
 
@@ -52,5 +53,14 @@ class Course::Group < ActiveRecord::Base
     (new_group_users - new_group_users.uniq(&:course_user)).each do |group_user|
       group_user.errors.add(:course_user, :taken)
     end
+  end
+
+  # Validate that each group has at least 1 group manager.
+  #
+  # Validation is only called on update action, as the default group manager is created for new
+  # records.
+  def validate_presence_of_group_manager
+    return if group_users.manager.count > 0
+    errors.add(:base, :no_manager)
   end
 end

--- a/app/models/course/group_user.rb
+++ b/app/models/course/group_user.rb
@@ -9,6 +9,8 @@ class Course::GroupUser < ActiveRecord::Base
   belongs_to :course_user, inverse_of: :group_users
   belongs_to :group, class_name: Course::Group.name, inverse_of: :group_users
 
+  scope :managers, -> { where(role: roles[:manager]) }
+
   private
 
   # Set default values

--- a/config/locales/en/activerecord/course/group.yml
+++ b/config/locales/en/activerecord/course/group.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/group:
+          no_manager: 'must have at least one group manager'

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -17,13 +17,27 @@ RSpec.describe Course::Group, type: :model do
       # TODO: Remove when using Rails 5.0
       self::MANAGER_ROLE = Course::GroupUser.roles[:manager]
 
-      context 'when a user is provided' do
+      context 'when the group creator is a course_user of the course' do
         subject { Course::Group.new(course: course, creator: owner) }
-        it 'sets the user as the owner of the group' do
+
+        it 'sets the group creator as the manager of the group' do
           expect(subject.group_users.length).to eq(1)
-          owner_group_user = subject.group_users.first
-          expect(owner_group_user.course_user).to eq(course_owner)
-          expect(owner_group_user.role).to eq('manager')
+          group_manager = subject.group_users.first
+          expect(group_manager.course_user).to eq(course_owner)
+          expect(group_manager.role).to eq('manager')
+        end
+      end
+
+      context 'when the group creator is not a course_user of the course' do
+        let(:other_course) { create(:course) }
+        let(:other_course_creator) { other_course.course_users.find_by(user: other_course.creator) }
+        subject { Course::Group.new(course: other_course, creator: owner) }
+
+        it 'sets the course owner as the manager of the group' do
+          expect(subject.group_users.length).to eq(1)
+          group_manager = subject.group_users.first
+          expect(group_manager.course_user).to eq(other_course_creator)
+          expect(group_manager.role).to eq('manager')
         end
       end
 

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -53,6 +53,25 @@ RSpec.describe Course::Group, type: :model do
         end
       end
 
+      context 'when all group managers are deleted from a group' do
+        let!(:group) { create(:course_group) }
+        subject do
+          group.group_users = []
+          group
+        end
+
+        it 'is an invalid group' do
+          expect(subject.save).to be(false)
+          expect(subject).not_to be_valid
+        end
+
+        it 'adds errors to group object' do
+          subject.valid?
+          expect(subject.errors.messages[:base]).
+            to include(I18n.t('activerecord.errors.models.course/group.no_manager'))
+        end
+      end
+
       context 'when multiple group_users reference a same user' do
         subject { create(:course_group, course: course) }
         let(:course_user) { create(:course_user, course: course) }

--- a/spec/models/course/group_user_spec.rb
+++ b/spec/models/course/group_user_spec.rb
@@ -7,8 +7,13 @@ RSpec.describe Course::GroupUser, type: :model do
 
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do
+    let!(:course) { create(:course) }
+    let!(:course_group) { create(:course_group, course: course) }
+    let!(:course_group_users) do
+      create_list(:course_group_user, 2, course: course, group: course_group)
+    end
+
     context 'when user is not enrolled in group\'s course' do
-      let(:course_group) { create(:course_group) }
       let(:other_course_user) do
         other_course = create(:course)
         create(:course_user, course: other_course)
@@ -18,6 +23,15 @@ RSpec.describe Course::GroupUser, type: :model do
       end
 
       it { is_expected.not_to be_valid }
+    end
+
+    describe '.managers' do
+      subject { course_group.group_users.managers }
+
+      it 'returns the managers of the group' do
+        managers = course_group.group_users.select(&:manager?)
+        expect(subject).to eq(managers)
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, when a Coursemology Admin creates a group in a Course that he/she is not in, an error will be thrown because there is no associated `course_user` for this group's creator. 

This PR fixes that by setting a default group creator, who will also be the `group_manager` of the group. Validations are added to ensure that each group has at least 1 group manager as well.  

This fixes #1040. 