### PR TITLE
Fix styling for achievement and assessment tables

### DIFF
--- a/app/assets/stylesheets/course/achievement.scss
+++ b/app/assets/stylesheets/course/achievement.scss
@@ -6,18 +6,50 @@
   .achievement-list,
   .achievement-form {
     .image > img {
-      height: $course-achievement-form-badge;
-      width: $course-achievement-form-badge;
+      @include no-stretch;
+      max-height: $course-achievement-form-badge;
+      max-width: $course-achievement-form-badge;
     }
   }
 
   .achievement-list {
+    table-layout: fixed;
+
+    td,
+    th {
+      vertical-align: middle;
+    }
+
+    ul {
+      padding-left: 10%;
+    }
+
+    .btn-group {
+      display: flex;
+    }
+
+    .btn-group-vertical {
+      @extend .pull-right;
+      margin-right: 25%;
+      width: 39px;
+    }
+
     .granted {
       background-color: $course-achievement-granted-bg;
     }
 
     .locked {
       background-color: $course-achievement-locked-bg;
+    }
+
+    .table-badge {
+      @extend .text-center;
+      width: $course-achievement-form-badge * 1.5;
+    }
+
+    .table-description {
+      @extend .hidden-xs;
+      @extend .hidden-sm;
     }
   }
 

--- a/app/assets/stylesheets/course/assessment/assessments.scss
+++ b/app/assets/stylesheets/course/assessment/assessments.scss
@@ -22,7 +22,50 @@
 
       .image > img {
         height: $course-assessment-achievement-badge;
+        margin-bottom: 3px;
         width: $course-assessment-achievement-badge;
+      }
+    }
+
+    .assessments-list {
+      table-layout: fixed;
+
+      td,
+      th {
+        vertical-align: middle;
+      }
+
+      .btn-group {
+        display: flex;
+      }
+
+      .fa-book {
+        margin-right: 4px;
+      }
+
+      .table-bonus-cut-off,
+      .table-requirement-for {
+        @extend .hidden-xs;
+        @extend .hidden-sm;
+        @extend .hidden-md;
+        @extend .text-center;
+      }
+
+      .table-end-at {
+        @extend .text-center;
+      }
+
+      .table-experience-points {
+        @extend .hidden-xs;
+        @extend .hidden-sm;
+        @extend .text-center;
+        width: 150px;
+      }
+
+
+      .table-start-at {
+        @extend .hidden-xs;
+        @extend .text-center;
       }
     }
   }

--- a/app/views/course/achievement/achievements/_achievement.html.slim
+++ b/app/views/course/achievement/achievements/_achievement.html.slim
@@ -2,7 +2,7 @@
                   class: draft_class(achievement) + \
                          achievement_status_class(achievement, current_course_user)) do
 
-  td
+  td.table-badge
     - if can?(:display_badge, achievement)
       = display_achievement_badge(achievement)
     - else
@@ -15,7 +15,7 @@
       small title=achievement
         =< fa_icon 'eye-slash'.freeze
 
-  td
+  td.table-description colspan=2
     div.description
       = format_html(achievement.description)
 
@@ -25,15 +25,9 @@
         - achievement.specific_conditions.each do |condition|
           li = condition.title
 
-  td
-    div.btn-group
-      - if can?(:award, achievement)
-        = link_to course_achievement_course_users_path(current_course, achievement),
-                  class: ['btn', 'btn-info'], title: t('.award_button') do
-          = fa_icon 'trophy'.freeze
-      - else
-        = content_tag(:span, class:['btn', 'btn-info'], title: t('.disabled_award_button'),
-                             disabled: true) do
-          = fa_icon 'trophy'.freeze
-      = edit_button([current_course, achievement]) if can?(:edit, achievement)
-      = delete_button([current_course, achievement]) if can?(:delete, achievement)
+  - if can?(:manage, achievement)
+    td
+      div.btn-group.hidden-xs
+        = render 'achievement_management_buttons', achievement: achievement
+      div.btn-group-vertical.visible-xs-block
+        = render 'achievement_management_buttons', achievement: achievement

--- a/app/views/course/achievement/achievements/_achievement_management_buttons.html.slim
+++ b/app/views/course/achievement/achievements/_achievement_management_buttons.html.slim
@@ -1,0 +1,10 @@
+- if can?(:award, achievement)
+  = link_to course_achievement_course_users_path(current_course, achievement),
+            class: ['btn', 'btn-info'], title: t('.award') do
+    = fa_icon 'trophy'.freeze
+- else
+  = content_tag(:span, class:['btn', 'btn-info'], title: t('.disabled_award'),
+                disabled: true) do
+    = fa_icon 'trophy'.freeze
+= edit_button([current_course, achievement]) if can?(:edit, achievement)
+= delete_button([current_course, achievement]) if can?(:delete, achievement)

--- a/app/views/course/achievement/achievements/_achievements.html.slim
+++ b/app/views/course/achievement/achievements/_achievements.html.slim
@@ -1,11 +1,13 @@
 table.table.achievement-list.table-hover
   thead
     tr
-      th = t('.badge')
+      th.table-badge = t('.badge')
       th = t('.title')
-      th = t('.description')
+      th.table-description = t('.description')
+      th.table-description
       th = t('.requirements') if include_requirements
-      th
+      - if can?(:manage, achievements.first)
+        th
   tbody
     = render partial: 'achievement',
              collection: achievements,

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -1,5 +1,5 @@
 = content_tag_for(:tr, assessment, class: time_period_class(assessment) + draft_class(assessment))
-  th
+  th colspan=2
     = link_to(format_inline_text(assessment.title),
               course_assessment_path(current_course, assessment))
     - unless assessment.currently_active?
