### PR TITLE
Automatically compute experience points awarded when grading submission

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/submission.js
+++ b/app/assets/javascripts/course/assessment/submission/submission.js
@@ -1,0 +1,79 @@
+(function($) {
+  'use strict';
+  var DOCUMENT_SELECTOR = '.course-assessment-submission-submissions.edit ';
+  var SUMMARY_GRADE_SELECTOR = '.submission-grades-summary-grade';
+  var GRADE_INPUT_SELECTOR = 'input.grade';
+  var POINTS_AWARDED_SELECTOR = 'input.submission-points-awarded';
+  var MAXIMUM_GRADE_SELECTOR = '#submission-statistics-maximum-grade';
+  var TOTAL_GRADE_SELECTOR = '#submission-statistics-total-grade';
+
+  /**
+   * Handles the event when a submission answer is graded or when the grade
+   * is changed. If the new grade is valid, three items are updated:
+   * - The grade for the question in the grades summary
+   * - The total grade in the submissions statistics
+   * - The experience points awarded
+   *
+   * @param {Event} event The event object.
+   */
+  function updateGradesAndPoints(event) {
+    var $changedGradeInput = $(event.target);
+    var newGrade = $changedGradeInput.val();
+
+    if (!$.isNumeric(newGrade)) { return; }
+
+    var answerId = $changedGradeInput.data('answer-id');
+    updateGradesSummary(answerId, newGrade);
+
+    var newTotalGrade = computeNewTotalGrade();
+    updateTotalGrade(newTotalGrade);
+    updateExperiencePointsAwarded(newTotalGrade);
+  }
+
+  /**
+   * Updates the grade for a particular answer in the grades summary.
+   *
+   * @param {Number} answerId The answer's ID
+   * @param {Number} newGrade The new grade
+   */
+  function updateGradesSummary(answerId, newGrade) {
+    $('#submission-grades-summary-answer-' + answerId + '-grade').text(newGrade);
+  }
+
+  /**
+   * Sums the grades of the individual answers based on the updated grades summary.
+   *
+   * @return {Number} The new total grade for the submission
+   */
+  function computeNewTotalGrade() {
+    return $(SUMMARY_GRADE_SELECTOR).toArray().reduce(function(sum, element) {
+      return sum + Number($(element).text());
+    }, 0);
+  }
+
+  /**
+   * Updates the total grade in the submissions statistics
+   *
+   * @param {Number} newTotalGrade The new total grade
+   */
+  function updateTotalGrade(newTotalGrade) {
+    $(TOTAL_GRADE_SELECTOR).text(newTotalGrade);
+  }
+
+  /**
+   * Computes and updates the experience points awarded for the submission based on
+   * the fraction of the maximum grade attained.
+   *
+   * @param {Number} newTotalGrade The new total grade
+   */
+  function updateExperiencePointsAwarded(newTotalGrade) {
+    var $pointsAwardedInput = $(POINTS_AWARDED_SELECTOR);
+    var basePoints = $pointsAwardedInput.data('base-points');
+    var maximumGrade = $(MAXIMUM_GRADE_SELECTOR).text();
+    var newPointsAwarded =
+      maximumGrade === 0 ? 0 : Math.floor(basePoints * newTotalGrade / maximumGrade);
+    $pointsAwardedInput.val(newPointsAwarded);
+  }
+
+  $(document).on('change', DOCUMENT_SELECTOR + GRADE_INPUT_SELECTOR, updateGradesAndPoints);
+})(jQuery);

--- a/app/views/course/assessment/answer/_grading.slim
+++ b/app/views/course/assessment/answer/_grading.slim
@@ -4,7 +4,8 @@
     div.panel-body
       div.form-group.submission_answers_grade.row
         div.col-lg-3.col-md-6.col-sm-6.col-xs-6
-          = base_answer_form.input_field :grade, class: ['form-control', 'grade']
+          = base_answer_form.input_field :grade, class: ['form-control', 'grade'],
+                                                 'data-answer-id' => answer.id
         div.col-lg-3.col-md-6.col-sm-6.col-xs-6
           = t('.maximum_grade', maximum_grade: answer.question.maximum_grade)
 - elsif answer.graded?

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -11,11 +11,20 @@ div.panel.panel-default
           td = @submission.workflow_state
         tr
           th = @submission.class.human_attribute_name(:grade)
-          td = @submission.grade
+          td
+            span#submission-statistics-total-grade>
+              = @submission.grade
+            ' /
+            span#submission-statistics-maximum-grade
+              = @submission.assessment.maximum_grade
         tr
           th = @submission.experience_points_record.class.human_attribute_name(:points_awarded)
           - if can?(:grade, @submission)
-            td = f.input :points_awarded, label: false
+            / TODO: Factor in time-based experience points
+            td
+              = f.input :points_awarded, label: false,
+                        input_html: { class: 'submission-points-awarded',
+                                      'data-base-points' => @submission.assessment.base_exp }
           - else
             td = @submission.points_awarded
         tr
@@ -44,4 +53,9 @@ div.panel.panel-default
           - @submission.answers.each do |answer|
             tr
               th = format_inline_text(answer.question.title)
-              td = answer.grade
+              td
+                span.submission-grades-summary-grade> (
+                    id="submission-grades-summary-answer-#{answer.id}-grade")
+                  = answer.grade
+                ' /
+                = answer.question.maximum_grade

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'Course: Assessments: Attempt' do
     let(:submission) do
       create(:course_assessment_submission, assessment: assessment, creator: student)
     end
-    let(:points_awarded) { 22 }
 
     context 'As a Course Student' do
       let(:user) { student }
@@ -87,7 +86,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
     context 'As a Course Staff' do
       let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
 
-      scenario "I can grade the student's work" do
+      scenario "I can grade the student's work", js: true do
         assessment.questions.attempt(submission).each(&:save!)
         submission.finalise!
         submission.save!
@@ -107,7 +106,10 @@ RSpec.describe 'Course: Assessments: Attempt' do
             submission_maximum_grade += answer.question.maximum_grade
           end
         end
-        fill_in 'submission_points_awarded', with: points_awarded
+
+        # This field should be automatically filled
+        expect(find_field('submission_points_awarded').value).
+          to eq(submission.assessment.base_exp.to_s)
 
         click_button I18n.t('course.assessment.submission.submissions.worksheet.publish')
         expect(current_path).to eq(
@@ -115,7 +117,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         )
         expect(submission.reload.graded?).to be(true)
         expect(submission.grade).to eq(submission_maximum_grade)
-        expect(submission.points_awarded).to eq(points_awarded)
+        expect(submission.points_awarded).to eq(submission.assessment.base_exp)
       end
     end
   end


### PR DESCRIPTION
Addresses #688 

The exact points awarding scheme might need to be refined, for example, to take into account time-based bonus experience points (#1123).

The experience points awarding for auto-graded assessments will be addressed in a separate PR.