### PR TITLE
Implement the display of actual comments 

### DIFF
--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -4,6 +4,6 @@ class Course::Discussion::TopicsController < Course::ComponentController
                                                  class: Course::Discussion::Topic.name,
                                                  parent: false
   def index
-    @topics = @topics.page(page_param)
+    @topics = @topics.globally_displayed.ordered_by_updated_at.page(page_param)
   end
 end

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Course::Discussion::TopicsHelper
+  # Display code lines in file.
+  #
+  # @param [Course::Assessment::Answer::ProgrammingFile] file The code file.
+  # @param [Integer] line_start The one based start line number.
+  # @param [Integer] line_end The one based end line line number.
+  # @return [String] A HTML fragment containing the code lines.
+  def display_code_lines(file, line_start, line_end)
+    code = file.lines((line_start - 1)..(line_end - 1)).join("\n")
+    # TODO: Line number is started from 1, need to fix the pipeline to display the correct numbers.
+    format_code_block(code, file.answer.question.actable.language)
+  end
+end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::Answer < ActiveRecord::Base
   include Workflow
   actable
-  acts_as :discussion_topic, class_name: Course::Discussion::Topic.name
+  acts_as_discussion_topic display_globally: true
 
   workflow do
     state :attempting do

--- a/app/models/course/assessment/answer/programming_file.rb
+++ b/app/models/course/assessment/answer/programming_file.rb
@@ -10,6 +10,28 @@ class Course::Assessment::Answer::ProgrammingFile < ActiveRecord::Base
   has_many :annotations, class_name: Course::Assessment::Answer::ProgrammingFileAnnotation.name,
                          dependent: :destroy, foreign_key: :file_id, inverse_of: :file
 
+  # Separate the lines by `\r` `\n` or `\r\n`
+  LINE_SEPARATOR = /\r\n|\r|\n/
+
+  # Returns the code at lines.
+  #
+  # @param [Integer|Range] line_numbers zero based line numbers, can be a Integer or Range.
+  # @return [Array<String>] the code lines. all lines will be returned if the `line_numbers` is not
+  #   specified.
+  def lines(line_numbers = nil)
+    lines = content.split(LINE_SEPARATOR)
+
+    case line_numbers
+    when Range
+      line_begin = line_numbers.min < 0 ? 0 : line_numbers.min
+      lines[line_begin..line_numbers.max]
+    when Integer
+      lines[line_numbers]
+    else
+      lines
+    end
+  end
+
   private
 
   # Normalises the filename for use across platforms.

--- a/app/models/course/assessment/answer/programming_file_annotation.rb
+++ b/app/models/course/assessment/answer/programming_file_annotation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::ProgrammingFileAnnotation < ActiveRecord::Base
-  acts_as :discussion_topic, class_name: Course::Discussion::Topic.name
+  acts_as_discussion_topic display_globally: true
 
   belongs_to :file, class_name: Course::Assessment::Answer::ProgrammingFile.name,
                     inverse_of: :annotations

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -16,6 +16,14 @@ class Course::Discussion::Topic < ActiveRecord::Base
     global_topic_model_names.map(&:constantize)
   end
 
+  # Topics to be displayed in the comments centre.
+  scope :globally_displayed, (lambda do
+    joins(:posts). # Make sure only topics with posts are returned.
+      where(actable_type: global_topic_models.map(&:name))
+  end)
+
+  scope :ordered_by_updated_at, -> { order(updated_at: :desc) }
+
   def to_partial_path
     'course/discussion/topic'.freeze
   end

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Course::Discussion::Topic < ActiveRecord::Base
   actable
+  class_attribute :global_topic_model_names
+  self.global_topic_model_names = []
 
   belongs_to :course, inverse_of: :discussion_topics
   has_many :posts, dependent: :destroy, inverse_of: :topic do
@@ -9,6 +11,10 @@ class Course::Discussion::Topic < ActiveRecord::Base
   has_many :subscriptions, dependent: :destroy, inverse_of: :topic
 
   accepts_nested_attributes_for :posts
+
+  def self.global_topic_models
+    global_topic_model_names.map(&:constantize)
+  end
 
   def to_partial_path
     'course/discussion/topic'.freeze

--- a/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
+++ b/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
@@ -1,1 +1,17 @@
-// TODO: Implement displaying of code annotations
+- file_annotation = discussion_topic_programming_file_annotation
+- answer = file_annotation.file.answer
+- question = answer.question
+- submission = answer.submission
+- assessment = question.assessment
+
+h3
+  = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
+h4
+  = t('.by_html', user: link_to_user(submission.creator))
+h4
+  = t('.question', title: question.title)
+
+= display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
+
+= render partial: 'course/discussion/topic', object: file_annotation.acting_as,
+         locals: { post_partial: 'course/assessment/answer/programming/annotation_post' }

--- a/app/views/course/assessment/answers/_discussion_topic_answer.html.slim
+++ b/app/views/course/assessment/answers/_discussion_topic_answer.html.slim
@@ -1,1 +1,14 @@
-// TODO: Implement displaying of answer comments
+- answer = discussion_topic_answer
+- question = answer.question
+- submission = answer.submission
+- assessment = question.assessment
+
+h3
+  = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
+h4
+  = t('.by_html', user: link_to_user(submission.creator))
+h4
+  = t('.question', title: question.title)
+
+= render partial: 'course/discussion/topic', object: answer.acting_as,
+         locals: { post_partial: 'course/assessment/answer/comment' }

