### PR TITLE
Fix bug where dropdown menu does not work on iOS devices

### DIFF
--- a/app/assets/javascripts/dropdown_mobile_fix.js
+++ b/app/assets/javascripts/dropdown_mobile_fix.js
@@ -1,0 +1,17 @@
+// Dropdown does not work on iOS devices as only click delegation for a and input are supported
+// Event delegation for iOS http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+// Proposed solution is modified from http://stackoverflow.com/a/22318440
+
+(function($) {
+  'use strict';
+
+  function initializeDropdownEventListener() {
+    $('[data-toggle=dropdown]').each(function() {
+      this.addEventListener('click', function() {}, false);
+    });
+  }
+
+  $(document).on('turbolinks:load', function() {
+    initializeDropdownEventListener();
+  });
+})(jQuery);

--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -15,9 +15,7 @@
 
   function initializeComponents(element) {
     $('[data-toggle="popover"]', element).popover();
-    // The design of Coursemology is such that tooltips are attached to any
-    // element with a title attribute, but we do not want that for the Facebook
-    // button
+    // Tooltips are attached to elements with a title attribute, except for the Facebook button.
     // See https://github.com/Coursemology/coursemology-theme/pull/5
     $('[title]', element).not('.fb-like *').tooltip();
     $('input.toggle-all[type="checkbox"]', element).checkboxToggleAll();


### PR DESCRIPTION
Fixes #1394. 

The dropdown doesn't work for iOS devices. After some reading, it seems like iOS doesn't support clicks event delegation (it doesn't recognise clicks on certain HTML elements) if it is an input or link. Because of that, tapping on the dropdown trigger doesn't trigger a 'click', but rather a 'touch'.

This PR fixes that by adding the event listeners for the elements that are declared to be `dropdown` (according to bootstrap's dropdown.js). Will need your guys help to see if I've wrote the javascript properly, as I don't write that much javascript >_<

According to the article below, apparently there is a slim chance that if a page has too many dropdowns, it is possible that there will be 'memory management' issues. In my testing with iPhone (and other android devices), I did not experience any significant difference before and after this fix. 

Readings:
 - More about event delegation on iOS:
  - [Article 1](http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html)
  - [Article 2](http://www.shdon.com/blog/2013/06/07/why-your-click-events-don-t-work-on-mobile-safari)
 - Proposed [fix on StackOverflow](http://stackoverflow.com/a/22318440)

From Article 2:
>By virtue of event bubbling, the parent (<body> in the jQuery example) catches all child elements `(<div class="clickable">)` being clicked. Such a construct enables you have only 1 click handler for any number of matching elements without needing to bind them to each element individually. This works on every standards-compliant browser. Mobile Safari chooses to differ, however. It does not generate click events for elements that do not have either or both of:
> - A directly bound onclick handler.
> - The cursor property set to pointer in CSS.

