### PR TITLE
Do not require invitation code if invited email belongs to user

### DIFF
--- a/app/views/course/user_registrations/_registration.html.slim
+++ b/app/views/course/user_registrations/_registration.html.slim
@@ -2,9 +2,17 @@
   - if current_course.course_users.exists?(user: current_user)
     - disable_message = t('.already_registered')
     - disabled = 'disabled'
-  div title=disable_message
-    div.input-group
-      = f.input :code, label: false, wrapper: false, placeholder: t('.registration_code'),
-                disabled: disabled
-      span.input-group-btn
-        = f.button :submit, value: t('.register'), class: 'register', disabled: disabled
+  - already_invited = Course::UserInvitation.joins { course_user }. \
+      where { course_user.course == my { current_course } }. \
+      where { course_user.workflow_state == 'invited' }. \
+      find_by(user_email: current_user.emails )
+  - if already_invited
+    = f.hidden_field :code
+    = f.button :submit, value: t('.enter_course'), class: 'register'
+  - else
+    div title=disable_message
+      div.input-group
+        = f.input :code, label: false, wrapper: false, placeholder: t('.registration_code'),
+                  disabled: disabled
+        span.input-group-btn
+          = f.button :submit, value: t('.register'), class: 'register', disabled: disabled

--- a/config/locales/en/course/user_registrations.yml
+++ b/config/locales/en/course/user_registrations.yml
@@ -4,6 +4,7 @@ en:
       registration:
         registration_code: 'Registration code'
         register: 'Register'
+        enter_course: 'Enter Course'
         already_registered: 'You have already registered for the course.'
       create:
         invalid_code: 'You have entered an invalid registration code.'


### PR DESCRIPTION
Prior to this PR, if a user tries to register for a course that he has invited to without a registration code, a new CourseUser is created. It should instead be reconciled with the CourseUser tied to his UserInvitation. 