### PR TITLE
Add scopes and change routes for group leaderboard

### DIFF
--- a/app/models/course/group.rb
+++ b/app/models/course/group.rb
@@ -54,6 +54,18 @@ class Course::Group < ActiveRecord::Base
       select { course_user_achievements.obtained_at }.limit(1).order('obtained_at DESC')
   end)
 
+  scope :ordered_by_experience_points, (lambda do
+    all.calculated(:average_experience_points).order('average_experience_points DESC')
+  end)
+
+  # Order course_users by achievement count for use in the group leaderboard.
+  #   In the event of a tie in count, the scope will then sort by the group which
+  #   obtained the current achievement count first.
+  scope :ordered_by_average_achievement_count, (lambda do
+    all.calculated(:average_achievement_count, :last_obtained_achievement).
+      order('average_achievement_count DESC, last_obtained_achievement ASC')
+  end)
+
   private
 
   # Set default values

--- a/app/models/course/group.rb
+++ b/app/models/course/group.rb
@@ -44,6 +44,16 @@ class Course::Group < ActiveRecord::Base
       SQL
   end)
 
+  # @!attribute [r] last_obtained_achievement
+  #   Returns the time of the last obtained achievement by group users in this group who are
+  #   students.
+  calculated :last_obtained_achievement, (lambda do
+    Course::GroupUser.where { group_id == course_groups.id }.
+      joins { course_user.course_user_achievements }.
+      where { course_user.role == CourseUser.roles[:student] }.
+      select { course_user_achievements.obtained_at }.limit(1).order('obtained_at DESC')
+  end)
+
   private
 
   # Set default values

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -161,5 +161,52 @@ RSpec.describe Course::Group, type: :model do
         end
       end
     end
+
+    describe '.ordered_by_experience_points' do
+      let(:student) { create(:course_student, :approved, course: course) }
+      let!(:group_user) { create(:course_group_user, group: group, course_user: student) }
+      let!(:other_group) { create(:course_group, course: course) }
+      let!(:experience_points_record) do
+        create(:course_experience_points_record, course_user: student)
+      end
+
+      it 'returns groups sorted by average experience points' do
+        course.groups.ordered_by_experience_points.each_cons(2) do |group1, group2|
+          expect(group1.average_experience_points).to be >= group2.average_experience_points
+        end
+      end
+    end
+
+    describe '.ordered_by_achievement_count' do
+      let(:student) { create(:course_student, :approved, course: course) }
+      let!(:group_user) { create(:course_group_user, group: group, course_user: student) }
+      let!(:course_user_achievement) { create(:course_user_achievement, course_user: student) }
+      let!(:later_group) { create(:course_group, course: course) }
+
+      it 'returns groups sorted by average achievement count' do
+        course.groups.ordered_by_average_achievement_count.each_cons(2) do |group1, group2|
+          expect(group1.average_achievement_count).to be >= group2.average_achievement_count
+        end
+      end
+
+      context 'when two groups have the same achievement count' do
+        let(:earlier_time) { course_user_achievement.obtained_at }
+        let!(:later_student) { create(:course_student, :approved, course: course) }
+        let!(:later_group_user) do
+          create(:course_group_user, group: later_group, course_user: later_student)
+        end
+        let!(:later_student_achievement) do
+          create(:course_user_achievement, course_user: later_student,
+                                           obtained_at: earlier_time + 2.days)
+        end
+
+        it 'returns the group who obtained the achievement count first' do
+          expect(group.average_achievement_count).to eq(later_group.average_achievement_count)
+          course.groups.ordered_by_average_achievement_count.each_cons(2) do |group1, group2|
+            expect(group1.last_obtained_achievement).to be <= group2.last_obtained_achievement
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -139,5 +139,27 @@ RSpec.describe Course::Group, type: :model do
         end
       end
     end
+
+    describe '#last_obtained_achievement' do
+      subject { group.last_obtained_achievement }
+
+      context 'when the group has no achievement' do
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the group has 1 or more achievements' do
+        let(:student) { create(:course_student, course: course) }
+        let!(:group_user) { create(:course_group_user, group: group, course_user: student) }
+        let!(:later_achievement) { create(:course_user_achievement, course_user: student) }
+        let!(:earlier_achievement) do
+          create(:course_user_achievement, course_user: student,
+                                           obtained_at: later_achievement.obtained_at - 1.day)
+        end
+
+        it 'returns the last obtained achievement' do
+          expect(subject).to eq(later_achievement.obtained_at)
+        end
+      end
+    end
   end
 end

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Course::Group, type: :model do
 
   let!(:instance) { create :instance }
   with_tenant(:instance) do
+    let(:owner) { create(:user) }
+    let(:course) { create(:course, creator: owner) }
+    let(:course_owner) { course.course_users.find_by(user: owner) }
+    let(:group) { create(:course_group, course: course) }
+
     describe '#initialize' do
-      let(:owner) { create(:user) }
-      let(:course) { create(:course, creator: owner) }
-      let(:course_owner) { course.course_users.find_by(user: owner) }
       subject { Course::Group.new(course: course, name: 'group') }
 
       # TODO: Remove when using Rails 5.0
@@ -90,6 +92,50 @@ RSpec.describe Course::Group, type: :model do
             expect(group_user.errors.messages[:course_user]).
               to include(I18n.t('errors.messages.taken'))
           end
+        end
+      end
+    end
+
+    describe '#average_achievement_count' do
+      subject { group.average_achievement_count }
+
+      context 'when there are no group users' do
+        it { is_expected.to eq(0) }
+      end
+
+      context 'when there is 1 or more group users' do
+        let(:student) { create(:course_student, course: course) }
+        let!(:group_user) { create(:course_group_user, group: group, course_user: student) }
+        let!(:other_group_user) { create(:course_group_user, course: course, group: group) }
+        let!(:achievements) { create_list(:course_user_achievement, 5, course_user: student) }
+
+        it 'returns the average achievement count' do
+          average_count = 1.0 * student.course_user_achievements.count /
+                          group.course_users.students.count
+          expect(subject).to eq(average_count)
+        end
+      end
+    end
+
+    describe '#average_experience_points' do
+      subject { group.average_experience_points }
+
+      context 'when there are no group users' do
+        it { is_expected.to eq(0) }
+      end
+
+      context 'when there is 1 or more group users' do
+        let(:student) { create(:course_student, course: course) }
+        let!(:group_user) { create(:course_group_user, group: group, course_user: student) }
+        let!(:other_group_user) { create(:course_group_user, course: course, group: group) }
+        let!(:experience_points) do
+          create_list(:course_experience_points_record, 2, course_user: student)
+        end
+
+        it 'returns the average experience points' do
+          average_count = 1.0 * group.course_users.map(&:experience_points).inject(:+) /
+                          group.course_users.students.count
+          expect(subject).to eq(average_count)
         end
       end
     end


### PR DESCRIPTION
This PR: 
- Adds calculated attributes and scopes to sort the group for the group leaderboard.

The calculated attributes are a little nasty since we had to manually calculate the 'calculated attributes' (achievement count and experience points) for each course user, so I've documented down the reasons for some of the scopes. 

Related to #634 