### PR TITLE
Add published state to submission

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -10,7 +10,7 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   end
 
   def pending
-    @submissions = pending_submissions.from_course(current_course).with_submitted_state
+    @submissions = pending_submissions.from_course(current_course).pending_for_grading
   end
 
   private

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -31,7 +31,7 @@ module Course::Assessment::Submission::SubmissionsHelper
 
   # Return the last attempted answer based on the status of current submission.
   # previous attempt if submission is in attempting state.
-  # current attempt if submission is in submitted or graded state.
+  # current attempt if submission is in submitted, graded or published state.
   #
   # @return [Course::Assessment::Answer]
   def last_attempt(answer)

--- a/app/models/concerns/course_user/staff_concern.rb
+++ b/app/models/concerns/course_user/staff_concern.rb
@@ -19,8 +19,8 @@ module CourseUser::StaffConcern
     end)
   end
 
-  def graded_submissions # rubocop:disable Metrics/AbcSize
-    @graded_submissions ||=
+  def published_submissions # rubocop:disable Metrics/AbcSize
+    @published_submissions ||=
       Course::Assessment::Submission.
       joins { experience_points_record.course_user }.
       where { experience_points_record.course_user.course_id == my { course_id } }.
@@ -53,7 +53,7 @@ module CourseUser::StaffConcern
 
   def valid_submissions
     @valid_submissions ||=
-      graded_submissions.
+      published_submissions.
       select { |s| s.submitted_at && s.published_at && s.published_at > s.submitted_at }
   end
 

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -51,8 +51,8 @@ module Course::Assessment::AssessmentAbility
     end
   end
 
-  def submission_submitted_or_graded_hash
-    { workflow_state: ['submitted', 'graded'] }
+  def submissions_without_attempting_hash
+    { workflow_state: ['submitted', 'graded', 'published'] }
   end
 
   def allow_students_show_assessments
@@ -97,10 +97,10 @@ module Course::Assessment::AssessmentAbility
   def allow_staff_grade_submissions
     can [:read, :update, :reload_answer],
         Course::Assessment::Submission, assessment: assessment_course_staff_hash
