### PR TITLE
Ensure that form contains whole upgrade-to-staff table

### DIFF
--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -4,10 +4,10 @@
 = render partial: 'tabs'
 
 div
-  table.table
-    = simple_form_for :course_user,
-                      url: course_users_upgrade_to_staff_path(current_course),
-                      method: :patch do |f|
+  = simple_form_for :course_user,
+                    url: course_users_upgrade_to_staff_path(current_course),
+                    method: :patch do |f|
+    table.table
       tr
         td = f.input :id, collection: @student_options,
                           label: false, selected: @student_options.first


### PR DESCRIPTION
Fixes #1525 

If form straddles multiple-cells, but not the whole table, the HTML is considered invalid and its behavior undefined.