### PR TITLE
Add Submission Statistics Page

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -4,6 +4,7 @@
 
 //== Colors
 //
+$red: #ff0000 !default;
 
 //## Variables for colors used in Coursemology.
 $course-achievement-granted-bg: $state-success-bg !default;
@@ -12,6 +13,7 @@ $course-assessment-submission-answer-correct-border-color: $state-success-border
 $course-assessment-submission-answer-correct-border-radius: $border-radius-base !default;
 $course-assessment-submission-answer-correct-bg: $state-success-bg !default;
 $course-assessment-submission-answer-correct-border-text: $state-success-text !default;
+$course-assessment-submission-not-started: $red !default;
 $course-discussion-post-border-color: $panel-default-border !default;
 $course-discussion-post-border-radius: $border-radius-base !default;
 $course-discussion-post-shadow-color: $gray-lighter !default;

--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -11,4 +11,14 @@
       padding: 0 3px;
     }
   }
+
+  &.index {
+    .submissions {
+      .no-submission {
+        strong {
+          color: $course-assessment-submission-not-started;
+        }
+      }
+    }
+  }
 }

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -11,6 +11,12 @@ class Course::Assessment::Submission::SubmissionsController < \
   delegate_to_service(:update)
   delegate_to_service(:load_or_create_answers)
 
+  def index
+    @submissions = @submissions.includes(experience_points_record: :course_user).
+                   with_submission_statistics
+    @course_students = current_course.course_users.students.with_approved_state
+  end
+
   def create
     raise IllegalStateError if @assessment.questions.empty?
     if @submission.save

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -85,6 +85,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
   #   Orders the submissions by date of creation. This defaults to reverse chronological order
   #   (newest submission first).
   scope :ordered_by_date, ->(direction = :desc) { order(created_at: direction) }
+  scope :with_submission_statistics, -> { all.calculated(:grade) }
 
   alias_method :finalise=, :finalise!
   alias_method :publish=, :publish!

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -13,18 +13,23 @@
   td = format_datetime(assessment.start_at)
   td = format_datetime(assessment.end_at) if assessment.end_at.present?
   td
-    - if current_course_user
-      - attempting_submission = assessment.submissions.find(&:attempting?)
-      - submitted_submission = assessment.submissions.find do |submission|
-        - submission != attempting_submission
-      - if attempting_submission
-        = link_to(t('.attempt'), edit_course_assessment_submission_path(current_course,
-            assessment, attempting_submission), class: ['btn', 'btn-info'])
-      - elsif submitted_submission
-        = link_to(t('.view'), edit_course_assessment_submission_path(current_course,
-            assessment, submitted_submission), class: ['btn', 'btn-info'])
-      - elsif can?(:attempt, assessment)
-        = button_to(t('.attempt'), course_assessment_submissions_path(current_course, assessment),
-                    class: ['btn-info'])
-    - else
-      = link_to(t('.attempt'), '#', class: ['btn', 'btn-info', 'disabled'])
+    div.btn-group
+      - if current_course_user
+        - attempting_submission = assessment.submissions.find(&:attempting?)
+        - submitted_submission = assessment.submissions.find do |submission|
+          - submission != attempting_submission
+        - if attempting_submission
+          = link_to(t('.attempt'), edit_course_assessment_submission_path(current_course,
+              assessment, attempting_submission), class: ['btn', 'btn-info'])
+        - elsif submitted_submission
+          = link_to(t('.view'), edit_course_assessment_submission_path(current_course,
+              assessment, submitted_submission), class: ['btn', 'btn-info'])
+        - elsif can?(:attempt, assessment)
+          = link_to(t('.attempt'), course_assessment_submissions_path(current_course, assessment),
+                    class: ['btn','btn-info'], method: :post)
+      - else
+        = link_to(t('.attempt'), '#', class: ['btn', 'btn-info', 'disabled'])
+
+      - if can?(:manage, assessment)
+        = link_to(t('.submissions'), course_assessment_submissions_path(current_course, assessment),
+                  class: ['btn', 'btn-default'])

--- a/app/views/course/assessment/submission/submissions/_no_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_no_submission.html.slim
@@ -1,0 +1,7 @@
+tr.no-submission
+  td = format_inline_text(course_user.name)
+  td
+    strong = t('.not_started')
+  td -
+  td -
+  td

--- a/app/views/course/assessment/submission/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submission.html.slim
@@ -1,0 +1,9 @@
+= content_tag_for(:tr, submission) do
+  td
+    = link_to edit_course_assessment_submission_path(current_course, submission.assessment,
+                                                     submission) do
+      = format_inline_text(submission.course_user.name)
+  td = submission.workflow_state.capitalize
+  td = submission.grade.to_i.to_s + ' / ' + submission.assessment.maximum_grade.to_s
+  td = submission.points_awarded.to_i.to_s
+  td

--- a/app/views/course/assessment/submission/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submissions.html.slim
@@ -1,0 +1,14 @@
+table.table.submissions
+  thead
+    tr
+      th = t('.student_name')
+      th = t('.status')
+      th = t('.grade')
+      th = t('.experience_points')
+      th
+  tbody
+    - course_users.each do |course_user|
+      - if submissions[course_user]
+        = render partial: 'submission', object: submissions[course_user]
+      - else
+        = render partial: 'no_submission', locals: { course_user: course_user }

