### PR TITLE
Change display_mode to mode

### DIFF
--- a/app/controllers/concerns/course/assessment/submission/submissions_controller_service_concern.rb
+++ b/app/controllers/concerns/course/assessment/submission/submissions_controller_service_concern.rb
@@ -8,7 +8,7 @@ module Course::Assessment::Submission::SubmissionsControllerServiceConcern
   #
   # @return [Class] The class of the service.
   def service_class
-    case @assessment.display_mode
+    case @assessment.mode
     when 'guided'
       Course::Assessment::Submission::UpdateGuidedAssessmentService
     when 'worksheet'

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -9,6 +9,12 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def new
+    @assessment.mode = case params[:mode]
+                       when 'guided'
+                         :guided
+                       else
+                         :worksheet
+                       end
   end
 
   def create

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -55,7 +55,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   def assessment_params
     params.require(:assessment).permit(:title, :description, :base_exp, :time_bonus_exp,
                                        :extra_bonus_exp, :start_at, :end_at, :bonus_end_at,
-                                       :draft, :display_mode, :autograded, folder_params)
+                                       :draft, :mode, :autograded, folder_params)
   end
 
   # Merges the parameters for category and tab IDs from either the assessment parameter or the

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -14,7 +14,7 @@ class Course::Assessment < ActiveRecord::Base
   validate :validate_prescence_of_questions, unless: :draft?
   validate :validate_only_autograded_questions, if: :autograded?
 
-  enum display_mode: { worksheet: 0, guided: 1 }
+  enum mode: { worksheet: 0, guided: 1 }
 
   belongs_to :tab, inverse_of: :assessments
 

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -9,7 +9,7 @@
       = specific_answer_form.hidden_field :id, value: answer.actable.id
       = render partial: specific_answer_form.object, locals: { f: specific_answer_form, last_attempt: last_attempt }
 
-      = render partial: "course/assessment/answer/#{answer.submission.assessment.display_mode}",
+      = render partial: "course/assessment/answer/#{answer.submission.assessment.mode}",
                locals: { base_answer_form: f, answer: answer, last_attempt: last_attempt }
 
       - if !submission.attempting?

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -12,10 +12,10 @@
     = f.input :draft
   = f.input :autograded, label: t('.autograded'),
                          hint: t('.autograded_hint')
-  = f.input :mode, as: :select, collection: Course::Assessment.modes.keys
   = f.folder
   = f.hidden_field :tab, value: @tab.id
   = f.hidden_field :category, value: @tab.category_id
+  = f.hidden_field :mode
 
   - if @assessment.persisted?
     = render partial: 'course/condition/conditions', locals: { conditional: @assessment }

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -12,7 +12,7 @@
     = f.input :draft
   = f.input :autograded, label: t('.autograded'),
                          hint: t('.autograded_hint')
-  = f.input :display_mode, as: :select, collection: Course::Assessment.display_modes.keys
+  = f.input :mode, as: :select, collection: Course::Assessment.modes.keys
   = f.folder
   = f.hidden_field :tab, value: @tab.id
   = f.hidden_field :category, value: @tab.category_id

--- a/app/views/course/assessment/assessments/index.html.slim
+++ b/app/views/course/assessment/assessments/index.html.slim
@@ -1,6 +1,19 @@
 = page_header format_inline_text(@category.title) do
   - if can?(:create, Course::Assessment.new(tab: @tab))
-    = new_button([current_course, :assessment, category: @category.id, tab: @tab.id])
+    div.pull-right
+      div.dropdown
+        button.btn.btn-info.dropdown-toggle#new-assessment type='button' data-toggle='dropdown' aria-expanded='true'
+          => t('common.new')
+          span.caret
+        ul.dropdown-menu.dropdown-menu-right role='menu' aria-labelledby='new-assessment'
+          li role='presentation'
+            = link_to(t('.new_assessment.guided'),
+              [:new, current_course, :assessment, category: @category.id, tab: @tab.id, mode: :guided],
+              role: 'menuitem')
+          li role='presentation'
+            = link_to(t('.new_assessment.worksheet'),
+              [:new, current_course, :assessment, category: @category.id, tab: @tab.id, mode: :worksheet],
+              role: 'menuitem')
 
 = display_assessment_tabs
 

--- a/app/views/course/assessment/assessments/new.html.slim
+++ b/app/views/course/assessment/assessments/new.html.slim
@@ -1,3 +1,3 @@
-- add_breadcrumb :new
-= page_header
+- add_breadcrumb t(".#{@assessment.mode}")
+= page_header t(".#{@assessment.mode}")
 = render partial: 'form'

--- a/app/views/course/assessment/submission/submissions/edit.html.slim
+++ b/app/views/course/assessment/submission/submissions/edit.html.slim
@@ -8,4 +8,4 @@
 = div_for(@assessment, 'data-assessment-id' => @assessment.id,
                        class: single_question_flag_class(@assessment)) do
   = div_for(@submission, 'data-submission-id' => @submission.id) do
-    = render @assessment.display_mode
+    = render @assessment.mode

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -69,8 +69,6 @@ en:
             index: :'course.assessment.assessments.index.header'
         controller:
           index: :'course.assessment.assessments.index.header'
-        assessments:
-          new: :'course.assessment.assessments.new.header'
         question:
           multiple_responses:
             new: :'course.assessment.question.multiple_responses.new.header'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -17,6 +17,9 @@ en:
           end_at: 'End At'
           maximum_experience_points: 'Maximum Experience Points'
           requirement_for: 'Requirement For'
+          new_assessment:
+            guided: 'Guided Assessment'
+            worksheet: 'Worksheet Assessment'
         assessment:
           attempt: 'Attempt'
           condition_not_satisfied: 'You do not fulfill the requirements of the assessment'
