### PR TITLE
Validates that submission creator is the same user as the course user...

### DIFF
--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -18,6 +18,8 @@ class Course::Assessment::Submission < ActiveRecord::Base
     state :graded
   end
 
+  validate :validate_consistent_user
+
   belongs_to :assessment, inverse_of: :submissions
 
   # @!attribute [r] answers
@@ -121,6 +123,14 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
     execute_after_commit do
       auto_grade!
+    end
+  end
+
+  # Validate that the submission creator is the same user as the course_user in the associated
+  # experience_points_record.
+  def validate_consistent_user
+    unless course_user && course_user.user == creator
+      errors.add(:experience_points_record, :inconsistent_user)
     end
   end
 end

--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -8,6 +8,9 @@ en:
         graded_at: :'activerecord.attributes.course/assessment/answer/graded_at'
     errors:
       models:
+        course/assessment/submission:
+          experience_points_record:
+            inconsistent_user: 'the creator of the submission must be the same as the course user'
         course/assessment/category:
           deletion: 'the last category cannot be deleted'
 

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
     let(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_programming_question, course: course) }
     let(:submission) do
-      create(:course_assessment_submission, :submitted, assessment: assessment, user: user)
+      create(:course_assessment_submission, :submitted, assessment: assessment, creator: user)
     end
     let(:answer) { submission.answers.first }
     let(:file) { answer.actable.files.first }

--- a/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     let(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_mcq_question, course: course) }
     let(:immutable_submission) do
-      create(:submission, assessment: assessment, user: user).tap do |stub|
+      create(:submission, assessment: assessment, creator: user).tap do |stub|
         assessment.questions.attempt(stub).each(&:save)
         allow(stub).to receive(:save).and_return(false)
       end

--- a/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     let(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_mcq_question, course: course) }
     let(:immutable_submission) do
-      create(:submission, assessment: assessment, creator: user).tap do |stub|
+      create(:course_assessment_submission, assessment: assessment, creator: user).tap do |stub|
         assessment.questions.attempt(stub).each(&:save)
         allow(stub).to receive(:save).and_return(false)
       end

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     let!(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
     let!(:immutable_submission) do
-      create(:submission, assessment: assessment, creator: user).tap do |stub|
+      create(:course_assessment_submission, assessment: assessment, creator: user).tap do |stub|
         allow(stub).to receive(:save).and_return(false)
         allow(stub).to receive(:update_attributes).and_return(false)
         allow(stub).to receive(:destroy).and_return(false)

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     let!(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
     let!(:immutable_submission) do
-      create(:submission, assessment: assessment, user: user).tap do |stub|
+      create(:submission, assessment: assessment, creator: user).tap do |stub|
         allow(stub).to receive(:save).and_return(false)
         allow(stub).to receive(:update_attributes).and_return(false)
         allow(stub).to receive(:destroy).and_return(false)

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     transient do
       grader { User.stamper }
       auto_grade true # Used only with any of the submitted or finalised traits.
+      creator
     end
     assessment { build(:assessment, course: course) }
 

--- a/spec/factories/course_experience_points_records.rb
+++ b/spec/factories/course_experience_points_records.rb
@@ -3,12 +3,12 @@ FactoryGirl.define do
   factory :course_experience_points_record, class: Course::ExperiencePointsRecord.name do
     transient do
       course { build(:course) }
-      user { build(:user) }
+      creator
     end
 
     course_user do
-      course.course_users.find_by(user: user) ||
-        build(:course_user, course: course, user: user)
+      course.course_users.find_by(user: creator) ||
+        build(:course_user, course: course, user: creator)
     end
     points_awarded { rand(1..20) * 100 }
     reason { 'Reason for manually-awarded experience points' if manually_awarded? }

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
     before { login_as(user, scope: :user) }
 
     let(:submission) do
-      create(:course_assessment_submission, *submission_traits, assessment: assessment, user: user)
+      create(:course_assessment_submission, *submission_traits, assessment: assessment,
+                                                                creator: user)
     end
     let(:submission_traits) { nil }
     let(:options) { assessment.questions.first.specific.options }

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
     before { login_as(user, scope: :user) }
 
     let(:submission) do
-      create(:course_assessment_submission, *submission_traits, assessment: assessment, user: user)
+      create(:course_assessment_submission, *submission_traits, assessment: assessment,
+                                                                creator: user)
     end
     let(:submission_traits) { nil }
 

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
     before { login_as(user, scope: :user) }
 
     let(:submission) do
-      create(:course_assessment_submission, *submission_traits, assessment: assessment, user: user)
+      create(:course_assessment_submission, *submission_traits, assessment: assessment,
+                                                                creator: user)
     end
     let(:submission_traits) { nil }
 

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
     let(:student) { create(:course_user, :approved, course: course).user }
     let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, user: student)
+      create(:course_assessment_submission, assessment: assessment, creator: student)
     end
     let(:points_awarded) { 22 }
 

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
     let(:student) { create(:course_user, :approved, course: course).user }
     let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, user: student)
