### PR TITLE
Modify submissions sidebar to direct to pending submissions for course_staff

### DIFF
--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -34,8 +34,7 @@ class Course::AssessmentsComponent < SimpleDelegator
         key: :assessments_submissions,
         title: t('course.assessment.submissions.sidebar_title'),
         weight: 2,
-        path: course_submissions_path(current_course,
-                                      category: current_course.assessment_categories.first)
+        path: assessment_submissions_url
       }
     ]
   end
@@ -63,5 +62,15 @@ class Course::AssessmentsComponent < SimpleDelegator
         path: course_admin_assessments_path(current_course)
       }
     ]
+  end
+
+  # Path for the submissions tab based on course_user role. Students will see submissions#index,
+  #   while course_staff will see submissions#pending.
+  def assessment_submissions_url
+    if current_course_user && current_course_user.staff?
+      pending_course_submissions_path(current_course)
+    else
+      course_submissions_path(current_course, category: current_course.assessment_categories.first)
+    end
   end
 end

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Course: Submissions Viewing' do
         end
       end
 
-      scenario 'I can view pending submissions' do
+      scenario 'I can access pending submissions from the sidebar and view pending submissions' do
         students = create_list(:course_student, 4, course: course)
         attempting_submission, submitted_submission1, submitted_submission2, graded_submission =
           students.zip([:attempting, :submitted, :submitted, :graded]).map do |student, trait|
@@ -49,7 +49,6 @@ RSpec.describe 'Course: Submissions Viewing' do
 
         # Staff without group can view all pending submissions
         visit pending_course_submissions_path(course)
-        save_page
         expect(page).to have_content_tag_for(submitted_submission1)
         expect(page).to have_content_tag_for(submitted_submission2)
         expect(page).not_to have_content_tag_for(attempting_submission)
@@ -66,6 +65,12 @@ RSpec.describe 'Course: Submissions Viewing' do
         expect(page).not_to have_content_tag_for(submitted_submission2)
         expect(page).not_to have_content_tag_for(attempting_submission)
         expect(page).not_to have_content_tag_for(graded_submission)
+
+        # Pending submissions can be assessed from the sidebar
+        within find('.sidebar') do
+          expect(page).to have_link(I18n.t('course.assessment.submissions.sidebar_title'),
+                                    href: pending_course_submissions_path(course))
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #1318.

This PR implements the following:
- Staff will directly access pending submissions from the submissions sidebar
