### PR TITLE
Try to reduce the random failure in specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: GROUP="checks"
 addons:
   postgresql: "9.4"
+  hosts:
+    - coursemology.lvh.me
 bundler_args: "--jobs=3 --retry=3 --without development:production --deployment"
 cache:
   bundler: true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,6 +51,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.x.default_host = 'coursemology.lvh.me'
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/spec/components/course/model_component_host_spec.rb
+++ b/spec/components/course/model_component_host_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::ModelComponentHost do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course, instance: instance) }
 

--- a/spec/controllers/attachment_references_controller_spec.rb
+++ b/spec/controllers/attachment_references_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe AttachmentReferencesController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/concerns/course/discussion/posts_concern_spec.rb
+++ b/spec/controllers/concerns/course/discussion/posts_concern_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Discussion::PostsConcern do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     describe 'default behaviours' do
       class self::DummyController < ApplicationController

--- a/spec/controllers/course/achievement/achievements_controller_spec.rb
+++ b/spec/controllers/course/achievement/achievements_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement::AchievementsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/course/achievement/condition/achievements_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/achievements_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement::Condition::AchievementsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/achievement/condition/assessments_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/assessments_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement::Condition::AssessmentsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/achievement/condition/levels_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/levels_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement::Condition::LevelsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/achievement/course_users_controller_spec.rb
+++ b/spec/controllers/course/achievement/course_users_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement::CourseUsersController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/course/admin/admin_controller_spec.rb
+++ b/spec/controllers/course/admin/admin_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::AdminController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     before { sign_in(user) }

--- a/spec/controllers/course/admin/assessment_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/assessment_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::AssessmentSettingsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/assessments/categories_controller_spec.rb
+++ b/spec/controllers/course/admin/assessments/categories_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::Assessments::CategoriesController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/assessments/tabs_controller_spec.rb
+++ b/spec/controllers/course/admin/assessments/tabs_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::Assessments::TabsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/component_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/component_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::ComponentSettingsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/discussion/topic_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/discussion/topic_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::Discussion::TopicSettingsController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/forum_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/forum_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::ForumSettingsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/leaderboard_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/leaderboard_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::LeaderboardSettingsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/material_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/material_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::MaterialSettingsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::SidebarSettingsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/announcements_controller_spec.rb
+++ b/spec/controllers/course/announcements_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::AnnouncementsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/course/assessment/assessments_component_spec.rb
+++ b/spec/controllers/course/assessment/assessments_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::AssessmentsComponent do
     Course::AssessmentsComponent.new(controller)
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { build(:course, instance: instance) }
 

--- a/spec/controllers/course/assessment/assessments_controller_spec.rb
+++ b/spec/controllers/course/assessment/assessments_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::AssessmentsController do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user) }

--- a/spec/controllers/course/assessment/controller_spec.rb
+++ b/spec/controllers/course/assessment/controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Assessment::Controller do
     end
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/assessment/programming_evaluations_controller_spec.rb
+++ b/spec/controllers/course/assessment/programming_evaluations_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::ProgrammingEvaluationsController do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user, :auto_grader) }

--- a/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::MultipleResponsesController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:multiple_response) { nil }
     let(:user) { create(:user) }

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::ProgrammingController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:programming_question) { nil }
     let(:user) { create(:user) }

--- a/spec/controllers/course/assessment/question/text_responses_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/text_responses_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::TextResponsesController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:text_response) { nil }
     let(:user) { create(:user) }

--- a/spec/controllers/course/assessment/skill_branches_controller_spec.rb
+++ b/spec/controllers/course/assessment/skill_branches_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::SkillBranchesController do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user) }

--- a/spec/controllers/course/assessment/skills_controller_spec.rb
+++ b/spec/controllers/course/assessment/skills_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::SkillsController do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user) }

--- a/spec/controllers/course/assessment/submission/answer/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/comments_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Submission::Answer::CommentsController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Submission::SubmissionsController do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Submission::SubmissionsController do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user) }

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::SubmissionsController do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user) }

--- a/spec/controllers/course/controller_spec.rb
+++ b/spec/controllers/course/controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Course::Controller, type: :controller do
     end
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
     let(:course) { create(:course, :opened) }

--- a/spec/controllers/course/course_controller_spec.rb
+++ b/spec/controllers/course/course_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::CoursesController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#recent_activity_feeds' do
       let(:course) { create(:course) }

--- a/spec/controllers/course/discussion/posts_controller_spec.rb
+++ b/spec/controllers/course/discussion/posts_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Discussion::PostsController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }

