### PR TITLE
Allow staff to update experience points records

### DIFF
--- a/app/assets/javascripts/course/experience_points_records.js
+++ b/app/assets/javascripts/course/experience_points_records.js
@@ -1,0 +1,10 @@
+//= require helpers/table_row_form_helpers
+
+(function($, TABLE_ROW_FORM_HELPERS) {
+  'use strict';
+
+  var DOCUMENT_SELECTOR = '.course-experience-points-records.index ';
+  var BUTTON_SELECTOR = 'tr.experience-points-record #update';
+
+  TABLE_ROW_FORM_HELPERS.initializeAjaxForms(DOCUMENT_SELECTOR + BUTTON_SELECTOR);
+})(jQuery, TABLE_ROW_FORM_HELPERS);

--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -29,8 +29,7 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
 
   def destroy_success #:nodoc:
     redirect_to course_user_experience_points_records_path(current_course, @course_user),
-                success: t('course.experience_points_records.destroy.success',
-                           reason: @experience_points_record.reason)
+                success: t('course.experience_points_records.destroy.success')
   end
 
   def destroy_failure #:nodoc:

--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -17,6 +17,14 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
       includes(:updater).order(updated_at: :desc).page(page_param)
   end
 
+  def update
+    if @experience_points_record.update_attributes(experience_points_record_params)
+      flash.now[:success] = t('.success')
+    else
+      flash.now[:danger] = @experience_points_record.errors.full_messages.to_sentence
+    end
+  end
+
   def destroy # :nodoc:
     if @experience_points_record.destroy
       destroy_success
@@ -26,6 +34,10 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
   end
 
   private
+
+  def experience_points_record_params
+    params.require(:experience_points_record).permit(:points_awarded, :reason)
+  end
 
   def destroy_success #:nodoc:
     redirect_to course_user_experience_points_records_path(current_course, @course_user),

--- a/app/views/course/experience_points_records/_experience_points_record.html.slim
+++ b/app/views/course/experience_points_records/_experience_points_record.html.slim
@@ -1,14 +1,32 @@
-= content_tag_for(:tr, experience_points_record)
-  td = link_to_user(@course_user_preload_service.course_user_for(experience_points_record.updater))
-  td
-    - if experience_points_record.manually_awarded?
-      = format_inline_text(experience_points_record.reason)
-    - else
-      = render partial: experience_points_record.specific, suffix: 'experience_points_reason'
-  td = experience_points_record.points_awarded
-  td = experience_points_record.updated_at
-  td
-    - if experience_points_record.manually_awarded? && can?(:destroy, experience_points_record)
-      = delete_button(course_user_experience_points_record_path(current_course,
-                                                                   @course_user,
-                                                                   experience_points_record))
+- can_update = can?(:update, experience_points_record)
+- points_record_path = course_user_experience_points_record_path(current_course,
+                                                                 @course_user,
+                                                                 experience_points_record)
+- row_options_hash = { class: 'experience-points-record' }.tap do |hash|
+  - hash.merge!({ 'data-action' => points_record_path, 'data-method' => 'patch' }) if can_update
+
+= content_tag_for(:tr, experience_points_record, row_options_hash)
+  = simple_fields_for experience_points_record do |f|
+    td
+      - updater = @course_user_preload_service.course_user_for(experience_points_record.updater)
+      = link_to_user(updater)
+    td
+      - if !experience_points_record.manually_awarded?
+        = render partial: experience_points_record.specific, suffix: 'experience_points_reason'
+      - elsif can_update
+        = f.input :reason, label: false
+      - else
+        = format_inline_text(experience_points_record.reason)
+    td
+      - if can_update
+        = f.input :points_awarded, label: false
+      - else
+        = experience_points_record.points_awarded
+    td
+      = experience_points_record.updated_at
+    td
+      - if can_update
+        = f.button :submit, id: 'update' do
+          = fa_icon 'save'.freeze
+      - if experience_points_record.manually_awarded? && can?(:destroy, experience_points_record)
+        = delete_button(points_record_path)

--- a/app/views/course/experience_points_records/update.js.erb
+++ b/app/views/course/experience_points_records/update.js.erb
@@ -1,0 +1,6 @@
+$('.course-experience-points-records.index').
+  parents('.container-fluid:first').
+  prepend('<%= j(flash_messages) %>');
+
+// Show users the flash messages
+window.scrollTo(0, 0);

