### PR TITLE
Support custom start line number in the pipeline

### DIFF
--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -31,9 +31,14 @@ module ApplicationHTMLFormattersHelper
   DefaultCodePipelineOptions = DefaultPipelineOptions.merge(css_table_class: 'table').freeze
 
   # The Code formatter pipeline.
-  DefaultCodePipeline = HTML::Pipeline.new(DefaultPipeline.filters +
-                                           [PreformattedTextLineNumbersFilter],
-                                           DefaultCodePipelineOptions)
+  #
+  # @param [Integer] starting_line_number The line number of the first line, default is 1.
+  # @return [HTML::Pipeline]
+  def default_code_pipeline(starting_line_number = 1)
+    HTML::Pipeline.new(DefaultPipeline.filters +
+                         [PreformattedTextLineNumbersFilter],
+                       DefaultCodePipelineOptions.merge(line_start: starting_line_number))
+  end
 
   # Replaces the Rails sanitizer with the one configured with HTML Pipeline.
   def sanitize(text)
@@ -65,7 +70,9 @@ module ApplicationHTMLFormattersHelper
   # @param [String] code The code to syntax highlight.
   # @param [Coursemology::Polyglot::Language] language The language to highlight the code block
   #   with.
-  def format_code_block(code, language = nil)
+  # @param [Integer] starting_line_number The line number of the first line, default is 1. This
+  #   should be provided if the code fragment does not start on the first line.
+  def format_code_block(code, language = nil, starting_line_number = 1)
     code = html_escape(code) unless code.html_safe?
     code = code.gsub(/\r\n|\r/, "\n")
     code = content_tag(:pre, lang: language ? language.rouge_lexer : nil) do
@@ -74,7 +81,7 @@ module ApplicationHTMLFormattersHelper
       end
     end
 
-    format_with_pipeline(DefaultCodePipeline, code)
+    format_with_pipeline(default_code_pipeline(starting_line_number), code)
   end
 
   private

--- a/app/helpers/course/discussion/code_display_helper.rb
+++ b/app/helpers/course/discussion/code_display_helper.rb
@@ -8,7 +8,6 @@ module Course::Discussion::CodeDisplayHelper
   # @return [String] A HTML fragment containing the code lines.
   def display_code_lines(file, line_start, line_end)
     code = file.lines((line_start - 1)..(line_end - 1)).join("\n")
-    # TODO: Line number is started from 1, need to fix the pipeline to display the correct numbers.
-    format_code_block(code, file.answer.question.actable.language)
+    format_code_block(code, file.answer.question.actable.language, [line_start, 1].max)
   end
 end

--- a/lib/autoload/preformatted_text_line_numbers_filter.rb
+++ b/lib/autoload/preformatted_text_line_numbers_filter.rb
@@ -3,6 +3,8 @@ class PreformattedTextLineNumbersFilter < HTML::Pipeline::Filter
   # The regex for splitting input by newlines.
   NEWLINE_REGEX = /\r\n|\r|\n/.freeze
 
+  # Adds a line number before the code block.
+  # Takes a :line_start option which specifies the start line number, default is 1.
   def call
     doc.search('pre').each do |pre|
       process_pre_tag(pre)
@@ -33,8 +35,9 @@ class PreformattedTextLineNumbersFilter < HTML::Pipeline::Filter
     table['class'] = [pre['class'], context[:css_class] || 'highlight', context[:css_table_class]].
                      compact.join(' ')
 
+    line_start = context[:line_start] || 1
     lines.each_with_index do |line, i|
-      tr = build_line_tag(i + 1, line, pre.attributes)
+      tr = build_line_tag(i + line_start, line, pre.attributes)
       table.add_child(tr)
     end
 

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe ApplicationFormattersHelper do
       it 'highlights the keywords' do
         expect(formatted_block).to have_tag('span.k', text: 'def')
       end
+
+      context 'when start line number is specified' do
+        let(:line_start) { 5 }
+        let(:formatted_block) { helper.format_code_block(snippet, language, line_start) }
+
+        it 'highlights the code with the given start line number' do
+          expect(formatted_block).to have_tag('td.line-number', count: 3)
+          expect(formatted_block).to have_tag('td.line-number', with: { 'data-line-number': '5' })
+          expect(formatted_block).to have_tag('td.line-number', with: { 'data-line-number': '6' })
+          expect(formatted_block).to have_tag('td.line-number', with: { 'data-line-number': '7' })
+        end
+      end
     end
 
     describe '#sanitize' do


### PR DESCRIPTION
### Why
There is an issue after #1065 
The code snippets line number all start from 1, which is not correct
### How
`PreformattedTextLineNumbersFilter` was modified to support custom line numbers.
 