--- a/spec/controllers/course/discussion/topics_controller_spec.rb
+++ b/spec/controllers/course/discussion/topics_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Discussion::TopicsController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/controllers/course/events_controller_spec.rb
+++ b/spec/controllers/course/events_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LessonPlan::EventsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/course/experience_points/disbursement_controller_spec.rb
+++ b/spec/controllers/course/experience_points/disbursement_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::ExperiencePoints::DisbursementController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/controllers/course/experience_points/forum_disbursement_spec.rb
+++ b/spec/controllers/course/experience_points/forum_disbursement_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::ExperiencePoints::ForumDisbursementController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/controllers/course/experience_points_records_controller_spec.rb
+++ b/spec/controllers/course/experience_points_records_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::ExperiencePointsRecordsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/controllers/course/forum/forums_controller_spec.rb
+++ b/spec/controllers/course/forum/forums_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum::ForumsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/forum/posts_controller_spec.rb
+++ b/spec/controllers/course/forum/posts_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum::PostsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/forum/topics_controller_spec.rb
+++ b/spec/controllers/course/forum/topics_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum::TopicsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/groups_controller_spec.rb
+++ b/spec/controllers/course/groups_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::GroupsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:admin) { create(:administrator) }
     let(:course) { create(:course, creator: admin) }

--- a/spec/controllers/course/leaderboards_controller_spec.rb
+++ b/spec/controllers/course/leaderboards_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LeaderboardsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/course/lesson_plan_milestones_controller_spec.rb
+++ b/spec/controllers/course/lesson_plan_milestones_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LessonPlan::MilestonesController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/course/levels_controller_spec.rb
+++ b/spec/controllers/course/levels_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LevelsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/course/material/folders_controller_spec.rb
+++ b/spec/controllers/course/material/folders_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Material::FoldersController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/material/materials_controller_spec.rb
+++ b/spec/controllers/course/material/materials_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Material::MaterialsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/course/user_invitations_controller_spec.rb
+++ b/spec/controllers/course/user_invitations_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::UserInvitationsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, :opened) }

--- a/spec/controllers/course/user_registrations_controller_spec.rb
+++ b/spec/controllers/course/user_registrations_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::UserRegistrationsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, :opened) }

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::UsersController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:course) { create(:course, :opened) }

--- a/spec/controllers/system/admin/admin_controller_spec.rb
+++ b/spec/controllers/system/admin/admin_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe System::Admin::AdminController do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/system/admin/announcements_controller_spec.rb
+++ b/spec/controllers/system/admin/announcements_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe System::Admin::AnnouncementsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/controllers/system/admin/controller_spec.rb
+++ b/spec/controllers/system/admin/controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe System::Admin::Controller, type: :controller do
 
   requires_login
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     it 'allows instance administrators to access the page' do

--- a/spec/controllers/system/admin/courses_controller_spec.rb
+++ b/spec/controllers/system/admin/courses_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe System::Admin::CoursesController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:admin) { create(:administrator) }

--- a/spec/controllers/system/admin/instance/announcements_controller_spec.rb
+++ b/spec/controllers/system/admin/instance/announcements_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe System::Admin::Instance::AnnouncementsController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
     let!(:announcement_stub) do

--- a/spec/controllers/system/admin/instance/courses_controller_spec.rb
+++ b/spec/controllers/system/admin/instance/courses_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe System::Admin::Instance::CoursesController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:instance_admin) { create(:instance_administrator).user }

--- a/spec/controllers/system/admin/instance/users_controller_spec.rb
+++ b/spec/controllers/system/admin/instance/users_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe System::Admin::Instance::UsersController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:instance_admin) { create(:instance_user, role: :administrator).user }

--- a/spec/controllers/system/admin/users_controller_spec.rb
+++ b/spec/controllers/system/admin/users_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe System::Admin::UsersController, type: :controller do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:admin) { create(:administrator) }

--- a/spec/controllers/user/emails_controller_spec.rb
+++ b/spec/controllers/user/emails_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe User::EmailsController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:administrator) }

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe User::OmniauthCallbacksController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     before { controller.request.env['devise.mapping'] = Devise.mappings[:user] }

--- a/spec/controllers/user/profiles_controller_spec.rb
+++ b/spec/controllers/user/profiles_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe User::ProfilesController, type: :controller do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:user) }

--- a/spec/controllers/user_login_spec.rb
+++ b/spec/controllers/user_login_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Devise::SessionsController, type: :controller do
 
   requires_login
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     context 'Users with multiple email addresses' do

--- a/spec/features/course/achievement_condition_management_spec.rb
+++ b/spec/features/course/achievement_condition_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Achievements' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/achievement_listing_spec.rb
+++ b/spec/features/course/achievement_listing_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Achievements' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:course) { create(:course) }

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Achievements' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.feature 'Course: Administration: Administration' do
   subject { page }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/announcement_settings_spec.rb
+++ b/spec/features/course/admin/announcement_settings_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Announcement' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Components' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/discussion/topic_settings_spec.rb
+++ b/spec/features/course/admin/discussion/topic_settings_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Discussion:: Topics' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/forum_settings_spec.rb
+++ b/spec/features/course/admin/forum_settings_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Forums' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/leaderboard_settings_spec.rb
+++ b/spec/features/course/admin/leaderboard_settings_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Leaderboard' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/material_settings_spec.rb
+++ b/spec/features/course/admin/material_settings_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Materials' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/admin/sidebar_settings_spec.rb
+++ b/spec/features/course/admin/sidebar_settings_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Sidebar' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Announcements' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/announcement_pagination_spec.rb
+++ b/spec/features/course/announcement_pagination_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
   describe 'Pagination' do
     subject { page }
 
