### PR TITLE
Implement job error recovery

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,7 +8,7 @@
 	"expr": true,
 	"immed": true,
 	"indent": 4,
-	"latedef": true,
+	"latedef": "nofunc",
 	"newcap": true,
 	"noarg": true,
 	"sub": true,

--- a/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
@@ -12,6 +12,17 @@
     submitFormAndWaitForJob($('.edit_submission'), answerId);
   }
 
+  // Find all the spinning jobs in the page and check their statuses.
+  function checkSubmittedJobs() {
+    $('a.btn.submitted').filter(DOCUMENT_SELECTOR + '*').each(function(index) {
+      var answer = $(this).closest('.answer');
+      var jobUrl = $(this).data('job-path');
+      var answerId = answer.data('answer-id');
+      // Use different delays, so that all the requests won't send at once.
+      waitForJob(jobUrl, answerId, (index + 1) * DELAY);
+    });
+  }
+
   function submitFormAndWaitForJob($form, answerId) {
     var action = $form.attr('action');
     var method = $form.attr('method');
@@ -29,7 +40,7 @@
     });
   }
 
-  function waitForJob(url, answerId) {
+  function waitForJob(url, answerId, delay) {
     setTimeout(function() {
       $.ajax({
         url: url,
@@ -42,7 +53,7 @@
         // Error message is rendered by the answer.
         reloadAnswer(answerId);
       })
-    }, DELAY);
+    }, delay || DELAY);
   }
 
   function onGetJobSuccess(data, url, answerId) {
@@ -72,4 +83,6 @@
   }
 
   $(document).on('click', DOCUMENT_SELECTOR + '.btn.submit-answer', onAnswerSubmit);
+  $(document).on('turbolinks:load', checkSubmittedJobs);
+
 })(jQuery);

--- a/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming_submit.js
@@ -6,16 +6,18 @@
   function onAnswerSubmit(e) {
     e.preventDefault();
 
+    var answerId = e.target.value;
     showSpinner($(this));
-    submitFormAndWaitForJob($('.edit_submission'), e.target.value);
+    hideErrorMessage(answerId);
+    submitFormAndWaitForJob($('.edit_submission'), answerId);
   }
 
