### PR TITLE
Only show test case identifiers to graders

### DIFF
--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -13,19 +13,25 @@ h3 = t('.test_cases')
 table.table.table-striped.table-hover
   thead
     tr
-      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier)
+      - if can?(:grade, answer.answer)
+        th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier)
       th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expression)
       th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expected)
       th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:hint)
       th = t('.passed')
   tbody
     tr
-      th colspan=5
-        = t('.public')
+      - if can?(:grade, answer.answer)
+        th colspan=5
+          = t('.public')
+      - else
+        th colspan = 4
+          = t('.public')
     - public_test_cases.each do |test_case|
       - test_case_result = answer_test_results_hash[test_case]
       = content_tag_for(:tr, test_case) do
-        th = format_html(test_case.identifier)
+        - if can?(:grade, answer.answer)
+          th = format_html(test_case.identifier)
         td = format_html(test_case.expression)
         td = format_html(test_case.expected)
         td = format_html(test_case.hint) if !test_case_result || !test_case_result.passed?


### PR DESCRIPTION
Fixes #1216.

The generated test case identifier makes no sense to the students so they shouldn't be allowed to see it.

However, if there are public test cases without metadata, the display will be strange as empty rows are generated.

This will be fixed in #1222.