--- a/config/locales/en/course/experience_points_records.yml
+++ b/config/locales/en/course/experience_points_records.yml
@@ -3,5 +3,7 @@ en:
     experience_points_records:
       index:
         header: 'Experience Points History for %{name}'
+      update:
+        success: 'Experience points record updated.'
       destroy:
         success: 'Experience points record deleted.'

--- a/config/locales/en/course/experience_points_records.yml
+++ b/config/locales/en/course/experience_points_records.yml
@@ -4,4 +4,4 @@ en:
       index:
         header: 'Experience Points History for %{name}'
       destroy:
-        success: 'Experience points record "%{reason}" was deleted.'
+        success: 'Experience points record deleted.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Rails.application.routes.draw do
       end
 
       resources :users, only: [:index, :show, :update, :destroy] do
-        resources :experience_points_records, only: [:index, :destroy]
+        resources :experience_points_records, only: [:index, :update, :destroy]
         get 'invite' => 'user_invitations#new', on: :collection
         post 'invite' => 'user_invitations#create', on: :collection
         get 'disburse_experience_points' => 'experience_points/disbursement#new', on: :collection

--- a/spec/controllers/course/experience_points_records_controller_spec.rb
+++ b/spec/controllers/course/experience_points_records_controller_spec.rb
@@ -14,10 +14,30 @@ RSpec.describe Course::ExperiencePointsRecordsController, type: :controller do
     let(:points_record_stub) do
       stub = build_stubbed(:course_experience_points_record, course_user: course_student)
       allow(stub).to receive(:destroy).and_return(false)
+      allow(stub).to receive(:update_attributes).and_return(false)
       stub
     end
 
     before { sign_in(user) }
+
+    describe '#update' do
+      subject do
+        patch :update, format: :js, course_id: course,
+                       user_id: course_student, id: points_record_stub,
+                       experience_points_record: { reason: 'reason' }
+      end
+
+      context 'when update fails' do
+        before do
+          controller.instance_variable_set(:@experience_points_record, points_record_stub)
+          subject
+        end
+
+        it 'sets an error flash message' do
+          expect(flash[:danger]).to eq('')
+        end
+      end
+    end
 
     describe '#destroy' do
       subject do

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -34,6 +34,32 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
         expect(page).to have_link(submission.assessment.title, href: submission_path)
       end
 
+      scenario "I can update a course student's active manually-awarded points records", js: true do
+        records
+        visit course_user_experience_points_records_path(course, course_student)
+
+        within find(content_tag_selector(record)) do
+          expect(page).to have_field('experience_points_record_points_awarded')
+          expect(page).not_to have_field('experience_points_record_reason')
+          expect(page).to have_button('update')
+        end
+
+        updated_points = manual_record.points_awarded + 1
+        updated_reason = 'updated reason'
+        within find(content_tag_selector(manual_record)) do
+          fill_in 'experience_points_record_points_awarded', with: updated_points
+          fill_in 'experience_points_record_reason', with: updated_reason
+          click_button 'update'
+        end
+
+        wait_for_ajax
+
+        update_success_message = I18n.t('course.experience_points_records.update.success')
+        expect(page).to have_selector('div', text: update_success_message)
+        expect(manual_record.reload.reason).to eq(updated_reason)
+        expect(manual_record.points_awarded).to eq(updated_points)
+      end
+
       scenario "I can delete a course student's active manually-awarded points records" do
         records
         visit course_user_experience_points_records_path(course, course_student)
@@ -61,6 +87,13 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
         expect(page).to have_content_tag_for(record)
         expect(page).to have_content_tag_for(manual_record)
         expect(page).not_to have_content_tag_for(inactive_record)
+
+        # Can view experience points attributes but cannot edit the experience points record
+        within find(content_tag_selector(manual_record)) do
+          expect(page).not_to have_field('experience_points_record_points_awarded')
+          expect(page).not_to have_field('experience_points_record_reason')
+          expect(page).not_to have_button('update')
+        end
       end
     end
   end


### PR DESCRIPTION
- Staff can update points awarded and reason (only for manually awarded points) from a student's experience points history page
- Remove reason from success message since `record.reason` no longer automatically generates the reason for non-manually-awarded points records. Probably not worth the computation to generate it for the success message.