### PR TITLE
Allow course enrolment requests to be deleted

### DIFF
--- a/app/views/course/users/requests.html.slim
+++ b/app/views/course/users/requests.html.slim
@@ -31,5 +31,7 @@ div.users
                 = f.radio_button :workflow_state, 'approved', checked: true
               td.course_user_workflow_state
                 = f.radio_button :workflow_state, 'rejected'
-              td = f.button :submit, id: 'update' do
-                = fa_icon 'save'.freeze
+              td
+                = f.button :submit, id: 'update' do
+                  = fa_icon 'save'.freeze
+                = delete_button([current_course, f.object])

--- a/spec/features/course/request_managmement_spec.rb
+++ b/spec/features/course/request_managmement_spec.rb
@@ -41,5 +41,19 @@ RSpec.feature 'Course: Requests' do
       visit course_users_requests_path(course)
       expect(page).not_to have_field('course_user_name', with: unregistered_user.name)
     end
+
+    # Allow user to request to enrol again in case she neglects to enter her
+    # invitation code the first time
+    scenario 'Course staff can delete request' do
+      visit course_users_requests_path(course)
+      expect(page).to have_field('course_user_name', with: unregistered_user.name)
+
+      within find_form(nil, action: course_user_path(course, unregistered_user)) do
+        find_link(nil, href: course_user_path(course, unregistered_user)).click
+      end
+
+      expect(CourseUser.where(course: course, user: unregistered_user.user)).
+        to be_empty
+    end
   end
 end


### PR DESCRIPTION
If a student does not enroll using the same email as the one used in the invitation, a user would have to key in the invitation code in order to claim the invitation.

This PR allow course managers to delete requests so that a user can enroll again if he requested to enroll without an invitation code the first time round.