### PR TITLE
Improve 'not published' and 'not yet open' indication for assessments

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -10,6 +10,7 @@ $forum-unread-highlight: #f8e3e3 !default;
 //## Variables for colors used in Coursemology.
 $course-achievement-granted-bg: $state-success-bg !default;
 $course-achievement-locked-bg: $gray-lighter !default;
+$course-assessment-not-started-bg: $gray-lighter !default;
 $course-assessment-submission-answer-correct-border-color: $state-success-border !default;
 $course-assessment-submission-answer-correct-border-radius: $border-radius-base !default;
 $course-assessment-submission-answer-correct-bg: $state-success-bg !default;

--- a/app/assets/stylesheets/course/assessment/assessments.scss
+++ b/app/assets/stylesheets/course/assessment/assessments.scss
@@ -30,6 +30,10 @@
     .assessments-list {
       table-layout: fixed;
 
+      tr.not-started {
+        background-color: $course-assessment-not-started-bg;
+      }
+
       td,
       th {
         vertical-align: middle;

--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -104,7 +104,7 @@ module ApplicationFormattersHelper
       ['not-started']
     elsif item.ended?
       ['ended']
-    else # Not started, not ended.
+    else # Started, but not yet ended.
       ['currently-active']
     end
   end

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -1,13 +1,10 @@
 = content_tag_for(:tr, assessment, class: time_period_class(assessment) + draft_class(assessment))
   th colspan=2
+    - if assessment.draft?
+      span title=draft_message(assessment)
+        => fa_icon 'ban'.freeze
     = link_to(format_inline_text(assessment.title),
               course_assessment_path(current_course, assessment))
-    - unless assessment.currently_active?
-      small title=time_period_message(assessment)
-        =< fa_icon 'calendar'.freeze
-    - if assessment.draft?
-      small title=draft_message(assessment)
-        =< fa_icon 'eye-slash'.freeze
 
   td.table-experience-points = assessment.total_exp
   td.achievement-badge.table-requirement-for


### PR DESCRIPTION
Fix for
> [Coursemology Dev] The symbols indicating which assignments are not published for v2 are bad. Can we switch back to the v1 version which is the non-published symbol at the front?