### PR TITLE
Differentiate Multiple Choice Questions from Multiple Response Questions

### DIFF
--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -6,6 +6,7 @@ class Course::Assessment::Question::MultipleResponsesController < \
                               through: :assessment, parent: false
 
   def new
+    @multiple_response_question.grading_scheme = :any_correct if params[:multiple_choice] == 'true'
   end
 
   def create

--- a/app/inputs/course_assessment_answer_multiple_response_input.rb
+++ b/app/inputs/course_assessment_answer_multiple_response_input.rb
@@ -7,7 +7,7 @@ class CourseAssessmentAnswerMultipleResponseInput < SimpleForm::Inputs::Collecti
   protected
 
   def check_boxes?
-    true
+    !object.question.specific.multiple_choice?
   end
 
   def has_required? # rubocop:disable Style/PredicateName

--- a/app/models/course/assessment/answer/multiple_response.rb
+++ b/app/models/course/assessment/answer/multiple_response.rb
@@ -5,4 +5,25 @@ class Course::Assessment::Answer::MultipleResponse < ActiveRecord::Base
   has_many :answer_options, class_name: Course::Assessment::Answer::MultipleResponseOption.name,
                             dependent: :destroy, foreign_key: :answer_id, inverse_of: :answer
   has_many :options, through: :answer_options
+
+  # Multiple Response Questions (MRQs) options are displayed in forms using radio buttons if they
+  # are Multiple Choice Questions (MCQs), otherwise, they are displayed using checkboxes. This
+  # method allows the radio button for the selected MCQ option to be marked as checked when the
+  # form is generated for display.
+  #
+  # In both the MCQ and non-MCQ cases, the options are rendered using the same custom simple_form
+  # input component which delegates the rendering to either a radio button or checkbox renderer
+  # as appropriate. The radio button renderer expects the attribute (i.e. #option_ids) to return
+  # an element, not an array of elements.
+  def override_option_ids_method_for_form_display!
+    define_singleton_method(:option_ids) do
+      ids = super()
+      if question.specific.multiple_choice?
+        raise IllegalStateError if ids.size > 1
+        ids[0]
+      else
+        ids
+      end
+    end
+  end
 end

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -4,6 +4,8 @@ class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
 
   enum grading_scheme: [:all_correct, :any_correct]
 
+  validate :validate_multiple_choice_has_solution, if: :multiple_choice?
+
   has_many :options, class_name: Course::Assessment::Question::MultipleResponseOption.name,
                      dependent: :destroy, foreign_key: :question_id, inverse_of: :question
 
@@ -34,5 +36,11 @@ class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
     end
 
     answer.acting_as
+  end
+
+  private
+
+  def validate_multiple_choice_has_solution
+    errors.add(:options, :no_correct_option) if options.select(&:correct?).empty?
   end
 end

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -9,6 +9,13 @@ class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
 
   accepts_nested_attributes_for :options
 
+  # A Multiple Response Question is considered to be a Multiple Choice Question (MCQ)
+  # if and only if it has an "any correct" grading scheme. The case where "any correct"
+  # questions are not MCQs (i.e. students select a subset of the correct answer by checking
+  # two or more option) is weak. MCQs can be graded with either scheme, but using
+  # "any correct" allows it to have more than one correct answer.
+  alias_method :multiple_choice?, :any_correct?
+
   def auto_gradable?
     true
   end

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -75,6 +75,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   def update_answer_type_params
     scalar_params = [].tap do |result|
       result.push(:answer_text) # Text response answer
+      result.push(:option_ids) # MCQ answer
     end
     # Parameters that must be an array of permitted values
     array_params = {}.tap do |result|

--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.html.slim
@@ -1,3 +1,4 @@
+- multiple_response.override_option_ids_method_for_form_display!
 - question = multiple_response.question.specific
 - readonly = cannot?(:update, multiple_response.answer)
 = f.association :options,

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -37,6 +37,11 @@
         span.caret
       ul.dropdown-menu.dropdown-menu-right role='menu' aria-labelledby='new-question'
         li role='presentation'
+          = link_to(t('.new_question.multiple_choice'),
+                    new_course_assessment_question_multiple_response_path(current_course, @assessment,
+                                                                          { multiple_choice: true }),
+                    role: 'menuitem')
+        li role='presentation'
           = link_to(t('.new_question.multiple_response'),
                     new_course_assessment_question_multiple_response_path(current_course, @assessment),
                     role: 'menuitem')

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -1,9 +1,7 @@
 = simple_form_for [current_course, @assessment, @multiple_response_question] do |f|
   = f.error_notification
   = render partial: 'course/assessment/questions/form', locals: { f: f }
