### PR TITLE
Implement level reached feed notification

### DIFF
--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -2,6 +2,8 @@
 class Course::ExperiencePointsRecord < ActiveRecord::Base
   actable
 
+  before_save :send_notification, if: :reached_new_level?
+
   validates :reason, presence: true, if: :manually_awarded?
 
   belongs_to :course_user, inverse_of: :experience_points_records
@@ -29,5 +31,30 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
   # @return [String] The formatted reason for the award
   def reason
     manually_awarded? ? super : specific.experience_points_display_reason
+  end
+
+  private
+
+  def send_notification
+    Course::LevelNotifier.level_reached(course_user.user, level_after_update)
+  end
+
+  # Test if the course_user will reach a new level after current update.
+  def reached_new_level?
+    return false unless points_awarded && points_awarded_changed?
+
+    level_after_update.level_number > level_before_update.level_number
+  end
+
+  def level_before_update
+    current_exp = course_user.experience_points
+    course_user.course.level_for(current_exp)
+  end
+
+  def level_after_update
+    # Since we are in the before_save callback, exp changes are not saved yet.
+    exp_changed = points_awarded - (points_awarded_was || 0)
+    current_exp = course_user.experience_points
+    course_user.course.level_for(current_exp + exp_changed)
   end
 end

--- a/app/notifiers/course/level_notifier.rb
+++ b/app/notifiers/course/level_notifier.rb
@@ -1,0 +1,9 @@
+class Course::LevelNotifier < Notifier::Base
+  # To be called when user reached a new level.
+  def level_reached(user, level)
+    create_activity(actor: user, object: level, event: :reached).
+      notify(level.course, :feed).
+      notify(user, :popup).
+      save
+  end
+end

--- a/app/views/notifiers/course/level_notifier/reached/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/level_notifier/reached/course_notifications/_feed.html.slim
@@ -1,0 +1,8 @@
+- activity = notification.activity
+- level = activity.object
+
+= div_for(notification) do
+  // TODO: Display user image here.
+  - user_link = link_to_user(activity.actor)
+  => t('.reached_level_html', user: user_link, level_number: level.level_number)
+  h6 = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/level_notifier/reached/user_notifications/popup.html.slim
+++ b/app/views/notifiers/course/level_notifier/reached/user_notifications/popup.html.slim
@@ -1,0 +1,1 @@
+// TODO: Implement popup notification.

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -11,3 +11,8 @@ en:
           course_notifications:
             feed:
               attempted_assessment_html: '%{user} attempted %{assessment}'
+      level_notifier:
+        reached:
+          course_notifications:
+            feed:
+              reached_level_html: '%{user} reached level %{level_number}'

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -17,5 +17,11 @@ FactoryGirl.define do
       event :attempted
       notifier_type Course::AssessmentNotifier.name
     end
+
+    trait :level_reached do
+      object { create(:course_level) }
+      event :reached
+      notifier_type Course::LevelNotifier.name
+    end
   end
 end

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -22,6 +22,13 @@ RSpec.feature 'Course: Homepage' do
                               activity: assessment_activity,
                               course: course)
 
+      # Level reached notification
+      level = create(:course_level, course: course)
+      level_activity = create(:activity, :level_reached, object: level)
+      notifications << create(:course_notification, :feed,
+                              activity: level_activity,
+                              course: course)
+
       notifications
     end
 

--- a/spec/models/course/experience_points_record_spec.rb
+++ b/spec/models/course/experience_points_record_spec.rb
@@ -28,6 +28,36 @@ RSpec.describe Course::ExperiencePointsRecord do
       end
     end
 
+    describe '#reached_new_level?' do
+      let(:course) do
+        course = create(:course)
+        create_list(:course_level, 3, course: course)
+        course.levels.reload
+        course
+      end
+      let(:record) { create(:course_experience_points_record, course: course, points_awarded: 0) }
+      subject do
+        record.points_awarded += exp_to_award
+        record.send(:reached_new_level?)
+      end
+
+      context 'when no exp is awarded' do
+        let(:exp_to_award) { 0 }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when enough exp is awarded' do
+        let(:exp_to_award) do
+          current_exp = record.course_user.experience_points
+          next_level = course.level_for(current_exp).next
+          next_level.experience_points_threshold - current_exp
+        end
+
+        it { is_expected.to be_truthy }
+      end
+    end
+
     context 'when manually created' do
       subject { build(:course_experience_points_record) }
 

--- a/spec/notifiers/course/level_notifier.rb
+++ b/spec/notifiers/course/level_notifier.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::LevelNotifier, type: :notifier do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    describe '#level_reached' do
+      let(:course) { create(:course) }
+      let(:level) { create(:course_level, course: course) }
+      let(:user) { create(:course_user, course: course).user }
+
+      subject { Course::LevelNotifier.level_reached(user, level) }
+
+      it 'sends a course notification' do
+        expect { subject }.to change(course.notifications, :count).by(1)
+      end
+
+      it 'sends a user notification' do
+        expect { subject }.to change(user.notifications, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Regarding #1080, Depends on #1087 

Changes in this PR:
- Implements a level reached notifier
- Add model methods in `ExperiencePointsRecord` to determine whether to send level notification after EXP changed. 

TODO:
Level reached popup notification need to be further implemented.