-    can :grade, Course::Assessment::Submission, submission_submitted_or_graded_hash.merge(
+    can :grade, Course::Assessment::Submission, submissions_without_attempting_hash.merge(
       assessment: assessment_course_staff_hash
     )
-    can :grade, Course::Assessment::Answer, submission: submission_submitted_or_graded_hash.merge(
+    can :grade, Course::Assessment::Answer, submission: submissions_without_attempting_hash.merge(
       assessment: assessment_course_staff_hash
     )
   end

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -36,7 +36,7 @@ class Course::Condition::Assessment < ActiveRecord::Base
 
     if minimum_grade_percentage
       minimum_grade = assessment.maximum_grade * minimum_grade_percentage / 100.0
-      graded_submissions_with_minimum_grade(user, minimum_grade).exists?
+      published_submissions_with_minimum_grade(user, minimum_grade).exists?
     else
       submitted_submissions_by_user(user).exists?
     end
@@ -59,11 +59,11 @@ class Course::Condition::Assessment < ActiveRecord::Base
 
   def submitted_submissions_by_user(user)
     # TODO: Replace with Rails 5 ActiveRecord::Relation#or with named scope
-    assessment.submissions.by_user(user).where(workflow_state: [:submitted, :graded])
+    assessment.submissions.by_user(user).where(workflow_state: [:submitted, :graded, :published])
   end
 
-  def graded_submissions_with_minimum_grade(user, minimum_grade)
-    assessment.submissions.by_user(user).with_graded_state.
+  def published_submissions_with_minimum_grade(user, minimum_grade)
+    assessment.submissions.by_user(user).with_published_state.
       joins { answers }.
       group { course_assessment_submissions.id }.
       having { coalesce(sum(answers.grade), 0) >= minimum_grade }

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -8,7 +8,7 @@ div.panel.panel-default
           td = display_course_user(@submission.course_user)
         tr
           th = t('.status')
-          td = @submission.workflow_state
+          td = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
         tr
           th = @submission.class.human_attribute_name(:grade)
           td

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -1,3 +1,4 @@
+- display_grading_results = @submission.published? || can?(:grade, @submission)
 div.panel.panel-default
   div.panel-heading = t('.statistics')
   div.panel-body.statistics
@@ -9,29 +10,30 @@ div.panel.panel-default
         tr
           th = t('.status')
           td = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
-        tr
-          th = @submission.class.human_attribute_name(:grade)
-          td
-            span#submission-statistics-total-grade>
-              = @submission.grade
-            ' /
-            span#submission-statistics-maximum-grade
-              = @submission.assessment.maximum_grade
-        tr
-          th = @submission.experience_points_record.class.human_attribute_name(:points_awarded)
-          - if can?(:grade, @submission)
-            / TODO: Factor in time-based experience points
+        - if display_grading_results
+          tr
+            th = @submission.class.human_attribute_name(:grade)
             td
-              = f.input :points_awarded, label: false,
-                        input_html: { class: 'submission-points-awarded',
-                                      'data-base-points' => @submission.assessment.base_exp },
-                        wrapper_html: { class: 'form-inline points-awarded'}
-              span = ' / ' + @submission.assessment.base_exp.to_s
-              div.exp-multiplier.form-inline
-                => t('.multiplier')
-                input.form-control type='number' max='1' min ='0' value='1' step='0.1'
-          - else
-            td = @submission.points_awarded
+              span#submission-statistics-total-grade>
+                = @submission.grade
+              ' /
+              span#submission-statistics-maximum-grade
+                = @submission.assessment.maximum_grade
+          tr
+            th = @submission.experience_points_record.class.human_attribute_name(:points_awarded)
+            - if can?(:grade, @submission)
+              / TODO: Factor in time-based experience points
+              td
+                = f.input :points_awarded, label: false,
+                          input_html: { class: 'submission-points-awarded',
+                                        'data-base-points' => @submission.assessment.base_exp },
+                          wrapper_html: { class: 'form-inline points-awarded'}
+                span = ' / ' + @submission.assessment.base_exp.to_s
+                div.exp-multiplier.form-inline
+                  => t('.multiplier')
+                  input.form-control type='number' max='1' min ='0' value='1' step='0.1'
+            - else
+              td = @submission.points_awarded
         tr
           th = t('.due_at')
           td = format_datetime(@assessment.end_at) if @assessment.end_at
@@ -41,14 +43,15 @@ div.panel.panel-default
         tr
           th = @submission.class.human_attribute_name(:submitted_at)
           td = format_datetime(@submission.submitted_at)
-        tr
-          th = @submission.class.human_attribute_name(:grader)
-          td = display_course_user(@submission.publisher) if @submission.publisher
-        tr
-          th = @submission.class.human_attribute_name(:graded_at)
-          td = format_datetime(@submission.published_at) if @submission.published_at
+        - if display_grading_results
+          tr
+            th = @submission.class.human_attribute_name(:grader)
+            td = display_course_user(@submission.publisher) if @submission.publisher
+          tr
+            th = @submission.class.human_attribute_name(:graded_at)
+            td = format_datetime(@submission.published_at) if @submission.published_at
 
-    - if @assessment.questions.length > 1
+    - if @assessment.questions.length > 1 && display_grading_results
       h4 = t('.grade_summary')
       table.table.table-striped
         thead

--- a/app/views/course/assessment/submission/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submission.html.slim
@@ -3,7 +3,7 @@
     = link_to edit_course_assessment_submission_path(current_course, submission.assessment,
                                                      submission) do
       = format_inline_text(submission.course_user.name)
-  td.col-md-3.col-xs-3 = submission.workflow_state.capitalize
+  td.col-md-3.col-xs-3 = Course::Assessment::Submission.human_attribute_name(submission.workflow_state)
   td = submission.grade.to_s + ' / ' + submission.assessment.maximum_grade.to_s
   td = submission.points_awarded.to_i.to_s
   td

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -25,6 +25,6 @@
           @submission), method: :post, class: ['btn', 'btn-info']
       = f.button :submit, t('.publish'), name: 'submission[publish]', class: ['btn-warning']
 
-    - if (@submission.submitted? || @submission.graded?) && can?(:grade, @submission)
+    - if (@submission.submitted? || @submission.graded? || @submission.published?) && can?(:grade, @submission)
       = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-danger'],
         data: { confirm: t('.confirm_unsubmit') }

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -12,7 +12,7 @@
           = link_to_course_user(manager) do |course_user|
             = format_inline_text(course_user.name)
 
-  - if submission.graded?
+  - if submission.published?
     td = submission.grade.to_s + ' / ' + assessment.maximum_grade.to_s
     td = submission.points_awarded
   - else

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -4,7 +4,7 @@
   td = link_to(format_inline_text(assessment.title),
                course_assessment_path(current_course, assessment))
   td = format_datetime(submission.submitted_at) if submission.submitted_at
-  td = submission.workflow_state.capitalize
+  td = Course::Assessment::Submission.human_attribute_name(submission.workflow_state)
   - if pending
     td
       - @service.group_managers_of(submission.course_user).each do |manager|

--- a/app/views/course/statistics/_staff_performance.html.slim
+++ b/app/views/course/statistics/_staff_performance.html.slim
@@ -3,7 +3,7 @@
     = index
   td = staff.name
   td.text-center
-    = staff.graded_submissions.size
+    = staff.published_submissions.size
   td.text-center
     = staff.my_students.count
   td.text-center

--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -7,6 +7,10 @@ en:
         submitted_at: :'activerecord.attributes.course/assessment/answer.submitted_at'
         grader: :'activerecord.attributes.course/assessment/answer.grader'
         graded_at: :'activerecord.attributes.course/assessment/answer.graded_at'
+        attempting: 'Attempting'
+        submitted: 'Submitted'
+        graded: 'Graded but not published'
+        published: 'Graded'
     errors:
       models:
         course/assessment/submission:

--- a/db/migrate/20161013115452_migrate_graded_submissions_to_published.rb
+++ b/db/migrate/20161013115452_migrate_graded_submissions_to_published.rb
@@ -1,0 +1,6 @@
+class MigrateGradedSubmissionsToPublished < ActiveRecord::Migration
+  def up
+    Course::Assessment::Submission.where(workflow_state: 'graded').
+      update_all(workflow_state: 'published')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161007061116) do
+ActiveRecord::Schema.define(version: 20161013115452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Course::Assessment::SubmissionsController do
         let(:student) { create(:course_student, course: course).user }
         let(:assessment) { create(:assessment, :with_all_question_types, course: course, tab: tab) }
         let!(:submission) do
-          create(:course_assessment_submission, :graded, creator: student, assessment: assessment)
+          create(:course_assessment_submission, :published,
+                 creator: student, assessment: assessment)
         end
         before { get :index, course_id: course, category: category }
 

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -33,6 +33,14 @@ FactoryGirl.define do
         end
 
         # Revert publisher and published at if given.
+        submission.mark!
+      end
+    end
+
+    trait :published do
+      graded
+      after(:build) do |submission, evaluator|
+        # Revert publisher and published at if given.
         submission.publish!
         submission.publisher = evaluator.publisher if evaluator.publisher
         submission.published_at = evaluator.published_at if evaluator.published_at

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -201,12 +201,12 @@ RSpec.describe 'Course: Assessments: Attempt' do
         expect(current_path).to eq(
           edit_course_assessment_submission_path(course, assessment, submission)
         )
-        expect(submission.reload.graded?).to be(true)
+        expect(submission.reload.published?).to be(true)
         expect(submission.grade).to eq(submission_maximum_grade)
         expect(submission.points_awarded).to eq(new_exp)
       end
 
-      scenario 'I can unsubmit a submitted or graded submission' do
+      scenario 'I can unsubmit a submitted or published submission' do
         # Submitted submission
         assessment.questions.attempt(submission).each(&:save!)
         submission.finalise!
@@ -219,7 +219,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         expect(submission.points_awarded).to be_nil
         expect(submission.latest_answers.all?(&:attempting?)).to be_truthy
 
-        # Graded submission
+        # Published submission
         submission.finalise!
         submission.publish!
         submission.save!

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         wait_for_job
         visit current_path
-        expect(page).to have_selector('td', text: 'graded')
+        expect(page).to have_selector('td', text: 'published')
       end
 
       scenario 'I can reset my answer to a programming question', js: true do
@@ -200,7 +200,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         click_button I18n.t('course.assessment.submission.submissions.guided.publish')
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))
-        expect(submission.reload.graded?).to be(true)
+        expect(submission.reload.published?).to be(true)
       end
 
       scenario 'I can skip steps' do

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
 
         [submitted_submission, attempting_submission, published_submission].each do |submission|
           within all(content_tag_selector(submission)).last do
