### PR TITLE
Modify the defaults for certain course_user factories to be approved

### DIFF
--- a/spec/controllers/course/admin/admin_controller_spec.rb
+++ b/spec/controllers/course/admin/admin_controller_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe Course::Admin::AdminController do
       subject { get :index, course_id: course }
 
       context 'when the user is a Course Manager' do
-        let(:user) { create(:course_manager, :approved, course: course).user }
+        let(:user) { create(:course_manager, course: course).user }
 
         it { is_expected.to render_template(:index) }
       end
 
       context 'when the user is a Teaching Assistant' do
-        let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+        let(:user) { create(:course_teaching_assistant, course: course).user }
 
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
 
       context 'when the user is a Course Student' do
-        let(:user) { create(:course_student, :approved, course: course).user }
+        let(:user) { create(:course_student, course: course).user }
 
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
@@ -34,7 +34,7 @@ RSpec.describe Course::Admin::AdminController do
       subject { patch :update, course_id: course, course: { title: title } }
 
       context 'when the user is a Course Manager' do
-        let(:user) { create(:course_manager, :approved, course: course).user }
+        let(:user) { create(:course_manager, course: course).user }
 
         it { is_expected.to redirect_to(course_admin_path(course)) }
 
@@ -46,13 +46,13 @@ RSpec.describe Course::Admin::AdminController do
       end
 
       context 'when the user is a Teaching Assistant' do
-        let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+        let(:user) { create(:course_teaching_assistant, course: course).user }
 
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
 
       context 'when the user is a Course Student' do
-        let(:user) { create(:course_student, :approved, course: course).user }
+        let(:user) { create(:course_student, course: course).user }
 
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
@@ -63,7 +63,7 @@ RSpec.describe Course::Admin::AdminController do
       before { controller.instance_variable_set(:@course, course) }
 
       context 'when the user is a Course Manager' do
-        let(:user) { create(:course_manager, :approved, course: course).user }
+        let(:user) { create(:course_manager, course: course).user }
 
         it 'destroys the course' do
           subject
@@ -92,13 +92,13 @@ RSpec.describe Course::Admin::AdminController do
       end
 
       context 'when the user is an Teaching Assistant' do
-        let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+        let(:user) { create(:course_teaching_assistant, course: course).user }
 
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
 
       context 'when the user is a Course Student' do
-        let(:user) { create(:course_student, :approved, course: course).user }
+        let(:user) { create(:course_student, course: course).user }
 
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end

--- a/spec/controllers/course/discussion/topics_controller_spec.rb
+++ b/spec/controllers/course/discussion/topics_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Discussion::TopicsController do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:staff) { create(:course_teaching_assistant, :approved, course: course).user }
+    let(:staff) { create(:course_teaching_assistant, course: course).user }
     let(:student) { create(:course_user, :approved, course: course).user }
     let!(:topic) do
       create(:course_assessment_answer, :with_post, course: course, creator: student).acting_as

--- a/spec/controllers/course/experience_points/disbursement_controller_spec.rb
+++ b/spec/controllers/course/experience_points/disbursement_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Course::ExperiencePoints::DisbursementController, type: :controll
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:course_student) { create(:course_student, :approved, course: course) }
-    let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+    let(:course_student) { create(:course_student, course: course) }
+    let(:user) { create(:course_teaching_assistant, course: course).user }
     let(:disbursement_stub) do
       stub = Course::ExperiencePoints::Disbursement.new(course: course)
       record_stub = Course::ExperiencePointsRecord.new(course_user: course_student, reason: nil)

--- a/spec/controllers/course/experience_points_records_controller_spec.rb
+++ b/spec/controllers/course/experience_points_records_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Course::ExperiencePointsRecordsController, type: :controller do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:course_student) { create(:course_student, :approved, course: course) }
-    let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+    let(:course_student) { create(:course_student, course: course) }
+    let(:user) { create(:course_teaching_assistant, course: course).user }
     let(:experience_points_history_path) do
       course_user_experience_points_records_path(course, course_student)
     end

--- a/spec/controllers/course/user_invitations_controller_spec.rb
+++ b/spec/controllers/course/user_invitations_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Course::UserInvitationsController, type: :controller do
       subject { post :create, course_id: course, course: invite_params }
 
       context 'when a course manager visits the page' do
-        let!(:course_lecturer) { create(:course_manager, :approved, course: course, user: user) }
+        let!(:course_lecturer) { create(:course_manager, course: course, user: user) }
 
         it { is_expected.to redirect_to(course_users_invitations_path(course)) }
 

--- a/spec/controllers/course/user_registrations_controller_spec.rb
+++ b/spec/controllers/course/user_registrations_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
           end
 
           context 'when the user is a manager of the course' do
-            let!(:course_manager) { create(:course_manager, :approved, course: course, user: user) }
+            let!(:course_manager) { create(:course_manager, course: course, user: user) }
 
             it { expect { subject }.not_to change { course.course_users.reload.count } }
             it { is_expected.to redirect_to(course_path(course)) }

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Course::UsersController, type: :controller do
       subject { get :students, course_id: course }
 
       context 'when a course manager visits the page' do
-        let!(:course_lecturer) { create(:course_manager, :approved, course: course, user: user) }
+        let!(:course_lecturer) { create(:course_manager, course: course, user: user) }
 
         it { is_expected.to render_template(:students) }
       end