-  = f.input :grading_scheme,
-            as: :select,
-            collection: Course::Assessment::Question::MultipleResponse.grading_schemes.keys
+  = f.hidden_field :grading_scheme
 
   table.table.table-striped.table-hover
     thead

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -3,6 +3,10 @@
   = render partial: 'course/assessment/questions/form', locals: { f: f }
   = f.hidden_field :grading_scheme
 
+  / workaround for plataformatec/simple_form#1284
+  div.has-error
+    = f.full_error :options
+
   table.table.table-striped.table-hover
     thead
       tr

--- a/app/views/course/assessment/question/multiple_responses/new.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/new.html.slim
@@ -1,3 +1,4 @@
-- add_breadcrumb :new
-= page_header
+- header = @multiple_response_question.multiple_choice? ? t('.multiple_choice_header') : t('.multiple_response_header')
+- add_breadcrumb header
+= page_header header
 = render partial: 'form'

--- a/config/locales/en/activerecord/course/assessment/question/multiple_response.yml
+++ b/config/locales/en/activerecord/course/assessment/question/multiple_response.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/question/multiple_response:
+          attributes:
+            options:
+              no_correct_option: 'must contain at least one correct option.'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -29,6 +29,7 @@ en:
           files: 'Files'
           questions: 'Questions'
           new_question:
+            multiple_choice: 'Multiple Choice'
             multiple_response: 'Multiple Response'
             text_response: 'Text Response'
             programming: 'Programming'

--- a/config/locales/en/course/assessment/question/multiple_responses.yml
+++ b/config/locales/en/course/assessment/question/multiple_responses.yml
@@ -4,7 +4,8 @@ en:
       question:
         multiple_responses:
           new:
-            header: 'New Multiple Response Question'
+            multiple_response_header: 'New Multiple Response Question'
+            multiple_choice_header: 'New Multiple Choice Question'
           create:
             success: 'The multiple response question was created.'
           update:

--- a/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }
-    let(:assessment) { create(:assessment, :with_mcq_question, course: course) }
+    let(:assessment) { create(:assessment, :with_mrq_question, course: course) }
     let(:immutable_submission) do
       create(:course_assessment_submission, assessment: assessment, creator: user).tap do |stub|
         assessment.questions.attempt(stub).each(&:save)

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     end
 
     context 'when the assessment is guided' do
-      let(:assessment) { create(:assessment, :guided, :with_mcq_question, course: course) }
+      let(:assessment) { create(:assessment, :guided, :with_mrq_question, course: course) }
       let!(:answer) do
         answer = assessment.questions.first.attempt(immutable_submission)
         answer.save

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -18,6 +18,14 @@ FactoryGirl.define do
 
     trait :with_mcq_question do
       after(:build) do |assessment|
+        question = build(:course_assessment_question_multiple_response,
+                         :multiple_choice, assessment: assessment)
+        assessment.questions << question.acting_as
+      end
+    end
+
+    trait :with_mrq_question do
+      after(:build) do |assessment|
         question = build(:course_assessment_question_multiple_response, assessment: assessment)
         assessment.questions << question.acting_as
       end
@@ -41,6 +49,7 @@ FactoryGirl.define do
 
     trait :with_all_question_types do
       with_mcq_question
+      with_mrq_question
       with_programming_question
       with_text_response_question
     end
@@ -63,6 +72,11 @@ FactoryGirl.define do
 
     trait :published_with_mcq_question do
       with_mcq_question
+      published
+    end
+
+    trait :published_with_mrq_question do
+      with_mrq_question
       published
     end
 

--- a/spec/factories/course_assessment_question_multiple_responses.rb
+++ b/spec/factories/course_assessment_question_multiple_responses.rb
@@ -29,5 +29,9 @@ FactoryGirl.define do
     trait :any_correct do
       grading_scheme :any_correct
     end
+
+    trait :multiple_choice do
+      grading_scheme :any_correct
+    end
   end
 end

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) do
-      create(:course_assessment_assessment, :published_with_mcq_question, course: course)
+      create(:course_assessment_assessment, :published_with_mrq_question, course: course)
     end
     before { login_as(user, scope: :user) }
 

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -22,17 +22,38 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
     context 'As a Course Student' do
       let(:user) { create(:course_user, :approved, course: course).user }
 
-      scenario 'I can save my submission' do
-        visit edit_course_assessment_submission_path(course, assessment, submission)
+      context 'when the question is a multiple choice question' do
+        let(:assessment) do
+          create(:course_assessment_assessment, :published_with_mcq_question, course: course)
+        end
 
