### PR TITLE
Modify assessment ability to be more explicit for course_users

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -25,7 +25,7 @@ module Course::Assessment::AssessmentAbility
 
   def submission_attempting_hash(user)
     { workflow_state: 'attempting' }.tap do |result|
-      result.reverse_merge(course_user: { user_id: user.id }) if user
+      result.reverse_merge(experience_points_record: { course_user: { user_id: user.id } }) if user
     end
   end
 
@@ -43,9 +43,11 @@ module Course::Assessment::AssessmentAbility
         lesson_plan_item: properties
       )
     end
-    can :create, Course::Assessment::Submission, course_user: { user_id: user.id }
+    can :create, Course::Assessment::Submission,
+        experience_points_record: { course_user: { user_id: user.id } }
     can :update, Course::Assessment::Submission, submission_attempting_hash(user)
-    can :read, Course::Assessment::Submission, course_user: { user_id: user.id }
+    can :read, Course::Assessment::Submission,
+        experience_points_record: { course_user: { user_id: user.id } }
   end
 
   def allow_students_update_own_submission

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment do
+  let!(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    subject { Ability.new(user) }
+    let(:course) { create(:course) }
+    let(:course_user) { create(:course_student, :approved, course: course) }
+    let(:assessment) do
+      create(:course_assessment_assessment, :with_all_question_types, course: course)
+    end
+    let(:attempting_submission) do
+      create(:submission, :attempting, assessment: assessment, user: course_user.user)
+    end
+    let(:submitted_submission) do
+      create(:submission, :submitted, assessment: assessment, user: course_user.user)
+    end
+
+    context 'when the user is a Course Student' do
+      let(:user) { course_user.user }
+
+      # Course Assessments
+      it { is_expected.to be_able_to(:read, assessment) }
+
+      # Course Assessment Submissions
+      it { is_expected.to be_able_to(:attempt, assessment) }
+      it { is_expected.to be_able_to(:create, attempting_submission) }
+      it { is_expected.to be_able_to(:update, attempting_submission) }
+      it { is_expected.to be_able_to(:read, submitted_submission) }
+    end
+
+    context 'when the user is a Course Staff' do
+      let(:user) { create(:course_manager, :approved, course: course).user }
+
+      # Course Assessments
+      it { is_expected.to be_able_to(:manage, assessment) }
+      it 'can manage all questions in the assessment' do
+        assessment.questions.each do |question|
+          expect(subject).to be_able_to(:manage, question.specific)
+        end
+      end
+
+      # Course Assessment Submissions
+      it { is_expected.to be_able_to(:read, attempting_submission) }
+      it { is_expected.not_to be_able_to(:grade, attempting_submission) }
+      it { is_expected.to be_able_to(:grade, submitted_submission) }
+
+      it 'sees all submissions for a given assessment' do
+        expect(assessment.submissions.accessible_by(subject)).
+          to contain_exactly(attempting_submission, submitted_submission)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why
This issue came about when I was trying to implement the submission statistics page:
> I somehow managed to invoke some weird ability bug when a course_stuff (not system admin) views submissions for the assessment (Rails assume that `course_user_id` is a column under `course_assessment_submissions` - it could be an acts_as bug.

> Unfortunately, I'm not able to reproduce that through testing the assessment abilities by itself though, but I've added that specs in. What I tried to do was to be as clear as I could in the commit message, unless it is preferred for me to add comments into the code? 

### How
Hence, this PR is created to set assessment abilities to be more explicit when being defined.
- Current ability assumes course_user_id can be derived straight from the course_assessment_submissions table. This happens when checking for ability for submissions for course_staff.
- Added specs to test Course Assessment Ability

### Discussion
I'm not sure if this is the most proper way to resolve this at the moment. Any ideas? Unless we go digging to acts_as?