@@ -38,7 +38,7 @@ RSpec.describe Course::UsersController, type: :controller do
       subject { get :staff, course_id: course }
 
       context 'when a course manager visits the page' do
-        let!(:course_lecturer) { create(:course_manager, :approved, course: course, user: user) }
+        let!(:course_lecturer) { create(:course_manager, course: course, user: user) }
 
         it { is_expected.to render_template(:staff) }
       end
@@ -60,9 +60,7 @@ RSpec.describe Course::UsersController, type: :controller do
       let(:updated_course_user) { { role: :teaching_assistant } }
 
       context 'when the user is a manager' do
-        let!(:logged_in_course_user) do
-          create(:course_manager, :approved, course: course, user: user)
-        end
+        let!(:logged_in_course_user) { create(:course_manager, course: course, user: user) }
         let(:course_user) { create(:course_manager, course: course) }
 
         it 'updates the Course User' do
@@ -91,6 +89,7 @@ RSpec.describe Course::UsersController, type: :controller do
         end
 
         context 'when the user transitions from the requested state to the approved state' do
+          let(:course_user) { create(:course_user, course: course, role: :manager) }
           let(:updated_course_user) { { workflow_state: :approved } }
           it 'sends a notification email to the user' do
             expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
@@ -117,7 +116,7 @@ RSpec.describe Course::UsersController, type: :controller do
       let!(:course_user_to_delete) { create(:course_user, course: course, user: create(:user)) }
 
       context 'when the user is a manager' do
-        let!(:course_user) { create(:course_manager, :approved, course: course, user: user) }
+        let!(:course_user) { create(:course_manager, course: course, user: user) }
 
         it 'destroys the registration record' do
           expect { subject }.to change { course.course_users.reload.count }.by(-1)
@@ -159,7 +158,7 @@ RSpec.describe Course::UsersController, type: :controller do
       subject { get :show, course_id: course, id: course_user }
 
       context 'when the user is not registered' do
-        let(:course_user) { create(:course_student, course: course) }
+        let(:course_user) { create(:course_user, course: course) }
         it 'raises an error' do
           expect { subject }.to raise_exception(ActiveRecord::RecordNotFound)
         end
@@ -169,8 +168,8 @@ RSpec.describe Course::UsersController, type: :controller do
     describe '#upgrade_to_staff' do
       before { sign_in(user) }
       subject { put :upgrade_to_staff, course_id: course, course_user: staff_to_be_params }
-      let!(:course_user) { create(:course_manager, :approved, course: course, user: user) }
-      let(:staff_to_be) { create(:course_student, :approved, course: course) }
+      let!(:course_user) { create(:course_manager, course: course, user: user) }
+      let(:staff_to_be) { create(:course_student, course: course) }
       let(:staff_to_be_params) { { id: staff_to_be.id, role: :teaching_assistant } }
       let(:staff_to_be_stub) do
         stub = staff_to_be

--- a/spec/factories/course_users.rb
+++ b/spec/factories/course_users.rb
@@ -7,25 +7,6 @@ FactoryGirl.define do
     role :student
     name 'default'
 
-    factory :course_student, parent: :course_user do
-      sequence(:name) { |n| "student #{n}" }
-    end
-
-    factory :course_teaching_assistant, parent: :course_user do
-      role :teaching_assistant
-      sequence(:name) { |n| "teaching assistant #{n}" }
-    end
-
-    factory :course_manager, parent: :course_user do
-      role :manager
-      sequence(:name) { |n| "manager #{n}" }
-    end
-
-    factory :course_owner, parent: :course_user do
-      role :owner
-      sequence(:name) { |n| "owner #{n}" }
-    end
-
     trait :approved do
       workflow_state :approved
     end
@@ -34,6 +15,36 @@ FactoryGirl.define do
     end
     trait :phantom do
       phantom true
+    end
+
+    # Course Student is an approved course_user by default.
+    # Manually build a course_user for unapproved course_users.
+    factory :course_student, parent: :course_user do
+      approved
+      sequence(:name) { |n| "student #{n}" }
+    end
+
+    # Course Teaching Assistant is an approved course_user by default.
+    # Manually build a course_user for unapproved course_users.
+    factory :course_teaching_assistant, parent: :course_user do
+      approved
+      role :teaching_assistant
+      sequence(:name) { |n| "teaching assistant #{n}" }
+    end
+
+    # Course Manager is an approved course_user by default.
+    # Manually build a course_user for unapproved course_users.
+    factory :course_manager, parent: :course_user do
+      approved
+      role :manager
+      sequence(:name) { |n| "manager #{n}" }
+    end
+
+    # Course Owner is an approved course_user by default.
+    factory :course_owner, parent: :course_user do
+      approved
+      role :owner
+      sequence(:name) { |n| "owner #{n}" }
     end
 
     trait :auto_grader do

--- a/spec/features/course/achievement_condition_management_spec.rb
+++ b/spec/features/course/achievement_condition_management_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Course: Achievements' do
     end
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
       let(:other_achievement) { create(:course_achievement, course: course) }
       let(:achievement_condition) do
         create(:achievement_condition, course: course, achievement: other_achievement)

