### PR TITLE
Fix spammy forum notifications.

### DIFF
--- a/app/notifiers/course/forum/post_notifier.rb
+++ b/app/notifiers/course/forum/post_notifier.rb
@@ -3,11 +3,7 @@ class Course::Forum::PostNotifier < Notifier::Base
   def post_replied(user, post)
     activity = create_activity(actor: user, object: post, event: :replied)
     activity.notify(post.topic.actable.forum.course, :feed)
-    topic_subscriptions = post.topic.subscriptions.includes(:user)
-    forum_subscriptions = post.topic.actable.forum.subscriptions.includes(:user)
-
-    # Send notification to both forum and topic subscribers
-    Set.new(topic_subscriptions + forum_subscriptions).each { |s| activity.notify(s.user, :email) }
+    post.topic.subscriptions.includes(:user).each { |s| activity.notify(s.user, :email) }
     activity.save!
   end
 end

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -1,11 +1,12 @@
 - post = @object
 - topic = post.topic.actable
 - course = topic.course
-- unsubscribe_link = subscribe_course_forum_topic_url(course, topic.forum, topic, subscribe: false)
+- unsubscribe_url = subscribe_course_forum_topic_url(course,topic.forum, topic, subscribe: false)
 
 - message.subject = t('.subject', course: course.title, topic: topic.title)
 
 = simple_format(t('.message',
                 topic: link_to(topic.title, course_forum_topic_url(course, topic.forum, topic))))
 
-= simple_format(t('.unsubscribe', unsubscribe_link: unsubscribe_link))
+= simple_format(t('.unsubscribe.message',
+                unsubscribe_link: link_to(t('.unsubscribe.tag'), unsubscribe_url)))

--- a/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
@@ -1,7 +1,7 @@
 - topic = @object
 - post = topic.posts.first
 - course = topic.course
-- unsubscribe_link = unsubscribe_course_forum_url(course, topic.forum)
+- unsubscribe_url = unsubscribe_course_forum_url(course, topic.forum)
 
 - message.subject = t('.subject', course: course.title, forum: topic.forum.name)
 
@@ -9,4 +9,5 @@
                 topic: link_to(topic.title, course_forum_topic_url(course, topic.forum, topic)),
                 post: post.text))
 
-= simple_format(t('.unsubscribe', unsubscribe_link: unsubscribe_link))
+= simple_format(t('.unsubscribe.message',
+                unsubscribe_link: link_to(t('.unsubscribe.tag'), unsubscribe_url)))

--- a/config/locales/en/course/forum/forums.yml
+++ b/config/locales/en/course/forum/forums.yml
@@ -33,11 +33,11 @@ en:
           success: 'Forum %{name} was deleted.'
           failure: 'Failed to delete forum: %{error}'
         subscribe:
-          tag: 'Subscribe'
+          tag: 'Subscribe to new topic notifications'
           success: 'You have subscribed to Forum %{name}.'
           failure: 'Fail to subscribe to Forum: %{error}'
         unsubscribe:
-          tag: 'Unsubscribe'
+          tag: 'Unsubscribe from new topic notifications'
           success: 'You have been unsubscribed from the Forum %{name}.'
           failure: 'Fail to unsubscribe from Forum: %{error}'
         search:

--- a/config/locales/en/course/forum/topics.yml
+++ b/config/locales/en/course/forum/topics.yml
@@ -24,11 +24,11 @@ en:
           success: 'Topic %{title} was deleted.'
           failure: 'Failed to delete topic: %{error}'
         subscribe:
-          tag: 'Subscribe'
+          tag: 'Subscribe to new post notifications'
           success: 'You have subscribed to topic.'
           failure: 'Failed to subscribe to topic.'
         unsubscribe:
-          tag: 'Unsubscribe'
+          tag: 'Unsubscribe from new post notifications'
           success: 'You have unsubscribed from topic.'
           failure: 'Failed to unsubscribe from topic.'
         locked:

--- a/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
@@ -11,7 +11,7 @@ en:
                   You can view the new reply here:
 
                   %{topic}
-                unsubscribe: >
-                  To unsubscribe from this topic, use the following link:
 
-                  %{unsubscribe_link}
+                unsubscribe:
+                  tag: 'Unsubscribe'
+                  message: '%{unsubscribe_link} from new post notification in this topic'

--- a/config/locales/en/notifiers/course/forum/topic_notifier/created/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/forum/topic_notifier/created/user_notifications/email.yml
@@ -11,7 +11,7 @@ en:
                   A new topic has been created in the forum: %{topic}
 
                   %{post}
-                unsubscribe: >
-                  To unsubscribe from this topic, use the following link:
 
-                  %{unsubscribe_link}
+                unsubscribe:
+                  tag: 'Unsubscribe'
+                  message: '%{unsubscribe_link} from new topic notification in this forum'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,12 +209,14 @@ Rails.application.routes.draw do
               put 'vote', on: :member
             end
 
+            get 'subscribe', on: :member
             post 'subscribe', on: :member
             delete 'subscribe', on: :member
             put 'locked' => 'topics#set_locked', on: :member
             put 'hidden' => 'topics#set_hidden', on: :member
           end
 
+          get 'unsubscribe', on: :member
           post 'subscribe', on: :member
           delete 'unsubscribe', on: :member
 


### PR DESCRIPTION
Separate the subscription of forums from topics. E.g. Topic's post updates will no longer send email notifications to the forum subscriber. Forum subscriber will now only receive new topic notifications.

Also updated the title of the subscribe/unsubscribe button to specify what the user are subscribing to.

Lastly, added the missing GET link to allow user to unsubscribe immediately from the link in email.