-        check correct_option
+        scenario 'I can save my submission' do
+          visit edit_course_assessment_submission_path(course, assessment, submission)
 
-        click_button I18n.t('common.save')
-        expect(current_path).to eq(
-          edit_course_assessment_submission_path(course, assessment, submission)
-        )
+          choose correct_option
 
-        expect(page).to have_checked_field(correct_option)
+          click_button I18n.t('common.save')
+          expect(current_path).to eq(
+            edit_course_assessment_submission_path(course, assessment, submission)
+          )
+
+          expect(page).to have_checked_field(correct_option)
+        end
+      end
+
+      context 'when the question is not a multiple choice question' do
+        scenario 'I can save my submission' do
+          visit edit_course_assessment_submission_path(course, assessment, submission)
+
+          check correct_option
+
+          click_button I18n.t('common.save')
+          expect(current_path).to eq(
+            edit_course_assessment_submission_path(course, assessment, submission)
+          )
+
+          expect(page).to have_checked_field(correct_option)
+        end
       end
 
       scenario 'I cannot update my submission after finalising' do

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
     context 'As a Course Manager' do
       let(:user) { course.creator }
 
-      scenario 'I can create a new question' do
+      scenario 'I can create a new multiple response question' do
         skill = create(:course_assessment_skill, course: course)
         visit course_assessment_path(course, assessment)
         click_link I18n.t('course.assessment.assessments.show.new_question.multiple_response')
@@ -20,6 +20,10 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         expect(current_path).to eq(
           new_course_assessment_question_multiple_response_path(course, assessment)
         )
+        expect(page).to have_text(
+          I18n.t('course.assessment.question.multiple_responses.new.multiple_response_header')
+        )
+
         question_attributes = attributes_for(:course_assessment_question_multiple_response)
         fill_in 'title', with: question_attributes[:title]
         fill_in 'description', with: question_attributes[:description]
@@ -33,8 +37,29 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
 
         question_created = assessment.questions.first.specific
         expect(page).to have_content_tag_for(question_created)
+        expect(question_created).not_to be_multiple_choice
         expect(question_created.skills).to contain_exactly(skill)
         expect(question_created.weight).to eq(question_attributes[:weight])
+      end
+
+      scenario 'I can create a new multiple choice question', js: true do
+        visit course_assessment_path(course, assessment)
+        click_link I18n.t('course.assessment.assessments.show.new_question.multiple_choice')
+
+        expect(current_path).to eq(
+          new_course_assessment_question_multiple_response_path(course, assessment)
+        )
+        expect(page).to have_text(
+          I18n.t('course.assessment.question.multiple_responses.new.multiple_choice_header')
+        )
+        question_attributes = attributes_for(:course_assessment_question_multiple_response)
+        fill_in 'title', with: question_attributes[:title]
+        fill_in 'maximum_grade', with: question_attributes[:maximum_grade]
+        click_button 'submit'
+
+        question_created = assessment.questions.first.specific
+        expect(page).to have_content_tag_for(question_created)
+        expect(question_created).to be_multiple_choice
       end
 
       scenario 'I can edit a question', js: true do

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) do
-      create(:assessment, :guided, :published_with_mcq_question, course: course)
+      create(:assessment, :guided, :published_with_mrq_question, course: course)
     end
-    let(:mcq_questions) { assessment.reload.questions.map(&:specific) }
-    let(:extra_mcq_question) do
+    let(:mrq_questions) { assessment.reload.questions.map(&:specific) }
+    let(:extra_mrq_question) do
       create(:course_assessment_question_multiple_response, assessment: assessment)
     end
     before { login_as(user, scope: :user) }
@@ -26,7 +26,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
       scenario 'I can save my submission' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
-        option = mcq_questions.first.options.first.option
+        option = mrq_questions.first.options.first.option
         check option
         click_button I18n.t('common.save')
 
@@ -37,10 +37,10 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
       end
 
       scenario 'I can navigate between questions' do
-        extra_mcq_question
+        extra_mrq_question
 
         # Add a correct answer to the first question
-        answer = mcq_questions.first.attempt(submission)
+        answer = mrq_questions.first.attempt(submission)
         answer.correct = true
         answer.save
 
@@ -50,17 +50,17 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
           path = edit_course_assessment_submission_path(course, assessment, submission, step: step)
           expect(page).to have_link(step, href: path)
         end
-        expect(page).to have_selector('h2', text: mcq_questions.first.title)
+        expect(page).to have_selector('h2', text: mrq_questions.first.title)
 
         click_link '2'
