### PR TITLE
Implement the unsubmission of submissions

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -3,7 +3,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   Course::Assessment::Submission::Controller
   include Course::Assessment::Submission::SubmissionsControllerServiceConcern
 
-  before_action :authorize_assessment, only: :create
+  before_action :authorize_assessment!, only: :create
   skip_authorize_resource :submission, only: [:edit, :update, :auto_grade]
   before_action :authorize_submission!, only: [:edit, :update]
   before_action :load_or_create_answers, only: [:edit, :update]
@@ -59,7 +59,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     { course_user: current_course_user }
   end
 
-  def authorize_assessment
+  def authorize_assessment!
     authorize!(:attempt, @assessment)
   end
 

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -13,6 +13,7 @@ class Course::Assessment::Answer < ActiveRecord::Base
       event :publish, transitions_to: :graded
     end
     state :graded do
+      event :unsubmit, transitions_to: :attempting
       event :publish, transitions_to: :graded # To re-grade an answer.
     end
   end
@@ -112,5 +113,12 @@ class Course::Assessment::Answer < ActiveRecord::Base
   # Set the course as the same course of the assessment.
   def set_course
     self.course ||= submission.assessment.course if submission && submission.assessment
+  end
+
+  def unsubmit
+    self.grade = nil
+    self.grader = nil
+    self.graded_at = nil
+    self.submitted_at = nil
   end
 end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -83,7 +83,9 @@ class Course::Assessment::Answer < ActiveRecord::Base
   end
 
   def validate_assessment_state
-    errors.add(:submission, :attemptable_state) unless submission.attempting?
+    if !submission.attempting? && !submission.unsubmitting?
+      errors.add(:submission, :attemptable_state)
+    end
   end
 
   def validate_consistent_grade

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -61,6 +61,8 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   #
   # This varies depending on the permissions of the user.
   def update_answers_params
+    return [] if unsubmit? # Attributes like grades should be not updated.
+
     [].tap do |result|
       actable_attributes = [:id]
       actable_attributes.push(update_answer_type_params) if can?(:update, @submission)
@@ -108,5 +110,9 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
     answer = @submission.answers.find(answer_id_param)
     answer.finalise! if answer.attempting?
     answer.auto_grade!(edit_submission_path)
+  end
+
+  def unsubmit?
+    params[:submission] && params[:submission][:unsubmit].present?
   end
 end

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -20,8 +20,14 @@ nav
   - unless @submission.attempting?
     = render 'statistics', f: f
 
-  - if @submission.submitted? && can?(:grade, @submission)
-    = link_to t('.auto_grade'),
-      auto_grade_course_assessment_submission_path(current_course, @submission.assessment,
-        @submission), method: :post, class: ['btn', 'btn-info']
-    = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger']
+    - if can?(:grade, @submission)
+      - if @submission.submitted?
+        = link_to t('.auto_grade'),
+                  auto_grade_course_assessment_submission_path(current_course,
+                                                               @submission.assessment,
+                                                               @submission),
+                  method: :post,
+                  class: ['btn', 'btn-info']
+        = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger']
+
+      = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -12,12 +12,16 @@
     = render 'statistics', f: f
 
   = f.button :submit, t('common.save')
+
   - if @submission.attempting? && can?(:update, @submission)
     = f.button :submit, t('.finalise'),
       name: 'submission[finalise]', class: ['btn-danger']
+
   - if @submission.submitted? && can?(:grade, @submission)
     = link_to t('.auto_grade'),
       auto_grade_course_assessment_submission_path(current_course, @submission.assessment,
         @submission), method: :post, class: ['btn', 'btn-info']
     = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger']
 
+  - if (@submission.submitted? || @submission.graded?) && can?(:grade, @submission)
+    = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -6,6 +6,7 @@ en:
           finalise: 'Finalise Submission'
           publish: 'Publish Grade'
           auto_grade: 'Auto Grade Submission'