-    let!(:instance) { create(:instance) }
+    let!(:instance) { Instance.default }
 
     with_tenant(:instance) do
       let!(:user) { create(:administrator) }

--- a/spec/features/course/announcement_sticky_spec.rb
+++ b/spec/features/course/announcement_sticky_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
   describe 'Sticky' do
     subject { page }
 
-    let!(:instance) { create(:instance) }
+    let!(:instance) { Instance.default }
 
     with_tenant(:instance) do
       let!(:user) { create(:administrator) }

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Attempt' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/assessment_viewing_spec.rb
+++ b/spec/features/course/assessment/assessment_viewing_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Viewing' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Questions: Programming Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/skill_branch_management_spec.rb
+++ b/spec/features/course/assessment/skill_branch_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Skill Branches' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/skill_management_spec.rb
+++ b/spec/features/course/assessment/skill_management_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Skills' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessment: Submissions: Guided' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessment: Submissions: Submissions' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Submissions Viewing' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment_condition_management_spec.rb
+++ b/spec/features/course/assessment_condition_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Assessments' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Assessments: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/category_management_spec.rb
+++ b/spec/features/course/category_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Category: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Topics: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/experience_points/disbursement_spec.rb
+++ b/spec/features/course/experience_points/disbursement_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Experience Points: Disbursement' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/experience_points/forum_disbrusement_spec.rb
+++ b/spec/features/course/experience_points/forum_disbrusement_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Experience Points: Forum Disbursement' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Courses: Experience Points Records: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Forum: Post: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/forum/search_spec.rb
+++ b/spec/features/course/forum/search_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Forum: Search' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:forum_topic) { create(:forum_topic, course: course) }

--- a/spec/features/course/forum/topic_management_spec.rb
+++ b/spec/features/course/forum/topic_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Forum: Topic: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/forum_management_spec.rb
+++ b/spec/features/course/forum_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Forum: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/group_management_spec.rb
+++ b/spec/features/course/group_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Courses: Groups' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Homepage' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course, :opened) }

--- a/spec/features/course/leaderboard_viewing_spec.rb
+++ b/spec/features/course/leaderboard_viewing_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Leaderboard: View' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/lesson_plan_event_management_spec.rb
+++ b/spec/features/course/lesson_plan_event_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Events' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:course) { create(:course) }

--- a/spec/features/course/lesson_plan_milestone_management_spec.rb
+++ b/spec/features/course/lesson_plan_milestone_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Lesson Plan Milestones' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:course) { create(:course) }

--- a/spec/features/course/lesson_plan_spec.rb
+++ b/spec/features/course/lesson_plan_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.feature 'Course: Lesson Plan' do
   subject { page }
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:course) { create(:course) }

--- a/spec/features/course/level_management_spec.rb
+++ b/spec/features/course/level_management_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.feature 'Course: Levels' do
   subject { page }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:course) { create(:course) }

--- a/spec/features/course/material/files_management_spec.rb
+++ b/spec/features/course/material/files_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Material: Files: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Material: Folders: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/registration_spec.rb
+++ b/spec/features/course/registration_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Courses: Registration' do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course, :opened) }

--- a/spec/features/course/request_managmement_spec.rb
+++ b/spec/features/course/request_managmement_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Requests' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:administrator) }

--- a/spec/features/course/staff_management_spec.rb
+++ b/spec/features/course/staff_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Courses: Staff Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/staff_statistics_spec.rb
+++ b/spec/features/course/staff_statistics_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.feature 'Course: Statistics: Staff' do
   subject { page }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:course) { create(:course) }

--- a/spec/features/course/student_management_spec.rb
+++ b/spec/features/course/student_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Courses: Students' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/student_statistics_spec.rb
+++ b/spec/features/course/student_statistics_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.feature 'Course: Student Statistics' do
   subject { page }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/tab_management_spec.rb
+++ b/spec/features/course/tab_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Assessments: Management' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/unread_status_management_spec.rb
+++ b/spec/features/course/unread_status_management_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Course: Announcements', type: :feature do
   describe 'Read/Unread' do
     subject { page }
 
-    let!(:instance) { create(:instance) }
+    let!(:instance) { Instance.default }
 
     with_tenant(:instance) do
       let!(:first_user) { create(:administrator) }

--- a/spec/features/course/user_listing_spec.rb
+++ b/spec/features/course/user_listing_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Courses: Course User Listing' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/course/user_profile_spec.rb
+++ b/spec/features/course/user_profile_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Courses: CourseUser Profile' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/global_announcements_spec.rb
+++ b/spec/features/global_announcements_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.feature 'Global announcements' do
   subject { page }
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user) { create(:user) }

--- a/spec/features/system/admin/announcement_management_spec.rb
+++ b/spec/features/system/admin/announcement_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'System: Administration: Announcements' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     before do
       login_as(user, scope: :user)

