### PR TITLE
Forum fixes

### DIFF
--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -11,6 +11,7 @@ class Course::Discussion::Post < ActiveRecord::Base
   before_destroy :reparent_children
 
   validate :parent_topic_consistency
+  validates :text, presence: true
 
   belongs_to :topic, inverse_of: :posts, touch: true
   has_many :votes, inverse_of: :post, dependent: :destroy

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -8,8 +8,6 @@ class Course::Discussion::Post < ActiveRecord::Base
   has_many_attachments
 
   after_initialize :set_topic, if: :new_record?
-  after_initialize :set_title, if: :new_record?
-  before_validation :set_title
   before_destroy :reparent_children
 
   validate :parent_topic_consistency
@@ -89,12 +87,6 @@ class Course::Discussion::Post < ActiveRecord::Base
 
   def set_topic
     self.topic ||= parent.topic if parent
-  end
-
-  def set_title
-    return unless parent
-
-    self.title ||= self.class.human_attribute_name('title_reply_template', title: parent.title)
   end
 
   def parent_topic_consistency

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -7,7 +7,6 @@ class Course::Forum::Topic < ActiveRecord::Base
   acts_as_discussion_topic
 
   after_initialize :generate_initial_post, unless: :persisted?
-  before_validation :set_initial_post_title, unless: :persisted?
   after_create :mark_as_read_for_creator
   after_update :mark_as_read_for_updater
 
@@ -101,10 +100,6 @@ class Course::Forum::Topic < ActiveRecord::Base
 
   def generate_initial_post
     posts.build if posts.empty?
-  end
-
-  def set_initial_post_title
-    posts.first.title = title
   end
 
   def mark_as_read_for_creator

--- a/app/views/course/forum/posts/_form.html.slim
+++ b/app/views/course/forum/posts/_form.html.slim
@@ -1,7 +1,6 @@
 = simple_form_for post, url: url do |f|
   = f.error_notification
-  = f.input :title
-  = f.input :text
+  = f.input :text, label: false
 
   = f.hidden_field :parent_id
 

--- a/app/views/course/forum/posts/_post.html.slim
+++ b/app/views/course/forum/posts/_post.html.slim
@@ -9,8 +9,6 @@
     h4.title
       - if post.unread?(current_user)
         => fa_icon 'envelope'.freeze
-      a
-        = format_inline_text(post.title)
       div.pull-right
         .timestamp
           => format_datetime(post.created_at)

--- a/app/views/course/forum/topics/_topic.html.slim
+++ b/app/views/course/forum/topics/_topic.html.slim
@@ -11,9 +11,6 @@
   td = topic.post_count
   td = topic.view_count
   td.latest-post
-    - last_post = topic.posts.first
+    - last_post = topic.posts.last
     - if last_post
-      = t('.last_post_html', post: link_to(format_inline_text(last_post.title),
-                                           course_forum_topic_path(current_course, @forum, topic)))
-      br
-      = t('.creator_html', creator: link_to_user(last_post.creator))
+      = link_to_user(last_post.creator)

--- a/config/locales/en/course/forum/forums.yml
+++ b/config/locales/en/course/forum/forums.yml
@@ -21,7 +21,7 @@ en:
           votes: 'Votes'
           posts: 'Posts'
           views: 'Views'
-          latest_post: 'Latest Post'
+          latest_post: 'Last Posted By'
           no_topic: 'No Topic'
         new:
           header: 'New Forum'

--- a/config/locales/en/course/forum/topics.yml
+++ b/config/locales/en/course/forum/topics.yml
@@ -4,8 +4,6 @@ en:
       topics:
         topic:
           started_by_html: 'Started by %{user}'
-          last_post_html: 'Last Post: %{post}'
-          creator_html: 'Creator: %{creator}'
         new_topic:
           header: 'New Topic'
         edit_topic:

