### PR TITLE
Add coffee-rails to Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,7 @@ end
 group :assets do
   # Compress image assets
   gem 'image_optim'
+  gem 'coffee-rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,13 @@ GEM
     cocoon (1.2.9)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
+    coffee-rails (4.1.1)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 5.1.x)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     consistency_fail (0.3.4)
     coursemology-polyglot (0.2.3)
@@ -544,6 +551,7 @@ DEPENDENCIES
   carrierwave
   cocoon
   codeclimate-test-reporter
+  coffee-rails
   consistency_fail
   coursemology-polyglot (>= 0.1.0)
   coveralls
@@ -619,4 +627,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
Stops "LoadError: cannot load such file — coffee_script" when
running tests.