### PR TITLE
Implement pending submissions

### DIFF
--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -82,11 +82,19 @@ class Course::Assessment::Submission < ActiveRecord::Base
       where { experience_points_record.course_user.user == user }
   end)
 
+  # @!method self.by_users(user)
+  #   @param [Fixnum|Array<Fixnum>] user_ids The user ids to filter submissions by
+  scope :by_users, ->(user_ids) { where { creator_id >> user_ids } }
+
   # @!method self.from_category(category)
   #   Finds all the submissions in the given category.
   #   @param [Course::Assessment::Category] category The category to filter submissions by
   scope :from_category, (lambda do |category|
     where { assessment_id >> category.assessments.select(:id) }
+  end)
+
+  scope :from_course, (lambda do |course|
+    joins { assessment.tab.category }.where { assessment.tab.category.course == course }
   end)
 
   # @!method self.ordered_by_date

--- a/app/views/course/assessment/submissions/_tabs.html.slim
+++ b/app/views/course/assessment/submissions/_tabs.html.slim
@@ -1,4 +1,6 @@
 = tabs do
+  - if current_course_user && current_course_user.staff? || can?(:manage, current_course)
+    = nav_to t('.pending'), pending_course_submissions_path(current_course)
   - current_course.assessment_categories.each do |category|
     = nav_to format_inline_text(category.title),
              course_submissions_path(current_course, category: category)

--- a/app/views/course/assessment/submissions/pending.html.slim
+++ b/app/views/course/assessment/submissions/pending.html.slim
@@ -1,0 +1,7 @@
+- add_breadcrumb :pending
+= page_header
+= render partial: 'tabs'
+
+= render partial: 'submissions', locals: { submissions: @submissions }
+
+= paginate @submissions

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -81,6 +81,7 @@ en:
           new: :'course.assessment.skill_branches.new.header'
         submissions:
           index: :'course.assessment.submissions.index.header'
+          pending: :'course.assessment.submissions.pending.header'
       groups:
         index: :'course.groups.index.header'
         new: :'course.groups.new.header'

--- a/config/locales/en/course/assessment/submissions.yml
+++ b/config/locales/en/course/assessment/submissions.yml
@@ -5,6 +5,10 @@ en:
         sidebar_title: :'course.assessment.submissions.index.header'
         index:
           header: 'Submissions'
+        pending:
+          header: 'Pending Submissions'
         submission:
           grade: 'Grade'
           view: 'View'
+        tabs:
+          pending: :'course.assessment.submissions.pending.header'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,7 +188,9 @@ Rails.application.routes.draw do
           collection do
             resources :skills, as: :assessments_skills, except: [:show]
             resources :skill_branches, as: :assessments_skill_branches, except: [:index, :show]
-            resources :submissions, only: [:index], concerns: :paginatable
+            resources :submissions, only: [:index], concerns: :paginatable do
+              get 'pending', on: :collection
+            end
           end
         end
       end

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'Course: Submissions Viewing' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:course_manager) { create(:course_manager, :approved, course: course) }
+      let(:user) { course_manager.user }
 
       scenario 'I can view all submitted and graded submissions' do
         students = create_list(:course_student, 3, :approved, course: course)
@@ -35,6 +36,36 @@ RSpec.describe 'Course: Submissions Viewing' do
             href: edit_course_assessment_submission_path(course, assessment, graded_submission)
           )
         end
+      end
+
+      scenario 'I can view pending submissions' do
+        students = create_list(:course_student, 4, :approved, course: course)
+        attempting_submission, submitted_submission1, submitted_submission2, graded_submission =
+          students.zip([:attempting, :submitted, :submitted, :graded]).map do |student, trait|
+            create(:course_assessment_submission, trait,
+                   assessment: assessment, course: course,
+                   creator: student.user, course_user: student)
+          end
+
+        # Staff without group can view all pending submissions
+        visit pending_course_submissions_path(course)
+        save_page
+        expect(page).to have_content_tag_for(submitted_submission1)
+        expect(page).to have_content_tag_for(submitted_submission2)
+        expect(page).not_to have_content_tag_for(attempting_submission)
+        expect(page).not_to have_content_tag_for(graded_submission)
+
+        # Staff with group view pending submissions of own group students
+        group = create(:course_group, course: course)
+        create(:course_group_manager, group: group, course: course, course_user: course_manager)
+        create(:course_group_user, group: group, course: course,
+                                   course_user: submitted_submission1.course_user)
+        visit pending_course_submissions_path(course)
+
+        expect(page).to have_content_tag_for(submitted_submission1)
+        expect(page).not_to have_content_tag_for(submitted_submission2)
+        expect(page).not_to have_content_tag_for(attempting_submission)
+        expect(page).not_to have_content_tag_for(graded_submission)
       end
     end
 

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -64,6 +64,19 @@ RSpec.describe Course::Assessment::Submission do
       end
     end
 
+    describe '.by_users' do
+      before do
+        submission1
+        submission2
+      end
+
+      it 'only returns the selected submissions by the provided user ids' do
+        expect(assessment.submissions.by_users(user1.id)).to contain_exactly(submission1)
+        expect(assessment.submissions.by_users([user1.id, user2.id])).
+          to contain_exactly(submission1, submission2)
+      end
+    end
+
     describe '.from_category' do
       let(:new_category) { create(:course_assessment_category, course: course) }
       let(:new_tab) { create(:course_assessment_tab, course: course, category: new_category) }
@@ -74,6 +87,19 @@ RSpec.describe Course::Assessment::Submission do
 
       it 'returns submissions from assessments in this category' do
         expect(subject).to contain_exactly(new_submission)
+      end
+    end
+
+    describe '.from_course' do
+      let(:new_course) { create(:course) }
+      let(:new_assessment) { create(:course_assessment_assessment, course: new_course) }
+      let!(:new_submission) { create(:course_assessment_submission, assessment: new_assessment) }
+
+      it 'returns submissions from assessments in the specified course' do
+        submission1
+        expect(Course::Assessment::Submission.from_course(course)).to contain_exactly(submission1)
+        expect(Course::Assessment::Submission.from_course(new_course)).
+          to contain_exactly(new_submission)
       end
     end
 


### PR DESCRIPTION
This PR implements Pending Submissions under the submissions page - it shows all submissions that are submitted (but not graded). Some details:
- If a `course_staff` has a `course_group` (or multiple groups), it will show all pending submissions from students from that group.
- If a `course_staff` has no `course_group`, it will show all pending submissions in the current course.

Fixes #614