### PR TITLE
Fix annotation reply button display bug

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/answer.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/answer.js
@@ -23,29 +23,21 @@
   /**
    * Shows reply buttons for annotations.
    *
-   * `addBack` is required since the AJAX response inserts the reply button footer separately
-   * rather than as part of the main discussion topic. `find` will fail to select the button if
-   * the button is `element` itself.
-   *
    * @param element
    */
   function showReplyButton(element) {
-    var REPLY_COMMENT_SELECTOR = DOCUMENT_SELECTOR + '.reply-annotation';
-    $(element).find(REPLY_COMMENT_SELECTOR).addBack(REPLY_COMMENT_SELECTOR).show();
+    var $button = $('.reply-annotation', element).filter(DOCUMENT_SELECTOR + '*');
+    $button.show();
   }
 
   /**
    * Shows forms for adding comments to answers.
    *
-   * `addBack` is required since the AJAX response inserts the reply button footer separately
-   * rather than as part of the main discussion topic. `find` will fail to select the button if
-   * the button is `element` itself.
-   *
    * @param element
    */
   function showAnswerCommentForm(element) {
-    var FORM_SELECTOR = DOCUMENT_SELECTOR + '.answer-comment-form';
-    $(element).find(FORM_SELECTOR).addBack(FORM_SELECTOR).show();
+    var $form = $('.answer-comment-form', element).filter(DOCUMENT_SELECTOR + '*');
+    $form.show();
   }
 
   /**

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -119,6 +119,9 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
         wait_for_ajax
         new_post = annotation.posts.last
         expect(new_post.text).to have_tag('*', text: annotation_text)
+        within find(content_tag_selector(annotation.discussion_topic)) do
+          expect(page).to have_selector('.reply-annotation', visible: true)
+        end
       end
 
       scenario 'I can edit my annotations', js: true do

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -68,6 +68,9 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
         comment_post = comment_topic.posts.reload.last
         expect(comment_post.text).to have_tag('*', text: comment_post_text)
         expect(comment_post.parent).to eq(comment_parent_post)
+        within find(content_tag_selector(comment_answer)) do
+          have_selector('.answer-comment-form', visible: true)
+        end
 
         submission.answers.each do |answer|
           within find(content_tag_selector(answer)) do


### PR DESCRIPTION
After adding the document selector, the button doesn't re-appear after a reply is made.