### PR TITLE
Fix for user profile width on users page to have fixed width

### DIFF
--- a/app/assets/stylesheets/course/users.scss
+++ b/app/assets/stylesheets/course/users.scss
@@ -23,6 +23,7 @@
       .image > img {
         @include no-stretch;
         height: $course-user-profile-picture;
+        width: $course-user-profile-picture;
         margin-top: 1em;
         border-radius: 50%;
       }
@@ -36,6 +37,7 @@
       .image > img {
         @include no-stretch;
         height: $course-user-listing-picture;
+        width: $course-user-listing-picture;
         margin-top: 1em;
         border-radius: 50%;
       }


### PR DESCRIPTION
1:1 ratio pic
![selection_007](https://cloud.githubusercontent.com/assets/10083037/18062017/99c6ac9a-6e57-11e6-9f44-d7170e682e7b.png)

Wide pic
![selection_008](https://cloud.githubusercontent.com/assets/10083037/18062018/99ce9d92-6e57-11e6-974b-0cd3d023086f.png)

Tall pic
![selection_009](https://cloud.githubusercontent.com/assets/10083037/18062019/9a16df62-6e57-11e6-887d-5c6e18612ae6.png)

Eventually we can consider having a UI to crop the picture to square/circle on uploading, if you don't like wide and tall pictures.