+      create(:course_assessment_submission, assessment: assessment, creator: student)
     end
 
     context 'As a Course Student' do

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
     let(:assessment) { create(:assessment, :with_programming_question, course: course) }
     let(:student) { create(:course_user, :approved, course: course).user }
     let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, user: student)
+      create(:course_assessment_submission, assessment: assessment, creator: student)
     end
     before { login_as(user, scope: :user) }
 

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
 
     let(:student) { create(:course_user, :approved, course: course).user }
     let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, user: student)
+      create(:course_assessment_submission, assessment: assessment, creator: student)
     end
 
     context 'As a Course Student' do

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_student) { create(:course_student, :approved, course: course) }
-    let(:record) { create(:submission, course_user: course_student).acting_as }
+    let(:record) { create(:submission, course: course, creator: course_student.user).acting_as }
     let(:manual_record) { create(:course_experience_points_record, course_user: course_student) }
     let(:inactive_record) do
       create(:course_experience_points_record, :inactive, course_user: course_student)

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -7,7 +7,9 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_student) { create(:course_student, :approved, course: course) }
-    let(:record) { create(:submission, course: course, creator: course_student.user).acting_as }
+    let(:record) do
+      create(:course_assessment_submission, course: course, creator: course_student.user).acting_as
+    end
     let(:manual_record) { create(:course_experience_points_record, course_user: course_student) }
     let(:inactive_record) do
       create(:course_experience_points_record, :inactive, course_user: course_student)

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe Course::Assessment do
       create(:course_assessment_assessment, :with_all_question_types, course: course)
     end
     let(:attempting_submission) do
-      create(:submission, :attempting, assessment: assessment, creator: course_user.user)
+      create(:course_assessment_submission, :attempting, assessment: assessment,
+                                                         creator: course_user.user)
     end
     let(:submitted_submission) do
-      create(:submission, :submitted, assessment: assessment, creator: course_user.user)
+      create(:course_assessment_submission, :submitted, assessment: assessment,
+                                                        creator: course_user.user)
     end
 
     context 'when the user is a Course Student' do

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Course::Assessment do
       create(:course_assessment_assessment, :with_all_question_types, course: course)
     end
     let(:attempting_submission) do
-      create(:submission, :attempting, assessment: assessment, user: course_user.user)
+      create(:submission, :attempting, assessment: assessment, creator: course_user.user)
     end
     let(:submitted_submission) do
-      create(:submission, :submitted, assessment: assessment, user: course_user.user)
+      create(:submission, :submitted, assessment: assessment, creator: course_user.user)
     end
 
     context 'when the user is a Course Student' do

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe Course::Assessment::Submission do
     end
     let(:submission2_traits) { [] }
 
