### PR TITLE
Implement achievement notifier and displaying course feed notifications

### DIFF
--- a/app/helpers/application_notifications_helper.rb
+++ b/app/helpers/application_notifications_helper.rb
@@ -6,7 +6,7 @@ module ApplicationNotificationsHelper
   # @return [String] The view path of the notification
   def notification_view_path(notification)
     activity = notification.activity
-    root_path = "notifiers/#{activity.notifier_type}/#{activity.event}"
+    root_path = "notifiers/#{activity.notifier_type.underscore}/#{activity.event}"
     notification_class_name = notification.class.name.underscore.tr('/', '_').pluralize
     "/#{root_path}/#{notification_class_name}/#{notification.notification_type}"
   end

--- a/app/models/course/user_achievement.rb
+++ b/app/models/course/user_achievement.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::UserAchievement < ActiveRecord::Base
   after_initialize :set_defaults, if: :new_record?
+  after_create :send_notification
 
   belongs_to :course_user, inverse_of: :course_user_achievements
   belongs_to :achievement, class_name: Course::Achievement.name,
@@ -11,5 +12,9 @@ class Course::UserAchievement < ActiveRecord::Base
   # Set default values
   def set_defaults
     self.obtained_at ||= Time.zone.now
+  end
+
+  def send_notification
+    Course::AchievementNotifier.achievement_gained(course_user.user, achievement)
   end
 end

--- a/app/notifiers/course/achievement_notifier.rb
+++ b/app/notifiers/course/achievement_notifier.rb
@@ -1,0 +1,9 @@
+class Course::AchievementNotifier < Notifier::Base
+  # To be called when user gained an achievement.
+  def achievement_gained(user, achievement)
+    create_activity(actor: user, object: achievement, event: :gained).
+      notify(achievement.course, :feed).
+      notify(user, :popup).
+      save
+  end
+end

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -10,7 +10,12 @@
   h2 = t('.instructors')
   div
     = render partial: 'layouts/user', collection: current_course.managers.includes(:user).map(&:user)
-  - if current_course.user?(current_user)
+  - if current_course.user?(current_user) || can?(:manage, current_course)
     h2 = t('.announcements')
     div
       = render current_course.announcements.currently_active
+
+    h2 = t('.activities')
+    div
+      - current_course.notifications.includes(activity: :object).each do |notification|
+        = render partial: notification_view_path(notification), locals: { notification: notification }

--- a/app/views/notifiers/course/achievement_notifier/gained/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/achievement_notifier/gained/course_notifications/_feed.html.slim
@@ -1,0 +1,9 @@
+- activity = notification.activity
+- achievement = activity.object
+
+= div_for(notification) do
+  // TODO: Display user image here.
+  - user_link = link_to_user(activity.actor)
+  - achievement_link = link_to achievement.title, course_achievement_path(current_course, achievement)
+  => t('.gained_achievement_html', user: user_link, achievement: achievement_link)
+  h6 = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/achievement_notifier/gained/user_notifications/popup.html.slim
+++ b/app/views/notifiers/course/achievement_notifier/gained/user_notifications/popup.html.slim
@@ -1,0 +1,1 @@
+// TODO: Implement popup notification.

--- a/config/locales/en/course/courses.yml
+++ b/config/locales/en/course/courses.yml
@@ -18,3 +18,4 @@ en:
         description: 'Description'
         instructors: 'Instructors'
         announcements: 'Announcements'
+        activities: 'Activities'

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -1,0 +1,9 @@
+en:
+  notifiers:
+    course:
+      achievement_notifier:
+        gained:
+          course_notifications:
+            feed:
+              gained_achievement_html: '%{user} gained achievement %{achievement}'
+

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -5,5 +5,11 @@ FactoryGirl.define do
     object { create(:user) }
     event 'test'
     notifier_type 'test_notifier'
+
+    trait :achievement_gained do
+      object { create(:course_achievement) }
+      event :gained
+      notifier_type Course::AchievementNotifier.name
+    end
   end
 end

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -6,6 +6,11 @@ RSpec.feature 'Course: Homepage' do
 
   with_tenant(:instance) do
     let(:course) { create(:course, :opened) }
+    let(:achievement_feed_notification) do
+      achievement = create(:course_achievement)
+      achievement_activity = create(:activity, :achievement_gained, object: achievement)
+      create(:course_notification, :feed, activity: achievement_activity, course: course)
+    end
 
     before do
       login_as(user, scope: :user)
@@ -18,6 +23,13 @@ RSpec.feature 'Course: Homepage' do
         visit course_path(course)
         expect(page).to have_content_tag_for(valid_announcement)
       end
+
+      scenario 'I am able to see the activity feed in course homepage' do
+        achievement_feed_notification
+
+        visit course_path(course)
+        expect(page).to have_content_tag_for(achievement_feed_notification)
+      end
     end
 
     context 'As a user not registered for the course' do
@@ -26,6 +38,13 @@ RSpec.feature 'Course: Homepage' do
         valid_announcement = create(:course_announcement, course: course)
         visit course_path(course)
         expect(page).not_to have_content_tag_for(valid_announcement)
+      end
+
+      scenario 'I am not able to see the activity feed in course homepage' do
+        achievement_feed_notification
+
+        visit course_path(course)
+        expect(page).not_to have_content_tag_for(achievement_feed_notification)
       end
 
       scenario 'I am only able to see approved owner and managers in instructors list' do

--- a/spec/helpers/application_notifications_helper_spec.rb
+++ b/spec/helpers/application_notifications_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ApplicationNotificationsHelper, type: :helper do
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do
     describe '#notification_view_path' do
-      let(:activity) { create(:activity, event: :tested, notifier_type: :user_notifier) }
+      let(:activity) { create(:activity, event: :tested, notifier_type: 'UserNotifier') }
       let(:stub_notification) do
         notification = OpenStruct.new
         notification.activity = activity

--- a/spec/notifiers/course/achievement_notifier.rb
+++ b/spec/notifiers/course/achievement_notifier.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::AchievementNotifier, type: :notifier do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    describe '#achievement_gained' do
+      let(:course) { create(:course) }
+      let(:achievement) { create(:course_achievement, course: course) }
+      let(:user) { create(:course_user, course: course).user }
+
+      subject { Course::AchievementNotifier.achievement_gained(user, achievement) }
+
+      it 'sends a course notification' do
+        expect { subject }.to change(course.notifications, :count).by(1)
+      end
+
+      it 'sends a user notification' do
+        expect { subject }.to change(user.notifications, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the achievement part of issue: https://github.com/Coursemology/coursemology2/issues/1080:

Detail:
- Fixed a view path issue of notifications, the view path should be underscored 
-  Added a `Course::AchievementNotifier` which sends the achievement related notifications 
- Implemented the display of course feeds and displays the achievement notifications

TODO: 
There is also a popup notification when user get the achievement, the views are pending to be implemented.
Also other kinds of notifications need to be implemented after this, this will serve as a sample of concrete notification.

