### PR TITLE
DRY test case and warning panel display code.

### DIFF
--- a/app/helpers/course/assessment/answer/programming_helper.rb
+++ b/app/helpers/course/assessment/answer/programming_helper.rb
@@ -51,6 +51,39 @@ module Course::Assessment::Answer::ProgrammingHelper
     output || ''
   end
 
+  # If the test case type has a failed test case, return the first one.
+  #
+  # @param [Hash] test_cases_by_type The test cases and their results keyed by type
+  # @return [Hash] Failed test case and its result, if any
+  def get_failed_test_cases_by_type(test_cases_and_results)
+    {}.tap do |result|
+      test_cases_and_results.each do |test_case_type, test_cases_and_results_of_type|
+        result[test_case_type] = get_first_failed_test(test_cases_and_results_of_type)
+      end
+    end
+  end
+
+  # Organize the test cases and test results into a hash, keyed by test case type.
+  # If there is no test result, the test case key points to nil.
+  # nil is needed to make sure test cases are still displayed before they have a test result.
+  # e.g. { 'public_test': { test_case_1: result_1, test_case_2: result_2, test_case_3: nil },
+  #        'private_test': { priv_case_1: priv_result_1 },
+  #        'evaluation_test': { eval_case1: eval_result_1 } }
+  #
+  # @param [Hash] test_cases_by_type The test cases keyed by type
+  # @param [Course::Assessment::Answer::ProgrammingAutoGrading] auto_grading Auto grading object
+  # @return [Hash] The hash structure described above
+  def get_test_cases_and_results(test_cases_by_type, auto_grading)
+    answer_test_results_hash = map_answers_to_test_results(auto_grading)
+    {}.tap do |result|
+      test_cases_by_type.each do |test_case_type, test_cases|
+        result[test_case_type] = test_cases.map do |test_case|
+          [test_case, answer_test_results_hash[test_case]]
+        end.to_h
+      end
+    end
+  end
+
   private
 
   # Inserts annotations into the generated code block.
@@ -122,5 +155,25 @@ module Course::Assessment::Answer::ProgrammingHelper
                   object: discussion_topic
 
     line_discussion_cell.inner_html = html
+  end
+
+  # Return a hash of the first failing test case and its test result
+  #
+  # @param [Hash] test_cases_and_results_of_type A hash of test cases and results keyed by type
+  # @return [Hash] the failed test case and result, nil if all tests passed
+  def get_first_failed_test(test_cases_and_results_of_type)
+    test_cases_and_results_of_type.each do |test_case, test_result|
+      return [[test_case, test_result]].to_h if test_result && !test_result.passed?
+    end
+    nil
+  end
+
+  # Convert an AutoGrading object to hash of test results, keyed by test case
+  #
+  # @param [Course::Assessment::Answer::ProgrammingAutoGrading] auto_grading Auto grading object
+  # @return [Hash] Hash of test results, keyed by test case
+  def map_answers_to_test_results(auto_grading)
+    return {} unless auto_grading
+    auto_grading.test_results.map { |result| [result.test_case, result] }.to_h
   end
 end

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -65,6 +65,14 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
     end
   end
 
+  # Groups test cases by test case type. Each key returns an array of all the test cases
+  # of that type.
+  #
+  # @return [Hash] A hash of the test cases keyed by test case type.
+  def test_cases_by_type
+    test_cases.group_by(&:test_case_type)
+  end
+
   private
 
   # Queues the new question package for processing.

--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -1,127 +1,45 @@
-- test_cases = question.test_cases
-- public_test_cases = test_cases.select(&:public_test?)
-- private_test_cases = test_cases.select(&:private_test?)
-- evaluation_test_cases = test_cases.select(&:evaluation_test?)
-- submission = answer.submission
 - auto_grading = answer.auto_grading ? answer.auto_grading.actable : nil
-- answer_test_results_hash = auto_grading ? \
-    auto_grading.test_results.map { |result| [result.test_case, result] }.to_h : \
-    {}
+- is_grader = can?(:grade, answer.answer)
+- test_cases_by_type = question.test_cases_by_type
+- test_cases_and_results = get_test_cases_and_results(test_cases_by_type, auto_grading)
 
+/ Test case results table
 h3 = t('.test_cases')
 