-            expect(page).to have_text(submission.workflow_state.capitalize)
+            expect(page).
+              to have_text(submission.class.human_attribute_name(submission.workflow_state))
             expect(page).to have_text(submission.points_awarded)
           end
         end

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
                                                          course: course,
                                                          creator: students[1].user)
     end
-    let!(:graded_submission) do
-      create(:course_assessment_submission, :graded, assessment: assessment,
+    let!(:published_submission) do
+      create(:course_assessment_submission, :published, assessment: assessment,
                                                      course: course,
                                                      creator: students[2].user)
     end
@@ -49,7 +49,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
         expect(page).
           to have_text(I18n.t('course.assessment.submission.submissions.index.other_header'))
 
-        [submitted_submission, attempting_submission, graded_submission].each do |submission|
+        [submitted_submission, attempting_submission, published_submission].each do |submission|
           within all(content_tag_selector(submission)).last do
             expect(page).to have_text(submission.workflow_state.capitalize)
             expect(page).to have_text(submission.points_awarded)

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe 'Course: Submissions Viewing' do
       let(:course_manager) { create(:course_manager, course: course) }
       let(:user) { course_manager.user }
 
-      scenario 'I can view all submitted and graded submissions' do
+      scenario 'I can view all submitted and published submissions' do
         students = create_list(:course_student, 3, course: course)
-        attempting_submission, submitted_submission, graded_submission =
-          students.zip([:attempting, :submitted, :graded]).map do |student, trait|
+        attempting_submission, submitted_submission, published_submission =
+          students.zip([:attempting, :submitted, :published]).map do |student, trait|
             create(:course_assessment_submission, trait,
                    assessment: assessment, creator: student.user)
           end
@@ -36,18 +36,18 @@ RSpec.describe 'Course: Submissions Viewing' do
             href: edit_course_assessment_submission_path(course, assessment, submitted_submission)
           )
         end
