### PR TITLE
Implement abilities for discussion topics

### DIFF
--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -4,7 +4,7 @@ module Course::Discussion::PostsConcern
 
   included do
     before_action :set_topic
-    authorize_resource :discussion_topic
+    authorize_resource :specific_topic
     load_and_authorize_resource :post, through: :discussion_topic,
                                        class: Course::Discussion::Post.name, parent: false
   end
@@ -57,5 +57,6 @@ module Course::Discussion::PostsConcern
 
   def set_topic
     @discussion_topic ||= discussion_topic
+    @specific_topic = discussion_topic.actable
   end
 end

--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -5,6 +5,10 @@ class Course::Discussion::TopicsController < Course::ComponentController
                                                  parent: false
   def index
     @topics = all_topics
+
+    if current_course_user && current_course_user.student?
+      @topics = @topics.from_user(current_course_user.user_id)
+    end
   end
 
   def pending

--- a/app/models/components/course/discussions_ability_component.rb
+++ b/app/models/components/course/discussions_ability_component.rb
@@ -5,6 +5,7 @@ module Course::DiscussionsAbilityComponent
   def define_permissions
     if user
       allow_course_users_show_topics
+      allow_staff_manage_discussion_topics
       allow_course_users_create_posts
       allow_course_users_update_delete_own_post
     end
@@ -15,7 +16,11 @@ module Course::DiscussionsAbilityComponent
   private
 
   def allow_course_users_show_topics
-    can :read, Course::Discussion::Topic
+    can :read, Course::Discussion::Topic, course_all_course_users_hash
+  end
+
+  def allow_staff_manage_discussion_topics
+    can :manage, Course::Discussion::Topic, course_staff_hash
   end
 
   def allow_course_users_create_posts

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -8,6 +8,10 @@ module Course::Assessment::AssessmentAbility
       allow_staff_manage_assessments
       allow_staff_grade_submissions
       allow_auto_grader_programming_evaluations
+      allow_students_manage_annotations_for_own_submissions
+      allow_staff_manage_annotations
+      allow_students_read_own_answers
+      allow_staff_read_answers
     end
 
     super
@@ -102,5 +106,23 @@ module Course::Assessment::AssessmentAbility
     can :read, Course::Assessment::ProgrammingEvaluation,
         course_course_user_hash(*CourseUser::AUTO_GRADER_ROLES.to_a)
     can :update_result, Course::Assessment::ProgrammingEvaluation, evaluator_id: user.id
+  end
+
+  def allow_students_manage_annotations_for_own_submissions
+    can :manage, Course::Assessment::Answer::ProgrammingFileAnnotation,
+        file: { answer: { submission: { creator_id: user.id } } }
+  end
+
+  def allow_staff_manage_annotations
+    can :manage, Course::Assessment::Answer::ProgrammingFileAnnotation,
+        discussion_topic: course_staff_hash
+  end
+
+  def allow_students_read_own_answers
+    can :read, Course::Assessment::Answer, submission: { creator_id: user.id }
+  end
+
+  def allow_staff_read_answers
+    can :read, Course::Assessment::Answer, discussion_topic: course_staff_hash
   end
 end

--- a/app/views/course/discussion/topics/_tabs.html.slim
+++ b/app/views/course/discussion/topics/_tabs.html.slim
@@ -1,5 +1,6 @@
-= tabs do
-  = nav_to t('.my_students_pending'), my_students_pending_course_topics_path(current_course)
-  = nav_to t('.pending'), pending_course_topics_path(current_course)
-  = nav_to t('.my_students'), my_students_course_topics_path(current_course)
-  = nav_to t('.all'), course_topics_path(current_course)
+- if current_course_user && current_course_user.staff? || can?(:manage, current_course)
+  = tabs do
+    = nav_to t('.my_students_pending'), my_students_pending_course_topics_path(current_course)
+    = nav_to t('.pending'), pending_course_topics_path(current_course)
+    = nav_to t('.my_students'), my_students_course_topics_path(current_course)
+    = nav_to t('.all'), course_topics_path(current_course)

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -15,14 +15,15 @@ RSpec.feature 'Course: Topics: Management' do
 
     before { login_as(user, scope: :user) }
 
-    context 'As a Course Manager' do
-      let(:user) { create(:administrator) }
+    context 'As a Course Teaching Assistant' do
+      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
 
       scenario 'I can see all the comments' do
         answer_comment
         code_annotation
         visit course_topics_path(course)
 
+        expect(page).to have_selector('.nav.nav-tabs')
         expect(page).to have_selector('div', text: answer_comment.question.assessment.title)
         expect(page).
           to have_selector('div', text: code_annotation.file.answer.question.assessment.title)
@@ -34,6 +35,52 @@ RSpec.feature 'Course: Topics: Management' do
         visit course_topics_path(course)
 
         comment = 'GOOD WORK!'
+        within find('.post-form') do
+          fill_in 'discussion_post[text]', with: comment
+          click_button 'course.discussion.posts.form.comment'
+        end
+        wait_for_ajax
+
+        post = topic.posts.reload.last
+        expect(post.text).to have_tag('*', text: comment)
+        expect(page).to have_content_tag_for(post)
+        within find(content_tag_selector(topic.acting_as)) do
+          expect(page).to have_tag('.post-form', count: 1)
+        end
+      end
+    end
+
+    context 'As a Course Student' do
+      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:student_answer) do
+        create(:course_assessment_answer, :with_post, course: course, creator: user)
+      end
+      let(:student_annotation) do
+        create(:course_assessment_answer_programming_file_annotation, :with_post,
+               course: course, creator: user)
+      end
+
+      scenario 'I can see all my comments' do
+        other_comments = [answer_comment, code_annotation].map(&:acting_as)
+        my_comments = [student_answer, student_annotation].map(&:acting_as)
+        visit course_topics_path(course)
+
+        expect(page).not_to have_selector('.nav.nav-tabs')
+        other_comments.each do |comment|
+          expect(page).not_to have_content_tag_for(comment)
+        end
+
+        my_comments.each do |comment|
+          expect(page).to have_content_tag_for(comment)
+        end
+      end
+
+      scenario 'I can reply to a comment topic', js: true do
+        # Randomly create a topic, either code_annotation or answer_comment.
+        topic = [true, false].sample ? student_answer : student_annotation
+        visit course_topics_path(course)
+
+        comment = 'THANKS !'
         within find('.post-form') do
           fill_in 'discussion_post[text]', with: comment
           click_button 'course.discussion.posts.form.comment'


### PR DESCRIPTION
Changes in this PR:
  - Authorise specific topic instead of abstract topic ( currently everyone can read `Course::Discussion::Topic` and `Course::Discussion::Post`, authorise the abstract topic will always pass)
  - Filtered the topics in student's view and hide the tabs for student. 
  - Specs for abilities.