@@ -9,19 +9,21 @@
       small title=draft_message(assessment)
         =< fa_icon 'eye-slash'.freeze
 
-  td = assessment.total_exp
-  td.achievement-badge
+  td.table-experience-points = assessment.total_exp
+  td.achievement-badge.table-requirement-for
     - achievement_conditionals = @conditional_service.achievement_conditional_for(assessment)
     - achievement_conditionals.each do |achievement|
       = link_to course_achievement_path(current_course, achievement) do
         = display_achievement_badge(achievement)
-  td
+  td.table-start-at
     - if condition_not_satisfied(assessment)
       div.condition-not-satisfied data-toggle='tooltip' title="#{t('.condition_not_satisfied')}"
-        = format_datetime(assessment.start_at)
+        = format_datetime(assessment.start_at, :short)
     - else
-      = format_datetime(assessment.start_at)
-  td = format_datetime(assessment.bonus_end_at) if assessment.bonus_end_at.present?
-  td = format_datetime(assessment.end_at) if assessment.end_at.present?
-  td
+      = format_datetime(assessment.start_at, :short)
+  td.table-bonus-cut-off
+    = format_datetime(assessment.bonus_end_at, :short) if assessment.bonus_end_at.present?
+  td.table-end-at
+    = format_datetime(assessment.end_at, :short) if assessment.end_at.present?
+  td.table-buttons colspan=2
     = render 'assessment_management_buttons', assessment: assessment

--- a/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
+++ b/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
@@ -16,5 +16,7 @@ div.btn-group
     = link_to(t('.attempt'), '#', class: ['btn', 'btn-info', 'disabled'])
 
   - if can?(:manage, assessment)
-    = link_to(t('.submissions'), course_assessment_submissions_path(current_course, assessment),
-              class: ['btn', 'btn-default'])
+    = link_to(course_assessment_submissions_path(current_course, assessment),
+              class: ['btn', 'btn-default']) do
+      span.visible-xs-block = fa_icon 'book'
+      span.hidden-xs = t('.submissions')

--- a/app/views/course/assessment/assessments/index.html.slim
+++ b/app/views/course/assessment/assessments/index.html.slim
@@ -8,11 +8,13 @@ table.table.assessments-list.table-hover
   thead
     tr
       th = t('.title')
-      th = t('.maximum_experience_points')
-      th = t('.requirement_for')
-      th = t('.start_at')
-      th = t('.bonus_cut_off')
-      th = t('.end_at')
+      th
+      th.table-experience-points = t('.maximum_experience_points')
+      th.table-requirement-for = t('.requirement_for')
+      th.table-start-at = t('.start_at')
+      th.table-bonus-cut-off = t('.bonus_cut_off')
+      th.table-end-at = t('.end_at')
+      th
       th
   tbody
     = render partial: 'assessment', collection: @assessments

--- a/config/locales/en/course/achievement/achievements.yml
+++ b/config/locales/en/course/achievement/achievements.yml
@@ -25,7 +25,7 @@ en:
           title: 'Title'
           description: 'Description'
           requirements: 'Requirements'
-        achievement:
-          award_button: :'course.achievement.course_users.course_users_form.header'
-          disabled_award_button: >
+        achievement_management_buttons:
+          award: :'course.achievement.course_users.course_users_form.header'
+          disabled_award: >
             Automatically-awarded achievements cannot be manually awarded to students.

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -40,7 +40,8 @@ RSpec.feature 'Course: Achievements' do
         visit course_achievements_path(course)
 
         within find(content_tag_selector(achievement)) do
-          expect { find(:css, 'a.delete').click }.to change { course.achievements.count }.by(-1)
+          # first is used because a duplicate set of buttons are used for mobile view.
+          expect { first(:css, 'a.delete').click }.to change { course.achievements.count }.by(-1)
         end
         expect(page).to have_selector('div', text: I18n.t('course.achievement.achievements.'\
                                                           'destroy.success'))
@@ -90,8 +91,11 @@ RSpec.feature 'Course: Achievements' do
           not_to have_link(nil,
                            href: course_achievement_course_users_path(course, auto_achievement))
 
-        expect(page).to have_content_tag_for(manual_achievement)
-        find_link(nil, href: course_achievement_course_users_path(course, manual_achievement)).click
+        within find(content_tag_selector(manual_achievement)) do
+          # first is used because a duplicate set of buttons are used for mobile view.
+          first(:link, href: course_achievement_course_users_path(course, manual_achievement)).click
+        end
+
         expect(page).to have_unchecked_field(course_user_id)
         expect(page).not_to have_field(unregistered_user_id)
         check course_user_id


### PR DESCRIPTION
Tables are almost impossible to work with for responsiveness. Anyway, this PR fixes some of the styling to ensure a slightly nicer user experience. Note that it is not perfect as there are still some kinks, but this should ensure that is is _usable_. 

For mobile views, I've taken the liberty to hide less important columns as the real estate decreases. Would be best to view it through the gifs below. 



### Assessment
![assessment-responsive](https://cloud.githubusercontent.com/assets/4353853/18910958/f664b958-85ac-11e6-9719-d454bba8e639.gif)

- At tablet size, hide `bonus_end_at` and `requirement_for`
- At mobile size, hide `start_at` and `max_exp_points`
- Shorten dates
- Centralise text for all except assessment title
- Made more space for assessment title column

### Achievement
![achievement-responsive](https://cloud.githubusercontent.com/assets/4353853/18910957/f663fea0-85ac-11e6-8a52-4a51480857b9.gif)

- At tablet size, hide `description`
- At mobile size, vertically stack buttons for staff
- Made more space for description column