+    describe 'validations' do
+      context 'when the course user is different from the submission creator' do
+        let(:course_student) { create(:course_student, :approved, course: course) }
+        subject do
+          build(:submission, assessment: assessment, course_user: course_student, creator: user1)
+        end
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages[:experience_points_record]).
+            to include(I18n.
+              t('activerecord.errors.models.course/assessment/submission.'\
+                'attributes.experience_points_record.inconsistent_user'))
+        end
+      end
+    end
+
     describe '.with_creator' do
       before do
         submission1

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Course::Assessment::Submission do
 
     let(:user1) { create(:user) }
     let(:submission1) do
-      create(:submission, *submission1_traits, assessment: assessment, user: user1)
+      create(:submission, *submission1_traits, assessment: assessment, creator: user1)
     end
     let(:submission1_traits) { [] }
     let(:user2) { create(:user) }
     let(:submission2) do
-      create(:submission, *submission2_traits, assessment: assessment, user: user2)
+      create(:submission, *submission2_traits, assessment: assessment, creator: user2)
     end
     let(:submission2_traits) { [] }
 

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -17,12 +17,14 @@ RSpec.describe Course::Assessment::Submission do
 
     let(:user1) { create(:user) }
     let(:submission1) do
-      create(:submission, *submission1_traits, assessment: assessment, creator: user1)
+      create(:course_assessment_submission, *submission1_traits, assessment: assessment,
+                                                                 creator: user1)
     end
     let(:submission1_traits) { [] }
     let(:user2) { create(:user) }
     let(:submission2) do
-      create(:submission, *submission2_traits, assessment: assessment, creator: user2)
+      create(:course_assessment_submission, *submission2_traits, assessment: assessment,
+                                                                 creator: user2)
     end
     let(:submission2_traits) { [] }
 

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -254,10 +254,16 @@ RSpec.describe Course::Assessment do
 
     describe '.with_submissions_by' do
       let(:user1) { create(:user) }
-      let(:submission1) { create(:submission, assessment: assessment, creator: user1) }
+      let(:submission1) do
+        create(:course_assessment_submission, assessment: assessment, creator: user1)
+      end
       let(:user2) { create(:user) }
-      let(:submission2) { create(:submission, assessment: assessment, creator: user2) }
-      let(:submission3) { create(:submission, assessment: assessment, creator: user2) }
+      let(:submission2) do
+        create(:course_assessment_submission, assessment: assessment, creator: user2)
+      end
+      let(:submission3) do
+        create(:course_assessment_submission, assessment: assessment, creator: user2)
+      end
 
       it 'returns all assessments' do
         assessment

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -254,10 +254,10 @@ RSpec.describe Course::Assessment do
 
     describe '.with_submissions_by' do
       let(:user1) { create(:user) }
-      let(:submission1) { create(:submission, assessment: assessment, user: user1) }
+      let(:submission1) { create(:submission, assessment: assessment, creator: user1) }
       let(:user2) { create(:user) }
-      let(:submission2) { create(:submission, assessment: assessment, user: user2) }
-      let(:submission3) { create(:submission, assessment: assessment, user: user2) }
+      let(:submission2) { create(:submission, assessment: assessment, creator: user2) }
+      let(:submission3) { create(:submission, assessment: assessment, creator: user2) }
 
       it 'returns all assessments' do
         assessment

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
     describe 'callbacks' do
       describe '#assessment' do
         context 'when the submission is being attempted' do
-          let(:submission) { create(:submission, :attempting) }
+          let(:submission) { create(:course_assessment_submission, :attempting) }
           it 'does not evaluate_conditional_for the affected course_user' do
             expect(Course::Condition::Assessment).
               to_not receive(:evaluate_conditional_for).with(submission.course_user)
@@ -84,7 +84,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         end
 
         context 'when the submission is being submitted' do
-          let(:submission) { create(:submission, :attempting) }
+          let(:submission) { create(:course_assessment_submission, :attempting) }
           it 'evaluate_conditional_for the affected course_user' do
             expect(Course::Condition::Assessment).
               to receive(:evaluate_conditional_for).with(submission.course_user)
@@ -94,7 +94,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         end
 
         context 'when the submission is being graded' do