-        within find(content_tag_selector(graded_submission)) do
+        within find(content_tag_selector(published_submission)) do
           expect(page).to have_link(
             I18n.t('course.assessment.submissions.submission.view'),
-            href: edit_course_assessment_submission_path(course, assessment, graded_submission)
+            href: edit_course_assessment_submission_path(course, assessment, published_submission)
           )
         end
       end
 
       scenario 'I can access pending submissions from the sidebar and view pending submissions' do
         students = create_list(:course_student, 4, course: course)
-        attempting_submission, submitted_submission1, submitted_submission2, graded_submission =
-          students.zip([:attempting, :submitted, :submitted, :graded]).map do |student, trait|
+        attempting_submission, submitted_submission1, submitted_submission2, published_submission =
+          students.zip([:attempting, :submitted, :submitted, :published]).map do |student, trait|
             create(:course_assessment_submission, trait,
                    assessment: assessment, course: course,
                    creator: student.user, course_user: student)
@@ -58,7 +58,7 @@ RSpec.describe 'Course: Submissions Viewing' do
         expect(page).to have_content_tag_for(submitted_submission1)
         expect(page).to have_content_tag_for(submitted_submission2)
         expect(page).not_to have_content_tag_for(attempting_submission)
-        expect(page).not_to have_content_tag_for(graded_submission)
+        expect(page).not_to have_content_tag_for(published_submission)
 
         # Staff with group view pending submissions of own group students
         group = create(:course_group, course: course)
