### PR TITLE
Implement file upload question

### DIFF
--- a/app/controllers/course/assessment/question/text_responses_controller.rb
+++ b/app/controllers/course/assessment/question/text_responses_controller.rb
@@ -6,12 +6,16 @@ class Course::Assessment::Question::TextResponsesController < \
                               through: :assessment, parent: false
 
   def new
+    if params[:file_upload] == 'true'
+      @text_response_question.hide_text = true
+      @text_response_question.allow_attachment = true
+    end
   end
 
   def create
     if @text_response_question.save
       redirect_to course_assessment_path(current_course, @assessment),
-                  success: t('.success')
+                  success: t('.success', name: question_type)
     else
       render 'new'
     end
@@ -23,20 +27,21 @@ class Course::Assessment::Question::TextResponsesController < \
   def update
     if @text_response_question.update_attributes(text_response_question_params)
       redirect_to course_assessment_path(current_course, @assessment),
-                  success: t('.success')
+                  success: t('.success', name: question_type)
     else
       render 'edit'
     end
   end
 
   def destroy
+    title = question_type
     if @text_response_question.destroy
       redirect_to course_assessment_path(current_course, @assessment),
-                  success: t('.success')
+                  success: t('.success', name: title)
     else
       error = @text_response_question.errors.full_messages.to_sentence
       redirect_to course_assessment_path(current_course, @assessment),
-                  danger: t('.failure', error: error)
+                  danger: t('.failure', name: title, error: error)
     end
   end
 
@@ -45,8 +50,13 @@ class Course::Assessment::Question::TextResponsesController < \
   def text_response_question_params
     params.require(:question_text_response).permit(
       :title, :description, :staff_only_comments, :maximum_grade, :weight, :allow_attachment,
+      :hide_text,
       skill_ids: [],
       solutions_attributes: [:_destroy, :id, :solution_type, :solution, :grade, :explanation]
     )
+  end
+
+  def question_type
+    @text_response_question.question_type
   end
 end

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -13,6 +13,20 @@ class Course::Assessment::Question::TextResponse < ActiveRecord::Base
     !solutions.empty?
   end
 
+  # Method provides readability to identifying whether a question is a file upload question.
+  #  Used with the front-end translations.
+  def file_upload_question?
+    hide_text
+  end
+
+  def question_type
+    if file_upload_question?
+      I18n.t('activerecord.attributes.models.course/assessment/question/text_response.file_upload')
+    else
+      I18n.t('activerecord.attributes.models.course/assessment/question/text_response.text_response')
+    end
+  end
+
   def auto_grader
     Course::Assessment::Answer::TextResponseAutoGradingService.new
   end

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -1,6 +1,7 @@
 - question = text_response.question.specific
-- readonly = cannot?(:update, text_response.answer)
-= f.input :answer_text, label: false, readonly: readonly
+- unless question.hide_text?
+  - readonly = cannot?(:update, text_response.answer)
+  = f.input :answer_text, label: false, readonly: readonly
 - if question.allow_attachment?
   = f.attachment
 

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -66,6 +66,11 @@
                       new_course_assessment_question_text_response_path(current_course, @assessment),
                       role: 'menuitem')
           li role='presentation'
+            = link_to(t('.new_question.file_upload'),
+                      new_course_assessment_question_text_response_path(current_course, @assessment,
+                                                                        { file_upload: true }),
+                      role: 'menuitem')
+          li role='presentation'
             = link_to(t('.new_question.programming'),
                       new_course_assessment_question_programming_path(current_course, @assessment),
                       role: 'menuitem')

--- a/app/views/course/assessment/question/text_responses/_form.html.slim
+++ b/app/views/course/assessment/question/text_responses/_form.html.slim
@@ -1,21 +1,30 @@
 = simple_form_for [current_course, @assessment, @text_response_question] do |f|
   = f.error_notification
   = render partial: 'course/assessment/questions/form', locals: { f: f }
-  = f.input :allow_attachment, label: t('.allow_upload_file')
+  = f.hidden_field :hide_text
 
-  table.table.table-striped.table-hover
-    thead
-      tr
-        th = t('.solution_type')
-        th = t('.solution')
-        th = t('.grade')
-        th = t('.explanation')
-        th
-          div.pull-right
-            = link_to_add_association t('.add_solution'), f, :solutions,
-                                      find_selector: 'tbody', insert_using: 'append'
-    tbody
-      = f.simple_fields_for :solutions do |solutions_form|
-        = render 'solution_fields', f: solutions_form
+  - if f.object.file_upload_question?
+    = f.hidden_field :allow_attachment
+  - else
+    = f.input :allow_attachment, label: t('.allow_upload_file')
+    table.table.table-striped.table-hover
+      thead
+        tr
+          th = t('.solution_type')
+          th = t('.solution')
+          th = t('.grade')
+          th = t('.explanation')
+          th
+            div.pull-right
+              = link_to_add_association t('.add_solution'), f, :solutions,
+                                        find_selector: 'tbody', insert_using: 'append'
+      tbody
+        = f.simple_fields_for :solutions do |solutions_form|
+          = render 'solution_fields', f: solutions_form
 