--- a/spec/features/course/achievement_listing_spec.rb
+++ b/spec/features/course/achievement_listing_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Course: Achievements' do
     end
 
     context 'As an Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can view all achievements' do
         expect(page).to have_link(nil, href: new_course_achievement_path(course))
@@ -31,8 +31,8 @@ RSpec.feature 'Course: Achievements' do
     end
 
     context 'As an Course Student' do
-      let!(:course_student1) { create(:course_student, :approved, course: course) }
-      let!(:course_student2) { create(:course_student, :approved, course: course) }
+      let!(:course_student1) { create(:course_student, course: course) }
+      let!(:course_student2) { create(:course_student, course: course) }
       let!(:unregistered_user) { create(:course_user, course: course) }
       let!(:phantom_user) { create(:course_user, :approved, :phantom, course: course) }
       let!(:user) { course_student1.user }

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Course: Achievements' do
     end
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create an achievement' do
         # Fields not yet filled
@@ -78,7 +78,7 @@ RSpec.feature 'Course: Achievements' do
         auto_achievement = create(:course_achievement, course: course)
         create(:course_condition_achievement, course: course, conditional: auto_achievement)
 
-        student = create(:course_student, :approved, course: course)
+        student = create(:course_student, course: course)
         course_user_id = "achievement_course_user_ids_#{student.id}"
         unregistered_user = create(:course_user, course: course)
         unregistered_user_id = "achievement_course_user_ids_#{unregistered_user.id}"

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Course: Administration: Administration' do
     before { login_as(user, scope: :user) }
 
     context 'As an Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can view the Course Admin Sidebar item' do
         visit course_path(course)
@@ -56,7 +56,7 @@ RSpec.feature 'Course: Administration: Administration' do
     end
 
     context 'As a Course Teaching Assistant' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       scenario 'I cannot view the Course Admin Sidebar item' do
         visit course_path(course)
@@ -66,7 +66,7 @@ RSpec.feature 'Course: Administration: Administration' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I cannot view the Course Admin Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/admin/announcement_settings_spec.rb
+++ b/spec/features/course/admin/announcement_settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Administration: Announcement' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can change the announcement pagination settings' do
         visit course_admin_announcements_path(course)

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Course: Administration: Components' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can view the list of enabled/disabled components' do
         visit course_admin_components_path(course)

--- a/spec/features/course/admin/discussion/topic_settings_spec.rb
+++ b/spec/features/course/admin/discussion/topic_settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Administration: Discussion:: Topics' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can change the discussion topics pagination' do
         visit course_admin_topics_path(course)

--- a/spec/features/course/admin/forum_settings_spec.rb
+++ b/spec/features/course/admin/forum_settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Administration: Forums' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can change the forums title' do
         visit course_admin_forums_path(course)

--- a/spec/features/course/admin/leaderboard_settings_spec.rb
+++ b/spec/features/course/admin/leaderboard_settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Administration: Leaderboard' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can change the leaderboard display user count setting' do
         visit course_admin_leaderboard_path(course)

--- a/spec/features/course/admin/material_settings_spec.rb
+++ b/spec/features/course/admin/material_settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Administration: Materials' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can change the materials title' do
         visit course_admin_materials_path(course)

--- a/spec/features/course/admin/sidebar_settings_spec.rb
+++ b/spec/features/course/admin/sidebar_settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Administration: Sidebar' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       let(:first_weight_field) { 'settings_sidebar_sidebar_items_attributes_0_weight' }
       let(:valid_weight) { 1 }

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Course: Announcements' do
     end
 
     context 'As an Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create new announcements' do
         visit new_course_announcement_path(course)
@@ -87,7 +87,7 @@ RSpec.feature 'Course: Announcements' do
     end
 
     context 'As an Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view the Announcement Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
     end
 
     context 'As Course Staff' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
       let(:submission_traits) { :submitted }
 
       scenario 'I can view the correct answer' do

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
     end
 
     context 'As Course Staff' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
       let(:submission_traits) { :submitted }
 
       scenario 'I can view the test cases' do

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
     end
 
     context 'As Course Staff' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
       let(:submission_traits) { :submitted }
 
       scenario 'I can view the grading scheme' do

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
     end
 
     context 'As a Course Staff' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       scenario 'I can attempt unsatisfied submission' do
         assessment_with_condition

--- a/spec/features/course/assessment/assessment_viewing_spec.rb
+++ b/spec/features/course/assessment/assessment_viewing_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Course: Assessments: Viewing' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Staff' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       scenario 'I can access all submissions of an assessment' do
         assessment

--- a/spec/features/course/assessment/skill_branch_management_spec.rb
+++ b/spec/features/course/assessment/skill_branch_management_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Course: Skill Branches' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create a skill branch' do
         visit course_assessments_skills_path(course)

--- a/spec/features/course/assessment/skill_management_spec.rb
+++ b/spec/features/course/assessment/skill_management_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Course: Skills' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create a skill' do
         visit course_assessments_skills_path(course)

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
     end
 
     context 'As a Course Staff' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       scenario "I can grade the student's work" do
         mcq_questions.each { |q| q.attempt(submission).save! }

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
     let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
     before { login_as(user, scope: :user) }
 
