### PR TITLE
Show access denied for non course users trying to visit the forums.

### DIFF
--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 class Course::Forum::ForumsController < Course::Forum::Controller
   before_action :load_forum, except: [:index, :new, :create, :search]
-  load_resource :forum, class: Course::Forum.name, through: :course, only: [:index, :new, :create]
+  load_and_authorize_resource :forum, class: Course::Forum.name, through: :course,
+                                      only: [:index, :new, :create]
   before_action :add_forum_item_breadcrumb
 
   def index

--- a/spec/features/course/forum_management_spec.rb
+++ b/spec/features/course/forum_management_spec.rb
@@ -143,5 +143,15 @@ RSpec.feature 'Course: Forum: Management' do
         expect(Course::Forum::Subscription.where(user: user, forum: forum).empty?).to eq(true)
       end
     end
+
+    context 'As a non Course Student' do
+      let(:user) { create(:user) }
+
+      scenario 'I am denied forum access' do
+        visit course_forums_path(course)
+        expect(page.status_code).to eq(403)
+        expect(page).to have_selector('div', text: 'pages.403.header')
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1230. References #1226.

@allenwq the spec actually passes with the original `load_resource` line too. But that's not the behaviour seen when testing manually.