### PR TITLE
Guided reset answer fixes

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -44,12 +44,13 @@ class Course::Assessment::Submission::SubmissionsController < \
   # Reload answer to either its latest status or to a fresh answer, depending on parameters.
   def reload_answer
     @answer = @submission.answers.find_by(id: reload_answer_params[:answer_id])
+    @current_question = @answer.try(:question)
+
     if @answer.nil?
       render status: :bad_request
     elsif reload_answer_params[:reset_answer]
       @new_answer = @answer.reset_answer
     else
-      @current_question = @answer.question
       @new_answer = @submission.answers.from_question(@current_question.id).last
     end
   end

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -50,7 +50,8 @@ module Course::Assessment::Submission::SubmissionsHelper
         current_course, assessment, submission, answer_id: answer.id, reset_answer: true
       )
     link_to t('course.assessment.answer.reset_answer.button'), path,
-            remote: true, method: :post, class: ['btn', 'btn-warning', 'reset-answer'],
+            remote: true, method: :post, class: ['btn', 'btn-default', 'reset-answer'],
+            title: t('course.assessment.answer.reset_answer.tooltip'),
             data: { confirm: t('course.assessment.answer.reset_answer.warning') }
   end
 

--- a/app/views/course/assessment/answer/_guided.html.slim
+++ b/app/views/course/assessment/answer/_guided.html.slim
@@ -3,11 +3,13 @@
     div.btn-group
       - if answer.specific.is_a?(Course::Assessment::Answer::Programming)
         = link_to_reset_answer(answer)
-      = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+      = base_answer_form.button :button, t('common.submit'), value: answer.id,
+          name: 'attempting_answer_id', class: ['btn-danger', 'submit-answer']
   - elsif answer.submitted? && job = answer.try(:auto_grading).try(:job)
     - if job.errored?
       p.bg-danger = t('.error')
-      = base_answer_form.button :button, t('common.submit'), value: answer.id, name: 'attempting_answer_id', class: 'submit-answer'
+      = base_answer_form.button :button, t('common.submit'), value: answer.id,
+          name: 'attempting_answer_id', class: ['btn-danger', 'submit-answer']
     - elsif job.submitted?
       = link_to '#', class: ['btn', 'btn-default', 'submitted'], 'data-job-path': job_path(job), disabled: true do
         => t('common.submit')

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -21,7 +21,8 @@ en:
           correct: 'Correct!'
           wrong: 'Wrong!'
         reset_answer:
-          button: 'Reset Answer'
+          button: 'Reset'
+          tooltip: 'Reset your current answer to the template'
           warning: >
             Are you sure you want to reset your answer? This action is irreversible and you will
             lose all your current work for this question.


### PR DESCRIPTION
1. Fix an issue that current answer is not reloaded after reset in guided mode.
2. Styling fix and add tooltip to reset answer ( some users are not aware of the purpose of the button)

Submit and reset button now: 

![screen shot 2016-09-13 at 8 30 57 pm](https://cloud.githubusercontent.com/assets/4983239/18473830/97020c16-79f1-11e6-92af-12a2b8b6ff44.png)
