### PR TITLE
Create submission when viewing assessment

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -6,6 +6,11 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def show
+    submission = Course::Assessment::Submission.new(assessment: @assessment,
+                                                    course_user: current_course_user)
+    suppress(Exception) do
+      submission.save!
+    end
   end
 
   def new

--- a/spec/features/course/assessment/assessment_viewing_spec.rb
+++ b/spec/features/course/assessment/assessment_viewing_spec.rb
@@ -51,15 +51,14 @@ RSpec.describe 'Course: Assessments: Viewing' do
         expect(page).to have_content_tag_for(condition_with_achievement_conditional)
       end
 
-      scenario 'I attempt the assessment from the show assessment page' do
-        # Create a random submission which does not belong to the user.
-        # The button should still be 'Attempt' with the random submission.
-        create(:course_assessment_submission, assessment: assessment)
+      scenario 'I resume the assessment from the show assessment page' do
         visit course_assessment_path(course, assessment)
+        submission = Course::Assessment::Submission.find_by(assessment: assessment, creator: user)
+        submission_path = edit_course_assessment_submission_path(course, assessment, submission)
 
         expect(page).to have_link(
-          I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-          href: course_assessment_submissions_path(course, assessment)
+          I18n.t('course.assessment.assessments.assessment_management_buttons.resume'),
+          href: submission_path
         )
       end
     end


### PR DESCRIPTION
Fixes #1529. Very rough draft for feedback and probably should not be merged in its current form.

This quick and dirty fix creates a submission when showing an assessment. If a submission already exists, validation fails and an exception is thrown. That is deliberately suppressed, but a more specific Exception name is welcome.

Need to see if this affects TAs testing out assessments, since the submission is immediately created with no questions.

This effectively bypasses the `create` action in the submissions controller and its check for an assessment with no questions.


