### PR TITLE
Do not show sidebar for users not in a course

### DIFF
--- a/app/models/components/course/course_ability_component.rb
+++ b/app/models/components/course/course_ability_component.rb
@@ -31,7 +31,7 @@ module Course::CourseAbilityComponent
   end
 
   def allow_registered_users_showing_course
-    can [:read], Course, course_user_hash
+    can [:read, :participate], Course, course_user_hash
   end
 
   def allow_owners_managing_course

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -13,12 +13,13 @@
         - if current_course_user.present? && !current_course_user.staff?
           = display_course_user_badge(current_course_user)
       nav.navbar-default role='navigation'
-        div.sidebar.collapse.navbar-collapse#course-navigation-sidebar
-          = sidebar_items(controller.sidebar_items(type: :normal))
+        - if can?(:participate, current_course)
+          div.sidebar.collapse.navbar-collapse#course-navigation-sidebar
+            = sidebar_items(controller.sidebar_items(type: :normal))
 
-          - unless (admin_sidebar_items = controller.sidebar_items(type: :admin)).empty?
-            h5 = t('.administration')
-            = sidebar_items(admin_sidebar_items)
+        - unless (admin_sidebar_items = controller.sidebar_items(type: :admin)).empty?
+          h5 = t('.administration')
+          = sidebar_items(admin_sidebar_items)
 
     div.col-lg-10.col-md-9.col-sm-8 class=page_class
       = yield

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -7,11 +7,12 @@
         div.hidden-xs.text-center#course-sidebar-logo
           = link_to course_path(current_course) do
             = display_course_logo(current_course)
-        div.col-xs-12.user
-          = display_user_image(current_user)
-          = link_to_user(current_course_user || current_user)
-        - if current_course_user.present? && !current_course_user.staff?
-          = display_course_user_badge(current_course_user)
+        - if current_course_user.present? && can?(:participate, current_course)
+          div.col-xs-12.user
+            = display_user_image(current_user)
+            = link_to_user(current_course_user || current_user)
+            - if !current_course_user.staff?
+              = display_course_user_badge(current_course_user)
       nav.navbar-default role='navigation'
         - if can?(:participate, current_course)
           div.sidebar.collapse.navbar-collapse#course-navigation-sidebar

--- a/spec/models/course_ability_spec.rb
+++ b/spec/models/course_ability_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Course, type: :model do
       it { is_expected.to be_able_to(:show, published_course) }
       it { is_expected.to be_able_to(:show, opened_course) }
       it { is_expected.not_to be_able_to(:show, closed_course) }
+      it { is_expected.not_to be_able_to(:participate, closed_course) }
 
       it 'sees the opened courses' do
         expect(Course.accessible_by(subject)).
@@ -28,6 +29,7 @@ RSpec.describe Course, type: :model do
       let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, course) }
+      it { is_expected.to be_able_to(:participate, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
     end
 


### PR DESCRIPTION
Fixes #1227 and #1234.

Add a new ability `:participate` for those who are actually enrolled in the course.
Display sidebar to those who can `:participate` or `:manage` (administrators).