### PR TITLE
Update course users using javascript for user management pages

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/answer.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/answer.js
@@ -40,8 +40,7 @@
    */
   function onCommentReplyFail(_, form) {
     // TODO: Implement error recovery.
-    var $form = $(form);
-    FORM_HELPERS.findFormFields($form).prop('disabled', false);
+    FORM_HELPERS.enableForm($(form));
   }
 
   showAnswerCommentForm(document);

--- a/app/assets/javascripts/course/assessment/submission/answer/programming.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming.js
@@ -243,9 +243,7 @@
    * @param {HTMLElement} form The form which was submitted
    */
   function onAnnotationFormSubmitFail(_, form) {
-    var $form = $(form);
-    FORM_HELPERS.findFormFields($form).prop('disabled', false);
-
+    FORM_HELPERS.enableForm($(form));
     // TODO: Implement error recovery.
   }
 

--- a/app/assets/javascripts/course/discussion/topics.js
+++ b/app/assets/javascripts/course/discussion/topics.js
@@ -23,8 +23,7 @@
   }
 
   function onPostFormSubmitFail(_, form) {
-    var $form = $(form);
-    FORM_HELPERS.findFormFields($form).prop('disabled', false);
+    FORM_HELPERS.enableForm($(form));
 
     // TODO: Display error messages.
   }

--- a/app/assets/javascripts/course/users.js
+++ b/app/assets/javascripts/course/users.js
@@ -1,0 +1,49 @@
+//= require helpers/form_helpers
+
+(function($, FORM_HELPERS) {
+  /* global Routes */
+  'use strict';
+  var DOCUMENT_SELECTOR = '.course-users ';
+  var UPDATE_BUTTON_SELECTOR = 'tr.course_user #update';
+
+  /**
+   * Shows update course user buttons.
+   */
+  function showUpdateCourseUserButtons() {
+    var $buttons = $(UPDATE_BUTTON_SELECTOR).filter(DOCUMENT_SELECTOR + '*');
+    $buttons.show();
+  }
+
+  /**
+   * Handles the update course user button click event.
+   *
+   * @param e The event object.
+   */
+  function onUpdateCourseUserButtonClick(e) {
+    var $button = $(e.target);
+    var $form = FORM_HELPERS.parentFormForElement($button);
+
+    FORM_HELPERS.submitAndDisableForm($form, onUpdateCourseUserSuccess,
+                                             onUpdateCourseUserFailure);
+    e.preventDefault();
+  }
+
+  /**
+   * Handles the successful update course user event.
+   */
+  function onUpdateCourseUserSuccess(_, form) {
+    FORM_HELPERS.enableForm($(form));
+  }
+
+  /**
+   * Handles the errored update course user event.
+   */
+  function onUpdateCourseUserFailure(_, form) {
+    // TODO: Implement error recovery.
+    FORM_HELPERS.enableForm($(form));
+  }
+
+  $(document).on('turbolinks:load', showUpdateCourseUserButtons);
+  $(document).on('click', DOCUMENT_SELECTOR + UPDATE_BUTTON_SELECTOR,
+                          onUpdateCourseUserButtonClick);
+})(jQuery, FORM_HELPERS);

