### PR TITLE
Add missing translation for comments center settings

### DIFF
--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -32,6 +32,9 @@ en:
           edit: :'course.forum.forums.sidebar_title'
         leaderboard_settings:
           edit: :'course.leaderboards.index.header'
+        discussion:
+          topic_settings:
+            edit: :'course.discussion.topics.index.header'
       users:
         index: 'Users'
         students: :'course.users.students.header'


### PR DESCRIPTION
@allenwq @kxmbrian Fixes the issue mentioned in https://github.com/Coursemology/coursemology2/pull/1121/commits/1b3f6566f93de8fe2c69aa3cd3bb86a3cce424c8. Apologies for the random PR if already fixed downstream.