### PR TITLE
Do not show annotations with no posts

### DIFF
--- a/app/views/course/assessment/answer/programming/_annotation_topic.html.slim
+++ b/app/views/course/assessment/answer/programming/_annotation_topic.html.slim
@@ -1,2 +1,3 @@
-= render partial: 'course/discussion/topic', object: annotation_topic,
-         locals: { post_partial: 'course/assessment/answer/programming/annotation_post' }
+- unless annotation_topic.posts.empty?
+  = render partial: 'course/discussion/topic', object: annotation_topic,
+           locals: { post_partial: 'course/assessment/answer/programming/annotation_post' }


### PR DESCRIPTION
Fixes #1146 

This bug becomes more visible when the annotation discussion topic has a footer, e.g. if we have a "Reply" button.