### PR TITLE
Implement assessment model methods to automatically release grades

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -54,7 +54,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   def assessment_params
     params.require(:assessment).permit(:title, :description, :base_exp, :time_bonus_exp,
                                        :extra_bonus_exp, :start_at, :end_at, :bonus_end_at,
-                                       :draft, :display_mode, folder_params)
+                                       :draft, :display_mode, :autograded, folder_params)
   end
 
   # Merges the parameters for category and tab IDs from either the assessment parameter or the

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -11,7 +11,8 @@ class Course::Assessment < ActiveRecord::Base
   before_validation :assign_folder_attributes
   before_validation :propagate_course
 
-  validate :validate_draft_status_if_no_questions
+  validate :validate_prescence_of_questions, unless: :draft?
+  validate :validate_only_autograded_questions, if: :autograded?
 
   enum display_mode: { worksheet: 0, guided: 1 }
 
@@ -100,8 +101,12 @@ class Course::Assessment < ActiveRecord::Base
     self.autograded ||= false
   end
 
-  def validate_draft_status_if_no_questions
-    return if draft
+  def validate_prescence_of_questions
     errors.add(:draft, :no_questions) unless questions.present?
+  end
+
+  def validate_only_autograded_questions
+    return if questions.all?(&:auto_gradable?)
+    errors.add(:base, :autograded)
   end
 end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -96,7 +96,8 @@ class Course::Assessment < ActiveRecord::Base
   end
 
   def set_defaults
-    self.draft ||= true
+    self.draft = true
+    self.autograded ||= false
   end
 
   def validate_draft_status_if_no_questions

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -3,6 +3,8 @@ class Course::Assessment::Question < ActiveRecord::Base
   actable
   has_many_attachments
 
+  validate :validate_assessment_is_not_autograded, unless: :auto_gradable?
+
   belongs_to :assessment, inverse_of: :questions
   has_and_belongs_to_many :skills
 
@@ -48,5 +50,12 @@ class Course::Assessment::Question < ActiveRecord::Base
   # @return [Boolean] True if the question is the last question, otherwise False.
   def last_question?
     assessment.questions.last == self
+  end
+
+  private
+
+  def validate_assessment_is_not_autograded
+    return unless assessment.autograded
+    errors.add(:base, :autograded_assessment)
   end
 end

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -10,6 +10,7 @@
   = f.input :bonus_end_at
   - unless @assessment.new_record?
     = f.input :draft
+  = f.input :autograded
   = f.input :display_mode, as: :select, collection: Course::Assessment.display_modes.keys
   = f.folder
   = f.hidden_field :tab, value: @tab.id

--- a/config/locales/en/activerecord/course/assessment.yml
+++ b/config/locales/en/activerecord/course/assessment.yml
@@ -7,3 +7,4 @@ en:
       models:
         course/assessment:
           no_questions: 'Assessment can exit draft mode only after adding questions'
+          autograded: 'Assessment can only be autograded if all questions are autograded'

--- a/config/locales/en/activerecord/course/assessment/question.yml
+++ b/config/locales/en/activerecord/course/assessment/question.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/question:
+          autograded_assessment: >
+            A non-autograded question cannot be added to an autograded assessment.
+

