### PR TITLE
Implement autograded assessment in submission workflow

### DIFF
--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -218,6 +218,16 @@ RSpec.describe Course::Assessment::Submission do
           expect(submission.answers.all?(&:submitted?)).to be(true)
         end
       end
+
+      context 'when the assessment is autograded' do
+        let(:assessment_traits) { [:with_all_question_types, :autograded] }
+
+        it 'changes the submission state to graded and grade all answers' do
+          submission.finalise!
+          expect(submission.graded?).to be(true)
+          expect(submission.answers.all?(&:graded?)).to be(true)
+        end
+      end
     end
 
     describe '#publish!' do


### PR DESCRIPTION
Fixes #876 

This PR implements the submission workflow states for autograded assessments. 

I've kept the logic of finalising and publishing answers within the `finalise` method, rather than rely on callbacks because it will result in two-staged finalising of a submission, which is complex. 

As such, I rather that `@submission` go straight to `graded` state if the assessment is autograded. 

@allenwq @kxmbrian do you think we need feature specs?