### PR TITLE
Use uuid for attachment_references

### DIFF
--- a/app/controllers/attachment_references_controller.rb
+++ b/app/controllers/attachment_references_controller.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 class AttachmentReferencesController < ApplicationController
   load_resource :attachment_reference
-  before_action :authorize_resource
 
   def show
     redirect_to @attachment_reference.url
-  end
-
-  private
-
-  def authorize_resource
-    authorize!(:read, @attachment_reference.attachable)
   end
 end

--- a/db/migrate/20160730044448_chang_attachment_references.rb
+++ b/db/migrate/20160730044448_chang_attachment_references.rb
@@ -1,0 +1,11 @@
+class ChangAttachmentReferences < ActiveRecord::Migration
+  def change
+    add_column :attachment_references, :uuid, :uuid, default: 'uuid_generate_v4()', null: false
+
+    change_table :attachment_references do |t|
+      t.remove :id
+      t.rename :uuid, :id
+    end
+    execute 'ALTER TABLE attachment_references ADD PRIMARY KEY (id);'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160729022656) do
+ActiveRecord::Schema.define(version: 20160730044448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 20160729022656) do
     t.datetime "updated_at",  :null=>false
   end
 
-  create_table "attachment_references", force: :cascade do |t|
+  create_table "attachment_references", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.integer  "attachable_id"
     t.string   "attachable_type", :limit=>255, :index=>{:name=>"fk__attachment_references_attachable_id", :with=>["attachable_id"]}
     t.integer  "attachment_id",   :null=>false, :index=>{:name=>"fk__attachment_references_attachment_id"}, :foreign_key=>{:references=>"attachments", :name=>"fk_attachment_references_attachment_id", :on_update=>:no_action, :on_delete=>:no_action}

--- a/lib/extensions/attachable/active_record/base.rb
+++ b/lib/extensions/attachable/active_record/base.rb
@@ -109,7 +109,8 @@ module Extensions::Attachable::ActiveRecord::Base
       ids
     end
 
-    ATTACHMENT_ID_REGEX = /\/attachments\/(\d+)$/
+    # Regex for filtering UUIDs.
+    ATTACHMENT_ID_REGEX = /\/attachments\/([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})$/
     # Parse attachment_reference from the given url.
     #
     # @param [String] url The url.
@@ -118,7 +119,7 @@ module Extensions::Attachable::ActiveRecord::Base
     def parse_attachment_reference_id_from_url(url)
       # TODO: Attachments from a third party domain with the same path should not be returned.
       result = url.match(ATTACHMENT_ID_REGEX)
-      result ? result[1].to_i : nil
+      result ? result[1] : nil
     end
   end
 

--- a/spec/libraries/acts_as_attachable_spec.rb
+++ b/spec/libraries/acts_as_attachable_spec.rb
@@ -36,6 +36,43 @@ RSpec.describe 'Extension: Acts as Attachable' do
         expect(attachable.attachments).to be_present
       end
     end
+
+    describe '#parse_attachment_reference_id_from_url' do
+      context 'with valid UUIDs' do
+        let(:uuids) do
+          [
+            'f24cfa8b-b9c7-4b16-9cdf-ec6e0f84511d',
+            '24449936-6bfa-4407-a7f2-8c7a360c3316',
+            '04ecba9a-c53c-487b-9191-22454be2b407'
+          ]
+        end
+
+        it 'returns the uuid' do
+          uuids.each do |uuid|
+            url = "/attachments/#{uuid}"
+            expect(attachable.send(:parse_attachment_reference_id_from_url, url)).to eq(uuid)
+          end
+        end
+      end
+
+      context 'with invalid UUIDs' do
+        let(:uuids) do
+          [
+            'f24cfa8b-b9c7-4b16-9cdf-',
+            'c53c-487b-9191-22454be2b407',
+            '24449936-6bfa-4407-8c7a360c3316',
+            '04ecba9a_c53c_487b_9191_22454be2b407'
+          ]
+        end
+
+        it 'returns nil' do
+          uuids.each do |uuid|
+            url = "/attachments/#{uuid}"
+            expect(attachable.send(:parse_attachment_reference_id_from_url, url)).to be_nil
+          end
+        end
+      end
+    end
   end
 
   describe self::SampleModelSingular do


### PR DESCRIPTION
This will fix #1195, I will re run the migration script after this.

#1195 is because user cannot read `Assessment::Question`. but to fix this in the general case, uuid is the way to go,  it's more safer ( user cannot just enumerate the ids of the attachments) and improves the performance.