### PR TITLE
Make reply comment button selector more specific

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/answer.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/answer.js
@@ -70,7 +70,7 @@
    * @param element
    */
   function showReplyButton(element) {
-    var REPLY_COMMENT_SELECTOR = '.reply-annotation';
+    var REPLY_COMMENT_SELECTOR = DOCUMENT_SELECTOR + '.reply-annotation';
     $(element).find(REPLY_COMMENT_SELECTOR).addBack(REPLY_COMMENT_SELECTOR).show();
   }
 


### PR DESCRIPTION
Fix for [issue](https://github.com/Coursemology/coursemology2/pull/1160/files/239fea8cad407971f7aa02de7bc36d9a92912aef#r71093929) raised in #1160.
