### PR TITLE
Implement set time zone and display time in the correct time zone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   include ApplicationInternationalizationConcern
   include ApplicationThemingConcern
   include ApplicationUserConcern
+  include ApplicationUserTimeZoneConcern
   include ApplicationAnnouncementsConcern
   include ApplicationPaginationConcern
 

--- a/app/controllers/concerns/application_user_time_zone_concern.rb
+++ b/app/controllers/concerns/application_user_time_zone_concern.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module ApplicationUserTimeZoneConcern
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :set_time_zone, if: :current_user
+  end
+
+  protected
+
+  # Set the time_zone for current request.
+  def set_time_zone(&block) # rubocop:disable Style/AccessorMethodName
+    Time.use_zone(current_user.time_zone || Application.config.x.default_user_time_zone, &block)
+  end
+end

--- a/app/controllers/user/profiles_controller.rb
+++ b/app/controllers/user/profiles_controller.rb
@@ -16,6 +16,6 @@ class User::ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.require(:user).permit(:name, :profile_photo)
+    params.require(:user).permit(:name, :time_zone, :profile_photo)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ActiveRecord::Base
 
   validates :email, :encrypted_password, :authentication_token, absence: true, if: :built_in?
   schema_validations except: [:encrypted_password]
+  validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.zones_map.keys }, allow_nil: true
 
   has_many :emails, -> { order('primary' => :desc) }, class_name: User::Email.name,
                                                       inverse_of: :user, dependent: :destroy

--- a/app/views/user/profiles/edit.html.slim
+++ b/app/views/user/profiles/edit.html.slim
@@ -3,6 +3,7 @@
 = simple_form_for current_user, url: user_profile_path do |f|
   = f.error_notification
   = f.input :name, required: true
+  = f.input :time_zone
   = f.label t('.profile_photo')
   div = display_user_image(current_user)
   = f.file_field :profile_photo, class: 'upload-btn'

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ class Application < Rails::Application
   config.eager_load_paths << "#{Rails.root}/app/notifiers"
 
   config.x.default_host = 'example.org'
+  config.x.default_user_time_zone = 'Singapore'
   config.x.public_download_folder = 'downloads'
   config.x.temp_folder = config.root.join('tmp')
 end

