### PR TITLE
Optimise the sorting of posts

### DIFF
--- a/app/models/concerns/course/discussion/post/ordering_concern.rb
+++ b/app/models/concerns/course/discussion/post/ordering_concern.rb
@@ -34,7 +34,7 @@ module Course::Discussion::Post::OrderingConcern
     private
 
     def sort(post_id)
-      children_posts = @posts.select { |child_post| child_post.parent_id == post_id }
+      children_posts, @posts = @posts.partition { |child_post| child_post.parent_id == post_id }
       children_posts.map do |child_post|
         [child_post].push(sort(child_post.id))
       end


### PR DESCRIPTION
The sorting goes crazy when there're duplications in the posts.  This will help to fix the CPU spike from my tests. 

Still need to figure out why there're duplications in the posts.