### PR TITLE
Mark test cases as failed if student code cannot be evaluated.

### DIFF
--- a/config/locales/en/course/assessment/answer/programming_auto_grading.yml
+++ b/config/locales/en/course/assessment/answer/programming_auto_grading.yml
@@ -1,0 +1,7 @@
+en:
+  course:
+    assessment:
+      answer:
+        programming_auto_grading:
+          grade:
+            evaluation_failed: 'Evaluation failed. Syntax error?'

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -35,72 +35,114 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
       let(:answer_traits) { [{ file_count: 1 }] }
       let(:grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
 
-      before do
-        allow(Course::Assessment::ProgrammingEvaluationService).to \
-          receive(:execute).and_wrap_original do |original, *args|
-            result = original.call(*args)
-            result.test_report = File.read(question_test_report_path)
-            result
+      context 'with a test report' do
+        before do
+          allow(Course::Assessment::ProgrammingEvaluationService).to \
+            receive(:execute).and_wrap_original do |original, *args|
+              result = original.call(*args)
+              result.test_report = File.read(question_test_report_path)
+              result
+            end
+        end
+
+        describe '#grade' do
+          subject { super().grade(grading) }
+          let(:answer_contents) { 'test code ' + SecureRandom.hex }
+          let(:answer_traits) { [{ file_contents: [answer_contents] }] }
+
+          it 'creates a new package with the correct file contents' do
+            expect(Course::Assessment::ProgrammingEvaluationService).to \
+              receive(:execute).and_wrap_original do |method, *args|
+              package = Course::Assessment::ProgrammingPackage.new(args[4])
+              expect(package.submission_files.values).to contain_exactly(answer_contents)
+              method.call(*args)
+            end
+            subject
           end
+
+          it 'creates a Programming Auto Grading record' do
+            subject
+            expect(grading.actable).to be_a(Course::Assessment::Answer::ProgrammingAutoGrading)
+          end
+
+          context 'when the answer is correct' do
+            let(:question_test_report_path) do
+              File.join(Rails.root,
+                        'spec/fixtures/course/programming_single_test_suite_report_pass.xml')
+            end
+
+            it 'marks the answer correct' do
+              subject
+              expect(answer.grade).to eq(question.maximum_grade)
+              expect(answer).to be_correct
+            end
+          end
+
+          context 'when the answer is wrong' do
+            it 'marks the answer wrong' do
+              subject
+              expect(answer).not_to be_correct
+            end
+
+            it 'gives a grade proportional to the number of test cases' do
+              subject
+              test_case_count = answer.question.actable.test_cases.count
+              expect(answer.grade).to eq(answer.question.maximum_grade / test_case_count)
+            end
+          end
+
+          context 'when there is an error' do
+            let(:question_test_report_path) do
+              File.join(Rails.root,
+                        'spec/fixtures/course/programming_single_test_suite_report.xml')
+            end
+
+            it 'sets the error message' do
+              subject
+              # Exact error is from the fixture
+              expect(answer.auto_grading.actable.test_results[0].message).
+                to eq('TypeError: mosaic() takes 1 positional argument but 4 were given')
+            end
+          end
+        end
       end
 
-      describe '#grade' do
-        subject { super().grade(grading) }
-        let(:answer_contents) { 'test code ' + SecureRandom.hex }
-        let(:answer_traits) { [{ file_contents: [answer_contents] }] }
-
-        it 'creates a new package with the correct file contents' do
-          expect(Course::Assessment::ProgrammingEvaluationService).to \
-            receive(:execute).and_wrap_original do |method, *args|
-            package = Course::Assessment::ProgrammingPackage.new(args[4])
-            expect(package.submission_files.values).to contain_exactly(answer_contents)
-            method.call(*args)
-          end
-          subject
+      context 'without a test report' do
+        before do
+          allow(Course::Assessment::ProgrammingEvaluationService).to \
+            receive(:execute).and_wrap_original do |original, *args|
+              result = original.call(*args)
+              result.test_report = nil
+              result
+            end
         end
 
-        it 'creates a Programming Auto Grading record' do
-          subject
-          expect(grading.actable).to be_a(Course::Assessment::Answer::ProgrammingAutoGrading)
-        end
+        describe '#grade' do
+          subject { super().grade(grading) }
 
-        context 'when the answer is correct' do
-          let(:question_test_report_path) do
-            File.join(Rails.root,
-                      'spec/fixtures/course/programming_single_test_suite_report_pass.xml')
-          end
-
-          it 'marks the answer correct' do
+          it 'sets grade to 0' do
             subject
-            expect(answer.grade).to eq(question.maximum_grade)
-            expect(answer).to be_correct
+            expect(answer.grade).to eq 0
           end
-        end
 
-        context 'when the answer is wrong' do
           it 'marks the answer wrong' do
             subject
             expect(answer).not_to be_correct
           end
 
-          it 'gives a grade proportional to the number of test cases' do
+          it 'sets each test result as failed' do
             subject
-            test_case_count = answer.question.actable.test_cases.count
-            expect(answer.grade).to eq(answer.question.maximum_grade / test_case_count)
-          end
-        end
-
-        context 'when there is an error' do
-          let(:question_test_report_path) do
-            File.join(Rails.root,
-                      'spec/fixtures/course/programming_single_test_suite_report.xml')
+            answer.auto_grading.specific.test_results.each do |test_result|
+              expect(test_result).not_to be_passed
+            end
           end
 
-          it 'sets the error message' do
+          it 'sets the message for each test result' do
             subject
-            # Exact error is from the fixture
-            expect(answer.auto_grading.actable.test_results[0].message).
-              to eq('TypeError: mosaic() takes 1 positional argument but 4 were given')
+            answer.auto_grading.specific.test_results.each do |test_result|
+              expect(test_result.message).
+                to eq 'course.assessment.answer.programming_auto_grading.grade.evaluation_failed'
+            end
           end
         end
       end


### PR DESCRIPTION
This is most likely due to a syntax error in the student's submission.

Fixes #1236 
