### PR TITLE
Set instance's host for links in email notification.

### DIFF
--- a/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
+++ b/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
@@ -1,9 +1,10 @@
 - announcement = @object
 - course = announcement.course
+- host = course.instance.host
 
 - message.subject = t('.subject', course: course.title, announcement: announcement.title)
 
-= simple_format(t('.message', course: link_to(course.title, course_url(course)),
+= simple_format(t('.message', course: link_to(course.title, course_url(course, host: host)),
                               announcement: link_to(:announcement,
-                                                    course_announcements_url(course)),
+                                                    course_announcements_url(course, host: host)),
                               content: announcement.content))

--- a/app/views/notifiers/course/assessment_notifier/submitted/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/submitted/user_notifications/email.html.slim
@@ -1,9 +1,10 @@
 - submission = @object
 - assessment = submission.assessment
 - course = assessment.course
-- submission_link = link_to(:submission,
-                            edit_course_assessment_submission_url(course, assessment, submission))
+- host = course.instance.host
+- submission_url = edit_course_assessment_submission_url(course, assessment, submission, host: host)
 
 - message.subject = t('.subject', course: course.title, assessment: submission.assessment.title)
 
-= simple_format(t('.message', submission: submission_link, user: submission.course_user.name))
+= simple_format(t('.message', submission: link_to(:submission, submission_url),
+                              user: submission.course_user.name))

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -1,12 +1,15 @@
 - post = @object
 - topic = post.topic.actable
 - course = topic.course
-- unsubscribe_url = subscribe_course_forum_topic_url(course,topic.forum, topic, subscribe: false)
+- host = course.instance.host
+- unsubscribe_url = subscribe_course_forum_topic_url(course, topic.forum, topic, subscribe: false,
+                                                     host: host)
 
 - message.subject = t('.subject', course: course.title, topic: topic.title)
 
 = simple_format(t('.message',
-                topic: link_to(topic.title, course_forum_topic_url(course, topic.forum, topic))))
+                topic: link_to(topic.title,
+                               course_forum_topic_url(course, topic.forum, topic, host: host))))
 
 = simple_format(t('.unsubscribe.message',
                 unsubscribe_link: link_to(t('.unsubscribe.tag'), unsubscribe_url)))

--- a/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
@@ -1,13 +1,14 @@
 - topic = @object
 - post = topic.posts.first
 - course = topic.course
-- unsubscribe_url = unsubscribe_course_forum_url(course, topic.forum)
+- host = course.instance.host
+
+- unsubscribe_url = unsubscribe_course_forum_url(course, topic.forum, host: host)
+- topic_url = course_forum_topic_url(course, topic.forum, topic, host: host)
 
 - message.subject = t('.subject', course: course.title, forum: topic.forum.name)
 
-= simple_format(t('.message',
-                topic: link_to(topic.title, course_forum_topic_url(course, topic.forum, topic)),
-                post: post.text))
+= simple_format(t('.message', topic: topic_url, post: post.text))
 
 = simple_format(t('.unsubscribe.message',
                 unsubscribe_link: link_to(t('.unsubscribe.tag'), unsubscribe_url)))


### PR DESCRIPTION
Fix #1349.

Allow links in email notification to direct to the instance's host instead of the default host.