-  = f.button :submit
+  - name = f.object.file_upload_question? ? t('.file_upload') : t('.text_response')
+  - if f.object.persisted?
+    - button_text =  t('helpers.buttons.update', model: name)
+  - else
+    - button_text =  t('helpers.buttons.create', model: name)
+  = f.button :submit, button_text

--- a/app/views/course/assessment/question/text_responses/new.html.slim
+++ b/app/views/course/assessment/question/text_responses/new.html.slim
@@ -1,3 +1,7 @@
-- add_breadcrumb :new
-= page_header
+- if @text_response_question.file_upload_question?
+  - add_breadcrumb :new_file_upload
+  = page_header t('.file_upload')
+- else
+  - add_breadcrumb :new_text_response
+  = page_header t('.text_response')
 = render partial: 'form'

--- a/config/locales/en/activerecord/course/assessment/question/text_response.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_response.yml
@@ -1,5 +1,10 @@
 en:
   activerecord:
+    attributes:
+      models:
+        course/assessment/question/text_response:
+          text_response: 'text response question'
+          file_upload: 'file upload question'
     errors:
       models:
         course/assessment/question/text_response:

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -75,7 +75,8 @@ en:
           multiple_responses:
             new: :'course.assessment.question.multiple_responses.new.header'
           text_responses:
-            new: :'course.assessment.question.text_responses.new.header'
+            new_text_response: :'course.assessment.question.text_responses.new.text_response'
+            new_file_upload: :'course.assessment.question.text_responses.new.file_upload'
           programming:
             new: :'course.assessment.question.programming.new.header'
         skills:

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -27,6 +27,8 @@ en:
         update: 'Update Assessment Condition'
     buttons:
       new: 'New %{model}'
+      create: 'Create %{model}'
       edit: 'Edit %{model}'
+      update: 'Update %{model}'
       delete: 'Delete %{model}'
       delete_confirm_message: 'Are you sure?'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -37,6 +37,7 @@ en:
             multiple_choice: 'Multiple Choice'
             multiple_response: 'Multiple Response'
             text_response: 'Text Response'
+            file_upload: 'File Upload'
             programming: 'Programming'
         new:
           header: 'New Assessment'

--- a/config/locales/en/course/assessment/question/text_response.yml
+++ b/config/locales/en/course/assessment/question/text_response.yml
@@ -20,6 +20,8 @@ en:
             grade: 'Grade'
             explanation: 'Explanation'
             add_solution: 'Add Solution'
+            file_upload: 'File Upload Question'
+            text_response: 'Text Response Question'
           solution_fields:
             explanation_hint: 'The explanation to show after the student submits his answer.'
             remove: 'Remove'

--- a/config/locales/en/course/assessment/question/text_response.yml
+++ b/config/locales/en/course/assessment/question/text_response.yml
@@ -4,14 +4,15 @@ en:
       question:
         text_responses:
           new:
-            header: 'New Text Response Question'
+            text_response: 'New Text Response Question'
+            file_upload: 'New File Upload Question'
           create:
-            success: 'The text response question was created.'
+            success: 'The %{name} was created.'
           update:
-            success: 'The text response question was updated.'
+            success: 'The %{name} was updated.'
           destroy:
-            success: 'The text response question was deleted.'
-            failure: 'Could not delete text response question: %{error}'
+            success: 'The %{name} was deleted.'
+            failure: 'Could not delete %{name}: %{error}'
           form:
             allow_upload_file: 'Allow file upload in the answer'
             solution_type: 'Type'

