### PR TITLE
Show when a submission was attempted

### DIFF
--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -36,6 +36,9 @@ div.panel.panel-default
           th = t('.due_at')
           td = format_datetime(@assessment.end_at) if @assessment.end_at
         tr
+          th = t('.attempted_at')
+          td = format_datetime(@submission.created_at)
+        tr
           th = @submission.class.human_attribute_name(:submitted_at)
           td = format_datetime(@submission.submitted_at)
         tr

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -44,6 +44,7 @@ en:
             student: :'course.users.role.student'
             status: 'Status'
             due_at: 'Due At'
+            attempted_at: 'Attempted At'
             statistics: 'Statistics'
             multiplier: 'Multiplier'
             question: 'Question'


### PR DESCRIPTION
Name the field 'Attempted At' as the time the submission was created is the
time the student first attempts the assessment.

Fixes #1506.

![screen shot 2016-09-19 at 4 02 29 pm](https://cloud.githubusercontent.com/assets/1902527/18625681/bf9f3186-7e82-11e6-8274-e659523b3128.png)
