### PR TITLE
Validate that assessment start date is not after end date

### DIFF
--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -5,7 +5,9 @@ class Course::LessonPlan::Item < ActiveRecord::Base
 
   after_initialize :set_default_values, if: :new_record?
 
-  validate :validate_presence_of_bonus_end_at
+  validate :validate_presence_of_bonus_end_at,
+           :validate_start_at_cannot_be_after_end_at
+
 
   # @!method self.ordered_by_date
   #   Orders the lesson plan items by the starting date.
@@ -37,5 +39,10 @@ class Course::LessonPlan::Item < ActiveRecord::Base
     if time_bonus_exp && time_bonus_exp > 0 && bonus_end_at.blank?
       errors.add(:bonus_end_at, :required)
     end
+  end
+
+  def validate_start_at_cannot_be_after_end_at
+    return unless end_at && start_at > end_at
+    errors.add(:start_at, :cannot_be_after_end_at)
   end
 end

--- a/config/locales/en/activerecord/course/lesson_plan.yml
+++ b/config/locales/en/activerecord/course/lesson_plan.yml
@@ -6,3 +6,5 @@ en:
           attributes:
             bonus_end_at:
               required: 'cannot be blank if time bonus exp is set'
+            start_at:
+              cannot_be_after_end_at: 'cannot be after end at'

--- a/spec/models/course/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan_item_spec.rb
@@ -36,14 +36,38 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
     end
 
     describe '#validations' do
+      subject { lesson_plan_item }
+
       context 'when time_bonus_exp is set without bonus_end_at' do
         let(:lesson_plan_item) do
           build(:course_lesson_plan_item, time_bonus_exp: 100, bonus_end_at: nil)
         end
 
         it 'is not valid' do
-          expect(lesson_plan_item).not_to be_valid
-          expect(lesson_plan_item.errors[:bonus_end_at]).to be_present
+          expect(subject).not_to be_valid
+          expect(subject.errors[:bonus_end_at]).to be_present
+        end
+      end
+
+      context 'when start_at is after end_at' do
+        let(:lesson_plan_item) do
+          build(:course_lesson_plan_item, start_at: 1.day.ago, end_at: 3.days.ago)
+        end
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:start_at]).to be_present
+        end
+      end
+
+      context 'when start_at is before end_at' do
+        let(:lesson_plan_item) do
+          build(:course_lesson_plan_item, start_at: 3.days.ago, end_at: 1.day.ago)
+        end
+
+        it 'is valid' do
+          expect(subject).to be_valid
+          expect(subject.errors[:start_at]).not_to be_present
         end
       end
     end


### PR DESCRIPTION
Due to ActiveRecord::ActsAs multiple table inheritance, the newly added
validation applies to both assessments and lesson plan events.

Fixes #1484.