### PR TITLE
Fixes to pending submission

### DIFF
--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -64,11 +64,16 @@ class Course::AssessmentsComponent < SimpleDelegator
     ]
   end
 
-  # Path for the submissions tab based on course_user role. Students will see submissions#index,
-  #   while course_staff will see submissions#pending.
+  # Path for the submissions tab based on course_user role:
+  #   course_owner & course_manager will be directed to all pending submissions
+  #   course_teaching_assistant will be directly to my students' pending submissions
+  #   course_user will see all their own submissions.
+  #   Other users that can see this (instance admins) will see all submissions in the course.
   def assessment_submissions_url
-    if current_course_user && current_course_user.staff?
-      pending_course_submissions_path(current_course)
+    if current_course_user && current_course_user.manager_or_owner?
+      pending_course_submissions_path(current_course, my_students: false)
+    elsif current_course_user && current_course_user.staff?
+      pending_course_submissions_path(current_course, my_students: true)
     else
       course_submissions_path(current_course, category: current_course.assessment_categories.first)
     end

--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::AssessmentsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
+  include Course::Assessment::SubmissionsHelper
 
   def self.display_name
     I18n.t('components.assessments.name')
@@ -34,7 +35,8 @@ class Course::AssessmentsComponent < SimpleDelegator
         key: :assessments_submissions,
         title: t('course.assessment.submissions.sidebar_title'),
         weight: 2,
-        path: assessment_submissions_url
+        path: assessment_submissions_url,
+        unread: submission_count
       }
     ]
   end
@@ -76,6 +78,20 @@ class Course::AssessmentsComponent < SimpleDelegator
       pending_course_submissions_path(current_course, my_students: true)
     else
       course_submissions_path(current_course, category: current_course.assessment_categories.first)
+    end
+  end
+
+  # Returns the number of pending submissions based on roles:
+  #   course_teacher_assistant: Number of submissions from students in my group
+  #   course_owner & course_manager: Number of pending submissions in the course
+  #   course_student or other users: 0
+  def submission_count
+    if current_course_user && current_course_user.manager_or_owner?
+      pending_submissions_count
+    elsif current_course_user && current_course_user.staff?
+      my_students_pending_submissions_count
+    else
+      0
     end
   end
 end

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -17,6 +17,10 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
     params.permit(:category)
   end
 
+  def pending_submission_params
+    params.permit(:my_students)
+  end
+
   # Load the current category, used to classify and load assessments.
   def category
     @category ||=
@@ -35,12 +39,10 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
                             experience_points_record: { course_user: :course })
   end
 
-  # Load pending submissions based on current course role:
-  #  Staff with students - show students in staff's groups with pending submissions
-  #  Staff without students - show all students in course with pending submissions
+  # Load pending submissions, either for the entire course, or for my students only.
   def pending_submissions
-    my_student_ids = current_course_user ? current_course_user.my_students.pluck(:user_id) : []
-    if !my_student_ids.empty?
+    if pending_submission_params[:my_students] == 'true'
+      my_student_ids = current_course_user ? current_course_user.my_students.select(:user_id) : []
       @submissions.by_users(my_student_ids)
     else
       @submissions

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -31,9 +31,10 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
       end
   end
 
-  # Load the submissions based on the current category.
+  # Load student submissions.
   def load_submissions
-    @submissions = Course::Assessment::Submission.
+    student_ids = @course.course_users.students.pluck(:user_id)
+    @submissions = Course::Assessment::Submission.by_users(student_ids).
                    ordered_by_submitted_date.accessible_by(current_ability).page(page_param).
                    includes(:assessment, :answers,
                             experience_points_record: { course_user: :course })

--- a/app/helpers/course/assessment/submissions_helper.rb
+++ b/app/helpers/course/assessment/submissions_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Course::Assessment::SubmissionsHelper
+  # Returns the count of submissions in a course that are pending grading
+  #
+  # @return [Fixnum] The required count
+  def pending_submissions_count
+    @pending_submissions_count ||=
+      Course::Assessment::Submission.from_course(current_course).with_submitted_state.count
+  end
+
+  # Returns the count of submissions of my students in a course that are pending grading
+  #
+  # @return [Fixnum] The required count
+  def my_students_pending_submissions_count
+    @my_student_pending_submissions ||= begin
+      my_student_ids = current_course_user ? current_course_user.my_students.select(:user_id) : []
+      Course::Assessment::Submission.from_course(current_course).with_submitted_state.
+        by_users(my_student_ids).count
+    end
+  end
+end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -101,6 +101,13 @@ class CourseUser < ActiveRecord::Base
     with_approved_state.exists?(user: user)
   end
 
