### PR TITLE
Fix deadlock

### DIFF
--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -62,8 +62,7 @@ class Course::Assessment::Answer < ActiveRecord::Base
     ensure_auto_grading!
     Course::Assessment::Answer::AutoGradingJob.
       perform_later(self, redirect_to_path, reattempt).tap do |job|
-      auto_grading.job_id = job.job_id
-      save!
+      auto_grading.update_column(:job_id, job.job_id)
     end
   end
 

--- a/lib/extensions/discussion_topic/active_record/base.rb
+++ b/lib/extensions/discussion_topic/active_record/base.rb
@@ -5,11 +5,15 @@ module Extensions::DiscussionTopic::ActiveRecord::Base
     #
     # @option options [Boolean] :display_globally Set to true if the topic need to be displayed in
     # comments center.
-    def acts_as_discussion_topic(display_globally: false)
+    # @option options [Boolean] :touch Set to true if the topic need to be touched upon updating.
+    def acts_as_discussion_topic(display_globally: false, touch: false)
       acts_as :discussion_topic, class_name: Course::Discussion::Topic.name
       # For autoload to work correctly after class changed, we store the model name first and
       # constantize later.
       Course::Discussion::Topic.global_topic_model_names << name if display_globally
+
+      # This can be removed after https://github.com/hzamani/active_record-acts_as/pull/78
+      define_method(:touch_actable) {} unless touch
     end
   end
 end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -312,7 +312,8 @@ RSpec.describe Course::Assessment::Submission do
                         submission: submission1, creator: user1).acting_as
         answer.update_column(:created_at, 1.day.ago)
         submission1.reload
-        # Unfinished jobs in the callbacks could cause a deadlock, need to wait for them to finish.
+        # Submission creates a grading job which could make answers go to the graded state, need to
+        # wait for them to finish.
         wait_for_job
         answer
       end


### PR DESCRIPTION
This will fix #1371 

When we save the auto grading ,there 3 duplicated queries for updating the timestamp of discussion_topics, it will cause a deadlock in some concurrency cases, similar to: http://elioxman.blogspot.sg/2013/02/postgres-deadlock.html

Also there are **13 queries** generated when we save the auto grading because of the validation and updating of answer... this could cause performance issues because answers grading runs quite frequently.  Changed to directly update the column and skipped the validation of answer, we should not update or validate the answer in this case, because answer is not changed at all.

@fonglh You can rebase #1323 after this, should be no more failures when run 2 processes in same container, I have verified in #1359 