### PR TITLE
Link user with existing invitation email if any

### DIFF
--- a/spec/factories/course_user_invitations.rb
+++ b/spec/factories/course_user_invitations.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
       if user.present?
         user.emails.take
       else
-        build(:user_email, user: user, primary: false)
+        build(:user_email, :without_user, primary: false)
       end
     end
 

--- a/spec/factories/user_emails.rb
+++ b/spec/factories/user_emails.rb
@@ -21,5 +21,11 @@ FactoryGirl.define do
     trait :unconfirmed do
       confirmed_at nil
     end
+
+    trait :without_user do
+      after(:build) do |user_email|
+        user_email.user = nil
+      end
+    end
   end
 end

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -26,5 +26,26 @@ RSpec.feature 'Users: Sign Up' do
         expect(instance.users.exists?(user)).to be_truthy
       end
     end
+
+    context 'As a user invited by course staffs' do
+      let!(:invitation) { create(:course_user_invitation, user: nil) }
+      let(:invited_email) { invitation.user_email.email }
+
+      scenario 'I can register for an account' do
+        visit new_user_registration_path
+
+        invited_user = attributes_for(:user).reverse_merge(email: invited_email)
+        fill_in 'user_name', with: invited_user[:name]
+        fill_in 'user_email', with: invited_user[:email]
+        fill_in 'user_password', with: invited_user[:password]
+        fill_in 'user_password_confirmation', with: invited_user[:password]
+
+        expect do
+          click_button I18n.t('user.registrations.new.sign_up')
+        end.to change(User, :count).by(1)
+        email = User::Email.find_by(email: invited_user[:email])
+        expect(email).to be_primary
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, user cannot sign up if there's an invitation, see the mailing list.

This is a quick fix for that, by linking existing invitation email to the user who is signing up.