@@ -40,7 +43,8 @@ en:
             file_upload: 'File Upload'
             programming: 'Programming'
         new:
-          header: 'New Assessment'
+          guided: 'New Guided Assessment'
+          worksheet: 'New Worksheet Assessment'
         create:
           success: 'Assessment %{title} was created.'
         update:

--- a/db/migrate/20161006063146_rename_assessments_display_mode.rb
+++ b/db/migrate/20161006063146_rename_assessments_display_mode.rb
@@ -1,0 +1,7 @@
+class RenameAssessmentsDisplayMode < ActiveRecord::Migration
+  def change
+    change_table :course_assessments do |t|
+      t.rename :display_mode, :mode
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161003094742) do
+ActiveRecord::Schema.define(version: 20161006063146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,13 +134,13 @@ ActiveRecord::Schema.define(version: 20161003094742) do
   end
 
   create_table "course_assessments", force: :cascade do |t|
-    t.integer  "tab_id",       :null=>false, :index=>{:name=>"fk__course_assessments_tab_id"}, :foreign_key=>{:references=>"course_assessment_tabs", :name=>"fk_course_assessments_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "display_mode", :default=>0, :null=>false
-    t.boolean  "autograded",   :null=>false
-    t.integer  "creator_id",   :null=>false, :index=>{:name=>"fk__course_assessments_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",   :null=>false, :index=>{:name=>"fk__course_assessments_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",   :null=>false
-    t.datetime "updated_at",   :null=>false
+    t.integer  "tab_id",     :null=>false, :index=>{:name=>"fk__course_assessments_tab_id"}, :foreign_key=>{:references=>"course_assessment_tabs", :name=>"fk_course_assessments_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "mode",       :default=>0, :null=>false
+    t.boolean  "autograded", :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessments_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_assessments_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "course_assessment_questions", force: :cascade do |t|

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -79,11 +79,11 @@ FactoryGirl.define do
     end
 
     trait :worksheet do
-      display_mode :worksheet
+      mode :worksheet
     end
 
     trait :guided do
-      display_mode :guided
+      mode :guided
     end
 
     # Note: Not to be used alone, as a published assessment requires at

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature 'Course: Assessments: Management' do
 
     context 'As a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
-      scenario 'I can create a new assessment' do
+
+      scenario 'I can create a new worksheet assessment' do
         assessment_tab = create(:course_assessment_tab,
                                 category: course.assessment_categories.first)
         assessment = build_stubbed(:assessment)
@@ -18,9 +19,11 @@ RSpec.feature 'Course: Assessments: Management' do
 
         visit course_assessments_path(course, category: assessment_tab.category,
                                               tab: assessment_tab)
-        click_link(I18n.t('helpers.buttons.assessment.new'))
+        click_link I18n.t('course.assessment.assessments.index.new_assessment.worksheet')
 
         expect(current_path).to eq(new_course_assessment_path(course))
+        expect(page).
+          to have_selector('h1', text: I18n.t('course.assessment.assessments.new.worksheet'))
 
         # Create an assessment with a missing title.
         fill_in 'assessment_description', with: assessment.description
@@ -30,9 +33,7 @@ RSpec.feature 'Course: Assessments: Management' do
         fill_in 'assessment_start_at', with: assessment.start_at
         fill_in 'assessment_end_at', with: assessment.end_at
         fill_in 'assessment_bonus_end_at', with: assessment.bonus_end_at
-        within '#assessment_display_mode' do
-          find("option[value='guided']").select_option
-        end
+
 
         click_button 'submit'
 
@@ -48,6 +49,34 @@ RSpec.feature 'Course: Assessments: Management' do
         expect(assessment_created.tab).to eq(assessment_tab)
         expect(page).to have_content_tag_for(assessment_created)
         expect(assessment_created.folder.materials).to be_present
+        expect(assessment_created).to be_worksheet
+      end
+
+      scenario 'I can create a new guided assessment' do
+        assessment_tab = create(:course_assessment_tab,
+                                category: course.assessment_categories.first)
+        assessment = build_stubbed(:assessment)
+
+        visit course_assessments_path(course, category: assessment_tab.category,
+                                              tab: assessment_tab)
+        click_link I18n.t('course.assessment.assessments.index.new_assessment.guided')
+
+        expect(page).
+          to have_selector('h1', text: I18n.t('course.assessment.assessments.new.guided'))
+
+        fill_in 'assessment_title', with: assessment.title
+        fill_in 'assessment_description', with: assessment.description
+        fill_in 'assessment_base_exp', with: assessment.base_exp
+        fill_in 'assessment_time_bonus_exp', with: assessment.time_bonus_exp
+        fill_in 'assessment_extra_bonus_exp', with: assessment.extra_bonus_exp
+        fill_in 'assessment_start_at', with: assessment.start_at
+        fill_in 'assessment_end_at', with: assessment.end_at
+        fill_in 'assessment_bonus_end_at', with: assessment.bonus_end_at
+
+        click_button 'submit'
+
+        assessment_created = course.assessments.last
+        expect(assessment_created.tab).to eq(assessment_tab)
         expect(assessment_created).to be_guided
       end
 


### PR DESCRIPTION
This PR helps with #1564

* Rename assessment `display_mode` to `mode`
* Use different buttons to create assessments in different mode (or type)

Now the difference of guided and worksheet are not only display but the backend logic as well. After PE comes, they will be more different, thus I did the rename. (There might be a display mode in future, but it will be single page display vs tab display and purely view layer).

I am planning to let the different type of assessments show a different set of attributes, thus the creation view will be different. 

In this case, I think `guided` and `worksheet` should be renamed too, any suggestions ? 