### PR TITLE
Text response question fixes

### DIFF
--- a/app/assets/stylesheets/course/assessment/submission/answer/answer.scss
+++ b/app/assets/stylesheets/course/assessment/submission/answer/answer.scss
@@ -4,4 +4,10 @@
   .answer .comments {
     @include discussion-post;
   }
+
+  .answer-comment-form {
+    .btn.reply-comment {
+      margin-top: -15px;
+    }
+  }
 }

--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -11,6 +11,10 @@
       padding: 0 3px;
     }
 
+    .answer .grading-panel {
+      margin-top: 0.5em;
+    }
+
     .submission-buttons .btn {
       margin: 10px 20px 10px 0;
     }

--- a/app/assets/stylesheets/course/discussion/comments_center.scss
+++ b/app/assets/stylesheets/course/discussion/comments_center.scss
@@ -4,4 +4,10 @@
   .discussion_topic {
     @include discussion-post;
   }
+
+  .post-form {
+    .btn {
+      margin-top: -15px;
+    }
+  }
 }

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -10,7 +10,7 @@ class Course::Assessment::Question::TextResponse < ActiveRecord::Base
   accepts_nested_attributes_for :solutions
 
   def auto_gradable?
-    true
+    !solutions.empty?
   end
 
   def auto_grader

--- a/app/views/course/assessment/answer/_grading.slim
+++ b/app/views/course/assessment/answer/_grading.slim
@@ -1,16 +1,17 @@
-- if !answer.attempting? && can?(:grade, @submission)
-  div.panel.panel-default
-    div.panel-heading = t('.grading')
-    div.panel-body
-      div.form-group.submission_answers_grade.row
-        div.col-lg-3.col-md-6.col-sm-6.col-xs-6
-          = base_answer_form.input_field :grade, class: ['form-control', 'grade'],
-                                                 'data-answer-id' => answer.id
-        div.col-lg-3.col-md-6.col-sm-6.col-xs-6
-          = t('.maximum_grade', maximum_grade: answer.question.maximum_grade)
-- elsif answer.graded?
+div.grading-panel
+  - if !answer.attempting? && can?(:grade, @submission)
     div.panel.panel-default
       div.panel-heading = t('.grading')
       div.panel-body
-        div.form-group.submission_answers_grade
-          = t('.grade', grade: answer.grade, maximum_grade: answer.question.maximum_grade)
+        div.form-group.submission_answers_grade.row
+          div.col-lg-3.col-md-6.col-sm-6.col-xs-6
+            = base_answer_form.input_field :grade, class: ['form-control', 'grade'],
+                                                   'data-answer-id' => answer.id
+          div.col-lg-3.col-md-6.col-sm-6.col-xs-6
+            = t('.maximum_grade', maximum_grade: answer.question.maximum_grade)
+  - elsif answer.graded?
+      div.panel.panel-default
+        div.panel-heading = t('.grading')
+        div.panel-body
+          div.form-group.submission_answers_grade
+            = t('.grade', grade: answer.grade, maximum_grade: answer.question.maximum_grade)

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -8,6 +8,6 @@
   = render partial: 'course/assessment/answer/explanation',
            locals: { answer: f.object }
 
-- if can?(:grade, text_response.answer)
+- if question.auto_gradable? && can?(:grade, text_response.answer)
   = render partial: 'course/assessment/answer/text_responses/solution',
     locals: { question: question }


### PR DESCRIPTION
1. Do not autograde text response question when there's no solutions
2. CSS fix to the grading page

![screen shot 2016-09-09 at 1 28 08 pm](https://cloud.githubusercontent.com/assets/4983239/18376390/4a97b14a-7691-11e6-8c20-14a74f75b501.png)
