### PR TITLE
Allow editing of programming file annotation posts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ cache: bundler
 
 before_install:
   - gem update bundler
+  # from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
 
 before_script:
   - psql -c 'create database coursemology_test;' -U postgres

--- a/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_post_form.jst.ejs
+++ b/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_post_form.jst.ejs
@@ -1,0 +1,17 @@
+<% formActionPath = Routes.course_assessment_submission_answer_programming_file_line_post_path(
+     courseId, assessmentId, submissionId, answerId, programmingFileId, lineNumber, postId) %>
+<div class="annotation-post-form" data-action="<%= formActionPath %>" data-method="patch">
+  <%= postCommenter %>
+  <div class="form-group text">
+    <textarea name="discussion_post[text]"
+              class="form-control text airmode"
+              aria-label="<%= I18n.t('javascript.course.assessment.submission.answer.programming.annotation_post_form.text.label') %>">
+      <%= postContent %>
+    </textarea>
+  </div>
+
+  <input type="reset" class="btn btn-default"
+         value="<%= I18n.t('javascript.course.assessment.submission.answer.programming.annotation_post_form.reset') %>" />
+  <input type="submit" class="btn btn-primary"
+         value="<%= I18n.t('javascript.course.assessment.submission.answer.programming.annotation_post_form.submit') %>" />
+</div>

--- a/app/controllers/course/assessment/submission/answer/programming/posts_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/posts_controller.rb
@@ -4,11 +4,19 @@ class Course::Assessment::Submission::Answer::Programming::PostsController < \
 
   include Course::Discussion::PostsConcern
 
+  def update
+    render status: :bad_request unless super
+  end
+
   def destroy
     render status: :bad_request unless super
   end
 
   private
+
+  def post_params
+    params.require(:discussion_post).permit(:text)
+  end
 
   def line_param
     params.key?(:line_id) ? params[:line_id].to_i : nil

--- a/app/views/course/assessment/answer/programming/_annotation_post.html.slim
+++ b/app/views/course/assessment/answer/programming/_annotation_post.html.slim
@@ -3,6 +3,9 @@
   div.toolbar.pull-right style='display: none'
     => link_to('#', class: ['reply']) do
       = fa_icon 'reply'.freeze
+    - if can?(:update, annotation_post)
+      => link_to('#', class: ['edit']) do
+        = fa_icon 'edit'.freeze
     - if can?(:destroy, annotation_post)
       = link_to('#', class: ['delete']) do
         = fa_icon 'trash'.freeze

--- a/app/views/course/assessment/submission/answer/programming/posts/update.js.erb
+++ b/app/views/course/assessment/submission/answer/programming/posts/update.js.erb
@@ -1,0 +1,3 @@
+$('#<%= dom_id(@post) %>').html(
+  '<%= escape_javascript(render partial: 'course/assessment/answer/programming/annotation_post',
+                                locals: { annotation_post: @post } ) %>');

--- a/config/locales/en/javascript/course/assessment/submission/answer/programming.yml
+++ b/config/locales/en/javascript/course/assessment/submission/answer/programming.yml
@@ -13,3 +13,8 @@ en:
                   label: 'Annotation body'
                 reset: 'Cancel' # TODO: Reference :'common.cancel', see fnando/i18n-js#392
                 submit: 'Comment'
+              annotation_post_form:
+                text:
+                  label: 'Annotation post body'
+                reset: 'Cancel' # TODO: Reference :'common.cancel', see fnando/i18n-js#392
+                submit: 'Save'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,7 +177,7 @@ Rails.application.routes.draw do
                     resources :files, only: [] do
                       resources :annotations, only: [:create]
                       resources :lines, only: [] do
-                        resources :posts, only: [:destroy]
+                        resources :posts, only: [:update, :destroy]
                       end
                     end
                   end

--- a/spec/controllers/course/assessment/submission/answer/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/comments_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Course::Assessment::Submission::Answer::CommentsController do
       let(:comment) { 'new answer comment' }
 
       subject do
