### PR TITLE
Remove redundant managers scope from GroupUser model

### DIFF
--- a/app/models/course/group.rb
+++ b/app/models/course/group.rb
@@ -79,7 +79,7 @@ class Course::Group < ActiveRecord::Base
   #
   # @return [Boolean]
   def should_create_manager?
-    course && creator && group_users.managers.count == 0
+    course && creator && group_users.manager.count == 0
   end
 
   # Returns the default course_user to be a group_manager.

--- a/app/models/course/group_user.rb
+++ b/app/models/course/group_user.rb
@@ -9,8 +9,6 @@ class Course::GroupUser < ActiveRecord::Base
   belongs_to :course_user, inverse_of: :group_users
   belongs_to :group, class_name: Course::Group.name, inverse_of: :group_users
 
-  scope :managers, -> { where(role: roles[:manager]) }
-
   private
 
   # Set default values

--- a/spec/models/course/group_user_spec.rb
+++ b/spec/models/course/group_user_spec.rb
@@ -5,33 +5,17 @@ RSpec.describe Course::GroupUser, type: :model do
   it { is_expected.to belong_to(:course_user).inverse_of(:group_users) }
   it { is_expected.to belong_to(:group).inverse_of(:group_users) }
 
-  let!(:instance) { create(:instance) }
+  let(:instance) { create(:instance) }
   with_tenant(:instance) do
-    let!(:course) { create(:course) }
-    let!(:course_group) { create(:course_group, course: course) }
-    let!(:course_group_users) do
-      create_list(:course_group_user, 2, course: course, group: course_group)
-    end
-
+    let(:course_group) { create(:course_group) }
     context 'when user is not enrolled in group\'s course' do
-      let(:other_course_user) do
-        other_course = create(:course)
-        create(:course_user, course: other_course)
-      end
+      let(:other_course_user) { create(:course_user) }
+
       subject do
         build(:course_group_user, group: course_group, course_user: other_course_user)
       end
 
       it { is_expected.not_to be_valid }
-    end
-
-    describe '.managers' do
-      subject { course_group.group_users.managers }
-
-      it 'returns the managers of the group' do
-        managers = course_group.group_users.select(&:manager?)
-        expect(subject).to eq(managers)
-      end
     end
   end
 end


### PR DESCRIPTION
`GroupUser.manager` gives the same result as `GroupUser.managers`