### PR TITLE
Implement model declarations of todo for lesson_plan_item

### DIFF
--- a/app/models/concerns/course/lesson_plan/item_todo_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item_todo_concern.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module Course::LessonPlan::ItemTodoConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :create_or_delete_todos, if: :has_todo?
+  end
+
+  def has_todo?
+    actable && actable.class.has_todo?
+  end
+
+  protected
+
+  # Callback to create or delete todos when lesson_plan_item's draft status is changed.
+  #    Todos are created for all course_users in the course.
+  # Uses ActiveModel::Dirty to check attribute changes.
+  def create_or_delete_todos
+    return unless draft_changed?
+    if draft_changed? from: true, to: false
+      Course::LessonPlan::Todo.create_for(self, course.course_users)
+    elsif draft_changed? from: false, to: true
+      Course::LessonPlan::Todo.delete_for(self)
+    end
+  end
+end

--- a/app/models/concerns/course_user/todo_concern.rb
+++ b/app/models/concerns/course_user/todo_concern.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module CourseUser::TodoConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_create :create_todos_for_course_user
+  end
+
+  def create_todos_for_course_user
+    items = course.lesson_plan_items.includes(:actable).where(draft: false).select(&:has_todo?)
+    Course::LessonPlan::Todo.create_for(items, self)
+  end
+end

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::LessonPlan::Item < ActiveRecord::Base
+  include Course::LessonPlan::ItemTodoConcern
+
   actable
   has_many_attachments
 

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -8,7 +8,6 @@ class Course::LessonPlan::Item < ActiveRecord::Base
   validate :validate_presence_of_bonus_end_at,
            :validate_start_at_cannot_be_after_end_at
 
-
   # @!method self.ordered_by_date
   #   Orders the lesson plan items by the starting date.
   scope :ordered_by_date, (lambda do
@@ -16,6 +15,7 @@ class Course::LessonPlan::Item < ActiveRecord::Base
   end)
 
   belongs_to :course, inverse_of: :lesson_plan_items
+  has_many :todos, class_name: Course::LessonPlan::Todo, inverse_of: :item, dependent: :destroy
 
   # Gives the maximum number of EXP Points that an EXP-awarding item
   # is allocated to give, which is the sum of base and bonus EXPs.

--- a/app/models/course/lesson_plan/todo.rb
+++ b/app/models/course/lesson_plan/todo.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+class Course::LessonPlan::Todo < ActiveRecord::Base
+  include Workflow
+
+  workflow do
+    state :not_started do
+      event :start, transitions_to: :in_progress
+    end
+    state :in_progress do
+      event :complete, transitions_to: :completed
+      event :revert, transitions_to: :not_started
+    end
+    state :completed do
+      event :restart, transitions_to: :not_started
+    end
+  end
+
+  belongs_to :user, inverse_of: :todos
+  belongs_to :item, class_name: Course::LessonPlan::Item.name, inverse_of: :todos
+
+  after_initialize :set_default_values, if: :new_record?
+
+  private
+
+  # Sets default values
+  def set_default_values
+    self.ignore ||= false
+  end
+end

--- a/app/models/course/lesson_plan/todo.rb
+++ b/app/models/course/lesson_plan/todo.rb
@@ -20,6 +20,36 @@ class Course::LessonPlan::Todo < ActiveRecord::Base
 
   after_initialize :set_default_values, if: :new_record?
 
+  class << self
+    # Creates todos to the given course_users for the given lesson_plan_item(s).
+    #
+    # @param [Course::LessonPlan::Item|Array<Course::LessonPlan::Item>] item
+    #   The lesson_plan_item, or array of lesson_plan_items to create todos for.
+    # @param [CourseUser|Array<CourseUser>] course_users
+    #   The course_user, or array of course_users to create todos for.
+    # @return [Array<Course::LessonPlan::Todo>|nil] Array of created todos, or nil if invalid params
+    def create_for(items, course_users)
+      return unless items && course_users
+      items = [items] if items.is_a?(Course::LessonPlan::Item)
+      course_users = [course_users] if course_users.is_a?(CourseUser)
+      user_item_hash = items.product(course_users).map { |ary| { item: ary[0], user: ary[1].user } }
+      Course::LessonPlan::Todo.create(user_item_hash)
+    end
+
+    # Destroy todos for the associated lesson_plan_item for specified course_users.
+    #   If no course_user is specified, destroy all todos for that lesson_plan_item.
+    #
+    # @param [Course::LessonPlan::Item] item Item's todos to be deleted
+    # @param [Array<CourseUser>] course_users If specified, filter of course_users to delete todos.
+    # @return [Array<Course::LessonPlan::Todo>|nil] The todos that are deleted, or nil if invalid
+    #   params
+    def delete_for(item, course_users = nil)
+      return unless item
+      user_ids = course_users ? course_users.select(:user_id) : item.todos.select(:user_id)
+      item.todos.where { user_id.in(user_ids) }.destroy_all
+    end
+  end
+
   private
 
   # Sets default values

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -3,6 +3,7 @@ class CourseUser < ActiveRecord::Base
   include Workflow
   include CourseUser::StaffConcern
   include CourseUser::LevelProgressConcern
