### PR TITLE
Support upload files in answers

### DIFF
--- a/app/controllers/course/assessment/question/text_responses_controller.rb
+++ b/app/controllers/course/assessment/question/text_responses_controller.rb
@@ -44,7 +44,7 @@ class Course::Assessment::Question::TextResponsesController < \
 
   def text_response_question_params
     params.require(:question_text_response).permit(
-      :title, :description, :staff_only_comments, :maximum_grade, :weight,
+      :title, :description, :staff_only_comments, :maximum_grade, :weight, :allow_attachment,
       skill_ids: [],
       solutions_attributes: [:_destroy, :id, :solution_type, :solution, :grade, :explanation]
     )

--- a/app/models/course/assessment/answer/text_response.rb
+++ b/app/models/course/assessment/answer/text_response.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::TextResponse < ActiveRecord::Base
   acts_as :answer, class_name: Course::Assessment::Answer.name
+  has_one_attachment
 
   after_initialize :set_default
   before_validation :strip_whitespace

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -77,6 +77,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
     scalar_params = [].tap do |result|
       result.push(:answer_text) # Text response answer
       result.push(:option_ids) # MCQ answer
+      result.push(attachments_params) # User uploaded files
     end
     # Parameters that must be an array of permitted values
     array_params = {}.tap do |result|

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -1,6 +1,8 @@
 - question = text_response.question.specific
 - readonly = cannot?(:update, text_response.answer)
 = f.input :answer_text, label: false, readonly: readonly
+- if question.allow_attachment?
+  = f.attachment
 
 - if last_attempt && last_attempt.auto_grading && last_attempt.auto_grading.result
   = render partial: 'course/assessment/answer/explanation',

--- a/app/views/course/assessment/question/text_responses/_form.html.slim
+++ b/app/views/course/assessment/question/text_responses/_form.html.slim
@@ -1,6 +1,7 @@
 = simple_form_for [current_course, @assessment, @text_response_question] do |f|
   = f.error_notification
   = render partial: 'course/assessment/questions/form', locals: { f: f }
+  = f.input :allow_attachment, label: t('.allow_upload_file')
 
   table.table.table-striped.table-hover
     thead

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for [current_course, @assessment, @submission] do |f|
+= simple_form_for [current_course, @assessment, @submission], html: { multipart: true } do |f|
   = f.error_notification
 
   / TODO: Implement flag to display all answers, or only latest answers.

--- a/config/locales/en/course/assessment/question/text_response.yml
+++ b/config/locales/en/course/assessment/question/text_response.yml
@@ -13,6 +13,7 @@ en:
             success: 'The text response question was deleted.'
             failure: 'Could not delete text response question: %{error}'
           form:
+            allow_upload_file: 'Allow file upload in the answer'
             solution_type: 'Type'
             solution: 'Solution'
             grade: 'Grade'

--- a/db/migrate/20160906091734_add_fields_to_course_assessment_answer_text_responses.rb
+++ b/db/migrate/20160906091734_add_fields_to_course_assessment_answer_text_responses.rb
@@ -1,0 +1,6 @@
+class AddFieldsToCourseAssessmentAnswerTextResponses < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_question_text_responses, :allow_attachment, :boolean,
+               default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160830023835) do
+ActiveRecord::Schema.define(version: 20160906091735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -297,6 +297,7 @@ ActiveRecord::Schema.define(version: 20160830023835) do
   add_index "course_assessment_question_programming_template_files", ["question_id", "filename"], :name=>"index_course_assessment_question_programming_template_filenames", :unique=>true, :case_sensitive=>false
 
   create_table "course_assessment_question_text_responses", force: :cascade do |t|
+    t.boolean "allow_attachment", :default=>false
   end
 
   create_table "course_assessment_question_text_response_solutions", force: :cascade do |t|

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -53,7 +53,8 @@ FactoryGirl.define do
     trait :with_text_response_question do
       after(:build) do |assessment, evaluator|
         evaluator.question_count.downto(1).each do
-          question = build(:course_assessment_question_text_response, assessment: assessment)
+          question = build(:course_assessment_question_text_response, :allow_attachment,
+                           assessment: assessment)
           assessment.questions << question.acting_as
         end
       end

--- a/spec/factories/course_assessment_question_text_responses.rb
+++ b/spec/factories/course_assessment_question_text_responses.rb
@@ -3,6 +3,8 @@ FactoryGirl.define do
   factory :course_assessment_question_text_response,
           class: Course::Assessment::Question::TextResponse,
           parent: :course_assessment_question do
+    allow_attachment false
+
     solutions do
       [
         build(:course_assessment_question_text_response_solution, :exact_match, question: nil),
@@ -20,6 +22,10 @@ FactoryGirl.define do
                 question: nil, solution: 'KeywordB')
         ]
       end
+    end
+
+    trait :allow_attachment do
+      allow_attachment true
     end
   end
 end

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
           end
         end
       end
+
+      scenario 'I upload an attachment to the answer' do
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        answer = submission.answers.last
+        attach_file "submission_answers_attributes_#{answer.id}_actable_attributes_file",
+                    File.join(Rails.root, '/spec/fixtures/files/text.txt')
+
+        click_button I18n.t('common.save')
+
+        expect(answer.specific.attachment).to be_present
+      end
     end
 
     context 'As Course Staff' do

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         fill_in 'staff_only_comments', with: question_attributes[:staff_only_comments]
         fill_in 'maximum_grade', with: question_attributes[:maximum_grade]
         fill_in 'weight', with: question_attributes[:weight]
+        check 'question_text_response_allow_attachment'
         within find_field('skills') do
           select skill.title
         end
@@ -35,6 +36,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         expect(page).to have_content_tag_for(question_created)
         expect(question_created.skills).to contain_exactly(skill)
         expect(question_created.weight).to eq(question_attributes[:weight])
+        expect(question_created.allow_attachment).to be_truthy
       end
 
       scenario 'I can edit a question', js: true do


### PR DESCRIPTION
Fix #1450 

1. Add a file upload option to text response question
2. Support attaching files to the answer