--- a/spec/features/system/admin/announcement_pagination_spec.rb
+++ b/spec/features/system/admin/announcement_pagination_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'System: Administration: Announcements', type: :feature do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     describe 'Pagination' do

--- a/spec/features/system/admin/course_management_spec.rb
+++ b/spec/features/system/admin/course_management_spec.rb
@@ -2,13 +2,13 @@
 require 'rails_helper'
 
 RSpec.feature 'System: Administration: Courses' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:last_page) { Course.unscoped.page.total_pages }
     let!(:courses) do
       courses = create_list(:course, 2)
-      other_instance = create(:instance)
+      other_instance = Instance.default
       courses.last.update_column(:instance_id, other_instance)
       Course.unscoped.ordered_by_title.page(last_page)
     end

--- a/spec/features/system/admin/instance_management_spec.rb
+++ b/spec/features/system/admin/instance_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'System: Administration: Instances' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     context 'As a system administrator' do
       let!(:user) { create(:administrator) }
@@ -29,6 +29,7 @@ RSpec.feature 'System: Administration: Instances' do
       end
 
       scenario 'I can edit instances' do
+        instance = create(:instance)
         visit edit_admin_instance_path(instance)
 
         fill_in 'instance_name', with: ''

--- a/spec/features/system/admin/masquerades_spec.rb
+++ b/spec/features/system/admin/masquerades_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 include DeviseMasquerade::Controllers::UrlHelpers
 
 RSpec.feature 'System: Administration: Masquerade' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let!(:user_to_masquerade) do

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'System: Administration: Users' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     context 'As a System Administrator' do

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -11,9 +11,9 @@ RSpec.feature 'System: Administration: Users' do
 
       let!(:users) do
         create_list(:user, 2)
-        User.human_users.ordered_by_name.page(1)
+        User.human_users.ordered_by_name.limit(5)
       end
-      scenario 'I can view all users in the system' do
+      scenario 'I can view the users in the system' do
         visit admin_users_path
 
         users.each do |user|

--- a/spec/features/user/email_management_spec.rb
+++ b/spec/features/user/email_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'User: Emails' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user) }

--- a/spec/features/user/omniauth_spec.rb
+++ b/spec/features/user/omniauth_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'User: Omniauth' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     context 'As a unregistered user' do

--- a/spec/features/user/password_management_spec.rb
+++ b/spec/features/user/password_management_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Users: Change password' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let!(:user) { create(:user) }
     before { login_as(user, scope: :user) }

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'User: Profile' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:user) { create(:user) }

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Users: Sign In' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     scenario 'I can sign in if I am a user in another instance' do
       other_instance = create(:instance)

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Users: Sign Up' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     context 'As an unregistered user' do
       scenario 'I can register for an account' do

--- a/spec/fixtures/course/invitation.csv
+++ b/spec/fixtures/course/invitation.csv
@@ -1,2 +1,0 @@
-Name,Email
-Name,test@example.org

--- a/spec/helpers/application_notifications_helper_spec.rb
+++ b/spec/helpers/application_notifications_helper_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationNotificationsHelper, type: :helper do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#notification_view_path' do
       let(:activity) { create(:activity, event: :tested, notifier_type: 'UserNotifier') }

--- a/spec/helpers/application_widgets_helper_spec.rb
+++ b/spec/helpers/application_widgets_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationWidgetsHelper, type: :helper do
     end
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#new_button' do
       let(:announcement) { create(:course_announcement) }

--- a/spec/helpers/course/achievement/controller_helper_spec.rb
+++ b/spec/helpers/course/achievement/controller_helper_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement::ControllerHelper do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:achievement) { create(:course_achievement) }
 

--- a/spec/helpers/course/assessment/answer/programming_helper_spec.rb
+++ b/spec/helpers/course/assessment/answer/programming_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Answer::ProgrammingHelper do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#format_programming_answer_file' do
       let(:language) { Coursemology::Polyglot::Language::Python::Python2Point7 }

--- a/spec/helpers/course/assessment/assessments_helper_spec.rb
+++ b/spec/helpers/course/assessment/assessments_helper_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::AssessmentsHelper do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#assessment_tabs' do
       let(:course) { create(:course) }

--- a/spec/helpers/course/assessment/question/programming_helper_spec.rb
+++ b/spec/helpers/course/assessment/question/programming_helper_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::ProgrammingHelper do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     def build_error(error_class, message = error_class.name)
       { 'class' => error_class.name, 'message' => message }

--- a/spec/helpers/course/assessment/submision/submissions_helper_spec.rb
+++ b/spec/helpers/course/assessment/submision/submissions_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Submission::SubmissionsHelper do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     describe '#new_comments_post' do

--- a/spec/helpers/course/assessment/submissions_helper_spec.rb
+++ b/spec/helpers/course/assessment/submissions_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::SubmissionsHelper do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/helpers/course/controller_helper_spec.rb
+++ b/spec/helpers/course/controller_helper_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::ControllerHelper do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     before(:all) do

--- a/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Answer::AutoGradingJob do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Assessment::Answer::AutoGradingJob }
     let(:answer) { create(:course_assessment_answer_multiple_response, :submitted).answer }