-  function submitFormAndWaitForJob($form, answer_id) {
+  function submitFormAndWaitForJob($form, answerId) {
     var action = $form.attr('action');
     var method = $form.attr('method');
 
     var data = $form.serializeArray();
-    data.push({name: "attempting_answer_id", value: answer_id});
+    data.push({name: 'attempting_answer_id', value: answerId});
     $.ajax({
       url: action,
       method: method,
@@ -23,11 +25,11 @@
       dataType: 'json',
       global: false
     }).done(function(data) {
-      waitForJob(data.redirect_url, answer_id);
+      waitForJob(data.redirect_url, answerId);
     });
   }
 
-  function waitForJob(url, answer_id) {
+  function waitForJob(url, answerId) {
     setTimeout(function() {
       $.ajax({
         url: url,
@@ -35,26 +37,27 @@
         dataType: 'json',
         global: false
       }).done(function(data) {
-        onGetJobSuccess(data, url, answer_id);
+        onGetJobSuccess(data, url, answerId);
+      }).fail(function() {
+        // Error message is rendered by the answer.
+        reloadAnswer(answerId);
       })
     }, DELAY);
   }
 
-  function onGetJobSuccess(data, url, answer_id) {
+  function onGetJobSuccess(data, url, answerId) {
     if (data.status == 'completed') {
-      reloadAnswer(answer_id);
+      reloadAnswer(answerId);
     } else if (data.status == 'submitted') {
-      waitForJob(url, answer_id);
-    } else {
-      // Show errors.
+      waitForJob(url, answerId);
     }
   }
 
-  function reloadAnswer(answer_id) {
+  function reloadAnswer(answerId) {
     $.ajax({
       url: 'reload_answer',
       method: 'POST',
-      data: { answer_id: answer_id },
+      data: { answer_id: answerId },
       global: false
     });
   }
@@ -62,6 +65,10 @@
   function showSpinner($button) {
     $button.prop('disabled', true);
     $button.append('<i class="fa fa-spinner fa-lg fa-spin"></i>');
+  }
+
+  function hideErrorMessage(answerId) {
+    $('div#answer_' + answerId).find('p.bg-danger').hide();
   }
 
   $(document).on('click', DOCUMENT_SELECTOR + '.btn.submit-answer', onAnswerSubmit);

--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -4,6 +4,10 @@
       - if answer.specific.is_a?(Course::Assessment::Answer::Programming)
         = link_to_reset_answer(answer)
       = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+  - elsif answer.submitted? && job = answer.try(:auto_grading).try(:job)
+    - if job.errored?
+      p.bg-danger = t('.error')
+      = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
 
   / Display a continue button if last attempt is correct
   - if !@current_question.last_question? && last_attempt && last_attempt.correct?

--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -8,6 +8,10 @@
     - if job.errored?
       p.bg-danger = t('.error')
       = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+    - elsif job.submitted?
+      = link_to '#', class: ['btn', 'btn-default', 'submitted'], 'data-job-path': job_path(job), disabled: true do
+        => t('common.submit')
+        = fa_icon 'spinner lg spin'
 
   / Display a continue button if last attempt is correct
   - if !@current_question.last_question? && last_attempt && last_attempt.correct?

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -4,6 +4,10 @@
       = link_to_reset_answer(answer)
       = base_answer_form.button :button, t('.run_code'), value: answer.id,
         name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger']
+  - elsif answer.submitted? && job = answer.try(:auto_grading).try(:job)
+    - if job.errored?
+      p.bg-danger = t('.error')
+      = base_answer_form.button :button, t('.run_code'), value: answer.id, name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger']
 
 h3 = t('.comments')
 div.comments id=comments_container_id(answer)

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -8,6 +8,10 @@
     - if job.errored?
       p.bg-danger = t('.error')
       = base_answer_form.button :button, t('.run_code'), value: answer.id, name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger']
+    - elsif job.submitted?
+      = link_to '#', class: ['btn', 'btn-danger', 'submitted'], 'data-job-path': job_path(job), disabled: true do
+        => t('.run_code')
+        = fa_icon 'spinner lg spin'
 
 h3 = t('.comments')
 div.comments id=comments_container_id(answer)

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -2,13 +2,16 @@ en:
   course:
     assessment:
       answer:
+        error: 'An error occurred while evaluating your answer, please try again.'
         worksheet:
           comments: 'Comments'
           run_code: 'Run Code'
+          error: :'course.assessment.answer.error'
         comments_footer:
           comment: 'Comment'
         guided:
           continue: 'Continue'
+          error: :'course.assessment.answer.error'
         grading:
           grading: 'Grading'
           maximum_grade: '/ %{maximum_grade}'

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -116,6 +116,28 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         expect(page).to have_selector('.btn', text: I18n.t('common.submit'))
       end
 
+      scenario 'I can resubmit the answer when job is errored', js: true do
+        # Build an answer with a failing job
+        errored_grading =
+          build(:course_assessment_answer_auto_grading, job: create(:trackable_job, :errored))
+        create(:course_assessment_answer_multiple_response,
+               :with_all_correct_options, :submitted,
+               auto_grading: errored_grading, question: assessment.questions.first,
+               submission: submission)
+
+        visit edit_course_assessment_submission_path(assessment.course, assessment, submission)
+
+        expect(page).to have_selector('p', text: 'course.assessment.answer.guided.error')
+
+        click_button I18n.t('common.submit')
+        wait_for_ajax
+
+        expect(page).
+          to have_selector('div.panel', text: 'course.assessment.answer.explanation.correct')
+        expect(page).to have_selector('h2', text: mrq_questions.first.display_title)
+        expect(page).to have_selector('.btn', text: I18n.t('common.submit'))
+      end
+
       scenario 'I can finalise my submission for auto grading' do
         assessment.autograded = true
         assessment.save!


### PR DESCRIPTION
This PR fixes #1370:
Allows users to track the status of the job even after page refreshing.
Allows users to resubmit the job when there's a timeout or other errors in the evaluation job.

So once the job failed, they won't complain to us that the buttons are missing :)