+  # Test whether this course_user is a manager (i.e. manager or owner)
+  #
+  # @return [Boolean] True if course_user is a staff
+  def manager_or_owner?
+    MANAGER_ROLES.include?(role.to_sym)
+  end
+
   # Test whether this course_user is a staff (i.e. teaching_assistant, manager or owner)
   #
   # @return [Boolean] True if course_user is a staff

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -7,8 +7,10 @@
   td = submission.workflow_state.capitalize
   - if submission.graded?
     td = submission.grade.to_i.to_s + ' / ' + assessment.maximum_grade.to_s
+    td = submission.points_awarded
   - else
     td = '-- / ' + assessment.maximum_grade.to_s
+    td
   td
     - button_class = ['btn', 'btn-block']
     - link_path = edit_course_assessment_submission_path(current_course, assessment, submission)

--- a/app/views/course/assessment/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submissions/_submissions.html.slim
@@ -6,6 +6,7 @@ table.table.table-middle-align.table-hover
       th = Course::Assessment::Submission.human_attribute_name(:submitted_at)
       th = Course::Assessment::Submission.human_attribute_name(:status)
       th = Course::Assessment::Submission.human_attribute_name(:grade)
+      th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
       th
       th
   tbody

--- a/app/views/course/assessment/submissions/_tabs.html.slim
+++ b/app/views/course/assessment/submissions/_tabs.html.slim
@@ -1,6 +1,9 @@
 = tabs do
   - if current_course_user && current_course_user.staff? || can?(:manage, current_course)
-    = nav_to t('.pending'), pending_course_submissions_path(current_course)
+    = nav_to t('.my_students_pending'),
+             pending_course_submissions_path(current_course, my_students: true)
+    = nav_to t('.all_pending'),
+             pending_course_submissions_path(current_course, my_students: false)
   - current_course.assessment_categories.each do |category|
     = nav_to format_inline_text(category.title),
              course_submissions_path(current_course, category: category)

--- a/app/views/course/assessment/submissions/_tabs.html.slim
+++ b/app/views/course/assessment/submissions/_tabs.html.slim
@@ -1,9 +1,11 @@
 = tabs do
   - if current_course_user && current_course_user.staff? || can?(:manage, current_course)
-    = nav_to t('.my_students_pending'),
-             pending_course_submissions_path(current_course, my_students: true)
-    = nav_to t('.all_pending'),
-             pending_course_submissions_path(current_course, my_students: false)
+    = nav_to pending_course_submissions_path(current_course, my_students: true) do
+      = t('.my_students_pending')
+      =< badge(my_students_pending_submissions_count) if my_students_pending_submissions_count > 0
+    = nav_to pending_course_submissions_path(current_course, my_students: false) do
+      = t('.all_pending')
+      =< badge(pending_submissions_count) if pending_submissions_count > 0
   - current_course.assessment_categories.each do |category|
     = nav_to format_inline_text(category.title),
              course_submissions_path(current_course, category: category)

--- a/config/locales/en/course/assessment/submissions.yml
+++ b/config/locales/en/course/assessment/submissions.yml
@@ -11,4 +11,5 @@ en:
           grade: 'Grade'
           view: 'View'
         tabs:
-          pending: :'course.assessment.submissions.pending.header'
+          my_students_pending: 'My Students'
+          all_pending: 'All Pending Submissions'

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -24,8 +24,11 @@ RSpec.describe Course::Assessment::SubmissionsController do
       context 'when a category is specified' do
         let(:category) { categories.first }
         let(:tab) { create(:course_assessment_tab, course: course, category: category) }
+        let(:student) { create(:course_student, course: course).user }
         let(:assessment) { create(:assessment, :with_all_question_types, course: course, tab: tab) }
-        let!(:submission) { create(:course_assessment_submission, :graded, assessment: assessment) }
+        let!(:submission) do
+          create(:course_assessment_submission, :graded, creator: student, assessment: assessment)
+        end
         before { get :index, course_id: course, category: category }
 
         it 'sets the category to be the specified category' do

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Course: Submissions Viewing' do
           end
 
         # Staff without group can view all pending submissions
-        visit pending_course_submissions_path(course)
+        visit pending_course_submissions_path(course, my_students: false)
         expect(page).to have_content_tag_for(submitted_submission1)
         expect(page).to have_content_tag_for(submitted_submission2)
         expect(page).not_to have_content_tag_for(attempting_submission)
