### PR TITLE
Destroy auto_grading and only unsubmit latest answers

### DIFF
--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -29,7 +29,7 @@ class Course::Assessment::Answer < ActiveRecord::Base
   belongs_to :question, class_name: Course::Assessment::Question.name, inverse_of: nil
   belongs_to :grader, class_name: User.name, inverse_of: nil
   has_one :auto_grading, class_name: Course::Assessment::Answer::AutoGrading.name,
-                         dependent: :destroy, inverse_of: :answer
+                         dependent: :destroy, inverse_of: :answer, autosave: true
 
   accepts_nested_attributes_for :actable
   accepts_nested_attributes_for :discussion_topic
@@ -122,5 +122,6 @@ class Course::Assessment::Answer < ActiveRecord::Base
     self.grader = nil
     self.graded_at = nil
     self.submitted_at = nil
+    auto_grading.mark_for_destruction if auto_grading
   end
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -183,10 +183,10 @@ class Course::Assessment::Submission < ActiveRecord::Base
   end
 
   def unsubmit_latest_answers
-    latest_answer_ids = answers.latest_answers.pluck(:id)
+    latest_answers = answers.latest_answers
     # Direct change #answers, so that they can be saved together with submission.
     answers.each do |answer|
-      next unless latest_answer_ids.include?(answer.id)
+      next unless latest_answers.include?(answer)
       answer.unsubmit!
     end
   end


### PR DESCRIPTION
Auto grading should be destroyed when answer is unsubmitted.
There's a bug that all answers are unsubmitted, fixed and added a test.