### PR TITLE
Fix a failing spec due to text link out of window

### DIFF
--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         visit edit_path
 
         solutions.each_with_index do |solution, i|
-          click_link I18n.t('course.assessment.question.text_responses.form.add_solution')
+          link = I18n.t('course.assessment.question.text_responses.form.add_solution')
+          find('a.add_fields', text: link).trigger('click')
           within all('.edit_question_text_response '\
             'tr.question_text_response_solution')[i] do
             find('textarea.text-response-solution').set solution[:solution]


### PR DESCRIPTION
1) Course: Assessments: Questions: Text Response Management with tenant :instance As a Course Manager I can edit a question
     Failure/Error: click_link I18n.t('course.assessment.question.text_responses.form.add_solution')

     Capybara::Poltergeist::MouseEventFailed:
       Firing a click at co-ordinates [973, 8.5] failed. Poltergeist detected another element with CSS selector 'html body nav.navbar.navbar-inverse.navbar-fixed-top div.container-fluid div#site-navigation-navbar.collapse.navbar-collapse ul.nav.navbar-nav.pull-right li a.dropdown-toggle' at this position. It may be overlapping the element you are trying to interact with. If you don't care about overlapping elements, try using node.trigger('click').

Caused by the link at the bottom right corner overflowed:
![screenshot_2016-09-09-10-48-49 757](https://cloud.githubusercontent.com/assets/4983239/18374150/eb601f82-767c-11e6-8ec0-eb35983dd58a.png)