+  include CourseUser::TodoConcern
 
   after_initialize :set_defaults, if: :new_record?
   before_validation :set_defaults, if: :new_record?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,7 @@ class User < ActiveRecord::Base
   end
   has_many :course_users, dependent: :destroy
   has_many :courses, through: :course_users
+  has_many :todos, class_name: Course::LessonPlan::Todo.name, inverse_of: :user, dependent: :destroy
 
   accepts_nested_attributes_for :emails
 

--- a/db/migrate/20161003094742_create_lesson_plan_todos.rb
+++ b/db/migrate/20161003094742_create_lesson_plan_todos.rb
@@ -1,0 +1,15 @@
+class CreateLessonPlanTodos < ActiveRecord::Migration
+  def change
+    create_table :course_lesson_plan_todos do |t|
+      t.references :item, null: false, references: :course_lesson_plan_items
+      t.references :user, null: false
+      t.string :workflow_state, null: false
+      t.boolean :ignore, null: false, default: false
+
+      t.userstamps null: false, foreign_key: { references: :users }
+      t.timestamps
+
+      t.index [:item_id, :user_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160920101847) do
+ActiveRecord::Schema.define(version: 20161003094742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -517,6 +517,18 @@ ActiveRecord::Schema.define(version: 20160920101847) do
     t.datetime "created_at",  :null=>false
     t.datetime "updated_at",  :null=>false
   end
+
+  create_table "course_lesson_plan_todos", force: :cascade do |t|
+    t.integer  "item_id",        :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_item_id"}, :foreign_key=>{:references=>"course_lesson_plan_items", :name=>"fk_course_lesson_plan_todos_item_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "user_id",        :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_todos_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "workflow_state", :limit=>255, :null=>false
+    t.boolean  "ignore",         :default=>false, :null=>false
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_todos_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_todos_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+  add_index "course_lesson_plan_todos", ["item_id", "user_id"], :name=>"index_course_lesson_plan_todos_on_item_id_and_user_id", :unique=>true
 
   create_table "course_levels", force: :cascade do |t|
     t.integer  "course_id",                   :null=>false, :index=>{:name=>"fk__course_levels_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_levels_course_id", :on_update=>:no_action, :on_delete=>:no_action}

--- a/lib/extensions/acts_as_helpers/active_record/base.rb
+++ b/lib/extensions/acts_as_helpers/active_record/base.rb
@@ -7,16 +7,37 @@ module Extensions::ActsAsHelpers::ActiveRecord::Base
       include ExperiencePointsInstanceMethods
     end
 
-    # Decorator for abstractions with concrete occurrences which have
-    # the potential to award course_users EXP Points
-    def acts_as_lesson_plan_item
+    # Decorator for abstractions with concrete occurrences for student activities with a start
+    #   and end date, with the option to: (i) Award course_users with EXP Points, and/or
+    #   (ii) Appear as a todo item for each course_user once it is published
+    #
+    # Todo acts as reminders for sutdents to act on. Todos are also automatically created
+    #   when the lesson_plan_item transits from draft to non-draft, and destroyed in the
+    #   reverse case (see Course::LessonPlan::ItemTodoConcern).
+    #
+    # To declare that an actable model has todos:
+    #   - Define has_todo as true when calling acts_as_lesson_plan_item
+    #   - Define hooks to update todo's workflow_state (see Course::LessonPlan::Todo)
+    def acts_as_lesson_plan_item(has_todo: false)
       acts_as :lesson_plan_item, class_name: Course::LessonPlan::Item.name
+
+      class << self
+        attr_accessor :has_todo
+      end
+      self.has_todo = has_todo ? true : false
+      extend LessonPlanItemClassMethods
     end
   end
 
   module ExperiencePointsInstanceMethods
     def manually_awarded?
       false
+    end
+  end
+
+  module LessonPlanItemClassMethods
+    def has_todo?
+      has_todo
     end
   end
 end

--- a/spec/factories/course_lesson_plan_todos.rb
+++ b/spec/factories/course_lesson_plan_todos.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_lesson_plan_todo, class: Course::LessonPlan::Todo.name, aliases: [:todo] do
+    transient do
+      course { create(:course) }
+      draft false
+    end
+    item { create(:course_lesson_plan_item, course: course, base_exp: 1000, draft: draft) }
+    add_attribute(:ignore) { false }
+    user
+
+    trait :not_started do
+      # Default according to workflow defined, no action required.
+    end
+
+    trait :in_progress do
+      workflow_state :started
+    end
+
+    trait :completed do
+      workflow_state :completed
+    end
+
+    after(:build) do |_todo, evaluator|
+      course_user = CourseUser.where(course: evaluator.course, user: evaluator.user)
+      create(:course_user, :approved, course: evaluator.course) if course_user.blank?
+    end
+  end
+end

--- a/spec/models/course/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan_item_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe Course::LessonPlan::Item, type: :model do
   it { is_expected.to belong_to(:course).inverse_of(:lesson_plan_items) }
+  it { is_expected.to have_many(:todos).inverse_of(:item).dependent(:destroy) }
 
   let!(:instance) { Instance.default }
   with_tenant(:instance) do

--- a/spec/models/course/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan_item_spec.rb
@@ -72,5 +72,39 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
         end
       end
     end
+
+    context 'when actable object is declared to have a todo' do
+      describe 'callbacks from Course::LessonPlan::TodoConcern' do
+        # TODO: To remove when this declaration is done on the model itself
+        Course::Assessment.class_eval { def self.has_todo?; true; end } # rubocop:disable Style/SingleLineMethods
+
+        let(:course) { create(:course) }
+        let!(:students) { create_list(:course_student, 3, course: course) }
+        let(:actable) { create(:course_assessment_assessment, :with_mcq_question, course: course) }
+        subject { actable.lesson_plan_item }
+
+        context 'when actable is a draft' do
+          it 'creates todos when the actable object changes to non-draft' do
+            expect do
+              subject.draft = false
+              subject.save
+            end.to change(Course::LessonPlan::Todo.all, :count).by(course.course_users.count)
+          end
+        end
+
+        context 'when actable is non-draft' do
+          before do
+            subject.draft = false
+            subject.save
+          end
+          it 'deletes associated todos when the actable object changes to draft' do
+            expect do
+              subject.draft = true
+              subject.save
+            end.to change(Course::LessonPlan::Todo.all, :count).by(-course.course_users.count)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/course/lesson_plan_todo_spec.rb
+++ b/spec/models/course/lesson_plan_todo_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::LessonPlan::Todo, type: :model do
+  it { is_expected.to belong_to(:item).inverse_of(:todos) }
+  it { is_expected.to belong_to(:user).inverse_of(:todos) }
+end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -346,5 +346,24 @@ RSpec.describe CourseUser, type: :model do
           and raise_error(ActiveRecord::RecordInvalid)
       end
     end
+
+    describe 'after_save callback for new course_user' do
+      context 'when there is a non-draft lesson_plan_items that have todos' do
+        let(:assessment) do
+          create(:course_assessment_assessment, :published_with_mcq_question, course: course)
+        end
+        subject { requested_course_user }
+
+        before do
+          # TODO: To remove when this declaration is done on the model itself
+          Course::Assessment.class_eval { def self.has_todo?; true; end } # rubocop:disable Style/SingleLineMethods
+          assessment
+        end
+
+        it 'creates todos for the lesson_plan_items' do
+          expect { subject }.to change(Course::LessonPlan::Todo.all, :count).by(1)
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe User do
       dependent(:destroy)
   end
   it { is_expected.to have_many(:instance_users) }
+  it { is_expected.to have_many(:todos).inverse_of(:user).dependent(:destroy) }
   it { is_expected.to have_many(:instances).through(:instance_users) }
   it { is_expected.to have_many(:identities).dependent(:destroy) }
   it { is_expected.to have_many(:course_users).dependent(:destroy) }


### PR DESCRIPTION
### What
This PR extends the base library of `acts_as_lesson_plan_item` to provide the basic behaviour for  todos for lesson_plan_items. For simplicity, I've named it `todo` instead of `pending action`. In steps:
 - Created todo models and factories
 - Implemented declaration of todos on `acts_as_lesson_plan_item`
 - Added hooks for `lesson_plan_item` and `course_user` to create/delete `todos` on certain event triggers.

### Next Steps
After this, my plan is to have 2 more 'large' PRs (which is not done yet):
 - Implement `has_todo?` for assessments, and implement hooks for submissions updates to `todos`. I will also need to implement a rake task to create the todos for the already published assessments. 
 - Implement the controller and views for todo. This includes the display on the course homepage, the ignore actions, and the required scopes to get the correct set of todos per student. Will also implement todo abilities here. 

### Action Required
- For this PR, would like to see if the proposed design makes sense. I've added the my future plans so feel free to ask questions and we can have a discussion. 

I also have some questions: 
 - Will there be cases where `lesson_plan_item` does not have an actable? Do we have to guard against those cases?  (Currently I use `#try` to get around that)
 - Do I need to validate on `todo` model that the associated `lesson_plan_item.actable.has_todo?` is true? 