--- a/db/migrate/20160920101847_add_hide_text_to_course_assessment_question_text_responses.rb
+++ b/db/migrate/20160920101847_add_hide_text_to_course_assessment_question_text_responses.rb
@@ -1,0 +1,6 @@
+class AddHideTextToCourseAssessmentQuestionTextResponses < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_question_text_responses, :hide_text, :boolean,
+               default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160916101014) do
+ActiveRecord::Schema.define(version: 20160920101847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -298,6 +298,7 @@ ActiveRecord::Schema.define(version: 20160916101014) do
 
   create_table "course_assessment_question_text_responses", force: :cascade do |t|
     t.boolean "allow_attachment", :default=>false
+    t.boolean "hide_text",        :default=>false
   end
 
   create_table "course_assessment_question_text_response_solutions", force: :cascade do |t|

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -60,11 +60,22 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_file_upload_question do
+      after(:build) do |assessment, evaluator|
+        evaluator.question_count.downto(1).each do
+          question = build(:course_assessment_question_text_response, :file_upload_question,
+                           assessment: assessment)
+          assessment.questions << question.acting_as
+        end
+      end
+    end
+
     trait :with_all_question_types do
       with_mcq_question
       with_mrq_question
       with_programming_question
       with_text_response_question
+      with_file_upload_question
     end
 
     trait :worksheet do
@@ -100,6 +111,11 @@ FactoryGirl.define do
 
     trait :published_with_programming_question do
       with_programming_question
+      published
+    end
+
+    trait :published_with_file_upload_question do
+      with_file_upload_question
       published
     end
 

--- a/spec/factories/course_assessment_question_text_responses.rb
+++ b/spec/factories/course_assessment_question_text_responses.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
           class: Course::Assessment::Question::TextResponse,
           parent: :course_assessment_question do
     allow_attachment false
+    hide_text false
 
     solutions do
       [
@@ -26,6 +27,11 @@ FactoryGirl.define do
 
     trait :allow_attachment do
       allow_attachment true
+    end
+
+    trait :file_upload_question do
+      allow_attachment true
+      hide_text true
     end
   end
 end

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
 
         expect(answer.specific.attachment).to be_present
       end
+
+      scenario 'I cannot see the text box for a file upload question' do
+        assessment = create(:assessment, :published_with_file_upload_question, course: course)
+        submission = create(:course_assessment_submission, assessment: assessment, creator: user)
+
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
+        file_upload_answer = submission.answers.first
+        within find(content_tag_selector(file_upload_answer)) do
+          expect(page).not_to have_selector('textarea:not(.comment)')
+        end
+      end
     end
 
     context 'As Course Staff' do

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -39,6 +39,27 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         expect(question_created.allow_attachment).to be_truthy
       end
 
+      scenario 'I can create a new file upload question' do
+        visit course_assessment_path(course, assessment)
+        click_link I18n.t('course.assessment.assessments.show.new_question.file_upload')
+
+        file_upload_path = new_course_assessment_question_text_response_path(course, assessment)
+        expect(current_path).to eq(file_upload_path)
+
+        question_attributes = attributes_for(:course_assessment_question_text_response)
+        fill_in 'title', with: question_attributes[:title]
+        fill_in 'description', with: question_attributes[:description]
+        fill_in 'staff_only_comments', with: question_attributes[:staff_only_comments]
+        fill_in 'maximum_grade', with: question_attributes[:maximum_grade]
+        fill_in 'weight', with: question_attributes[:weight]
+        click_button I18n.t('helpers.buttons.create')
+
+        question_created = assessment.questions.first.specific
+        expect(page).to have_content_tag_for(question_created)
+        expect(question_created.hide_text).to be_truthy
+        expect(question_created.allow_attachment).to be_truthy
+      end
+
       scenario 'I can edit a text response question', js: true do
         question = create(:course_assessment_question_text_response, assessment: assessment,
                                                                      solutions: [])

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
     context 'As a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
 
-      scenario 'I can create a new question' do
+      scenario 'I can create a new text response question' do
         skill = create(:course_assessment_skill, course: course)
         visit course_assessment_path(course, assessment)
         click_link I18n.t('course.assessment.assessments.show.new_question.text_response')
@@ -30,7 +30,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         within find_field('skills') do
           select skill.title
         end
-        click_button 'submit'
+        click_button I18n.t('helpers.buttons.create')
 
         question_created = assessment.questions.first.specific
         expect(page).to have_content_tag_for(question_created)
@@ -39,7 +39,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         expect(question_created.allow_attachment).to be_truthy
       end
 
-      scenario 'I can edit a question', js: true do
+      scenario 'I can edit a text response question', js: true do
         question = create(:course_assessment_question_text_response, assessment: assessment,
                                                                      solutions: [])
         solutions = [
@@ -53,7 +53,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
 
         maximum_grade = 999.9
         fill_in 'maximum_grade', with: maximum_grade
-        click_button 'submit'
+        click_button I18n.t('helpers.buttons.update')
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(question.reload.maximum_grade).to eq(maximum_grade)
@@ -77,12 +77,12 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
             end
           end
         end
-        click_button 'submit'
+        click_button I18n.t('helpers.buttons.update')
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).to have_selector('div.alert.alert-success')
       end
 
-      scenario 'I can delete a question' do
+      scenario 'I can delete a text response question' do
         question = create(:course_assessment_question_text_response, assessment: assessment)
         visit course_assessment_path(course, assessment)
 

--- a/spec/models/course/assessment/question/text_response_spec.rb
+++ b/spec/models/course/assessment/question/text_response_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
       end
     end
 
+    describe '#file_upload_question?' do
+      subject { question.file_upload_question? }
+
+      context 'when hide_text is enabled' do
+        let(:question) { build(:course_assessment_question_text_response, :file_upload_question) }
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when hide_text is disabled' do
+        let(:question) { build(:course_assessment_question_text_response) }
+        it { is_expected.to eq(false) }
+      end
+    end
+
     describe 'validations' do
       subject { create(:course_assessment_question_text_response, maximum_grade: 10) }
 


### PR DESCRIPTION
Fixes #1516. 

Would need to check for design, I'm doing a few funny workarounds to ensure the translations are correct (for breadcrumbs, page_header, buttons, success/failure messages).

After this is merged, I think it will be a good idea to rename `Course::Assessment::Question::TextResponse` to something more general. Will separate that from this as we discuss the design of it here. 