@@ -70,7 +70,7 @@ RSpec.describe 'Course: Submissions Viewing' do
         expect(page).to have_content_tag_for(submitted_submission1)
         expect(page).not_to have_content_tag_for(submitted_submission2)
         expect(page).not_to have_content_tag_for(attempting_submission)
-        expect(page).not_to have_content_tag_for(graded_submission)
+        expect(page).not_to have_content_tag_for(published_submission)
 
         # Pending submissions tab shows the tutors for the students if it exists.
         visit pending_course_submissions_path(course, my_students: false)
@@ -91,11 +91,11 @@ RSpec.describe 'Course: Submissions Viewing' do
     context 'As a Course Student' do
       let(:user) { create(:course_student, course: course).user }
 
-      scenario 'I can view my submitted and graded submissions' do
+      scenario 'I can view my submitted and published submissions' do
         # Attach a submission of each trait to a unique assessment
         assessments = create_list(:course_assessment_assessment, 3, course: course)
-        attempting_submission, submitted_submission, graded_submission =
-          assessments.zip([:attempting, :submitted, :graded]).map do |assessment, trait|
+        attempting_submission, submitted_submission, published_submission =
+          assessments.zip([:attempting, :submitted, :published]).map do |assessment, trait|
             create(:course_assessment_submission, trait,
                    assessment: assessment, creator: user)
           end
@@ -105,7 +105,7 @@ RSpec.describe 'Course: Submissions Viewing' do
         expect(page).not_to have_content_tag_for(attempting_submission)
         expect(page).not_to have_selector('div.submissions-filter')
 
