### PR TITLE
Implement reply comments in comments center

### DIFF
--- a/app/assets/javascripts/course/discussion/topics.js
+++ b/app/assets/javascripts/course/discussion/topics.js
@@ -1,0 +1,37 @@
+(function($) {
+  'use strict';
+  var DOCUMENT_SELECTOR = '.course-discussion-topics.index ';
+
+  // The comment boxes are hidden by default, show the boxes if the browser supports javascript.
+  function showCommentBoxes() {
+    var $forms = $('.post-form').filter(DOCUMENT_SELECTOR + '*');
+    $forms.show();
+  }
+
+  function onPostFormSubmit(e) {
+    e.preventDefault();
+
+    var $form = $(e.target);
+    var action = $form.attr('action');
+    var method = $form.attr('method');
+
+    $.ajax({ url: action, method: method, data: $form.serialize() }).
+    fail(function(data) { onPostFormSubmitFail(data, $form[0]); });
+
+    findInputFields($form).prop('disabled', true);
+  }
+
+  function onPostFormSubmitFail(_, form) {
+    var $form = $(form);
+    findInputFields($form).prop('disabled', false);
+
+    // TODO: Display error messages.
+  }
+
+  function findInputFields($form) {
+    return $form.find('textarea, input');
+  }
+
+  $(document).on('page:load ready', showCommentBoxes);
+  $(document).on('submit', DOCUMENT_SELECTOR + '.post-form', onPostFormSubmit);
+})(jQuery);

--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class Course::Discussion::PostsController < Course::ComponentController
+  before_action :load_topic
+  authorize_resource :topic
+
+  include Course::Discussion::PostsConcern
+
+  def create
+    render status: :bad_request unless super
+  end
+
+  protected
+
+  def discussion_topic
+    @topic
+  end
+
+  def create_topic_subscription
+    # TODO: Implement topic subscriptions
+    true
+  end
+
+  private
+
+  def topic_id_param
+    params.permit(:topic_id)[:topic_id]
+  end
+
+  def load_topic
+    @topic ||= Course::Discussion::Topic.find(topic_id_param)
+  end
+end

--- a/app/helpers/course/discussion/code_display_helper.rb
+++ b/app/helpers/course/discussion/code_display_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Course::Discussion::CodeDisplayHelper
+  # Display code lines in file.
+  #
+  # @param [Course::Assessment::Answer::ProgrammingFile] file The code file.
+  # @param [Integer] line_start The one based start line number.
+  # @param [Integer] line_end The one based end line line number.
+  # @return [String] A HTML fragment containing the code lines.
+  def display_code_lines(file, line_start, line_end)
+    code = file.lines((line_start - 1)..(line_end - 1)).join("\n")
+    # TODO: Line number is started from 1, need to fix the pipeline to display the correct numbers.
+    format_code_block(code, file.answer.question.actable.language)
+  end
+end

--- a/app/helpers/course/discussion/posts_helper.rb
+++ b/app/helpers/course/discussion/posts_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
-module Course::Discussion::TopicsHelper
+module Course::Discussion::PostsHelper
   include Course::Discussion::CodeDisplayHelper
 end

--- a/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
+++ b/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
@@ -1,17 +1,22 @@
 - file_annotation = discussion_topic_programming_file_annotation
+- topic = file_annotation.acting_as
 - answer = file_annotation.file.answer
 - question = answer.question
 - submission = answer.submission
 - assessment = question.assessment
 
-h3
-  = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
-h4
-  = t('.by_html', user: link_to_user(submission.creator))
-h4
-  = t('.question', title: question.title)
+= div_for(topic) do
+  h3
+    = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
+  h4
+    = t('.by_html', user: link_to_user(submission.creator))
+  h4
+    = t('.question', title: question.title)
 
-= display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
+  = display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
 
-= render partial: 'course/discussion/topic', object: file_annotation.acting_as,
-         locals: { post_partial: 'course/assessment/answer/programming/annotation_post' }
+  = render partial: 'course/discussion/topic', object: topic,
+           locals: { \
+             post_partial: 'course/assessment/answer/programming/annotation_post', \
+             footer: 'course/discussion/posts/form' \
+           }

