### PR TITLE
Implement reset answer for programming questions

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -40,15 +40,16 @@ class Course::Assessment::Submission::SubmissionsController < \
     redirect_to(job_path(job.job))
   end
 
-  # Reload current answer to its latest status.
+  # Reload answer to either its latest status or to a fresh answer, depending on parameters.
   def reload_answer
-    @answer = @submission.answers.find_by(id: answer_id_param)
-
-    if @answer
+    @answer = @submission.answers.find_by(id: reload_answer_params[:answer_id])
+    if @answer.nil?
+      render status: :bad_request
+    elsif reload_answer_params[:reset_answer]
+      @new_answer = @answer.reset_answer
+    else
       @current_question = @answer.question
       @new_answer = @submission.answers.from_question(@current_question.id).last
-    else
-      render status: :bad_request
     end
   end
 
@@ -70,7 +71,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     end
   end
 
-  def answer_id_param
-    params.permit(:answer_id)[:answer_id]
+  def reload_answer_params
+    params.permit(:answer_id, :reset_answer)
   end
 end

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -39,4 +39,18 @@ module Course::Assessment::Submission::SubmissionsHelper
     attempts = submission.answers.from_question(answer.question_id)
     submission.attempting? ? attempts[-2] : attempts[-1]
   end
+
+  # Display button to allow the resetting of an answer.
+  #
+  # @return [String]
+  def link_to_reset_answer(answer)
+    submission, assessment = answer.submission, answer.submission.assessment
+    path =
+      reload_answer_course_assessment_submission_path(
+        current_course, assessment, submission, answer_id: answer.id, reset_answer: true
+      )
+    link_to t('course.assessment.answer.reset_answer.button'), path,
+            remote: true, method: :post, class: ['btn', 'btn-warning', 'reset-answer'],
+            data: { confirm: t('course.assessment.answer.reset_answer.warning') }
+  end
 end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -67,6 +67,16 @@ class Course::Assessment::Answer < ActiveRecord::Base
     end
   end
 
+  # Resets the answer by modifying the answer to the default.
+  #
+  # @return [Course::Assessment::Answer] The reset answer corresponding to the question. It is
+  #   required that the {Course::Assessment::Answer#question} property be the same as +self+.
+  # @raise [NotImplementedError] answer#reset_answer was not implemented.
+  def reset_answer
+    raise NotImplementedError unless actable.self_respond_to?(:reset_answer)
+    actable.reset_answer
+  end
+
   protected
 
   def finalise

--- a/app/models/course/assessment/answer/multiple_response.rb
+++ b/app/models/course/assessment/answer/multiple_response.rb
@@ -26,4 +26,10 @@ class Course::Assessment::Answer::MultipleResponse < ActiveRecord::Base
       end
     end
   end
+
+  # Specific implementation of Course::Assessment::Answer#reset_answer
+  def reset_answer
+    options.clear
+    acting_as
+  end
 end

--- a/app/models/course/assessment/answer/programming.rb
+++ b/app/models/course/assessment/answer/programming.rb
@@ -13,4 +13,14 @@ class Course::Assessment::Answer::Programming < ActiveRecord::Base
   def to_partial_path
     'course/assessment/answer/programming/programming'.freeze
   end
+
+  # Specific implementation of Course::Assessment::Answer#reset_answer
+  def reset_answer
+    self.class.transaction do
+      files.clear
+      question.specific.copy_template_files_to(self)
+      raise ActiveRecord::Rollback unless save
+    end
+    acting_as
+  end
 end

--- a/app/models/course/assessment/answer/text_response.rb
+++ b/app/models/course/assessment/answer/text_response.rb
@@ -5,6 +5,13 @@ class Course::Assessment::Answer::TextResponse < ActiveRecord::Base
   after_initialize :set_default
   before_validation :strip_whitespace
 
