### PR TITLE
Allow users to hide global announcements they have read

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 class AnnouncementsController < ApplicationController
+  load_resource :announcement, class: GenericAnnouncement.name, only: :mark_as_read,
+                               id_param: :announcement_id
+
   add_breadcrumb :index, :announcements_path
 
   def index
     @announcements = global_announcements.includes(:creator)
+  end
+
+  # Marks the current GenericAnnouncement as read by the current user and responds without a body.
+  # This is meant to be called via javascript.
+  def mark_as_read
+    @announcement.mark_as_read! for: current_user
+    head :ok
   end
 end

--- a/app/controllers/concerns/application_announcements_concern.rb
+++ b/app/controllers/concerns/application_announcements_concern.rb
@@ -2,6 +2,16 @@
 module ApplicationAnnouncementsConcern
   extend ActiveSupport::Concern
 
+  # Returns active global announcements unread by the current user, if one is signed in.
+  #
+  # @return [Array<GenericAnnouncement>] Unread announcements
+  def unread_global_announcements
+    user_signed_in? ? global_announcements.unread_by(current_user) : global_announcements
+  end
+
+  # Returns all active global announcements.
+  #
+  # @return [Array<GenericAnnouncement>] Active announcements
   def global_announcements
     GenericAnnouncement.for_instance(current_tenant).currently_active
   end

--- a/app/views/announcements/_global_announcement.html.slim
+++ b/app/views/announcements/_global_announcement.html.slim
@@ -1,0 +1,11 @@
+div.panel.panel-primary.global-announcement id="global_announcement_#{global_announcement.id}"
+  div.panel-heading
+    div.pull-right
+      = link_to announcement_mark_as_read_path(global_announcement), remote: true, method: :post do
+        button.close (type='button' data-dismiss='alert' aria-label=t('.close')
+                      data-target='#global_announcement_#{global_announcement.id}')
+          span aria-hidden='true'
+            | &times;
+    = format_inline_text(global_announcement.title)
+  div.panel-body
+    = format_html(global_announcement.content)

--- a/app/views/announcements/_global_announcements.html.slim
+++ b/app/views/announcements/_global_announcements.html.slim
@@ -1,18 +1,2 @@
-- announcements = controller.global_announcements.limit(2)
-- if announcements.length > 0 # Loads the announcements if they are present.
-  - announcement = announcements.first
-  div.panel.panel-primary.global-announcement
-    div.panel-heading
-      div.pull-right
-        button.close type='button' data-dismiss='alert' data-target='.global-announcement' aria-label=t('.close')
-          span aria-hidden='true'
-            | &times;
-      = format_inline_text(announcement.title)
-    div.panel-body
-      = format_html(announcement.content)
-    - if announcements.size > 1
-      div.panel-footer
-        div.pull-right
-          = link_to(t('.more_announcements'), '/announcements')
-        br.clearfix
-
+- announcements = controller.unread_global_announcements
+= render partial: 'announcements/global_announcement', collection: announcements

--- a/config/locales/en/announcements.yml
+++ b/config/locales/en/announcements.yml
@@ -4,6 +4,5 @@ en:
       header: 'All Announcements'
     announcement:
       sticky: 'Sticky'
-    global_announcements:
+    global_announcement:
       close: 'Close'
-      more_announcements: 'More Announcements...'

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -1,5 +1,7 @@
 en:
   breadcrumbs:
+    announcements:
+      index: :'announcements.index.header'
     course:
       levels:
         index: :'course.levels.index.header'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,9 @@ Rails.application.routes.draw do
     masquerades: 'user/masquerades'
   }
 
-  resources :announcements, only: [:index]
+  resources :announcements, only: [:index] do
+    post 'mark_as_read'
+  end
   resources :jobs, only: [:show]
 
   namespace :user do

--- a/spec/features/global_announcements_spec.rb
+++ b/spec/features/global_announcements_spec.rb
@@ -61,17 +61,24 @@ RSpec.feature 'Global announcements' do
           with_tag('div.panel-body', text: announcements.last.content)
         end
 
-        expect(page).to have_tag('div.global-announcement') do
-          with_tag('div.panel-footer',
-                   text: I18n.t('announcements.global_announcements.more_announcements'))
-        end
-
         announcements.select(&:currently_active?).each do |s|
           expect(page).to have_content_tag_for(s)
         end
         announcements.reject(&:currently_active?).each do |s|
           expect(page).not_to have_content_tag_for(s)
         end
+      end
+
+      scenario 'I can hide announcements that I have read' do
+        announcement = create(:instance_announcement, instance: instance)
+        expect(announcement.unread?(user)).to be_truthy
+
+        visit root_path
+        find_link(nil, href: announcement_mark_as_read_path(announcement)).click
+        expect(announcement.unread?(user)).to be_falsey
+
+        visit root_path
+        expect(page).not_to have_selector('div.global-announcement')
       end
     end
   end


### PR DESCRIPTION
For #597 

# Previously
<img width="694" alt="screen shot 2016-07-04 at 12 40 35 pm" src="https://cloud.githubusercontent.com/assets/6252919/16550973/b2c8206a-41e4-11e6-97d2-2d33b8bf5f25.png">
- Can close the panel, but it reappears when you refresh or go to another page. In effect, it acts like a sticky announcement.
- Only shows latest announcement. "More Announcements..." link is shown if there are any other active global announcements.

# Now
<img width="701" alt="screen shot 2016-07-04 at 12 25 19 pm" src="https://cloud.githubusercontent.com/assets/6252919/16550974/b2c846d0-41e4-11e6-9b15-de20b45bed62.png">
- Closed announcement panels will not reappear
- Since they can be closed, better to show all unread announcements rather than have the user see the next announcement only upon refreshing the page or by going to the global announcements index page.
- Once merged, need to raise issue to provide link to the global announcements index page so that user can view active announcements that he has closed.
- Even when the user has visited the global announcements index page, she will still have to mark each one as read by closing the panels. Don't want to just mark all as read when the user requests the index page since the server cannot guarantee that nothing will go wrong after the response has been sent, i.e. cannot guarantee user will read the announcements.