--- a/app/views/course/assessment/answers/_discussion_topic_answer.html.slim
+++ b/app/views/course/assessment/answers/_discussion_topic_answer.html.slim
@@ -1,14 +1,19 @@
 - answer = discussion_topic_answer
+- topic = answer.acting_as
 - question = answer.question
 - submission = answer.submission
 - assessment = question.assessment
 
-h3
-  = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
-h4
-  = t('.by_html', user: link_to_user(submission.creator))
-h4
-  = t('.question', title: question.title)
+= div_for(topic) do
+  h3
+    = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
+  h4
+    = t('.by_html', user: link_to_user(submission.creator))
+  h4
+    = t('.question', title: question.title)
 
-= render partial: 'course/discussion/topic', object: answer.acting_as,
-         locals: { post_partial: 'course/assessment/answer/comment' }
+  = render partial: 'course/discussion/topic', object: answer.acting_as,
+           locals: { \
+             post_partial: 'course/assessment/answer/comment', \
+             footer: 'course/discussion/posts/form' \
+           }

--- a/app/views/course/discussion/_topic.html.slim
+++ b/app/views/course/discussion/_topic.html.slim
@@ -7,3 +7,5 @@
 - posts_locals[:post_locals] = post_locals if defined?(post_locals)
 - posts_locals[:max_depth] = max_depth if defined?(max_depth)
 = render partial: 'course/discussion/posts', locals: posts_locals
+br
+= render partial: footer, locals: { topic: topic } if defined?(footer)

--- a/app/views/course/discussion/posts/_form.html.slim
+++ b/app/views/course/discussion/posts/_form.html.slim
@@ -1,0 +1,6 @@
+/ Hide the form if the browser does not support javascript.
+div.post-form style='display: none'
+  = simple_form_for Course::Discussion::Post.new(parent_id: topic.post_ids.first), url: course_topic_posts_path(current_course, topic) do |f|
+    = f.hidden_field :parent_id
+    = f.input :text, label: false
+    = f.button :submit, t('.comment')

--- a/app/views/course/discussion/posts/create.js.erb
+++ b/app/views/course/discussion/posts/create.js.erb
@@ -1,0 +1,5 @@
+$('#<%= "discussion_topic_#{@topic.id}"%>').replaceWith(
+    '<%= escape_javascript(render partial: @topic.actable, prefix: 'discussion_topic') %>'
+);
+
+$('.post-form').show();

--- a/config/locales/en/course/discussion/posts.yml
+++ b/config/locales/en/course/discussion/posts.yml
@@ -10,3 +10,5 @@ en:
         destroy:
           success: 'Post was deleted'
           failure: 'Fail to delete post: %{error}'
+        form:
+          comment: 'Comment'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ Rails.application.routes.draw do
           get 'pending', on: :collection
           get 'my_students', on: :collection
           get 'my_students_pending', on: :collection
+          resources :posts, only: [:create]
         end
       end
     end

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -27,6 +27,26 @@ RSpec.feature 'Course: Topics: Management' do
         expect(page).
           to have_selector('div', text: code_annotation.file.answer.question.assessment.title)
       end
+
+      scenario 'I can reply to a comment topic', js: true do
+        # Randomly create a topic, either code_annotation or answer_comment.
+        topic = [true, false].sample ? code_annotation : answer_comment
+        visit course_topics_path(course)
+
+        comment = 'GOOD WORK!'
+        within find('.post-form') do
+          fill_in 'discussion_post[text]', with: comment
+          click_button 'course.discussion.posts.form.comment'
+        end
+        wait_for_ajax
+
+        post = topic.posts.reload.last
+        expect(post.text).to have_tag('*', text: comment)
+        expect(page).to have_content_tag_for(post)
+        within find(content_tag_selector(topic.acting_as)) do
+          expect(page).to have_tag('.post-form', count: 1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
User can create post in comments center now.

The deleting and the edit action will be further implemented.

Screen shot:
![screen shot 2016-06-17 at 4 45 45 pm](https://cloud.githubusercontent.com/assets/4983239/16145499/8e7da748-34ab-11e6-9b08-7107b8415131.png)
