### PR TITLE
Minor styling fixes

### DIFF
--- a/app/views/course/admin/component_settings/edit.html.slim
+++ b/app/views/course/admin/component_settings/edit.html.slim
@@ -13,4 +13,4 @@
           th = f.label
           td = f.check_box
 
-  = f.button :submit
+  = f.button :submit, t('.button')

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -21,4 +21,9 @@
       = f.simple_fields_for :options do |options_form|
         = render 'option_fields', f: options_form
 
-  = f.button :submit
+  - if @multiple_response_question.multiple_choice?
+    - button_text = t('.multiple_choice_button')
+  - else
+    - button_text = t('.multiple_response_button')
+  = f.button :submit, button_text
+

--- a/app/views/course/assessment/questions/_question.html.slim
+++ b/app/views/course/assessment/questions/_question.html.slim
@@ -1,4 +1,4 @@
-= div_for(question) do
+= div_for(question, class: ['clearfix']) do
   div.pull-right
     div.btn-group
       = edit_button(edit_path)

--- a/config/locales/en/course/admin/component_settings.yml
+++ b/config/locales/en/course/admin/component_settings.yml
@@ -8,5 +8,6 @@ en:
           header: 'Enable/Disable Components'
           name: 'Name'
           enabled: 'Enabled?'
+          button: 'Update Component Settings'
         update:
           success: 'Settings updated successfully.'

--- a/config/locales/en/course/assessment/question/multiple_responses.yml
+++ b/config/locales/en/course/assessment/question/multiple_responses.yml
@@ -18,6 +18,8 @@ en:
             option: 'Option'
             explanation: 'Explanation'
             add_option: 'Add Option'
+            multiple_choice_button: 'Create Multiple Choice Question'
+            multiple_response_button: 'Create Multiple Response Question'
           option_fields:
             explanation_hint: 'The explanation to show after the student submits his answer.'
             remove: 'Remove'

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Course: Administration: Components' do
         visit course_admin_components_path(course)
 
         check(sample_component_id)
-        click_button 'submit'
+        click_button I18n.t('course.admin.component_settings.edit.button')
         expect(page).to have_checked_field(sample_component_id)
       end
 
@@ -43,7 +43,7 @@ RSpec.feature 'Course: Administration: Components' do
         visit course_admin_components_path(course)
 
         uncheck(sample_component_id)
-        click_button 'submit'
+        click_button I18n.t('course.admin.component_settings.edit.button')
         expect(page).to have_unchecked_field(sample_component_id)
       end
     end

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         within find_field('skills') do
           select skill.title
         end
-        click_button 'submit'
+        click_button I18n.t(
+          'course.assessment.question.multiple_responses.form.multiple_response_button'
+        )
 
         question_created = assessment.questions.first.specific
         expect(page).to have_content_tag_for(question_created)
@@ -56,7 +58,9 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         question_attributes = attributes_for(:course_assessment_question_multiple_response)
         fill_in 'title', with: question_attributes[:title]
         fill_in 'maximum_grade', with: question_attributes[:maximum_grade]
-        click_button 'submit'
+        click_button I18n.t(
+          'course.assessment.question.multiple_responses.form.multiple_choice_button'
+        )
 
         # Cannot create multiple choice question without a correct option
         expect(current_path).to eq(
@@ -77,7 +81,9 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
           check find('input[type="checkbox"]')[:name]
         end
 
-        click_button 'submit'
+        click_button I18n.t(
+          'course.assessment.question.multiple_responses.form.multiple_choice_button'
+        )
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
         question_created = assessment.questions.first.specific
@@ -99,7 +105,9 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
 
         maximum_grade = 999.9
         fill_in 'maximum_grade', with: maximum_grade
-        click_button 'submit'
+        click_button I18n.t(
+          'course.assessment.question.multiple_responses.form.multiple_response_button'
+        )
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(mrq.reload.maximum_grade).to eq(maximum_grade)
@@ -119,7 +127,10 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
             end
           end
         end
-        click_button 'submit'
+        click_button I18n.t(
+          'course.assessment.question.multiple_responses.form.multiple_response_button'
+        )
+
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).to have_selector('div.alert.alert-success')
       end


### PR DESCRIPTION
- Fixed issue where edit and delete question buttons on Assessment#show page are misaligned when question description is empty
- Modified text on buttons for: `updating enable/disable components` and `Create MCQ / MRQ`