### PR TITLE
Implement model and controller for all submissions page

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+class Course::Assessment::SubmissionsController < Course::ComponentController
+  before_action :load_submissions
+
+  def index #:nodoc:
+    @submissions = @submissions.with_submission_statistics.page(page_param).
+                   includes(:assessment, experience_points_record: { course_user: :course })
+  end
+
+  private
+
+  def submission_params
+    params.permit(:category)
+  end
+
+  # Load the current category, used to classify and load assessments.
+  def category
+    @category ||=
+      if submission_params[:category]
+        current_course.assessment_categories.find(submission_params[:category])
+      else
+        current_course.assessment_categories.first!
+      end
+  end
+
+  # Load the submissions based on the current category.
+  def load_submissions
+    @submissions = Course::Assessment::Submission.from_category(category).confirmed.
+                   ordered_by_submitted_date.accessible_by(current_ability)
+  end
+end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -82,10 +82,28 @@ class Course::Assessment::Submission < ActiveRecord::Base
       where { experience_points_record.course_user.user == user }
   end)
 
+  # @!method self.from_category(category)
+  #   Finds all the submissions in the given category.
+  #   @param [Course::Assessment::Category] category The category to filter submissions by
+  scope :from_category, (lambda do |category|
+    where { assessment_id >> category.assessments.select(:id) }
+  end)
+
   # @!method self.ordered_by_date
   #   Orders the submissions by date of creation. This defaults to reverse chronological order
   #   (newest submission first).
   scope :ordered_by_date, ->(direction = :desc) { order(created_at: direction) }
+
+  # @!method self.ordered_by_submitted date
+  #   Orders the submissions by date of submission (newest submission first).
+  scope :ordered_by_submitted_date, (lambda do
+    all.calculated(:submitted_at).order('submitted_at DESC')
+  end)
+
+  # @!method self.confirmed
+  #   Returns submissions which have been submitted (which may or may not be graded).
+  scope :confirmed, -> { where(workflow_state: [:submitted, :graded]) }
+
   scope :with_submission_statistics, -> { all.calculated(:grade) }
 
   alias_method :finalise=, :finalise!

--- a/app/views/course/assessment/submissions/index.html.slim
+++ b/app/views/course/assessment/submissions/index.html.slim
@@ -1,0 +1,1 @@
+/To be implemented.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,7 @@ Rails.application.routes.draw do
           collection do
             resources :skills, as: :assessments_skills, except: [:show]
             resources :skill_branches, as: :assessments_skill_branches, except: [:index, :show]
+            resources :submissions, only: [:index], concerns: :paginatable
           end
         end
       end

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::SubmissionsController do
+  let!(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let!(:course) { create(:course, creator: user) }
+    let(:categories) { create_list(:course_assessment_category, 2, course: course) }
+
+    before { sign_in(user) }
+
+    describe '#index' do
+      context 'when no category is specified' do
+        before { get :index, course_id: course }
+
+        it 'sets the category to the first category' do
+          first_category = course.assessment_categories.first
+          expect(controller.instance_variable_get(:@category)).to eq(first_category)
+        end
+      end
+
+      context 'when a category is specified' do
+        let(:category) { categories.first }
+        let(:tab) { create(:course_assessment_tab, course: course, category: category) }
+        let(:assessment) { create(:assessment, :with_all_question_types, course: course, tab: tab) }
+        let!(:submission) { create(:course_assessment_submission, :graded, assessment: assessment) }
+        before { get :index, course_id: course, category: category }
+
+        it 'sets the category to be the specified category' do
+          expect(controller.instance_variable_get(:@category)).to eq(category)
+        end
+
+        it 'loads the submissions from assessments in the specified category' do
+          submissions = controller.instance_variable_get(:@submissions)
+          expect(submissions).to contain_exactly(submission)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the model and controller to display all submissions. The intent is for the `index` action to display all submissions of assessments belonging to a category.

Hence, the controller:
- Set the category and load submissions through the category
- Orders the submissions based on the `submitted_at` date.
- ~~Orders the submissions based on course_user:~~
  - ~~If `staff`, load `submitted` and `graded` submissions only, and order `submitted` submissions first (to make the `staff` grade these submissions~~
  - ~~If `student`, load all of my own submissions, and order `attempting` submissions first (to make the `student` attempt these submissions.~~

To support this, I've added quite a few scopes in the `submissions` model. 

---

I will split the views and do a separate PR because this is too large on its own.