### PR TITLE
Implement email notification for submission and forum.

### DIFF
--- a/app/notifiers/course/assessment_notifier.rb
+++ b/app/notifiers/course/assessment_notifier.rb
@@ -3,6 +3,20 @@ class Course::AssessmentNotifier < Notifier::Base
   def assessment_attempted(user, assessment)
     create_activity(actor: user, object: assessment, event: :attempted).
       notify(assessment.tab.category.course, :feed).
-      save
+      save!
+  end
+
+  # To be called when user submitted an assessment.
+  def assessment_submitted(user, course_user, submission)
+    # TODO: Replace with a group_manager method in course_user
+    managers = course_user.groups.includes(group_users: [course_user: [:user]]).
+               flat_map { |g| g.group_users.select(&:manager?) }.map(&:course_user)
+
+    # Default to course manager if the course user do not have any group manager
+    managers = course_user.course.managers.includes(:user) unless managers.count > 0
+
+    activity = create_activity(actor: user, object: submission, event: :submitted)
+    managers.each { |manager| activity.notify(manager.user, :email) }
+    activity.save!
   end
 end

--- a/app/notifiers/course/forum/post_notifier.rb
+++ b/app/notifiers/course/forum/post_notifier.rb
@@ -1,8 +1,13 @@
 class Course::Forum::PostNotifier < Notifier::Base
   # To be called when user replied a forum post.
   def post_replied(user, post)
-    create_activity(actor: user, object: post, event: :replied).
-      notify(post.topic.actable.forum.course, :feed).
-      save!
+    activity = create_activity(actor: user, object: post, event: :replied)
+    activity.notify(post.topic.actable.forum.course, :feed)
+    topic_subscriptions = post.topic.subscriptions.includes(:user)
+    forum_subscriptions = post.topic.actable.forum.subscriptions.includes(:user)
+
+    # Send notification to both forum and topic subscribers
+    Set.new(topic_subscriptions + forum_subscriptions).each { |s| activity.notify(s.user, :email) }
+    activity.save!
   end
 end

--- a/app/notifiers/course/forum/topic_notifier.rb
+++ b/app/notifiers/course/forum/topic_notifier.rb
@@ -1,8 +1,9 @@
 class Course::Forum::TopicNotifier < Notifier::Base
   # To be called when user created a new forum topic.
   def topic_created(user, topic)
-    create_activity(actor: user, object: topic, event: :created).
-      notify(topic.forum.course, :feed).
-      save
+    activity = create_activity(actor: user, object: topic, event: :created)
+    activity.notify(topic.forum.course, :feed)
+    topic.forum.subscriptions.includes(:user).each { |s| activity.notify(s.user, :email) }
+    activity.save!
   end
 end

--- a/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
+++ b/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
@@ -7,4 +7,3 @@
                               announcement: link_to(:announcement,
                                                     course_announcements_url(course)),
                               content: announcement.content))
-

--- a/app/views/notifiers/course/assessment_notifier/submitted/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/submitted/user_notifications/email.html.slim
@@ -1,0 +1,9 @@
+- submission = @object
+- assessment = submission.assessment
+- course = assessment.course
+- submission_link = link_to(:submission,
+                            edit_course_assessment_submission_url(course, assessment, submission))
+
+- message.subject = t('.subject', course: course.title, assessment: submission.assessment.title)
+
+= simple_format(t('.message', submission: submission_link, user: submission.course_user.name))

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -1,0 +1,11 @@
+- post = @object
+- topic = post.topic.actable
+- course = topic.course
+- unsubscribe_link = subscribe_course_forum_topic_url(course, topic.forum, topic, subscribe: false)
+
+- message.subject = t('.subject', course: course.title, topic: topic.title)
+
+= simple_format(t('.message',
+                topic: link_to(topic.title, course_forum_topic_url(course, topic.forum, topic))))
+
+= simple_format(t('.unsubscribe', unsubscribe_link: unsubscribe_link))

--- a/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
@@ -1,0 +1,12 @@
+- topic = @object
+- post = topic.posts.first
+- course = topic.course
+- unsubscribe_link = unsubscribe_course_forum_url(course, topic.forum)
+
+- message.subject = t('.subject', course: course.title, forum: topic.forum.name)
+
+= simple_format(t('.message',
+                topic: link_to(topic.title, course_forum_topic_url(course, topic.forum, topic)),
+                post: post.text))
+
+= simple_format(t('.unsubscribe', unsubscribe_link: unsubscribe_link))

--- a/config/locales/en/notifiers/course/assessment_notifier/submitted/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment_notifier/submitted/user_notifications/email.yml
@@ -1,0 +1,12 @@
+en:
+  notifiers:
+    course:
+      assessment_notifier:
+        submitted:
+          user_notifications:
+            email:
+              subject: '%{course} New Submission on : %{assessment}'
+              message: >
+                There is a new submission by %{user}
+
+                Please review and grade the %{submission}.

