### PR TITLE
Switch position and color for publish grade and unsubmit submission buttons

### DIFF
--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -12,11 +12,7 @@
     }
 
     .submission-buttons .btn {
-      margin: 10px 10px 10px 0;
-
-      &[name="submission[publish]"] {
-        margin-right: 0;
-      }
+      margin: 10px 20px 10px 0;
     }
 
     .exp-multiplier,

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -12,21 +12,21 @@ nav
     = render partial: 'course/assessment/answer/answer', object: base_answer_form.object,
              locals: { base_answer_form: base_answer_form }
 
+    - unless @submission.attempting?
+      = render 'statistics', f: f
+
     div.submission-buttons
       - if base_answer_form.object.attempting?
         = f.button :submit, t('common.save')
 
       - if @submission.attempting? && can?(:update, @submission)
-        = f.button :submit, t('.finalise'), name: 'submission[finalise]', class: ['btn-danger', 'finalise', 'pull-right'],
+        = f.button :submit, t('.finalise'), name: 'submission[finalise]', class: ['btn-danger', 'finalise'],
                                             data: { confirm: t('.confirm_finalise') },
                                             style: guided_next_unanswered_question.nil? ? '' : 'display: none'
 
       - unless @submission.attempting?
-        = render 'statistics', f: f
-
         - if can?(:grade, @submission)
           = f.button :submit, t('common.save')
-          = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']
 
           - if @submission.submitted?
             = link_to t('.auto_grade'),
@@ -35,4 +35,8 @@ nav
                                                                    @submission),
                       method: :post,
                       class: ['btn', 'btn-info']
-            = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger', 'pull-right']
+            = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-warning']
+
+
+          = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-danger'],
+            data: { confirm: t('.confirm_unsubmit') }

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -16,15 +16,15 @@
       = f.button :submit, t('common.save')
 
     - if @submission.attempting? && can?(:update, @submission)
-      = f.button :submit, t('.finalise'),
-        name: 'submission[finalise]', class: ['btn-danger', 'pull-right'],
+      = f.button :submit, t('.finalise'), name: 'submission[finalise]', class: ['btn-danger'],
         data: { confirm: t('.confirm_finalise') }
 
     - if @submission.submitted? && can?(:grade, @submission)
       = link_to t('.auto_grade'),
         auto_grade_course_assessment_submission_path(current_course, @submission.assessment,
           @submission), method: :post, class: ['btn', 'btn-info']
-      = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-danger', 'pull-right']
+      = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-warning']
 
     - if (@submission.submitted? || @submission.graded?) && can?(:grade, @submission)
-      = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-warning']
+      = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-danger'],
+        data: { confirm: t('.confirm_unsubmit') }

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -11,6 +11,12 @@ en:
             THIS ACTION IS IRREVERSIBLE
             
             Are you sure you want to submit? You will no longer be able to amend your submission!
+          confirm_unsubmit: |+
+            This will reset the submission time and permit the student to change his submission.
+
+            NOTE THAT YOU CANNOT UNDO THIS!!
+
+            Are you sure you want to proceed?
           index:
             submissions: 'Submissions'
             student_header: 'Student Submissions'
@@ -25,12 +31,14 @@ en:
             auto_grade: :'course.assessment.submission.submissions.auto_grade'
             unsubmit: :'course.assessment.submission.submissions.unsubmit'
             confirm_finalise: :'course.assessment.submission.submissions.confirm_finalise'
+            confirm_unsubmit: :'course.assessment.submission.submissions.confirm_unsubmit'
           guided:
             finalise: :'course.assessment.submission.submissions.finalise'
             publish: :'course.assessment.submission.submissions.publish'
             auto_grade: :'course.assessment.submission.submissions.auto_grade'
             unsubmit: :'course.assessment.submission.submissions.unsubmit'
             confirm_finalise: :'course.assessment.submission.submissions.confirm_finalise'
+            confirm_unsubmit: :'course.assessment.submission.submissions.confirm_unsubmit'
           statistics:
             student: :'course.users.role.student'
             status: 'Status'


### PR DESCRIPTION
- Add confirmation for unsubmit
- Use larger margin instead of right align
![127 0 0 1-9000-courses-2-assessments-2-submissions-3-edit 1](https://cloud.githubusercontent.com/assets/7753104/18240933/21501f24-7381-11e6-86f2-e70d4fc69c44.png)
![127 0 0 1-9000-courses-2-assessments-2-submissions-3-edit](https://cloud.githubusercontent.com/assets/7753104/18240940/26e05580-7381-11e6-9fcf-eb9b51b741dd.png)

