### PR TITLE
Improve css to differentiate between comments and code

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -14,6 +14,7 @@ $course-assessment-submission-answer-correct-border-radius: $border-radius-base 
 $course-assessment-submission-answer-correct-bg: $state-success-bg !default;
 $course-assessment-submission-answer-correct-border-text: $state-success-text !default;
 $course-assessment-submission-not-started: $red !default;
+$course-discussion-post-border: 1px solid $panel-default-border !default;
 $course-discussion-post-border-color: $panel-default-border !default;
 $course-discussion-post-border-radius: $border-radius-base !default;
 $course-discussion-post-shadow-color: $gray-lighter !default;

--- a/app/assets/stylesheets/course/assessment/submission/answer/programming.scss
+++ b/app/assets/stylesheets/course/assessment/submission/answer/programming.scss
@@ -2,12 +2,16 @@
 
 .course-assessment-submission-submissions.edit {
   table.codehilite {
+    border: $course-discussion-post-border;
+    border-collapse: separate;
+    border-radius: $course-discussion-post-border-radius;
+
     tr {
       span.add-annotation {
         display: none;
         float: left;
         height: 1em;
-        margin-left: -1em;
+        margin-left: -1.5em;
         position: relative;
         width: 1em;
       }
@@ -18,8 +22,29 @@
         }
       }
 
+      td.line-number {
+        border-right: $course-discussion-post-border;
+        padding-left: 0.5em;
+        text-align: right;
+      }
+
+      td.line-content {
+        padding-left: 0.5em;
+      }
+
       td.line-annotation {
         @include discussion-post;
+
+        border-bottom: $course-discussion-post-border;
+        border-top: $course-discussion-post-border;
+        padding: 1em;
+
+        // scss-lint:disable SelectorFormat
+        .annotation-form,
+        .discussion_post {
+          // scss-lint:enable SelectorFormat
+          max-width: 960px;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/course/discussion/_post.scss
+++ b/app/assets/stylesheets/course/discussion/_post.scss
@@ -1,21 +1,44 @@
 @mixin discussion-post {
   .discussion_post { // scss-lint:disable SelectorFormat
+    border: $course-discussion-post-border;
+    border-radius: $course-discussion-post-border-radius;
     margin-bottom: 1em;
 
-    .user {
-      float: left;
-      margin: 0 1em 0 0;
-      padding-top: 4px;
+    .header,
+    .content {
+      padding: 0.5em;
+    }
 
-      h5 {
-        font-size: $font-size-base;
-        margin: 0;
+    .header {
+      background-color: $panel-default-heading-bg;
+      border-bottom: $course-discussion-post-border;
+
+      .user,
+      .timestamp {
+        display: inline-block;
+      }
+
+      .user {
+        margin-right: 0.5em;
+
+        h5 {
+          font-size: $font-size-base;
+          margin: 0;
+        }
+      }
+
+      .timestamp {
+        color: $text-muted;
+        font-size: $font-size-small;
+      }
+
+      .toolbar {
+        margin-top: -2px;
       }
     }
 
-    .timestamp {
-      color: $text-muted;
-      font-size: $font-size-small;
+    .edit-discussion-post-form {
+      padding: 0.5em;
     }
   }
 

--- a/app/views/course/discussion/_post.html.slim
+++ b/app/views/course/discussion/_post.html.slim
@@ -1,18 +1,21 @@
 = div_for(post, 'data-post-id' => post.id) do
-  / Hide toolbar; only JavaScript-enabled clients will show this div.
-  div.toolbar.pull-right style='display: none'
-    - if can?(:update, post)
-      => link_to('#', class: ['edit']) do
-        = fa_icon 'edit'.freeze
-    - if can?(:destroy, post)
-      = link_to('#', class: ['delete']) do
-        = fa_icon 'trash'.freeze
 
-  div.user
-    h5 = link_to_user(post.creator)
+  div.header
+    div.user
+      h5 = link_to_user(post.creator)
+
+    div.timestamp
+      = format_datetime(post.created_at)
+
+    / Hide toolbar; only JavaScript-enabled clients will show this div.
+    div.toolbar.pull-right style='display: none'
+      div.btn-group
+        - if can?(:update, post)
+          => link_to('#', class: ['edit', 'btn', 'btn-default']) do
+            = fa_icon 'edit'.freeze
+        - if can?(:destroy, post)
+          = link_to('#', class: ['delete', 'btn', 'btn-danger']) do
+            = fa_icon 'trash'.freeze
 
   div.content
     = format_html(post.text)
-
-  div.timestamp
-    = format_datetime(post.created_at)


### PR DESCRIPTION
Follow how github does it for now.

![127 0 0 1-9000-courses-2-assessments-2-submissions-2-edit](https://cloud.githubusercontent.com/assets/7753104/17838999/053c3bc0-680e-11e6-93e3-ac4e93a24331.png)

There are still some issues with the javascript:

1. If a new annotation is added to a non-annotated line and the user clicks `Cancel`, there will be an empty row.
![screen shot 2016-08-22 at 2 16 27 am](https://cloud.githubusercontent.com/assets/7753104/17839019/796a51f8-680e-11e6-9bbf-d0fe88a2d499.png)

2. If the user tries to add annotation to a annotated line, the text-editor shows up below the reply button.
![screen shot 2016-08-22 at 2 18 46 am](https://cloud.githubusercontent.com/assets/7753104/17839031/cbc2d3da-680e-11e6-9a2e-fff2908fd953.png)

3. Continuing from the previous point, if the user clicks reply, then there will be 2 text-editors.
![screen shot 2016-08-22 at 2 19 55 am](https://cloud.githubusercontent.com/assets/7753104/17839037/ef4f4270-680e-11e6-978c-3853d8858667.png)
