### PR TITLE
Don't apply tooltip to the Facebook like button

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -15,7 +15,11 @@
 
   function initializeComponents(element) {
     $('[data-toggle="popover"]', element).popover();
-    $('[title]', element).tooltip();
+    // The design of Coursemology is such that tooltips are attached to any
+    // element with a title attribute, but we do not want that for the Facebook
+    // button
+    // See https://github.com/Coursemology/coursemology-theme/pull/5
+    $('[title]', element).not('.fb-like *').tooltip();
     $('input.toggle-all[type="checkbox"]', element).checkboxToggleAll();
     $('textarea.code', element).ace();
     initializeSummernote(element);


### PR DESCRIPTION
The current design of Coursemology will attach a tooltip to any element
with a "title" attribute. This is incompatible with the Facebook like
button. We do not want a tooltip attached to the Facebook button.

This fix is required to support any layout that wants to include the
official Facebook like button.