+          unsubmit: 'Unsubmit Submission'
           index:
             submissions: 'Submissions'
             student_header: 'Student Submissions'
@@ -18,10 +19,12 @@ en:
             finalise: :'course.assessment.submission.submissions.finalise'
             publish: :'course.assessment.submission.submissions.publish'
             auto_grade: :'course.assessment.submission.submissions.auto_grade'
+            unsubmit: :'course.assessment.submission.submissions.unsubmit'
           guided:
             finalise: :'course.assessment.submission.submissions.finalise'
             publish: :'course.assessment.submission.submissions.publish'
             auto_grade: :'course.assessment.submission.submissions.auto_grade'
+            unsubmit: :'course.assessment.submission.submissions.unsubmit'
           statistics:
             student: :'course.users.role.student'
             status: 'Status'

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -187,6 +187,28 @@ RSpec.describe 'Course: Assessments: Attempt' do
         expect(submission.grade).to eq(submission_maximum_grade)
         expect(submission.points_awarded).to eq(submission.assessment.base_exp)
       end
+
+      scenario 'I can unsubmit a submitted or graded submission' do
+        # Submitted submission
+        assessment.questions.attempt(submission).each(&:save!)
+        submission.finalise!
+        submission.save!
+
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        click_button I18n.t('course.assessment.submission.submissions.worksheet.unsubmit')
+        expect(submission.reload.attempting?).to be_truthy
+
+        # Graded submission
+        submission.finalise!
+        submission.publish!
+        submission.save!
+
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        click_button I18n.t('course.assessment.submission.submissions.worksheet.unsubmit')
+        expect(submission.reload.attempting?).to be_truthy
+      end
     end
   end
 end

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -137,6 +137,17 @@ RSpec.describe Course::Assessment::Answer do
       end
     end
 
+    describe '#unsubmit!' do
+      before { subject.finalise! }
+      it 'sets grade, grader, graded_at and submitted_at to nil' do
+        subject.unsubmit!
+        expect(subject.grade).to be_nil
+        expect(subject.grader).to be_nil
+        expect(subject.graded_at).to be_nil
+        expect(subject.submitted_at).to be_nil
+      end
+    end
+
     describe '#auto_grade!' do
       let(:question) { build(:course_assessment_question_multiple_response).question }
       let(:answer_traits) { :submitted }

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -265,5 +265,39 @@ RSpec.describe Course::Assessment::Submission do
         end
       end
     end
+
+    describe '#unsubmit!' do
+      let(:assessment_traits) { [:with_all_question_types] }
+      subject { submission1 }
+      before do
+        subject.unsubmit!
+        subject.save!
+        subject.reload
+      end
+
+      context 'when the submission is submitted' do
+        let(:submission1_traits) { :submitted }
+
+        it 'resets the experience points awarded' do
+          expect(subject.points_awarded).to be_nil
+        end
+
+        it 'sets all latest answers in the submission to attempting' do
+          expect(subject.answers.latest_answers.all?(&:attempting?)).to be(true)
+        end
+      end
+
+      context 'when the submission is graded' do
+        let(:submission1_traits) { :graded }
+
+        it 'resets the experience points awarded' do
+          expect(subject.points_awarded).to be_nil
+        end
+
+        it 'sets all latest answers in the submission to attempting' do
+          expect(subject.answers.latest_answers.all?(&:attempting?)).to be(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
For #875 

Key points:
- `course_users` who can `:grade` submissions can `unsubmit` submissions.
- Course Users can unsubmit `submitted` or `graded` submissions.
- When `unsubmitting` submissions:
 - ~~`manually_graded` answers will revert from `graded` to `attempting` via the `unsubmit` even on answers.~~
 - ~~`auto_graded` answers will remain as `auto_graded` state.~~
 - Latest `answers` will be unsubmitted 
 - Submission will have `nil` exp