### PR TITLE
Only let first process create the folder

### DIFF
--- a/config/initializers/send_file.rb
+++ b/config/initializers/send_file.rb
@@ -2,6 +2,11 @@
 public_download_dir = File.join(Rails.public_path, Application.config.x.public_download_folder)
 
 if Rails.env.development? || Rails.env.test?
+  if Rails.env.test? && !ParallelTests.first_process?
+    # Let all other processes wait until the first process created the folder
+    sleep 0.5 until Dir.exist?(public_download_dir)
+  end
+
   Dir.mkdir(public_download_dir) unless Dir.exist?(public_download_dir)
 end
 


### PR DESCRIPTION
This will fix a race condition in spec setup: `Errno::EEXIST: File exists @ dir_s_mkdir - /home/travis/build/Coursemology/coursemology2/tmp/spec/public/downloads`
