### PR TITLE
Force an exception if invalid test cases are saved so errors will be

### DIFF
--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -50,7 +50,7 @@ class Course::Assessment::Question::ProgrammingImportService
     template_import_thread.join
 
     raise evaluation_result if evaluation_result.error?
-    save(template_import_thread.value, evaluation_result)
+    save!(template_import_thread.value, evaluation_result)
   end
 
   # Extracts the templates from the package.
@@ -76,12 +76,12 @@ class Course::Assessment::Question::ProgrammingImportService
   # @param [Hash<Pathname, String>] template_files The templates found in the package.
   # @param [Course::Assessment::ProgrammingEvaluationService::Result] evaluation_result The
   #   result of evaluating the package.
-  def save(template_files, evaluation_result)
+  def save!(template_files, evaluation_result)
     @question.imported_attachment = @attachment
     @question.template_files = build_template_file_records(template_files)
     @question.test_cases = build_test_case_records(evaluation_result.test_report)
 
-    @question.save
+    @question.save!
   end
 
   # Builds the template file records from the templates loaded from the package.

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
       it 'does not trigger another attachment import' do
         expect(question).to receive(:imported_attachment=).with(attachment)
         mock_result = Course::Assessment::ProgrammingEvaluationService::Result.new('', '', nil, 1)
-        subject.send(:save, {}, mock_result)
+        subject.send(:save!, {}, mock_result)
       end
     end
 


### PR DESCRIPTION
shown to the tutor.

For example, if the expression is too long and cannot be saved to the
database.

Related to #1273.