### PR TITLE
Ajax submission of a single answer for both worksheet and guided

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
@@ -1,0 +1,41 @@
+(function($) {
+  'use strict';
+  var DOCUMENT_SELECTOR = '.course-assessment-submission-submissions.edit ';
+
+  function onAnswerSubmit(e) {
+    e.preventDefault();
+
+    showSpinner($(this));
+    submitFormAndWaitForJob($('.edit_submission'), e.target.value);
+  }
+
+  function submitFormAndWaitForJob($form, answer_id) {
+    var action = $form.attr('action');
+    var method = $form.attr('method');
+
+    var $input = $('<input>').attr('type', 'hidden').
+    attr('name', 'attempting_answer_id').val(answer_id);
+    $form = $form.clone().append($input);
+
+    var data = $form.serialize();
+    $.ajax({
+      url: action,
+      method: method,
+      data: data,
+      dataType: 'json',
+      global: false
+    }).done(function(data) {
+      waitForJob(data.redirect_url, answer_id);
+    });
+  }
+
+  function waitForJob(url, answer_id) {
+  }
+
+  function showSpinner($button) {
+    $button.prop('disabled', true);
+    $button.append('<i class="fa fa-spinner fa-lg fa-spin"></i>');
+  }
+
+  $(document).on('click', DOCUMENT_SELECTOR + '.btn.submit-answer', onAnswerSubmit);
+})(jQuery);

