### PR TITLE
Fix nesting of admin sidebar items

### DIFF
--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -18,9 +18,9 @@
           div.sidebar.collapse.navbar-collapse#course-navigation-sidebar
             = sidebar_items(controller.sidebar_items(type: :normal))
 
-        - unless (admin_sidebar_items = controller.sidebar_items(type: :admin)).empty?
-          h5 = t('.administration')
-          = sidebar_items(admin_sidebar_items)
+            - unless (admin_sidebar_items = controller.sidebar_items(type: :admin)).empty?
+              h5 = t('.administration')
+              = sidebar_items(admin_sidebar_items)
 
     div.col-lg-10.col-md-9.col-sm-8 class=page_class
       = yield


### PR DESCRIPTION
Together with https://github.com/Coursemology/coursemology-theme/pull/4, this should make Coursemology usable on mobile. This would nest the sidebar properly, and allow it to collapse. 

To deploy only when other PR in the theme is merged. 