--- a/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
@@ -1,0 +1,17 @@
+en:
+  notifiers:
+    course:
+      forum:
+        post_notifier:
+          replied:
+            user_notifications:
+              email:
+                subject: '%{course} New reply for forum topic: %{topic}'
+                message: >
+                  You can view the new reply here:
+
+                  %{topic}
+                unsubscribe: >
+                  To unsubscribe from this topic, use the following link:
+
+                  %{unsubscribe_link}

--- a/config/locales/en/notifiers/course/forum/topic_notifier/created/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/forum/topic_notifier/created/user_notifications/email.yml
@@ -1,0 +1,17 @@
+en:
+  notifiers:
+    course:
+      forum:
+        topic_notifier:
+          created:
+            user_notifications:
+              email:
+                subject: '%{course} New topic created in forum: %{forum}'
+                message: >
+                  A new topic has been created in the forum: %{topic}
+
+                  %{post}
+                unsubscribe: >
+                  To unsubscribe from this topic, use the following link:
+
+                  %{unsubscribe_link}

--- a/lib/autoload/notifier/base/activity_wrapper.rb
+++ b/lib/autoload/notifier/base/activity_wrapper.rb
@@ -14,13 +14,21 @@ class Notifier::Base::ActivityWrapper < SimpleDelegator
 
   # Save activity and send out pending emails
   def save(*)
-    super.tap do |result|
-      execute_after_commit { @notifier.send(:send_pending_emails) } if result
-    end
+    super.tap { |result| send_pending_email if result }
+  end
+
+  def save!(*)
+    super.tap { |_| send_pending_email }
   end
 
   def initialize(notifier, activity) #:nodoc:
     super(activity)
     @notifier = notifier
+  end
+
+  private
+
+  def send_pending_email
+    execute_after_commit { @notifier.send(:send_pending_emails) }
   end
 end

--- a/spec/notifiers/course/assessment_notifier.rb
+++ b/spec/notifiers/course/assessment_notifier.rb
@@ -16,5 +16,35 @@ RSpec.describe Course::AssessmentNotifier, type: :notifier do
         expect { subject }.to change(course.notifications, :count).by(1)
       end
     end
+
+    describe '#assessment_submitted' do
+      let(:course) { create(:course) }
+      let(:submission) { create(:course_assessment_submission, course: course) }
+      let(:course_user) { create(:course_user, course: course) }
+      let(:user) { course_user.user }
+
+      context 'when user do not belongs to any group' do
+        subject { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }
+
+        it 'sends an email notification' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
+      end
+
+      context 'when user belongs to a group' do
+        let(:group) { create(:course_group, course: course) }
+        let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
+        let!(:group_manager) do
+          create(:course_group_manager, group: group, course_user: teaching_assistant)
+        end
+        let!(:group_user) { create(:course_group_user, group: group, course_user: course_user) }
+
+        subject { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }
+
+        it 'sends an email notification' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(2)
+        end
+      end
+    end
   end
 end

--- a/spec/notifiers/course/forum/post_notifier.rb
+++ b/spec/notifiers/course/forum/post_notifier.rb
@@ -9,13 +9,21 @@ RSpec.describe Course::Forum::PostNotifier, type: :notifier do
     let(:forum) { create(:forum, course: course) }
     let!(:topic) { create(:forum_topic, forum: forum) }
     let(:post) { create(:course_discussion_post, topic: topic.acting_as) }
-    let(:user) { create(:course_user, course: course).user }
+    let(:user) do
+      user = create(:course_user, course: course).user
+      topic.subscriptions.create(user: user)
+      user
+    end
 
     describe '#post_replied' do
       subject { Course::Forum::PostNotifier.post_replied(user, post) }
 
       it 'sends a course notification' do
         expect { subject }.to change(course.notifications, :count).by(1)
+      end
+
+      it 'sends an email notification' do
+        expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end
   end

--- a/spec/notifiers/course/forum/topic_notifier.rb
+++ b/spec/notifiers/course/forum/topic_notifier.rb
@@ -9,12 +9,20 @@ RSpec.describe Course::Forum::TopicNotifier, type: :notifier do
       let(:course) { create(:course) }
       let(:forum) { create(:forum, course: course) }
       let!(:topic) { create(:forum_topic, forum: forum) }
-      let(:user) { create(:course_user, course: course).user }
+      let(:user) do
+        user = create(:course_user, course: course).user
+        forum.subscriptions.create(user: user)
+        user
+      end
 
       subject { Course::Forum::TopicNotifier.topic_created(user, topic) }
 
       it 'sends a course notification' do
         expect { subject }.to change(course.notifications, :count).by(1)
+      end
+
+      it 'sends an email notification' do
+        expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
Partial fix for #1009.

Implement email notification for new submission and for forum topic creation and post replies.