-    let(:students) { create_list(:course_student, 3, :approved, course: course) }
-    let(:phantom_student) { create(:course_student, :approved, :phantom, course: course) }
+    let(:students) { create_list(:course_student, 3, course: course) }
+    let(:phantom_student) { create(:course_student, :phantom, course: course) }
     let!(:submitted_submission) do
       create(:course_assessment_submission, :submitted, assessment: assessment,
                                                         course: course,
@@ -28,7 +28,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
     end
 
     context 'As a Course Staff' do
-      let(:course_staff) { create(:course_manager, :approved, course: course).user }
+      let(:course_staff) { create(:course_manager, course: course).user }
       let(:user) { course_staff }
 
       scenario 'I can view all submissions of an assessment' do

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe 'Course: Submissions Viewing' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:course_manager) { create(:course_manager, :approved, course: course) }
+      let(:course_manager) { create(:course_manager, course: course) }
       let(:user) { course_manager.user }
 
       scenario 'I can view all submitted and graded submissions' do
-        students = create_list(:course_student, 3, :approved, course: course)
+        students = create_list(:course_student, 3, course: course)
         attempting_submission, submitted_submission, graded_submission =
           students.zip([:attempting, :submitted, :graded]).map do |student, trait|
             create(:course_assessment_submission, trait,
@@ -39,7 +39,7 @@ RSpec.describe 'Course: Submissions Viewing' do
       end
 
       scenario 'I can view pending submissions' do
-        students = create_list(:course_student, 4, :approved, course: course)
+        students = create_list(:course_student, 4, course: course)
         attempting_submission, submitted_submission1, submitted_submission2, graded_submission =
           students.zip([:attempting, :submitted, :submitted, :graded]).map do |student, trait|
             create(:course_assessment_submission, trait,
@@ -70,7 +70,7 @@ RSpec.describe 'Course: Submissions Viewing' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view my submitted and graded submissions' do
         attempting_submission, submitted_submission, graded_submission =

--- a/spec/features/course/assessment_condition_management_spec.rb
+++ b/spec/features/course/assessment_condition_management_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Assessments' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
       let!(:assessment) { create(:course_assessment_assessment, course: course) }
       let(:other_assessment) { create(:assessment, course: course) }
       let!(:assessment_condition) do

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Course: Topics: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Teaching Assistant' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       scenario 'I can see all the comments' do
         answer_comment
@@ -51,7 +51,7 @@ RSpec.feature 'Course: Topics: Management' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
       let(:student_answer) do
         create(:course_assessment_answer, :with_post, course: course, creator: user)
       end

--- a/spec/features/course/experience_points/disbursement_spec.rb
+++ b/spec/features/course/experience_points/disbursement_spec.rb
@@ -6,10 +6,8 @@ RSpec.feature 'Course: Experience Points: Disbursement' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:approved_course_students) { create_list(:course_student, 3, :approved, course: course) }
-    let(:course_teaching_assistant) do
-      create(:course_teaching_assistant, :approved, course: course)
-    end
+    let(:approved_course_students) { create_list(:course_student, 3, course: course) }
+    let(:course_teaching_assistant) { create(:course_teaching_assistant, course: course) }
 
     before { login_as(user, scope: :user) }
 
@@ -49,7 +47,7 @@ RSpec.feature 'Course: Experience Points: Disbursement' do
 
       scenario 'I can disburse experience points' do
         approved_course_students
-        unapproved_course_student = create(:course_student, course: course)
+        unapproved_course_student = create(:course_user, course: course)
 
         visit disburse_experience_points_course_users_path(course)
 

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:course_student) { create(:course_student, :approved, course: course) }
+    let(:course_student) { create(:course_student, course: course) }
     let(:record) do
       create(:course_assessment_submission, course: course, creator: course_student.user).acting_as
     end
@@ -19,7 +19,7 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario "I can view a course student's active experience points records" do
         records

--- a/spec/features/course/forum/topic_management_spec.rb
+++ b/spec/features/course/forum/topic_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Course: Forum: Topic: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
       scenario 'I can see topics' do
         topics = create_list(:forum_topic, 2, forum: forum)
         visit course_forum_path(course, forum)
@@ -181,7 +181,7 @@ RSpec.feature 'Course: Forum: Topic: Management' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view the Forum Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/forum_management_spec.rb
+++ b/spec/features/course/forum_management_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Forum: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
       scenario 'I can see forums' do
         forums = create_list(:forum, 2, course: course)
         visit course_forums_path(course)
@@ -108,7 +108,7 @@ RSpec.feature 'Course: Forum: Management' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
       scenario 'I can see forums' do
         forums = create_list(:forum, 2, course: course)
         visit course_forums_path(course)

--- a/spec/features/course/group_management_spec.rb
+++ b/spec/features/course/group_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Courses: Groups' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can view the Group Sidebar item' do
         visit course_path(course)
@@ -113,7 +113,7 @@ RSpec.feature 'Courses: Groups' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I cannot view the Group Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Course: Homepage' do
     end
 
     context 'As a user registered for the course' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
       scenario 'I am able to see announcements in course homepage' do
         valid_announcement = create(:course_announcement, course: course)
         visit course_path(course)
@@ -97,8 +97,8 @@ RSpec.feature 'Course: Homepage' do
       end
 
       scenario 'I am only able to see approved owner and managers in instructors list' do
