### PR TITLE
Remove Ruby 2.2.5 and ruby-head from the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ branches:
   except:
     - /^bundle-update-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}+$/
 rvm:
-  - 2.2.5
   - 2.3.1
-  - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
Leaves more containers for running PR builds concurrently.

[skip ci]