### PR TITLE
Fixed styling on mobile devices (announcement image overflow & breadcrumbs)

### DIFF
--- a/app/assets/stylesheets/breadcrumbs.scss
+++ b/app/assets/stylesheets/breadcrumbs.scss
@@ -1,0 +1,3 @@
+.breadcrumb > li {
+  display: inline;
+}

--- a/app/assets/stylesheets/course/_announcement.scss
+++ b/app/assets/stylesheets/course/_announcement.scss
@@ -74,4 +74,8 @@
   ul {
     list-style: none;
   }
+
+  img {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
This PR fixes two things: 
 - All large images in announcements to fit within the container width - otherwise large images (wider than the container) will screw up the page markup. 
 - Breadcrumbs used to be `inline-block` level elements resulting in weird breadcrumb positioning for long course titles. They are currently fixed to inline to allow for better readability.

Before:
<img width="473" alt="screen shot 2016-10-06 at 3 17 30 pm" src="https://cloud.githubusercontent.com/assets/4353853/19143703/376ca5ce-8bd8-11e6-96f6-f4cb8dcb3e01.png">

After: 
<img width="379" alt="screen shot 2016-10-06 at 3 18 18 pm" src="https://cloud.githubusercontent.com/assets/4353853/19143705/3ad46e36-8bd8-11e6-8468-aab2d345bb09.png">
