### PR TITLE
Make sure edit and save post does not change the original content

### DIFF
--- a/app/assets/javascripts/helpers/discussion/edit_post.js
+++ b/app/assets/javascripts/helpers/discussion/edit_post.js
@@ -22,7 +22,7 @@ var EDIT_DISCUSSION_POST = (function($, FORM_HELPERS,
     var courseId = COURSE_HELPERS.courseIdForElement($element);
     var topicId = $topic.data('topicId');
     var postId = $post.data('postId');
-    var postContent = $post.find('.content').text();
+    var postContent = $post.find('.content').html();
     var postCommenter = $post.find('.user').html();
 
     $post.children().hide();

--- a/app/assets/javascripts/templates/course/discussion/post.jst.ejs
+++ b/app/assets/javascripts/templates/course/discussion/post.jst.ejs
@@ -4,9 +4,8 @@
   <div class="form-group text">
     <textarea name="discussion_post[text]"
               class="form-control text airmode"
-              aria-label="<%= I18n.t('javascript.course.discussion.post.text.label') %>">
-      <%= postContent %>
-    </textarea>
+              aria-label="<%= I18n.t('javascript.course.discussion.post.text.label') %>"
+      ><%= postContent %></textarea>
   </div>
 
   <input type="reset" class="btn btn-default"

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -73,7 +73,8 @@ RSpec.feature 'Course: Topics: Management' do
                course: course, creator: user)
       end
       let(:student_reply) do
-        create(:course_discussion_post, topic: student_answer.acting_as, creator: user)
+        create(:course_discussion_post, topic: student_answer.acting_as, creator: user,
+                                        text: '<p>Content with html tags</p>')
       end
 
       scenario 'I can see all my comments' do
@@ -118,8 +119,17 @@ RSpec.feature 'Course: Topics: Management' do
         visit course_topics_path(course)
 
         # Test post editing
+        old_text = my_comment_post.text
         find(content_tag_selector(my_comment_post)).find('.edit').click
+        within find('.edit-discussion-post-form') do
+          click_button I18n.t('javascript.course.discussion.post.submit')
+        end
+        wait_for_ajax
+        # Edit and save should not change the old content
+        expect(my_comment_post.reload.text).to eq(old_text)
+
         new_post_text = 'new post text'
+        find(content_tag_selector(my_comment_post)).find('.edit').click
         within find('.edit-discussion-post-form') do
           fill_in 'discussion_post[text]', with: new_post_text
           click_button I18n.t('javascript.course.discussion.post.submit')


### PR DESCRIPTION
* Remove white spaces in the JST template
* Pass html instead of text to the edit form

Fixes #1487, the bug that new lines are missing when editing the comment form. 