+  # Specific implementation of Course::Assessment::Answer#reset_answer
+  def reset_answer
+    self.answer_text = ''
+    save
+    acting_as
+  end
+
   private
 
   def set_default

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -42,6 +42,7 @@ class Course::Assessment::Question < ActiveRecord::Base
   # @return [Course::Assessment::Answer] The answer corresponding to the question. It is required
   #   that the {Course::Assessment::Answer#question} property be the same as +self+. The result
   #   should not be persisted.
+  # @raise [NotImplementedError] question#attempt was not implemented.
   def attempt(submission, last_attempt = nil)
     if actable && actable.self_respond_to?(:attempt)
       return actable.attempt(submission, last_attempt ? last_attempt.actable : nil)

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -51,8 +51,6 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
     clear_attribute_changes(:attachment)
   end
 
-  private
-
   # Copies the template files from this question to the specified answer.
   #
   # @param [Course::Assessment::Answer::Programming] answer The answer to copy the template files
@@ -62,6 +60,8 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
       template_file.copy_template_to(answer)
     end
   end
+
+  private
 
   # Queues the new question package for processing.
   #

--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -1,6 +1,9 @@
 - if answer.submission.attempting?
   - if answer.attempting?
-    = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+    div.btn-group
+      - if answer.specific.is_a?(Course::Assessment::Answer::Programming)
+        = link_to_reset_answer(answer)
+      = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
 
   / Display a continue button if last attempt is correct
   - if !@current_question.last_question? && last_attempt && last_attempt.correct?

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -1,6 +1,8 @@
 - if answer.submission.attempting? && answer.specific.is_a?(Course::Assessment::Answer::Programming)
   - if answer.attempting?
-    = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+    div.btn-group
+      = link_to_reset_answer(answer)
+      = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
 
 h3 = t('.comments')
 div.comments id=comments_container_id(answer)

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -15,3 +15,8 @@ en:
         explanation:
           correct: 'Correct!'
           wrong: 'Wrong!'
+        reset_answer:
+          button: 'Reset Answer'
+          warning: >
+            Are you sure you want to reset your answer? This action is irreversible and you will
+            lose all your current work for this question.

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
 
       context 'when answer_id does not exist' do
         subject do
-          post :reload_answer, course_id: course, assessment_id: assessment,
+          post :reload_answer, course_id: course, assessment_id: assessment.id,
                                id: submission.id, answer_id: -1, format: :js
         end
 

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
     let(:assessment) do
       create(:course_assessment_assessment, :published_with_programming_question, course: course)
     end
-    before { login_as(user, scope: :user) }
-
     let(:submission) do
       create(:course_assessment_submission, *submission_traits, assessment: assessment,
                                                                 creator: user)
     end
     let(:submission_traits) { nil }
+
+    before { login_as(user, scope: :user) }
 
     context 'As a Course Student' do
       let(:user) { create(:course_user, :approved, course: course).user }

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
     let(:submission) do
       create(:course_assessment_submission, assessment: assessment, creator: student)
     end
+    let(:programming_assessment) do
+      create(:assessment, :guided, :published_with_programming_question, course: course)
+    end
+    let(:programming_assessment_submission) do
+      create(:course_assessment_submission, assessment: programming_assessment, creator: student)
+    end
 
     context 'As a Course Student' do
       let(:user) { student }
@@ -129,6 +135,16 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         wait_for_job
         visit current_path
         expect(page).to have_selector('td', text: 'graded')
+      end
+
+      # Feature spec does not fully test the logic (but the existence of the button)
+      # This is because the logic of question reset is tested in +worksheet_spec.rb+.
+      scenario 'I can see the button to reset my answer to a programming question', js: true do
+        programming_assessment_submission
+
+        visit edit_course_assessment_submission_path(course, programming_assessment,
+                                                     programming_assessment_submission)
+        expect(page).to have_selector('.btn.reset-answer', count: 1)
       end
     end
 

