### PR TITLE
Implement views for submissions page

### DIFF
--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -13,6 +13,10 @@ class Course::AssessmentsComponent < SimpleDelegator
   private
 
   def main_sidebar_items
+    assessment_categories + assessment_submissions
+  end
+
+  def assessment_categories
     current_course.assessment_categories.select(&:persisted?).map do |category|
       {
         key: :assessments,
@@ -22,6 +26,18 @@ class Course::AssessmentsComponent < SimpleDelegator
         unread: 0
       }
     end
+  end
+
+  def assessment_submissions
+    [
+      {
+        key: :assessments_submissions,
+        title: t('course.assessment.submissions.sidebar_title'),
+        weight: 2,
+        path: course_submissions_path(current_course,
+                                      category: current_course.assessment_categories.first)
+      }
+    ]
   end
 
   def admin_sidebar_items

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::SubmissionsController < Course::ComponentController
   before_action :load_submissions
+  before_action :add_submissions_breadcrumb
 
   def index #:nodoc:
     @submissions = @submissions.with_submission_statistics.page(page_param).
@@ -27,5 +28,9 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   def load_submissions
     @submissions = Course::Assessment::Submission.from_category(category).confirmed.
                    ordered_by_submitted_date.accessible_by(current_ability)
+  end
+
+  def add_submissions_breadcrumb
+    add_breadcrumb :index, course_submissions_path(current_course, category: category)
   end
 end

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -1,0 +1,16 @@
+- assessment = submission.assessment
+= content_tag_for(:tr, submission) do
+  td = link_to_course_user(submission.course_user)
+  td = link_to(format_inline_text(assessment.title),
+               course_assessment_path(current_course, assessment))
+  td = format_datetime(submission.submitted_at) if submission.submitted_at
+  td = submission.workflow_state.capitalize
+  td = submission.grade.to_i.to_s + ' / ' + assessment.maximum_grade.to_s
+  td
+    - button_class = ['btn', 'btn-block']
+    - link_path = edit_course_assessment_submission_path(current_course, assessment, submission)
+    - if current_course_user.staff? && submission.submitted?
+      = link_to(t('.grade'), link_path, class: button_class + ['btn-info'])
+    - else
+      = link_to(t('.view'), link_path, class: button_class + ['btn-primary'])
+  td

--- a/app/views/course/assessment/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submissions/_submissions.html.slim
@@ -1,0 +1,12 @@
+table.table.table-middle-align.table-hover
+  thead
+    tr
+      th = CourseUser.human_attribute_name(:name)
+      th = Course::Assessment.human_attribute_name(:title)
+      th = Course::Assessment::Submission.human_attribute_name(:submitted_at)
+      th = Course::Assessment::Submission.human_attribute_name(:status)
+      th = Course::Assessment::Submission.human_attribute_name(:grade)
+      th
+      th
+  tbody
+    = render submissions

--- a/app/views/course/assessment/submissions/_tabs.html.slim
+++ b/app/views/course/assessment/submissions/_tabs.html.slim
@@ -1,0 +1,4 @@
+= tabs do
+  - current_course.assessment_categories.each do |category|
+    = nav_to format_inline_text(category.title),
+             course_submissions_path(current_course, category: category)

--- a/app/views/course/assessment/submissions/index.html.slim
+++ b/app/views/course/assessment/submissions/index.html.slim
@@ -1,1 +1,6 @@
-/To be implemented.
+= page_header
+= render partial: 'tabs'
+
+= render partial: 'submissions', locals: { submissions: @submissions }
+
+= paginate @submissions

--- a/app/views/course/assessment/submissions/index.html.slim
+++ b/app/views/course/assessment/submissions/index.html.slim
@@ -1,3 +1,4 @@
+- add_breadcrumb format_inline_text(@category.title)
 = page_header
 = render partial: 'tabs'
 

--- a/config/locales/en/activerecord/course/assessment/assessment.yml
+++ b/config/locales/en/activerecord/course/assessment/assessment.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      course/assessment/assessment:
+        title: 'Title'

--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -3,9 +3,10 @@ en:
     attributes:
       course/assessment/submission:
         grade: 'Total Grade'
-        submitted_at: :'activerecord.attributes.course/assessment/answer/submitted_at'
-        grader: :'activerecord.attributes.course/assessment/answer/grader'
-        graded_at: :'activerecord.attributes.course/assessment/answer/graded_at'
+        status: 'Status'
+        submitted_at: :'activerecord.attributes.course/assessment/answer.submitted_at'
+        grader: :'activerecord.attributes.course/assessment/answer.grader'
+        graded_at: :'activerecord.attributes.course/assessment/answer.graded_at'
     errors:
       models:
         course/assessment/submission:

