### PR TITLE
Course index pages issue fixes 

### DIFF
--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -3,7 +3,7 @@ class Course::CoursesController < Course::Controller
   include Course::ActivityFeedsConcern
 
   def index # :nodoc:
-    @courses = @courses.page(page_param)
+    @courses = Course.publicly_accessible.page(page_param)
   end
 
   def show # :nodoc:

--- a/app/models/components/course/course_ability_component.rb
+++ b/app/models/components/course/course_ability_component.rb
@@ -5,6 +5,7 @@ module Course::CourseAbilityComponent
   def define_permissions
     allow_showing_open_courses
     if user
+      allow_instructors_create_courses
       allow_unregistered_users_registering_open_courses
       allow_registered_users_showing_course
       allow_owners_managing_course
@@ -15,6 +16,10 @@ module Course::CourseAbilityComponent
   end
 
   private
+
+  def allow_instructors_create_courses
+    can :create, Course if user.instance_users.instructor.present?
+  end
 
   def allow_showing_open_courses
     # TODO: Replace with just the symbols when Rails 5 is released.

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,7 +10,11 @@ class Course < ActiveRecord::Base
   after_initialize :set_defaults, if: :new_record?
   before_validation :set_defaults, if: :new_record?
 
+  # closed: Closed for registering.
+  # published: Accessible in courses index page.
+  # opened: published + opened for registering.
   enum status: { closed: 0, published: 1, opened: 2 }
+  PUBLIC_STATUSES = Set[:published, :opened].freeze
 
   belongs_to :instance, inverse_of: :courses
   has_many :course_users, inverse_of: :course, dependent: :destroy
@@ -54,6 +58,7 @@ class Course < ActiveRecord::Base
 
   scope :ordered_by_title, -> { order(:title) }
   scope :ordered_by_end_at, ->(direction = :desc) { order(end_at: direction) }
+  scope :publicly_accessible, -> { where(status: PUBLIC_STATUSES.map { |s| statuses[s] }) }
 
   # @!method containing_user
   #   Selects all the courses with user as one of its approved members

--- a/app/views/course/courses/index.html.slim
+++ b/app/views/course/courses/index.html.slim
@@ -1,5 +1,5 @@
 = page_header do
-  = new_button([:course]) if can?(:create, Course.new)
+  = new_button([:course]) if can?(:create, Course)
 
 = render @courses
 

--- a/spec/factories/instance_users.rb
+++ b/spec/factories/instance_users.rb
@@ -8,6 +8,10 @@ FactoryGirl.define do
       instance_user.user ||= build(:user, instance_users: [instance_user])
     end
 
+    trait :instructor do
+      role :instructor
+    end
+
     trait :auto_grader do
       role :auto_grader
     end

--- a/spec/features/course_management_spec.rb
+++ b/spec/features/course_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Courses' do
   let(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    let(:user) { create(:administrator) }
+    let(:user) { create(:instance_user, :instructor).user }
     before { login_as(user, scope: :user) }
 
     scenario 'Users can see a list of published courses' do

--- a/spec/features/course_management_spec.rb
+++ b/spec/features/course_management_spec.rb
@@ -9,8 +9,9 @@ RSpec.feature 'Courses' do
     let(:user) { create(:administrator) }
     before { login_as(user, scope: :user) }
 
-    scenario 'Users can see a list of all courses' do
+    scenario 'Users can see a list of published courses' do
       create(:course)
+      create(:course, [:published, :opened].sample)
 
       visit courses_path
       expect(all('.course').count).to eq(1)


### PR DESCRIPTION
For #1185 and #1186 

For #1186 Users should not see non published courses even they enrolled in the course. This will avoid the performance issue for index page as well. But the issue is still there if code referees to `Course.accessible_by(xx)`