### PR TITLE
Implement caching of phantomjs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,23 @@ matrix:
 addons:
   postgresql: "9.4"
 bundler_args: "--jobs=3 --retry=3 --without development:production --deployment"
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - travis-phantomjs
 
 before_install:
   - gem update bundler
   # from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
-  - mkdir travis-phantomjs
-  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  # and also from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-200965782
+  - phantomjs --version
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+  - phantomjs --version
+  # Clear cache and download new copy of PhantomJS if the current version doesn't match 2.1.1.
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis-phantomjs; mkdir -p $PWD/travis-phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs; fi"
+  - phantomjs --version
 
 before_script:
   - psql -c 'create database coursemology_test;' -U postgres


### PR DESCRIPTION
The Bitbucket URL is throttled and sometimes times out, causing the
build to fail.

Caching a copy on Travis will reduce the dependency on the throttled
version on Bitbucket.

Fixes #1182.