-        manager = create(:course_manager, :approved, course: course)
-        teaching_assistant = create(:course_teaching_assistant, :approved, course: course)
+        manager = create(:course_manager, course: course)
+        teaching_assistant = create(:course_teaching_assistant, course: course)
         visit course_path(course)
         course.course_users.owner.with_approved_state.each do |course_user|
           expect(page).to have_selector('span.name', text: course_user.user.name)

--- a/spec/features/course/leaderboard_viewing_spec.rb
+++ b/spec/features/course/leaderboard_viewing_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Course: Leaderboard: View' do
     end
 
     context 'As a student' do
-      let!(:students) { create_list(:course_student, 2, :approved, course: course) }
+      let!(:students) { create_list(:course_student, 2, course: course) }
       let!(:unregistered_user) { create(:course_user, course: course) }
       let!(:phantom_user) { create(:course_user, :approved, :phantom, course: course) }
       let(:user) { students[0].user }

--- a/spec/features/course/lesson_plan_event_management_spec.rb
+++ b/spec/features/course/lesson_plan_event_management_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Course: Events' do
     end
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create a course event' do
         visit course_lesson_plan_path(course)

--- a/spec/features/course/lesson_plan_milestone_management_spec.rb
+++ b/spec/features/course/lesson_plan_milestone_management_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Course: Lesson Plan Milestones' do
     end
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create a milestone' do
         visit course_lesson_plan_path(course)

--- a/spec/features/course/lesson_plan_spec.rb
+++ b/spec/features/course/lesson_plan_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Course: Lesson Plan' do
     end
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can view all lesson plan items grouped by milestone' do
         visit course_lesson_plan_path(course)
@@ -55,7 +55,7 @@ RSpec.feature 'Course: Lesson Plan' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view the LessonPlan Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/level_management_spec.rb
+++ b/spec/features/course/level_management_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Course: Levels' do
     end
 
     context 'As a Course Administrator' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can view the Level Sidebar item' do
         visit course_path(course)
@@ -52,7 +52,7 @@ RSpec.feature 'Course: Levels' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I cannot view the Level Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/material/files_management_spec.rb
+++ b/spec/features/course/material/files_management_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Course: Material: Files: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
       scenario 'I can view all the materials' do
         visit course_material_folder_path(course, folder)
         materials.each do |material|
@@ -56,7 +56,7 @@ RSpec.feature 'Course: Material: Files: Management' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view all the materials' do
         visit course_material_folder_path(course, folder)

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Course: Material: Folders: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
       scenario 'I can view all the subfolders' do
         visit course_material_folder_path(course, parent_folder)
         subfolders.each do |subfolder|
@@ -116,7 +116,7 @@ RSpec.feature 'Course: Material: Folders: Management' do
     end
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view the Material Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/registration_spec.rb
+++ b/spec/features/course/registration_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Courses: Registration' do
     end
 
     context 'when the user is registered in the course' do
-      let!(:course_student) { create(:course_student, :approved, course: course, user: user) }
+      let!(:course_student) { create(:course_student, course: course, user: user) }
       scenario 'Users cannot re-register for a course' do
         visit course_path(course)
 

--- a/spec/features/course/request_managmement_spec.rb
+++ b/spec/features/course/request_managmement_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Course: Requests' do
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
     let(:course) { create(:course) }
-    let!(:unregistered_user) { create(:course_student, course: course) }
+    let!(:unregistered_user) { create(:course_user, course: course) }
     before { login_as(user, scope: :user) }
 
     scenario 'Course staff can approve request' do

--- a/spec/features/course/staff_management_spec.rb
+++ b/spec/features/course/staff_management_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature 'Courses: Staff Management' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let!(:course_approved_students) { create_list(:course_student, 2, :approved, course: course) }
-    let!(:course_unapproved_students) { create_list(:course_student, 2, course: course) }
-    let!(:course_managers) { create_list(:course_manager, 2, :approved, course: course) }
+    let!(:course_approved_students) { create_list(:course_student, 2, course: course) }
+    let!(:course_unapproved_students) { create_list(:course_user, 2, course: course) }
+    let!(:course_managers) { create_list(:course_manager, 2, course: course) }
     before { login_as(user, scope: :user) }
 
     context 'As a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       scenario 'I cannot view the Users Management Sidebar item' do
         visit course_path(course)
@@ -23,9 +23,7 @@ RSpec.feature 'Courses: Staff Management' do
 
     context 'As a Course Teaching Assistant' do
       let(:user) { create(:user) }
-      let!(:course_staff) do
-        create(:course_teaching_assistant, :approved, course: course, user: user)
-      end
+      let!(:course_staff) { create(:course_teaching_assistant, course: course, user: user) }
 
       scenario 'I cannot view the Users Management Sidebar item' do
         visit course_path(course)
@@ -40,7 +38,7 @@ RSpec.feature 'Courses: Staff Management' do
     end
 
     context 'As a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can view the Users Management Sidebar item' do
         visit course_path(course)

--- a/spec/features/course/student_management_spec.rb
+++ b/spec/features/course/student_management_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Courses: Students' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:user) { create(:administrator) }
-    let!(:course_students) { create_list(:course_student, 3, :approved, course: course) }
+    let!(:course_students) { create_list(:course_student, 3, course: course) }
     let!(:unregistered_user) { create(:course_user, course: course) }
     before { login_as(user, scope: :user) }
 

