### PR TITLE
Implement forum related feed notifications

### DIFF
--- a/app/controllers/course/forum/posts_controller.rb
+++ b/app/controllers/course/forum/posts_controller.rb
@@ -8,6 +8,7 @@ class Course::Forum::PostsController < Course::Forum::ComponentController
 
   def create
     if super
+      Course::Forum::PostNotifier.post_replied(@post.creator, @post)
       redirect_to course_forum_topic_path(current_course, @forum, @topic),
                   success: t('course.discussion.posts.create.success')
     else

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -9,6 +9,7 @@ class Course::Forum::Topic < ActiveRecord::Base
   after_initialize :generate_initial_post, unless: :persisted?
   before_validation :set_initial_post_title, unless: :persisted?
   after_create :mark_as_read_for_creator
+  after_create :send_notification
   after_update :mark_as_read_for_updater
 
   enum topic_type: { normal: 0, question: 1, sticky: 2, announcement: 3 }
@@ -118,5 +119,9 @@ class Course::Forum::Topic < ActiveRecord::Base
   # Set the course as the same course of the forum.
   def set_course
     self.course ||= forum.course if forum
+  end
+
+  def send_notification
+    Course::Forum::TopicNotifier.topic_created(creator, self)
   end
 end

--- a/app/notifiers/course/forum/post_notifier.rb
+++ b/app/notifiers/course/forum/post_notifier.rb
@@ -1,0 +1,8 @@
+class Course::Forum::PostNotifier < Notifier::Base
+  # To be called when user replied a forum post.
+  def post_replied(user, post)
+    create_activity(actor: user, object: post, event: :replied).
+      notify(post.topic.actable.forum.course, :feed).
+      save!
+  end
+end

--- a/app/notifiers/course/forum/topic_notifier.rb
+++ b/app/notifiers/course/forum/topic_notifier.rb
@@ -1,0 +1,8 @@
+class Course::Forum::TopicNotifier < Notifier::Base
+  # To be called when user created a new forum topic.
+  def topic_created(user, topic)
+    create_activity(actor: user, object: topic, event: :created).
+      notify(topic.forum.course, :feed).
+      save
+  end
+end

--- a/app/views/notifiers/course/forum/post_notifier/replied/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/course_notifications/_feed.html.slim
@@ -1,0 +1,10 @@
+- activity = notification.activity
+- post = activity.object
+- topic = post.topic.actable
+
+= div_for(notification) do
+  // TODO: Display user image here.
+  - user_link = link_to_user(activity.actor)
+  - topic_link = link_to topic.title, course_forum_topic_path(notification.course, topic.forum, topic)
+  => t('.replied_to_topic_html', user: user_link, topic: topic_link)
+  h6 = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/forum/topic_notifier/created/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/topic_notifier/created/course_notifications/_feed.html.slim
@@ -1,0 +1,9 @@
+- activity = notification.activity
+- topic = activity.object
+
+= div_for(notification) do
+  // TODO: Display user image here.
+  - user_link = link_to_user(activity.actor)
+  - topic_link = link_to topic.title, course_forum_topic_path(notification.course, topic.forum, topic)
+  => t('.created_topic_html', user: user_link, topic: topic_link)
+  h6 = format_datetime(activity.created_at)

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -16,3 +16,9 @@ en:
           course_notifications:
             feed:
               reached_level_html: '%{user} reached level %{level_number}'
+      forum:
+        topic_notifier:
+          created:
+            course_notifications:
+              feed:
+                created_topic_html: '%{user} created topic %{topic}'

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -22,3 +22,8 @@ en:
             course_notifications:
               feed:
                 created_topic_html: '%{user} created topic %{topic}'
+        post_notifier:
+          replied:
+            course_notifications:
+              feed:
+                replied_to_topic_html: '%{user} replied to %{topic}'

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -23,5 +23,11 @@ FactoryGirl.define do
       event :reached
       notifier_type Course::LevelNotifier.name
     end
+
+    trait :forum_topic_created do
+      object { create(:forum_topic) }
+      event :created
+      notifier_type Course::Forum::TopicNotifier.name
+    end
   end
 end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -29,5 +29,14 @@ FactoryGirl.define do
       event :created
       notifier_type Course::Forum::TopicNotifier.name
     end
+
+    trait :forum_post_replied do
+      object do
+        topic = create(:forum_topic)
+        create(:course_discussion_post, topic: topic.acting_as)
+      end
+      event :replied
+      notifier_type Course::Forum::PostNotifier.name
+    end
   end
 end

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -37,6 +37,12 @@ RSpec.feature 'Course: Homepage' do
                               activity: topic_activity,
                               course: course)
 
+      # Forum post replied notification
+      post = create(:course_discussion_post, topic: topic.acting_as)
+      post_replied_activity = create(:activity, :forum_post_replied, object: post)
+      notifications << create(:course_notification, :feed,
+                              activity: post_replied_activity,
+                              course: course)
       notifications
     end
 

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -29,6 +29,14 @@ RSpec.feature 'Course: Homepage' do
                               activity: level_activity,
                               course: course)
 
+      # Forum topic created notification
+      forum = create(:forum, course: course)
+      topic = create(:forum_topic, forum: forum)
+      topic_activity = create(:activity, :forum_topic_created, object: topic)
+      notifications << create(:course_notification, :feed,
+                              activity: topic_activity,
+                              course: course)
+
       notifications
     end
 

--- a/spec/notifiers/course/forum/post_notifier.rb
+++ b/spec/notifiers/course/forum/post_notifier.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Forum::PostNotifier, type: :notifier do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:forum) { create(:forum, course: course) }
+    let!(:topic) { create(:forum_topic, forum: forum) }
+    let(:post) { create(:course_discussion_post, topic: topic.acting_as) }
+    let(:user) { create(:course_user, course: course).user }
+
+    describe '#post_replied' do
+      subject { Course::Forum::PostNotifier.post_replied(user, post) }
+
+      it 'sends a course notification' do
+        expect { subject }.to change(course.notifications, :count).by(1)
+      end
+    end
+  end
+end

--- a/spec/notifiers/course/forum/topic_notifier.rb
+++ b/spec/notifiers/course/forum/topic_notifier.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Forum::TopicNotifier, type: :notifier do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    describe '#topic_created' do
+      let(:course) { create(:course) }
+      let(:forum) { create(:forum, course: course) }
+      let!(:topic) { create(:forum_topic, forum: forum) }
+      let(:user) { create(:course_user, course: course).user }
+
+      subject { Course::Forum::TopicNotifier.topic_created(user, topic) }
+
+      it 'sends a course notification' do
+        expect { subject }.to change(course.notifications, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Regarding #1080, depends on #1088

Changes in this PR:
- Implements `Course::Forum::TopicNotifier` to handle the notification when topics are created.
- Implements `Course::Forum::PostNotifier` to handle the notification when posts are created or voted.
