### PR TITLE
Move weekly cap default for forum disbursement to model

### DIFF
--- a/app/models/course/experience_points/forum_disbursement.rb
+++ b/app/models/course/experience_points/forum_disbursement.rb
@@ -45,9 +45,12 @@ class Course::ExperiencePoints::ForumDisbursement < Course::ExperiencePoints::Di
   # @!attribute [rw] weekly_cap
   # The cap on the number of experience points to give out per week for forum participation.
   # This will be pro-rated based on the number of weeks in the period.
+  # A default of 100 is set. This can be made a setting when the needs arises.
   #
   # @return [Integer]
-  attr_reader :weekly_cap
+  def weekly_cap
+    @weekly_cap ||= 100
+  end
 
   # @param [String] weekly_cap_param
   def weekly_cap=(weekly_cap_param)

--- a/app/models/course/experience_points/forum_disbursement.rb
+++ b/app/models/course/experience_points/forum_disbursement.rb
@@ -107,7 +107,7 @@ class Course::ExperiencePoints::ForumDisbursement < Course::ExperiencePoints::Di
   # @return [Integer]
   def actual_cap
     seconds_in_a_week = 604_800
-    @acutal_cap ||= (weekly_cap * (end_time - start_time) / seconds_in_a_week).ceil
+    @actual_cap ||= (weekly_cap * (end_time - start_time) / seconds_in_a_week).ceil
   end
 
   # Returns a hash that maps each student to the computed forum participation points.

--- a/app/views/course/experience_points/forum_disbursement/new.html.slim
+++ b/app/views/course/experience_points/forum_disbursement/new.html.slim
@@ -14,8 +14,7 @@ div.panel.panel-primary.forum-participation-search-panel
       = f.error_notification
       = f.input :start_time, as: :bootstrap_date_time
       = f.input :end_time, as: :bootstrap_date_time
-      = f.input :weekly_cap, as: :integer,
-                             input_html: { value: f.object.weekly_cap || 100 }
+      = f.input :weekly_cap, as: :integer
       = f.button :submit, t('.search')
 
 = simple_form_for @disbursement, url: forum_disbursement_course_users_path, method: :post do |f|

--- a/spec/features/course/experience_points/forum_disbrusement_spec.rb
+++ b/spec/features/course/experience_points/forum_disbrusement_spec.rb
@@ -16,13 +16,21 @@ RSpec.feature 'Course: Experience Points: Forum Disbursement' do
       let(:user) { course_teaching_assistant.user }
 
       scenario 'I can compute and award forum participation points' do
-        posts = students.map do |student|
+        recent_date = DateTime.current.at_beginning_of_week.end_of_day.in_time_zone - 2.days
+        create(:course_discussion_post, topic: forum_topic.acting_as,
+                                        creator: students.first.user, updater: students.first.user,
+                                        created_at: recent_date, updated_at: recent_date)
+        older_posts = students.map do |student|
           create(:course_discussion_post, topic: forum_topic.acting_as,
                                           creator: student.user, updater: student.user,
                                           created_at: 3.weeks.ago, updated_at: 3.weeks.ago)
         end
-        create(:course_discussion_post_vote, post: posts[0])
+        create(:course_discussion_post_vote, post: older_posts[0])
         visit forum_disbursement_course_users_path(course)
+
+        within find(content_tag_selector(students[0])) do
+          expect(find('.points_awarded').value).to eq('100')
+        end
 
         within find('.forum-participation-search-panel') do
           fill_in 'experience_points_forum_disbursement[start_time]', with: 4.weeks.ago


### PR DESCRIPTION
This is to ensure that `weekly_cap` is never nil.

Currently, forum disbursement page raises an exception as long as there is one forum participant found during the default disbursement period. This PR fixes the bug.