### PR TITLE
Better handling of whitespace issue when copying in safari

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/answer/programming.js
+++ b/app/assets/javascripts/course/assessment/submission/answer/programming.js
@@ -131,20 +131,16 @@
     var submissionId = ANSWER_HELPERS.submissionIdForElement($target);
     var answerId = ANSWER_HELPERS.answerIdForElement($target);
     var programmingFileId = programmingFileIdForRow($target);
-    var lineNumber = $line.find('.line-number').data('lineNumber');
+    var $lineNumberCell = $line.find('.line-number:first');
+    var lineNumber = $lineNumberCell.data('lineNumber');
 
     var $code = $line.parents('table:first');
     var $cell = findOrCreateAnnotationCell($code, programmingFileId, lineNumber);
     findOrCreateAnnotationForm($cell, courseId, assessmentId, submissionId, answerId,
                                programmingFileId, lineNumber);
 
-    var $lineNumberCell = $line.find('.line-number:first');
-
     if ($lineNumberCell.children('.line-annotation-trigger').length === 0) {
-      $lineNumberCell.html(render('annotation_row_trigger', {}));
-      // Removes all whitespace between html tags so that in Safari, a whitespace is not added
-      // when trying to copy and paste a selection of code which includes the trigger bubble.
-      $line.html($line.html().replace(/>\s+</g, '><'));
+      $lineNumberCell.replaceWith(render('line_number_cell', {lineNumber: lineNumber}));
     }
 
     $line.find('.collapse-annotation').click();

--- a/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_row_trigger.jst.ejs
+++ b/app/assets/javascripts/templates/course/assessment/submission/answer/programming/annotation_row_trigger.jst.ejs
@@ -1,4 +1,0 @@
-<% /* ejs port of views/course/assessment/answer/programming/annotation_row_trigger */ %>
-<span class="line-annotation-trigger">
-  <span class="fa fa-comment"></span><span class="fa fa-chevron-down"></span>
-</span>

--- a/app/assets/javascripts/templates/course/assessment/submission/answer/programming/line_number_cell.jst.ejs
+++ b/app/assets/javascripts/templates/course/assessment/submission/answer/programming/line_number_cell.jst.ejs
@@ -1,0 +1,7 @@
+<% /* Do not add any whitespace between html tags.
+      Includes ejs port of views/course/assessment/answer/programming/annotation_row_trigger */
+%><td class="line-number" data-line-number="<%= lineNumber %>"
+  ><span class="line-annotation-trigger"
+    ><span class="fa fa-comment"></span><span class="fa fa-chevron-down"></span
+  ></span
+></td>


### PR DESCRIPTION
Less hacky fix for safari issue in #1420 
No longer uses regex, which will remove unnecessary whitespace in the student's code