--- a/spec/models/course/assessment/answer/multiple_response_spec.rb
+++ b/spec/models/course/assessment/answer/multiple_response_spec.rb
@@ -12,4 +12,20 @@ RSpec.describe Course::Assessment::Answer::MultipleResponse do
     expect(subject).to have_many(:options).
       class_name(Course::Assessment::Question::MultipleResponseOption.name)
   end
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '#reset_answer' do
+      let(:answer) { create(:course_assessment_answer_multiple_response, :with_one_correct_option) }
+      subject { answer.reset_answer }
+
+      it 'removes all multiple response options' do
+        expect(subject.specific.options.count).to eq(0)
+      end
+
+      it 'returns an Answer' do
+        expect(subject).to be_a(Course::Assessment::Answer)
+      end
+    end
+  end
 end

--- a/spec/models/course/assessment/answer/programming_spec.rb
+++ b/spec/models/course/assessment/answer/programming_spec.rb
@@ -9,4 +9,28 @@ RSpec.describe Course::Assessment::Answer::Programming do
       class_name(Course::Assessment::Answer::ProgrammingFile.name).dependent(:destroy)
   end
   it { is_expected.to accept_nested_attributes_for(:files).allow_destroy(true) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '#reset_answer' do
+      let(:question) { create(:course_assessment_question_programming, template_file_count: 1) }
+      let(:answer) { create(:course_assessment_answer_programming, question: question.question) }
+      subject { answer.reset_answer }
+
+      it 'replaces the answer with the original template files from the question' do
+        question.template_files.each do |template_file|
+          matching_answer_file = subject.specific.files.find do |answer_file|
+            answer_file.filename == template_file.filename &&
+              answer_file.content == template_file.content
+          end
+          expect(matching_answer_file).not_to be_nil
+        end
+        expect(question.template_files.count).to eq(subject.specific.files.size)
+      end
+
+      it 'returns an Answer' do
+        expect(subject).to be_a(Course::Assessment::Answer)
+      end
+    end
+  end
 end

--- a/spec/models/course/assessment/answer/text_response_spec.rb
+++ b/spec/models/course/assessment/answer/text_response_spec.rb
@@ -18,5 +18,18 @@ RSpec.describe Course::Assessment::Answer::TextResponse, type: :model do
         end
       end
     end
+
+    describe '#reset_answer' do
+      let(:answer) { create(:course_assessment_answer_text_response) }
+      subject { answer.reset_answer }
+
+      it 'sets the text response answer to a blank' do
+        expect(subject.specific.answer_text).to be_blank
+      end
+
+      it 'returns an Answer' do
+        expect(subject).to be_a(Course::Assessment::Answer)
+      end
+    end
   end
 end

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -214,5 +214,22 @@ RSpec.describe Course::Assessment::Answer do
         end
       end
     end
+
+    describe '#reset_answer' do
+      subject { answer.reset_answer }
+
+      it "calls the polymorphic object's methods" do
+        answer = create(:course_assessment_answer_multiple_response).answer
+        expect(answer.specific).to receive(:reset_answer).and_return(nil)
+        answer.reset_answer
+      end
+
+      context 'when the question does not implement #reset_attempt' do
+        let(:answer) { create(:course_assessment_answer) }
+        it 'raises a not implemented error' do
+          expect { subject }.to raise_error(NotImplementedError)
+        end
+      end
+    end
   end
 end

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -99,10 +99,6 @@ RSpec.describe Course::Assessment::Question do
     end
 
     describe '#attempt' do
-      it 'fails' do
-        expect { subject.attempt(nil) }.to raise_error(NotImplementedError)
-      end
-
       context 'when the question is polymorphic' do
         let(:question) { self.class::TestPolymorphicQuestion.new }
         subject { question.question }


### PR DESCRIPTION
This PR implements reset answer for programming questions and fixes #1281.

Some points:
- I have implemented `answer#reset_answer` as a model method for all answer types. Currently it is not used, but it could come in useful when we decide to implement `reattempting` of questions after it has been graded. 
- In view layer, I only implement reset answer for programming questions as it is not good to include a `reset answer` button for MCQ/MRQ/text response (potentially confusing). 

Have 1 question - if I call `answer.reset`, should I reset the answer to default and save? Or just build and return the`default_answer`? Would like help to check if I implemented it correctly for the specific answers. Thanks!