### PR TITLE
Force to display time in user's zone

### DIFF
--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -85,6 +85,13 @@ module ApplicationFormattersHelper
   # @param [DateTime] date The datetime to be formatted
   # @return [String] the formatted datetime string
   def format_datetime(date, format = :long)
+    user_zone = (current_user ? current_user.time_zone : nil) ||
+                Application.config.x.default_user_time_zone
+    # TODO: Fix the query. This is a workaround to display the time in the correct zone, there are
+    # places where datetimes are directly fetched from db and skipped AR, which result in incorrect
+    # time zone.
+    date = date.in_time_zone(user_zone) if date.zone != user_zone
+
     date.to_formatted_s(format)
   end
 


### PR DESCRIPTION
There are places we directly select the time from db: https://github.com/Coursemology/coursemology2/blob/master/app/models/course/assessment.rb#L55, those skipped the time zone.

I am not able to fix the query given the time, used a quick workaround here.

Fixes #1272.