-table.table.table-striped.table-hover
-  thead
-    tr
-      - if can?(:grade, answer.answer)
-        th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier)
-      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expression)
-      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expected)
-      - if can?(:grade, answer.answer)
-        th = t('.output')
-      - if @submission.attempting?
-        th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:hint)
-      th = t('.passed')
-  tbody
-    tr
-      - if can?(:grade, answer.answer)
-        th colspan=5
-          = t('.public')
-      - else
-        th colspan = 4
-          = t('.public')
-    - public_test_cases.each do |test_case|
-      - test_case_result = answer_test_results_hash[test_case]
-      = content_tag_for(:tr, test_case) do
-        - if can?(:grade, answer.answer)
-          th = format_html(test_case.identifier)
-        td = format_html(test_case.expression)
-        td
-          div.expected = format_html(test_case.expected)
-        - if can?(:grade, answer.answer)
-          td = simple_format(get_output(test_case_result))
-        - if @submission.attempting?
-          td
-            - if !test_case_result || !test_case_result.passed?
-              = simple_format(get_hint(test_case, test_case_result))
-        td
-          - if test_case_result && test_case_result.passed?
-            = fa_icon 'check'.freeze
-          - elsif test_case_result
-            = fa_icon 'times'.freeze
+- if test_cases_and_results.key?('public_test')
+  = render partial: 'course/assessment/answer/programming/test_cases_of_type',
+    locals: { test_cases_and_results: test_cases_and_results['public_test'],
+              type_heading: t('.public'), is_grader: is_grader }
 
-  - if can?(:grade, answer.answer)
-    tbody
-      tr
-        th colspan=5
-          = t('.private')
-          span.bg-danger.text-danger<
-            =fa_icon 'exclamation-triangle'.freeze
-            =<t('.privacy_warning')
-      - private_test_cases.each do |test_case|
-        - test_case_result = answer_test_results_hash[test_case]
-        = content_tag_for(:tr, test_case) do
-          th = format_html(test_case.identifier)
-          td = format_html(test_case.expression)
-          td
-            div.expected = format_html(test_case.expected)
-          - if can?(:grade, answer.answer)
-            td = simple_format(get_output(test_case_result))
-          - if @submission.attempting?
-            td
-              - if !test_case_result || !test_case_result.passed?
-                = simple_format(get_hint(test_case, test_case_result))
-          td
-            - if test_case_result && test_case_result.passed?
-              = fa_icon 'check'.freeze
-            - elsif test_case_result
-              = fa_icon 'times'.freeze
-      tbody
-        tr
-          th colspan=5
-            = t('.evaluation')
-        - evaluation_test_cases.each do |test_case|
-          - test_case_result = answer_test_results_hash[test_case]
-          = content_tag_for(:tr, test_case) do
-            th = format_html(test_case.identifier)
-            td = format_html(test_case.expression)
-            td
-              div.expected = format_html(test_case.expected)
-            - if can?(:grade, answer.answer)
-              td = simple_format(get_output(test_case_result))
-            - if @submission.attempting?
-              td
-                - if !test_case_result || !test_case_result.passed?
-                  = simple_format(get_hint(test_case, test_case_result))
-            td
-              - if test_case_result && test_case_result.passed?
-                = fa_icon 'check'.freeze
-              - elsif test_case_result
-                = fa_icon 'times'.freeze
+- if is_grader
+  - if test_cases_by_type.key?('private_test') || test_cases_by_type.key?('evaluation_test')
+    span.bg-danger.text-danger
+      = fa_icon 'exclamation-triangle'.freeze
+      =< t('.privacy_warning')
 
-- failed_public_test_cases = public_test_cases. \
-    select { |t| answer_test_results_hash[t] && !answer_test_results_hash[t].passed? }
-- if !failed_public_test_cases.empty?
-    - test_case = failed_public_test_cases.first
-    - test_case_result = answer_test_results_hash[test_case]
-    div.panel.panel-danger
-      div.panel-heading = t('.failed_public_message')
-      div.panel-body = simple_format(get_hint(test_case, test_case_result))
+  - if test_cases_and_results.key?('private_test')
+    = render partial: 'course/assessment/answer/programming/test_cases_of_type',
+      locals: { test_cases_and_results: test_cases_and_results['private_test'],
+                type_heading: t('.private'), is_grader: is_grader }
 
-- failed_private_test_cases = private_test_cases. \
-    select { |t| answer_test_results_hash[t] && !answer_test_results_hash[t].passed? }
-- if failed_public_test_cases.empty? && !failed_private_test_cases.empty?
-    - test_case = failed_private_test_cases.first
-    - test_case_result = answer_test_results_hash[test_case]
-    div.panel.panel-danger
-      div.panel-heading = t('.failed_private_message')
-      div.panel-body = simple_format(get_hint(test_case, test_case_result))
+  - if test_cases_and_results.key?('evaluation_test')
+    = render partial: 'course/assessment/answer/programming/test_cases_of_type',
+      locals: { test_cases_and_results: test_cases_and_results['evaluation_test'],
+                type_heading: t('.evaluation'), is_grader: is_grader }
 
