### PR TITLE
Allow user to view his courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -53,6 +53,15 @@ class Course < ActiveRecord::Base
   accepts_nested_attributes_for :invitations, :assessment_categories
 
   scope :ordered_by_title, -> { order(:title) }
+  scope :ordered_by_end_at, ->(direction = :desc) { order(end_at: direction) }
+
+  # @!method containing_user
+  #   Selects all the courses with user as one of its approved members
+  scope :containing_user, (lambda do |user|
+    joins { course_users }.
+    merge(CourseUser.with_approved_state).
+    where { course_users.user_id == user.id }
+  end)
 
   # @!method with_owners
   #   Includes all course_users with the role of owner.

--- a/app/themes/default/views/layouts/default.html.slim
+++ b/app/themes/default/views/layouts/default.html.slim
@@ -33,7 +33,18 @@ html
         div.collapse.navbar-collapse#site-navigation-navbar
           ul.nav.navbar-nav.pull-right
             li
-              = link_to(t('layout.navbar.courses'), courses_path)
+              - my_courses = user_signed_in? && Course.containing_user(current_user).ordered_by_end_at
+              - if my_courses.present?
+                a.dropdown-toggle data-toggle="dropdown"
+                  => t('layout.navbar.courses')
+                  span.caret
+                ul.dropdown-menu.pull-right
+                  - my_courses.each do |course|
+                    li = link_to(format_inline_text(course.title), course_path(course))
+                  li.divider role='separator'
+                  li = link_to(t('layout.navbar.all_courses'), courses_path)
+              - else
+                = link_to(t('layout.navbar.courses'), courses_path)
             li
               = link_to(t('layout.navbar.help'), '#')
             - if user_signed_in?

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -5,6 +5,7 @@ en:
       toggle_sidebar: 'Toggle Sidebar'
       toggle_navigation: 'Toggle Navigation'
       courses: 'Courses'
+      all_courses: 'All Courses'
       help: 'Help'
       register: 'Register'
       sign_in: 'Sign In'

--- a/spec/features/course_management_spec.rb
+++ b/spec/features/course_management_spec.rb
@@ -9,12 +9,23 @@ RSpec.feature 'Courses' do
     let(:user) { create(:administrator) }
     before { login_as(user, scope: :user) }
 
-    scenario 'Users can see a list of courses' do
+    scenario 'Users can see a list of all courses' do
       create(:course)
 
       visit courses_path
       expect(all('.course').count).to eq(1)
       expect(subject).to have_link(nil, href: new_course_path)
+    end
+
+    scenario 'Users can see a list of their courses' do
+      course_attending = create(:course_student, :approved, user: user).course
+      course_teaching = create(:course_teaching_assistant, :approved, user: user).course
+      other_course = create(:course)
+
+      visit root_path
+      expect(page).to have_link(course_attending.title, href: course_path(course_attending))
+      expect(page).to have_link(course_teaching.title, href: course_path(course_teaching))
+      expect(page).not_to have_link(other_course.title, href: course_path(other_course))
     end
 
     scenario 'Users can create a new course' do


### PR DESCRIPTION
Adds a dropdown menu to the top navigation bar with links to courses that the user is an approved member of.

In the future, we could add a separate "My Courses" page that summarizes information on the courses like roles, opening/closing dates, participation etc.

For #1113 