### PR TITLE
Stick with simple_form 3.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,7 +176,7 @@ gem 'themes_on_rails', '>= 0.3.1', github: 'lowjoel/themes_on_rails',
                                    branch: 'cache-theme-templates'
 
 # Forms made easy for Rails
-gem 'simple_form'
+gem 'simple_form', '~> 3.2.1'
 gem 'simple_form-bootstrap'
 # Dynamic nested forms
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,7 +449,7 @@ GEM
     should_not (1.1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simple_form (3.3.1)
+    simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
     simple_form-bootstrap (1.4.0)
@@ -603,7 +603,7 @@ DEPENDENCIES
   settings_on_rails
   should_not
   shoulda-matchers
-  simple_form
+  simple_form (~> 3.2.1)
   simple_form-bootstrap
   simple_token_authentication!
   simplecov


### PR DESCRIPTION
The type of the actable columns cannot be correctly deduced in simple_form 3.3. Probably something to do with https://github.com/hzamani/active_record-acts_as