### PR TITLE
Make toolbar less obtrusive for comment replying interface

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -3,12 +3,21 @@
 
 (function($) {
   'use strict';
+
+  function initializeSummernote(element) {
+    var airmodeOptions = $.extend(true, { airMode: true },
+                                        { popover: $.summernote.options.popover });
+    airmodeOptions.popover.air.unshift(['style', ['style']]);
+    $('textarea.text.airmode', element).summernote(airmodeOptions);
+    $('textarea.text', element).summernote();
+  }
+
   function initializeComponents(element) {
     $('[data-toggle="popover"]', element).popover();
     $('[title]', element).tooltip();
     $('input.toggle-all[type="checkbox"]', element).checkboxToggleAll();
-    $('textarea.text', element).summernote();
     $('textarea.code', element).ace();
+    initializeSummernote(element);
   }
 
   // Queue component initialisation until the script has completely loaded.

--- a/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_form.jst.ejs
+++ b/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_form.jst.ejs
@@ -6,7 +6,7 @@
     <input type="hidden" name="discussion_post[id]" />
     <input type="hidden" name="discussion_post[parent_id]" value="<%= parentId %>" />
     <textarea name="discussion_post[text]"
-              class="form-control text"
+              class="form-control text airmode"
               placeholder="<%= I18n.t('javascript.course.assessment.submission.answer.programming.annotation_form.text.placeholder') %>"
               aria-label="<%= I18n.t('javascript.course.assessment.submission.answer.programming.annotation_form.text.label') %>"></textarea>
   </div>

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -37,6 +37,12 @@ textarea.code {
   font-size: $code-font-size;
 }
 
+// Add frame to summernote editors in airMode
+.note-editor {
+  @extend .note-editor.note-frame;
+  @extend .panel;
+}
+
 table.codehilite {
   tr {
     td {

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -8,4 +8,4 @@ div.comments
     - new_post = new_comments_post(discussion_topic_form.object)
     = discussion_topic_form.simple_fields_for :posts, new_post do |discussion_post_form|
       = discussion_post_form.hidden_field :parent_id
-      = discussion_post_form.input :text, label: false, input_html: { class: 'comment' }
+      = discussion_post_form.input :text, label: false, input_html: { class: ['comment', 'airmode'] }

--- a/app/views/course/discussion/posts/_form.html.slim
+++ b/app/views/course/discussion/posts/_form.html.slim
@@ -2,5 +2,5 @@
 div.post-form style='display: none'
   = simple_form_for Course::Discussion::Post.new(parent_id: topic.post_ids.first), url: course_topic_posts_path(current_course, topic) do |f|
     = f.hidden_field :parent_id
-    = f.input :text, label: false
+    = f.input :text, label: false, input_html: { class: ['airmode'] }
     = f.button :submit, t('.comment')


### PR DESCRIPTION
Use Summernote airMode where simple commenting is enough. Change applied to textareas in the following places:
- Comments center
- Code annotations
- Answer comments

<img width="693" alt="screen shot 2016-07-12 at 5 46 57 pm" src="https://cloud.githubusercontent.com/assets/6252919/16763043/bb2da7ae-4859-11e6-9d2d-fe8b25963625.png">