-- failed_evaluation_test_cases = evaluation_test_cases. \
-    select { |t| answer_test_results_hash[t] && !answer_test_results_hash[t].passed? }
-- if can?(:grade, answer.answer) && !failed_evaluation_test_cases.empty?
-    - test_case = failed_evaluation_test_cases.first
-    - test_case_result = answer_test_results_hash[test_case]
-    div.panel.panel-danger
-      div.panel-heading = t('.failed_evaluation_message')
-      div.panel-body = simple_format(get_hint(test_case, test_case_result))
+/ Test failure warning panel display
+- failed_test_cases_by_type = get_failed_test_cases_by_type(test_cases_and_results)
+
+- if failed_test_cases_by_type['public_test']
+  = render partial: 'course/assessment/answer/programming/test_cases_warning_panels',
+    locals: { test_case_and_result: failed_test_cases_by_type['public_test'],
+              panel_heading: t('.failed_public_message') }
+- elsif failed_test_cases_by_type['private_test']
+  = render partial: 'course/assessment/answer/programming/test_cases_warning_panels',
+    locals: { test_case_and_result: failed_test_cases_by_type['private_test'],
+              panel_heading: t('.failed_private_message') }
+
+- if is_grader && failed_test_cases_by_type['evaluation_test']
+  = render partial: 'course/assessment/answer/programming/test_cases_warning_panels',
+    locals: { test_case_and_result: failed_test_cases_by_type['evaluation_test'],
+              panel_heading: t('.failed_evaluation_message') }

--- a/app/views/course/assessment/answer/programming/_test_cases_of_type.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases_of_type.html.slim
@@ -1,0 +1,29 @@
+h4 = type_heading
+table.table.table-striped.table-hover
+  thead
+    tr
+      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier) if is_grader
+      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expression)
+      th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expected)
+      th = t('.output') if is_grader
+      - if @submission.attempting?
+        th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:hint)
+      th = t('.passed')
+  tbody
+    tr
+    - test_cases_and_results.each do |test_case, test_case_result|
+      = content_tag_for(:tr, test_case) do
+        th = format_html(test_case.identifier) if is_grader
+        td = format_html(test_case.expression)
+        td
+          div.expected = format_html(test_case.expected)
+        td = simple_format(get_output(test_case_result)) if is_grader
+        - if @submission.attempting?
+          td
+            - unless test_case_result && test_case_result.passed?
+              = simple_format(get_hint(test_case, test_case_result))
+        td
+          - if test_case_result && test_case_result.passed?
+            = fa_icon 'check'.freeze
+          - elsif test_case_result
+            = fa_icon 'times'.freeze

--- a/app/views/course/assessment/answer/programming/_test_cases_warning_panels.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases_warning_panels.html.slim
@@ -1,0 +1,5 @@
+div.panel.panel-danger
+  div.panel-heading = panel_heading
+  div.panel-body
+    - test_case_and_result.each do |test_case, test_result|
+      = simple_format(get_hint(test_case, test_result))

--- a/config/locales/en/course/assessment/answer/programming.yml
+++ b/config/locales/en/course/assessment/answer/programming.yml
@@ -10,15 +10,16 @@ en:
           file_fields:
             expand_comments: 'Expand all comments'
           test_cases:
-            passed: 'Passed'
             private: :'course.assessment.question.programming.form_test_cases.private'
             privacy_warning: :'course.assessment.question.programming.form_test_cases.privacy_warning'
             public: :'course.assessment.question.programming.form_test_cases.public'
             evaluation: :'course.assessment.question.programming.form_test_cases.evaluation'
             test_cases: :'course.assessment.question.programming.form_test_cases.test_cases'
-            output: 'Output'
             failed_public_message: 'Your code fails one or more public test cases.'
             failed_private_message: 'Your code fails one or more private test cases.'
             failed_evaluation_message: "Student's code has failed one or more evaluation test cases."
+          test_cases_of_type:
+            output: 'Output'
+            passed: 'Passed'
           annotation_footer:
             reply: 'Reply'

--- a/config/locales/en/course/assessment/question/programming.yml
+++ b/config/locales/en/course/assessment/question/programming.yml
@@ -33,7 +33,7 @@ en:
             test_cases: 'Test Cases'
             public: 'Public Test Cases'
             private: 'Private Test Cases'
-            privacy_warning: 'You are able to view the private test cases because you are staff. Students will not be able to see them.'
+            privacy_warning: 'You are able to view the test cases below because you are staff. Students will not be able to see them.'
             evaluation: 'Evaluation Test Cases'
             identifier: 'Identifier'
             hint: 'Hint'


### PR DESCRIPTION
Fixes #1515.

Use the same table code for all test case types.
Split test case display into separate tables for each type.

![screen shot 2016-09-28 at 8 15 29 pm](https://cloud.githubusercontent.com/assets/1902527/18913067/5cd19584-85b8-11e6-9ee4-f45728fc41d0.png)

Separate out test results table into its own partial, reduces the
switching logic that goes into the view.

Separate out warning table display into its own partial, makes the logic
of what to display more explicit.

Helper functions are to massage the test case and test result data into a hash which is easier to run `.each` over.