-        controller.instance_variable_set(:@answer, immutable_answer)
         post :create, format: :js, course_id: course, assessment_id: assessment,
                       submission_id: submission, answer_id: immutable_answer,
                       discussion_post: {
@@ -33,8 +32,12 @@ RSpec.describe Course::Assessment::Submission::Answer::CommentsController do
       end
 
       context 'when comment creation fails' do
-        it 'returns HTTP 400' do
+        before do
+          controller.instance_variable_set(:@answer, immutable_answer)
           subject
+        end
+
+        it 'returns HTTP 400' do
           expect(response.status).to eq(400)
         end
       end

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
     describe '#create' do
       let(:post_text) { 'test post text' }
       subject do
-        controller.instance_variable_set(:@annotation, immutable_annotation)
         post :create, format: :js, course_id: course, assessment_id: assessment,
                       submission_id: submission, answer_id: answer, file_id: file,
                       id: immutable_annotation,
@@ -36,8 +35,12 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
       end
 
       context 'when saving fails' do
-        it 'returns HTTP 400' do
+        before do
+          controller.instance_variable_set(:@annotation, immutable_annotation)
           subject
+        end
+
+        it 'returns HTTP 400' do
           expect(response.status).to eq(400)
         end
       end

--- a/spec/controllers/course/assessment/submission/answer/programming/posts_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/posts_controller_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::PostsControl
     describe '#update' do
       let(:post_text) { 'updated post text' }
       subject do
-        controller.instance_variable_set(:@post, immutable_post)
         post :update, format: :js, course_id: course, assessment_id: assessment,
                       submission_id: submission, answer_id: answer, file_id: file,
                       line_id: annotation.line, id: immutable_post,
@@ -32,8 +31,12 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::PostsControl
       end
 
       context 'when updating fails' do
-        it 'returns HTTP 400' do
+        before do
+          controller.instance_variable_set(:@post, immutable_post)
           subject
+        end
+
+        it 'returns HTTP 400' do
           expect(response.status).to eq(400)
         end
       end

--- a/spec/controllers/course/assessment/submission/answer/programming/posts_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/posts_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Submission::Answer::Programming::PostsController do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let(:course) { create(:course, creator: user) }
+    let(:assessment) { create(:assessment, :with_programming_question, course: course) }
+    let(:submission) do
+      create(:course_assessment_submission, :submitted, assessment: assessment, creator: user)
+    end
+    let(:answer) { submission.answers.first }
+    let(:file) { answer.actable.files.first }
+    let(:annotation) { create(:course_assessment_answer_programming_file_annotation, file: file) }
+    let(:immutable_post) do
+      create(:course_discussion_post, topic: annotation, creator: user, updater: user).tap do |stub|
+        allow(stub).to receive(:update_attributes).and_return(false)
+      end
+    end
+
+    before { sign_in(user) }
+
+    describe '#update' do
+      let(:post_text) { 'updated post text' }
+      subject do
+        controller.instance_variable_set(:@post, immutable_post)
+        post :update, format: :js, course_id: course, assessment_id: assessment,
+                      submission_id: submission, answer_id: answer, file_id: file,
+                      line_id: annotation.line, id: immutable_post,
+                      discussion_post: { text: post_text }
+      end
+
+      context 'when updating fails' do
+        it 'returns HTTP 400' do
+          subject
+          expect(response.status).to eq(400)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
@@ -26,8 +26,12 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
       let(:comments_params) { update_params[:answers_attributes]['0'] }
       let(:post_params) { comments_params[:discussion_topic_attributes][:posts_attributes] }
 
-      subject do
+      before do
         controller.instance_variable_set(:@submission, immutable_submission)
+        subject
+      end
+
+      subject do
         post :update, course_id: course, assessment_id: assessment, id: immutable_submission,
                       submission: {
                         answers_attributes: {
@@ -39,7 +43,6 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
       context 'when no comment text is specified' do
         let(:post_attributes) { { text: '' } }
         it 'removes the post' do
-          subject
           expect(post_params.first).to be_nil
         end
       end
@@ -47,8 +50,6 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
       context 'when comment text is specified' do
         let(:post_attributes) { { text: 'test' } }
         it 'sets the title of the post to the title of the assessment' do
-          subject
-
           expect(post_params.first.second[:title]).to eq(assessment.title)
         end
       end

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -121,6 +121,24 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
         expect(new_post.text).to have_tag('*', text: annotation_text)
       end
 
+      scenario 'I can edit my annotations', js: true do
+        post = create(:course_discussion_post, topic: annotation.discussion_topic, creator: user)
+
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+        find(content_tag_selector(post)).find('.edit').click
+
+        annotation_text = 'updated annotation'
+        within find_form('.annotation-post-form') do
+          fill_in 'discussion_post[text]', with: annotation_text
+          click_button I18n.t('javascript.course.assessment.submission.answer.programming.'\
+                              'annotation_post_form.submit')
+        end
+
+        wait_for_ajax
+        updated_post = post.reload
+        expect(updated_post.text).to have_tag('*', text: annotation_text)
+      end
+
       scenario 'I can delete my annotations', js: true do
         post = create(:course_discussion_post, topic: annotation.discussion_topic, creator: user)
 


### PR DESCRIPTION
Depends on #1156 

![edit_annotation](https://cloud.githubusercontent.com/assets/6252919/16796782/f3da3294-4916-11e6-96d7-96c7813938d0.gif)

I used a separate annotation form for editing because I felt the forms were different enough so that it was cleaner to keep them separate. Consequently, `programming.js` doesn't feel very DRY.

Is it a good idea to split `programming.js` but introduce some global variables? 

