### PR TITLE
Display a useful error message when a submission already exists.

### DIFF
--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -12,6 +12,7 @@ en:
         course/assessment/submission:
           experience_points_record:
             inconsistent_user: 'the creator of the submission must be the same as the course user'
+          submission_already_exists: "Looks like you have already created a submission. Try again?"
         course/assessment/category:
           deletion: 'the last category cannot be deleted'
 

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -49,6 +49,24 @@ RSpec.describe Course::Assessment::Submission do
                 'attributes.experience_points_record.inconsistent_user'))
         end
       end
+
+      context 'when a submission for the user and assessment already exists' do
+        before do
+          submission2
+        end
+
+        subject do
+          build(:course_assessment_submission, assessment: assessment, creator: user2)
+        end
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages[:base]).
+            to include(I18n.
+              t('activerecord.errors.models.course/assessment/submission.'\
+                'submission_already_exists'))
+        end
+      end
     end
 
     describe '.answers' do


### PR DESCRIPTION
Fixes #1314.