### PR TITLE
Show test case output to staff.

### DIFF
--- a/app/helpers/course/assessment/answer/programming_helper.rb
+++ b/app/helpers/course/assessment/answer/programming_helper.rb
@@ -24,6 +24,33 @@ module Course::Assessment::Answer::ProgrammingHelper
     "line_annotation_file_#{file.id}_line_#{line_number}_annotation"
   end
 
+  # Get a hint message. Use the one from test_result if available, else fallback to the one from
+  # the test case.
+  #
+  # @param [Course::Assessment::Question::ProgrammingTestCase] The test case
+  # @param [Course::Assessment::Answer::ProgrammingAutoGradingTestResult] The test result
+  # @return [String] The hint, or an empty string if there isn't one
+  def get_hint(test_case, test_case_result)
+    hint = test_case_result.messages['hint'] if test_case_result
+    hint ||= test_case.hint
+    hint || ''
+  end
+
+  # Get the output message for the tutors to see when grading. Use the output meta attribute if
+  # available, else fallback to the failure message, error message, and finally empty string.
+  #
+  # @param [Course::Assessment::Answer::ProgrammingAutoGradingTestResult] The test result
+  # @return [String] The output, failure message, error message or empty string
+  #   if the previous 3 don't exist.
+  def get_output(test_case_result)
+    if test_case_result
+      output = test_case_result.messages['output']
+      output = test_case_result.messages['failure'] if output.blank?
+      output = test_case_result.messages['error'] if output.blank?
+    end
+    output || ''
+  end
+
   private
 
   # Inserts annotations into the generated code block.
@@ -95,17 +122,5 @@ module Course::Assessment::Answer::ProgrammingHelper
                   object: discussion_topic
 
     line_discussion_cell.inner_html = html
-  end
-
-  # Get a hint message. Use the one from test_result if available, else fallback to the one from
-  # the test case.
-  #
-  # @param [Course::Assessment::Question::ProgrammingTestCase] The test case
-  # @param [Course::Assessment::Answer::ProgrammingAutoGradingTestResult] The test result
-  # @return [String] The hint, or an empty string if there isn't one
-  def get_hint(test_case, test_case_result)
-    hint = test_case_result.messages['hint'] if test_case_result
-    hint ||= test_case.hint
-    hint || ''
   end
 end

--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -17,7 +17,10 @@ table.table.table-striped.table-hover
         th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier)
       th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expression)
       th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expected)
-      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:hint)
+      - if can?(:grade, answer.answer)
+        th = t('.output')
+      - if @submission.attempting?
+        th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:hint)
       th = t('.passed')
   tbody
     tr
@@ -35,14 +38,18 @@ table.table.table-striped.table-hover
         td = format_html(test_case.expression)
         td
           div.expected = format_html(test_case.expected)
-        td
-          - if !test_case_result || !test_case_result.passed?
-            = simple_format(get_hint(test_case, test_case_result))
+        - if can?(:grade, answer.answer)
+          td = simple_format(get_output(test_case_result))
+        - if @submission.attempting?
+          td
+            - if !test_case_result || !test_case_result.passed?
+              = simple_format(get_hint(test_case, test_case_result))
         td
           - if test_case_result && test_case_result.passed?
             = fa_icon 'check'.freeze
           - elsif test_case_result
             = fa_icon 'times'.freeze
+
   - if can?(:grade, answer.answer)
     tbody
       tr
@@ -58,9 +65,12 @@ table.table.table-striped.table-hover
           td = format_html(test_case.expression)
           td
             div.expected = format_html(test_case.expected)
-          td
-            - if !test_case_result || !test_case_result.passed?
-              = simple_format(get_hint(test_case, test_case_result))
+          - if can?(:grade, answer.answer)
+            td = simple_format(get_output(test_case_result))
+          - if @submission.attempting?
+            td
+              - if !test_case_result || !test_case_result.passed?
+                = simple_format(get_hint(test_case, test_case_result))
           td
             - if test_case_result && test_case_result.passed?
               = fa_icon 'check'.freeze