--- a/spec/features/course/user_listing_spec.rb
+++ b/spec/features/course/user_listing_spec.rb
@@ -6,15 +6,13 @@ RSpec.feature 'Courses: Course User Listing' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let!(:course_student_list) { create_list(:course_student, 5, :approved, course: course) }
+    let!(:course_student_list) { create_list(:course_student, 5, course: course) }
     let!(:unregistered_user) { create(:course_user, course: course) }
     let!(:phantom_user) { create(:course_user, :approved, :phantom, course: course) }
-    let!(:course_teaching_assistant) do
-      create(:course_teaching_assistant, :approved, course: course)
-    end
+    let!(:course_teaching_assistant) { create(:course_teaching_assistant, course: course) }
 
     context 'As a Course Student' do
-      let(:student) { create(:course_student, :approved, course: course) }
+      let(:student) { create(:course_student, course: course) }
       before { login_as(student.user, scope: :user) }
 
       scenario 'I can view all confirmed students in my course' do

--- a/spec/features/course/user_profile_spec.rb
+++ b/spec/features/course/user_profile_spec.rb
@@ -6,11 +6,9 @@ RSpec.feature 'Courses: CourseUser Profile' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:course_student) { create(:course_student, :approved, course: course) }
+    let(:course_student) { create(:course_student, course: course) }
     let(:achievement) { create(:course_user_achievement, course_user: course_student).achievement }
-    let(:course_teaching_assistant) do
-      create(:course_teaching_assistant, :approved, course: course)
-    end
+    let(:course_teaching_assistant) { create(:course_teaching_assistant, course: course) }
 
     context 'As a Course Teaching Assistant' do
       before { login_as(course_teaching_assistant.user, scope: :user) }
@@ -28,7 +26,7 @@ RSpec.feature 'Courses: CourseUser Profile' do
     end
 
     context 'As a Course Student' do
-      let(:student_user) { create(:course_student, :approved, course: course).user }
+      let(:student_user) { create(:course_student, course: course).user }
 
       scenario "I can view a staff's profile" do
         login_as(student_user, scope: :user)

--- a/spec/features/course_management_spec.rb
+++ b/spec/features/course_management_spec.rb
@@ -18,8 +18,8 @@ RSpec.feature 'Courses' do
     end
 
     scenario 'Users can see a list of their courses' do
-      course_attending = create(:course_student, :approved, user: user).course
-      course_teaching = create(:course_teaching_assistant, :approved, user: user).course
+      course_attending = create(:course_student, user: user).course
+      course_teaching = create(:course_teaching_assistant, user: user).course
       other_course = create(:course)
 
       visit root_path

--- a/spec/features/system/admin/instance/course_management_spec.rb
+++ b/spec/features/system/admin/instance/course_management_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'System: Administration: Instance: Courses' do
     let(:last_page) { Course.unscoped.page.total_pages }
     let!(:courses) do
       courses = create_list(:course, 2)
-      create(:course_manager, :approved, course: courses.sample)
+      create(:course_manager, course: courses.sample)
       create(:course_student, course: courses.sample)
 
       courses

--- a/spec/models/course/achievement_ability_spec.rb
+++ b/spec/models/course/achievement_ability_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::Achievement do
     let!(:draft_achievement) { create(:course_achievement, course: course, draft: true) }
 
     context 'when the user is a Course Student' do
-      let(:course_user) { create(:course_student, :approved, course: course) }
+      let(:course_user) { create(:course_student, course: course) }
       let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, achievement) }
@@ -31,7 +31,7 @@ RSpec.describe Course::Achievement do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, achievement) }
       it { is_expected.to be_able_to(:manage, draft_achievement) }

--- a/spec/models/course/announcement_ability_spec.rb
+++ b/spec/models/course/announcement_ability_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Course::Announcement do
     let!(:valid_announcement) { create(:course_announcement, course: course) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, valid_announcement) }
       it { is_expected.to be_able_to(:show, ended_announcement) }
@@ -25,7 +25,7 @@ RSpec.describe Course::Announcement do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, valid_announcement) }
       it { is_expected.to be_able_to(:manage, ended_announcement) }

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment do
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }
-    let(:course_user) { create(:course_student, :approved, course: course) }
+    let(:course_user) { create(:course_student, course: course) }
     let(:draft_assessment) do
       create(:course_assessment_assessment, :with_all_question_types, course: course, draft: true)
     end
@@ -38,7 +38,7 @@ RSpec.describe Course::Assessment do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       # Course Assessments
       it { is_expected.to be_able_to(:manage, draft_assessment) }

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Course::Assessment::Submission do
 
     describe 'validations' do
       context 'when the course user is different from the submission creator' do
-        let(:course_student) { create(:course_student, :approved, course: course) }
+        let(:course_student) { create(:course_student, course: course) }
         subject do
           build(:submission, assessment: assessment, course_user: course_student, creator: user1)
         end

