### PR TITLE
Seed users depending on environment

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,3 +31,5 @@ ActsAsTenant.with_tenant(Instance.default) do
     user.save!
   end
 end
+
+load(Rails.root.join( 'db', 'seeds', "#{Rails.env.downcase}.rb"))

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,15 +21,6 @@ ActsAsTenant.with_tenant(Instance.default) do
   unless User.exists?(User::DELETED_USER_ID)
     User.create!(id: User::DELETED_USER_ID, name: 'Deleted')
   end
-
-  # Create the default user account.
-  user = User::Email.find_by_email('test@example.org')
-  unless user
-    user = User.new(name: 'Administrator', email: 'test@example.org',
-                    password: 'Coursemology!', role: :administrator)
-    user.skip_confirmation!
-    user.save!
-  end
 end
 
 load(Rails.root.join( 'db', 'seeds', "#{Rails.env.downcase}.rb"))

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,0 +1,29 @@
+ActsAsTenant.with_tenant(Instance.default) do
+  # Create the default user account (administrator).
+  user = User::Email.find_by_email('test@example.org')
+  unless user
+    user = User.new(name: 'Administrator', email: 'test@example.org',
+                    password: 'Coursemology!', role: :administrator)
+    user.skip_confirmation!
+    user.save!
+  end
+
+  # Create an autograder account.
+  user = User::Email.find_by_email('autograder@example.org')
+  unless user
+    user = User.new(name: 'Autograder', email: 'autograder@example.org',
+                    password: 'randompassword', role: :auto_grader,
+                    authentication_token: 'randomtoken')
+    user.skip_confirmation!
+    user.save!
+  end
+
+  # Create a normal user account.
+  user = User::Email.find_by_email('user1@example.org')
+  unless user
+    user = User.new(name: 'user1', email: 'user1@example.org',
+                    password: 'Coursemology!', role: :normal)
+    user.skip_confirmation!
+    user.save!
+  end
+end

--- a/db/seeds/test.rb
+++ b/db/seeds/test.rb
@@ -1,0 +1,10 @@
+ActsAsTenant.with_tenant(Instance.default) do
+  # Create the default user account (administrator).
+  user = User::Email.find_by_email('test@example.org')
+  unless user
+    user = User.new(name: 'Administrator', email: 'test@example.org',
+                    password: 'Coursemology!', role: :administrator)
+    user.skip_confirmation!
+    user.save!
+  end
+end


### PR DESCRIPTION
Makes initial setup for testing locally less painful.

Separates out the creation of the admin user from `db:seed` so it isn't accidentally populated in a production database.