### PR TITLE
Enforce maximum evaluation time

### DIFF
--- a/app/models/course/assessment/programming_evaluation.rb
+++ b/app/models/course/assessment/programming_evaluation.rb
@@ -16,6 +16,9 @@ class Course::Assessment::ProgrammingEvaluation < ActiveRecord::Base
   # evaluator.
   TIMEOUT = 5.minutes
 
+  # The maximum amount of CPU time a job can take before it gets killed.
+  CPU_TIMEOUT = 10.seconds
+
   before_save :copy_package, if: :package_path_changed?
   after_destroy :delete_package, if: :package_path
 

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -7,7 +7,11 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
 
   before_save :process_new_package, if: :attachment_changed?
 
-  validates :memory_limit, :time_limit, numericality: { greater_then: 0 }, allow_nil: true
+  validates :memory_limit, numericality: { greater_than: 0 }, allow_nil: true
+  validates :time_limit, numericality: { greater_than: 0,
+                                         less_than_or_equal_to:
+                                           Course::Assessment::ProgrammingEvaluation::CPU_TIMEOUT },
+                         allow_nil: true
 
   belongs_to :import_job, class_name: TrackableJob::Job.name, inverse_of: nil
   belongs_to :language, class_name: Coursemology::Polyglot::Language.name, inverse_of: nil

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -3,6 +3,7 @@
 class Course::Assessment::ProgrammingEvaluationService
   # The default timeout for the job to finish.
   DEFAULT_TIMEOUT = Course::Assessment::ProgrammingEvaluation::TIMEOUT
+  CPU_TIMEOUT = Course::Assessment::ProgrammingEvaluation::CPU_TIMEOUT
 
   # Represents a result of evaluating a package.
   Result = Struct.new(:stdout, :stderr, :test_report, :exit_code) do
@@ -84,7 +85,7 @@ class Course::Assessment::ProgrammingEvaluationService
     @course = course
     @language = language
     @memory_limit = memory_limit
-    @time_limit = time_limit
+    @time_limit = time_limit || CPU_TIMEOUT
     @package = package
     @timeout = timeout || DEFAULT_TIMEOUT
   end
@@ -107,7 +108,7 @@ class Course::Assessment::ProgrammingEvaluationService
   def create_evaluation
     Course::Assessment::ProgrammingEvaluation.create(
       course: @course, language: @language, package_path: @package, memory_limit: @memory_limit,
-      time_limit: @time_limit.to_i
+      time_limit: @time_limit
     )
   end
 

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Course::Assessment::Question::Programming do
 
       it { is_expected.to validate_numericality_of(:time_limit).allow_nil }
       it { is_expected.to validate_numericality_of(:memory_limit).allow_nil }
+      it 'validates time_limit' do
+        expect(subject).to validate_numericality_of(:time_limit).is_greater_than(0).
+          is_less_than_or_equal_to(10)
+      end
     end
 
     describe 'callbacks' do


### PR DESCRIPTION
Fixes #1438.

Leaving the time limit blank resulted in a 1 second limit as nil was converted to 0, which sets a limit of 1 when used in `ulimit`.

A TA can specify any time limit he wants and cause a denial of evaluator service if the limit is too high and the submitted code has an infinite loop.

Limit the time limit to a maximum of 10 seconds for TA input and use the same maximum if no time limit is specified.
