### PR TITLE
Sync forum disbursement spec time zone with app

### DIFF
--- a/spec/features/course/experience_points/forum_disbrusement_spec.rb
+++ b/spec/features/course/experience_points/forum_disbrusement_spec.rb
@@ -16,7 +16,9 @@ RSpec.feature 'Course: Experience Points: Forum Disbursement' do
       let(:user) { course_teaching_assistant.user }
 
       scenario 'I can compute and award forum participation points' do
-        recent_date = DateTime.current.at_beginning_of_week.end_of_day.in_time_zone - 2.days
+        recent_date = Time.use_zone(Application.config.x.default_user_time_zone) do
+          DateTime.current.at_beginning_of_week.end_of_day.in_time_zone - 2.days
+        end
         create(:course_discussion_post, topic: forum_topic.acting_as,
                                         creator: students.first.user, updater: students.first.user,
                                         created_at: recent_date, updated_at: recent_date)


### PR DESCRIPTION
Without this, the test will fail between 0000 and 0800 Singapore time.

Addresses an issue in #1477.