--- a/spec/models/course/condition/achievement_ability_spec.rb
+++ b/spec/models/course/condition/achievement_ability_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Condition::Achievement do
     let(:condition) { create(:achievement_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end

--- a/spec/models/course/condition/assessment_ability_spec.rb
+++ b/spec/models/course/condition/assessment_ability_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Course::Condition::Assessment do
     let(:condition) { create(:assessment_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       context 'when the assessment is published but has not started' do
         let(:unopened_assessment) do

--- a/spec/models/course/condition/level_ability_spec.rb
+++ b/spec/models/course/condition/level_ability_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Condition::Level do
     let(:condition) { create(:level_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end

--- a/spec/models/course/experience_points_record_ability_spec.rb
+++ b/spec/models/course/experience_points_record_ability_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Course::ExperiencePointsRecord do
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }
-    let(:course_student) { create(:course_student, :approved, course: course) }
+    let(:course_student) { create(:course_student, course: course) }
     let(:points_record) do
       create(:course_experience_points_record, course_user: course_student)
     end
 
     context 'when the user is a Course Student' do
       let(:user) { course_student.user }
-      let(:classmate) { create(:course_student, :approved, course: course) }
+      let(:classmate) { create(:course_student, course: course) }
       let(:classmate_points_record) do
         create(:course_experience_points_record, course_user: classmate)
       end
@@ -42,7 +42,7 @@ RSpec.describe Course::ExperiencePointsRecord do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
       let(:foreign_points_record) { create(:course_experience_points_record) }
 
       context 'when record belongs to a student from the same course' do

--- a/spec/models/course/forum/topic_ability_spec.rb
+++ b/spec/models/course/forum/topic_ability_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Course::Forum::Topic, type: :model do
     let(:hidden_topic) { build_stubbed(:forum_topic, forum: forum, hidden: true) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
       let(:my_shown_topic) do
         build_stubbed(:forum_topic, forum: forum, hidden: false, creator: user)
       end
@@ -29,7 +29,7 @@ RSpec.describe Course::Forum::Topic, type: :model do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, shown_topic) }
       it { is_expected.to be_able_to(:manage, hidden_topic) }

--- a/spec/models/course/forum_ability_spec.rb
+++ b/spec/models/course/forum_ability_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Course::Forum, type: :model do
     let(:forum) { create(:forum, course: course) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, forum) }
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, forum) }
     end

--- a/spec/models/course/group_ability_spec.rb
+++ b/spec/models/course/group_ability_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Course::Group do
     let!(:group) { create(:course_group, course: course) }
 
     context 'when the user is a Course Staff' do
-      let!(:course_manager) { create(:course_manager, :approved, course: course, user: user) }
+      let!(:course_manager) { create(:course_manager, course: course, user: user) }
 
       it { is_expected.to be_able_to(:manage, group) }
 

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Course::Group, type: :model do
     end
 
     describe '.ordered_by_experience_points' do
-      let(:student) { create(:course_student, :approved, course: course) }
+      let(:student) { create(:course_student, course: course) }
       let!(:group_user) { create(:course_group_user, group: group, course_user: student) }
       let!(:other_group) { create(:course_group, course: course) }
       let!(:experience_points_record) do
@@ -178,7 +178,7 @@ RSpec.describe Course::Group, type: :model do
     end
 
     describe '.ordered_by_achievement_count' do
-      let(:student) { create(:course_student, :approved, course: course) }
+      let(:student) { create(:course_student, course: course) }
       let!(:group_user) { create(:course_group_user, group: group, course_user: student) }
       let!(:course_user_achievement) { create(:course_user_achievement, course_user: student) }
       let!(:later_group) { create(:course_group, course: course) }
@@ -191,7 +191,7 @@ RSpec.describe Course::Group, type: :model do
 
       context 'when two groups have the same achievement count' do
         let(:earlier_time) { course_user_achievement.obtained_at }
-        let!(:later_student) { create(:course_student, :approved, course: course) }
+        let!(:later_student) { create(:course_student, course: course) }
         let!(:later_group_user) do
           create(:course_group_user, group: later_group, course_user: later_student)
         end

--- a/spec/models/course/lesson_plan_event_ability_spec.rb
+++ b/spec/models/course/lesson_plan_event_ability_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::LessonPlan::Event do
     let(:lesson_plan_event) { create(:course_lesson_plan_event, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, lesson_plan_event) }
 
@@ -21,7 +21,7 @@ RSpec.describe Course::LessonPlan::Event do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_event) }
       it { is_expected.not_to be_able_to(:manage, lesson_plan_event) }

--- a/spec/models/course/lesson_plan_item_ability_spec.rb
+++ b/spec/models/course/lesson_plan_item_ability_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::LessonPlan::Item do
     let(:lesson_plan_item) { create(:course_lesson_plan_item, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, lesson_plan_item) }
 
@@ -21,7 +21,7 @@ RSpec.describe Course::LessonPlan::Item do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_item) }
       it { is_expected.not_to be_able_to(:manage, lesson_plan_item) }

--- a/spec/models/course/lesson_plan_milestone_ability_spec.rb
+++ b/spec/models/course/lesson_plan_milestone_ability_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::LessonPlan::Milestone do
     let(:lesson_plan_milestone) { create(:course_lesson_plan_milestone, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, lesson_plan_milestone) }
 
@@ -21,7 +21,7 @@ RSpec.describe Course::LessonPlan::Milestone do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_milestone) }
       it { is_expected.not_to be_able_to(:manage, lesson_plan_milestone) }