--- a/config/locales/en/activerecord/course_user.yml
+++ b/config/locales/en/activerecord/course_user.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      course/course_user:
+        name: 'Name'

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -79,6 +79,8 @@ en:
         skill_branches:
           index: :'breadcrumbs.course.assessment.skills.index'
           new: :'course.assessment.skill_branches.new.header'
+        submissions:
+          index: :'course.assessment.submissions.index.header'
       groups:
         index: :'course.groups.index.header'
         new: :'course.groups.new.header'

--- a/config/locales/en/course/assessment/submissions.yml
+++ b/config/locales/en/course/assessment/submissions.yml
@@ -2,6 +2,7 @@ en:
   course:
     assessment:
       submissions:
+        sidebar_title: :'course.assessment.submissions.index.header'
         index:
           header: 'Submissions'
         submission:

--- a/config/locales/en/course/assessment/submissions.yml
+++ b/config/locales/en/course/assessment/submissions.yml
@@ -1,0 +1,9 @@
+en:
+  course:
+    assessment:
+      submissions:
+        index:
+          header: 'Submissions'
+        submission:
+          grade: 'Grade'
+          view: 'View'

--- a/spec/controllers/course/assessment/assessments_component_spec.rb
+++ b/spec/controllers/course/assessment/assessments_component_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Course::AssessmentsComponent do
         let!(:new_category) { course.assessment_categories.build(title: new_category_title) }
 
         it 'excludes the category from the list' do
-          expect(subject.send(:main_sidebar_items).map(&:title)).not_to include(new_category_title)
+          expect(subject.send(:assessment_categories).map(&:title)).
+            not_to include(new_category_title)
         end
       end
     end

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'Course: Submissions Viewing' do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:course_assessment_assessment, course: course) }
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Manager' do
+      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:students) { create_list(:course_student, 3, :approved, course: course) }
+      let(:attempting_submission) do
+        create(:course_assessment_submission, :attempting, assessment: assessment,
+                                                           creator: students[0].user)
+      end
+      let(:submitted_submission) do
+        create(:course_assessment_submission, :submitted, assessment: assessment,
+                                                          creator: students[1].user)
+      end
+      let(:graded_submission) do
+        create(:course_assessment_submission, :graded, assessment: assessment,
+                                                       creator: students[2].user)
+      end
+      let!(:submissions) { [attempting_submission, submitted_submission, graded_submission] }
+
+      scenario 'I can view all submitted and graded submissions' do
+        visit course_submissions_path(course)
+
+        expect(page).not_to have_content_tag_for(attempting_submission)
+
+        within find(content_tag_selector(submitted_submission)) do
+          expect(page).to have_link(
+            I18n.t('course.assessment.submissions.submission.grade'),
+            href: edit_course_assessment_submission_path(course, assessment, submitted_submission)
+          )
+        end
+        within find(content_tag_selector(graded_submission)) do
+          expect(page).to have_link(
+            I18n.t('course.assessment.submissions.submission.view'),
+            href: edit_course_assessment_submission_path(course, assessment, graded_submission)
+          )
+        end
+      end
+    end
+
+    context 'As a Course Student' do
+      let(:user) { create(:course_student, :approved, course: course).user }
+      let!(:attempting_submission) do
+        create(:course_assessment_submission, :attempting, assessment: assessment, creator: user)
+      end
+      let!(:submitted_submission) do
+        create(:course_assessment_submission, :submitted, assessment: assessment, creator: user)
+      end
+      let!(:graded_submission) do
+        create(:course_assessment_submission, :graded, assessment: assessment, creator: user)
+      end
+
+      scenario 'I can view my submitted and graded submissions' do
+        visit course_submissions_path(course)
+
+        expect(page).not_to have_content_tag_for(attempting_submission)
+
+        [submitted_submission, graded_submission].each do |submission|
+          within find(content_tag_selector(submission)) do
+            expect(page).to have_link(
+              I18n.t('course.assessment.submissions.submission.view'),
+              href: edit_course_assessment_submission_path(course, assessment, submission)
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of #614 

This implements the views for the submissions page, which includes breadcrumbs and the sidebar component. 

Stuff not implemented:
- Pending submissions
- Filters for submissions