### PR TITLE
Attempt to speed up build times with parallel_tests gem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ branches:
   except:
     - /^bundle-update-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}+$/
 rvm:
+  - 2.2.5
   - 2.3.1
 matrix:
   allow_failures:
     - rvm: ruby-head
+  exclude:
+    - rvm: 2.2.5
+      env: GROUP="checks"
 addons:
   postgresql: "9.4"
 bundler_args: "--jobs=3 --retry=3 --without development:production --deployment"
@@ -15,6 +19,13 @@ cache:
   bundler: true
   directories:
     - travis-phantomjs
+env:
+  global:
+    - RAILS_ENV=test
+    - COVERALLS_PARALLEL=true
+  matrix:
+    - GROUP="checks"
+    - GROUP="test"
 
 before_install:
   - gem update bundler
@@ -31,13 +42,17 @@ before_install:
 
 before_script:
   - psql -c 'create database coursemology_test;' -U postgres
-  - bundle exec rake db:setup
+  - psql -c 'create database coursemology_test2;' -U postgres
+#  - bundle exec rake db:setup
+  - bundle exec rake parallel:setup[2]
 
 script:
-  - bundle exec consistency_fail
-  - bundle exec i18n-tasks health
-  - bundle exec rake spec
+  - 'if [ "$GROUP" = "checks" ]; then bundle exec consistency_fail; fi'
+  - 'if [ "$GROUP" = "checks" ]; then bundle exec i18n-tasks health; fi'
+  - 'if [ "$GROUP" = "checks" ]; then bundle exec rake assets:precompile; fi'
+  - 'if [ "$GROUP" = "test" ]; then bundle exec rake parallel:spec[2]; fi'
 
 notifications:
-  slack:
-    secure: h++bTbn+z5gm8QAF+Fk9ExyCX+Oe++O++1jN/CrakTL7p19w0Cd8Xbt8VsNevaWWeu/CAd3mjTlkF4iE+VQCax0WO1Z1qJTCcj4fiVwJSF9ojRZoNTaQeZCaDsmce3XA1gUITvN+n/iu0aNQYi7XKsXBFwmkC/BkoA4e/euzft4=
+  webhooks:
+    - https://coveralls.io/webhook?repo_token=klIDCAuOFrfbf5Eq6qt7P6lsBwXhc6vpQ
+  slack: coursemology:kdSjdF4xtXGOBIvMsbIF4gQ6

--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,8 @@ group :development, :test do
 
   # Prevent N+1 queries.
   gem 'bullet', '>= 4.14.9'
+
+  gem 'parallel_tests'
 end
 
 group :ci do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,9 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
+    parallel (1.9.0)
+    parallel_tests (2.7.1)
+      parallel
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
@@ -576,6 +579,7 @@ DEPENDENCIES
   nokogiri (>= 1.6.8)
   omniauth
   omniauth-facebook
+  parallel_tests
   pg (>= 0.18.2)
   poltergeist
   puma

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: coursemology_test
+  database: coursemology_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   <<: *default


### PR DESCRIPTION
Use 3 containers for each set of tests.
1 for consistency and i18n checks.
1 for Ruby 2.2.5 and 1 for Ruby 2.3.1.

Running on 2 Ruby versions allows us to cross check and see if a test
failure is random.
On each container running the tests, run 2 processes in parallel using
the parallel_tests gem.

Update slack notification.

Closes #1345.