### PR TITLE
Show grade on assessment submission page as decimal number.

### DIFF
--- a/app/views/course/assessment/submission/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submission.html.slim
@@ -4,6 +4,6 @@
                                                      submission) do
       = format_inline_text(submission.course_user.name)
   td = submission.workflow_state.capitalize
-  td = submission.grade.to_i.to_s + ' / ' + submission.assessment.maximum_grade.to_s
+  td = submission.grade.to_s + ' / ' + submission.assessment.maximum_grade.to_s
   td = submission.points_awarded.to_i.to_s
   td


### PR DESCRIPTION
This is when clicking on the 'Submissions' button beside an individual assessment.

References #1400 and #1402.