### PR TITLE
Add tutor names to pending submissions and groups listing page

### DIFF
--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -5,6 +5,14 @@
                course_assessment_path(current_course, assessment))
   td = format_datetime(submission.submitted_at) if submission.submitted_at
   td = submission.workflow_state.capitalize
+  - if pending
+    td
+      ul
+        - @service.group_managers_of(submission.course_user).each do |manager|
+          li
+            = link_to_course_user(manager) do |course_user|
+              = format_inline_text(course_user.name)
+
   - if submission.graded?
     td = submission.grade.to_i.to_s + ' / ' + assessment.maximum_grade.to_s
     td = submission.points_awarded

--- a/app/views/course/assessment/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submissions/_submissions.html.slim
@@ -5,9 +5,11 @@ table.table.table-middle-align.table-hover
       th = Course::Assessment.human_attribute_name(:title)
       th = Course::Assessment::Submission.human_attribute_name(:submitted_at)
       th = Course::Assessment::Submission.human_attribute_name(:status)
+      - if pending
+        th = Course::GroupUser.human_attribute_name(:manager)
       th = Course::Assessment::Submission.human_attribute_name(:grade)
       th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
       th
       th
   tbody
-    = render submissions
+    = render partial: 'submission', collection: submissions, locals: { pending: pending }

--- a/app/views/course/assessment/submissions/index.html.slim
+++ b/app/views/course/assessment/submissions/index.html.slim
@@ -2,6 +2,6 @@
 = page_header
 = render partial: 'tabs'
 
-= render partial: 'submissions', locals: { submissions: @submissions }
+= render partial: 'submissions', locals: { submissions: @submissions, pending: false }
 
 = paginate @submissions

--- a/app/views/course/assessment/submissions/pending.html.slim
+++ b/app/views/course/assessment/submissions/pending.html.slim
@@ -2,6 +2,6 @@
 = page_header
 = render partial: 'tabs'
 
-= render partial: 'submissions', locals: { submissions: @submissions }
+= render partial: 'submissions', locals: { submissions: @submissions, pending: true }
 
 = paginate @submissions

--- a/app/views/course/groups/_group.html.slim
+++ b/app/views/course/groups/_group.html.slim
@@ -2,5 +2,11 @@
   th = format_inline_text(group.name)
   td = group.course_users.with_approved_state.count
   td
+    ul
+      - group.course_users.managers.each do |manager|
+        li
+          = link_to_course_user(manager) do
+            = format_inline_text(manager.name)
+  td
     = edit_button(edit_course_group_path(current_course, group))
     = delete_button(course_group_path(current_course, group))

--- a/app/views/course/groups/index.html.slim
+++ b/app/views/course/groups/index.html.slim
@@ -6,6 +6,7 @@ table.table.table-hover
     tr
       th = t('.name')
       th = t('.members')
+      th = t('.managers')
       th
 
   tbody

--- a/config/locales/en/activerecord/course/group_user.yml
+++ b/config/locales/en/activerecord/course/group_user.yml
@@ -4,3 +4,6 @@ en:
       models:
         course/group_user:
           not_enrolled: 'must be enrolled in same course as group'
+    attributes:
+      course/group_user:
+        manager: 'Tutor'

--- a/config/locales/en/course/groups.yml
+++ b/config/locales/en/course/groups.yml
@@ -6,6 +6,7 @@ en:
         header: 'Groups'
         name: 'Name'
         members: 'Members'
+        managers: 'Managers'
       new:
         header: 'New Group'
       create:

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe 'Course: Submissions Viewing' do
         expect(page).not_to have_content_tag_for(attempting_submission)
         expect(page).not_to have_content_tag_for(graded_submission)
 
+        # Pending submissions tab shows the tutors for the students if it exists.
+        visit pending_course_submissions_path(course, my_students: false)
+        expect(page).to have_content_tag_for(submitted_submission1)
+        within find(content_tag_selector(submitted_submission1)) do
+          expect(page).to have_text(course_manager.name)
+        end
+
         # All Pending submissions can be assessed from the sidebar
         within find('.sidebar') do
           expect(page).


### PR DESCRIPTION
This PR adds tutor names to two pages:
- Pending Submissions page
- Group#index (group listing) page

For pending submissions I use `Tutor`, but we might want to generalise this later on. 