-          let(:submission) { create(:submission, :submitted) }
+          let(:submission) { create(:course_assessment_submission, :submitted) }
           it 'evaluate_conditional_for the affected course_user' do
             expect(Course::Condition::Assessment).
               to receive(:evaluate_conditional_for).with(submission.course_user)
@@ -104,7 +104,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         end
 
         context 'when the submission is already graded' do
-          let(:submission) { create(:submission, :graded) }
+          let(:submission) { create(:course_assessment_submission, :graded) }
           it 'does not evaluate_conditional_for the affected course_user' do
             expect(Course::Condition::Assessment).
               to_not receive(:evaluate_conditional_for).with(submission.course_user)
@@ -157,24 +157,27 @@ RSpec.describe Course::Condition::Assessment, type: :model do
 
         context 'when the submission is attempted' do
           it 'returns false' do
-            create(:submission, workflow_state: :attempting, assessment: assessment,
-                                creator: course_user.user)
+            create(:course_assessment_submission, workflow_state: :attempting,
+                                                  assessment: assessment,
+                                                  creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_falsey
           end
         end
 
         context 'when the submission is submitted' do
           it 'returns true' do
-            create(:submission, workflow_state: :submitted, assessment: assessment,
-                                creator: course_user.user)
+            create(:course_assessment_submission, workflow_state: :submitted,
+                                                  assessment: assessment,
+                                                  creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_truthy
           end
         end
 
         context 'when the submission is graded' do
           it 'returns true' do
-            create(:submission, workflow_state: :graded, assessment: assessment,
-                                creator: course_user.user)
+            create(:course_assessment_submission, workflow_state: :graded,
+                                                  assessment: assessment,
+                                                  creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_truthy
           end
         end
@@ -189,16 +192,18 @@ RSpec.describe Course::Condition::Assessment, type: :model do
 
         context 'when there are submitted submissions' do
           it 'returns false' do
-            create(:submission, workflow_state: :submitted, assessment: assessment,
-                                creator: course_user.user)
+            create(:course_assessment_submission, workflow_state: :submitted,
+                                                  assessment: assessment,
+                                                  creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_falsey
           end
         end
 
         context 'when there are graded submissions' do
           let(:submission) do
-            create(:submission, workflow_state: :graded, assessment: assessment,
-                                creator: course_user.user)
+            create(:course_assessment_submission, workflow_state: :graded,
+                                                  assessment: assessment,
+                                                  creator: course_user.user)
           end
 
           context 'when there is no answer' do

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         context 'when the submission is attempted' do
           it 'returns false' do
             create(:submission, workflow_state: :attempting, assessment: assessment,
-                                user: course_user.user)
+                                creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_falsey
           end
         end
@@ -166,7 +166,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         context 'when the submission is submitted' do
           it 'returns true' do
             create(:submission, workflow_state: :submitted, assessment: assessment,
-                                user: course_user.user)
+                                creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_truthy
           end
         end
@@ -174,7 +174,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         context 'when the submission is graded' do
           it 'returns true' do
             create(:submission, workflow_state: :graded, assessment: assessment,
-                                user: course_user.user)
+                                creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_truthy
           end
         end
@@ -190,7 +190,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         context 'when there are submitted submissions' do
           it 'returns false' do
             create(:submission, workflow_state: :submitted, assessment: assessment,
-                                user: course_user.user)
+                                creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_falsey
           end
         end
@@ -198,7 +198,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         context 'when there are graded submissions' do
           let(:submission) do
             create(:submission, workflow_state: :graded, assessment: assessment,
-                                user: course_user.user)
+                                creator: course_user.user)
           end
 
           context 'when there is no answer' do


### PR DESCRIPTION
... of the associated experience_points_record

#### Intent
The PR adds a validation between `submission.creator` and `submission.experience_points_record.course_user.user`. 

#### Why
- The submission creator is used to identify the submissions associated to the user

#### How
- This commit enforces the creator of the submission to be the same user as the receipient of the experience points  
- The factory is modified to set the creator to be the same user as the course_user in the experience_points_record