--- a/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
@@ -1,6 +1,7 @@
 (function($) {
   'use strict';
   var DOCUMENT_SELECTOR = '.course-assessment-submission-submissions.edit ';
+  var DELAY = 500; // Delay between each job request in ms.
 
   function onAnswerSubmit(e) {
     e.preventDefault();
@@ -30,6 +31,35 @@
   }
 
   function waitForJob(url, answer_id) {
+    setTimeout(function() {
+      $.ajax({
+        url: url,
+        method: 'GET',
+        dataType: 'json',
+        global: false
+      }).done(function(data) {
+        onGetJobSuccess(data, url, answer_id);
+      })
+    }, DELAY);
+  }
+
+  function onGetJobSuccess(data, url, answer_id) {
+    if (data.status == 'completed') {
+      reloadAnswer(answer_id);
+    } else if (data.status == 'submitted') {
+      waitForJob(url, answer_id);
+    } else {
+      // Show errors.
+    }
+  }
+
+  function reloadAnswer(answer_id) {
+    $.ajax({
+      url: 'reload_answer',
+      method: 'GET',
+      data: { answer_id: answer_id },
+      global: false
+    });
   }
 
   function showSpinner($button) {

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -40,6 +40,12 @@ class Course::Assessment::Submission::SubmissionsController < \
     redirect_to(job_path(job.job))
   end
 
+  def reload_answer
+    @answer = @submission.answers.find_by(id: answer_id_param)
+    @current_question = @answer.question
+    render :bad_request unless @answer
+  end
+
   private
 
   def create_params
@@ -56,5 +62,9 @@ class Course::Assessment::Submission::SubmissionsController < \
     else
       authorize!(:read, @submission)
     end
+  end
+
+  def answer_id_param
+    params.permit(:answer_id)[:answer_id]
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -25,7 +25,10 @@ class JobsController < ApplicationController
   end
 
   def show_completed_job
-    redirect_to @job.redirect_to if @job.redirect_to.present?
+    respond_to do |format|
+      format.html { redirect_to @job.redirect_to if @job.redirect_to.present? }
+      format.json {}
+    end
   end
 
   def show_errored_job

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -70,7 +70,7 @@ module Course::Assessment::AssessmentAbility
     can :create, Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
     can :update, Course::Assessment::Submission, submission_attempting_hash(user)
-    can :read, Course::Assessment::Submission,
+    can [:read, :reload_answer], Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
   end
 
@@ -89,7 +89,8 @@ module Course::Assessment::AssessmentAbility
   end
 
   def allow_staff_grade_submissions
-    can :read, Course::Assessment::Submission, assessment: assessment_course_staff_hash
+    can [:read, :reload_answer],
+        Course::Assessment::Submission, assessment: assessment_course_staff_hash
     can :grade, Course::Assessment::Submission, submission_submitted_or_graded_hash.merge(
       assessment: assessment_course_staff_hash
     )

--- a/app/services/course/assessment/submission/update_guided_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_guided_assessment_service.rb
@@ -2,16 +2,6 @@
 class Course::Assessment::Submission::UpdateGuidedAssessmentService <
   Course::Assessment::Submission::UpdateService
 
-  def update
-    if params[:attempting_answer_id]
-      submit_answer
-    elsif params[:attempting_question_id]
-      reattempt_question
-    else
-      super
-    end
-  end
-
   def load_or_create_answers
     super if @submission.attempting?
 
@@ -20,28 +10,8 @@ class Course::Assessment::Submission::UpdateGuidedAssessmentService <
 
   private
 
-  def answer_id_param
-    params.permit(:attempting_answer_id)[:attempting_answer_id]
-  end
-
-  def question_id_param
-    params.permit(:attempting_question_id)[:attempting_question_id]
-  end
-
   def step_param
     params.permit(:step)[:step]
-  end
-
-  def submit_answer
-    if @submission.update_attributes(update_params)
-      answer = @submission.answers.find(answer_id_param)
-      answer.finalise!
-      job = answer.auto_grade!(current_step_path)
-
-      redirect_to job_path(job.job)
-    else
-      render 'edit'
-    end
   end
 
   def reattempt_question

--- a/app/services/course/assessment/submission/update_worksheet_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_worksheet_assessment_service.rb
@@ -39,4 +39,15 @@ class Course::Assessment::Submission::UpdateWorksheetAssessmentService <
       result.push(options)
     end
   end
+
+  def question_id_param
+    params.permit(:attempting_question_id)[:attempting_question_id]
+  end
+
+  def reattempt_question
+    question = @assessment.questions.find(question_id_param)
+    question.attempt(@submission)
+
+    redirect_to edit_submission_path if @submission.save
+  end
 end

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -1,8 +1,12 @@
-= base_answer_form.simple_fields_for :actable do |specific_answer_form|
-  = render partial: specific_answer_form.object.specific, locals: { f: specific_answer_form }
+= simple_fields_for :"submission[answers_attributes][#{answer.id}]", answer do |f|
+  = f.hidden_field :id
 
-= render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
-         locals: { base_answer_form: base_answer_form, answer: answer }
+  = f.simple_fields_for :actable do |specific_answer_form|
+    = specific_answer_form.hidden_field :id, value: answer.actable.id
+    = render partial: specific_answer_form.object, locals: { f: specific_answer_form }
 
-= render partial: 'course/assessment/answer/grading',
-         locals: { base_answer_form: base_answer_form, answer: answer }
+    = render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
+             locals: { base_answer_form: f, answer: answer }
+
+    = render partial: 'course/assessment/answer/grading',
+             locals: { base_answer_form: f, answer: answer }

--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -1,6 +1,6 @@
 - if answer.submission.attempting?
   - if answer.attempting?
-    = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id'
+    = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
   - elsif !answer.correct?
     = base_answer_form.button :button, t('.reattempt'), value: answer.question.id, name: 'attempting_question_id'
   - elsif !@current_question.last_question?

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -1,3 +1,9 @@
+- if answer.submission.attempting? && answer.specific.is_a?(Course::Assessment::Answer::Programming)
+  - if answer.attempting?
+    = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+  - elsif !answer.correct?
+    = base_answer_form.button :button, t('.reattempt'), value: answer.question.id, name: 'attempting_question_id'
+
 h3 = t('.comments')
 div.comments id=comments_container_id(answer)
   - topic = answer.discussion_topic

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -5,12 +5,9 @@
   - answers_by_question = f.object.answers.latest_answers.group_by(&:question)
   - f.object.assessment.questions.each do |question|
     = render partial: question, suffix: 'question'
-
-    = f.simple_fields_for :answers, answers_by_question[question] do |base_answer_form|
-      = content_tag_for(:div, base_answer_form.object,
-                        'data-answer-id' => base_answer_form.object.id) do
-        = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
-                 locals: { base_answer_form: base_answer_form }
+    - answer = answers_by_question[question].last
+    = content_tag_for(:div, answer, 'data-answer-id' => answer.id) do
+      = render partial: 'course/assessment/answer/answer', object: answer
 
   - unless @submission.attempting?
     = render 'statistics', f: f
@@ -24,3 +21,4 @@
       auto_grade_course_assessment_submission_path(current_course, @submission.assessment,
         @submission), method: :post, class: ['btn', 'btn-info']
     = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger']
+

--- a/app/views/course/assessment/submission/submissions/reload_answer.js.erb
+++ b/app/views/course/assessment/submission/submissions/reload_answer.js.erb
@@ -1,0 +1,3 @@
+$('<%= "#answer_#{@answer.id}"%>').html(
+    '<%= escape_javascript(render partial: 'course/assessment/answer/answer', object: @answer) %>'
+);

--- a/app/views/jobs/_completed.json.jbuilder
+++ b/app/views/jobs/_completed.json.jbuilder
@@ -1,1 +1,2 @@
+json.status 'completed'
 json.message t('.completed')

--- a/app/views/jobs/_errored.json.jbuilder
+++ b/app/views/jobs/_errored.json.jbuilder
@@ -1,1 +1,2 @@
+json.status 'errored'
 json.message t('.errored')

--- a/app/views/jobs/_submitted.json.jbuilder
+++ b/app/views/jobs/_submitted.json.jbuilder
@@ -1,0 +1,1 @@
+json.status 'submitted'

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -2,13 +2,15 @@ en:
   course:
     assessment:
       answer:
+        reattempt: 'Reattempt'
         worksheet:
           comments: 'Comments'
+          reattempt: :'course.assessment.answer.reattempt'
         comments_footer:
           comment: 'Comment'
         guided:
           continue: 'Continue'
-          reattempt: 'Reattempt'
+          reattempt: :'course.assessment.answer.reattempt'
         grading:
           grading: 'Grading'
           maximum_grade: '/ %{maximum_grade}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,7 +169,7 @@ Rails.application.routes.draw do
           scope module: :submission do
             resources :submissions, only: [:index, :create, :edit, :update] do
               post :auto_grade, on: :member
-
+              get :reload_answer, on: :member
               scope module: :answer do
                 resources :answers, only: [] do
                   resources :comments, only: [:create]

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         expect(page).to have_selector('h2', text: assessment.questions.second.title)
       end
 
-      scenario 'I can continue to the next question when current answer is correct' do
+      scenario 'I can continue to the next question when current answer is correct', js: true do
         mcq_questions
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
@@ -63,7 +63,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         check correct_option
 
         click_button I18n.t('common.submit')
-        wait_for_job
+        wait_for_ajax
         expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grading')
         expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grade')
 

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
     let(:submission) do
       create(:course_assessment_submission, assessment: assessment, creator: student)
     end
+    let(:programming_question) do
+      create(:course_assessment_question_programming, assessment: assessment)
+    end
 
     context 'As a Course Student' do
       let(:user) { student }
@@ -31,6 +34,14 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
           edit_course_assessment_submission_path(course, assessment, submission)
         )
         expect(page).to have_checked_field(option)
+      end
+
+      scenario 'I can only submit programming answers' do
+        programming_question
+        submission
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        expect(page).to have_selector('.btn.submit-answer', count: 1)
       end
 
       scenario 'I can finalise my submission only once' do


### PR DESCRIPTION
To replace #1181, Fix #1167 and #1168 

Change the redirection of jobs to ajax polling jobs.
Support submit programming questions in worksheet submission.