--- a/db/migrate/20160722020938_add_time_zone_to_users.rb
+++ b/db/migrate/20160722020938_add_time_zone_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :time_zone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,209 +11,210 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160716091234) do
+ActiveRecord::Schema.define(version: 20160722020938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "users", force: :cascade do |t|
-    t.string   "name",                   limit: 255,              null: false
-    t.integer  "role",                   default: 0,  null: false
+    t.string   "name",                   :limit=>255, :null=>false
+    t.integer  "role",                   :default=>0, :null=>false
+    t.string   "time_zone",              :limit=>255
     t.text     "profile_photo"
-    t.string   "encrypted_password",     limit: 255, default: "", null: false
-    t.string   "authentication_token",   limit: 255, index: {name: "index_users_on_authentication_token", unique: true}
-    t.string   "reset_password_token",   limit: 255, index: {name: "index_users_on_reset_password_token", unique: true}
+    t.string   "encrypted_password",     :limit=>255, :default=>"", :null=>false
+    t.string   "authentication_token",   :limit=>255, :index=>{:name=>"index_users_on_authentication_token", :unique=>true}
+    t.string   "reset_password_token",   :limit=>255, :index=>{:name=>"index_users_on_reset_password_token", :unique=>true}
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          :default=>0, :null=>false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",             :null=>false
+    t.datetime "updated_at",             :null=>false
   end
 
   create_table "activities", force: :cascade do |t|
-    t.integer  "actor_id",      null: false, index: {name: "fk__activities_actor_id"}, foreign_key: {references: "users", name: "fk_activities_actor_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "object_id",     null: false
-    t.string   "object_type",   limit: 255, null: false
-    t.string   "event",         limit: 255, null: false
-    t.string   "notifier_type", limit: 255, null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.integer  "actor_id",      :null=>false, :index=>{:name=>"fk__activities_actor_id"}, :foreign_key=>{:references=>"users", :name=>"fk_activities_actor_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "object_id",     :null=>false
+    t.string   "object_type",   :limit=>255, :null=>false
+    t.string   "event",         :limit=>255, :null=>false
+    t.string   "notifier_type", :limit=>255, :null=>false
+    t.datetime "created_at",    :null=>false
+    t.datetime "updated_at",    :null=>false
   end
 
   create_table "attachments", force: :cascade do |t|
-    t.string   "name",        limit: 255, null: false, index: {name: "index_attachments_on_name", unique: true}
-    t.text     "file_upload", null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.string   "name",        :limit=>255, :null=>false, :index=>{:name=>"index_attachments_on_name", :unique=>true}
+    t.text     "file_upload", :null=>false
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
 
   create_table "attachment_references", force: :cascade do |t|
     t.integer  "attachable_id"
-    t.string   "attachable_type", limit: 255, index: {name: "fk__attachment_references_attachable_id", with: ["attachable_id"]}
-    t.integer  "attachment_id",   null: false, index: {name: "fk__attachment_references_attachment_id"}, foreign_key: {references: "attachments", name: "fk_attachment_references_attachment_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "name",            limit: 255, null: false
+    t.string   "attachable_type", :limit=>255, :index=>{:name=>"fk__attachment_references_attachable_id", :with=>["attachable_id"]}
+    t.integer  "attachment_id",   :null=>false, :index=>{:name=>"fk__attachment_references_attachment_id"}, :foreign_key=>{:references=>"attachments", :name=>"fk_attachment_references_attachment_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "name",            :limit=>255, :null=>false
     t.datetime "expires_at"
-    t.integer  "creator_id",      null: false, index: {name: "fk__attachment_references_creator_id"}, foreign_key: {references: "users", name: "fk_attachment_references_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",      null: false, index: {name: "fk__attachment_references_updater_id"}, foreign_key: {references: "users", name: "fk_attachment_references_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__attachment_references_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_attachment_references_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__attachment_references_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_attachment_references_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",      :null=>false
+    t.datetime "updated_at",      :null=>false
   end
 
   create_table "instances", force: :cascade do |t|
-    t.string "name",     limit: 255, null: false
-    t.string "host",     limit: 255, null: false, comment: "Stores the host name of the instance. The www prefix is automatically handled by the application", index: {name: "index_instances_on_host", unique: true, case_sensitive: false}
+    t.string "name",     :limit=>255, :null=>false
+    t.string "host",     :limit=>255, :null=>false, :comment=>"Stores the host name of the instance. The www prefix is automatically handled by the application", :index=>{:name=>"index_instances_on_host", :unique=>true, :case_sensitive=>false}
     t.text   "settings"
   end
 
   create_table "courses", force: :cascade do |t|
-    t.integer  "instance_id",      null: false, index: {name: "fk__courses_instance_id"}, foreign_key: {references: "instances", name: "fk_courses_instance_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",            limit: 255,             null: false
+    t.integer  "instance_id",      :null=>false, :index=>{:name=>"fk__courses_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_courses_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",            :limit=>255, :null=>false
     t.text     "description"
     t.text     "logo"
-    t.integer  "status",           default: 0, null: false
-    t.string   "registration_key", limit: 16, index: {name: "index_courses_on_registration_key", unique: true}
+    t.integer  "status",           :default=>0, :null=>false
+    t.string   "registration_key", :limit=>16, :index=>{:name=>"index_courses_on_registration_key", :unique=>true}
     t.text     "settings"
-    t.datetime "start_at",         null: false
-    t.datetime "end_at",           null: false
-    t.integer  "creator_id",       null: false, index: {name: "fk__courses_creator_id"}, foreign_key: {references: "users", name: "fk_courses_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",       null: false, index: {name: "fk__courses_updater_id"}, foreign_key: {references: "users", name: "fk_courses_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "start_at",         :null=>false
+    t.datetime "end_at",           :null=>false
+    t.integer  "creator_id",       :null=>false, :index=>{:name=>"fk__courses_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_courses_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",       :null=>false, :index=>{:name=>"fk__courses_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_courses_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",       :null=>false
+    t.datetime "updated_at",       :null=>false
   end
 
   create_table "course_achievements", force: :cascade do |t|
-    t.integer  "course_id",   null: false, index: {name: "fk__course_achievements_course_id"}, foreign_key: {references: "courses", name: "fk_course_achievements_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",       limit: 255, null: false
+    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_achievements_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_achievements_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",       :limit=>255, :null=>false
     t.text     "description"
     t.text     "badge"
-    t.integer  "weight",      null: false
-    t.boolean  "draft",       null: false
-    t.integer  "creator_id",  null: false, index: {name: "fk__course_achievements_creator_id"}, foreign_key: {references: "users", name: "fk_course_achievements_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__course_achievements_updater_id"}, foreign_key: {references: "users", name: "fk_course_achievements_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "weight",      :null=>false
+    t.boolean  "draft",       :null=>false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_achievements_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_achievements_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_achievements_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_achievements_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_announcements", force: :cascade do |t|
-    t.integer  "course_id",  null: false, index: {name: "fk__course_announcements_course_id"}, foreign_key: {references: "courses", name: "fk_course_announcements_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",      limit: 255,                 null: false
+    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_announcements_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_announcements_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",      :limit=>255, :null=>false
     t.text     "content"
-    t.boolean  "sticky",     default: false, null: false
-    t.datetime "start_at",   null: false
-    t.datetime "end_at",     null: false
-    t.integer  "creator_id", null: false, index: {name: "fk__course_announcements_creator_id"}, foreign_key: {references: "users", name: "fk_course_announcements_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id", null: false, index: {name: "fk__course_announcements_updater_id"}, foreign_key: {references: "users", name: "fk_course_announcements_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.boolean  "sticky",     :default=>false, :null=>false
+    t.datetime "start_at",   :null=>false
+    t.datetime "end_at",     :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_announcements_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_announcements_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_announcements_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_announcements_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "course_assessment_categories", force: :cascade do |t|
-    t.integer  "course_id",  null: false, index: {name: "fk__course_assessment_categories_course_id"}, foreign_key: {references: "courses", name: "fk_course_assessment_categories_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",      limit: 255, null: false
-    t.integer  "weight",     null: false
-    t.integer  "creator_id", null: false, index: {name: "fk__course_assessment_categories_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_categories_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id", null: false, index: {name: "fk__course_assessment_categories_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_categories_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_assessment_categories_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_categories_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",      :limit=>255, :null=>false
+    t.integer  "weight",     :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessment_categories_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_categories_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_assessment_categories_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_categories_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "course_assessment_tabs", force: :cascade do |t|
-    t.integer  "category_id", null: false, index: {name: "fk__course_assessment_tabs_category_id"}, foreign_key: {references: "course_assessment_categories", name: "fk_course_assessment_tabs_category_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",       limit: 255, null: false
-    t.integer  "weight",      null: false
-    t.integer  "creator_id",  null: false, index: {name: "fk__course_assessment_tabs_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_tabs_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__course_assessment_tabs_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_tabs_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "category_id", :null=>false, :index=>{:name=>"fk__course_assessment_tabs_category_id"}, :foreign_key=>{:references=>"course_assessment_categories", :name=>"fk_course_assessment_tabs_category_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",       :limit=>255, :null=>false
+    t.integer  "weight",      :null=>false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessment_tabs_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_tabs_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessment_tabs_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_tabs_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_assessments", force: :cascade do |t|
-    t.integer  "tab_id",       null: false, index: {name: "fk__course_assessments_tab_id"}, foreign_key: {references: "course_assessment_tabs", name: "fk_course_assessments_tab_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "display_mode", default: 0, null: false
-    t.boolean  "autograded",   null: false
-    t.integer  "creator_id",   null: false, index: {name: "fk__course_assessments_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessments_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",   null: false, index: {name: "fk__course_assessments_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessments_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.integer  "tab_id",       :null=>false, :index=>{:name=>"fk__course_assessments_tab_id"}, :foreign_key=>{:references=>"course_assessment_tabs", :name=>"fk_course_assessments_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "display_mode", :default=>0, :null=>false
+    t.boolean  "autograded",   :null=>false
+    t.integer  "creator_id",   :null=>false, :index=>{:name=>"fk__course_assessments_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",   :null=>false, :index=>{:name=>"fk__course_assessments_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",   :null=>false
+    t.datetime "updated_at",   :null=>false
   end
 
   create_table "course_assessment_questions", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",  limit: 255, index: {name: "index_course_assessment_questions_actable", with: ["actable_id"], unique: true}
-    t.integer  "assessment_id", null: false, index: {name: "fk__course_assessment_questions_assessment_id"}, foreign_key: {references: "course_assessments", name: "fk_course_assessment_questions_assessment_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",         limit: 255,             null: false
+    t.string   "actable_type",        :limit=>255, :index=>{:name=>"index_course_assessment_questions_actable", :with=>["actable_id"], :unique=>true}
+    t.integer  "assessment_id",       :null=>false, :index=>{:name=>"fk__course_assessment_questions_assessment_id"}, :foreign_key=>{:references=>"course_assessments", :name=>"fk_course_assessment_questions_assessment_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",               :limit=>255, :null=>false
     t.text     "description"
     t.text     "staff_only_comments"
-    t.integer  "maximum_grade", null: false
-    t.integer  "weight",        default: 0, null: false
-    t.integer  "creator_id",    null: false, index: {name: "fk__course_assessment_questions_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_questions_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",    null: false, index: {name: "fk__course_assessment_questions_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_questions_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.integer  "maximum_grade",       :null=>false
+    t.integer  "weight",              :default=>0, :null=>false
+    t.integer  "creator_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_questions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_questions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",          :null=>false
+    t.datetime "updated_at",          :null=>false
   end
 
   create_table "course_assessment_submissions", force: :cascade do |t|
-    t.integer  "assessment_id",  null: false, index: {name: "fk__course_assessment_submissions_assessment_id"}, foreign_key: {references: "course_assessments", name: "fk_course_assessment_submissions_assessment_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "workflow_state", limit: 255, null: false
-    t.integer  "creator_id",     null: false, index: {name: "fk__course_assessment_submissions_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_submissions_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",     null: false, index: {name: "fk__course_assessment_submissions_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_submissions_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.integer  "assessment_id",  :null=>false, :index=>{:name=>"fk__course_assessment_submissions_assessment_id"}, :foreign_key=>{:references=>"course_assessments", :name=>"fk_course_assessment_submissions_assessment_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "workflow_state", :limit=>255, :null=>false
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_submissions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_submissions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
   end
 
   create_table "course_assessment_answers", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",   limit: 255, index: {name: "index_course_assessment_answers_actable", with: ["actable_id"], unique: true}
-    t.integer  "submission_id",  null: false, index: {name: "fk__course_assessment_answers_submission_id"}, foreign_key: {references: "course_assessment_submissions", name: "fk_course_assessment_answers_submission_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "question_id",    null: false, index: {name: "fk__course_assessment_answers_question_id"}, foreign_key: {references: "course_assessment_questions", name: "fk_course_assessment_answers_question_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "workflow_state", limit: 255, null: false
+    t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_assessment_answers_actable", :with=>["actable_id"], :unique=>true}
+    t.integer  "submission_id",  :null=>false, :index=>{:name=>"fk__course_assessment_answers_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_answers_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "question_id",    :null=>false, :index=>{:name=>"fk__course_assessment_answers_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_answers_question_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "workflow_state", :limit=>255, :null=>false
     t.datetime "submitted_at"
     t.integer  "grade"
-    t.boolean  "correct",        comment: "Correctness is independent of the grade (depends on the grading schema)"
-    t.integer  "grader_id",      index: {name: "fk__course_assessment_answers_grader_id"}, foreign_key: {references: "users", name: "fk_course_assessment_answers_grader_id", on_update: :no_action, on_delete: :no_action}
+    t.boolean  "correct",        :comment=>"Correctness is independent of the grade (depends on the grading schema)"
+    t.integer  "grader_id",      :index=>{:name=>"fk__course_assessment_answers_grader_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_answers_grader_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "graded_at"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
   end
 
   create_table "jobs", id: :uuid, default: nil, force: :cascade do |t|
-    t.integer "status",      default: 0, null: false
-    t.string  "redirect_to", limit: 255
+    t.integer "status",      :default=>0, :null=>false
+    t.string  "redirect_to", :limit=>255
     t.json    "error"
   end
 
   create_table "course_assessment_answer_auto_gradings", force: :cascade do |t|
-    t.integer  "actable_id",   index: {name: "index_course_assessment_answer_auto_gradings_on_actable", with: ["actable_type"], unique: true}
-    t.string   "actable_type", limit: 255
-    t.integer  "answer_id",    null: false, index: {name: "index_course_assessment_answer_auto_gradings_on_answer_id", unique: true}, foreign_key: {references: "course_assessment_answers", name: "fk_course_assessment_answer_auto_gradings_answer_id", on_update: :no_action, on_delete: :no_action}
-    t.uuid     "job_id",       index: {name: "index_course_assessment_answer_auto_gradings_on_job_id", unique: true}, foreign_key: {references: "jobs", name: "fk_course_assessment_answer_auto_gradings_job_id", on_update: :no_action, on_delete: :nullify}
+    t.integer  "actable_id",   :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_actable", :with=>["actable_type"], :unique=>true}
+    t.string   "actable_type", :limit=>255
+    t.integer  "answer_id",    :null=>false, :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_answer_id", :unique=>true}, :foreign_key=>{:references=>"course_assessment_answers", :name=>"fk_course_assessment_answer_auto_gradings_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.uuid     "job_id",       :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_job_id", :unique=>true}, :foreign_key=>{:references=>"jobs", :name=>"fk_course_assessment_answer_auto_gradings_job_id", :on_update=>:no_action, :on_delete=>:nullify}
     t.json     "result"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",   :null=>false
+    t.datetime "updated_at",   :null=>false
   end
 
   create_table "course_assessment_answer_multiple_responses", force: :cascade do |t|
   end
 
   create_table "course_assessment_question_multiple_responses", force: :cascade do |t|
-    t.integer "question_type", default: 0, null: false
+    t.integer "question_type", :default=>0, :null=>false
   end
 
   create_table "course_assessment_question_multiple_response_options", force: :cascade do |t|
-    t.integer "question_id", null: false, index: {name: "fk__course_assessment_multiple_response_option_question"}, foreign_key: {references: "course_assessment_question_multiple_responses", name: "fk_course_assessment_question_multiple_response_options_questio", on_update: :no_action, on_delete: :no_action}
-    t.boolean "correct",     null: false
-    t.text    "option",      null: false
+    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_question"}, :foreign_key=>{:references=>"course_assessment_question_multiple_responses", :name=>"fk_course_assessment_question_multiple_response_options_questio", :on_update=>:no_action, :on_delete=>:no_action}
+    t.boolean "correct",     :null=>false
+    t.text    "option",      :null=>false
     t.text    "explanation"
   end
 
   create_table "course_assessment_answer_multiple_response_options", force: :cascade do |t|
-    t.integer "answer_id", null: false, index: {name: "fk__course_assessment_multiple_response_option_answer"}, foreign_key: {references: "course_assessment_answer_multiple_responses", name: "fk_course_assessment_answer_multiple_response_options_answer_id", on_update: :no_action, on_delete: :no_action}
-    t.integer "option_id", null: false, index: {name: "fk__course_assessment_multiple_response_option_question_option"}, foreign_key: {references: "course_assessment_question_multiple_response_options", name: "fk_course_assessment_answer_multiple_response_options_option_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "answer_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_answer"}, :foreign_key=>{:references=>"course_assessment_answer_multiple_responses", :name=>"fk_course_assessment_answer_multiple_response_options_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "option_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_question_option"}, :foreign_key=>{:references=>"course_assessment_question_multiple_response_options", :name=>"fk_course_assessment_answer_multiple_response_options_option_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
 
   create_table "course_assessment_answer_programming", force: :cascade do |t|
@@ -223,43 +224,43 @@ ActiveRecord::Schema.define(version: 20160716091234) do
   end
 
   create_table "polyglot_languages", force: :cascade do |t|
-    t.string  "type",      limit: 255, null: false, comment: "The class of language, as perceived by the application."
-    t.string  "name",      limit: 255, null: false, index: {name: "index_polyglot_languages_on_name", unique: true, case_sensitive: false}
-    t.integer "parent_id", index: {name: "fk__polyglot_languages_parent_id"}, foreign_key: {references: "polyglot_languages", name: "fk_polyglot_languages_parent_id", on_update: :no_action, on_delete: :no_action}
+    t.string  "type",      :limit=>255, :null=>false, :comment=>"The class of language, as perceived by the application."
+    t.string  "name",      :limit=>255, :null=>false, :index=>{:name=>"index_polyglot_languages_on_name", :unique=>true, :case_sensitive=>false}
+    t.integer "parent_id", :index=>{:name=>"fk__polyglot_languages_parent_id"}, :foreign_key=>{:references=>"polyglot_languages", :name=>"fk_polyglot_languages_parent_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
 
   create_table "course_assessment_question_programming", force: :cascade do |t|
-    t.integer "language_id",   null: false, index: {name: "fk__course_assessment_question_programming_language_id"}, foreign_key: {references: "polyglot_languages", name: "fk_course_assessment_question_programming_language_id", on_update: :no_action, on_delete: :no_action}
-    t.integer "memory_limit",  comment: "Memory limit, in MiB"
-    t.integer "time_limit",    comment: "Time limit, in seconds"
-    t.uuid    "import_job_id", comment: "The ID of the importing job", index: {name: "index_course_assessment_question_programming_on_import_job_id", unique: true}, foreign_key: {references: "jobs", name: "fk_course_assessment_question_programming_import_job_id", on_update: :no_action, on_delete: :nullify}
+    t.integer "language_id",   :null=>false, :index=>{:name=>"fk__course_assessment_question_programming_language_id"}, :foreign_key=>{:references=>"polyglot_languages", :name=>"fk_course_assessment_question_programming_language_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "memory_limit",  :comment=>"Memory limit, in MiB"
+    t.integer "time_limit",    :comment=>"Time limit, in seconds"
+    t.uuid    "import_job_id", :comment=>"The ID of the importing job", :index=>{:name=>"index_course_assessment_question_programming_on_import_job_id", :unique=>true}, :foreign_key=>{:references=>"jobs", :name=>"fk_course_assessment_question_programming_import_job_id", :on_update=>:no_action, :on_delete=>:nullify}
   end
 
   create_table "course_assessment_question_programming_test_cases", force: :cascade do |t|
-    t.integer "question_id", null: false, index: {name: "fk__course_assessment_quest_18b37224652fc59d955122a17ba20d07"}, foreign_key: {references: "course_assessment_question_programming", name: "fk_course_assessment_questi_ee00a2daf4389c4c2ddba3041a15c35f", on_update: :no_action, on_delete: :no_action}
-    t.string  "identifier",  limit: 255, null: false, comment: "Test case identifier generated by the testing framework", index: {name: "index_course_assessment_question_programming_test_case_ident", with: ["question_id"], unique: true}
-    t.boolean "public",      null: false
-    t.text    "description", null: false
+    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_assessment_quest_18b37224652fc59d955122a17ba20d07"}, :foreign_key=>{:references=>"course_assessment_question_programming", :name=>"fk_course_assessment_questi_ee00a2daf4389c4c2ddba3041a15c35f", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string  "identifier",  :limit=>255, :null=>false, :comment=>"Test case identifier generated by the testing framework", :index=>{:name=>"index_course_assessment_question_programming_test_case_ident", :with=>["question_id"], :unique=>true}
+    t.boolean "public",      :null=>false
+    t.text    "description", :null=>false
     t.text    "hint"
   end
 
   create_table "course_assessment_answer_programming_auto_grading_test_results", force: :cascade do |t|
-    t.integer "auto_grading_id", null: false, index: {name: "fk__course_assessment_answe_57b22f114b54911fd4e1519680ebfd49"}, foreign_key: {references: "course_assessment_answer_programming_auto_gradings", name: "fk_course_assessment_answer_e3d785447112439bb306849be8690102", on_update: :no_action, on_delete: :no_action}
-    t.integer "test_case_id",    index: {name: "fk__course_assessment_answe_29a2568d5e2fb3a47c0561815786f9ab"}, foreign_key: {references: "course_assessment_question_programming_test_cases", name: "fk_course_assessment_answer_bbb492885b1e3dca4433b8af8cb95906", on_update: :no_action, on_delete: :no_action}
-    t.boolean "passed",          null: false
+    t.integer "auto_grading_id", :null=>false, :index=>{:name=>"fk__course_assessment_answe_57b22f114b54911fd4e1519680ebfd49"}, :foreign_key=>{:references=>"course_assessment_answer_programming_auto_gradings", :name=>"fk_course_assessment_answer_e3d785447112439bb306849be8690102", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "test_case_id",    :index=>{:name=>"fk__course_assessment_answe_29a2568d5e2fb3a47c0561815786f9ab"}, :foreign_key=>{:references=>"course_assessment_question_programming_test_cases", :name=>"fk_course_assessment_answer_bbb492885b1e3dca4433b8af8cb95906", :on_update=>:no_action, :on_delete=>:no_action}
+    t.boolean "passed",          :null=>false
     t.text    "message"
   end
 
   create_table "course_assessment_answer_programming_files", force: :cascade do |t|
-    t.integer "answer_id", null: false, index: {name: "fk__course_assessment_answer_programming_files_answer_id"}, foreign_key: {references: "course_assessment_answer_programming", name: "fk_course_assessment_answer_programming_files_answer_id", on_update: :no_action, on_delete: :no_action}
-    t.string  "filename",  limit: 255,              null: false
-    t.text    "content",   default: "", null: false
+    t.integer "answer_id", :null=>false, :index=>{:name=>"fk__course_assessment_answer_programming_files_answer_id"}, :foreign_key=>{:references=>"course_assessment_answer_programming", :name=>"fk_course_assessment_answer_programming_files_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string  "filename",  :limit=>255, :null=>false
+    t.text    "content",   :default=>"", :null=>false
   end
-  add_index "course_assessment_answer_programming_files", ["answer_id", "filename"], name: "index_course_assessment_answer_programming_files_filename", unique: true, case_sensitive: false
+  add_index "course_assessment_answer_programming_files", ["answer_id", "filename"], :name=>"index_course_assessment_answer_programming_files_filename", :unique=>true, :case_sensitive=>false
 
   create_table "course_assessment_answer_programming_file_annotations", force: :cascade do |t|
-    t.integer "file_id", null: false, index: {name: "fk__course_assessment_answe_09c4b638af92d0f8252d7cdef59bd6f3"}, foreign_key: {references: "course_assessment_answer_programming_files", name: "fk_course_assessment_answer_ed21459e7a2a5034dcf43a14812cb17d", on_update: :no_action, on_delete: :no_action}
-    t.integer "line",    null: false
+    t.integer "file_id", :null=>false, :index=>{:name=>"fk__course_assessment_answe_09c4b638af92d0f8252d7cdef59bd6f3"}, :foreign_key=>{:references=>"course_assessment_answer_programming_files", :name=>"fk_course_assessment_answer_ed21459e7a2a5034dcf43a14812cb17d", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "line",    :null=>false
   end
 
   create_table "course_assessment_answer_text_responses", force: :cascade do |t|
@@ -267,367 +268,367 @@ ActiveRecord::Schema.define(version: 20160716091234) do
   end
 
   create_table "course_assessment_programming_evaluations", force: :cascade do |t|
-    t.integer  "course_id",    null: false, index: {name: "fk__course_assessment_programming_evaluations_course_id"}, foreign_key: {references: "courses", name: "fk_course_assessment_programming_evaluations_course_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "language_id",  null: false, index: {name: "fk__course_assessment_programming_evaluations_language_id"}, foreign_key: {references: "polyglot_languages", name: "fk_course_assessment_programming_evaluations_language_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "package_path", limit: 255, null: false
-    t.integer  "memory_limit", comment: "Memory limit, in MiB"
-    t.integer  "time_limit",   comment: "Time limit, in seconds"
-    t.string   "status",       limit: 255, null: false
-    t.integer  "evaluator_id", index: {name: "fk__course_assessment_programming_evaluations_evaluator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_programming_evaluations_evaluator_id", on_update: :no_action, on_delete: :no_action}
+    t.integer  "course_id",    :null=>false, :index=>{:name=>"fk__course_assessment_programming_evaluations_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_programming_evaluations_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "language_id",  :null=>false, :index=>{:name=>"fk__course_assessment_programming_evaluations_language_id"}, :foreign_key=>{:references=>"polyglot_languages", :name=>"fk_course_assessment_programming_evaluations_language_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "package_path", :limit=>255, :null=>false
+    t.integer  "memory_limit", :comment=>"Memory limit, in MiB"
+    t.integer  "time_limit",   :comment=>"Time limit, in seconds"
+    t.string   "status",       :limit=>255, :null=>false
+    t.integer  "evaluator_id", :index=>{:name=>"fk__course_assessment_programming_evaluations_evaluator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_programming_evaluations_evaluator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "assigned_at"
     t.text     "stdout"
     t.text     "stderr"
     t.text     "test_report"
     t.integer  "exit_code"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",   :null=>false
+    t.datetime "updated_at",   :null=>false
   end
 
   create_table "course_assessment_question_programming_template_files", force: :cascade do |t|
-    t.integer "question_id", null: false, index: {name: "fk__course_assessment_quest_dbf3aed51f19fcc63a25d296a057dd1f"}, foreign_key: {references: "course_assessment_question_programming", name: "fk_course_assessment_questi_0788633b496294e558f55f2b41bc7c45", on_update: :no_action, on_delete: :no_action}
-    t.string  "filename",    limit: 255, null: false
-    t.text    "content",     null: false
+    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_assessment_quest_dbf3aed51f19fcc63a25d296a057dd1f"}, :foreign_key=>{:references=>"course_assessment_question_programming", :name=>"fk_course_assessment_questi_0788633b496294e558f55f2b41bc7c45", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string  "filename",    :limit=>255, :null=>false
+    t.text    "content",     :null=>false
   end
-  add_index "course_assessment_question_programming_template_files", ["question_id", "filename"], name: "index_course_assessment_question_programming_template_filenames", unique: true, case_sensitive: false
+  add_index "course_assessment_question_programming_template_files", ["question_id", "filename"], :name=>"index_course_assessment_question_programming_template_filenames", :unique=>true, :case_sensitive=>false
 
   create_table "course_assessment_question_text_responses", force: :cascade do |t|
   end
 
   create_table "course_assessment_question_text_response_solutions", force: :cascade do |t|
-    t.integer "question_id",   null: false, index: {name: "fk__course_assessment_text_response_solution_question"}, foreign_key: {references: "course_assessment_question_text_responses", name: "fk_course_assessment_questi_2fbeabfad04f21c2d05c8b2d9100d1c4", on_update: :no_action, on_delete: :no_action}
-    t.integer "solution_type", default: 0, null: false
-    t.text    "solution",      null: false
-    t.integer "grade",         default: 0, null: false
+    t.integer "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_text_response_solution_question"}, :foreign_key=>{:references=>"course_assessment_question_text_responses", :name=>"fk_course_assessment_questi_2fbeabfad04f21c2d05c8b2d9100d1c4", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "solution_type", :default=>0, :null=>false
+    t.text    "solution",      :null=>false
+    t.integer "grade",         :default=>0, :null=>false
     t.text    "explanation"
   end
 
   create_table "course_assessment_skill_branches", force: :cascade do |t|
-    t.integer  "course_id",   null: false, index: {name: "fk__course_assessment_skill_branches_course_id"}, foreign_key: {references: "courses", name: "fk_course_assessment_skill_branches_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",       limit: 255, null: false
-    t.text     "description", null: false
-    t.integer  "creator_id",  null: false, index: {name: "fk__course_assessment_skill_branches_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skill_branches_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__course_assessment_skill_branches_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skill_branches_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_skill_branches_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",       :limit=>255, :null=>false
+    t.text     "description", :null=>false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skill_branches_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skill_branches_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_assessment_skills", force: :cascade do |t|
-    t.integer  "course_id",       null: false, index: {name: "fk__course_assessment_skills_course_id"}, foreign_key: {references: "courses", name: "fk_course_assessment_skills_course_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "skill_branch_id", index: {name: "fk__course_assessment_skills_skill_branch_id"}, foreign_key: {references: "course_assessment_skill_branches", name: "fk_course_assessment_skills_skill_branch_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",           limit: 255, null: false
-    t.text     "description",     null: false
-    t.integer  "creator_id",      null: false, index: {name: "fk__course_assessment_skills_creator_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skills_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",      null: false, index: {name: "fk__course_assessment_skills_updater_id"}, foreign_key: {references: "users", name: "fk_course_assessment_skills_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.integer  "course_id",       :null=>false, :index=>{:name=>"fk__course_assessment_skills_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_skills_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "skill_branch_id", :index=>{:name=>"fk__course_assessment_skills_skill_branch_id"}, :foreign_key=>{:references=>"course_assessment_skill_branches", :name=>"fk_course_assessment_skills_skill_branch_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",           :limit=>255, :null=>false
+    t.text     "description",     :null=>false
+    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skills_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skills_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",      :null=>false
+    t.datetime "updated_at",      :null=>false
   end
 
   create_table "course_assessment_questions_skills", force: :cascade do |t|
-    t.integer "question_id", null: false, index: {name: "course_assessment_question_skills_question_index"}, foreign_key: {references: "course_assessment_questions", name: "fk_course_assessment_questions_skills_question_id", on_update: :no_action, on_delete: :no_action}
-    t.integer "skill_id",    null: false, index: {name: "course_assessment_question_skills_skill_index"}, foreign_key: {references: "course_assessment_skills", name: "fk_course_assessment_questions_skills_skill_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "question_id", :null=>false, :index=>{:name=>"course_assessment_question_skills_question_index"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_questions_skills_question_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "skill_id",    :null=>false, :index=>{:name=>"course_assessment_question_skills_skill_index"}, :foreign_key=>{:references=>"course_assessment_skills", :name=>"fk_course_assessment_questions_skills_skill_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
 
   create_table "course_condition_achievements", force: :cascade do |t|
-    t.integer "achievement_id", null: false, index: {name: "fk__course_condition_achievements_achievement_id"}, foreign_key: {references: "course_achievements", name: "fk_course_condition_achievements_achievement_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "achievement_id", :null=>false, :index=>{:name=>"fk__course_condition_achievements_achievement_id"}, :foreign_key=>{:references=>"course_achievements", :name=>"fk_course_condition_achievements_achievement_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
 
   create_table "course_condition_assessments", force: :cascade do |t|
-    t.integer "assessment_id",            null: false, index: {name: "fk__course_condition_assessments_assessment_id"}, foreign_key: {references: "course_assessments", name: "fk_course_condition_assessments_assessment_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "assessment_id",            :null=>false, :index=>{:name=>"fk__course_condition_assessments_assessment_id"}, :foreign_key=>{:references=>"course_assessments", :name=>"fk_course_condition_assessments_assessment_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.float   "minimum_grade_percentage"
   end
 
   create_table "course_condition_levels", force: :cascade do |t|
-    t.integer "minimum_level", null: false
+    t.integer "minimum_level", :null=>false
   end
 
   create_table "course_conditions", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",     limit: 255, index: {name: "index_course_conditions_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
-    t.integer  "course_id",        null: false, index: {name: "fk__course_conditions_course_id"}, foreign_key: {references: "courses", name: "fk_course_conditions_course_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "conditional_id",   null: false
-    t.string   "conditional_type", limit: 255, null: false, index: {name: "index_course_conditions_on_conditional_type_and_conditional_id", with: ["conditional_id"]}
-    t.integer  "creator_id",       null: false, index: {name: "fk__course_conditions_creator_id"}, foreign_key: {references: "users", name: "fk_course_conditions_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",       null: false, index: {name: "fk__course_conditions_updater_id"}, foreign_key: {references: "users", name: "fk_course_conditions_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.string   "actable_type",     :limit=>255, :index=>{:name=>"index_course_conditions_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
+    t.integer  "course_id",        :null=>false, :index=>{:name=>"fk__course_conditions_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_conditions_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "conditional_id",   :null=>false
+    t.string   "conditional_type", :limit=>255, :null=>false, :index=>{:name=>"index_course_conditions_on_conditional_type_and_conditional_id", :with=>["conditional_id"]}
+    t.integer  "creator_id",       :null=>false, :index=>{:name=>"fk__course_conditions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_conditions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",       :null=>false, :index=>{:name=>"fk__course_conditions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_conditions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",       :null=>false
+    t.datetime "updated_at",       :null=>false
   end
 
   create_table "course_discussion_topics", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",        limit: 255, index: {name: "index_course_discussion_topics_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
-    t.integer  "course_id",           null: false, index: {name: "fk__course_discussion_topics_course_id"}, foreign_key: {references: "courses", name: "fk_course_discussion_topics_course_id", on_update: :no_action, on_delete: :no_action}
-    t.boolean  "pending_staff_reply", default: false, null: false
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.string   "actable_type",        :limit=>255, :index=>{:name=>"index_course_discussion_topics_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
+    t.integer  "course_id",           :null=>false, :index=>{:name=>"fk__course_discussion_topics_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_discussion_topics_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.boolean  "pending_staff_reply", :default=>false, :null=>false
+    t.datetime "created_at",          :null=>false
+    t.datetime "updated_at",          :null=>false
   end
 
   create_table "course_discussion_posts", force: :cascade do |t|
-    t.integer  "parent_id",  index: {name: "fk__course_discussion_posts_parent_id"}, foreign_key: {references: "course_discussion_posts", name: "fk_course_discussion_posts_parent_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "topic_id",   null: false, index: {name: "fk__course_discussion_posts_topic_id"}, foreign_key: {references: "course_discussion_topics", name: "fk_course_discussion_posts_topic_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",      limit: 255, null: false
+    t.integer  "parent_id",  :index=>{:name=>"fk__course_discussion_posts_parent_id"}, :foreign_key=>{:references=>"course_discussion_posts", :name=>"fk_course_discussion_posts_parent_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "topic_id",   :null=>false, :index=>{:name=>"fk__course_discussion_posts_topic_id"}, :foreign_key=>{:references=>"course_discussion_topics", :name=>"fk_course_discussion_posts_topic_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",      :limit=>255, :null=>false
     t.text     "text"
-    t.integer  "creator_id", null: false, index: {name: "fk__course_discussion_posts_creator_id"}, foreign_key: {references: "users", name: "fk_course_discussion_posts_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id", null: false, index: {name: "fk__course_discussion_posts_updater_id"}, foreign_key: {references: "users", name: "fk_course_discussion_posts_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_posts_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_posts_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "course_discussion_post_votes", force: :cascade do |t|
-    t.integer  "post_id",    null: false, index: {name: "fk__course_discussion_post_votes_post_id"}, foreign_key: {references: "course_discussion_posts", name: "fk_course_discussion_post_votes_post_id", on_update: :no_action, on_delete: :no_action}
-    t.boolean  "vote_flag",  null: false
-    t.integer  "creator_id", null: false, index: {name: "fk__course_discussion_post_votes_creator_id"}, foreign_key: {references: "users", name: "fk_course_discussion_post_votes_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id", null: false, index: {name: "fk__course_discussion_post_votes_updater_id"}, foreign_key: {references: "users", name: "fk_course_discussion_post_votes_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "post_id",    :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_post_id"}, :foreign_key=>{:references=>"course_discussion_posts", :name=>"fk_course_discussion_post_votes_post_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.boolean  "vote_flag",  :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_post_votes_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_post_votes_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
-  add_index "course_discussion_post_votes", ["post_id", "creator_id"], name: "index_course_discussion_post_votes_on_post_id_and_creator_id", unique: true
+  add_index "course_discussion_post_votes", ["post_id", "creator_id"], :name=>"index_course_discussion_post_votes_on_post_id_and_creator_id", :unique=>true
 
   create_table "course_discussion_topic_subscriptions", force: :cascade do |t|
-    t.integer "topic_id", null: false, index: {name: "fk__course_discussion_topic_subscriptions_topic_id"}, foreign_key: {references: "course_discussion_topics", name: "fk_course_discussion_topic_subscriptions_topic_id", on_update: :no_action, on_delete: :no_action}
-    t.integer "user_id",  null: false, index: {name: "fk__course_discussion_topic_subscriptions_user_id"}, foreign_key: {references: "users", name: "fk_course_discussion_topic_subscriptions_user_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "topic_id", :null=>false, :index=>{:name=>"fk__course_discussion_topic_subscriptions_topic_id"}, :foreign_key=>{:references=>"course_discussion_topics", :name=>"fk_course_discussion_topic_subscriptions_topic_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "user_id",  :null=>false, :index=>{:name=>"fk__course_discussion_topic_subscriptions_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_topic_subscriptions_user_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
-  add_index "course_discussion_topic_subscriptions", ["topic_id", "user_id"], name: "index_topic_subscriptions_on_topic_id_and_user_id", unique: true
+  add_index "course_discussion_topic_subscriptions", ["topic_id", "user_id"], :name=>"index_topic_subscriptions_on_topic_id_and_user_id", :unique=>true
 
   create_table "course_users", force: :cascade do |t|
-    t.integer  "course_id",      null: false, index: {name: "fk__course_users_course_id"}, foreign_key: {references: "courses", name: "fk_course_users_course_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "user_id",        index: {name: "fk__course_users_user_id"}, foreign_key: {references: "users", name: "fk_course_users_user_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "workflow_state", limit: 255,                 null: false
-    t.integer  "role",           default: 0,     null: false
-    t.string   "name",           limit: 255,                 null: false
-    t.boolean  "phantom",        default: false, null: false
+    t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_users_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_users_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "user_id",        :index=>{:name=>"fk__course_users_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_users_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "workflow_state", :limit=>255, :null=>false
+    t.integer  "role",           :default=>0, :null=>false
+    t.string   "name",           :limit=>255, :null=>false
+    t.boolean  "phantom",        :default=>false, :null=>false
     t.datetime "last_active_at"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.integer  "creator_id",     null: false, index: {name: "fk__course_users_creator_id"}, foreign_key: {references: "users", name: "fk_course_users_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",     null: false, index: {name: "fk__course_users_updater_id"}, foreign_key: {references: "users", name: "fk_course_users_updater_id", on_update: :no_action, on_delete: :no_action}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_users_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_users_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_users_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_users_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
-  add_index "course_users", ["course_id", "user_id"], name: "index_course_users_on_course_id_and_user_id", unique: true
+  add_index "course_users", ["course_id", "user_id"], :name=>"index_course_users_on_course_id_and_user_id", :unique=>true
 
   create_table "course_experience_points_records", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",   limit: 255, index: {name: "index_course_experience_points_records_on_actable", with: ["actable_id"], unique: true}
+    t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_experience_points_records_on_actable", :with=>["actable_id"], :unique=>true}
     t.integer  "points_awarded"
-    t.integer  "course_user_id", null: false, index: {name: "fk__course_experience_points_records_course_user_id"}, foreign_key: {references: "course_users", name: "fk_course_experience_points_records_course_user_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "reason",         limit: 255
-    t.integer  "creator_id",     null: false, index: {name: "fk__course_experience_points_records_creator_id"}, foreign_key: {references: "users", name: "fk_course_experience_points_records_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",     null: false, index: {name: "fk__course_experience_points_records_updater_id"}, foreign_key: {references: "users", name: "fk_course_experience_points_records_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.integer  "course_user_id", :null=>false, :index=>{:name=>"fk__course_experience_points_records_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_experience_points_records_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "reason",         :limit=>255
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_experience_points_records_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_experience_points_records_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
   end
 
   create_table "course_forums", force: :cascade do |t|
-    t.integer  "course_id",   null: false, index: {name: "fk__course_forums_course_id"}, foreign_key: {references: "courses", name: "fk_course_forums_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "name",        limit: 255, null: false
-    t.string   "slug",        limit: 255
+    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_forums_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_forums_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "name",        :limit=>255, :null=>false
+    t.string   "slug",        :limit=>255
     t.text     "description"
-    t.integer  "creator_id",  null: false, index: {name: "fk__course_forums_creator_id"}, foreign_key: {references: "users", name: "fk_course_forums_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__course_forums_updater_id"}, foreign_key: {references: "users", name: "fk_course_forums_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_forums_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forums_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_forums_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forums_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
-  add_index "course_forums", ["course_id", "slug"], name: "index_course_forums_on_course_id_and_slug", unique: true
+  add_index "course_forums", ["course_id", "slug"], :name=>"index_course_forums_on_course_id_and_slug", :unique=>true
 
   create_table "course_forum_subscriptions", force: :cascade do |t|
-    t.integer "forum_id", null: false, index: {name: "fk__course_forum_subscriptions_forum_id"}, foreign_key: {references: "course_forums", name: "fk_course_forum_subscriptions_forum_id", on_update: :no_action, on_delete: :no_action}
-    t.integer "user_id",  null: false, index: {name: "fk__course_forum_subscriptions_user_id"}, foreign_key: {references: "users", name: "fk_course_forum_subscriptions_user_id", on_update: :no_action, on_delete: :no_action}
+    t.integer "forum_id", :null=>false, :index=>{:name=>"fk__course_forum_subscriptions_forum_id"}, :foreign_key=>{:references=>"course_forums", :name=>"fk_course_forum_subscriptions_forum_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "user_id",  :null=>false, :index=>{:name=>"fk__course_forum_subscriptions_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_subscriptions_user_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
-  add_index "course_forum_subscriptions", ["forum_id", "user_id"], name: "index_course_forum_subscriptions_on_forum_id_and_user_id", unique: true
+  add_index "course_forum_subscriptions", ["forum_id", "user_id"], :name=>"index_course_forum_subscriptions_on_forum_id_and_user_id", :unique=>true
 
   create_table "course_forum_topics", force: :cascade do |t|
-    t.integer  "forum_id",   null: false, index: {name: "fk__course_forum_topics_forum_id"}, foreign_key: {references: "course_forums", name: "fk_course_forum_topics_forum_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",      limit: 255,                 null: false
-    t.string   "slug",       limit: 255
-    t.boolean  "locked",     default: false
-    t.boolean  "hidden",     default: false
-    t.integer  "topic_type", default: 0
-    t.integer  "creator_id", null: false, index: {name: "fk__course_forum_topics_creator_id"}, foreign_key: {references: "users", name: "fk_course_forum_topics_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id", null: false, index: {name: "fk__course_forum_topics_updater_id"}, foreign_key: {references: "users", name: "fk_course_forum_topics_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "forum_id",   :null=>false, :index=>{:name=>"fk__course_forum_topics_forum_id"}, :foreign_key=>{:references=>"course_forums", :name=>"fk_course_forum_topics_forum_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",      :limit=>255, :null=>false
+    t.string   "slug",       :limit=>255
+    t.boolean  "locked",     :default=>false
+    t.boolean  "hidden",     :default=>false
+    t.integer  "topic_type", :default=>0
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_forum_topics_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_forum_topics_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
-  add_index "course_forum_topics", ["forum_id", "slug"], name: "index_course_forum_topics_on_forum_id_and_slug", unique: true
+  add_index "course_forum_topics", ["forum_id", "slug"], :name=>"index_course_forum_topics_on_forum_id_and_slug", :unique=>true
 
   create_table "course_forum_topic_views", force: :cascade do |t|
-    t.integer  "topic_id",   null: false, index: {name: "fk__course_forum_topic_views_topic_id"}, foreign_key: {references: "course_forum_topics", name: "fk_course_forum_topic_views_topic_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "user_id",    null: false, index: {name: "fk__course_forum_topic_views_user_id"}, foreign_key: {references: "users", name: "fk_course_forum_topic_views_user_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "topic_id",   :null=>false, :index=>{:name=>"fk__course_forum_topic_views_topic_id"}, :foreign_key=>{:references=>"course_forum_topics", :name=>"fk_course_forum_topic_views_topic_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__course_forum_topic_views_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topic_views_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "course_groups", force: :cascade do |t|
-    t.integer  "course_id",  null: false, index: {name: "fk__course_groups_course_id"}, foreign_key: {references: "courses", name: "fk_course_groups_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "name",       limit: 255, default: "", null: false
-    t.integer  "creator_id", null: false, index: {name: "fk__course_groups_creator_id"}, foreign_key: {references: "users", name: "fk_course_groups_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id", null: false, index: {name: "fk__course_groups_updater_id"}, foreign_key: {references: "users", name: "fk_course_groups_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_groups_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_groups_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "name",       :limit=>255, :default=>"", :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_groups_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_groups_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_groups_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_groups_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
-  add_index "course_groups", ["course_id", "name"], name: "index_course_groups_on_course_id_and_name", unique: true
+  add_index "course_groups", ["course_id", "name"], :name=>"index_course_groups_on_course_id_and_name", :unique=>true
 
   create_table "course_group_users", force: :cascade do |t|
-    t.integer  "group_id",       null: false, index: {name: "fk__course_group_users_course_group_id"}, foreign_key: {references: "course_groups", name: "fk_course_group_users_course_group_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "course_user_id", null: false, index: {name: "fk__course_group_users_course_user_id"}, foreign_key: {references: "course_users", name: "fk_course_group_users_course_user_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "role",           null: false
-    t.integer  "creator_id",     null: false, index: {name: "fk__course_group_users_creator_id"}, foreign_key: {references: "users", name: "fk_course_group_users_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",     null: false, index: {name: "fk__course_group_users_updater_id"}, foreign_key: {references: "users", name: "fk_course_group_users_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.integer  "group_id",       :null=>false, :index=>{:name=>"fk__course_group_users_course_group_id"}, :foreign_key=>{:references=>"course_groups", :name=>"fk_course_group_users_course_group_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_user_id", :null=>false, :index=>{:name=>"fk__course_group_users_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_group_users_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "role",           :null=>false
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_group_users_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_group_users_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_group_users_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_group_users_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
   end
-  add_index "course_group_users", ["course_user_id", "group_id"], name: "index_course_group_users_on_course_user_id_and_course_group_id", unique: true
+  add_index "course_group_users", ["course_user_id", "group_id"], :name=>"index_course_group_users_on_course_user_id_and_course_group_id", :unique=>true
 
   create_table "course_lesson_plan_events", force: :cascade do |t|
-    t.string  "location",   limit: 255
-    t.integer "event_type", default: 0, null: false
+    t.string  "location",   :limit=>255
+    t.integer "event_type", :default=>0, :null=>false
   end
 
   create_table "course_lesson_plan_items", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",    limit: 255, index: {name: "index_course_lesson_plan_items_on_actable_type_and_actable_id", with: ["actable_id"], unique: true}
-    t.integer  "course_id",       null: false, index: {name: "fk__course_lesson_plan_items_course_id"}, foreign_key: {references: "courses", name: "fk_course_lesson_plan_items_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",           limit: 255,                 null: false
+    t.string   "actable_type",    :limit=>255, :index=>{:name=>"index_course_lesson_plan_items_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
+    t.integer  "course_id",       :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_items_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",           :limit=>255, :null=>false
     t.text     "description"
-    t.boolean  "draft",           default: false, null: false
-    t.integer  "base_exp",        null: false
-    t.integer  "time_bonus_exp",  null: false
-    t.integer  "extra_bonus_exp", null: false
-    t.datetime "start_at",        null: false
+    t.boolean  "draft",           :default=>false, :null=>false
+    t.integer  "base_exp",        :null=>false
+    t.integer  "time_bonus_exp",  :null=>false
+    t.integer  "extra_bonus_exp", :null=>false
+    t.datetime "start_at",        :null=>false
     t.datetime "bonus_end_at"
     t.datetime "end_at"
-    t.integer  "creator_id",      null: false, index: {name: "fk__course_lesson_plan_items_creator_id"}, foreign_key: {references: "users", name: "fk_course_lesson_plan_items_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",      null: false, index: {name: "fk__course_lesson_plan_items_updater_id"}, foreign_key: {references: "users", name: "fk_course_lesson_plan_items_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",      :null=>false
+    t.datetime "updated_at",      :null=>false
   end
 
   create_table "course_lesson_plan_milestones", force: :cascade do |t|
-    t.integer  "course_id",   index: {name: "fk__course_lesson_plan_milestones_course_id"}, foreign_key: {references: "courses", name: "fk_course_lesson_plan_milestones_course_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",       limit: 255, null: false
+    t.integer  "course_id",   :index=>{:name=>"fk__course_lesson_plan_milestones_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_milestones_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",       :limit=>255, :null=>false
     t.text     "description"
-    t.datetime "start_at",    null: false
-    t.integer  "creator_id",  null: false, index: {name: "fk__course_lesson_plan_milestones_creator_id"}, foreign_key: {references: "users", name: "fk_course_lesson_plan_milestones_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__course_lesson_plan_milestones_updater_id"}, foreign_key: {references: "users", name: "fk_course_lesson_plan_milestones_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "start_at",    :null=>false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_milestones_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_milestones_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_levels", force: :cascade do |t|
-    t.integer  "course_id",                   null: false, index: {name: "fk__course_levels_course_id"}, foreign_key: {references: "courses", name: "fk_course_levels_course_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "experience_points_threshold", null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.integer  "course_id",                   :null=>false, :index=>{:name=>"fk__course_levels_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_levels_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "experience_points_threshold", :null=>false
+    t.datetime "created_at",                  :null=>false
+    t.datetime "updated_at",                  :null=>false
   end
-  add_index "course_levels", ["course_id", "experience_points_threshold"], name: "index_experience_points_threshold_on_course_id", unique: true
+  add_index "course_levels", ["course_id", "experience_points_threshold"], :name=>"index_experience_points_threshold_on_course_id", :unique=>true
 
   create_table "course_material_folders", force: :cascade do |t|
-    t.integer  "parent_id",          index: {name: "fk__course_material_folders_parent_id"}, foreign_key: {references: "course_material_folders", name: "fk_course_material_folders_parent_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "course_id",          null: false, index: {name: "fk__course_material_folders_course_id"}, foreign_key: {references: "courses", name: "fk_course_material_folders_course_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "owner_id",           index: {name: "index_course_material_folders_on_owner_id_and_owner_type", with: ["owner_type"], unique: true}
-    t.string   "owner_type",         limit: 255, index: {name: "fk__course_material_folders_owner_id", with: ["owner_id"]}
-    t.string   "name",               limit: 255,                 null: false
+    t.integer  "parent_id",          :index=>{:name=>"fk__course_material_folders_parent_id"}, :foreign_key=>{:references=>"course_material_folders", :name=>"fk_course_material_folders_parent_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",          :null=>false, :index=>{:name=>"fk__course_material_folders_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_material_folders_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "owner_id",           :index=>{:name=>"index_course_material_folders_on_owner_id_and_owner_type", :with=>["owner_type"], :unique=>true}
+    t.string   "owner_type",         :limit=>255, :index=>{:name=>"fk__course_material_folders_owner_id", :with=>["owner_id"]}
+    t.string   "name",               :limit=>255, :null=>false
     t.text     "description"
-    t.boolean  "can_student_upload", default: false, null: false
-    t.datetime "start_at",           null: false
+    t.boolean  "can_student_upload", :default=>false, :null=>false
+    t.datetime "start_at",           :null=>false
     t.datetime "end_at"
-    t.integer  "creator_id",         null: false, index: {name: "fk__course_material_folders_creator_id"}, foreign_key: {references: "users", name: "fk_course_material_folders_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",         null: false, index: {name: "fk__course_material_folders_updater_id"}, foreign_key: {references: "users", name: "fk_course_material_folders_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.integer  "creator_id",         :null=>false, :index=>{:name=>"fk__course_material_folders_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_material_folders_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",         :null=>false, :index=>{:name=>"fk__course_material_folders_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_material_folders_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",         :null=>false
+    t.datetime "updated_at",         :null=>false
   end
-  add_index "course_material_folders", ["parent_id", "name"], name: "index_course_material_folders_on_parent_id_and_name", unique: true, case_sensitive: false
+  add_index "course_material_folders", ["parent_id", "name"], :name=>"index_course_material_folders_on_parent_id_and_name", :unique=>true, :case_sensitive=>false
 
   create_table "course_materials", force: :cascade do |t|
-    t.integer  "folder_id",   null: false, index: {name: "fk__course_materials_folder_id"}, foreign_key: {references: "course_material_folders", name: "fk_course_materials_folder_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "name",        limit: 255, null: false
+    t.integer  "folder_id",   :null=>false, :index=>{:name=>"fk__course_materials_folder_id"}, :foreign_key=>{:references=>"course_material_folders", :name=>"fk_course_materials_folder_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "name",        :limit=>255, :null=>false
     t.text     "description"
-    t.integer  "creator_id",  null: false, index: {name: "fk__course_materials_creator_id"}, foreign_key: {references: "users", name: "fk_course_materials_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__course_materials_updater_id"}, foreign_key: {references: "users", name: "fk_course_materials_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_materials_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_materials_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_materials_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_materials_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
-  add_index "course_materials", ["folder_id", "name"], name: "index_course_materials_on_folder_id_and_name", unique: true, case_sensitive: false
+  add_index "course_materials", ["folder_id", "name"], :name=>"index_course_materials_on_folder_id_and_name", :unique=>true, :case_sensitive=>false
 
   create_table "course_notifications", force: :cascade do |t|
-    t.integer  "activity_id",       null: false, index: {name: "index_course_notifications_on_activity_id"}, foreign_key: {references: "activities", name: "fk_course_notifications_activity_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "course_id",         null: false, index: {name: "index_course_notifications_on_course_id"}, foreign_key: {references: "courses", name: "fk_course_notifications_course_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "notification_type", default: 0, null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.integer  "activity_id",       :null=>false, :index=>{:name=>"index_course_notifications_on_activity_id"}, :foreign_key=>{:references=>"activities", :name=>"fk_course_notifications_activity_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",         :null=>false, :index=>{:name=>"index_course_notifications_on_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_notifications_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "notification_type", :default=>0, :null=>false
+    t.datetime "created_at",        :null=>false
+    t.datetime "updated_at",        :null=>false
   end
 
   create_table "course_user_achievements", force: :cascade do |t|
-    t.integer  "course_user_id", index: {name: "fk__course_user_achievements_course_user_id"}, foreign_key: {references: "course_users", name: "fk_course_user_achievements_course_user_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "achievement_id", index: {name: "fk__course_user_achievements_achievement_id"}, foreign_key: {references: "course_achievements", name: "fk_course_user_achievements_achievement_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "obtained_at",    null: false
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.integer  "course_user_id", :index=>{:name=>"fk__course_user_achievements_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_user_achievements_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "achievement_id", :index=>{:name=>"fk__course_user_achievements_achievement_id"}, :foreign_key=>{:references=>"course_achievements", :name=>"fk_course_user_achievements_achievement_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "obtained_at",    :null=>false
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
   end
-  add_index "course_user_achievements", ["course_user_id", "achievement_id"], name: "index_user_achievements_on_course_user_id_and_achievement_id", unique: true
+  add_index "course_user_achievements", ["course_user_id", "achievement_id"], :name=>"index_user_achievements_on_course_user_id_and_achievement_id", :unique=>true
 
   create_table "user_emails", force: :cascade do |t|
-    t.boolean  "primary",              default: false, null: false
-    t.integer  "user_id",              index: {name: "index_user_emails_on_user_id_and_primary", with: ["primary"], unique: true, where: "(\"primary\" <> false)"}, foreign_key: {references: "users", name: "fk_user_emails_user_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "email",                limit: 255,                 null: false, index: {name: "index_user_emails_on_email", unique: true, case_sensitive: false}
-    t.string   "confirmation_token",   limit: 255, index: {name: "index_user_emails_on_confirmation_token", unique: true}
+    t.boolean  "primary",              :default=>false, :null=>false
+    t.integer  "user_id",              :index=>{:name=>"index_user_emails_on_user_id_and_primary", :with=>["primary"], :unique=>true, :where=>"(\"primary\" <> false)"}, :foreign_key=>{:references=>"users", :name=>"fk_user_emails_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "email",                :limit=>255, :null=>false, :index=>{:name=>"index_user_emails_on_email", :unique=>true, :case_sensitive=>false}
+    t.string   "confirmation_token",   :limit=>255, :index=>{:name=>"index_user_emails_on_confirmation_token", :unique=>true}
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email",    limit: 255
+    t.string   "unconfirmed_email",    :limit=>255
   end
 
   create_table "course_user_invitations", force: :cascade do |t|
-    t.integer  "course_user_id", null: false, index: {name: "index_course_user_invitations_on_course_user_id", unique: true}, foreign_key: {references: "course_users", name: "fk_course_user_invitations_course_user_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "user_email_id",  null: false, index: {name: "fk__course_user_invitations_user_email_id"}, foreign_key: {references: "user_emails", name: "fk_course_user_invitations_user_email_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "invitation_key", limit: 16, null: false, index: {name: "index_course_user_invitations_on_invitation_key", unique: true}
-    t.integer  "creator_id",     null: false, index: {name: "fk__course_user_invitations_creator_id"}, foreign_key: {references: "users", name: "fk_course_user_invitations_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",     null: false, index: {name: "fk__course_user_invitations_updater_id"}, foreign_key: {references: "users", name: "fk_course_user_invitations_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.integer  "course_user_id", :null=>false, :index=>{:name=>"index_course_user_invitations_on_course_user_id", :unique=>true}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_user_invitations_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "user_email_id",  :null=>false, :index=>{:name=>"fk__course_user_invitations_user_email_id"}, :foreign_key=>{:references=>"user_emails", :name=>"fk_course_user_invitations_user_email_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "invitation_key", :limit=>16, :null=>false, :index=>{:name=>"index_course_user_invitations_on_invitation_key", :unique=>true}
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
   end
 
   create_table "generic_announcements", force: :cascade do |t|
-    t.string   "type",        limit: 255, null: false
-    t.integer  "instance_id", comment: "The instance this announcement is associated with. This only applies to instance announcements.", index: {name: "fk__generic_announcements_instance_id"}, foreign_key: {references: "instances", name: "fk_generic_announcements_instance_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "title",       limit: 255, null: false
+    t.string   "type",        :limit=>255, :null=>false
+    t.integer  "instance_id", :comment=>"The instance this announcement is associated with. This only applies to instance announcements.", :index=>{:name=>"fk__generic_announcements_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_generic_announcements_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",       :limit=>255, :null=>false
     t.text     "content"
-    t.datetime "start_at",    null: false
-    t.datetime "end_at",      null: false
-    t.integer  "creator_id",  null: false, index: {name: "fk__generic_announcements_creator_id"}, foreign_key: {references: "users", name: "fk_generic_announcements_creator_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "updater_id",  null: false, index: {name: "fk__generic_announcements_updater_id"}, foreign_key: {references: "users", name: "fk_generic_announcements_updater_id", on_update: :no_action, on_delete: :no_action}
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "start_at",    :null=>false
+    t.datetime "end_at",      :null=>false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__generic_announcements_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_generic_announcements_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__generic_announcements_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_generic_announcements_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
 
   create_table "instance_users", force: :cascade do |t|
-    t.integer  "instance_id", null: false, index: {name: "fk__instance_users_instance_id"}, foreign_key: {references: "instances", name: "fk_instance_users_instance_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "user_id",     null: false, foreign_key: {references: "users", name: "fk_instance_users_user_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "role",        default: 0, null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "instance_id", :null=>false, :index=>{:name=>"fk__instance_users_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_instance_users_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "user_id",     :null=>false, :foreign_key=>{:references=>"users", :name=>"fk_instance_users_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "role",        :default=>0, :null=>false
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
   end
-  add_index "instance_users", ["instance_id", "user_id"], name: "index_instance_users_on_instance_id_and_user_id", unique: true
+  add_index "instance_users", ["instance_id", "user_id"], :name=>"index_instance_users_on_instance_id_and_user_id", :unique=>true
 
   create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"
-    t.string   "readable_type", limit: 255, null: false
-    t.integer  "reader_id",     null: false, index: {name: "fk__read_marks_user_id"}, foreign_key: {references: "users", name: "fk_read_marks_user_id", on_update: :no_action, on_delete: :no_action}
+    t.string   "readable_type", :limit=>255, :null=>false
+    t.integer  "reader_id",     :null=>false, :index=>{:name=>"fk__read_marks_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_read_marks_user_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "timestamp"
-    t.string   "reader_type",   limit: 255
+    t.string   "reader_type",   :limit=>255
   end
-  add_index "read_marks", ["reader_id", "reader_type", "readable_type", "readable_id"], name: "read_marks_reader_readable_index"
+  add_index "read_marks", ["reader_id", "reader_type", "readable_type", "readable_id"], :name=>"read_marks_reader_readable_index"
 
   create_table "user_identities", force: :cascade do |t|
-    t.integer  "user_id",    null: false, index: {name: "fk__user_identities_user_id"}, foreign_key: {references: "users", name: "fk_user_identities_user_id", on_update: :no_action, on_delete: :no_action}
-    t.string   "provider",   limit: 255, null: false, index: {name: "index_user_identities_on_provider_and_uid", with: ["uid"], unique: true}
-    t.string   "uid",        limit: 255, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__user_identities_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_user_identities_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "provider",   :limit=>255, :null=>false, :index=>{:name=>"index_user_identities_on_provider_and_uid", :with=>["uid"], :unique=>true}
+    t.string   "uid",        :limit=>255, :null=>false
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "user_notifications", force: :cascade do |t|
-    t.integer  "activity_id",       null: false, index: {name: "index_user_notifications_on_activity_id"}, foreign_key: {references: "activities", name: "fk_user_notifications_activity_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "user_id",           null: false, index: {name: "index_user_notifications_on_user_id"}, foreign_key: {references: "users", name: "fk_user_notifications_user_id", on_update: :no_action, on_delete: :no_action}
-    t.integer  "notification_type", default: 0, null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.integer  "activity_id",       :null=>false, :index=>{:name=>"index_user_notifications_on_activity_id"}, :foreign_key=>{:references=>"activities", :name=>"fk_user_notifications_activity_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "user_id",           :null=>false, :index=>{:name=>"index_user_notifications_on_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_user_notifications_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "notification_type", :default=>0, :null=>false
+    t.datetime "created_at",        :null=>false
+    t.datetime "updated_at",        :null=>false
   end
 
 end

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -37,12 +37,15 @@ RSpec.feature 'Course: Announcements' do
 
       scenario 'I can edit announcements' do
         announcement = create(:course_announcement, course: course)
+        time_zone = user.time_zone || Application.config.x.default_user_time_zone
         visit edit_course_announcement_path(course, announcement)
 
         expect(page).to have_field('announcement_title', with: announcement.title)
         expect(page).to have_field('announcement_content', with: announcement.content)
-        expect(page).to have_field('announcement[start_at]', with: announcement.start_at)
-        expect(page).to have_field('announcement[end_at]', with: announcement.end_at)
+        expect(page).to have_field('announcement[start_at]',
+                                   with: announcement.start_at.in_time_zone(time_zone))
+        expect(page).to have_field('announcement[end_at]',
+                                   with: announcement.end_at.in_time_zone(time_zone))
 
         fill_in 'announcement_title', with: ''
         click_button I18n.t('helpers.submit.announcement.update')

--- a/spec/features/system/admin/instance/instance_announcement_management_spec.rb
+++ b/spec/features/system/admin/instance/instance_announcement_management_spec.rb
@@ -36,12 +36,16 @@ RSpec.feature 'System: Administration: Instance Announcements' do
 
       scenario 'I can edit instance announcements' do
         announcement = create(:instance_announcement, instance: instance)
+        time_zone = user.time_zone || Application.config.x.default_user_time_zone
+
         visit edit_admin_instance_announcement_path(announcement)
 
         expect(page).to have_field('announcement[title]', with: announcement.title)
         expect(page).to have_field('announcement[content]', with: announcement.content)
-        expect(page).to have_field('announcement[start_at]', with: announcement.start_at)
-        expect(page).to have_field('announcement[end_at]', with: announcement.end_at)
+        expect(page).to have_field('announcement[start_at]',
+                                   with: announcement.start_at.in_time_zone(time_zone))
+        expect(page).to have_field('announcement[end_at]',
+                                   with: announcement.end_at.in_time_zone(time_zone))
 
         fill_in 'announcement[title]', with: ''
         click_button I18n.t('helpers.submit.announcement.update')

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -15,18 +15,21 @@ RSpec.feature 'User: Profile' do
       scenario 'I can change my profile' do
         new_name = 'New Name'
         empty_name = ''
+        time_zone = 'Singapore'
 
         fill_in :user_name, with: empty_name
         click_button 'submit'
         expect(page).to have_selector('div.alert-danger')
 
         fill_in :user_name, with: new_name
+        find('#user_time_zone').find(:xpath, "option[@value='#{time_zone}']").select_option
         attach_file :user_profile_photo, File.join(Rails.root, '/spec/fixtures/files/picture.jpg')
         click_button 'submit'
 
         expect(page).to have_selector('div', text: I18n.t('user.profiles.update.success'))
         expect(page).to have_field('user_name', with: new_name)
         expect(user.reload.profile_photo.url).to be_present
+        expect(user.reload.time_zone).to eq(time_zone)
       end
 
       scenario 'I can link my account to facebook' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -154,6 +154,28 @@ RSpec.describe User do
         it { is_expected.to validate_absence_of(:encrypted_password) }
         it { is_expected.to validate_absence_of(:authentication_token) }
       end
+
+      describe '#time_zone' do
+        subject { build(:user) }
+
+        context 'when time_zone is not set' do
+          before { subject.time_zone = nil }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when time_zone is invalid' do
+          before { subject.time_zone = 'LOL' }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when time_zone is valid' do
+          before { subject.time_zone = 'Tokyo' }
+
+          it { is_expected.to be_valid }
+        end
+      end
     end
 
     describe '#send_reset_password_instructions' do


### PR DESCRIPTION
For #1133 

User now is able to set their time zone in account settings. 

Time will be displayed in user's current time zone, it will fall back to the default one in the configuration if not set.

BTW, I haven't investigated why the format of schema.rb changed after `db:migrate`, I suspect it's due to some gem update. Is it same for all of you guys ? @kxmbrian @weiqingtoh 

