### PR TITLE
Do not escape characters in code block

### DIFF
--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -74,7 +74,7 @@ module ApplicationHTMLFormattersHelper
   #   should be provided if the code fragment does not start on the first line.
   def format_code_block(code, language = nil, starting_line_number = 1)
     code = html_escape(code) unless code.html_safe?
-    code = code.gsub(/\r\n|\r/, "\n")
+    code = code.gsub(/\r\n|\r/, "\n").html_safe
     code = content_tag(:pre, lang: language ? language.rouge_lexer : nil) do
       content_tag(:code) do
         code

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ApplicationFormattersHelper do
       let(:language) { Coursemology::Polyglot::Language::Python::Python2Point7 }
       let(:snippet) do
         <<-PYTHON
+          # '1' < "2" is True
           def hello:
             pass
         PYTHON
@@ -54,8 +55,8 @@ RSpec.describe ApplicationFormattersHelper do
       end
 
       it 'enumerates every line' do
-        expect(formatted_block).to have_tag('td.line-number', count: 3)
-        expect(formatted_block).to have_tag('td.line-content', count: 3)
+        expect(formatted_block).to have_tag('td.line-number', count: 4)
+        expect(formatted_block).to have_tag('td.line-content', count: 4)
       end
 
       it 'highlights the keywords' do
@@ -67,11 +68,17 @@ RSpec.describe ApplicationFormattersHelper do
         let(:formatted_block) { helper.format_code_block(snippet, language, line_start) }
 
         it 'highlights the code with the given start line number' do
-          expect(formatted_block).to have_tag('td.line-number', count: 3)
+          expect(formatted_block).to have_tag('td.line-number', count: 4)
           expect(formatted_block).to have_tag('td.line-number', with: { 'data-line-number': '5' })
           expect(formatted_block).to have_tag('td.line-number', with: { 'data-line-number': '6' })
           expect(formatted_block).to have_tag('td.line-number', with: { 'data-line-number': '7' })
+          expect(formatted_block).to have_tag('td.line-number', with: { 'data-line-number': '8' })
         end
+      end
+
+      it 'does not escape code' do
+        expect(formatted_block).to have_text('<')
+        expect(formatted_block).to have_text('"')
       end
     end
 


### PR DESCRIPTION
Fix for #1287

Is this safe to do since each row will be placed within a `<code>` block?