### PR TITLE
Button improvements for assessment

### DIFF
--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -10,6 +10,14 @@
       color: $course-assessment-submission-answer-correct-border-text;
       padding: 0 3px;
     }
+
+    .submission-buttons .btn {
+      margin: 10px 10px 10px 0;
+
+      &[name="submission[publish]"] {
+        margin-right: 0;
+      }
+    }
   }
 
   &.index {

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -2,7 +2,8 @@
   - if answer.attempting?
     div.btn-group
       = link_to_reset_answer(answer)
-      = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+      = base_answer_form.button :button, t('.run_code'), value: answer.id,
+        name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger']
 
 h3 = t('.comments')
 div.comments id=comments_container_id(answer)

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -11,25 +11,27 @@ nav
     = render partial: base_answer_form.object.question, suffix: 'question'
     = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
              locals: { base_answer_form: base_answer_form }
-    - if base_answer_form.object.attempting?
-      = f.button :submit, t('common.save')
 
-  - if @submission.attempting? && can?(:update, @submission)
-    = f.button :submit, t('.finalise'), name: 'submission[finalise]', class: ['btn-danger', 'finalise'],
-                                        data: { confirm: t('.confirm_finalise') },
-                                        style: guided_next_unanswered_question.nil? ? '' : 'display: none'
+    div.submission-buttons
+      - if base_answer_form.object.attempting?
+        = f.button :submit, t('common.save')
 
-  - unless @submission.attempting?
-    = render 'statistics', f: f
+      - if @submission.attempting? && can?(:update, @submission)
+        = f.button :submit, t('.finalise'), name: 'submission[finalise]', class: ['btn-danger', 'finalise', 'pull-right'],
+                                            data: { confirm: t('.confirm_finalise') },
+                                            style: guided_next_unanswered_question.nil? ? '' : 'display: none'
 
-    - if can?(:grade, @submission)
-      - if @submission.submitted?
-        = link_to t('.auto_grade'),
-                  auto_grade_course_assessment_submission_path(current_course,
-                                                               @submission.assessment,
-                                                               @submission),
-                  method: :post,
-                  class: ['btn', 'btn-info']
-        = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger']
+      - unless @submission.attempting?
+        = render 'statistics', f: f
 
-      = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']
+        - if can?(:grade, @submission)
+          = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']
+
+          - if @submission.submitted?
+            = link_to t('.auto_grade'),
+                      auto_grade_course_assessment_submission_path(current_course,
+                                                                   @submission.assessment,
+                                                                   @submission),
+                      method: :post,
+                      class: ['btn', 'btn-info']
+            = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger', 'pull-right']

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -11,18 +11,19 @@
   - unless @submission.attempting?
     = render 'statistics', f: f
 
-  = f.button :submit, t('common.save')
+  div.submission-buttons
+    = f.button :submit, t('common.save')
 
-  - if @submission.attempting? && can?(:update, @submission)
-    = f.button :submit, t('.finalise'),
-      name: 'submission[finalise]', class: ['btn-danger'],
-      data: { confirm: t('.confirm_finalise') }
+    - if @submission.attempting? && can?(:update, @submission)
+      = f.button :submit, t('.finalise'),
+        name: 'submission[finalise]', class: ['btn-danger', 'pull-right'],
+        data: { confirm: t('.confirm_finalise') }
 
-  - if @submission.submitted? && can?(:grade, @submission)
-    = link_to t('.auto_grade'),
-      auto_grade_course_assessment_submission_path(current_course, @submission.assessment,
-        @submission), method: :post, class: ['btn', 'btn-info']
-    = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger']
+    - if @submission.submitted? && can?(:grade, @submission)
+      = link_to t('.auto_grade'),
+        auto_grade_course_assessment_submission_path(current_course, @submission.assessment,
+          @submission), method: :post, class: ['btn', 'btn-info']
+      = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger', 'pull-right']
 
-  - if (@submission.submitted? || @submission.graded?) && can?(:grade, @submission)
-    = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']
+    - if (@submission.submitted? || @submission.graded?) && can?(:grade, @submission)
+      = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -4,6 +4,7 @@ en:
       answer:
         worksheet:
           comments: 'Comments'
+          run_code: 'Run Code'
         comments_footer:
           comment: 'Comment'
         guided:


### PR DESCRIPTION
- Add margins to buttons to prevent accidental clicking
- Align `Publish Grade` to the right
  
![127 0 0 1-9000-courses-2-assessments-2-submissions-3-edit](https://cloud.githubusercontent.com/assets/7753104/18045701/bd064964-6e06-11e6-92aa-414aa1880cc5.png)

- Change submit button to run code for worksheet to minimize confusion
  
![127 0 0 1-9000-courses-2-assessments-2-submissions-3-edit 1](https://cloud.githubusercontent.com/assets/7753104/18045706/c473d662-6e06-11e6-99ef-2f9705e42b9d.png)
