### PR TITLE
Update user invitation email

### DIFF
--- a/app/views/course/mailer/user_invitation_email.html.slim
+++ b/app/views/course/mailer/user_invitation_email.html.slim
@@ -1,5 +1,6 @@
 = simple_format(t('.message', course: link_to(@course.title, course_url(@course)),
                               coursemology: link_to(t('layout.coursemology'), root_url),
+                              email: @invitation.user_email.email,
                               sign_up: link_to(t('layout.navbar.register'), new_user_registration_url)))
 
 pre

--- a/app/views/course/mailer/user_invitation_email.text.erb
+++ b/app/views/course/mailer/user_invitation_email.text.erb
@@ -1,5 +1,6 @@
 <%= t('.message', course: plain_link_to(@course.title, course_url(@course)),
                   coursemology: plain_link_to(t('layout.coursemology'), root_url),
+                  email: @invitation.user_email.email,
                   sign_up: plain_link_to(t('layout.navbar.register'), new_user_registration_url)) %>
 
 <%= @invitation.invitation_key %>

--- a/config/locales/en/course/mailer/user_invitation_email.yml
+++ b/config/locales/en/course/mailer/user_invitation_email.yml
@@ -7,5 +7,7 @@ en:
           You are invited to register for %{course} on %{coursemology}.
 
 
-          You do not seem to have an account registered at this email address; please %{sign_up}
-          for an account, and register for %{course} using the following registration code:
+          You do not seem to have an account registered at this email address (%{email});
+          please %{sign_up} for an account before visiting %{course} to enrol for the course.
+          If you have an existing Coursemology account registered under a different email,
+          enrol with the following non-transferable registration code:


### PR DESCRIPTION
Key changes:
- Make the email used for the invitation explicit.
- Make it clearer where they should visit to register for the course.
- Invitation code is only necessary if user wants to sign up with an email other than the invitation email.
- Indicate that the code is personal, i.e. that they should not share it with other students.