### PR TITLE
Minor changes to achievement tables styling

### DIFF
--- a/app/assets/stylesheets/course/achievement.scss
+++ b/app/assets/stylesheets/course/achievement.scss
@@ -20,20 +20,6 @@
       vertical-align: middle;
     }
 
-    ul {
-      padding-left: 10%;
-    }
-
-    .btn-group {
-      display: flex;
-    }
-
-    .btn-group-vertical {
-      @extend .pull-right;
-      margin-right: 25%;
-      width: 39px;
-    }
-
     .granted {
       background-color: $course-achievement-granted-bg;
     }
@@ -44,12 +30,51 @@
 
     .table-badge {
       @extend .text-center;
-      width: $course-achievement-form-badge * 1.5;
+
+      @media (min-width: $screen-xs-max){
+        width: $course-achievement-form-badge * 1.5;
+      }
+
+      @media (max-width: $screen-sm-max){
+        width: 20%;
+
+        .image > img {
+          width: 100%;
+        }
+      }
     }
 
     .table-description {
       @extend .hidden-xs;
       @extend .hidden-sm;
+    }
+
+    .table-buttons {
+      @media (max-width: $screen-xs-max) {
+        width: 15%;
+      }
+
+      .btn-group {
+        display: flex;
+      }
+
+      .btn-group-vertical {
+        @extend .pull-right;
+      }
+    }
+
+    .table-requirement {
+      @media (max-width: $screen-sm-max){
+        ul {
+          padding-left: 10%;
+        }
+      }
+    }
+
+    .table-title {
+      @media (max-width: $screen-xs-max) {
+        width: 30%;
+      }
     }
   }
 

--- a/app/views/course/achievement/achievements/_achievement.html.slim
+++ b/app/views/course/achievement/achievements/_achievement.html.slim
@@ -20,13 +20,13 @@
       = format_html(achievement.description)
 
   - if include_requirements
-    td
+    td.table-requirement
       ul
         - achievement.specific_conditions.each do |condition|
           li = condition.title
 
   - if can?(:manage, achievement)
-    td
+    td.table-buttons
       div.btn-group.hidden-xs
         = render 'achievement_management_buttons', achievement: achievement
       div.btn-group-vertical.visible-xs-block

--- a/app/views/course/achievement/achievements/_achievements.html.slim
+++ b/app/views/course/achievement/achievements/_achievements.html.slim
@@ -2,12 +2,12 @@ table.table.achievement-list.table-hover
   thead
     tr
       th.table-badge = t('.badge')
-      th = t('.title')
+      th.table-title = t('.title')
       th.table-description = t('.description')
       th.table-description
       th = t('.requirements') if include_requirements
       - if can?(:manage, achievements.first)
-        th
+        th.table-buttons
   tbody
     = render partial: 'achievement',
              collection: achievements,


### PR DESCRIPTION
Follow up to #1539. 

Basically this PR uses media queries to modify css attributes in the achievement tables for different screen sizes.

![achievement-responsive](https://cloud.githubusercontent.com/assets/4353853/18999053/32fbf01c-876e-11e6-88dd-7324d14f8705.gif)