-        [submitted_submission, graded_submission].each do |submission|
+        [submitted_submission, published_submission].each do |submission|
           within find(content_tag_selector(submission)) do
             expect(page).to have_link(
               I18n.t('course.assessment.submissions.submission.view'),

--- a/spec/features/course/staff_statistics_spec.rb
+++ b/spec/features/course/staff_statistics_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Course: Statistics: Staff' do
         submitted_at = 1.day.ago
         published_at = submitted_at + 1.day + 1.hour + 1.minute + 1.second
         assessment = create(:course_assessment_assessment, course: course)
-        submission = create(:course_assessment_submission, :graded,
+        submission = create(:course_assessment_submission, :published,
                             assessment: assessment, course: course, publisher: tutor1.user,
                             published_at: published_at)
         create(:course_assessment_answer_multiple_response, :graded,
@@ -36,7 +36,7 @@ RSpec.feature 'Course: Statistics: Staff' do
         submitted_at = 2.days.ago
         published_at = submitted_at + 2.days
         assessment = create(:course_assessment_assessment, course: course)
-        submission = create(:course_assessment_submission, :graded,
+        submission = create(:course_assessment_submission, :published,
                             assessment: assessment, course: course, publisher: tutor2.user,
                             published_at: published_at)
         create(:course_assessment_answer_multiple_response, :graded,

--- a/spec/helpers/course/assessment/submissions_helper_spec.rb
+++ b/spec/helpers/course/assessment/submissions_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Course::Assessment::SubmissionsHelper do
       # Create submissions of various statuses, but only 1 which is pending submission.
       create(:submission, :attempting, assessment: assessment, creator: students[0].user)
       create(:submission, :submitted, assessment: assessment, creator: students[1].user)
-      create(:submission, :graded, assessment: assessment, creator: students[2].user)
+      create(:submission, :published, assessment: assessment, creator: students[2].user)
     end
 
     describe '#pending_submissions_count' do

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -174,12 +174,12 @@ RSpec.describe Course::Assessment::Submission do
     describe '.confirmed' do
       let(:submission1_traits) { :attempting }
       let(:submission2_traits) { :submitted }
-      let(:submission3_traits) { :graded }
+      let(:submission3_traits) { :published }
       let!(:submissions) { [submission1, submission2, submission3] }
 
-      it 'returns the submissions with submitted or graded workflow state' do
+      it 'returns the submissions with submitted or publidhrf workflow state' do
         states = assessment.submissions.confirmed.map(&:workflow_state)
-        expect(states).to contain_exactly('graded', 'submitted')
+        expect(states).to contain_exactly('published', 'submitted')
       end
     end
 
@@ -267,7 +267,7 @@ RSpec.describe Course::Assessment::Submission do
 
     describe '#graded_at' do
       let(:assessment_traits) { [:with_all_question_types] }
-      let(:submission1_traits) { :graded }
+      let(:submission1_traits) { :published }
       let(:submission) { submission1 }
 
       it 'takes the maximum graded_at' do
@@ -402,8 +402,8 @@ RSpec.describe Course::Assessment::Submission do
         end
       end
 
-      context 'when the submission is graded' do
-        let(:submission1_traits) { :graded }
+      context 'when the submission is published' do
+        let(:submission1_traits) { :published }
 
         it 'resets the experience points awarded' do
           expect(subject.points_awarded).to be_nil

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe Course::Condition::Assessment, type: :model do
           end
         end
 
-        context 'when the submission is already graded' do
-          let(:submission) { create(:course_assessment_submission, :graded) }
+        context 'when the submission is already published' do
+          let(:submission) { create(:course_assessment_submission, :published) }
           it 'does not evaluate_conditional_for the affected course_user' do
             expect(Course::Condition::Assessment).
               to_not receive(:evaluate_conditional_for).with(submission.course_user)
@@ -175,9 +175,9 @@ RSpec.describe Course::Condition::Assessment, type: :model do
           end
         end
 
-        context 'when the submission is graded' do
+        context 'when the submission is published' do
           it 'returns true' do
-            create(:course_assessment_submission, workflow_state: :graded,
+            create(:course_assessment_submission, workflow_state: :published,
                                                   assessment: assessment,
                                                   creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_truthy
@@ -201,9 +201,9 @@ RSpec.describe Course::Condition::Assessment, type: :model do
           end
         end
 
-        context 'when there are graded submissions' do
+        context 'when there are published submissions' do
           let(:submission) do
-            create(:course_assessment_submission, workflow_state: :graded,
+            create(:course_assessment_submission, workflow_state: :published,
                                                   assessment: assessment,
                                                   creator: course_user.user)
           end
@@ -214,7 +214,7 @@ RSpec.describe Course::Condition::Assessment, type: :model do
             end
           end
 
-          context 'when all graded submissions are below the minimum grade percentage' do
+          context 'when all published submissions are below the minimum grade percentage' do
             it 'returns false' do
               answers = assessment.questions.attempt(submission)
               answers.each do |answer|

--- a/spec/services/course/assessment/submission/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/submission/auto_grading_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
         end
 
         it 'gives the correct experience points' do
-          expect(submission).to be_graded
+          expect(submission).to be_published
 
           correct_exp = (assessment.time_bonus_exp + assessment.base_exp).to_f / 2
           expect(submission.points_awarded).to eq(correct_exp.to_i)


### PR DESCRIPTION
Helps with #1565 

The `graded` state is renamed to `published`, now `graded` state means graded but haven't published yet.

Also, the grading results are hidden for students before the grading is published. 

