### PR TITLE
Convert integer grade columns to decimal.

### DIFF
--- a/db/migrate/20160830023835_alter_grade_type.rb
+++ b/db/migrate/20160830023835_alter_grade_type.rb
@@ -1,0 +1,8 @@
+class AlterGradeType < ActiveRecord::Migration
+  def change
+    change_column :course_assessment_answers, :grade, :decimal, precision: 4, scale: 1
+    change_column :course_assessment_questions, :maximum_grade, :decimal, precision: 4, scale: 1
+    change_column :course_assessment_question_text_response_solutions, :grade, :decimal,
+                  precision: 4, scale: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160823094126) do
+ActiveRecord::Schema.define(version: 20160830023835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define(version: 20160823094126) do
     t.string   "title",               :limit=>255
     t.text     "description"
     t.text     "staff_only_comments"
-    t.integer  "maximum_grade",       :null=>false
+    t.decimal  "maximum_grade",       :precision=>4, :scale=>1, :null=>false
     t.integer  "weight",              :default=>0, :null=>false
     t.integer  "creator_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_questions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_questions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
@@ -177,7 +177,7 @@ ActiveRecord::Schema.define(version: 20160823094126) do
     t.integer  "question_id",    :null=>false, :index=>{:name=>"fk__course_assessment_answers_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_answers_question_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.string   "workflow_state", :limit=>255, :null=>false
     t.datetime "submitted_at"
-    t.integer  "grade"
+    t.decimal  "grade",          :precision=>4, :scale=>1
     t.boolean  "correct",        :comment=>"Correctness is independent of the grade (depends on the grading schema)"
     t.integer  "grader_id",      :index=>{:name=>"fk__course_assessment_answers_grader_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_answers_grader_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "graded_at"
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define(version: 20160823094126) do
     t.integer "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_text_response_solution_question"}, :foreign_key=>{:references=>"course_assessment_question_text_responses", :name=>"fk_course_assessment_questi_2fbeabfad04f21c2d05c8b2d9100d1c4", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer "solution_type", :default=>0, :null=>false
     t.text    "solution",      :null=>false
-    t.integer "grade",         :default=>0, :null=>false
+    t.decimal "grade",         :precision=>4, :scale=>1, :default=>0.0, :null=>false
     t.text    "explanation"
   end
 

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         edit_path = edit_course_assessment_question_multiple_response_path(course, assessment, mrq)
         find_link(nil, href: edit_path).click
 
-        maximum_grade = 9999
+        maximum_grade = 999.9
         fill_in 'maximum_grade', with: maximum_grade
         click_button 'submit'
 

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         edit_path = edit_course_assessment_question_programming_path(course, assessment, question)
         find_link(nil, href: edit_path).click
 
-        maximum_grade = 9999
+        maximum_grade = 999.9
         fill_in 'maximum_grade', with: maximum_grade
         click_button 'submit'
 

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         edit_path = edit_course_assessment_question_text_response_path(course, assessment, question)
         find_link(nil, href: edit_path).click
 
-        maximum_grade = 9999
+        maximum_grade = 999.9
         fill_in 'maximum_grade', with: maximum_grade
         click_button 'submit'
 


### PR DESCRIPTION
With precision 4 and scale 1 (maximum of 4 digits total, 1 decimal
place).

Supports finer granularity in grades.

Fixes #1391.