### PR TITLE
Render announcements on landing page within a "box."

### DIFF
--- a/app/assets/stylesheets/course/courses.scss
+++ b/app/assets/stylesheets/course/courses.scss
@@ -10,9 +10,16 @@
       @extend .col-md-4;
     }
 
-    .announcement {
-      @include announcement;
+    .announcement-holder {
+      border: 1px solid $gray-lighter;
+      border-radius: 4px;
+      padding: 10px;
+
+      .announcement {
+        @include announcement;
+      }
     }
+
   }
 
   &.index {

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -16,9 +16,8 @@
 
   - if current_course.user?(current_user) || can?(:manage, current_course)
     h2 = t('.announcements')
-    hr
-    div
-      = render current_course.announcements.currently_active
+    div.announcement-holder
+      = render partial: current_course.announcements.currently_active, spacer_template: 'announcements/announcement_spacer'
 
     h2 = t('.activities')
     div


### PR DESCRIPTION
Also render spacers between announcements on landing page, similar to the announcements page.

@allenwq as spoken... to make things look slightly less jarring

![screenshot from 2016-09-06 15-33-30](https://cloud.githubusercontent.com/assets/8869365/18265477/867ac80a-7448-11e6-8bb5-6ea04a7c2b2a.png)
