### PR TITLE
Allow achievements and assessments (which are conditions) to be deleted

### DIFF
--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -9,6 +9,8 @@ class Course::Achievement < ActiveRecord::Base
   has_many :course_user_achievements, class_name: Course::UserAchievement.name,
                                       inverse_of: :achievement, dependent: :destroy
   has_many :course_users, through: :course_user_achievements, class_name: CourseUser.name
+  has_many :achievement_conditions, class_name: Course::Condition::Achievement.name,
+                                    inverse_of: :achievement, dependent: :destroy
 
   default_scope { order(weight: :asc) }
 

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -34,6 +34,8 @@ class Course::Assessment < ActiveRecord::Base
   has_many :programming_questions,
            through: :questions, inverse_through: :question, source: :actable,
            source_type: Course::Assessment::Question::Programming.name
+  has_many :assessment_conditions, class_name: Course::Condition::Assessment.name,
+                                   inverse_of: :assessment, dependent: :destroy
 
   # @!attribute [r] maximum_grade
   #   Gets the maximum grade allowed by this assessment. This is the sum of all questions'

--- a/app/models/course/condition/achievement.rb
+++ b/app/models/course/condition/achievement.rb
@@ -9,7 +9,7 @@ class Course::Condition::Achievement < ActiveRecord::Base
 
   validate :validate_achievement_condition, if: :achievement_id_changed?
 
-  belongs_to :achievement, class_name: Course::Achievement.name, inverse_of: false
+  belongs_to :achievement, class_name: Course::Achievement.name, inverse_of: :achievement_conditions
 
   default_scope { includes(:achievement) }
 

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -11,7 +11,7 @@ class Course::Condition::Assessment < ActiveRecord::Base
 
   validate :validate_assessment_condition, if: :assessment_id_changed?
 
-  belongs_to :assessment, class_name: Course::Assessment.name, inverse_of: false
+  belongs_to :assessment, class_name: Course::Assessment.name, inverse_of: :assessment_conditions
 
   default_scope { includes(:assessment) }
 

--- a/spec/models/course/achievement_spec.rb
+++ b/spec/models/course/achievement_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Course::Achievement, type: :model do
   it { is_expected.to have_many :conditions }
   it { is_expected.to validate_presence_of :title }
   it { is_expected.to belong_to(:course).inverse_of :achievements }
+  it { is_expected.to have_many(:achievement_conditions).dependent(:destroy) }
 
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Course::Assessment do
   it { is_expected.to have_many(:programming_questions).through(:questions) }
   it { is_expected.to have_many(:submissions).dependent(:destroy) }
   it { is_expected.to have_many(:conditions) }
+  it { is_expected.to have_many(:assessment_conditions).dependent(:destroy) }
 
   let(:instance) { create(:instance) }
   with_tenant(:instance) do


### PR DESCRIPTION
This PR is aimed at solving #759 (not deleting assessment for submission, but deleting assessments which exist as conditions for other conditionals). What it does: 

> Modify conditions and dependent objects to have a two-way association
> - Helps destroy the associated condition records when destroying achievements or assessments

I'm not sure if this is the best way to do it. Another way would be to add the following to `app/models/course/condition/assessment.rb`:
```ruby
# Trigger for deleting conditions before the base model
  Course::Assessment.before_destroy do |assessment|
    Course::Condition::Assessment.where(assessment: assessment).destory
  end
```

Or another way would be to do some meta-programming on the `acts_as_condition` declaration. 

What do you all think? @allenwq @kxmbrian 