### PR TITLE
Auto-fill experience points and grade for pages without grades summary

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/submission.js
+++ b/app/assets/javascripts/course/assessment/submission/submission.js
@@ -1,6 +1,8 @@
 (function($) {
   'use strict';
   var DOCUMENT_SELECTOR = '.course-assessment-submission-submissions.edit ';
+  var SINGLE_QUESTION_ASSESSMENT_SELECTOR = DOCUMENT_SELECTOR + '.single-question ';
+  var MULTI_QUESTION_ASSESSMENT_SELECTOR = DOCUMENT_SELECTOR + '.multi-question ';
   var SUMMARY_GRADE_SELECTOR = '.submission-grades-summary-grade';
   var GRADE_INPUT_SELECTOR = 'input.grade';
   var POINTS_AWARDED_SELECTOR = 'input.submission-points-awarded';
@@ -28,6 +30,23 @@
     var newTotalGrade = computeNewTotalGrade();
     updateTotalGrade(newTotalGrade);
     updateExperiencePointsAwarded(newTotalGrade);
+  }
+
+  /**
+   * Updates the total grade and experience points awarded in the submission statistics
+   * when the submission's assessment has only one question. Unlike `updateGradesAndPoints`
+   * this method updates the statistics directly instead of via the Grades Summary.
+   *
+   * @param {Event} event The event object.
+   */
+  function updateGradesAndPointsSingleQuestion(event) {
+    var $changedGradeInput = $(event.target);
+    var newGrade = $changedGradeInput.val();
+
+    if (!$.isNumeric(newGrade)) { return; }
+
+    updateTotalGrade(newGrade);
+    updateExperiencePointsAwarded(newGrade);
   }
 
   /**
@@ -75,5 +94,8 @@
     $pointsAwardedInput.val(newPointsAwarded);
   }
 
-  $(document).on('change', DOCUMENT_SELECTOR + GRADE_INPUT_SELECTOR, updateGradesAndPoints);
+  $(document).on('change', MULTI_QUESTION_ASSESSMENT_SELECTOR + GRADE_INPUT_SELECTOR,
+                           updateGradesAndPoints);
+  $(document).on('change', SINGLE_QUESTION_ASSESSMENT_SELECTOR + GRADE_INPUT_SELECTOR,
+                           updateGradesAndPointsSingleQuestion);
 })(jQuery);

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -53,4 +53,8 @@ module Course::Assessment::Submission::SubmissionsHelper
             remote: true, method: :post, class: ['btn', 'btn-warning', 'reset-answer'],
             data: { confirm: t('course.assessment.answer.reset_answer.warning') }
   end
+
+  def single_question_flag_class(assessment)
+    assessment.questions.length > 1 ? 'multi-question' : 'single-question'
+  end
 end

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -40,7 +40,7 @@ div.panel.panel-default
           th = @submission.class.human_attribute_name(:graded_at)
           td = format_datetime(@submission.published_at) if @submission.published_at
 
-    - if @submission.answers.length > 1
+    - if @assessment.questions.length > 1
       h4 = t('.grade_summary')
       table.table.table-striped
         thead

--- a/app/views/course/assessment/submission/submissions/edit.html.slim
+++ b/app/views/course/assessment/submission/submissions/edit.html.slim
@@ -1,7 +1,7 @@
 - add_breadcrumb t('.attempt')
 = page_header format_inline_text(@assessment.title)
 
-= div_for(@assessment, 'data-assessment-id' => @assessment.id) do
+= div_for(@assessment, 'data-assessment-id' => @assessment.id,
+                       class: single_question_flag_class(@assessment)) do
   = div_for(@submission, 'data-submission-id' => @submission.id) do
     = render @assessment.display_mode
-


### PR DESCRIPTION
- Properly hide grade summary when there is only one question. Existing implementation incorrectly assumes that each question has only one answer.
- Worksheets currently auto-fills the experience points and grades correctly only when there is a grades summary. This PR ensures that all worksheets fill in the items correctly.