### PR TITLE
Modify activity feed page to skip deleted activity objects

### DIFF
--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -8,7 +8,7 @@ class Course::CoursesController < Course::Controller
 
   def show # :nodoc:
     @registration = Course::Registration.new
-    @activity_feeds = recent_activity_feeds.limit(20).includes(:activity)
+    @activity_feeds = recent_activity_feeds.limit(20).includes(activity: [:object, :actor])
     render layout: 'course'
   end
 

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -17,5 +17,7 @@
 
     h2 = t('.activities')
     div
-      - current_course.notifications.includes(activity: :object).each do |notification|
-        = render partial: notification_view_path(notification), locals: { notification: notification }
+      - @activity_feeds.each do |notification|
+        - if notification.activity.object
+          = render partial: notification_view_path(notification),
+                   locals: { notification: notification }

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -66,6 +66,17 @@ RSpec.feature 'Course: Homepage' do
           expect(page).to have_content_tag_for(notification)
         end
       end
+
+      scenario 'I am unable to see activities with deleted objects in my course homepage' do
+        feed_notifications.each do |notification|
+          notification.activity.object.delete
+        end
+
+        visit course_path(course)
+        feed_notifications.each do |notification|
+          expect(page).not_to have_content_tag_for(notification)
+        end
+      end
     end
 
     context 'As a user not registered for the course' do


### PR DESCRIPTION
- Each activity may have 1 or more notifiers. Most notifiers are one-off and static (execpt activity feed).
- In the case of activity feed, underlying objects can be deleted, triggering errors when loading course homepage.
- Commit makes views to do a check before rendering the partials.

Fixes #1115.