### PR TITLE
Comment out view rendering of filename field in programming answers.

### DIFF
--- a/app/views/course/assessment/answer/programming/_file_fields.html.slim
+++ b/app/views/course/assessment/answer/programming/_file_fields.html.slim
@@ -1,9 +1,11 @@
 - programming_answer = f.object.answer
 - programming_question = programming_answer.question.actable
 = div_for(f.object, class: ['nested-fields'], 'data-programming-file-id' => f.object.id) do
-  = link_to_remove_association t('.delete'), f, class: ['pull-right']
+  / Remove delete file link for CS1010S as submissions all have a single file.
+  / = link_to_remove_association t('.delete'), f, class: ['pull-right']
   - readonly = !programming_answer.attempting? || cannot?(:update, programming_answer.answer)
-  = f.input :filename, readonly: readonly
+  / Filename is unnecessary as there's only 1 file for CS1010S.
+  / = f.input :filename, readonly: readonly
   - if readonly
     = format_programming_answer_file(f.object, programming_question.language)
   - else

--- a/app/views/course/assessment/answer/programming/_programming.html.slim
+++ b/app/views/course/assessment/answer/programming/_programming.html.slim
@@ -1,7 +1,8 @@
 - question = programming.question.specific
 div.files
   - file_fields_path = 'course/assessment/answer/programming/file_fields'.freeze
-  = link_to_add_association t('.add_file'), f, :files, partial: file_fields_path,
+  / Remove add file link because first course CS1010S' submissions only have 1 file.
+  / = link_to_add_association t('.add_file'), f, :files, partial: file_fields_path,
                             find_selector: 'this', insert_using: 'after'
   = f.simple_fields_for :files do |files_form|
     = render file_fields_path, f: files_form

--- a/config/locales/en/course/assessment/answer/programming.yml
+++ b/config/locales/en/course/assessment/answer/programming.yml
@@ -3,10 +3,10 @@ en:
     assessment:
       answer:
         programming:
-          programming:
-            add_file: 'Add file'
-          file_fields:
-            delete: 'Delete file'
+#          programming:
+#            add_file: 'Add file'
+#          file_fields:
+#            delete: 'Delete file'
           test_cases:
             passed: 'Passed'
             private: :'course.assessment.question.programming.form_test_cases.private'

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
       let(:user) { create(:course_user, :approved, course: course).user }
 
       scenario 'I can save my submission', js: true do
+        pending 'Removed add/delete file links for CS1010S'
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
         # Fill in every single successive item


### PR DESCRIPTION
Also comment out add/delete file links as they are unnecessary for
CS1010S and cause confusion to TAs and students.

Change spec for submission to pending as the add/delete links are no
longer present.

Fixes #1237.