### PR TITLE
Only show latest answers in assessment submission views

### DIFF
--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
@@ -1,6 +1,4 @@
 - question = multiple_response.question.specific
-h2 = format_inline_text(question.title)
-= format_html(question.description)
 - readonly = cannot?(:update, multiple_response.answer)
 = f.association :options, as: :course_assessment_answer_multiple_response,
                           collection: question.options,

--- a/app/views/course/assessment/answer/programming/_programming.html.slim
+++ b/app/views/course/assessment/answer/programming/_programming.html.slim
@@ -1,9 +1,6 @@
 - question = programming.question.specific
-- file_fields_path = 'course/assessment/answer/programming/file_fields'.freeze
-h2 = format_inline_text(question.title)
-= format_html(question.description)
-
 div.files
+  - file_fields_path = 'course/assessment/answer/programming/file_fields'.freeze
   = link_to_add_association t('.add_file'), f, :files, partial: file_fields_path,
                             find_selector: 'this', insert_using: 'after'
   = f.simple_fields_for :files do |files_form|

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -1,6 +1,4 @@
 - question = text_response.question.specific
-h2 = format_inline_text(question.title)
-= format_html(question.description)
 - readonly = cannot?(:update, text_response.answer)
 = f.input :answer_text, label: false, readonly: readonly
 

--- a/app/views/course/assessment/question/multiple_responses/_multiple_response_question.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_multiple_response_question.html.slim
@@ -1,0 +1,3 @@
+- question = multiple_response_question.specific
+h2 = format_inline_text(question.title)
+= format_html(question.description)

--- a/app/views/course/assessment/question/programming/_programming_question.html.slim
+++ b/app/views/course/assessment/question/programming/_programming_question.html.slim
@@ -1,0 +1,3 @@
+- question = programming_question.specific
+h2 = format_inline_text(question.title)
+= format_html(question.description)

--- a/app/views/course/assessment/question/text_responses/_text_response_question.html.slim
+++ b/app/views/course/assessment/question/text_responses/_text_response_question.html.slim
@@ -1,0 +1,3 @@
+- question = text_response_question.specific
+h2 = format_inline_text(question.title)
+= format_html(question.description)

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -10,6 +10,7 @@ nav
   = f.simple_fields_for :answers, guided_current_answer do |base_answer_form|
     = content_tag_for(:div, base_answer_form.object,
                       'data-answer-id' => base_answer_form.object.id) do
+      = render partial: base_answer_form.object.question, suffix: 'question'
       = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
                locals: { base_answer_form: base_answer_form }
       - if base_answer_form.object.attempting?

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -50,12 +50,14 @@ div.panel.panel-default
             th = t('.question')
             th = @submission.class.human_attribute_name(:grade)
         tbody
-          - @submission.answers.each do |answer|
+          - answer_by_question = @submission.answers.latest_answers.group_by(&:question)
+          - @submission.assessment.questions.each do |question|
+            - answer = answer_by_question[question].first
             tr
-              th = format_inline_text(answer.question.title)
+              th = format_inline_text(question.title)
               td
                 span.submission-grades-summary-grade> (
                     id="submission-grades-summary-answer-#{answer.id}-grade")
                   = answer.grade
                 ' /
-                = answer.question.maximum_grade
+                = question.maximum_grade

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -1,10 +1,16 @@
 = simple_form_for [current_course, @assessment, @submission] do |f|
   = f.error_notification
-  = f.simple_fields_for :answers do |base_answer_form|
-    = content_tag_for(:div, base_answer_form.object,
-                      'data-answer-id' => base_answer_form.object.id) do
-      = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
-               locals: { base_answer_form: base_answer_form }
+
+  / TODO: Implement flag to display all answers, or only latest answers.
+  - answers_by_question = f.object.answers.latest_answers.group_by(&:question)
+  - f.object.assessment.questions.each do |question|
+    = render partial: question, suffix: 'question'
+
+    = f.simple_fields_for :answers, answers_by_question[question] do |base_answer_form|
+      = content_tag_for(:div, base_answer_form.object,
+                        'data-answer-id' => base_answer_form.object.id) do
+        = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
+                 locals: { base_answer_form: base_answer_form }
 
   - unless @submission.attempting?
     = render 'statistics', f: f


### PR DESCRIPTION
This PR is a follow up from #1159, to adjust submission views given that the `latest_answers` scope has been implemented. 
- In worksheet mode, each assessment question is displayed once, and only the latest answer is shown. 
- In submission statistics, only the `latest_answer` appears as part of the grade breakdown.

Arising from this is a feature for Worksheet view - implement the viewing of all answers for each question (currently it only shows the latest).  