### PR TITLE
Improve experience points disbursement page

### DIFF
--- a/app/assets/javascripts/course/experience_points_disbursement.js
+++ b/app/assets/javascripts/course/experience_points_disbursement.js
@@ -1,0 +1,12 @@
+(function($) {
+  'use strict';
+  var COPY_BUTTON_SELECTOR = '#experience-points-disbursement-copy-button';
+
+  function copyExperiencePoints(event) {
+    event.preventDefault();
+    var valueToCopy = $('.course_user:first').find('.points_awarded:first').val();
+    $('.points_awarded').val(valueToCopy);
+  }
+
+  $(document).on('click', COPY_BUTTON_SELECTOR, copyExperiencePoints);
+})(jQuery);

--- a/app/views/course/experience_points_disbursement/new.slim
+++ b/app/views/course/experience_points_disbursement/new.slim
@@ -37,10 +37,11 @@
     tbody
       - number_of_records = @experience_points_disbursement.experience_points_records.length
       = f.simple_fields_for :experience_points_records do |record_fields|
-        = content_tag_for(:tr, record_fields.object.course_user)
-          td = display_course_user(record_fields.object.course_user)
+        - course_user = record_fields.object.course_user
+        = content_tag_for(:tr, course_user)
+          td = link_to_course_user(course_user)
           td = record_fields.input :points_awarded, label: false,
-                                   input_html: { class: 'points_awarded' }
+                                                    input_html: { class: 'points_awarded' }
           td
             - if (record_fields.index == 0) && (number_of_records > 1)
               button.btn.btn-link#experience-points-disbursement-copy-button = t('.copy_value')

--- a/app/views/course/experience_points_disbursement/new.slim
+++ b/app/views/course/experience_points_disbursement/new.slim
@@ -33,12 +33,17 @@
       tr
         th = CourseUser.human_attribute_name(:name)
         th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
+        th
     tbody
+      - number_of_records = @experience_points_disbursement.experience_points_records.length
       = f.simple_fields_for :experience_points_records do |record_fields|
         = content_tag_for(:tr, record_fields.object.course_user)
           td = display_course_user(record_fields.object.course_user)
           td = record_fields.input :points_awarded, label: false,
                                    input_html: { class: 'points_awarded' }
+          td
+            - if (record_fields.index == 0) && (number_of_records > 1)
+              button.btn.btn-link#experience-points-disbursement-copy-button = t('.copy_value')
           = record_fields.hidden_field :course_user_id
 
   = f.button :submit, t('.submit')

--- a/config/locales/en/course/experience_points_disbursement.yml
+++ b/config/locales/en/course/experience_points_disbursement.yml
@@ -10,6 +10,7 @@ en:
         filter_selected: 'Showing students from %{group}'
         filter_not_selected: 'Filter by group'
         show_all: 'Show all students'
+        copy_value: 'Copy value for all students'
       create:
         success:
           zero: 'No experience points were disbursed.'

--- a/spec/features/course/experience_points_disbursement_spec.rb
+++ b/spec/features/course/experience_points_disbursement_spec.rb
@@ -61,12 +61,8 @@ RSpec.feature 'Course: Experience Points Disbursement' do
 
         expect(page).not_to have_content_tag_for(unapproved_course_student)
         expect(page).to have_content_tag_for(student_to_leave_blank)
-        within find(content_tag_selector(student_to_award_points)) do
-          find('input.points_awarded').set '100'
-        end
-        within find(content_tag_selector(student_to_set_zero)) do
-          find('input.points_awarded').set '00'
-        end
+        find(content_tag_selector(student_to_award_points)).find('input.points_awarded').set '100'
+        find(content_tag_selector(student_to_set_zero)).find('input.points_awarded').set '00'
 
         # ExperiencePointsRecord is not created when points_awarded is zero
         expect do

--- a/spec/features/course/experience_points_disbursement_spec.rb
+++ b/spec/features/course/experience_points_disbursement_spec.rb
@@ -33,6 +33,21 @@ RSpec.feature 'Course: Experience Points Disbursement' do
         expect(page).not_to have_content_tag_for(ungrouped_student)
       end
 
+      scenario 'I can copy points awarded for first student to all students', js: true do
+        approved_course_students
+        visit disburse_experience_points_course_users_path(course)
+
+        find(content_tag_selector(approved_course_students[0])).
+          find('input.points_awarded').set '100'
+
+        click_button 'experience-points-disbursement-copy-button'
+
+        approved_course_students.each do |student|
+          points_awarded = find(content_tag_selector(student)).find('input.points_awarded').value
+          expect(points_awarded).to eq('100')
+        end
+      end
+
       scenario 'I can disburse experience points' do
         approved_course_students
         unapproved_course_student = create(:course_student, course: course)


### PR DESCRIPTION
Interface improvements:
- Add feature to duplicate experience points value for all students.
- Clicking on the student's name allows you view the student's profile.

Addresses #688 