--- a/spec/jobs/course/assessment/question/programming_import_job_spec.rb
+++ b/spec/jobs/course/assessment/question/programming_import_job_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::ProgrammingImportJob do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Assessment::Question::ProgrammingImportJob }
     let(:question) do

--- a/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Submission::AutoGradingJob do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Assessment::Submission::AutoGradingJob }
     let(:answer) { create(:course_assessment_answer_multiple_response, :submitted).answer }

--- a/spec/jobs/course/conditionals/conditional_satisfiability_evaluation_job_spec.rb
+++ b/spec/jobs/course/conditionals/conditional_satisfiability_evaluation_job_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Conditional::ConditionalSatisfiabilityEvaluationJob do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course_user) { create(:course_user) }
     subject { Course::Conditional::ConditionalSatisfiabilityEvaluationJob }

--- a/spec/jobs/course/material/zip_download_job_spec.rb
+++ b/spec/jobs/course/material/zip_download_job_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Material::ZipDownloadJob do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:folder) { create(:material).folder }
     subject { Course::Material::ZipDownloadJob }

--- a/spec/libraries/activity_wrapper_spec.rb
+++ b/spec/libraries/activity_wrapper_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Notifier::Base::ActivityWrapper, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#notify' do
       let(:notifier) { Notifier::Base.new }

--- a/spec/libraries/acts_as_condition_spec.rb
+++ b/spec/libraries/acts_as_condition_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Extension: Acts as Condition', type: :model do
     end
 
     describe '.evaluate_conditional_for' do
-      let(:instance) { create(:instance) }
+      let(:instance) { Instance.default }
       with_tenant(:instance) do
         let(:course_user) { create(:course_user) }
 

--- a/spec/libraries/sign_in_with_callback_spec.rb
+++ b/spec/libraries/sign_in_with_callback_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Extension: Devise: sign_in with resource', type: :controller do
     include Devise::Controllers::SignInOut
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { self.class::TestUser.new }
     subject { controller.sign_in(:user, user, bypass: true) }

--- a/spec/mailers/activity_mailer_spec.rb
+++ b/spec/mailers/activity_mailer_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe ActivityMailer, type: :mailer do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:template) { 'activity_mailer/test_email' }

--- a/spec/mailers/course/mailer_spec.rb
+++ b/spec/mailers/course/mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Mailer, type: :mailer do
   subject { mail }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:text) { mail.body.parts.find { |part| part.content_type.start_with?('text/plain') }.to_s }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Activity, type: :model do
   it { is_expected.to belong_to(:actor).inverse_of(:activities).class_name(User.name) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:activity) { create(:activity) }
     let(:user) { create(:user) }

--- a/spec/models/attachment_reference_spec.rb
+++ b/spec/models/attachment_reference_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AttachmentReference do
     end
   end
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:attachable) { create(:material) }
     let(:attachment_reference) { attachable.attachment_reference }

--- a/spec/models/course/achievement_ability_spec.rb
+++ b/spec/models/course/achievement_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Achievement do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/achievement_spec.rb
+++ b/spec/models/course/achievement_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Achievement, type: :model do
   it { is_expected.to validate_presence_of :title }
   it { is_expected.to belong_to(:course).inverse_of :achievements }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_user) { create(:course_user, course: course) }

