### PR TITLE
Fix submission resume button bug

### DIFF
--- a/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
+++ b/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
@@ -1,8 +1,8 @@
 div.btn-group
   - if current_course_user
-    - attempting_submission = assessment.submissions.find(&:attempting?)
-    - submitted_submission = assessment.submissions.find do |submission|
-      - submission != attempting_submission
+    - submissions = assessment.submissions.select { |s| s.creator == current_user }
+    - attempting_submission = submissions.find(&:attempting?)
+    - submitted_submission = submissions.find { |s| !s.attempting? }
     - if attempting_submission
       = link_to(t('.resume'), edit_course_assessment_submission_path(current_course,
           assessment, attempting_submission), class: ['btn', 'btn-info'])

--- a/spec/features/course/assessment/assessment_viewing_spec.rb
+++ b/spec/features/course/assessment/assessment_viewing_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe 'Course: Assessments: Viewing' do
       end
 
       scenario 'I attempt the assessment from the show assessment page' do
+        # Create a random submission which does not belong to the user.
+        # The button should still be 'Attempt' with the random submission.
+        create(:course_assessment_submission, assessment: assessment)
         visit course_assessment_path(course, assessment)
 
         expect(page).to have_link(


### PR DESCRIPTION
It goes to the first submission of the assessment.

This issue is because the partial is shared by index and show page of the assessment, in `index` page it works because submissions are manually preloaded, `assessment.submissions` will only return current user's submission. In the `show` page that's not true.

I still modified the existing specs to let it fail for this case but think it won't help too much. To prevent this in future we need be careful when to preload and overwrite the association. Think it's better to use a different method to get the preloaded records ( instead of overwriting existing association ).