--- a/config/locales/en/course/assessment/answer/programming_file_annotations.yml
+++ b/config/locales/en/course/assessment/answer/programming_file_annotations.yml
@@ -1,0 +1,8 @@
+en:
+  course:
+    assessment:
+      answer:
+        programming_file_annotations:
+          discussion_topic_programming_file_annotation:
+            by_html: 'By: %{user}'
+            question: 'Question: %{title}'

--- a/config/locales/en/course/assessment/answers.yml
+++ b/config/locales/en/course/assessment/answers.yml
@@ -1,0 +1,7 @@
+en:
+  course:
+    assessment:
+      answers:
+        discussion_topic_answer:
+          by_html: 'By: %{user}'
+          question: 'Question: %{title}'

--- a/lib/extensions/discussion_topic.rb
+++ b/lib/extensions/discussion_topic.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+module Extensions::DiscussionTopic; end

--- a/lib/extensions/discussion_topic/active_record.rb
+++ b/lib/extensions/discussion_topic/active_record.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+module Extensions::DiscussionTopic::ActiveRecord; end

--- a/lib/extensions/discussion_topic/active_record/base.rb
+++ b/lib/extensions/discussion_topic/active_record/base.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Extensions::DiscussionTopic::ActiveRecord::Base
+  module ClassMethods
+    # Declare this in model, for it to support discussions.
+    #
+    # @option options [Boolean] :display_globally Set to true if the topic need to be displayed in
+    # comments center.
+    def acts_as_discussion_topic(display_globally: false)
+      acts_as :discussion_topic, class_name: Course::Discussion::Topic.name
+      # For autoload to work correctly after class changed, we store the model name first and
+      # constantize later.
+      Course::Discussion::Topic.global_topic_model_names << name if display_globally
+    end
+  end
+end

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature 'Course: Topics: Management' do
         visit course_topics_path(course)
 
         expect(page).to have_selector('div', text: answer_comment.question.assessment.title)
-        pending 'Implement displaying of actual comments'
         expect(page).
           to have_selector('div', text: code_annotation.file.answer.question.assessment.title)
       end

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature 'Course: Topics: Management' do
         code_annotation
         visit course_topics_path(course)
 
-        pending 'Implement displaying of actual comments'
         expect(page).to have_selector('div', text: answer_comment.question.assessment.title)
+        pending 'Implement displaying of actual comments'
         expect(page).
           to have_selector('div', text: code_annotation.file.answer.question.assessment.title)
       end

--- a/spec/models/course/assessment/answer/programming_file_spec.rb
+++ b/spec/models/course/assessment/answer/programming_file_spec.rb
@@ -22,5 +22,43 @@ RSpec.describe Course::Assessment::Answer::ProgrammingFile do
         end
       end
     end
+
+    describe '#lines' do
+      let(:file) do
+        content = (0..10).to_a.join("\n")
+        create(:course_assessment_answer_programming_file, content: content)
+      end
+      let(:line_numbers) { 0..5 }
+      subject { file.lines(line_numbers) }
+
+      it { is_expected.to eq((0..5).map(&:to_s)) }
+
+      context 'when line_numbers is not specified' do
+        it 'returns all the lines' do
+          expect(file.lines).to eq((0..10).map(&:to_s))
+        end
+      end
+
+      context 'when start line is less than 0' do
+        let(:line_numbers) { -1..5 }
+        it { is_expected.to eq((0..5).map(&:to_s)) }
+      end
+
+      context 'when end line is greater than total lines' do
+        let(:line_numbers) { 0..30 }
+        it { is_expected.to eq((0..10).map(&:to_s)) }
+      end
+
+      context 'when end line is not covered in range' do
+        let(:line_numbers) { 0...10 }
+        it { is_expected.to eq((0..9).map(&:to_s)) }
+      end
+
+      context 'when line_numbers is a integer' do
+        let(:line_numbers) { 1 }
+
+        it { is_expected.to eq('1') }
+      end
+    end
   end
 end

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -83,5 +83,36 @@ RSpec.describe Course::Discussion::Topic, type: :model do
         end
       end
     end
+
+    describe '.globally_displayed' do
+      let(:course) { create(:course) }
+      let!(:annotation) do
+        create(:course_assessment_answer_programming_file_annotation, :with_post, course: course).
+          acting_as
+      end
+      let!(:comment) do
+        create(:course_assessment_answer, :with_post, course: course).acting_as
+      end
+      let!(:comment_without_post) do
+        create(:course_assessment_answer, course: course).acting_as
+      end
+
+      it 'only returns comments and annotations with posts' do
+        expect(course.discussion_topics.globally_displayed).
+          to contain_exactly(annotation, comment)
+      end
+    end
+
+    describe '.ordered_by_updated_at' do
+      let!(:topics) do
+        create(:course_assessment_answer)
+        create(:course_assessment_answer_programming_file_annotation)
+      end
+
+      it 'orders the topics by descending updated_at' do
+        topics = Course::Discussion::Topic.ordered_by_updated_at.limit(10)
+        expect(topics.each_cons(2).all? { |a, b| a.updated_at >= b.updated_at }).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
Depends on #1059 

The display of answer comments and code annotations is implemented in this PR.
The reply of the comments will be implemented in a later PR.

Screenshot:
![screen shot 2016-05-18 at 11 15 38 pm](https://cloud.githubusercontent.com/assets/4983239/15364273/81a339ee-1d4e-11e6-9305-3cff1aa279fc.png)