--- a/db/migrate/20160916101014_change_discussion_posts_title.rb
+++ b/db/migrate/20160916101014_change_discussion_posts_title.rb
@@ -1,0 +1,5 @@
+class ChangeDiscussionPostsTitle < ActiveRecord::Migration
+  def change
+    change_column :course_discussion_posts, :title, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160908100211) do
+ActiveRecord::Schema.define(version: 20160916101014) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -371,7 +371,7 @@ ActiveRecord::Schema.define(version: 20160908100211) do
   create_table "course_discussion_posts", force: :cascade do |t|
     t.integer  "parent_id",  :index=>{:name=>"fk__course_discussion_posts_parent_id"}, :foreign_key=>{:references=>"course_discussion_posts", :name=>"fk_course_discussion_posts_parent_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "topic_id",   :null=>false, :index=>{:name=>"fk__course_discussion_posts_topic_id"}, :foreign_key=>{:references=>"course_discussion_topics", :name=>"fk_course_discussion_posts_topic_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",      :limit=>255, :null=>false
+    t.string   "title",      :limit=>255
     t.text     "text"
     t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_posts_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_posts_updater_id", :on_update=>:no_action, :on_delete=>:no_action}

--- a/spec/factories/course_discussion_posts.rb
+++ b/spec/factories/course_discussion_posts.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     updater
     parent nil
     association :topic, factory: :course_discussion_topic
-    sequence(:title) { |n| "post #{n}" }
     text 'This is a test post'
   end
 end

--- a/spec/factories/course_forum_topics.rb
+++ b/spec/factories/course_forum_topics.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
 
     after(:build) do |forum_topic, evaluator|
       forum_topic.course = evaluator.course
+      forum_topic.posts.each { |p| p.text = 'I am a post' }
     end
   end
 end

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -23,9 +23,9 @@ RSpec.feature 'Course: Forum: Post: Management' do
       scenario 'I can create a post' do
         visit course_forum_topic_path(course, forum, topic)
 
-        # Create a post with a missing title.
+        # Create a post with empty content.
         within '#new_discussion_post' do
-          fill_in 'discussion_post_title', with: nil
+          fill_in 'discussion_post_text', with: nil
           click_button 'submit'
         end
 
@@ -39,9 +39,6 @@ RSpec.feature 'Course: Forum: Post: Management' do
         end
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
-        expect(topic.reload.posts.last.title).to \
-          eq(I18n.t('activerecord.attributes.course/discussion/post.title_reply_template',
-                    title: topic.title))
         expect(topic.reload.posts.last.text).to eq('test')
         expect(topic.reload.subscriptions.where(user: user).count).to eq(1)
       end
@@ -55,19 +52,17 @@ RSpec.feature 'Course: Forum: Post: Management' do
                                                                      topic.posts.last))
 
         # Edit with invalid information.
-        fill_in 'discussion_post_title', with: nil
+        fill_in 'discussion_post_text', with: nil
         click_button 'submit'
         expect(current_path).to eq(course_forum_topic_post_path(course, forum, topic,
                                                                 topic.posts.last))
         expect(page).to have_selector('div.alert.alert-danger')
 
         # Edit with valid information.
-        fill_in 'discussion_post_title', with: 'new_title'
         fill_in 'discussion_post_text', with: 'new_text'
         click_button 'submit'
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
-        expect(topic.reload.posts.last.title).to eq('new_title')
         expect(topic.reload.posts.last.text).to eq('new_text')
       end
 
@@ -90,9 +85,9 @@ RSpec.feature 'Course: Forum: Post: Management' do
         find_link(nil, href: reply_course_forum_topic_post_path(course, forum, topic, post)).click
         expect(current_path).to eq(reply_course_forum_topic_post_path(course, forum, topic, post))
 
-        # Reply a post with a missing title.
+        # Reply a post with empty content.
         within '#new_discussion_post' do
-          fill_in 'discussion_post_title', with: nil
+          fill_in 'discussion_post_text', with: nil
           click_button 'submit'
         end
 
@@ -108,9 +103,6 @@ RSpec.feature 'Course: Forum: Post: Management' do
         end
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
-        expect(topic.reload.posts.last.title).to \
-          eq(I18n.t('activerecord.attributes.course/discussion/post.title_reply_template',
-                    title: post.title))
         expect(topic.reload.posts.last.text).to eq('test')
         expect(topic.reload.posts.last.parent).to eq(post)
       end
@@ -122,7 +114,7 @@ RSpec.feature 'Course: Forum: Post: Management' do
         visit course_forum_topic_path(course, forum, topic)
 
         post_content = 'test post content'
-        fill_in 'text', with: post_content
+        fill_in 'discussion_post_text', with: post_content
         click_button 'submit'
 
         new_post = topic.posts.reload.last
