### PR TITLE
Modify assessment ability for course_students to only see and attempt non-draft assessments

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -36,6 +36,10 @@ module Course::Assessment::AssessmentAbility
     { tab: { category: course_all_course_users_hash } }
   end
 
+  def assessment_non_draft_all_course_users_hash
+    { lesson_plan_item: { draft: false } }.reverse_merge(assessment_all_course_users_hash)
+  end
+
   def assessment_course_staff_hash
     { tab: { category: course_staff_hash } }
   end
@@ -51,12 +55,12 @@ module Course::Assessment::AssessmentAbility
   end
 
   def allow_students_show_assessments
-    can :read, Course::Assessment, assessment_all_course_users_hash
+    can :read, Course::Assessment, assessment_non_draft_all_course_users_hash
   end
 
   def allow_students_attempt_assessment
     can :attempt, Course::Assessment do |assessment|
-      assessment.started? && assessment.conditions_satisfied_by?(
+      assessment.started? && !assessment.draft? && assessment.conditions_satisfied_by?(
         user.course_users.find_by(course: assessment.course)
       )
     end

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     trait :with_mcq_question do
       after(:build) do |assessment|
         question = build(:course_assessment_question_multiple_response, assessment: assessment)
-        assessment.multiple_response_questions << question
+        assessment.questions << question.acting_as
       end
     end
 
@@ -26,14 +26,14 @@ FactoryGirl.define do
         question = build(:course_assessment_question_programming, :auto_gradable,
                          template_package: true, template_package_deferred: false,
                          assessment: assessment)
-        assessment.programming_questions << question
+        assessment.questions << question.acting_as
       end
     end
 
     trait :with_text_response_question do
       after(:build) do |assessment|
         question = build(:course_assessment_question_text_response, assessment: assessment)
-        assessment.text_response_questions << question
+        assessment.questions << question.acting_as
       end
     end
 
@@ -49,6 +49,34 @@ FactoryGirl.define do
 
     trait :guided do
       display_mode :guided
+    end
+
+    # Note: Not to be used alone, as a published assessment requires at
+    #   least 1 other question. Use the other published traits intead.
+    trait :published do
+      after(:build) do |assessment|
+        assessment.draft = false
+      end
+    end
+
+    trait :published_with_mcq_question do
+      with_mcq_question
+      published
+    end
+
+    trait :published_with_text_response_question do
+      with_text_response_question
+      published
+    end
+
+    trait :published_with_programming_question do
+      with_programming_question
+      published
+    end
+
+    trait :published_with_all_question_types do
+      with_all_question_types
+      published
     end
   end
 end

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:course_assessment_assessment, :with_mcq_question, course: course) }
+    let(:assessment) do
+      create(:course_assessment_assessment, :published_with_mcq_question, course: course)
+    end
     before { login_as(user, scope: :user) }
 
     let(:submission) do

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) do
-      create(:course_assessment_assessment, :with_programming_question, course: course)
+      create(:course_assessment_assessment, :published_with_programming_question, course: course)
     end
     before { login_as(user, scope: :user) }
 

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) do
-      create(:course_assessment_assessment, :with_text_response_question, course: course)
+      create(:course_assessment_assessment, :published_with_text_response_question, course: course)
     end
     before { login_as(user, scope: :user) }
 

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:empty_assessment) { create(:assessment, course: course) }
+    let(:empty_assessment) { create(:assessment, course: course, draft: true) }
     let(:unopened_assessment) do
-      create(:assessment, :with_all_question_types, :unopened, course: course)
+      create(:assessment, :published_with_all_question_types, :unopened, course: course)
     end
-    let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
+    let(:assessment) { create(:assessment, :published_with_all_question_types, course: course) }
     let(:assessment_with_condition) do
-      assessment_with_condition = create(:assessment, :with_all_question_types, course: course)
+      assessment_with_condition = create(:assessment, :published_with_all_question_types,
+                                         course: course)
       create(:assessment_condition,
              course: course,
              assessment: assessment,
@@ -34,16 +35,11 @@ RSpec.describe 'Course: Assessments: Attempt' do
     context 'As a Course Student' do
       let(:user) { student }
 
-      scenario 'I cannot attempt empty assessments' do
+      scenario 'I cannot see draft assessments which are empty' do
         empty_assessment
         visit course_assessments_path(course)
 
-        within find(content_tag_selector(empty_assessment)) do
-          find_link(I18n.t('course.assessment.assessments.assessment.attempt'),
-                    href: course_assessment_submissions_path(course, empty_assessment)).click
-        end
-
-        expect(page.status_code).to eq(422)
+        expect(page).not_to have_content_tag_for(empty_assessment)
       end
 
       scenario 'I cannot attempt unsatisfied assessments' do

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:assessment, :guided, course: course) }
-    let(:mcq_questions) do
-      create_list(:course_assessment_question_multiple_response, 2, assessment: assessment)
+    let(:assessment) do
+      create(:assessment, :guided, :published_with_mcq_question, :with_mcq_question, course: course)
     end
+    let(:mcq_questions) { assessment.questions.map(&:specific) }
     before { login_as(user, scope: :user) }
 
     let(:student) { create(:course_user, :approved, course: course).user }

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:assessment, :with_programming_question, course: course) }
+    let(:assessment) { create(:assessment, :published_with_programming_question, course: course) }
     let(:student) { create(:course_user, :approved, course: course).user }
     let(:submission) do
       create(:course_assessment_submission, assessment: assessment, creator: student)

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:assessment, :worksheet, :with_mcq_question, course: course) }
+    let(:assessment) do
+      create(:assessment, :worksheet, :published_with_mcq_question, course: course)
+    end
     before { login_as(user, scope: :user) }
 
     let(:student) { create(:course_user, :approved, course: course).user }

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -85,9 +85,10 @@ RSpec.feature 'Course: Assessments: Management' do
         expect(page).to have_selector('li', text: assessment_sidebar)
       end
 
-      scenario 'I can see assessments' do
+      scenario 'I can see non-draft assessments' do
         category = course.assessment_categories.first
-        assessment = create(:assessment, course: course, tab: category.tabs.first)
+        assessment = create(:assessment, :published_with_mcq_question,
+                            course: course, tab: category.tabs.first)
         visit course_assessments_path(course)
 
         find_link(assessment.title, href: course_assessment_path(course, assessment)).click

--- a/spec/models/course/condition/assessment_ability_spec.rb
+++ b/spec/models/course/condition/assessment_ability_spec.rb
@@ -17,15 +17,17 @@ RSpec.describe Course::Condition::Assessment do
     context 'when the user is a Course Student' do
       let(:user) { create(:course_student, :approved, course: course).user }
 
-      context 'when the assessment has not started' do
-        let(:unopened_assessment) { create(:assessment, :unopened, course: course) }
+      context 'when the assessment is published but has not started' do
+        let(:unopened_assessment) do
+          create(:assessment, :published_with_mcq_question, :unopened, course: course)
+        end
 
         it { is_expected.to_not be_able_to(:attempt, unopened_assessment) }
       end
 
       context 'when the assessment has started' do
-        let(:assessment1) { create(:assessment, course: course) }
-        let(:assessment2) { create(:assessment, course: course) }
+        let(:assessment1) { create(:assessment, :published_with_mcq_question, course: course) }
+        let(:assessment2) { create(:assessment, :published_with_mcq_question, course: course) }
         let!(:condition) do
           create(:assessment_condition,
                  course: course,


### PR DESCRIPTION
Fixes #1170. 

This PR modifies the assessment ability to only allow students to `read` and `attempt` non-draft assessments. 