### PR TITLE
Fixes to pending submissions bubble

### DIFF
--- a/app/helpers/course/assessment/submissions_helper.rb
+++ b/app/helpers/course/assessment/submissions_helper.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 module Course::Assessment::SubmissionsHelper
-  # Returns the count of submissions in a course that are pending grading
+  # Returns the count of student submissions in a course that are pending grading.
   #
   # @return [Fixnum] The required count
   def pending_submissions_count
-    @pending_submissions_count ||=
-      Course::Assessment::Submission.from_course(current_course).with_submitted_state.count
+    @pending_submissions_count ||= begin
+      student_ids = current_course.course_users.students.select(:user_id)
+      Course::Assessment::Submission.from_course(current_course).by_users(student_ids).
+        with_submitted_state.count
+    end
   end
 
   # Returns the count of submissions of my students in a course that are pending grading

--- a/spec/helpers/course/assessment/submissions_helper_spec.rb
+++ b/spec/helpers/course/assessment/submissions_helper_spec.rb
@@ -19,8 +19,22 @@ RSpec.describe Course::Assessment::SubmissionsHelper do
     end
 
     describe '#pending_submissions_count' do
+      let(:student_ids) { students.map(&:user_id) }
       subject { helper.pending_submissions_count }
-      it { is_expected.to eq(assessment.submissions.with_submitted_state.count) }
+      it 'returns the number of pending submisssions' do
+        expect(subject).
+          to eq(assessment.submissions.by_users(student_ids).with_submitted_state.count)
+      end
+
+      context 'when there is a staff submission' do
+        let!(:staff_submission) do
+          create(:submission, :submitted, assessment: assessment, creator: course_owner.user)
+        end
+        it 'does not reflect the staff submission in the count' do
+          expect(subject).
+            to eq(assessment.submissions.by_users(student_ids).with_submitted_state.count)
+        end
+      end
     end
 
     describe '#my_students_pending_submissions_count' do


### PR DESCRIPTION
This PR fixes 2 things:
- Bug where I included staff submissions in the bubble count for `Submissions` (sidebar) and `Pending Submissions` (tab).
- Use `select` instead of `pluck` to save an SQL call. 