-        expect(page).to have_selector('h2', text: mcq_questions.second.title)
+        expect(page).to have_selector('h2', text: mrq_questions.second.title)
       end
 
       scenario 'I can continue to the next question when current answer is correct', js: true do
-        extra_mcq_question
+        extra_mrq_question
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        correct_option = mcq_questions.first.options.correct.first.option
+        correct_option = mrq_questions.first.options.correct.first.option
         check correct_option
 
         click_button I18n.t('common.submit')
@@ -71,14 +71,14 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         expect(page).to have_checked_field(correct_option)
 
         click_link I18n.t('course.assessment.answer.guided.continue')
-        expect(page).to have_selector('h2', text: mcq_questions.second.title)
+        expect(page).to have_selector('h2', text: mrq_questions.second.title)
       end
 
       scenario 'I can resubmit the question when submission is not finalised', js: true do
         visit edit_course_assessment_submission_path(assessment.course, assessment, submission)
 
-        wrong_option = mcq_questions.first.options.where(correct: false).first.option
-        correct_option = mcq_questions.first.options.correct.first.option
+        wrong_option = mrq_questions.first.options.where(correct: false).first.option
+        correct_option = mrq_questions.first.options.correct.first.option
 
         # Submit a wrong solution
         check wrong_option
@@ -87,7 +87,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         expect(page).
           to have_selector('div.panel', text: 'course.assessment.answer.explanation.wrong')
-        expect(page).to have_selector('h2', text: mcq_questions.first.title)
+        expect(page).to have_selector('h2', text: mrq_questions.first.title)
         # Check that previous attempt is restored.
         expect(page).to have_checked_field(wrong_option)
         expect(page).to have_selector('.btn', text: I18n.t('common.submit'))
@@ -100,7 +100,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         expect(page).
           to have_selector('div.panel', text: 'course.assessment.answer.explanation.correct')
-        expect(page).to have_selector('h2', text: mcq_questions.first.title)
+        expect(page).to have_selector('h2', text: mrq_questions.first.title)
         expect(page).to have_checked_field(correct_option)
         expect(page).to have_selector('.btn', text: I18n.t('common.submit'))
       end
@@ -123,7 +123,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
 
       scenario "I can grade the student's work" do
-        mcq_questions.each { |q| q.attempt(submission).save! }
+        mrq_questions.each { |q| q.attempt(submission).save! }
         submission.finalise!
         submission.save!
 

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) do
-      create(:assessment, :worksheet, :published_with_mcq_question, course: course)
+      create(:assessment, :worksheet, :published_with_mrq_question, course: course)
     end
     before { login_as(user, scope: :user) }
 

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature 'Course: Assessments: Management' do
 
       scenario 'I can see non-draft assessments' do
         category = course.assessment_categories.first
-        assessment = create(:assessment, :published_with_mcq_question,
+        assessment = create(:assessment, :published_with_mrq_question,
                             course: course, tab: category.tabs.first)
         visit course_assessments_path(course)
 

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Course::Assessment::Submission do
     describe '.answers' do
       describe '.latest_answers' do
         context 'when the submission has multiple answers for the same question' do
-          let(:assessment_traits) { [:with_mcq_question] }
+          let(:assessment_traits) { [:with_mrq_question] }
           let(:submission1_traits) { :submitted }
           subject { submission1.answers.latest_answers }
 

--- a/spec/models/course/condition/assessment_ability_spec.rb
+++ b/spec/models/course/condition/assessment_ability_spec.rb
@@ -19,15 +19,15 @@ RSpec.describe Course::Condition::Assessment do
 
       context 'when the assessment is published but has not started' do
         let(:unopened_assessment) do
-          create(:assessment, :published_with_mcq_question, :unopened, course: course)
+          create(:assessment, :published_with_mrq_question, :unopened, course: course)
         end
 
         it { is_expected.to_not be_able_to(:attempt, unopened_assessment) }
       end
 
       context 'when the assessment has started' do
-        let(:assessment1) { create(:assessment, :published_with_mcq_question, course: course) }
-        let(:assessment2) { create(:assessment, :published_with_mcq_question, course: course) }
+        let(:assessment1) { create(:assessment, :published_with_mrq_question, course: course) }
+        let(:assessment2) { create(:assessment, :published_with_mrq_question, course: course) }
         let!(:condition) do
           create(:assessment_condition,
                  course: course,


### PR DESCRIPTION
Fixes #1229 

MCQs can be considered as a special case of MRQs. This PR allows MCQs to be displayed differently from non-MCQs.