### PR TITLE
State achievements that depend on assessments in assessment listings

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -41,6 +41,7 @@ $picture-large: 140px !default;
 //## Variables for icons or logos used in Coursemology.
 $course-achievement-form-badge:   $picture-small !default;
 $course-achievement-user-profile: $picture-small !default;
+$course-assessment-achievement-badge: $picture-thumb !default;
 $course-user-achievement-badge: $picture-medium !default;
 $course-leaderboard-groupuser-picture: $picture-small !default;
 $course-leaderboard-user-picture: $picture-small !default;

--- a/app/assets/stylesheets/course/assessment/assessments.scss
+++ b/app/assets/stylesheets/course/assessment/assessments.scss
@@ -14,5 +14,16 @@
     .condition-not-satisfied {
       color: $red;
     }
+
+    .achievement-badge {
+      a {
+        text-decoration: none;
+      }
+
+      .image > img {
+        height: $course-assessment-achievement-badge;
+        width: $course-assessment-achievement-badge;
+      }
+    }
   }
 }

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -2,6 +2,7 @@
 class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   def index
     @assessments = @assessments.ordered_by_date.with_submissions_by(current_user)
+    @conditional_service = Course::Assessment::AchievementPreloadService.new(@assessments)
   end
 
   def show

--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module Course::Assessment::AssessmentsHelper
+  include Course::Achievement::AchievementsHelper
+
   def display_assessment_tabs
     return nil if @category.tabs.count == 1
     tabs do

--- a/app/services/course/assessment/achievement_preload_service.rb
+++ b/app/services/course/assessment/achievement_preload_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# This service preloads all Achievement conditionals which lists Assessments as conditions.
+# Used for Assessments#Index to reduce n+1 queries.
+class Course::Assessment::AchievementPreloadService
+  # Initialises the service with the listed assessments.
+  #
+  # @param [Array<Course::Assessment>] assessments
+  def initialize(assessments)
+    @assessment_ids = assessments.map(&:id)
+  end
+
+  # Returns all achievement conditionals listing the given assessment as a condition.
+  #
+  # @param [Course::Assessment] assessment
+  # @return [Array<Course::Achievement>]
+  def achievement_conditional_for(assessment)
+    achievement_ids = assessment_achievement_hash[assessment.id]
+    return [] unless achievement_ids
+    achievements.select { |ach| achievement_ids.include?(ach.id) }
+  end
+
+  private
+
+  # Loads the relevant assessment_conditions
+  def assessment_condition_ids
+    @assessment_condition_ids ||=
+      Course::Condition::Assessment.where(assessment_id: @assessment_ids)
+  end
+
+  # Loads the relevant achievements
+  def achievements
+    @achievements ||= begin
+      achievement_ids = assessment_achievement_hash.values.flatten.uniq
+      Course::Achievement.where(id: achievement_ids)
+    end
+  end
+
+  # Builds the hash linking the specific assessment_id to the achievement_id.
+  # eg. { 1: [2, 4], 3: [4] } Indicates assessment 1 is required for achievements 2 and 4,
+  #   while assessment 3 is required for achievement 4.
+  #
+  # @return [Hash]
+  def assessment_achievement_hash
+    @hash ||= {}.tap do |result|
+      assessment_condition_with_achievement_conditional.map do |condition|
+        assessment_id = condition.specific.assessment_id
+        result[assessment_id] = [] unless result.key?(assessment_id)
+        result[assessment_id] << condition.conditional_id
+      end
+    end
+  end
+
+  # Loads the conditions with Assessments as the condition and Achievements as the conditional
+  # Query also eager loads the specific condition.
+  def assessment_condition_with_achievement_conditional
+    Course::Condition.where(actable_type: Course::Condition::Assessment.name,
+                            actable_id: assessment_condition_ids,
+                            conditional_type: Course::Achievement.name).
+      includes(:actable)
+  end
+end

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -10,6 +10,11 @@
         =< fa_icon 'eye-slash'.freeze
 
   td = assessment.total_exp
+  td.achievement-badge
+    - achievement_conditionals = @conditional_service.achievement_conditional_for(assessment)
+    - achievement_conditionals.each do |achievement|
+      = link_to course_achievement_path(current_course, achievement) do
+        = display_achievement_badge(achievement)
   td
     - if condition_not_satisfied(assessment)
       div.condition-not-satisfied data-toggle='tooltip' title="#{t('.condition_not_satisfied')}"

--- a/app/views/course/assessment/assessments/index.html.slim
+++ b/app/views/course/assessment/assessments/index.html.slim
@@ -9,6 +9,7 @@ table.table.assessments-list.table-hover
     tr
       th = t('.title')
       th = t('.maximum_experience_points')
+      th = t('.requirement_for')
       th = t('.start_at')
       th = t('.bonus_cut_off')
       th = t('.end_at')

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -16,6 +16,7 @@ en:
           bonus_cut_off: 'Bonus Cut Off'
           end_at: 'End At'
           maximum_experience_points: 'Maximum Experience Points'
+          requirement_for: 'Requirement For'
         assessment:
           attempt: 'Attempt'
           condition_not_satisfied: 'You do not fulfill the requirements of the assessment'

--- a/spec/services/course/assessment/achievement_preload_service_spec.rb
+++ b/spec/services/course/assessment/achievement_preload_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::AchievementPreloadService, type: :service do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let!(:course) { create(:course) }
+    let!(:assessments) { create_list(:assessment, 2, course: course) }
+    let!(:assessment_condition) do
+      create(:course_condition_assessment, :achievement_conditional,
+             course: course, assessment: assessments[0])
+    end
+
+    describe '#achievement_condition_for' do
+      subject do
+        service = Course::Assessment::AchievementPreloadService.new(assessments)
+        service.achievement_conditional_for(assessment)
+      end
+
+      context 'when the assessment is a condition for an achievement conditional' do
+        let(:assessment) { assessments[0] }
+        let(:achievement) { assessment_condition.conditional }
+
+        it 'returns the achievement' do
+          expect(subject).to contain_exactly(achievement)
+        end
+      end
+
+      context 'when the assessment is not a condition for any achievements' do
+        let(:assessment) { assessments[1] }
+
+        it 'returns an empty array' do
+          expect(subject).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1044 

To prevent N+1, I used a service to preload all the assessments and achievements (along with the conditions and conditionals). 