### PR TITLE
Show 'Resume' button on assessments listing.

### DIFF
--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -19,7 +19,7 @@
         - submitted_submission = assessment.submissions.find do |submission|
           - submission != attempting_submission
         - if attempting_submission
-          = link_to(t('.attempt'), edit_course_assessment_submission_path(current_course,
+          = link_to(t('.resume'), edit_course_assessment_submission_path(current_course,
               assessment, attempting_submission), class: ['btn', 'btn-info'])
         - elsif submitted_submission
           = link_to(t('.view'), edit_course_assessment_submission_path(current_course,

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -17,6 +17,7 @@ en:
           maximum_experience_points: 'Maximum Experience Points'
         assessment:
           attempt: 'Attempt'
+          resume: 'Resume'
           view: 'View'
           submissions: 'Submissions'
         show:

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         visit course_assessments_path(course)
 
         submission_path = edit_course_assessment_submission_path(course, assessment, submission)
-        expect(page).to have_link(I18n.t('course.assessment.assessments.assessment.attempt'),
+        expect(page).to have_link(I18n.t('course.assessment.assessments.assessment.resume'),
                                   href: submission_path)
       end
 


### PR DESCRIPTION
Differentiates between an unattempted assessment and one which has been
looked at before.

Update feature spec to look for the correct button.

Fixes #1340.