--- a/spec/models/course/level_ability_spec.rb
+++ b/spec/models/course/level_ability_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Course::Level do
     let!(:default_level) { course.reload.levels.first }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, level) }
       it { is_expected.not_to be_able_to(:destroy, default_level) }

--- a/spec/models/course/material/folder_ability_spec.rb
+++ b/spec/models/course/material/folder_ability_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Course::Material::Folder, type: :model do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, valid_folder) }
       it { is_expected.not_to be_able_to(:show, not_started_folder) }
@@ -27,7 +27,7 @@ RSpec.describe Course::Material::Folder, type: :model do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, valid_folder) }
       it { is_expected.to be_able_to(:manage, not_started_folder) }

--- a/spec/models/course/material_ability_spec.rb
+++ b/spec/models/course/material_ability_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Course::Material do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, valid_material) }
       it { is_expected.not_to be_able_to(:show, not_started_material) }
@@ -40,7 +40,7 @@ RSpec.describe Course::Material do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:manage, valid_material) }
       it { is_expected.to be_able_to(:manage, not_started_material) }

--- a/spec/models/course_ability_spec.rb
+++ b/spec/models/course_ability_spec.rb
@@ -25,21 +25,21 @@ RSpec.describe Course, type: :model do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, :approved, course: course).user }
+      let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
     end
 
     context 'when the user is a Course Teaching Assistant' do
-      let(:user) { create(:course_teaching_assistant, :approved, course: course).user }
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
     end
 
     context 'when the user is a Course Manager' do
-      let(:user) { create(:course_manager, :approved, course: course).user }
+      let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.to be_able_to(:manage, course) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Course, type: :model do
       let(:course) { create(:course, creator: owner, updater: owner) }
       let(:course_owner) { course.course_users.find_by!(user: owner) }
       let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
-      let(:manager) { create(:course_manager, :approved, course: course) }
+      let(:manager) { create(:course_manager, course: course) }
 
       it 'returns all the staff in course' do
         expect(course.staff).to contain_exactly(teaching_assistant, manager, course_owner)

--- a/spec/models/course_user_ability_spec.rb
+++ b/spec/models/course_user_ability_spec.rb
@@ -5,24 +5,24 @@ RSpec.describe Course, type: :model do
   let(:instance) { create(:instance) }
   with_tenant(:instance) do
     subject { Ability.new(user) }
-    let(:course_user) { create(:course_student, :approved) }
+    let(:course_user) { create(:course_student) }
 
     context 'when the user is from the same course' do
       context 'when the user is approved' do
-        let(:user) { create(:course_student, :approved, course: course_user.course).user }
+        let(:user) { create(:course_student, course: course_user.course).user }
 
         it { is_expected.to be_able_to(:read, course_user) }
       end
 
       context 'when the user is not approved' do
-        let(:user) { create(:course_student, course: course_user.course).user }
+        let(:user) { create(:course_user, course: course_user.course).user }
 
         it { is_expected.not_to be_able_to(:read, course_user) }
       end
     end
 
     context 'when the user is from a different course' do
-      let(:user) { create(:course_student, :approved).user }
+      let(:user) { create(:course_student).user }
 
       it { is_expected.not_to be_able_to(:read, course_user) }
     end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe CourseUser, type: :model do
   with_tenant(:instance) do
     let(:owner) { create(:user) }
     let(:course) { create(:course, creator: owner, updater: owner) }
+    let(:requested_course_user) { create(:course_user, course: course) }
     let!(:student) { create(:course_student, course: course) }
     let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
     let(:manager) { create(:course_manager, course: course) }
@@ -90,13 +91,6 @@ RSpec.describe CourseUser, type: :model do
     end
 
     describe '.approved' do
-      before do
-        student.approve!
-        student.save!
-        teaching_assistant.approve!
-        teaching_assistant.save!
-      end
-
       it 'returns all approved course users' do
         expect(course.course_users.with_approved_state).to contain_exactly(student,
                                                                            teaching_assistant,
@@ -107,7 +101,7 @@ RSpec.describe CourseUser, type: :model do
     describe '.pending' do
       it 'returns all pending course users' do
         expect(course.course_users.with_requested_state).
-          to contain_exactly(student, teaching_assistant, manager)
+          to contain_exactly(requested_course_user)
       end
     end
 
@@ -168,14 +162,14 @@ RSpec.describe CourseUser, type: :model do
     end
 
     describe '#approve!' do
-      subject { student.tap(&:approve!).tap(&:save!) }
+      subject { requested_course_user.tap(&:approve!).tap(&:save!) }
       it 'increases approved course users\' count' do
         expect { subject }.to change(CourseUser.with_approved_state, :count).by(1)
       end
     end
 
     describe '#reject!' do
-      subject { student.tap(&:reject!) }
+      subject { requested_course_user.tap(&:reject!) }
       it 'destroys the record' do
         expect(subject.destroyed?).to be_truthy
       end


### PR DESCRIPTION
Fixes #1094 

This PR:
- Sets `course_student`, `course_teaching_assistant`, `course_manager` and `course_owner` factories to be approved by default. See above issue for discussion. 
- Removes the `:approved` traits in specs that use the above factories (those with `:course_user` are not modified).