@@ -77,9 +87,12 @@ table.table.table-striped.table-hover
             td = format_html(test_case.expression)
             td
               div.expected = format_html(test_case.expected)
-            td
-              - if !test_case_result || !test_case_result.passed?
-                = simple_format(get_hint(test_case, test_case_result))
+            - if can?(:grade, answer.answer)
+              td = simple_format(get_output(test_case_result))
+            - if @submission.attempting?
+              td
+                - if !test_case_result || !test_case_result.passed?
+                  = simple_format(get_hint(test_case, test_case_result))
             td
               - if test_case_result && test_case_result.passed?
                 = fa_icon 'check'.freeze

--- a/config/locales/en/course/assessment/answer/programming.yml
+++ b/config/locales/en/course/assessment/answer/programming.yml
@@ -16,6 +16,7 @@ en:
             public: :'course.assessment.question.programming.form_test_cases.public'
             evaluation: :'course.assessment.question.programming.form_test_cases.evaluation'
             test_cases: :'course.assessment.question.programming.form_test_cases.test_cases'
+            output: 'Output'
             failed_public_message: 'Your code fails one or more public test cases.'
             failed_private_message: 'Your code fails one or more private test cases.'
             failed_evaluation_message: "Student's code has failed one or more evaluation test cases."

--- a/spec/factories/course_assessment_answer_programming_auto_grading_test_results.rb
+++ b/spec/factories/course_assessment_answer_programming_auto_grading_test_results.rb
@@ -4,5 +4,29 @@ FactoryGirl.define do
           class: Course::Assessment::Answer::ProgrammingAutoGradingTestResult do
     auto_grading { build(:course_assessment_answer_programming_auto_grading) }
     passed true
+
+    trait :failed do
+      passed false
+      messages { { 'failure': 'simulated failure message' } }
+    end
+
+    trait :errored do
+      passed false
+      messages { { 'error': 'simulated error message' } }
+    end
+
+    trait :output do
+      messages { { 'output': 'simulated test function output' } }
+    end
+
+    trait :failed_with_output do
+      passed false
+      messages do
+        {
+          'failure': 'simulated failure message',
+          'output': 'simulated failed output'
+        }
+      end
+    end
   end
 end

--- a/spec/helpers/course/assessment/answer/programming_helper_spec.rb
+++ b/spec/helpers/course/assessment/answer/programming_helper_spec.rb
@@ -57,5 +57,43 @@ RSpec.describe Course::Assessment::Answer::ProgrammingHelper do
         end
       end
     end
+
+    describe '#get_output' do
+      let(:test_result) do
+        build_stubbed(:course_assessment_answer_programming_auto_grading_test_result,
+                      test_result_trait)
+      end
+      subject { get_output(test_result) }
+
+      context 'when there are no messages' do
+        let(:test_result_trait) {}
+
+        it { is_expected.to eq('') }
+      end
+
+      context 'when test failed' do
+        let(:test_result_trait) { :failed }
+
+        it { is_expected.to eq(test_result.messages['failure']) }
+      end
+
+      context 'when test errored' do
+        let(:test_result_trait) { :errored }
+
+        it { is_expected.to eq(test_result.messages['error']) }
+      end
+
+      context 'when output attribute is set' do
+        let(:test_result_trait) { :output }
+
+        it { is_expected.to eq(test_result.messages['output']) }
+      end
+
+      context 'when both output and failure messages are present' do
+        let(:test_result_trait) { :failed_with_output }
+
+        it { is_expected.to eq(test_result.messages['output']) }
+      end
+    end
   end
 end


### PR DESCRIPTION
If there is no output attribute, fallback to failure message, error
message, then empty string.

Hide hint when submission is not being attempted.

Fixes #1461, fixes #1499.

![screen shot 2016-09-20 at 2 38 28 pm](https://cloud.githubusercontent.com/assets/1902527/18659889/fad04a52-7f3f-11e6-93e3-088451ebc710.png)
