### PR TITLE
Linearize submission answer discussions

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/programming.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming.js
@@ -418,20 +418,6 @@
   }
 
   /**
-   * Handles the annotation post reply button click event.
-   *
-   * @param e The event object.
-   */
-  function onAnnotationPostReply(e) {
-    var $element = $(e.target);
-    var $post = $element.parents('.discussion_post:first');
-    var $form = findOrCreateAnnotationReplyFormForPost($post);
-
-    $form.find('textarea').focus();
-    e.preventDefault();
-  }
-
-  /**
    * Handles the annotation reply button click event. Replying to an annotation is
    * equivalent to replying to its last post.
    *
@@ -491,8 +477,6 @@
     onAnnotationDelete);
   $(document).on('click', DOCUMENT_SELECTOR + '.discussion_post .toolbar .edit',
     onAnnotationEdit);
-  $(document).on('click', DOCUMENT_SELECTOR + '.discussion_post .toolbar .reply',
-    onAnnotationPostReply);
   $(document).on('click', DOCUMENT_SELECTOR + '.discussion_topic .reply-annotation',
     onAnnotationReply);
 })(jQuery, FORM_HELPERS, ANSWER_HELPERS);

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -2,13 +2,14 @@
 class Course::Discussion::Post < ActiveRecord::Base
   extend Course::Discussion::Post::OrderingConcern
 
-  acts_as_forest order: :created_at, dependent: :destroy
+  acts_as_forest order: :created_at
   acts_as_readable on: :updated_at
   has_many_attachments
 
   after_initialize :set_topic, if: :new_record?
   after_initialize :set_title, if: :new_record?
   before_validation :set_title
+  before_destroy :reparent_children
 
   validate :parent_topic_consistency
 
@@ -97,5 +98,9 @@ class Course::Discussion::Post < ActiveRecord::Base
 
   def parent_topic_consistency
     errors.add(:topic_inconsistent) if parent && topic != parent.topic
+  end
+
+  def reparent_children
+    children.update_all(parent_id: parent_id)
   end
 end

--- a/app/views/course/assessment/answer/programming/_annotation_post.html.slim
+++ b/app/views/course/assessment/answer/programming/_annotation_post.html.slim
@@ -1,8 +1,6 @@
 = div_for(annotation_post, 'data-post-id' => annotation_post.id) do
   / Hide toolbar; only JavaScript-enabled clients will show this div.
   div.toolbar.pull-right style='display: none'
-    => link_to('#', class: ['reply']) do
-      = fa_icon 'reply'.freeze
     - if can?(:update, annotation_post)
       => link_to('#', class: ['edit']) do
         = fa_icon 'edit'.freeze

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -83,26 +83,6 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
         expect(page).to have_content_tag_for(answer_discussion_topic.posts.first)
       end
 
-      scenario 'I can reply to an existing annotation post', js: true do
-        post = create(:course_discussion_post, topic: annotation.discussion_topic, creator: user)
-
-        visit edit_course_assessment_submission_path(course, assessment, submission)
-        within find(content_tag_selector(post)) do
-          find('.reply').click
-        end
-
-        annotation_text = 'reply annotation'
-        within find_form('.annotation-form') do
-          fill_in 'discussion_post[text]', with: annotation_text
-          click_button I18n.t('javascript.course.assessment.submission.answer.programming.'\
-                              'annotation_form.submit')
-        end
-
-        wait_for_ajax
-        new_post = post.children.reload.last
-        expect(new_post.text).to have_tag('*', text: annotation_text)
-      end
-
       scenario 'I can reply to an existing annotation topic', js: true do
         create(:course_discussion_post, topic: annotation.discussion_topic, creator: user)
 


### PR DESCRIPTION
In this PR:
- Re-parent children instead of deleting them when the parent post is deleted. 
- Disallow user from replying to posts except for the last one thereby linearising the conversation thread.

Next up:
- Allow editing and deletion of posts in comments center
- Allow only course staff to be able to delete forum posts