--- a/spec/models/course/announcement_ability_spec.rb
+++ b/spec/models/course/announcement_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Announcement do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/announcement_spec.rb
+++ b/spec/models/course/announcement_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::Announcement, type: :model do
   it { is_expected.to belong_to(:course).inverse_of(:announcements) }
   it { is_expected.to validate_presence_of(:title) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let!(:user) { create(:user) }
     let(:course) { create(:course) }

--- a/spec/models/course/assessment/answer/multiple_response_spec.rb
+++ b/spec/models/course/assessment/answer/multiple_response_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Course::Assessment::Answer::MultipleResponse do
       class_name(Course::Assessment::Question::MultipleResponseOption.name)
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#reset_answer' do
       let(:answer) { create(:course_assessment_answer_multiple_response, :with_one_correct_option) }

--- a/spec/models/course/assessment/answer/programming_file_spec.rb
+++ b/spec/models/course/assessment/answer/programming_file_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingFile do
       dependent(:destroy)
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { build_stubbed(:course_assessment_answer_programming_file) }
 

--- a/spec/models/course/assessment/answer/programming_spec.rb
+++ b/spec/models/course/assessment/answer/programming_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::Assessment::Answer::Programming do
   end
   it { is_expected.to accept_nested_attributes_for(:files).allow_destroy(true) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#reset_answer' do
       let(:question) { create(:course_assessment_question_programming, template_file_count: 1) }

--- a/spec/models/course/assessment/answer/text_response_spec.rb
+++ b/spec/models/course/assessment/answer/text_response_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Answer::TextResponse, type: :model do
   it { is_expected.to act_as(Course::Assessment::Answer) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe 'validations' do
       subject do

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::Assessment::Answer do
   it { is_expected.to accept_nested_attributes_for(:actable) }
   it { is_expected.to have_one(:auto_grading).dependent(:destroy) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { create(:course_assessment_answer) }
 

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/assessment/category_spec.rb
+++ b/spec/models/course/assessment/category_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment::Category do
   it { is_expected.to have_many(:tabs) }
   it { is_expected.to have_many(:assessments).through(:tabs) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     describe 'callbacks' do
       describe 'after category was initialized' do

--- a/spec/models/course/assessment/programming_evaluation_spec.rb
+++ b/spec/models/course/assessment/programming_evaluation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment::ProgrammingEvaluation do
   it { is_expected.to belong_to(:language) }
   it { is_expected.to belong_to(:evaluator) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:evaluation_traits) { nil }
     let(:course) { create(:course) }

--- a/spec/models/course/assessment/question/multiple_response_option_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_option_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Course::Assessment::Question::MultipleResponseOption do
       class_name(Course::Assessment::Question::MultipleResponse.name)
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '.correct' do
       let(:question) { create(:course_assessment_question_multiple_response) }

--- a/spec/models/course/assessment/question/multiple_response_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
   end
   it { is_expected.to accept_nested_attributes_for(:options) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#auto_gradable?' do
       subject { create(:course_assessment_question_multiple_response) }

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Course::Assessment::Question::Programming do
       class_name(Course::Assessment::Question::ProgrammingTestCase.name).dependent(:destroy)
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe 'validations' do
       subject { build(:course_assessment_question_programming) }

--- a/spec/models/course/assessment/question/programming_template_file_spec.rb
+++ b/spec/models/course/assessment/question/programming_template_file_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingTemplateFile do
       class_name(Course::Assessment::Question::Programming.name)
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { build_stubbed(:course_assessment_question_programming_template_file) }
 

--- a/spec/models/course/assessment/question/text_response_solution_spec.rb
+++ b/spec/models/course/assessment/question/text_response_solution_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Course::Assessment::Question::TextResponseSolution, type: :model 
       class_name(Course::Assessment::Question::TextResponse.name)
   end
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe 'validations' do
       describe '#answer_text' do

--- a/spec/models/course/assessment/question/text_response_spec.rb
+++ b/spec/models/course/assessment/question/text_response_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
   end
   it { is_expected.to accept_nested_attributes_for(:solutions) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#auto_gradable?' do
       subject { create(:course_assessment_question_text_response) }

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Course::Assessment::Question do
   it { is_expected.to belong_to(:assessment) }
   it { is_expected.to have_and_belong_to_many(:skills) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { build_stubbed(:course_assessment_question) }
 

--- a/spec/models/course/assessment/skill_spec.rb
+++ b/spec/models/course/assessment/skill_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment::Skill do
   it { is_expected.to belong_to(:skill_branch) }
   it { is_expected.to have_and_belong_to_many(:questions) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { build(:course) }
     let(:skill_branch) { nil }

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Assessment::Submission do
   it { is_expected.to have_many(:programming_answers).through(:answers) }
   it { is_expected.to accept_nested_attributes_for(:answers) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, *assessment_traits, course: course) }

--- a/spec/models/course/assessment/tab_spec.rb
+++ b/spec/models/course/assessment/tab_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::Assessment::Tab do
   it { is_expected.to belong_to(:category) }
   it { is_expected.to have_many(:assessments).dependent(:destroy) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '.default_scope' do
       let(:course) { create(:course) }

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Course::Assessment do
   it { is_expected.to have_many(:conditions) }
   it { is_expected.to have_many(:assessment_conditions).dependent(:destroy) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, *assessment_traits, course: course) }

--- a/spec/models/course/condition/achievement_ability_spec.rb
+++ b/spec/models/course/condition/achievement_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Condition::Achievement do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/condition/achievement_spec.rb
+++ b/spec/models/course/condition/achievement_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Achievement, type: :model do
   it { is_expected.to act_as(Course::Condition) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
 

--- a/spec/models/course/condition/assessment_ability_spec.rb
+++ b/spec/models/course/condition/assessment_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Condition::Assessment do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Assessment, type: :model do
   it { is_expected.to act_as(Course::Condition) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
 

--- a/spec/models/course/condition/level_ability_spec.rb
+++ b/spec/models/course/condition/level_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Condition::Level do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/condition/level_spec.rb
+++ b/spec/models/course/condition/level_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Level, type: :model do
   it { is_expected.to act_as(Course::Condition) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course_user) { create(:course_user) }
     describe 'callbacks' do

--- a/spec/models/course/condition_spec.rb
+++ b/spec/models/course/condition_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::Condition, type: :model do
   it { is_expected.to be_actable }
   it { is_expected.to belong_to(:conditional) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/models/course/discussion/post/vote_spec.rb
+++ b/spec/models/course/discussion/post/vote_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Discussion::Post::Vote do
   it { is_expected.to belong_to(:post).inverse_of(:votes) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:post) { create(:course_discussion_post) }

--- a/spec/models/course/discussion/post_spec.rb
+++ b/spec/models/course/discussion/post_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Course::Discussion::Post, type: :model do
   it { is_expected.to have_many(:votes).inverse_of(:post).dependent(:destroy) }
   it { is_expected.to have_many(:children) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '.all' do
       let(:topic) { create(:course_discussion_topic) }

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Discussion::Topic, type: :model do
   it { is_expected.to have_many(:posts).inverse_of(:topic).dependent(:destroy) }
   it { is_expected.to have_many(:subscriptions).inverse_of(:topic).dependent(:destroy) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
     let(:topic) { create(:forum_topic) }

--- a/spec/models/course/experience_points/forum_disbursement_spec.rb
+++ b/spec/models/course/experience_points/forum_disbursement_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::ExperiencePoints::ForumDisbursement, type: :model do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:forum_disbursement) { Course::ExperiencePoints::ForumDisbursement.new(params) }
 

--- a/spec/models/course/experience_points_record_ability_spec.rb
+++ b/spec/models/course/experience_points_record_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::ExperiencePointsRecord do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/experience_points_record_spec.rb
+++ b/spec/models/course/experience_points_record_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::ExperiencePointsRecord do
   it { is_expected.to belong_to(:course_user).inverse_of(:experience_points_records) }
   it { is_expected.to validate_presence_of(:course_user) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_user) { create(:course_user, course: course) }

--- a/spec/models/course/forum/search_spec.rb
+++ b/spec/models/course/forum/search_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum::Search, type: :model do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Forum::Search.new(search_hash) }
 

--- a/spec/models/course/forum/topic_ability_spec.rb
+++ b/spec/models/course/forum/topic_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum::Topic, type: :model do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject(:ability) { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/forum/topic_spec.rb
+++ b/spec/models/course/forum/topic_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Course::Forum::Topic, type: :model do
   it { is_expected.to belong_to(:forum).inverse_of(:topics) }
   it { is_expected.to belong_to(:creator) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:forum) { create(:forum) }
 

--- a/spec/models/course/forum_ability_spec.rb
+++ b/spec/models/course/forum_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum, type: :model do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject(:ability) { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/forum_spec.rb
+++ b/spec/models/course/forum_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Forum, type: :model do
   it { is_expected.to have_many(:subscriptions).inverse_of(:forum).dependent(:destroy) }
   it { is_expected.to belong_to(:course).inverse_of(:forums) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
 

--- a/spec/models/course/group_ability_spec.rb
+++ b/spec/models/course/group_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Group do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     subject { Ability.new(user) }

--- a/spec/models/course/group_user_spec.rb
+++ b/spec/models/course/group_user_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::GroupUser, type: :model do
   it { is_expected.to belong_to(:course_user).inverse_of(:group_users) }
   it { is_expected.to belong_to(:group).inverse_of(:group_users) }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course_group) { create(:course_group) }
     context 'when user is not enrolled in group\'s course' do

--- a/spec/models/course/lesson_plan_event_ability_spec.rb
+++ b/spec/models/course/lesson_plan_event_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LessonPlan::Event do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     subject { Ability.new(user) }

--- a/spec/models/course/lesson_plan_item_ability_spec.rb
+++ b/spec/models/course/lesson_plan_item_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LessonPlan::Item do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     subject { Ability.new(user) }

--- a/spec/models/course/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan_item_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::LessonPlan::Item, type: :model do
   it { is_expected.to belong_to(:course).inverse_of(:lesson_plan_items) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:lesson_plan_item) { create(:course_lesson_plan_item, course: course) }

--- a/spec/models/course/lesson_plan_milestone_ability_spec.rb
+++ b/spec/models/course/lesson_plan_milestone_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LessonPlan::Milestone do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     subject { Ability.new(user) }

--- a/spec/models/course/level_ability_spec.rb
+++ b/spec/models/course/level_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Level do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     subject { Ability.new(user) }

--- a/spec/models/course/level_spec.rb
+++ b/spec/models/course/level_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Level, type: :model do
       is_greater_than_or_equal_to(0)
   end
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let!(:course) { build(:course) }
 

--- a/spec/models/course/material/folder_ability_spec.rb
+++ b/spec/models/course/material/folder_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Material::Folder, type: :model do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject(:ability) { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/material/folder_spec.rb
+++ b/spec/models/course/material/folder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::Material::Folder, type: :model do
   it { is_expected.to have_many(:materials).autosave(true) }
   it { is_expected.to have_many(:children).dependent(:destroy) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     context 'when two subfolders have the same name' do
       let(:parent) { create(:course_material_folder) }

--- a/spec/models/course/material_ability_spec.rb
+++ b/spec/models/course/material_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Material do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     subject(:ability) { Ability.new(user) }
     let(:course) { create(:course) }

--- a/spec/models/course/material_spec.rb
+++ b/spec/models/course/material_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::Material, type: :model do
   it { is_expected.to belong_to(:folder).inverse_of(:materials).touch(true) }
   it { is_expected.to belong_to(:creator) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     context 'when two materials have the same name' do
       let(:folder) { create(:folder) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:owner) { create(:user) }
 

--- a/spec/models/course_user_ability_spec.rb
+++ b/spec/models/course_user_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course_user) { create(:course_student) }

--- a/spec/models/user/email_ability_spec.rb
+++ b/spec/models/user/email_ability_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe User::Email do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:email) { create(:user_email) }

--- a/spec/models/user/email_spec.rb
+++ b/spec/models/user/email_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe User::Email, type: :model do
   it { is_expected.to belong_to(:user).inverse_of(:emails) }
 
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:email) { build(:user_email) }

--- a/spec/notifiers/course/achievement_notifier.rb
+++ b/spec/notifiers/course/achievement_notifier.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::AchievementNotifier, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     describe '#achievement_gained' do

--- a/spec/notifiers/course/announcement_notifier.rb
+++ b/spec/notifiers/course/announcement_notifier.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::AnnouncementNotifier, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     describe '#new_announcement' do

--- a/spec/notifiers/course/assessment_notifier.rb
+++ b/spec/notifiers/course/assessment_notifier.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::AssessmentNotifier, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     describe '#assessment_attempted' do

--- a/spec/notifiers/course/forum/post_notifier.rb
+++ b/spec/notifiers/course/forum/post_notifier.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum::PostNotifier, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/notifiers/course/forum/topic_notifier.rb
+++ b/spec/notifiers/course/forum/topic_notifier.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Forum::TopicNotifier, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     describe '#topic_created' do

--- a/spec/notifiers/course/level_notifier.rb
+++ b/spec/notifiers/course/level_notifier.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::LevelNotifier, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
     describe '#level_reached' do

--- a/spec/notifiers/notifier/base_spec.rb
+++ b/spec/notifiers/notifier/base_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Notifier::Base, type: :notifier do
-  let!(:instance) { create(:instance) }
+  let!(:instance) { Instance.default }
   with_tenant(:instance) do
     class self::DummyNotifier < Notifier::Base
       def dummy_created(actor, object, user)

--- a/spec/requests/course/assessment/programming_evaluations_processing_spec.rb
+++ b/spec/requests/course/assessment/programming_evaluations_processing_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Course: Assessments: Programming Evaluations Processing' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:user) { create(:user, *user_traits) }

--- a/spec/requests/user_sign_in_spec.rb
+++ b/spec/requests/user_sign_in_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Users: Sign In with Token' do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { build(:user) }
     context 'when a user token is specified in the HTTP headers' do

--- a/spec/services/course/assessment/answer/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/auto_grading_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Answer::AutoGradingService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:answer) do
       create(:course_assessment_answer_multiple_response, :submitted,

--- a/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Answer::MultipleResponseAutoGradingService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:answer) do
       arguments = *answer_traits

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     with_active_job_queue_adapter(:test) do
       let(:answer) do

--- a/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Answer::TextResponseAutoGradingService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:answer) do
       arguments = *answer_traits

--- a/spec/services/course/assessment/programming_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_evaluation_service_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
 
   subject { Course::Assessment::ProgrammingEvaluationService }
 
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
 

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::ProgrammingImportService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:question) { create(:course_assessment_question_programming, template_file_count: 0) }
     let(:package_path) do

--- a/spec/services/course/assessment/submission/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/submission/auto_grading_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Submission::AutoGradingService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:answer) { create(:course_assessment_answer_multiple_response, :submitted).answer }
     let(:submission) { answer.submission.tap { |submission| submission.answers.reload } }

--- a/spec/services/course/conditional/conditional_satisfiability_evaluation_service_spec.rb
+++ b/spec/services/course/conditional/conditional_satisfiability_evaluation_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Conditional::ConditionalSatisfiabilityEvaluationService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
 

--- a/spec/services/course/conditional/satisfiability_graph_build_service_spec.rb
+++ b/spec/services/course/conditional/satisfiability_graph_build_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Conditional::SatisfiabilityGraphBuildService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let!(:achievement) { create(:achievement, course: course) }

--- a/spec/services/course/material/zip_download_service_spec.rb
+++ b/spec/services/course/material/zip_download_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Material::ZipDownloadService do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     # Folder hierarchy:
     #      f_a

--- a/spec/services/course/user_registration_service_spec.rb
+++ b/spec/services/course/user_registration_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::UserRegistrationService, type: :service do
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course, :opened) }
     let(:user) { create(:user) }

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -4,7 +4,7 @@ require 'carrierwave/test/matchers'
 
 RSpec.describe ImageUploader, type: :model do
   include CarrierWave::Test::Matchers
-  let(:instance) { create(:instance) }
+  let(:instance) { Instance.default }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }


### PR DESCRIPTION
See #1426 and #1427 

Randomized hostname leads to lots of random failure in travis. 

1. Use default instance with a fixed hostname for most of the specs, this will hopefully reduce the random test failure rate a lot.
2. Limit the users in admin users spec, the failure before is because the users are created in other places while running the specs.

Test performance should also be improved since fewer records are created. 