### PR TITLE
Configure travis to setup lvh.me in /etc/hosts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: GROUP="checks"
 addons:
   postgresql: "9.4"
+  hosts:
+    - lvh.me
 bundler_args: "--jobs=3 --retry=3 --without development:production --deployment"
 cache:
   bundler: true


### PR DESCRIPTION
Should reduce/eliminate random test failures from being unable to reach
lvh.me.

References #1426.

See https://docs.travis-ci.com/user/hosts/ and http://stackoverflow.com/questions/31813313/how-do-you-specify-ip-addresses-for-traviscis-host-addon