### PR TITLE
Fix multiple response autograder bug

### DIFF
--- a/app/services/course/assessment/answer/multiple_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/multiple_response_auto_grading_service.rb
@@ -32,7 +32,7 @@ class Course::Assessment::Answer::MultipleResponseAutoGradingService < \
   # @param [Course::Assessment::Answer::MultipleResponse] answer The answer from the user.
   def grade_any_correct(question, answer)
     correct_selection = question.options.correct & answer.options
-    correct = !correct_selection.empty?
+    correct = !correct_selection.empty? && (correct_selection.length == answer.options.length)
 
     [correct, grade_for(question, correct), explanations_for(answer.options)]
   end
@@ -44,7 +44,8 @@ class Course::Assessment::Answer::MultipleResponseAutoGradingService < \
   def grade_all_correct(question, answer)
     correct_answers = question.options.correct
     correct_selection = correct_answers & answer.options
-    correct = correct_selection.length == correct_answers.length
+    correct = (correct_selection.length == correct_answers.length) &&
+              (correct_selection.length == answer.options.length)
 
     [correct, grade_for(question, correct), explanations_for(answer.options)]
   end

--- a/spec/factories/course_assessment_answer_multiple_responses.rb
+++ b/spec/factories/course_assessment_answer_multiple_responses.rb
@@ -12,18 +12,27 @@ FactoryGirl.define do
             assessment: assessment).question
     end
 
-    trait :wrong do
+    trait :with_all_wrong_options do
       after(:build) do |answer|
         question = answer.question.actable
-        answer.options = question.options - question.options.select(&:correct)
+        wrong_options = question.options - question.options.select(&:correct)
+        wrong_options.each { |option| answer.options << option }
       end
     end
 
-    trait :correct do
+    trait :with_all_correct_options do
       after(:build) do |answer|
         question = answer.question.actable
-        answer.options = question.options.select(&:correct)
-        answer.options = answer.options.sample(1) if question.any_correct?
+        correct_options = question.options.select(&:correct)
+        correct_options.each { |option| answer.options << option }
+      end
+    end
+
+    trait :with_one_correct_option do
+      after(:build) do |answer|
+        question = answer.question.actable
+        correct_options = question.options.select(&:correct)
+        answer.options << correct_options.sample(1)
       end
     end
   end

--- a/spec/factories/course_assessment_question_multiple_responses.rb
+++ b/spec/factories/course_assessment_question_multiple_responses.rb
@@ -12,9 +12,12 @@ FactoryGirl.define do
                 question: nil, option: 'false', explanation: 'wrong')
         ]
 
-      options << build(:course_assessment_question_multiple_response_option,
-                       question: nil, option: 'false',
-                       explanation: 'wrong alternatve') if question_type.to_s == 'any_correct'
+      if any_correct?
+        options << build(:course_assessment_question_multiple_response_option, :wrong,
+                         question: nil, option: 'false', explanation: 'wrong alternatve')
+        options << build(:course_assessment_question_multiple_response_option, :correct,
+                         question: nil, option: 'also true', explanation: 'correct alternatve')
+      end
 
       options
     end

--- a/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
@@ -20,56 +20,92 @@ RSpec.describe Course::Assessment::Answer::MultipleResponseAutoGradingService do
     end
 
     describe '#grade' do
-      context 'when the question is requires all correct options' do
-        context 'when the correct answer is given' do
-          let(:answer_traits) { :correct }
+      context 'when the question requires all correct options' do
+        context 'when only the correct answer is selected' do
+          let(:answer_traits) { :with_all_correct_options }
 
           it 'marks the answer correct' do
             subject.grade(grading)
             expect(answer.grade).to eq(question.maximum_grade)
             expect(answer).to be_correct
-            expect(grading.result['messages']).to \
-              contain_exactly(question.options.correct.first.explanation)
+            expect(grading.result['messages']).
+              to contain_exactly(*answer.specific.options.map(&:explanation))
           end
         end
 
-        context 'when the wrong answer is given' do
-          let(:answer_traits) { :wrong }
+        context 'when only the wrong answer is selected' do
+          let(:answer_traits) { :with_all_wrong_options }
 
           it 'marks the answer wrong' do
             subject.grade(grading)
             expect(answer).not_to be_correct
             expect(answer.grade).to eq(0)
-            expect(grading.result['messages']).to \
-              contain_exactly(answer.specific.options.first.explanation)
+            expect(grading.result['messages']).
+              to contain_exactly(*answer.specific.options.map(&:explanation))
+          end
+        end
+
+        context 'when the wrong and right answers are selected' do
+          let(:answer_traits) { [:with_all_correct_options, :with_all_wrong_options] }
+
+          it 'marks the answer wrong' do
+            subject.grade(grading)
+            expect(answer).not_to be_correct
+            expect(answer.grade).to eq(0)
+            expect(grading.result['messages']).
+              to contain_exactly(*answer.specific.options.map(&:explanation))
           end
         end
       end
 
-      context 'when a question is requires any correct option' do
+      context 'when a question requires any correct option' do
         let(:question_traits) { :any_correct }
 
-        context 'when the correct answer is given' do
-          let(:answer_traits) { :correct }
+        context 'when only the correct answer is selected' do
+          let(:answer_traits) { :with_all_correct_options }
 
           it 'marks the answer correct' do
             subject.grade(grading)
             expect(answer).to be_correct
             expect(answer.grade).to eq(question.maximum_grade)
-            expect(grading.result['messages']).to \
-              contain_exactly(question.options.correct.first.explanation)
+            expect(grading.result['messages']).
+              to contain_exactly(*answer.specific.options.map(&:explanation))
           end
         end
 
-        context 'when the wrong answer is given' do
-          let(:answer_traits) { :wrong }
+        context 'when only the wrong answer is selected' do
+          let(:answer_traits) { :with_all_wrong_options }
 
           it 'marks the answer wrong' do
             subject.grade(grading)
             expect(answer).not_to be_correct
             expect(answer.grade).to eq(0)
-            expect(grading.result['messages']).to \
-              contain_exactly(*answer.specific.options.reject(&:correct).map(&:explanation))
+            expect(grading.result['messages']).
+              to contain_exactly(*answer.specific.options.map(&:explanation))
+          end
+        end
+
+        context 'when the wrong and right answers are selected' do
+          let(:answer_traits) { [:with_all_correct_options, :with_all_wrong_options] }
+
+          it 'marks the answer wrong' do
+            subject.grade(grading)
+            expect(answer).not_to be_correct
+            expect(answer.grade).to eq(0)
+            expect(grading.result['messages']).
+              to contain_exactly(*answer.specific.options.map(&:explanation))
+          end
+        end
+
+        context 'when only one of two right answers is selected' do
+          let(:answer_traits) { :with_one_correct_option }
+
+          it 'marks the answer correct' do
+            subject.grade(grading)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly(*answer.specific.options.map(&:explanation))
           end
         end
       end


### PR DESCRIPTION
Currently the Multiple Response Autograder only checks for the existence of correct options. This is incorrect: students can select right + wrong options, with the answer still graded correctly. 

This PR:
- Fixes this bug at the grading service, by checking if any incorrect/wrong selections were made. 
- Adds tests to ensure that bug doesn't occur. 
- Modified `course_assessment_answer_mutiple_response` factory to allow multiple traits for testing.