### PR TITLE
Make sure posts are always under the new answer

### DIFF
--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -38,6 +38,19 @@ class Course::Discussion::Topic < ActiveRecord::Base
 
   scope :pending_staff_reply, -> { where(pending_staff_reply: true) }
 
+  # Move posts and pending status from a topic to another topic.
+  def self.migrate!(from:, to:)
+    return if from.posts.empty?
+
+    from.posts.update_all(topic_id: to.id)
+    if from.pending_staff_reply
+      to.pending_staff_reply = true
+      from.pending_staff_reply = false
+      from.save!
+      to.save!
+    end
+  end
+
   # Return if a user has subscribed to this topic
   #
   # @param [User] user The user to check

--- a/app/services/course/assessment/answer/auto_grading_service.rb
+++ b/app/services/course/assessment/answer/auto_grading_service.rb
@@ -29,7 +29,14 @@ class Course::Assessment::Answer::AutoGradingService
     def save!(answer, reattempt)
       Course::Assessment::Answer.transaction do
         answer.save!
-        answer.question.attempt(answer.submission, answer).save! if reattempt
+        if reattempt
+          new_answer = answer.question.attempt(answer.submission, answer)
+          new_answer.save!
+          # Move posts to the new answer.
+          # TODO: Mount posts under a join table between submission and answer.
+          Course::Discussion::Topic.migrate!(from: answer.discussion_topic,
+                                             to: new_answer.discussion_topic)
+        end
       end
     end
   end

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -157,5 +157,27 @@ RSpec.describe Course::Discussion::Topic, type: :model do
         it { is_expected.to contain_exactly(annotation, comment) }
       end
     end
+
+    describe '.migrate!' do
+      let(:from_topic) { create(:course_assessment_answer, :with_post, :pending).acting_as }
+      let(:to_topic) { create(:course_assessment_answer).acting_as }
+      let(:posts) { from_topic.posts }
+
+      subject { Course::Discussion::Topic.migrate!(from: from_topic, to: to_topic) }
+
+      it 'moves all the posts to the new topic' do
+        subject
+
+        expect(from_topic.posts.count).to be(0)
+        expect(to_topic.posts).to contain_exactly(*posts)
+      end
+
+      it 'sets the pending status of the new topic' do
+        subject
+
+        expect(from_topic.pending_staff_reply).to be_falsey
+        expect(to_topic.pending_staff_reply).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR shifts all the posts and topic state from old answer to the new answer.

It's a workaround for now, but it helps when later we refactor and add a join table between answer and submission: can just move all the posts from latest answer to the new join table that time. 