### PR TITLE
Specify the name of the file downloaded

### DIFF
--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -3,7 +3,7 @@ class Course::Material::MaterialsController < Course::Material::Controller
   load_and_authorize_resource :material, through: :folder, class: Course::Material.name
 
   def show
-    redirect_to @material.attachment.url
+    redirect_to @material.attachment.url(filename: @material.name)
   end
 
   def edit

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -16,6 +16,17 @@ class FileUploader < CarrierWave::Uploader::Base
     "#{model.name}.#{file.extension}"
   end
 
+  # Manipulate the 'response-content-disposition' header to support file name.
+  #
+  # @param [String] filename The file name of the downloaded file.
+  # @return [String] The url with options.
+  def url(filename: nil)
+    query_option = { 'response-content-disposition' => 'attachment;' }
+    query_option['response-content-disposition'] += " filename=\"#{filename}\"" if filename
+
+    super(query: query_option)
+  end
+
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url
   #   # For Rails 3.1+ asset pipeline compatibility:

--- a/app/views/layouts/_materials.html.slim
+++ b/app/views/layouts/_materials.html.slim
@@ -1,6 +1,6 @@
 - unless folder.materials.empty?
   - folder.materials.includes(:attachment_references).each do |material|
     div
-      = link_to material.attachment.url do
+      = link_to [current_course, folder, material] do
         => fa_icon 'file-o'.freeze
         = format_inline_text(material.name)


### PR DESCRIPTION
Now the filenames downloaded are hashed, this PR fixes that. 

Note that in order to let this work for S3, `config.fog_public = false` must be set, it has the following effects:
1. The AWS links that users get will expire after 10min. ( this might be a good thing for security )
2. The option is irreversible, new files uploaded will no long be accessible if we change `fog_public = true`, unless we reset all the ACL info of the files. 