### PR TITLE
Implement latest_answers for submission.answers

### DIFF
--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -2,7 +2,8 @@
 module Course::Assessment::Submission::AnswersConcern
   extend ActiveSupport::Concern
 
+  # Scope to obtain the latest answers for each question for Course::Assessment::Submission.
   def latest_answers
-    all
+    select('DISTINCT ON (question_id) *').order(:question_id, created_at: :desc)
   end
 end

--- a/db/migrate/20160714053644_add_timestamps_to_course_assessment_answers.rb
+++ b/db/migrate/20160714053644_add_timestamps_to_course_assessment_answers.rb
@@ -1,0 +1,7 @@
+class AddTimestampsToCourseAssessmentAnswers < ActiveRecord::Migration
+  def change
+    change_table :course_assessment_answers do |t|
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160628052136) do
+ActiveRecord::Schema.define(version: 20160714053644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,6 +176,8 @@ ActiveRecord::Schema.define(version: 20160628052136) do
     t.boolean  "correct",        comment: "Correctness is independent of the grade (depends on the grading schema)"
     t.integer  "grader_id",      index: {name: "fk__course_assessment_answers_grader_id"}, foreign_key: {references: "users", name: "fk_course_assessment_answers_grader_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "graded_at"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
 
   create_table "jobs", id: :uuid, default: nil, force: :cascade do |t|

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe Course::Assessment::Submission do
       end
     end
 
+    describe '.answers' do
+      describe '.latest_answers' do
+        context 'when the submission has multiple answers for the same question' do
+          let(:assessment_traits) { [:with_mcq_question] }
+          let(:submission1_traits) { :submitted }
+          subject { submission1.answers.latest_answers }
+
+          it 'only returns the latest answer' do
+            submission1
+            new_answer = create(:course_assessment_answer_multiple_response, :submitted,
+                                assessment: assessment, question: assessment.questions.first,
+                                submission: submission1, creator: user1).acting_as
+            expect(subject).to contain_exactly(new_answer)
+          end
+        end
+      end
+    end
+
     describe '.by_user' do
       before do
         submission1


### PR DESCRIPTION
This PR implements the association extension to allow:
`submissions.answers.latest_answers` to only return the latest_answer for each question. 

If this is okay and merged, next steps would be to edit the necessary areas for assessment submissions.