### PR TITLE
Apply styling to all tabs in comments center

### DIFF
--- a/app/assets/stylesheets/course/discussion/comments_center.scss
+++ b/app/assets/stylesheets/course/discussion/comments_center.scss
@@ -1,6 +1,6 @@
 @import 'post';
 
-.course-discussion-topics.index {
+.course-discussion-topics {
   .discussion_topic {
     @include discussion-post;
   }


### PR DESCRIPTION
Styling was only applied to the index tab before, after this, all tabs in comments center will be styled like:
![screen shot 2016-09-01 at 11 40 41 am](https://cloud.githubusercontent.com/assets/4983239/18154635/f26730e4-7038-11e6-92fe-1286e5b60fbf.png)
