### PR TITLE
Rename `StudentStatisticsService` to `GroupManagerPreloadService`

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -56,7 +56,7 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   def load_group_managers
     course_staff = current_course.course_users.staff.with_approved_state.without_phantom_users.
                    includes(:groups)
-    @service = Course::StudentStatisticsService.new(course_staff)
+    @service = Course::GroupManagerPreloadService.new(course_staff)
   end
 
   def add_submissions_breadcrumb

--- a/app/controllers/course/statistics_controller.rb
+++ b/app/controllers/course/statistics_controller.rb
@@ -8,7 +8,7 @@ class Course::StatisticsController < Course::ComponentController
     staff = course_users.staff.without_phantom_users
     all_students = course_users.students.ordered_by_experience_points
     @phantom_students, @students = all_students.partition(&:phantom?)
-    @service = Course::StudentStatisticsService.new(staff)
+    @service = Course::GroupManagerPreloadService.new(staff)
   end
 
   def staff

--- a/app/services/course/group_manager_preload_service.rb
+++ b/app/services/course/group_manager_preload_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Performs calculations for Student Statistics Pages.
-class Course::StudentStatisticsService
+# Allows querying of group managers of users in a given collection without generating N+1 queries.
+class Course::GroupManagerPreloadService
   # Sets the collection of CourseUsers which `group_managers_of` will search from.
   # Assumes that GroupUsers and their Groups have been loaded for each CourseUser.
   #


### PR DESCRIPTION
Standardize naming with #1505