### PR TITLE
Use manager instead of course creator in specs

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -20,6 +20,7 @@ module Course::Assessment::AssessmentAbility
   end
 
   def define_staff_permissions
+    allow_managers_manage_tab_and_categories
     allow_staff_manage_assessments
     allow_staff_grade_submissions
     allow_staff_manage_annotations
@@ -86,6 +87,11 @@ module Course::Assessment::AssessmentAbility
         question: { assessment: assessment_course_staff_hash }
     can :manage, Course::Assessment::Question::Programming,
         question: { assessment: assessment_course_staff_hash }
+  end
+
+  def allow_managers_manage_tab_and_categories
+    can :manage, Course::Assessment::Tab, category: course_managers_hash
+    can :manage, Course::Assessment::Category, course_managers_hash
   end
 
   def allow_staff_grade_submissions

--- a/spec/features/course/announcement_pagination_spec.rb
+++ b/spec/features/course/announcement_pagination_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Course: Announcements', type: :feature do
     let!(:instance) { Instance.default }
 
     with_tenant(:instance) do
-      let!(:user) { create(:administrator) }
-      let!(:course) { create(:course) }
+      let(:course) { create(:course) }
+      let(:user) { create(:course_manager, course: course).user }
       let!(:announcements) do
         create_list(:course_announcement, 30, course: course)
       end

--- a/spec/features/course/announcement_sticky_spec.rb
+++ b/spec/features/course/announcement_sticky_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Course: Announcements', type: :feature do
     let!(:instance) { Instance.default }
 
     with_tenant(:instance) do
-      let!(:user) { create(:administrator) }
-      let!(:course) { create(:course) }
+      let(:course) { create(:course) }
+      let(:user) { create(:course_manager, course: course).user }
 
       before do
         login_as(user, scope: :user)

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { course.creator }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create a new multiple response question' do
         skill = create(:course_assessment_skill, course: course)

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { course.creator }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create a new question' do
         skill = create(:course_assessment_skill, course: course)

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { course.creator }
+      let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can create a new question' do
         skill = create(:course_assessment_skill, course: course)

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Assessments: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { course.creator }
+      let(:user) { create(:course_manager, course: course).user }
       scenario 'I can create a new assessment' do
         assessment_tab = create(:course_assessment_tab,
                                 category: course.assessment_categories.first)

--- a/spec/features/course/category_management_spec.rb
+++ b/spec/features/course/category_management_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Category: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { course.creator }
+      let(:user) { create(:course_manager, course: course).user }
       scenario 'I can create a new category' do
         category = attributes_for(:course_assessment_category)
 

--- a/spec/features/course/request_managmement_spec.rb
+++ b/spec/features/course/request_managmement_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature 'Course: Requests' do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    let(:user) { create(:administrator) }
     let(:course) { create(:course) }
+    let(:user) { create(:course_manager, course: course).user }
     let(:registrants) { create_list(:course_user, 2, course: course) }
     before { login_as(user, scope: :user) }
 

--- a/spec/features/course/student_management_spec.rb
+++ b/spec/features/course/student_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Courses: Students' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:user) { create(:administrator) }
+    let(:user) { create(:course_manager, course: course).user }
     let!(:course_students) { create_list(:course_student, 3, course: course) }
     let!(:unregistered_user) { create(:course_user, course: course) }
     before { login_as(user, scope: :user) }

--- a/spec/features/course/tab_management_spec.rb
+++ b/spec/features/course/tab_management_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Course: Assessments: Management' do
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
-      let(:user) { course.creator }
+      let(:user) { create(:course_manager, course: course).user }
       let(:category) { course.assessment_categories.first }
       let(:tab) { category.tabs.first }
 


### PR DESCRIPTION
* Creator is actually the default admin (test@example.org). There are some failures due to admin has too many courses under him.

This is a more correct way as it tests the ability of manager instead of admin. And this will further help reduce the random failure. 