### PR TITLE
Put all users in the same achievement award form.

### DIFF
--- a/app/views/course/achievement/course_users/_course_users_form.html.slim
+++ b/app/views/course/achievement/course_users/_course_users_form.html.slim
@@ -2,11 +2,12 @@
   = f.error_notification
   = f.error :achievement
 
+  - collection = course.course_users.with_approved_state.without_phantom_users.students.order_alphabetically
   table.table.table-hover
     thead
       th = t('.name')
       th
-        input.toggle-all id="toggle-all-#{css}-achievements" type='checkbox' style='display: none'
+        input.toggle-all id="toggle-all-normal-achievements" type='checkbox' style='display: none'
         '
         label for='toggle-all-achievements'
           = t('.enabled')
@@ -14,6 +15,24 @@
       = f.collection_check_boxes :course_user_ids, collection, :id, :name do |f|
         tr
           th = link_to_course_user(f.object)
-          td = f.check_box 'data-for-select-all' => "toggle-all-#{css}-achievements"
+          td = f.check_box 'data-for-select-all' => "toggle-all-normal-achievements"
 
-  = f.button :submit, t(".#{button}")
+  br
+  h4 = t('.phantom_user_header')
+
+  - collection = course.course_users.with_approved_state.phantom.students.order_alphabetically
+  table.table.table-hover
+    thead
+      th = t('.name')
+      th
+        input.toggle-all id="toggle-all-phantom-achievements" type='checkbox' style='display: none'
+        '
+        label for='toggle-all-achievements'
+          = t('.enabled')
+    tbody
+      = f.collection_check_boxes :course_user_ids, collection, :id, :name do |f|
+        tr
+          th = link_to_course_user(f.object)
+          td = f.check_box 'data-for-select-all' => "toggle-all-phantom-achievements"
+
+  = f.button :submit, t(".button")

--- a/app/views/course/achievement/course_users/index.html.slim
+++ b/app/views/course/achievement/course_users/index.html.slim
@@ -6,13 +6,4 @@
 div.alert.alert-info
   = simple_format(t('.notice'))
 
-- collection = @course.course_users.with_approved_state.without_phantom_users.students.order_alphabetically
-= render partial: 'course_users_form', locals: { course: @course, achievement: @achievement, collection: collection,
-                                                 css: 'normal', button: 'button' }
-
-br
-h4 = t('.phantom_user_header')
-
-- collection = @course.course_users.with_approved_state.phantom.students.order_alphabetically
-= render partial: 'course_users_form', locals: { course: @course, achievement: @achievement, collection: collection,
-                                                 css: 'phantom', button: 'phantom_button' }
+= render partial: 'course_users_form', locals: { course: @course, achievement: @achievement }

--- a/config/locales/en/course/achievement/course_users.yml
+++ b/config/locales/en/course/achievement/course_users.yml
@@ -7,9 +7,8 @@ en:
           name: 'Student Name'
           enabled: 'Obtained Achievement'
           button: 'Update Users'
-          phantom_button: 'Update Phantom Users'
-        index:
           phantom_user_header: 'Phantom Users'
+        index:
           notice: >
             If an Achievement has conditions associated with it, Coursemology will automatically
             award achievements when the student meets those conditions.

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -83,6 +83,8 @@ RSpec.feature 'Course: Achievements' do
         course_user_id = "achievement_course_user_ids_#{student.id}"
         unregistered_user = create(:course_user, course: course)
         unregistered_user_id = "achievement_course_user_ids_#{unregistered_user.id}"
+        phantom_user = create(:course_user, :approved, :phantom, course: course)
+        phantom_user_id = "achievement_course_user_ids_#{phantom_user.id}"
 
         visit course_achievements_path(course)
 
@@ -97,12 +99,15 @@ RSpec.feature 'Course: Achievements' do
         end
 
         expect(page).to have_unchecked_field(course_user_id)
+        expect(page).to have_unchecked_field(phantom_user_id)
         expect(page).not_to have_field(unregistered_user_id)
         check course_user_id
+        check phantom_user_id
+
 
         expect do
           click_button I18n.t('course.achievement.course_users.course_users_form.button')
-        end.to change(manual_achievement.course_users, :count).by(1)
+        end.to change(manual_achievement.course_users, :count).by(2)
       end
     end
   end


### PR DESCRIPTION
Putting them into separate forms causes errors when each form is
updated. The achievements for the other type of user gets totally
cleared.

References #1583.