--- a/db/migrate/20160716091234_add_autograded_to_course_assessments.rb
+++ b/db/migrate/20160716091234_add_autograded_to_course_assessments.rb
@@ -1,0 +1,5 @@
+class AddAutogradedToCourseAssessments < ActiveRecord::Migration
+  def change
+    add_column :course_assessments, :autograded, :boolean, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160714053644) do
+ActiveRecord::Schema.define(version: 20160716091234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 20160714053644) do
   create_table "course_assessments", force: :cascade do |t|
     t.integer  "tab_id",       null: false, index: {name: "fk__course_assessments_tab_id"}, foreign_key: {references: "course_assessment_tabs", name: "fk_course_assessments_tab_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "display_mode", default: 0, null: false
+    t.boolean  "autograded",   null: false
     t.integer  "creator_id",   null: false, index: {name: "fk__course_assessments_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessments_creator_id", on_update: :no_action, on_delete: :no_action}
     t.integer  "updater_id",   null: false, index: {name: "fk__course_assessments_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessments_updater_id", on_update: :no_action, on_delete: :no_action}
     t.datetime "created_at",   null: false

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -9,6 +9,8 @@ FactoryGirl.define do
     end
     title { generate(:course_assessment_assessment_name) }
     base_exp 1000
+    autograded false
+    draft true
 
     trait :unopened do
       start_at { 1.day.from_now }

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -80,5 +80,9 @@ FactoryGirl.define do
       with_all_question_types
       published
     end
+
+    trait :autograded do
+      autograded true
+    end
   end
 end

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::Programming do
   it { is_expected.to act_as(Course::Assessment::Question) }
-  it { is_expected.to validate_numericality_of(:time_limit).allow_nil }
-  it { is_expected.to validate_numericality_of(:memory_limit).allow_nil }
 
   it 'belongs to an import job' do
     expect(subject).to belong_to(:import_job).
@@ -23,6 +21,13 @@ RSpec.describe Course::Assessment::Question::Programming do
 
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
+    describe 'validations' do
+      subject { build(:course_assessment_question_programming) }
+
+      it { is_expected.to validate_numericality_of(:time_limit).allow_nil }
+      it { is_expected.to validate_numericality_of(:memory_limit).allow_nil }
+    end
+
     describe 'callbacks' do
       let(:question_attributes) { [] }
       subject { build(:course_assessment_question_programming, *question_attributes) }
@@ -85,9 +90,6 @@ RSpec.describe Course::Assessment::Question::Programming do
       end
     end
 
-    describe 'validations' do
-    end
-
     describe '#auto_gradable?' do
       subject do
         build_stubbed(:course_assessment_question_programming, test_case_count: test_case_count)
@@ -138,6 +140,7 @@ RSpec.describe Course::Assessment::Question::Programming do
 
     describe '#imported_attachment=' do
       with_active_job_queue_adapter(:test) do
+        subject { build(:course_assessment_question_programming) }
         it 'does not enqueue another import job' do
           subject.imported_attachment = build(:attachment_reference)
           expect { subject.save }.not_to have_enqueued_job

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -18,6 +18,29 @@ RSpec.describe Course::Assessment::Question do
   with_tenant(:instance) do
     subject { build_stubbed(:course_assessment_question) }
 
+    describe 'validations' do
+      context 'when assessment automatically releases grades' do
+        let(:assessment) { create(:assessment, :autograded) }
+        let!(:question) { build(:course_assessment_question, assessment: assessment) }
+        subject { question }
+
+        context 'when question is autograded' do
+          before { allow(question).to receive(:auto_gradable?).and_return(true) }
+          it { is_expected.to be_valid }
+        end
+
+        context 'when question is not autograded' do
+          before { allow(question).to receive(:auto_gradable?).and_return(false) }
+
+          it 'is not valid' do
+            expect(subject).not_to be_valid
+            expect(subject.errors[:base]).to include(I18n.t('activerecord.errors.models.' \
+            'course/assessment/question.autograded_assessment'))
+          end
+        end
+      end
+    end
+
     describe '#auto_gradable?' do
       it 'defaults to false' do
         expect(subject.auto_gradable?).to eq(false)

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -57,6 +57,31 @@ RSpec.describe Course::Assessment do
           it { is_expected.to be_valid }
         end
       end
+
+      context 'when the assessment is set to be autograded' do
+        let!(:question) do
+          create(:course_assessment_question_programming, *question_traits, assessment: assessment)
+        end
+        subject do
+          assessment.autograded = true
+          assessment
+        end
+
+        context 'when the assessment has a non-autograded question' do
+          let(:question_traits) { nil }
+
+          it 'is not valid' do
+            expect(subject).not_to be_valid
+            expect(subject.errors['actable.base']).
+              to include(I18n.t('activerecord.errors.models.course/assessment.autograded'))
+          end
+        end
+
+        context 'when the assessment only has autograded questions' do
+          let(:question_traits) { [:auto_gradable] }
+          it { is_expected.to be_valid }
+        end
+      end
     end
 
     describe 'callbacks' do


### PR DESCRIPTION
Related to #876. 

This implements:
- Addition of flag to automatically release grades.
- Validations on `Assessment` and `Question` models for these flags. 
- Workflow changes to automatically release grades for submissions.