### PR TITLE
Do not show submissions filter to students

### DIFF
--- a/app/views/course/assessment/submissions/index.html.slim
+++ b/app/views/course/assessment/submissions/index.html.slim
@@ -1,7 +1,9 @@
 - add_breadcrumb format_inline_text(@category.title)
 = page_header
 = render partial: 'tabs'
-= render partial: 'filter', locals: { category: @category }
+
+- if current_course_user && current_course_user.staff? || can?(:manage, current_course)
+  = render partial: 'filter', locals: { category: @category }
 
 = render partial: 'submissions', locals: { submissions: @submissions, pending: false }
 

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'Course: Submissions Viewing' do
 
         visit course_submissions_path(course)
 
+        expect(page).to have_selector('div.submissions-filter')
+
         # Submissions page should not have show attempting submissions or staff submissions.
         expect(page).not_to have_content_tag_for(attempting_submission)
         expect(page).not_to have_content_tag_for(staff_submission)
@@ -101,6 +103,7 @@ RSpec.describe 'Course: Submissions Viewing' do
         visit course_submissions_path(course)
 
         expect(page).not_to have_content_tag_for(attempting_submission)
+        expect(page).not_to have_selector('div.submissions-filter')
 
         [submitted_submission, graded_submission].each do |submission|
           within find(content_tag_selector(submission)) do


### PR DESCRIPTION
Currently students can see the submissions filter but cannot query. 