### PR TITLE
Course main page UI improvements

### DIFF
--- a/app/assets/stylesheets/course/_announcement.scss
+++ b/app/assets/stylesheets/course/_announcement.scss
@@ -1,11 +1,15 @@
-@mixin announcement {
-  padding-left: 8px;
-
+@mixin timestamp {
   .timestamp {
     color: $gray-light;
     font-size: 13px;
     line-height: 18px;
   }
+}
+
+@mixin announcement {
+  padding-left: 8px;
+
+  @include timestamp;
 
   .content {
     font-size: 13px;

--- a/app/assets/stylesheets/course/achievement.scss
+++ b/app/assets/stylesheets/course/achievement.scss
@@ -25,11 +25,11 @@
     @include automatically-clear;
 
     .course-user-achievement {
+      text-align: center;
+
       .image > img {
         @include fit-round-img($course-achievement-user-profile);
       }
-
-      text-align: center;
     }
   }
 }

--- a/app/assets/stylesheets/course/courses.scss
+++ b/app/assets/stylesheets/course/courses.scss
@@ -10,10 +10,11 @@
       @extend .col-md-4;
     }
 
-    .announcement-holder {
+    .message-holder {
       border: 1px solid $gray-lighter;
       border-radius: 4px;
       padding: 10px;
+      margin-bottom: 10px;
 
       .announcement {
         @include announcement;

--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -1,4 +1,6 @@
 .course-layout {
+  @include timestamp;
+
   #course-user-badge {
     #course-user-progress {
       .progress {
@@ -54,6 +56,7 @@
 
     #user-sidebar {
       font-size: 18px;
+      font-weight: bold;
     }
 
     .image,
@@ -63,8 +66,7 @@
     }
   }
 
-  .notification > h6 {
-    margin-top: 0;
+  .notification + .notification {
+    margin-top: 10px;
   }
-
 }

--- a/app/assets/stylesheets/mixins/_image.scss
+++ b/app/assets/stylesheets/mixins/_image.scss
@@ -3,6 +3,7 @@
   object-fit: cover;
   object-position: center;
 }
+
 @mixin fit-round-img($width, $height: $width) {
   @include no-stretch;
   width: $width;

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -16,11 +16,11 @@
 
   - if current_course.user?(current_user) || can?(:manage, current_course)
     h2 = t('.announcements')
-    div.announcement-holder
+    div.message-holder
       = render partial: current_course.announcements.currently_active, spacer_template: 'announcements/announcement_spacer'
 
     h2 = t('.activities')
-    div
+    div.message-holder
       - @activity_feeds.each do |notification|
         - if notification.activity.object
           = render partial: notification_view_path(notification),

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -9,9 +9,8 @@
             = display_course_logo(current_course)
         - if current_course_user.present? && can?(:participate, current_course)
           div.col-xs-12.user
-            table
-              = display_user_image(current_user)
-              span#user-sidebar = link_to_user(current_course_user || current_user)
+            = display_user_image(current_user)
+            span#user-sidebar = link_to_user(current_course_user || current_user)
             - if !current_course_user.staff?
               = display_course_user_badge(current_course_user)
       nav.navbar-default role='navigation'

--- a/app/views/notifiers/course/achievement_notifier/gained/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/achievement_notifier/gained/course_notifications/_feed.html.slim
@@ -6,4 +6,4 @@
   - user_link = link_to_user(activity.actor)
   - achievement_link = link_to achievement.title, course_achievement_path(current_course, achievement)
   => t('.gained_achievement_html', user: user_link, achievement: achievement_link)
-  h6 = format_datetime(activity.created_at)
+  i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/assessment_notifier/attempted/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/attempted/course_notifications/_feed.html.slim
@@ -6,4 +6,4 @@
   - user_link = link_to_user(activity.actor)
   - assessment_link = link_to assessment.title, course_assessment_path(notification.course, assessment)
   => t('.attempted_assessment_html', user: user_link, assessment: assessment_link)
-  h6 = format_datetime(activity.created_at)
+  i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/forum/post_notifier/replied/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/course_notifications/_feed.html.slim
@@ -7,4 +7,4 @@
   - user_link = link_to_user(activity.actor)
   - topic_link = link_to topic.title, course_forum_topic_path(notification.course, topic.forum, topic)
   => t('.replied_to_topic_html', user: user_link, topic: topic_link)
-  h6 = format_datetime(activity.created_at)
+  i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/forum/topic_notifier/created/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/topic_notifier/created/course_notifications/_feed.html.slim
@@ -6,4 +6,4 @@
   - user_link = link_to_user(activity.actor)
   - topic_link = link_to topic.title, course_forum_topic_path(notification.course, topic.forum, topic)
   => t('.created_topic_html', user: user_link, topic: topic_link)
-  h6 = format_datetime(activity.created_at)
+  i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/level_notifier/reached/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/level_notifier/reached/course_notifications/_feed.html.slim
@@ -5,4 +5,4 @@
   // TODO: Display user image here.
   - user_link = link_to_user(activity.actor)
   => t('.reached_level_html', user: user_link, level_number: level.level_number)
-  h6 = format_datetime(activity.created_at)
+  i.clearfix.timestamp = format_datetime(activity.created_at)


### PR DESCRIPTION
- Adjusts timestamp of Latest Activity to be aligned with Announcements (italicized and grey)
### new (left) vs old (right)
![selection_023](https://cloud.githubusercontent.com/assets/10083037/18323757/9ec9f04c-756b-11e6-9000-932ae66702ab.png)

- Modified "announcement-holder" to "message-holder" to make Latest Activity look similar to Announcements (grey border box)
![selection_024](https://cloud.githubusercontent.com/assets/10083037/18324189/cbaabffe-756d-11e6-9249-9339fc06fa41.png)

- Bolds username