### PR TITLE
Rename question_type as grading_scheme for Question::MultipleResponse

### DIFF
--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -44,7 +44,7 @@ class Course::Assessment::Question::MultipleResponsesController < \
 
   def multiple_response_question_params
     params.require(:question_multiple_response).permit(
-      :title, :description, :staff_only_comments, :maximum_grade, :weight, :question_type,
+      :title, :description, :staff_only_comments, :maximum_grade, :weight, :grading_scheme,
       skill_ids: [],
       options_attributes: [:_destroy, :id, :correct, :option, :explanation]
     )

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
   acts_as :question, class_name: Course::Assessment::Question.name
 
-  enum question_type: [:all_correct, :any_correct]
+  enum grading_scheme: [:all_correct, :any_correct]
 
   has_many :options, class_name: Course::Assessment::Question::MultipleResponseOption.name,
                      dependent: :destroy, foreign_key: :question_id, inverse_of: :question

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -1,9 +1,9 @@
 = simple_form_for [current_course, @assessment, @multiple_response_question] do |f|
   = f.error_notification
   = render partial: 'course/assessment/questions/form', locals: { f: f }
-  = f.input :question_type,
+  = f.input :grading_scheme,
             as: :select,
-            collection: Course::Assessment::Question::MultipleResponse.question_types.keys
+            collection: Course::Assessment::Question::MultipleResponse.grading_schemes.keys
 
   table.table.table-striped.table-hover
     thead

--- a/db/migrate/20160801084814_rename_question_type_to_grading_scheme.rb
+++ b/db/migrate/20160801084814_rename_question_type_to_grading_scheme.rb
@@ -1,0 +1,5 @@
+class RenameQuestionTypeToGradingScheme < ActiveRecord::Migration
+  def change
+    rename_column :course_assessment_question_multiple_responses, :question_type, :grading_scheme
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160730044448) do
+ActiveRecord::Schema.define(version: 20160801084814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,7 +202,7 @@ ActiveRecord::Schema.define(version: 20160730044448) do
   end
 
   create_table "course_assessment_question_multiple_responses", force: :cascade do |t|
-    t.integer "question_type", :default=>0, :null=>false
+    t.integer "grading_scheme", :default=>0, :null=>false
   end
 
   create_table "course_assessment_question_multiple_response_options", force: :cascade do |t|

--- a/spec/factories/course_assessment_question_multiple_responses.rb
+++ b/spec/factories/course_assessment_question_multiple_responses.rb
@@ -27,7 +27,7 @@ FactoryGirl.define do
     end
 
     trait :any_correct do
-      question_type :any_correct
+      grading_scheme :any_correct
     end
   end
 end


### PR DESCRIPTION
This is to prepare for a PR that implements Multiple Choice Questions based on Multiple Response Questions. Making PR for this first because this is blocking data migration.