--- a/app/views/course/assessment/submission/submissions/index.html.slim
+++ b/app/views/course/assessment/submission/submissions/index.html.slim
@@ -1,0 +1,11 @@
+- add_breadcrumb t('.submissions')
+= page_header format_inline_text(@assessment.title)
+
+- submissions = @submissions.map { |s| [s.course_user, s] }.to_h
+h3 = t('.student_header')
+- students = @course_students.without_phantom_users
+= render partial: 'submissions', object: submissions, locals: { course_users: students }
+
+h3 = t('.other_header')
+- other_users = @course_students - students
+= render partial: 'submissions', object: submissions, locals: { course_users: other_users }

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -18,6 +18,7 @@ en:
         assessment:
           attempt: 'Attempt'
           view: 'View'
+          submissions: 'Submissions'
         show:
           description: 'Description'
           start_at: :'course.assessment.assessments.index.start_at'

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -6,6 +6,10 @@ en:
           finalise: 'Finalise Submission'
           publish: 'Publish Grade'
           auto_grade: 'Auto Grade Submission'
+          index:
+            submissions: 'Submissions'
+            student_header: 'Student Submissions'
+            other_header: 'Other Submissions'
           create:
             failure: 'Could not create submission: %{error}'
           edit:
@@ -28,3 +32,10 @@ en:
           update:
             success: 'Submission was updated.'
             failure: 'Failed to update submission: %{error}'
+          submissions:
+            student_name: 'Student Name'
+            status: 'Submission Status'
+            grade: 'Grade'
+            experience_points: 'Experience Points'
+          no_submission:
+            not_started: 'Not Started'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,7 @@ Rails.application.routes.draw do
             resources :programming, only: [:new, :create, :edit, :update, :destroy]
           end
           scope module: :submission do
-            resources :submissions, only: [:create, :edit, :update] do
+            resources :submissions, only: [:index, :create, :edit, :update] do
               post :auto_grade, on: :member
 
               scope module: :answer do

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe 'Course: Assessments: Attempt' do
         visit course_assessments_path(course)
 
         within find(content_tag_selector(empty_assessment)) do
-          find_button(I18n.t('course.assessment.assessments.assessment.attempt')).click
+          find_link(I18n.t('course.assessment.assessments.assessment.attempt'),
+                    href: course_assessment_submissions_path(course, empty_assessment)).click
         end
 
         expect(page.status_code).to eq(422)
@@ -38,7 +39,8 @@ RSpec.describe 'Course: Assessments: Attempt' do
         visit course_assessments_path(course)
 
         within find(content_tag_selector(assessment)) do
-          find_button(I18n.t('course.assessment.assessments.assessment.attempt')).click
+          find_link(I18n.t('course.assessment.assessments.assessment.attempt'),
+                    href: course_assessment_submissions_path(course, assessment)).click
         end
 
         created_submission = assessment.submissions.last

--- a/spec/features/course/assessment/assessment_viewing_spec.rb
+++ b/spec/features/course/assessment/assessment_viewing_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Course: Assessments: Viewing' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) do
+      create(:course_assessment_assessment, :with_all_question_types, course: course)
+    end
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Staff' do
+      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+
+      scenario 'I can access all submissions of an assessment' do
+        assessment
+        visit course_assessments_path(course)
+
+        within find(content_tag_selector(assessment)) do
+          click_link I18n.t('course.assessment.assessments.assessment.submissions')
+        end
+
+        expect(current_path).to eq(course_assessment_submissions_path(course, assessment))
+      end
+    end
+  end
+end

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Course: Assessment: Submissions: Submissions' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
+    before { login_as(user, scope: :user) }
+
+    let(:students) { create_list(:course_student, 3, :approved, course: course) }
+    let(:phantom_student) { create(:course_student, :approved, :phantom, course: course) }
+    let!(:submitted_submission) do
+      create(:course_assessment_submission, :submitted, assessment: assessment,
+                                                        course: course,
+                                                        creator: students[0].user)
+    end
+    let!(:attempting_submission) do
+      create(:course_assessment_submission, :attempting, assessment: assessment,
+                                                         course: course,
+                                                         creator: students[1].user)
+    end
+    let!(:graded_submission) do
+      create(:course_assessment_submission, :graded, assessment: assessment,
+                                                     course: course,
+                                                     creator: students[2].user)
+    end
+
+    context 'As a Course Staff' do
+      let(:course_staff) { create(:course_manager, :approved, course: course).user }
+      let(:user) { course_staff }
+
+      scenario 'I can view all submissions of an assessment' do
+        phantom_student
+        visit course_assessment_submissions_path(course, assessment)
+
+        expect(page).
+          to have_text(I18n.t('course.assessment.submission.submissions.index.student_header'))
+        expect(page).
+          to have_text(I18n.t('course.assessment.submission.submissions.index.other_header'))
+
+        [submitted_submission, attempting_submission, graded_submission].each do |submission|
+          within find(content_tag_selector(submission)) do
+            expect(page).to have_text(submission.workflow_state.capitalize)
+            expect(page).to have_text(submission.points_awarded)
+          end
+        end
+
+        # Phantom student did not attempt submissions
+        expect(page).to have_tag('tr.no-submission', count: 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR: 
- Adds a submission statistics page for each assessment
- Adds a button at the assessment index page for course_stuff to access the submissions

(PRs are merged)
~~In doing so, I've had to: ~~
~~Redefine the abilities slightly because rails was thinking that `course_user_id` was a column on the `course_assessment_submissions` table.~~
~~Define a helper method for inline numbers (`format_inline_number`) to handle 'nil' values.~~