@@ -59,17 +59,18 @@ RSpec.describe 'Course: Submissions Viewing' do
         create(:course_group_manager, group: group, course: course, course_user: course_manager)
         create(:course_group_user, group: group, course: course,
                                    course_user: submitted_submission1.course_user)
-        visit pending_course_submissions_path(course)
+        visit pending_course_submissions_path(course, my_students: true)
 
         expect(page).to have_content_tag_for(submitted_submission1)
         expect(page).not_to have_content_tag_for(submitted_submission2)
         expect(page).not_to have_content_tag_for(attempting_submission)
         expect(page).not_to have_content_tag_for(graded_submission)
 
-        # Pending submissions can be assessed from the sidebar
+        # All Pending submissions can be assessed from the sidebar
         within find('.sidebar') do
-          expect(page).to have_link(I18n.t('course.assessment.submissions.sidebar_title'),
-                                    href: pending_course_submissions_path(course))
+          expect(page).
+            to have_link(I18n.t('course.assessment.submissions.sidebar_title'),
+                         href: pending_course_submissions_path(course, my_students: false))
         end
       end
     end

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -19,10 +19,14 @@ RSpec.describe 'Course: Submissions Viewing' do
             create(:course_assessment_submission, trait,
                    assessment: assessment, creator: student.user)
           end
+        staff_submission = create(:course_assessment_submission, :submitted,
+                                  assessment: assessment, creator: course_manager.user)
 
         visit course_submissions_path(course)
 
+        # Submissions page should not have show attempting submissions or staff submissions.
         expect(page).not_to have_content_tag_for(attempting_submission)
+        expect(page).not_to have_content_tag_for(staff_submission)
 
         within find(content_tag_selector(submitted_submission)) do
           expect(page).to have_link(

--- a/spec/helpers/course/assessment/submissions_helper_spec.rb
+++ b/spec/helpers/course/assessment/submissions_helper_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::SubmissionsHelper do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:course_owner) { course.course_users.owner.first }
+    let(:assessment) { create(:assessment, :published_with_mcq_question, course: course) }
+    let(:students) { create_list(:course_student, 3, course: course) }
+    before do
+      helper.define_singleton_method(:current_course) {}
+      allow(helper).to receive(:current_course).and_return(course)
+
+      # Create submissions of various statuses, but only 1 which is pending submission.
+      create(:submission, :attempting, assessment: assessment, creator: students[0].user)
+      create(:submission, :submitted, assessment: assessment, creator: students[1].user)
+      create(:submission, :graded, assessment: assessment, creator: students[2].user)
+    end
+
+    describe '#pending_submissions_count' do
+      subject { helper.pending_submissions_count }
+      it { is_expected.to eq(assessment.submissions.with_submitted_state.count) }
+    end
+
+    describe '#my_students_pending_submissions_count' do
+      let!(:staff) { create(:course_teaching_assistant, course: course) }
+      before do
+        helper.define_singleton_method(:current_course_user) {}
+        allow(helper).to receive(:current_course_user).and_return(staff)
+      end
+      subject { helper.my_students_pending_submissions_count }
+
+      context 'when current course user is a staff and has no students in my group' do
+        it { is_expected.to eq(0) }
+      end
+
+      context 'when current course user is a staff and has group students' do
+        let!(:group) { create(:course_group, course: course) }
+        let!(:group_manager) { create(:course_group_manager, course_user: staff, group: group) }
+        let!(:group_user) do
+          create(:course_group_user, course: course, group: group, course_user: students[1])
+        end
+
+        it { is_expected.to eq(1) }
+      end
+    end
+  end
+end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -162,6 +162,15 @@ RSpec.describe CourseUser, type: :model do
       end
     end
 
+    describe '#manager_or_owner?' do
+      it 'returns true if the role is manager or owner' do
+        expect(student.manager_or_owner?).to be_falsey
+        expect(teaching_assistant.manager_or_owner?).to be_falsey
+        expect(manager.manager_or_owner?).to be_truthy
+        expect(course_owner.manager_or_owner?).to be_truthy
+      end
+    end
+
     describe '#real_student?' do
       it 'returns true if the role is student and not phantom' do
         expect(student.real_student?).to be_truthy


### PR DESCRIPTION
Depends on #1339.

This PR fixes two issues: 
- Hides staff submissions from the submissions page. This was not a major issue as only staff could see these submissions as we used abilities to load the submissions.
- Add the EXP awarded per submission. 

Fixes #1337