### PR TITLE
Implement assessment attempt feed notification

### DIFF
--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -6,6 +6,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
   include Course::Assessment::Submission::ExperiencePointsDisplayConcern
 
   after_save :auto_grade_submission, if: :submitted?
+  after_create :send_notification
 
   workflow do
     state :attempting do
@@ -132,5 +133,9 @@ class Course::Assessment::Submission < ActiveRecord::Base
     unless course_user && course_user.user == creator
       errors.add(:experience_points_record, :inconsistent_user)
     end
+  end
+
+  def send_notification
+    Course::AssessmentNotifier.assessment_attempted(creator, assessment)
   end
 end

--- a/app/notifiers/course/assessment_notifier.rb
+++ b/app/notifiers/course/assessment_notifier.rb
@@ -1,0 +1,8 @@
+class Course::AssessmentNotifier < Notifier::Base
+  # To be called when user attempted an assessment.
+  def assessment_attempted(user, assessment)
+    create_activity(actor: user, object: assessment, event: :attempted).
+      notify(assessment.tab.category.course, :feed).
+      save
+  end
+end

--- a/app/views/notifiers/course/assessment_notifier/attempted/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/attempted/course_notifications/_feed.html.slim
@@ -1,0 +1,9 @@
+- activity = notification.activity
+- assessment = activity.object
+
+= div_for(notification) do
+  // TODO: Display user image here.
+  - user_link = link_to_user(activity.actor)
+  - assessment_link = link_to assessment.title, course_assessment_path(notification.course, assessment)
+  => t('.attempted_assessment_html', user: user_link, assessment: assessment_link)
+  h6 = format_datetime(activity.created_at)

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -6,4 +6,8 @@ en:
           course_notifications:
             feed:
               gained_achievement_html: '%{user} gained achievement %{achievement}'
-
+      assessment_notifier:
+        attempted:
+          course_notifications:
+            feed:
+              attempted_assessment_html: '%{user} attempted %{assessment}'

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -11,5 +11,11 @@ FactoryGirl.define do
       event :gained
       notifier_type Course::AchievementNotifier.name
     end
+
+    trait :assessment_attempted do
+      object { create(:assessment) }
+      event :attempted
+      notifier_type Course::AssessmentNotifier.name
+    end
   end
 end

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -6,10 +6,23 @@ RSpec.feature 'Course: Homepage' do
 
   with_tenant(:instance) do
     let(:course) { create(:course, :opened) }
-    let(:achievement_feed_notification) do
-      achievement = create(:course_achievement)
+    let(:feed_notifications) do
+      notifications = []
+      # Achievement gained notification
+      achievement = create(:course_achievement, course: course)
       achievement_activity = create(:activity, :achievement_gained, object: achievement)
-      create(:course_notification, :feed, activity: achievement_activity, course: course)
+      notifications << create(:course_notification, :feed,
+                              activity: achievement_activity,
+                              course: course)
+
+      # Assessment attempted notification
+      assessment = create(:assessment, course: course)
+      assessment_activity = create(:activity, :assessment_attempted, object: assessment)
+      notifications << create(:course_notification, :feed,
+                              activity: assessment_activity,
+                              course: course)
+
+      notifications
     end
 
     before do
@@ -25,10 +38,12 @@ RSpec.feature 'Course: Homepage' do
       end
 
       scenario 'I am able to see the activity feed in course homepage' do
-        achievement_feed_notification
+        feed_notifications
 
         visit course_path(course)
-        expect(page).to have_content_tag_for(achievement_feed_notification)
+        feed_notifications.each do |notification|
+          expect(page).to have_content_tag_for(notification)
+        end
       end
     end
 
@@ -41,10 +56,12 @@ RSpec.feature 'Course: Homepage' do
       end
 
       scenario 'I am not able to see the activity feed in course homepage' do
-        achievement_feed_notification
+        feed_notifications
 
         visit course_path(course)
-        expect(page).not_to have_content_tag_for(achievement_feed_notification)
+        feed_notifications.each do |notification|
+          expect(page).not_to have_content_tag_for(notification)
+        end
       end
 
       scenario 'I am only able to see approved owner and managers in instructors list' do

--- a/spec/notifiers/course/assessment_notifier.rb
+++ b/spec/notifiers/course/assessment_notifier.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::AssessmentNotifier, type: :notifier do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    describe '#assessment_attempted' do
+      let(:course) { create(:course) }
+      let(:assessment) { create(:course_assessment_assessment, course: course) }
+      let(:user) { create(:course_user, course: course).user }
+
+      subject { Course::AssessmentNotifier.assessment_attempted(user, assessment) }
+
+      it 'sends a course notification' do
+        expect { subject }.to change(course.notifications, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Regarding discussion in #1080

Changes in this PR:
Similar to #1081, this implements the logic to send and display course feed notifications when user attempts the assessment. 

