### PR TITLE
Fix annotation bubble being selected in safari

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/programming.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming.js
@@ -138,10 +138,13 @@
     findOrCreateAnnotationForm($cell, courseId, assessmentId, submissionId, answerId,
                                programmingFileId, lineNumber);
 
-    var $lineNumberCell = $line.find('.line-number');
+    var $lineNumberCell = $line.find('.line-number:first');
 
     if ($lineNumberCell.children('.line-annotation-trigger').length === 0) {
-      $lineNumberCell.html(render('annotation_row_trigger'), {});
+      $lineNumberCell.html(render('annotation_row_trigger', {}));
+      // Removes all whitespace between html tags so that in Safari, a whitespace is not added
+      // when trying to copy and paste a selection of code which includes the trigger bubble.
+      $line.html($line.html().replace(/>\s+</g, '><'));
     }
 
     $line.find('.collapse-annotation').click();
@@ -351,7 +354,7 @@
     var expandAll = e.target.checked;
     var $answer = $(e.target).parents('.answer_programming_file:first');
 
-    toggleAnnotation($answer.find('div.line-annotation-trigger'), expandAll);
+    toggleAnnotation($answer.find('.line-annotation-trigger'), expandAll);
   }
 
   /**

--- a/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_row_trigger.jst.ejs
+++ b/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_row_trigger.jst.ejs
@@ -1,4 +1,4 @@
 <% /* ejs port of views/course/assessment/answer/programming/annotation_row_trigger */ %>
-<div class="line-annotation-trigger">
+<span class="line-annotation-trigger">
   <span class="fa fa-comment"></span><span class="fa fa-chevron-down"></span>
-</div>
+</span>

--- a/app/assets/stylesheets/course/assessment/submission/answer/programming.scss
+++ b/app/assets/stylesheets/course/assessment/submission/answer/programming.scss
@@ -24,9 +24,10 @@
 
       td.line-number {
         border-right: $course-discussion-post-border;
-        padding-left: 2em;
+        padding-left: 2.5em;
         position: relative;
         text-align: right;
+        user-select: none;
       }
 
       td.line-content {
@@ -48,7 +49,7 @@
         }
       }
 
-      div.line-annotation-trigger {
+      span.line-annotation-trigger {
         background: $course-discussion-post-annotation-trigger-bg-color;
         border: $course-discussion-post-border;
         border-bottom-color: $course-discussion-post-annotation-trigger-bg-color;
@@ -78,7 +79,7 @@
         }
       }
 
-      div.collapse-annotation span.fa-chevron-down {
+      span.collapse-annotation span.fa-chevron-down {
         transform: rotate(-90deg) scale(0.7);
       }
     }

--- a/app/views/course/assessment/answer/programming/_annotation_row_trigger.html.slim
+++ b/app/views/course/assessment/answer/programming/_annotation_row_trigger.html.slim
@@ -1,4 +1,4 @@
 / Slim port of assets/javascripts/templates/course/assessment/answer/programming/annotation_row_trigger
-div.line-annotation-trigger
+span.line-annotation-trigger
   span.fa.fa-comment
   span.fa.fa-chevron-down


### PR DESCRIPTION
- Set the annotation bubbles to be non-selectable
- In safari, if there are whitespace between html tags, selection of the tags will produce an extra whitespace during copy and paste. This will affect the indentation of the code. 

  This will produce the whitespace:
  ```html
  <tr>
    <td>
      <span/>
    </td>
  </td>
  ```
  This will not:
  ```html
  <tr><td><span/></td></tr>
  ```

  So the hack solution for now is:
    1. For backend rendered annotation bubbles, use `span` instead of `div` so that Nokogiri doesn't add the extra whitespace.
    2. For frontend, use regex to remove whitespace.