### PR TITLE
Modify submissions filter to handle categories

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -6,7 +6,7 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
 
   def index #:nodoc:
     @submissions = @submissions.from_category(category).confirmed
-    @submissions = @submissions.filter(filter_params) if filter_params
+    @submissions = @submissions.filter(filter_params) unless filter_params.blank?
   end
 
   def pending
@@ -23,11 +23,20 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
     params.permit(:my_students)
   end
 
+  def filter_params
+    return {} if params[:filter].blank?
+    params[:filter].permit(:assessment_id, :group_id, :user_id, :category_id)
+  end
+
+  def category_param
+    submission_params[:category] || filter_params[:category_id]
+  end
+
   # Load the current category, used to classify and load assessments.
   def category
     @category ||=
-      if submission_params[:category]
-        current_course.assessment_categories.find(submission_params[:category])
+      if category_param
+        current_course.assessment_categories.find(category_param)
       else
         current_course.assessment_categories.first!
       end
@@ -61,9 +70,5 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
 
   def add_submissions_breadcrumb
     add_breadcrumb :index, course_submissions_path(current_course, category: category)
-  end
-
-  def filter_params
-    params[:filter] ? params[:filter].permit(:assessment_id, :group_id, :user_id) : nil
   end
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -110,9 +110,12 @@ class Course::Assessment::Submission < ActiveRecord::Base
   #   Returns submissions which have been submitted (which may or may not be graded).
   scope :confirmed, -> { where(workflow_state: [:submitted, :graded]) }
 
-  # Filter submissions by assessment_id, group_id or user_id (creator)
+  # Filter submissions by category_id, assessment_id, group_id and/or user_id (creator)
   scope :filter, (lambda do |filter_params|
     result = all
+    if filter_params[:category_id].present?
+      result = result.from_category(Course::Assessment::Category.find(filter_params[:category_id]))
+    end
     if filter_params[:assessment_id].present?
       result = result.where(assessment_id: filter_params[:assessment_id])
     end

--- a/app/views/course/assessment/submissions/_filter.html.slim
+++ b/app/views/course/assessment/submissions/_filter.html.slim
@@ -5,6 +5,7 @@ div.submissions-filter
     - assessment_id = params[:filter][:assessment_id].to_i if params[:filter]
     - group_id = params[:filter][:group_id].to_i if params[:filter]
     - user_id = params[:filter][:user_id].to_i if params[:filter]
+    = f.hidden_field :category_id, value: category.id
 
     = f.input :assessment_id,
         as: :select,

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Course::Assessment::SubmissionsController do
           submissions = controller.instance_variable_get(:@submissions)
           expect(submissions).to contain_exactly(submission)
         end
+
+        context 'when the category is specified in the filter' do
+          before { get :index, course_id: course, filter: { category_id: category.id } }
+
+          it 'sets the category to be the specified category' do
+            expect(controller.instance_variable_get(:@category)).to eq(category)
+          end
+        end
       end
     end
   end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -229,6 +229,19 @@ RSpec.describe Course::Assessment::Submission do
             to contain_exactly(submission1, submission2, submission3)
         end
       end
+
+      context 'when category id is given' do
+        let(:new_category) { create(:course_assessment_category, course: course) }
+        let(:new_tab) { create(:course_assessment_tab, course: course, category: new_category) }
+        let(:new_assessment) { create(:course_assessment_assessment, course: course, tab: new_tab) }
+        let(:new_submission) { create(:course_assessment_submission, assessment: new_assessment) }
+        let(:params) { { category_id: new_category.id } }
+
+        it 'filters submissions by category' do
+          new_submission
+          expect(Course::Assessment::Submission.filter(params)).to contain_exactly(new_submission)
+        end
+      end
     end
 
     describe '#grade' do


### PR DESCRIPTION
Fixes #1552. The model scope and controller params did not factor category in, which resulted in the controller deducing first category every time, leading to the bug. 

This PR adds that functionality so users are able to effectively filter submissions within each category. 

