### PR TITLE
Allow users to withdraw their registration requests

### DIFF
--- a/app/controllers/course/user_registrations_controller.rb
+++ b/app/controllers/course/user_registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::UserRegistrationsController < Course::ComponentController
   before_action :ensure_unregistered_user, only: [:create]
-  before_action :authorize_register!
+  before_action :authorize_register!, only: [:create]
   before_action :load_registration
 
   def create # :nodoc:
@@ -11,6 +11,19 @@ class Course::UserRegistrationsController < Course::ComponentController
       create_success
     else
       render 'course/courses/show'
+    end
+  end
+
+  # Allow users to withdraw their requests to register for a course that are pending
+  # approval/rejection.
+  def destroy
+    @course_user ||= current_course_user
+    authorize!(:deregister, @course_user)
+    if @course_user.destroy
+      redirect_to course_path(current_course), success: t('.success')
+    else
+      redirect_to course_path(current_course),
+                  danger: @course_user.errors.full_messages.to_sentence
     end
   end
 

--- a/app/models/components/course/course_user_ability_component.rb
+++ b/app/models/components/course/course_user_ability_component.rb
@@ -3,7 +3,10 @@ module Course::CourseUserAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_course_users_show_coursemates if user
+    if user
+      allow_course_users_show_coursemates
+      allow_users_cancel_own_registration_requests
+    end
 
     super
   end
@@ -12,5 +15,9 @@ module Course::CourseUserAbilityComponent
 
   def allow_course_users_show_coursemates
     can :read, CourseUser, course_all_course_users_hash
+  end
+
+  def allow_users_cancel_own_registration_requests
+    can :deregister, CourseUser, user: user, workflow_state: 'requested'
   end
 end

--- a/app/views/course/user_registrations/_registration.html.slim
+++ b/app/views/course/user_registrations/_registration.html.slim
@@ -1,15 +1,14 @@
-= simple_form_for @registration, url: course_register_path(current_course) do |f|
-  - if current_course.course_users.exists?(user: current_user)
-    - disable_message = t('.already_registered')
-    - disabled = 'disabled'
-  - invitation = current_course.invitations.pending_acceptance.for_user(current_user)
-  - if invitation.present?
-    = f.hidden_field :code
-    = f.button :submit, value: t('.enter_course')
-  - else
-    div title=disable_message
+- if current_course_user.nil?
+  = simple_form_for @registration, url: course_register_path(current_course) do |f|
+    - invitation = current_course.invitations.pending_acceptance.for_user(current_user)
+    - if invitation.present?
+      = f.hidden_field :code
+      = f.button :submit, value: t('.enter_course')
+    - else
       div.input-group
-        = f.input :code, label: false, wrapper: false, placeholder: t('.registration_code'),
-                  disabled: disabled
+        = f.input :code, label: false, wrapper: false, placeholder: t('.registration_code')
         span.input-group-btn
-          = f.button :submit, value: t('.register'), class: 'register', disabled: disabled
+          = f.button :submit, value: t('.register'), class: 'register'
+- elsif current_course_user.requested? && can?(:deregister, current_course_user)
+  = delete_button(course_deregister_path(current_course)) do
+    = t('.deregister')

--- a/config/locales/en/course/user_registrations.yml
+++ b/config/locales/en/course/user_registrations.yml
@@ -4,9 +4,11 @@ en:
       registration:
         registration_code: 'Registration code'
         register: 'Register'
+        deregister: 'Cancel Registration Request'
         enter_course: 'Enter Course'
-        already_registered: 'You have already registered for the course.'
       create:
         invalid_code: 'You have entered an invalid registration code.'
         requested: 'You have submitted registration to the course as a %{role}.'
         registered: 'You have been registered as a %{role}.'
+      destroy:
+        success: 'Registration request cancelled.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,6 +232,7 @@ Rails.application.routes.draw do
              on: :collection
       end
       post 'register' => 'user_registrations#create'
+      delete 'deregister' => 'user_registrations#destroy'
       get 'students' => 'users#students', as: :users_students
       get 'staff' => 'users#staff', as: :users_staff
       patch 'upgrade_to_staff' => 'users#upgrade_to_staff', as: :users_upgrade_to_staff

--- a/spec/controllers/course/user_registrations_controller_spec.rb
+++ b/spec/controllers/course/user_registrations_controller_spec.rb
@@ -152,5 +152,28 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
         end
       end
     end
+
+    describe '#destroy' do
+      before { sign_in(user) }
+      let(:course_user_immutable_stub) do
+        stub = create(:course_user, course: course, user: user)
+        allow(stub).to receive(:destroy).and_return(false)
+        stub
+      end
+
+      subject { delete :destroy, course_id: course }
+
+      context 'when the user cannot cancel his registration' do
+        before do
+          controller.instance_variable_set(:@course_user, course_user_immutable_stub)
+          subject
+        end
+
+        it { is_expected.to redirect_to(course_path(course)) }
+        it 'sets an error flash message' do
+          expect(flash[:danger]).to eq('')
+        end
+      end
+    end
   end
 end

--- a/spec/factories/course_users.rb
+++ b/spec/factories/course_users.rb
@@ -13,6 +13,9 @@ FactoryGirl.define do
     trait :invited do
       workflow_state :invited
     end
+    trait :rejected do
+      workflow_state :rejected
+    end
     trait :phantom do
       phantom true
     end

--- a/spec/features/course/registration_spec.rb
+++ b/spec/features/course/registration_spec.rb
@@ -21,12 +21,36 @@ RSpec.feature 'Courses: Registration' do
       expect(page).not_to have_button('.register')
     end
 
-    context 'when the user is registered in the course' do
-      let!(:course_student) { create(:course_student, course: course, user: user) }
-      scenario 'Users cannot re-register for a course' do
-        visit course_path(course)
+    context 'when the user has requested to register for a course' do
+      let!(:requested_student) { create(:course_user, course: course, user: user) }
 
-        expect(page).not_to have_button('course.user_registrations.registration.register')
+      scenario 'user can cancel his registration request' do
+        visit course_path(course)
+        expect(page).not_to have_button(I18n.t('course.user_registrations.registration.register'))
+
+        click_link I18n.t('course.user_registrations.registration.deregister')
+        expect(current_path).to eq(course_path(course))
+        expect(page).to have_button(I18n.t('course.user_registrations.registration.register'))
+      end
+    end
+
+    context 'when the user has been approved' do
+      let!(:approved_student) { create(:course_student, course: course, user: user) }
+
+      scenario 'user cannot de-register or re-register for the course' do
+        visit course_path(course)
+        expect(page).not_to have_button(I18n.t('course.user_registrations.registration.register'))
+        expect(page).not_to have_link(I18n.t('course.user_registrations.registration.deregister'))
+      end
+    end
+
+    context 'when the user has been rejected' do
+      let!(:rejected_student) { create(:course_user, :rejected, course: course, user: user) }
+
+      scenario 'user cannot de-register or re-register for the course' do
+        visit course_path(course)
+        expect(page).not_to have_button(I18n.t('course.user_registrations.registration.register'))
+        expect(page).not_to have_link(I18n.t('course.user_registrations.registration.deregister'))
       end
     end
   end


### PR DESCRIPTION
Use case: 
Student clicks 'register' without entering her invitation code. This feature allows the student to redo the registration with the invitation code without intervention from a staff member.