### PR TITLE
Assign invitation email to user who claims the invitation

### DIFF
--- a/app/services/course/user_registration_service.rb
+++ b/app/services/course/user_registration_service.rb
@@ -161,8 +161,19 @@ class Course::UserRegistrationService
   def accept_invitation(registration, invitation)
     registration.course_user = invitation.course_user
     invitation.course_user.accept!(registration.user)
-    invitation.course_user.save
+    CourseUser.transaction do
+      assign_email_to_user(invitation.user_email, invitation.course_user.user)
+      invitation.course_user.save
+    end
     invitation.course_user
+  end
+
+  # Assigns an unclaimed email address to a given user.
+  #
+  # @param [User::Email] email
+  # @param [User] user
+  def assign_email_to_user(email, user)
+    email.update(user: user) if email.user.nil?
   end
 
   # Sends an email to the course staff to approve the given course registration request.

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -110,7 +110,22 @@ RSpec.feature 'Courses: Invitations', js: true do
       let(:instance_user) { create(:instance_user) }
       let(:user) { instance_user.user }
 
-      context 'when I have an invitation code' do
+      context 'when I have been invited using my current email address' do
+        let(:user_email) { user.emails.first }
+        let!(:invitation) do
+          create(:course_user_invitation, course: course, user_email: user_email)
+        end
+
+        scenario 'I can enter the course' do
+          visit course_path(course)
+          expect(page).not_to have_button('.register')
+
+          click_button I18n.t('course.user_registrations.registration.enter_course')
+          expect(invitation.course_user.reload).to be_approved
+        end
+      end
+
+      context 'when I have an invitation code for another email address' do
         let(:invitation) { create(:course_user_invitation, course: course) }
 
         scenario 'I can accept invitations' do

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -134,6 +134,7 @@ RSpec.feature 'Courses: Invitations', js: true do
           click_button I18n.t('course.user_registrations.registration.register')
 
           expect(page).not_to have_selector('div.register')
+          expect(user.reload.emails).to include(invitation.user_email)
         end
       end
 

--- a/spec/features/course/registration_spec.rb
+++ b/spec/features/course/registration_spec.rb
@@ -29,18 +29,5 @@ RSpec.feature 'Courses: Registration' do
         expect(page).not_to have_button('course.user_registrations.registration.register')
       end
     end
-
-    context 'when the user has been invited for the course' do
-      let(:user_email) { user.emails.first }
-      let!(:invitation) { create(:course_user_invitation, course: course, user_email: user_email) }
-
-      scenario 'user can enter the course' do
-        visit course_path(course)
-        expect(page).not_to have_button('.register')
-
-        click_button I18n.t('course.user_registrations.registration.enter_course')
-        expect(invitation.course_user.reload).to be_approved
-      end
-    end
   end
 end


### PR DESCRIPTION
If the user is able to claim an invitation, the user must be the owner of the email the invitation key was sent to. This PR assigns the emails to the user if it is unclaimed.