@@ -216,7 +208,7 @@ RSpec.feature 'Course: Forum: Post: Management' do
         visit course_forum_topic_path(course, forum, topic)
 
         post_content = 'test post content'
-        fill_in 'text', with: post_content
+        fill_in 'discussion_post_text', with: post_content
         click_button 'submit'
 
         new_post = topic.posts.reload.last

--- a/spec/features/course/forum/topic_management_spec.rb
+++ b/spec/features/course/forum/topic_management_spec.rb
@@ -46,7 +46,6 @@ RSpec.feature 'Course: Forum: Topic: Management' do
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, forum.topics.last))
         expect(forum.topics.last.topic_type).to eq('announcement')
-        expect(forum.topics.last.posts.first.title).to eq(topic.title)
         expect(forum.topics.last.posts.first.text).to eq('test')
 
         # Create a sticky topic with a title.
@@ -54,6 +53,7 @@ RSpec.feature 'Course: Forum: Topic: Management' do
         find_link(nil, href: new_course_forum_topic_path(course, forum)).click
 
         fill_in 'title', with: topic.title
+        fill_in 'text', with: 'awesome text'
 
         within '#topic_topic_type' do
           find("option[value='sticky']").select_option
@@ -227,7 +227,6 @@ RSpec.feature 'Course: Forum: Topic: Management' do
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, forum.topics.last))
         expect(forum.topics.last.topic_type).to eq('normal')
-        expect(forum.topics.last.posts.first.title).to eq(topic.title)
         expect(forum.topics.last.posts.first.text).to eq('test')
 
         # Create a sticky topic with a title.
@@ -235,6 +234,7 @@ RSpec.feature 'Course: Forum: Topic: Management' do
         find_link(nil, href: new_course_forum_topic_path(course, forum)).click
 
         fill_in 'title', with: topic.title
+        fill_in 'text', with: 'awesome text'
 
         within '#topic_topic_type' do
           find("option[value='question']").select_option

--- a/spec/models/course/discussion/post_spec.rb
+++ b/spec/models/course/discussion/post_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Course::Discussion::Post, type: :model do
   it { is_expected.to belong_to(:creator) }
   it { is_expected.to have_many(:votes).inverse_of(:post).dependent(:destroy) }
   it { is_expected.to have_many(:children) }
+  it { is_expected.to validate_presence_of(:text) }
 
   let(:instance) { Instance.default }
   with_tenant(:instance) do
@@ -35,7 +36,7 @@ RSpec.describe Course::Discussion::Post, type: :model do
 
         { root: root, a: a, b: b, c: c } # Already in topological order.
       end
-      subject { graph[:root].topic.posts.ordered_topologically }
+      subject { graph[:root].topic.posts.reload.ordered_topologically }
 
       it 'sorts the posts topologically' do
         root_post = subject.to_a.first

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Course::Discussion::Topic, type: :model do
         subject
 
         expect(from_topic.posts.count).to be(0)
-        expect(to_topic.posts).to contain_exactly(*posts)
+        expect(to_topic.reload.posts).to contain_exactly(*posts)
       end
 
       it 'sets the pending status of the new topic' do

--- a/spec/models/course/forum/topic_spec.rb
+++ b/spec/models/course/forum/topic_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Course::Forum::Topic, type: :model do
       context 'when creating a new topic' do
         it 'generates an initial post with the same title as the topic' do
           expect(topic.posts.count).to eq(1)
-          expect(topic.posts.first.title).to eq('lol')
         end
       end
 
@@ -59,7 +58,6 @@ RSpec.describe Course::Forum::Topic, type: :model do
         it 'does not change the number of posts and the title of the initial post' do
           expect(topic.posts.count).to eq(1)
           expect(topic.title).to eq('new title')
-          expect(topic.posts.first.title).to eq('lol')
         end
       end
     end


### PR DESCRIPTION
The "RE RE RE" thing makes forum experience quite frustrated, examples here: https://beta.coursemology.org/courses/2/forums/reflections-on-lectures

This PR:
- Make post title optional and do not display post title in forum
- Validates that post content cannot be empty

Maybe we should remove the title in db next.

![screen shot 2016-09-16 at 8 37 21 pm](https://cloud.githubusercontent.com/assets/4983239/18586229/3424e7da-7c4e-11e6-87de-cbf7253ac61f.png)