### PR TITLE
Sort course_users alphabetically by name for more manageable display.

### DIFF
--- a/app/controllers/concerns/course/users_controller_management_concern.rb
+++ b/app/controllers/concerns/course/users_controller_management_concern.rb
@@ -51,7 +51,8 @@ module Course::UsersControllerManagementConcern
   end
 
   def invitations # :nodoc:
-    @course_users = @course_users.joins { invitation }.includes(invitation: :user_email)
+    @course_users = @course_users.joins { invitation }.includes(invitation: :user_email).
+                    order(workflow_state: :desc, name: :asc)
   end
 
   private

--- a/app/controllers/concerns/course/users_controller_management_concern.rb
+++ b/app/controllers/concerns/course/users_controller_management_concern.rb
@@ -27,13 +27,15 @@ module Course::UsersControllerManagementConcern
   end
 
   def students # :nodoc:
-    @course_users = @course_users.students.with_approved_state.includes(user: :emails)
+    @course_users = @course_users.students.with_approved_state.includes(user: :emails).
+                    order_alphabetically
   end
 
   def staff # :nodoc:
     @student_options =
       @course_users.students.with_approved_state.order_alphabetically.pluck(:name, :id)
-    @course_users = @course_users.staff.with_approved_state.includes(user: :emails)
+    @course_users = @course_users.staff.with_approved_state.includes(user: :emails).
+                    order_alphabetically
   end
 
   def upgrade_to_staff # :nodoc:

--- a/app/controllers/course/users_controller.rb
+++ b/app/controllers/course/users_controller.rb
@@ -20,7 +20,7 @@ class Course::UsersController < Course::ComponentController
     case params[:action]
     when 'index'
       @course_users ||= course_users.with_approved_state.without_phantom_users.students.
-                        includes(:user)
+                        includes(:user).order_alphabetically
     else
       return if super
       @course_user ||= course_users.includes(:user).find(params[:id])


### PR DESCRIPTION
Makes it possible to find a student in large courses.

Fixes #1232 and fixes #1256 .
Also sorts the listing on the staff tab and the page at `courses/<id>/users`.