--- a/app/assets/javascripts/helpers/discussion/edit_post.js
+++ b/app/assets/javascripts/helpers/discussion/edit_post.js
@@ -121,8 +121,7 @@ var EDIT_DISCUSSION_POST = (function($, FORM_HELPERS,
    * @param {HTMLElement} form The form which was submitted
    */
   function onPostFormSubmitFailure(_, form) {
-    var $form = $(form);
-    FORM_HELPERS.findFormFields($form).prop('disabled', false);
+    FORM_HELPERS.enableForm($(form));
 
     // TODO: Implement error recovery.
   }

--- a/app/assets/javascripts/helpers/form_helpers.js
+++ b/app/assets/javascripts/helpers/form_helpers.js
@@ -47,25 +47,15 @@ var FORM_HELPERS = (function (){
   /**
    * Builds the form data from the given form.
    *
-   * This is a less sophisticated version of $.serialize() in that it only supports inputs and
-   * textareas.
-   *
    * @param {jQuery} $form The form being submitted.
-   * @returns {Object} The form data to be submitted.
+   * @returns {Array} The form data to be submitted.
    */
   function buildFormData ($form) {
-    var $fields = findFormFields($form, ':not(:disabled)');
-    var data = {
+    var data = $form.find(":input").serializeArray();
+    var token = {
       authenticity_token: $(document).find('meta[name="csrf-token"]').attr('content')
     };
-    $fields.each(function() {
-      if (this.name === '') {
-        return;
-      }
-
-      data[this.name] = $(this).val();
-    });
-
+    data.push(token);
     return data;
   };
 

--- a/app/assets/javascripts/helpers/form_helpers.js
+++ b/app/assets/javascripts/helpers/form_helpers.js
@@ -112,7 +112,7 @@ var FORM_HELPERS = (function (){
    * @param {jQuery} $element The form's child element
    */
   function parentFormForElement($element) {
-    return $element.parents('div[data-action]:first');
+    return $element.parents('[data-action]:first');
   }
 
   /**

--- a/app/assets/javascripts/helpers/form_helpers.js
+++ b/app/assets/javascripts/helpers/form_helpers.js
@@ -108,6 +108,15 @@ var FORM_HELPERS = (function (){
   }
 
   /**
+   * Enables the input fields of a form.
+   *
+   * @param {jQuery} $form The form being enabled
+   */
+  function enableForm($form) {
+    findFormFields($form).prop('disabled', false);
+  }
+
+  /**
    * Finds the form which $element is a child of.
    *
    * @param {jQuery} $element The form's child element
@@ -127,8 +136,8 @@ var FORM_HELPERS = (function (){
 
   return {
     renderFromPath: renderFromPath,
-    findFormFields: findFormFields,
     submitAndDisableForm: submitAndDisableForm,
+    enableForm: enableForm,
     parentFormForElement: parentFormForElement,
     removeParentForm: removeParentForm
   };

--- a/app/views/course/users/requests.html.slim
+++ b/app/views/course/users/requests.html.slim
@@ -18,11 +18,9 @@ div.users
 
       tbody
         - @course_users.each do |user|
-          = simple_form_for [current_course, user], resource: :course_user, \
-            wrapper: :inline_form do |f|
-            = f.error_notification
-            = f.error :course_user
-            tr
+          = content_tag_for(:tr, user, 'data-action' => course_user_path(current_course, user),
+                                       'data-method' => 'patch')
+            = simple_fields_for user, resource: :course_user, wrapper: :inline_form do |f|
               th = f.input :name
               td = f.object.user.email
               td = f.input :role, as: :select, collection: CourseUser.roles.keys
@@ -32,6 +30,6 @@ div.users
               td.course_user_workflow_state
                 = f.radio_button :workflow_state, 'rejected'
               td
-                = f.button :submit, id: 'update' do
+                = f.button :submit, id: 'update', style: 'display: none' do
                   = fa_icon 'save'.freeze
                 = delete_button([current_course, f.object])

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -28,15 +28,14 @@ div.users
 
       tbody
         - @course_users.each do |user|
-          = simple_form_for [current_course, user], resource: :course_user do |f|
-            = f.error_notification
-            = f.error :course_user
-            tr
+          = content_tag_for(:tr, user, 'data-action' => course_user_path(current_course, user),
+                                       'data-method' => 'patch')
+            = simple_fields_for user, resource: :course_user do |f|
               th = f.input :name, label: false
               td = f.object.user.email
               td = f.input :role, as: :select, collection: CourseUser.roles.keys, label: false
               td = f.input :phantom
               td
-                = f.button :submit, id: 'update' do
+                = f.button :submit, id: 'update', style: 'display: none' do
                   = fa_icon 'save'.freeze
                 = delete_button([current_course, f.object])

--- a/app/views/course/users/students.html.slim
+++ b/app/views/course/users/students.html.slim
@@ -15,14 +15,13 @@ div.users
 
       tbody
         - @course_users.each do |user|
-          = simple_form_for [current_course, user], resource: :course_user do |f|
-            = f.error_notification
-            = f.error :course_user
-            tr
+          = content_tag_for(:tr, user, 'data-action' => course_user_path(current_course, user),
+                                       'data-method' => 'patch')
+            = simple_fields_for user, resource: :course_user do |f|
               th = f.input :name, label: false
               td = f.object.user.email
               td = f.input :phantom, label: false
               td
-                = f.button :submit, id: 'update' do
+                = f.button :submit, id: 'update', style: 'display: none' do
                   = fa_icon 'save'.freeze
                 = delete_button([current_course, f.object])

--- a/app/views/course/users/update.js.erb
+++ b/app/views/course/users/update.js.erb
@@ -1,0 +1,9 @@
+$('.course-layout').parents('.container-fluid:first').prepend('<%= flash_messages %>');
+
+// Show users the flash messages
+window.scrollTo(0, 0);
+
+<% if @update_request_origin == :requests %>
+  $('#<%= dom_id(@course_user) %>').remove();
+  $('.nav-tabs .badge').remove();
+<% end %>

--- a/config/locales/en/course/users.yml
+++ b/config/locales/en/course/users.yml
@@ -20,7 +20,8 @@ en:
       new:
         already_registered: 'You are already registered as a %{role}.'
       update:
-        success: 'Registration updated. You are now registered as %{role}.'
+        success: 'Record for %{name} has been updated.'
+        request_success: '%{name} is %{workflow_state} as a %{role}.'
       destroy:
         success: 'Deleted %{role} registration from %{email}.'
       students:

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe Course::UsersController, type: :controller do
 
     describe '#update' do
       before { sign_in(user) }
-      subject { put :update, course_id: course, id: course_user, course_user: updated_course_user }
+      subject do
+        put :update, format: :js, course_id: course, id: course_user,
+                     course_user: updated_course_user
+      end
       let!(:course_user_to_update) { create(:course_user) }
       let(:updated_course_user) { { role: :teaching_assistant } }
 
@@ -82,7 +85,7 @@ RSpec.describe Course::UsersController, type: :controller do
             subject
           end
 
-          it { is_expected.to redirect_to(course_users_staff_path(course)) }
+          it { is_expected.to render_template(:update) }
           it 'sets an error flash message' do
             expect(flash[:danger]).to eq('')
           end

--- a/spec/features/course/request_managmement_spec.rb
+++ b/spec/features/course/request_managmement_spec.rb
@@ -7,52 +7,53 @@ RSpec.feature 'Course: Requests' do
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
     let(:course) { create(:course) }
-    let!(:unregistered_user) { create(:course_user, course: course) }
+    let(:registrants) { create_list(:course_user, 2, course: course) }
     before { login_as(user, scope: :user) }
 
-    scenario 'Course staff can approve request' do
+    scenario 'Course staff can approve and reject requests', js: true do
+      user_to_approve, user_to_reject = registrants
       visit course_users_requests_path(course)
-      expect(page).to have_field('course_user_name', with: unregistered_user.name)
 
-      within find_form(nil, action: course_user_path(course, unregistered_user)) do
+      within find(content_tag_selector(user_to_approve)) do
         choose('course_user_workflow_state_approved')
-        find_button('update').click
+        click_button 'update'
       end
 
-      expect(current_path).to eq(course_users_requests_path(course))
-      expect(page).to_not have_field('course_user_name', with: unregistered_user.name)
+      wait_for_ajax
+      expect(user_to_approve.reload).to be_approved
+      expect(page).not_to have_content_tag_for(user_to_approve)
+      expect(page).to have_text('course.users.update.request_success')
+
+      find('.alert .close').click
+      expect(page).not_to have_text('course.users.update.request_success')
+
+      within find(content_tag_selector(user_to_reject)) do
+        choose('course_user_workflow_state_rejected')
+        click_button 'update'
+      end
+
+      wait_for_ajax
+      expect(user_to_reject.reload).to be_rejected
+      expect(page).not_to have_content_tag_for(user_to_reject)
+      expect(page).to have_text('course.users.update.request_success')
 
       visit course_users_students_path(course)
-      expect(page).to have_field('course_user_name', with: unregistered_user.name)
-    end
-
-    scenario 'Course staff can reject request' do
-      visit course_users_requests_path(course)
-      expect(page).to have_field('course_user_name', with: unregistered_user.name)
-
-      within find_form(nil, action: course_user_path(course, unregistered_user)) do
-        choose('course_user_workflow_state_rejected')
-        find_button('update').click
-      end
-
-      expect(current_path).to eq(course_users_requests_path(course))
-      expect(page).not_to have_field('course_user_name', with: unregistered_user.name)
-
-      visit course_users_requests_path(course)
-      expect(page).not_to have_field('course_user_name', with: unregistered_user.name)
+      expect(page).to have_content_tag_for(user_to_approve)
+      expect(page).not_to have_content_tag_for(user_to_reject)
     end
 
     # Allow user to request to enrol again in case she neglects to enter her
     # invitation code the first time
     scenario 'Course staff can delete request' do
+      registrant = registrants.first
       visit course_users_requests_path(course)
-      expect(page).to have_field('course_user_name', with: unregistered_user.name)
+      expect(page).to have_field('course_user_name', with: registrant.name)
 
-      within find_form(nil, action: course_user_path(course, unregistered_user)) do
-        find_link(nil, href: course_user_path(course, unregistered_user)).click
+      within find(content_tag_selector(registrant)) do
+        find_link(nil, href: course_user_path(course, registrant)).click
       end
 
-      expect(CourseUser.where(course: course, user: unregistered_user.user)).
+      expect(CourseUser.where(course: course, user: registrant.user)).
         to be_empty
     end
   end

--- a/spec/features/course/staff_management_spec.rb
+++ b/spec/features/course/staff_management_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Courses: Staff Management' do
 
       scenario 'I can change staff roles', js: true do
         new_name = 'new staff name'
-        staff_to_change = course_managers[Random.rand(course_managers.length)]
+        staff_to_change = course_managers.sample
         visit course_users_staff_path(course)
 
         within find(content_tag_selector(staff_to_change)) do
@@ -92,7 +92,7 @@ RSpec.feature 'Courses: Staff Management' do
       end
 
       scenario 'I can delete staff' do
-        staff_to_delete = course_managers[Random.rand(course_managers.length)]
+        staff_to_delete = course_managers.sample
         visit course_users_staff_path(course)
 
         expect do

--- a/spec/features/course/staff_management_spec.rb
+++ b/spec/features/course/staff_management_spec.rb
@@ -58,18 +58,23 @@ RSpec.feature 'Courses: Staff Management' do
         end
       end
 
-      scenario 'I can change staff role' do
+      scenario 'I can change staff roles', js: true do
+        new_name = 'new staff name'
         staff_to_change = course_managers[Random.rand(course_managers.length)]
         visit course_users_staff_path(course)
 
-        field = find_field('course_user_name', with: staff_to_change.name)
-        within field.find(:xpath, '../../../..') do
-          fill_in 'course_user_name', with: staff_to_change.name + '!'
-          select 'owner', from: 'course_user_role'
-          find_button('update').click
+        within find(content_tag_selector(staff_to_change)) do
+          fill_in 'course_user_name', with: new_name
+          find('.dropdown-toggle').click
+          find('ul.dropdown-menu.inner').find('span', text: 'owner').click
+          click_button 'update'
         end
 
-        expect(page).to have_field('course_user_name', with: staff_to_change.name + '!')
+        wait_for_ajax
+
+        expect(staff_to_change.reload).to be_owner
+        expect(staff_to_change.name).to eq(new_name)
+        expect(page).to have_text('course.users.update.success')
       end
 
       scenario 'I can add new staff' do
@@ -92,7 +97,7 @@ RSpec.feature 'Courses: Staff Management' do
 
         expect do
           find_link(nil, href: course_user_path(course, staff_to_delete)).click
-        end.to change { page.all('form.edit_course_user').count }.by(-1)
+        end.to change { page.all('.course_user').count }.by(-1)
         expect(page).not_to have_field('course_user_name', with: staff_to_delete.name)
       end
     end

--- a/spec/features/course/student_management_spec.rb
+++ b/spec/features/course/student_management_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Courses: Students' do
     end
 
     scenario "Course staff can update students' records", js: true do
-      student_to_update = course_students[Random.rand(course_students.length)]
+      student_to_update = course_students.sample
       new_name = 'NewNamePerson'.freeze
 
       visit course_users_students_path(course)

--- a/spec/features/course/student_management_spec.rb
+++ b/spec/features/course/student_management_spec.rb
@@ -20,27 +20,24 @@ RSpec.feature 'Courses: Students' do
       end
     end
 
-    scenario "Course staff can change students' names" do
+    scenario "Course staff can update students' records", js: true do
+      student_to_update = course_students[Random.rand(course_students.length)]
       new_name = 'NewNamePerson'.freeze
 
       visit course_users_students_path(course)
-      within('form.edit_course_user:first') do
+
+      within find(content_tag_selector(student_to_update)) do
         fill_in 'course_user_name', with: new_name
-        click_button 'update'
-      end
-      expect(page).to have_field('course_user_name', with: new_name)
-    end
-
-    scenario "Course staff can change students' phantom status" do
-      user_to_change = course_students[Random.rand(course_students.length)]
-
-      visit course_users_students_path(course)
-      within find_field('course_user_name', with: user_to_change.name).find(:xpath, '../../..') do
         check 'course_user_phantom'
         click_button 'update'
-
-        expect(page).to have_checked_field('course_user_phantom')
       end
+
+      wait_for_ajax
+
+      student_to_update = student_to_update.reload
+      expect(student_to_update).to be_phantom
+      expect(student_to_update.name).to eq(new_name)
+      expect(page).to have_text('course.users.update.success')
     end
 
     scenario 'Course staff can delete students' do
@@ -49,7 +46,7 @@ RSpec.feature 'Courses: Students' do
       visit course_users_students_path(course)
       expect do
         find_link(nil, href: course_user_path(course, user_to_delete)).click
-      end.to change { page.all('form.edit_course_user').count }.by(-1)
+      end.to change { page.all('.course_user').count }.by(-1)
       expect(page).to_not have_field('course_user_name', with: user_to_delete.name)
     end
   end


### PR DESCRIPTION
Fixes #1252 by treating a table row itself as a form instead of having a form or div nested in it.