### PR TITLE
Implement auto reattempt questions

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
@@ -45,7 +45,7 @@
 
   function onGetJobSuccess(data, url, answer_id) {
     if (data.status == 'completed') {
-      reloadAnswer(answer_id);
+      reattemptQuestion(answer_id);
     } else if (data.status == 'submitted') {
       waitForJob(url, answer_id);
     } else {
@@ -53,10 +53,10 @@
     }
   }
 
-  function reloadAnswer(answer_id) {
+  function reattemptQuestion(answer_id) {
     $.ajax({
-      url: 'reload_answer',
-      method: 'GET',
+      url: 'reattempt_question',
+      method: 'POST',
       data: { answer_id: answer_id },
       global: false
     });

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -40,10 +40,17 @@ class Course::Assessment::Submission::SubmissionsController < \
     redirect_to(job_path(job.job))
   end
 
-  def reload_answer
+  # Reattempt current question and create a new answer based on previous answer.
+  def reattempt_question
     @answer = @submission.answers.find_by(id: answer_id_param)
-    @current_question = @answer.question
-    render :bad_request unless @answer
+
+    if @answer
+      @current_question = @answer.question
+      @new_answer = @current_question.attempt(@submission, @answer)
+      render status: :bad_request unless @new_answer.save
+    else
+      render status: :bad_request
+    end
   end
 
   private

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -28,4 +28,15 @@ module Course::Assessment::Submission::SubmissionsHelper
   def explanation_panel_class(answer)
     answer.correct ? 'panel-success' : 'panel-danger'
   end
+
+  # Return the last attempted answer based on the status of current submission.
+  # previous attempt if submission is in attempting state.
+  # current attempt if submission is in submitted or graded state.
+  #
+  # @return [Course::Assessment::Answer]
+  def last_attempt(answer)
+    submission = answer.submission
+    attempts = submission.answers.order(:created_at).from_question(answer.question_id)
+    submission.attempting? ? attempts[-2] : attempts[-1]
+  end
 end

--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -6,4 +6,9 @@ module Course::Assessment::Submission::AnswersConcern
   def latest_answers
     select('DISTINCT ON (question_id) *').order(:question_id, created_at: :desc)
   end
+
+  # Load the answers of specific question.
+  def from_question(question_id)
+    order(:created_at).where(question_id: question_id)
+  end
 end

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -70,7 +70,7 @@ module Course::Assessment::AssessmentAbility
     can :create, Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
     can :update, Course::Assessment::Submission, submission_attempting_hash(user)
-    can [:read, :reload_answer], Course::Assessment::Submission,
+    can [:read, :reattempt_question], Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
   end
 
@@ -89,7 +89,7 @@ module Course::Assessment::AssessmentAbility
   end
 
   def allow_staff_grade_submissions
-    can [:read, :reload_answer],
+    can [:read, :reattempt_question],
         Course::Assessment::Submission, assessment: assessment_course_staff_hash
     can :grade, Course::Assessment::Submission, submission_submitted_or_graded_hash.merge(
       assessment: assessment_course_staff_hash

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -37,11 +37,15 @@ class Course::Assessment::Question < ActiveRecord::Base
   #
   # @param [Course::Assessment::Submission] submission The submission which the answer should
   #   belong to.
+  # @param [Course::Assessment::Answer|nil] last_attempt If last_attempt is given, fields in the
+  #   new answer will be pre-populated with data from it.
   # @return [Course::Assessment::Answer] The answer corresponding to the question. It is required
   #   that the {Course::Assessment::Answer#question} property be the same as +self+. The result
   #   should not be persisted.
-  def attempt(submission)
-    return actable.attempt(submission) if actable && actable.self_respond_to?(:attempt)
+  def attempt(submission, last_attempt = nil)
+    if actable && actable.self_respond_to?(:attempt)
+      return actable.attempt(submission, last_attempt ? last_attempt.actable : nil)
+    end
     raise NotImplementedError, 'Questions must implement the #attempt method for submissions.'
   end
 

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -17,7 +17,15 @@ class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
     Course::Assessment::Answer::MultipleResponseAutoGradingService.new
   end
 
-  def attempt(submission)
-    submission.multiple_response_answers.build(submission: submission, question: question).answer
+  def attempt(submission, last_attempt = nil)
+    answer =
+      submission.multiple_response_answers.build(submission: submission, question: question)
+    if last_attempt
+      last_attempt.answer_options.each do |answer_option|
+        answer.answer_options.build(option_id: answer_option.option_id)
+      end
+    end
+
+    answer.acting_as
   end
 end

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -25,10 +25,16 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
     Course::Assessment::Answer::ProgrammingAutoGradingService.new
   end
 
-  def attempt(submission)
+  def attempt(submission, last_attempt = nil)
     answer = submission.programming_answers.build(submission: submission, question: question)
-    copy_template_files_to(answer)
-    answer.answer
+    if last_attempt
+      last_attempt.files.each do |file|
+        answer.files.build(filename: file.filename, content: file.content)
+      end
+    else
+      copy_template_files_to(answer)
+    end
+    answer.acting_as
   end
 
   def to_partial_path

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -17,8 +17,10 @@ class Course::Assessment::Question::TextResponse < ActiveRecord::Base
     Course::Assessment::Answer::TextResponseAutoGradingService.new
   end
 
-  def attempt(submission)
-    submission.text_response_answers.build(submission: submission, question: question).answer
+  def attempt(submission, last_attempt = nil)
+    answer = submission.text_response_answers.build(submission: submission, question: question)
+    answer.answer_text = last_attempt.answer_text if last_attempt
+    answer.acting_as
   end
 
   private

--- a/app/services/course/assessment/submission/update_guided_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_guided_assessment_service.rb
@@ -14,18 +14,6 @@ class Course::Assessment::Submission::UpdateGuidedAssessmentService <
     params.permit(:step)[:step]
   end
 
-  def reattempt_question
-    question = @assessment.questions.find(question_id_param)
-    question.attempt(@submission)
-    if @submission.save
-      redirect_to current_step_path
-    else
-      redirect_to current_step_path,
-                  danger: t('course.assessment.submission.submissions.update.failure',
-                            error: @submission.errors.full_messages.to_sentence)
-    end
-  end
-
   def questions_to_attempt
     @assessment.questions.where(id: current_question)
   end
@@ -41,10 +29,5 @@ class Course::Assessment::Submission::UpdateGuidedAssessmentService <
           @assessment.questions.fetch(step)
         end
       end
-  end
-
-  def current_step_path
-    edit_course_assessment_submission_path(current_course, @assessment,
-                                           @submission, step: step_param)
   end
 end

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -3,8 +3,6 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   def update
     if params[:attempting_answer_id]
       submit_answer
-    elsif params[:attempting_question_id]
-      reattempt_question
     elsif @submission.update_attributes(update_params)
       redirect_to edit_submission_path,
                   success: t('course.assessment.submission.submissions.update.success')
@@ -87,10 +85,6 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
 
   def answer_id_param
     params.permit(:attempting_answer_id)[:attempting_answer_id]
-  end
-
-  def question_id_param
-    params.permit(:attempting_question_id)[:attempting_question_id]
   end
 
   def edit_submission_path

--- a/app/services/course/assessment/submission/update_worksheet_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_worksheet_assessment_service.rb
@@ -39,15 +39,4 @@ class Course::Assessment::Submission::UpdateWorksheetAssessmentService <
       result.push(options)
     end
   end
-
-  def question_id_param
-    params.permit(:attempting_question_id)[:attempting_question_id]
-  end
-
-  def reattempt_question
-    question = @assessment.questions.find(question_id_param)
-    question.attempt(@submission)
-
-    redirect_to edit_submission_path if @submission.save
-  end
 end

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -1,15 +1,16 @@
 - submission = answer.submission
 - last_attempt = last_attempt(answer)
 
-= simple_fields_for :"submission[answers_attributes][#{answer.id}]", answer do |f|
-  = f.hidden_field :id
+= content_tag_for(:div, answer, 'data-answer-id' => answer.id) do
+  = simple_fields_for :"submission[answers_attributes][#{answer.id}]", answer do |f|
+    = f.hidden_field :id
 
-  = f.simple_fields_for :actable do |specific_answer_form|
-    = specific_answer_form.hidden_field :id, value: answer.actable.id
-    = render partial: specific_answer_form.object, locals: { f: specific_answer_form, last_attempt: last_attempt }
+    = f.simple_fields_for :actable do |specific_answer_form|
+      = specific_answer_form.hidden_field :id, value: answer.actable.id
+      = render partial: specific_answer_form.object, locals: { f: specific_answer_form, last_attempt: last_attempt }
 
-    = render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
-             locals: { base_answer_form: f, answer: answer, last_attempt: last_attempt }
+      = render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
+               locals: { base_answer_form: f, answer: answer, last_attempt: last_attempt }
 
-    = render partial: 'course/assessment/answer/grading',
-             locals: { base_answer_form: f, answer: answer }
+      = render partial: 'course/assessment/answer/grading',
+               locals: { base_answer_form: f, answer: answer }

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -12,5 +12,6 @@
       = render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
                locals: { base_answer_form: f, answer: answer, last_attempt: last_attempt }
 
-      = render partial: 'course/assessment/answer/grading',
-               locals: { base_answer_form: f, answer: answer }
+      - if !submission.attempting?
+        = render partial: 'course/assessment/answer/grading',
+                 locals: { base_answer_form: f, answer: answer }

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -1,12 +1,15 @@
+- submission = answer.submission
+- last_attempt = last_attempt(answer)
+
 = simple_fields_for :"submission[answers_attributes][#{answer.id}]", answer do |f|
   = f.hidden_field :id
 
   = f.simple_fields_for :actable do |specific_answer_form|
     = specific_answer_form.hidden_field :id, value: answer.actable.id
-    = render partial: specific_answer_form.object, locals: { f: specific_answer_form }
+    = render partial: specific_answer_form.object, locals: { f: specific_answer_form, last_attempt: last_attempt }
 
     = render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
-             locals: { base_answer_form: f, answer: answer }
+             locals: { base_answer_form: f, answer: answer, last_attempt: last_attempt }
 
     = render partial: 'course/assessment/answer/grading',
              locals: { base_answer_form: f, answer: answer }

--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -2,8 +2,11 @@
   - if answer.attempting?
     = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
   - elsif !answer.correct?
-    = base_answer_form.button :button, t('.reattempt'), value: answer.question.id, name: 'attempting_question_id'
-  - elsif !@current_question.last_question?
+    - path = reattempt_question_course_assessment_submission_path(current_course, @assessment, @submission, answer_id: answer.id)
+    = link_to t('.reattempt'), path, remote: true, method: :post, class: [ 'btn', 'btn-default']
+
+  / Display a continue button if last attempt is correct
+  - if !@current_question.last_question? && last_attempt && last_attempt.correct?
     = link_to t('.continue'),
       edit_course_assessment_submission_path(current_course, @assessment, @submission, step: guided_current_step + 1),
       class: ['btn', 'btn-success']

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -2,7 +2,8 @@
   - if answer.attempting?
     = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
   - elsif !answer.correct?
-    = base_answer_form.button :button, t('.reattempt'), value: answer.question.id, name: 'attempting_question_id'
+    - path = reattempt_question_course_assessment_submission_path(current_course, @assessment, @submission, answer_id: answer.id)
+    = link_to t('.reattempt'), path, remote: true, method: :post, class: ['btn', 'btn-default']
 
 h3 = t('.comments')
 div.comments id=comments_container_id(answer)

--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
@@ -5,6 +5,6 @@
                           display_solution: can?(:grade, multiple_response.answer),
                           label_method: :option, label: false, disabled: readonly
 
-- if f.object.auto_grading && f.object.auto_grading.result
+- if last_attempt && last_attempt.auto_grading && last_attempt.auto_grading.result
   = render partial: 'course/assessment/answer/explanation',
-           locals: { answer: f.object }
+           locals: { answer: last_attempt }

--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
@@ -1,9 +1,10 @@
 - question = multiple_response.question.specific
 - readonly = cannot?(:update, multiple_response.answer)
-= f.association :options, as: :course_assessment_answer_multiple_response,
-                          collection: question.options,
-                          display_solution: can?(:grade, multiple_response.answer),
-                          label_method: :option, label: false, disabled: readonly
+= f.association :options,
+  as: :course_assessment_answer_multiple_response,
+  collection: question.options,
+  display_solution: can?(:grade, multiple_response.answer) && !multiple_response.submission.attempting?,
+  label_method: :option, label: false, disabled: readonly
 
 - if last_attempt && last_attempt.auto_grading && last_attempt.auto_grading.result
   = render partial: 'course/assessment/answer/explanation',

--- a/app/views/course/assessment/answer/programming/_programming.html.slim
+++ b/app/views/course/assessment/answer/programming/_programming.html.slim
@@ -6,5 +6,6 @@ div.files
   = f.simple_fields_for :files do |files_form|
     = render file_fields_path, f: files_form
 
+- answer = last_attempt ? last_attempt.actable: programming
 = render partial: 'course/assessment/answer/programming/test_cases',
-         locals: { question: question, answer: programming }
+         locals: { question: question, answer: answer }

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -2,7 +2,7 @@
 - readonly = cannot?(:update, text_response.answer)
 = f.input :answer_text, label: false, readonly: readonly
 
-- if f.object.auto_grading && f.object.auto_grading.result
+- if last_attempt && last_attempt.auto_grading && last_attempt.auto_grading.result
   = render partial: 'course/assessment/answer/explanation',
            locals: { answer: f.object }
 

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -8,13 +8,11 @@ nav
   = f.error_notification
   = hidden_field_tag :step, guided_current_step
   = f.simple_fields_for :answers, guided_current_answer do |base_answer_form|
-    = content_tag_for(:div, base_answer_form.object,
-                      'data-answer-id' => base_answer_form.object.id) do
-      = render partial: base_answer_form.object.question, suffix: 'question'
-      = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
-               locals: { base_answer_form: base_answer_form }
-      - if base_answer_form.object.attempting?
-        = f.button :submit, t('common.save')
+    = render partial: base_answer_form.object.question, suffix: 'question'
+    = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
+             locals: { base_answer_form: base_answer_form }
+    - if base_answer_form.object.attempting?
+      = f.button :submit, t('common.save')
 
   - if @submission.attempting? && guided_next_unanswered_question.nil?
     = f.button :submit, t('.finalise'), name: 'submission[finalise]', class: ['btn-danger']

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -6,8 +6,7 @@
   - f.object.assessment.questions.each do |question|
     = render partial: question, suffix: 'question'
     - answer = answers_by_question[question].last
-    = content_tag_for(:div, answer, 'data-answer-id' => answer.id) do
-      = render partial: 'course/assessment/answer/answer', object: answer
+    = render partial: 'course/assessment/answer/answer', object: answer
 
   - unless @submission.attempting?
     = render 'statistics', f: f

--- a/app/views/course/assessment/submission/submissions/reattempt_question.js.erb
+++ b/app/views/course/assessment/submission/submissions/reattempt_question.js.erb
@@ -1,0 +1,3 @@
+$('<%= "#answer_#{@answer.id}"%>').replaceWith(
+    '<%= escape_javascript(render partial: 'course/assessment/answer/answer', object: @new_answer) %>'
+);

--- a/app/views/course/assessment/submission/submissions/reload_answer.js.erb
+++ b/app/views/course/assessment/submission/submissions/reload_answer.js.erb
@@ -1,3 +1,0 @@
-$('<%= "#answer_#{@answer.id}"%>').html(
-    '<%= escape_javascript(render partial: 'course/assessment/answer/answer', object: @answer) %>'
-);

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -31,7 +31,6 @@ en:
             grade_summary: 'Grade Summary'
           update:
             success: 'Submission was updated.'
-            failure: 'Failed to update submission: %{error}'
           submissions:
             student_name: 'Student Name'
             status: 'Submission Status'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,7 +169,7 @@ Rails.application.routes.draw do
           scope module: :submission do
             resources :submissions, only: [:index, :create, :edit, :update] do
               post :auto_grade, on: :member
-              get :reload_answer, on: :member
+              post :reattempt_question, on: :member
               scope module: :answer do
                 resources :answers, only: [] do
                   resources :comments, only: [:create]

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
       end
     end
 
+    describe '#reattempt_question' do
+      let(:submission) do
+        create(:course_assessment_submission, assessment: assessment, creator: user)
+      end
+
+      context 'when answer_id does not exist' do
+        subject do
+          post :reattempt_question, course_id: course, assessment_id: assessment,
+                                    id: submission.id, answer_id: -1, format: :js
+        end
+
+        it { is_expected.to have_http_status(:bad_request) }
+      end
+    end
+
     context 'when the assessment is guided' do
       let(:assessment) { create(:assessment, :guided, :with_mcq_question, course: course) }
       let!(:answer) do
@@ -86,25 +101,6 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
           end
 
           it { is_expected.to render_template('edit') }
-        end
-      end
-
-      describe '#re_attempt_question' do
-        subject do
-          put :update, course_id: course, assessment_id: assessment, id: immutable_submission,
-                       attempting_question_id: answer.question.id, submission: { title: '' }
-        end
-
-        context 'when update fails' do
-          before do
-            controller.instance_variable_set(:@submission, immutable_submission)
-            subject
-          end
-
-          it 'sets a flash with error messages' do
-            expect(flash[:danger]).
-              to eq(I18n.t('course.assessment.submission.submissions.update.failure'))
-          end
         end
       end
     end

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -64,14 +64,16 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         click_button I18n.t('common.submit')
         wait_for_ajax
-        expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grading')
-        expect(page).to have_selector('div', text: 'course.assessment.answer.grading.grade')
+        # Check that previous attempt is restored.
+        expect(page).
+          to have_selector('div.panel', text: 'course.assessment.answer.explanation.correct')
+        expect(page).to have_checked_field(correct_option)
 
         click_link I18n.t('course.assessment.answer.guided.continue')
         expect(page).to have_selector('h2', text: mcq_questions.second.title)
       end
 
-      scenario 'I can reattempt the question when current answer is not correct' do
+      scenario 'I can resubmit the question when current answer is not correct', js: true do
         mcq_questions
 
         visit edit_course_assessment_submission_path(assessment.course, assessment, submission)
@@ -79,11 +81,14 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         wrong_option = mcq_questions.first.options.where(correct: false).first.option
         check wrong_option
         click_button I18n.t('common.submit')
-        wait_for_job
+        wait_for_ajax
 
-        click_button I18n.t('course.assessment.answer.guided.reattempt')
+        expect(page).
+          to have_selector('div.panel', text: 'course.assessment.answer.explanation.wrong')
         expect(page).to have_selector('h2', text: mcq_questions.first.title)
-        expect(page).not_to have_checked_field(wrong_option)
+        # Check that previous attempt is restored.
+        expect(page).to have_checked_field(wrong_option)
+        expect(page).to have_selector('.btn', text: I18n.t('common.submit'))
       end
 
       scenario 'I can finalise my submission' do

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -36,10 +36,18 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
         expect(page).to have_checked_field(option)
       end
 
-      scenario 'I can only submit programming answers' do
+      scenario 'I can submit and reattempt programming questions', js: true do
         programming_question
         submission
+
         visit edit_course_assessment_submission_path(course, assessment, submission)
+        expect(page).to have_selector('.btn.submit-answer', count: 1)
+
+        answer = submission.reload.answers.find_by(question_id: programming_question.acting_as.id)
+        answer.finalise! && answer.save!
+
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+        click_link I18n.t('course.assessment.answer.worksheet.reattempt')
 
         expect(page).to have_selector('.btn.submit-answer', count: 1)
       end

--- a/spec/models/course/assessment/question/multiple_response_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
         answer = subject.attempt(submission)
         expect(submission.multiple_response_answers).to include(answer.actable)
       end
+
+      context 'when last_attempt is given' do
+        let(:last_attempt) do
+          create(:course_assessment_answer_multiple_response,
+                 :with_one_correct_option,
+                 question: subject.question, submission: submission)
+        end
+
+        it 'builds a new answer with old options' do
+          answer = subject.attempt(submission, last_attempt).actable
+          answer.save!
+
+          expect(last_attempt.option_ids).
+            to contain_exactly(*answer.answer_options.map(&:option_id))
+        end
+      end
     end
   end
 end

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -136,6 +136,23 @@ RSpec.describe Course::Assessment::Question::Programming do
           expect(matching_answer_file).not_to be_nil
         end
       end
+
+      context 'when last_attempt is given' do
+        let(:last_attempt) do
+          create(:course_assessment_answer_programming, file_contents: ['python file', 'js file'])
+        end
+
+        it 'builds a new answer with old file contents' do
+          answer = subject.attempt(submission, last_attempt).actable
+          answer.save!
+
+          expect(last_attempt.files.map(&:filename)).
+            to contain_exactly(*answer.files.map(&:filename))
+
+          expect(last_attempt.files.map(&:content)).
+            to contain_exactly(*answer.files.map(&:content))
+        end
+      end
     end
 
     describe '#imported_attachment=' do

--- a/spec/models/course/assessment/question/text_response_spec.rb
+++ b/spec/models/course/assessment/question/text_response_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
         answer = subject.attempt(submission)
         expect(submission.text_response_answers).to include(answer.actable)
       end
+
+      context 'when last_attempt is given' do
+        let(:last_attempt) { build(:course_assessment_answer_text_response) }
+
+        it 'builds a new answer with old answer_text' do
+          answer = subject.attempt(submission, last_attempt).actable
+          answer.save!
+
+          expect(last_attempt.answer_text).to eq(answer.answer_text)
+        end
+      end
     end
 
     describe 'validations' do


### PR DESCRIPTION
Automatically reattempt the question after current answer is graded.
Show the grading results of last attempt instead. 

Certain issues need to be fixed after this PR:  
1. For one question, students might have multiple correct answers，should fix the display of grading page.
2. For worksheet submission, this is an N + 1 query due to the loading of previous attempt(will fix this in a later PR when all urgent issues fixed). 
