### PR TITLE
Link to uploaded single attachments

### DIFF
--- a/app/controllers/attachment_references_controller.rb
+++ b/app/controllers/attachment_references_controller.rb
@@ -3,6 +3,6 @@ class AttachmentReferencesController < ApplicationController
   load_resource :attachment_reference
 
   def show
-    redirect_to @attachment_reference.url
+    redirect_to @attachment_reference.url(filename: @attachment_reference.name)
   end
 end

--- a/app/views/layouts/_attachment_uploader.html.slim
+++ b/app/views/layouts/_attachment_uploader.html.slim
@@ -9,6 +9,7 @@
 - else
   - if f.object.attachment.present?
     strong => t('.uploaded_file')
-    = link_to format_inline_text(f.object.attachment.name), '#'
+    = link_to format_inline_text(f.object.attachment.name),
+              attachment_reference_path(f.object.attachment), target: "_blank"
   div
     = f.file_field :file

--- a/spec/libraries/acts_as_attachable_spec.rb
+++ b/spec/libraries/acts_as_attachable_spec.rb
@@ -187,10 +187,11 @@ RSpec.describe 'Extension: Acts as Attachable' do
   describe 'form_builder helper' do
     class self::SampleView < ActionView::Base
       include ApplicationFormattersHelper
+      include Rails.application.routes.url_helpers
     end
     class self::SampleFormBuilder < ActionView::Helpers::FormBuilder; end
 
-    let(:attachment) { build(:attachment_reference) }
+    let(:attachment) { create(:attachment_reference) }
     let(:template) { self.class::SampleView.new(Rails.root.join('app', 'views')) }
     let(:resource) do
       stub = self.class::SampleModelMultiple.new


### PR DESCRIPTION
Allows code evaluation package to be downloaded, but filename is the hashed name when tested locally.

Existing code in https://github.com/Coursemology/coursemology2/blob/master/app/uploaders/file_uploader.rb#L23 for modifying the content header to support a human readable filename does not work locally but should be ok in production.

This is needed urgently to help debug programming test cases, fix the usability problems later.

Fixes #1356.