### PR TITLE
Make annotations collapsible

### DIFF
--- a/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_row_trigger.jst.ejs
+++ b/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_row_trigger.jst.ejs
@@ -1,0 +1,4 @@
+<% /* ejs port of views/course/assessment/answer/programming/annotation_row_trigger */ %>
+<div class="line-annotation-trigger">
+  <span class="fa fa-comment"></span><span class="fa fa-chevron-down"></span>
+</div>

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -18,6 +18,9 @@ $course-discussion-post-border: 1px solid $panel-default-border !default;
 $course-discussion-post-border-color: $panel-default-border !default;
 $course-discussion-post-border-radius: $border-radius-base !default;
 $course-discussion-post-shadow-color: $gray-lighter !default;
+$course-discussion-post-annotation-trigger-bg-color: $body-bg !default;
+$course-discussion-post-annotation-trigger-color: $brand-primary !default;
+
 
 //== Fonts
 //

--- a/app/assets/stylesheets/course/assessment/submission/answer/programming.scss
+++ b/app/assets/stylesheets/course/assessment/submission/answer/programming.scss
@@ -24,7 +24,8 @@
 
       td.line-number {
         border-right: $course-discussion-post-border;
-        padding-left: 0.5em;
+        padding-left: 2em;
+        position: relative;
         text-align: right;
       }
 
@@ -45,6 +46,40 @@
           // scss-lint:enable SelectorFormat
           max-width: 960px;
         }
+      }
+
+      div.line-annotation-trigger {
+        background: $course-discussion-post-annotation-trigger-bg-color;
+        border: $course-discussion-post-border;
+        border-bottom-color: $course-discussion-post-annotation-trigger-bg-color;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-top-left-radius: $course-discussion-post-border-radius;
+        border-top-right-radius: $course-discussion-post-border-radius;
+        cursor: pointer;
+        left: 0;
+        position: absolute;
+        top: 0;
+
+        &.collapse-annotation {
+          border: $course-discussion-post-border;
+          border-bottom-left-radius: $course-discussion-post-border-radius;
+          border-bottom-right-radius: $course-discussion-post-border-radius;
+        }
+
+        span.fa-chevron-down {
+          transform: rotate(0deg) scale(0.7);
+          transition: transform 100ms ease;
+        }
+
+        span.fa-comment {
+          color: $course-discussion-post-annotation-trigger-color;
+          transform: scaleX(-1);
+        }
+      }
+
+      div.collapse-annotation span.fa-chevron-down {
+        transform: rotate(-90deg) scale(0.7);
       }
     }
   }

--- a/app/assets/stylesheets/course/discussion/_post.scss
+++ b/app/assets/stylesheets/course/discussion/_post.scss
@@ -13,9 +13,20 @@
       background-color: $panel-default-heading-bg;
       border-bottom: $course-discussion-post-border;
 
+      .profile-picture,
       .user,
       .timestamp {
         display: inline-block;
+      }
+
+      .profile-picture {
+        .image > img {
+          @include no-stretch;
+          border-radius: 50%;
+          height: $picture-thumb;
+          margin-right: 5px;
+          width: $picture-thumb;
+        }
       }
 
       .user {

--- a/app/assets/stylesheets/mixins/_image.scss
+++ b/app/assets/stylesheets/mixins/_image.scss
@@ -1,5 +1,5 @@
 // Keep the aspect ratio of the image.
 @mixin no-stretch {
-  object-fit: contain;
+  object-fit: cover;
   object-position: center;
 }

--- a/app/helpers/course/assessment/answer/programming_helper.rb
+++ b/app/helpers/course/assessment/answer/programming_helper.rb
@@ -37,6 +37,9 @@ module Course::Assessment::Answer::ProgrammingHelper
     document = Nokogiri::XML.parse(code_block_html)
 
     programming_answer_file.annotations.each do |annotation|
+      if annotation.discussion_topic.posts.empty?
+        next
+      end
       insert_annotation_block(document, annotation)
     end
 
@@ -51,6 +54,10 @@ module Course::Assessment::Answer::ProgrammingHelper
   def insert_annotation_block(document, annotation)
     document.search(".//td[@data-line-number='#{annotation.line}']").each do |line_number|
       line_number_row = line_number.at('..')
+      line_number_cell = line_number_row.at('.//td[@class="line-number"]')
+
+      trigger_html = render partial: 'course/assessment/answer/programming/annotation_row_trigger'
+      line_number_cell.inner_html = Nokogiri::XML::DocumentFragment.parse(trigger_html)
 
       line_discussion_row = build_annotation_row(annotation)
       line_number_row.add_next_sibling(line_discussion_row)

--- a/app/views/course/assessment/answer/programming/_annotation_row_trigger.html.slim
+++ b/app/views/course/assessment/answer/programming/_annotation_row_trigger.html.slim
@@ -1,0 +1,4 @@
+/ Slim port of assets/javascripts/templates/course/assessment/answer/programming/annotation_row_trigger
+div.line-annotation-trigger
+  span.fa.fa-comment
+  span.fa.fa-chevron-down

--- a/app/views/course/assessment/answer/programming/_file_fields.html.slim
+++ b/app/views/course/assessment/answer/programming/_file_fields.html.slim
@@ -7,6 +7,10 @@
   / Filename is unnecessary as there's only 1 file for CS1010S.
   / = f.input :filename, readonly: readonly
   - if readonly
+    div.checkbox
+      label
+        input.annotation-trigger-toggle-all type='checkbox' checked='checked'
+          = t('.expand_comments')
     = format_programming_answer_file(f.object, programming_question.language)
   - else
     = f.input :content, as: :code, language: programming_question.language.ace_mode,

--- a/app/views/course/discussion/_post.html.slim
+++ b/app/views/course/discussion/_post.html.slim
@@ -1,6 +1,9 @@
 = div_for(post, 'data-post-id' => post.id) do
 
   div.header
+    div.profile-picture
+      = display_user_image(post.creator)
+
     div.user
       h5 = link_to_user(post.creator)
 

--- a/app/views/course/discussion/_topic.html.slim
+++ b/app/views/course/discussion/_topic.html.slim
@@ -8,5 +8,4 @@
 - posts_locals[:max_depth] = max_depth if defined?(max_depth)
 div.posts
   = render partial: 'course/discussion/posts', locals: posts_locals
-br
 = render partial: footer, locals: { topic: topic } if defined?(footer) && footer

--- a/config/locales/en/course/assessment/answer/programming.yml
+++ b/config/locales/en/course/assessment/answer/programming.yml
@@ -7,6 +7,8 @@ en:
 #            add_file: 'Add file'
 #          file_fields:
 #            delete: 'Delete file'
+          file_fields:
+            expand_comments: 'Expand all comments'
           test_cases:
             passed: 'Passed'
             private: :'course.assessment.question.programming.form_test_cases.private'


### PR DESCRIPTION
- Added profile picture to the comments
- Profile picture should expand to a full circle now
- Adding a new annotation and clicking cancel will not result in a blank row anymore
- Fix issue where there are blank rows on page load, `discussion_topic` exists but posts count = 0?
- Expand/collapse annotations
- Expand/collapse all checkbox

![sep-01-2016 00-22-20](https://cloud.githubusercontent.com/assets/7753104/18138169/046411dc-6fde-11e6-84fc-45403c6f0c7a.gif)
