### PR TITLE
Implement todo transitions for submissions

### DIFF
--- a/app/models/concerns/course/assessment/submission/todo_concern.rb
+++ b/app/models/concerns/course/assessment/submission/todo_concern.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Course::Assessment::Submission::TodoConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_create :update_todo
+    after_destroy :restart_todo
+
+    # Overrides #finalise method, which is part of the workflow event transition handler
+    # Given the need to override this method, this concern has to be placed after the
+    #   event transition handlers defined in Course::Assessment::Submission class.
+    define_method :finalise do |*args|
+      super(*args) if defined?(super)
+      return unless todo.in_progress?
+      todo.complete!
+      todo.save!
+    end
+
+    # Overrides #unsubmit method, which is part of the workflow event transition handler
+    # Given the need to override this method, this concern has to be placed after the
+    #   event transition handlers defined in Course::Assessment::Submission class.
+    define_method :unsubmit do |*args|
+      super(*args) if defined?(super)
+      return unless todo.completed?
+      todo.uncomplete!
+      todo.save!
+    end
+  end
+
+  def todo
+    @todo ||= begin
+      lesson_plan_item_id = assessment.lesson_plan_item.id
+      Course::LessonPlan::Todo.find_by(item_id: lesson_plan_item_id, user_id: creator_id)
+    end
+  end
+
+  def update_todo
+    return unless todo.not_started?
+    todo.start!
+    todo.save!
+  end
+
+  def restart_todo
+    return if todo.not_started?
+    todo.restart!
+    todo.save!
+  end
+end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module Course::Assessment::Submission::WorkflowEventConcern
+  extend ActiveSupport::Concern
+
+  protected
+
+  # Handles the finalisation of a submission.
+  #
+  # This finalises all the answers as well.
+  def finalise(_ = nil)
+    answers.select(&:attempting?).each(&:finalise!)
+  end
+
+  # Handles the marking of a submission. This will grade all the answers.
+  def mark(_ = nil)
+    answers.each do |answer|
+      answer.publish! if answer.submitted?
+    end
+  end
+
+  # Handles the publishing of a submission.
+  #
+  # This grades all the answers as well.
+  def publish(_ = nil)
+    answers.each do |answer|
+      answer.publish! if answer.submitted?
+    end
+    self.publisher = User.stamper || User.system
+    self.published_at = Time.zone.now
+  end
+
+  # Handles the unsubmission of a submitted submission.
+  def unsubmit(_ = nil)
+    # Skip the state validation in answers.
+    @unsubmitting = true
+
+    unsubmit_latest_answers
+    self.points_awarded = nil
+  end
+end

--- a/app/models/concerns/course/lesson_plan/item_todo_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item_todo_concern.rb
@@ -3,7 +3,7 @@ module Course::LessonPlan::ItemTodoConcern
   extend ActiveSupport::Concern
 
   included do
-    after_save :create_or_delete_todos, if: :has_todo?
+    after_create :create_todos, if: :has_todo?
   end
 
   def has_todo?
@@ -12,15 +12,9 @@ module Course::LessonPlan::ItemTodoConcern
 
   protected
 
-  # Callback to create or delete todos when lesson_plan_item's draft status is changed.
-  #    Todos are created for all course_users in the course.
-  # Uses ActiveModel::Dirty to check attribute changes.
-  def create_or_delete_todos
-    return unless draft_changed?
-    if draft_changed? from: true, to: false
-      Course::LessonPlan::Todo.create_for(self, course.course_users)
-    elsif draft_changed? from: false, to: true
-      Course::LessonPlan::Todo.delete_for(self)
-    end
+  # Create todos for the given lesson_plan_item for all course_users in the course.
+  def create_todos
+    course_users = CourseUser.where(course_id: course_id)
+    Course::LessonPlan::Todo.create_for(self, course_users)
   end
 end

--- a/app/models/concerns/course_user/todo_concern.rb
+++ b/app/models/concerns/course_user/todo_concern.rb
@@ -7,7 +7,8 @@ module CourseUser::TodoConcern
   end
 
   def create_todos_for_course_user
-    items = course.lesson_plan_items.includes(:actable).where(draft: false).select(&:has_todo?)
+    items =
+      Course::LessonPlan::Item.where(course_id: course_id).includes(:actable).select(&:has_todo?)
     Course::LessonPlan::Todo.create_for(items, self)
   end
 end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -3,6 +3,8 @@
 #
 # An assessment is a collection of questions that can be asked.
 class Course::Assessment < ActiveRecord::Base
+  # TODO: Remove when entire todo feature is ready
+  # acts_as_lesson_plan_item has_todo: true
   acts_as_lesson_plan_item
   acts_as_conditional
   has_one_folder

--- a/app/models/course/lesson_plan/todo.rb
+++ b/app/models/course/lesson_plan/todo.rb
@@ -8,9 +8,10 @@ class Course::LessonPlan::Todo < ActiveRecord::Base
     end
     state :in_progress do
       event :complete, transitions_to: :completed
-      event :revert, transitions_to: :not_started
+      event :restart, transitions_to: :not_started
     end
     state :completed do
+      event :uncomplete, transitions_to: :in_progress
       event :restart, transitions_to: :not_started
     end
   end

--- a/spec/controllers/course/assessment/submission/answer/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/comments_controller_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe Course::Assessment::Submission::Answer::CommentsController do
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_programming_question, course: course) }
-    let(:submission) do
-      create(:course_assessment_submission, :submitted, assessment: assessment, creator: user)
-    end
+    let(:submission) { create(:submission, :submitted, assessment: assessment, creator: user) }
     let(:immutable_answer) do
       submission.answers.first.tap do |stub|
         allow(stub).to receive(:save).and_return(false)

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
     let(:user) { create(:user) }
     let(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_programming_question, course: course) }
-    let(:submission) do
-      create(:course_assessment_submission, :submitted, assessment: assessment, creator: user)
-    end
+    let(:submission) { create(:submission, :submitted, assessment: assessment, creator: user) }
     let(:answer) { submission.answers.first }
     let(:file) { answer.actable.files.first }
     let(:immutable_annotation) do

--- a/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submission_worksheet_assessment_service_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     let(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :with_mrq_question, course: course) }
     let(:immutable_submission) do
-      create(:course_assessment_submission, assessment: assessment, creator: user).tap do |stub|
+      create(:submission, assessment: assessment, creator: user).tap do |stub|
         assessment.questions.attempt(stub).each(&:save)
         allow(stub).to receive(:save).and_return(false)
       end

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     let!(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :published, :with_all_question_types, course: course) }
     let(:immutable_submission) do
-      create(:course_assessment_submission, assessment: assessment, creator: user).tap do |stub|
+      create(:submission, assessment: assessment, creator: user).tap do |stub|
         allow(stub).to receive(:save).and_return(false)
         allow(stub).to receive(:update_attributes).and_return(false)
         allow(stub).to receive(:destroy).and_return(false)
@@ -79,9 +79,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     end
 
     describe '#reload_answer' do
-      let(:submission) do
-        create(:course_assessment_submission, assessment: assessment, creator: user)
-      end
+      let(:submission) { create(:submission, assessment: assessment, creator: user) }
 
       context 'when answer_id does not exist' do
         subject do

--- a/spec/controllers/course/assessment/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submissions_controller_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe Course::Assessment::SubmissionsController do
         let(:student) { create(:course_student, course: course).user }
         let(:assessment) { create(:assessment, :with_all_question_types, course: course, tab: tab) }
         let!(:submission) do
-          create(:course_assessment_submission, :published,
-                 creator: student, assessment: assessment)
+          create(:submission, :published, creator: student, assessment: assessment)
         end
         before { get :index, course_id: course, category: category }
 

--- a/spec/factories/course_assessment_answer_programming.rb
+++ b/spec/factories/course_assessment_answer_programming.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
       question_traits nil
       file_count nil
       file_contents nil
+      creator { create(:user) }
     end
 
     question do

--- a/spec/factories/course_assessment_answers.rb
+++ b/spec/factories/course_assessment_answers.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
   factory :course_assessment_answer, class: Course::Assessment::Answer,
                                      parent: :course_discussion_topic do
     transient do
+      course { build(:course) }
       assessment { build(:assessment, course: course) }
       # The creator in userstamps must be persisted.
       creator { create(:user) }
@@ -14,6 +15,7 @@ FactoryGirl.define do
       options = traits.extract_options!
       options[:assessment] = question.assessment
       options[:creator] = creator
+      options[:course] = course
       build(:course_assessment_submission, *traits, options)
     end
     question { build(:course_assessment_question, assessment: assessment) }

--- a/spec/factories/course_lesson_plan_todos.rb
+++ b/spec/factories/course_lesson_plan_todos.rb
@@ -22,8 +22,8 @@ FactoryGirl.define do
     end
 
     after(:build) do |_todo, evaluator|
-      course_user = CourseUser.where(course: evaluator.course, user: evaluator.user)
-      create(:course_user, :approved, course: evaluator.course) if course_user.blank?
+      course_user = CourseUser.find_by(course: evaluator.course, user: evaluator.user)
+      create(:course_user, :approved, course: evaluator.course) unless course_user
     end
   end
 end

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -6,14 +6,11 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) do
-      create(:course_assessment_assessment, :published_with_mrq_question, course: course)
-    end
+    let(:assessment) { create(:assessment, :published_with_mrq_question, course: course) }
     before { login_as(user, scope: :user) }
 
     let(:submission) do
-      create(:course_assessment_submission, *submission_traits, assessment: assessment,
-                                                                creator: user)
+      create(:submission, *submission_traits, assessment: assessment, creator: user)
     end
     let(:submission_traits) { nil }
     let(:options) { assessment.questions.first.specific.options }
@@ -23,9 +20,7 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
       let(:user) { create(:course_user, :approved, course: course).user }
 
       context 'when the question is a multiple choice question' do
-        let(:assessment) do
-          create(:course_assessment_assessment, :published_with_mcq_question, course: course)
-        end
+        let(:assessment) { create(:assessment, :published_with_mcq_question, course: course) }
 
         scenario 'I can save my submission' do
           visit edit_course_assessment_submission_path(course, assessment, submission)

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -6,12 +6,9 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) do
-      create(:course_assessment_assessment, :published_with_programming_question, course: course)
-    end
+    let(:assessment) { create(:assessment, :published_with_programming_question, course: course) }
     let(:submission) do
-      create(:course_assessment_submission, *submission_traits, assessment: assessment,
-                                                                creator: user)
+      create(:submission, *submission_traits, assessment: assessment, creator: user)
     end
     let(:submission_traits) { nil }
 

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -6,14 +6,11 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) do
-      create(:course_assessment_assessment, :published_with_text_response_question, course: course)
-    end
+    let(:assessment) { create(:assessment, :published_with_text_response_question, course: course) }
     before { login_as(user, scope: :user) }
 
     let(:submission) do
-      create(:course_assessment_submission, *submission_traits, assessment: assessment,
-                                                                creator: user)
+      create(:submission, *submission_traits, assessment: assessment, creator: user)
     end
     let(:submission_traits) { nil }
 
@@ -48,7 +45,7 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
 
       scenario 'I cannot see the text box for a file upload question' do
         assessment = create(:assessment, :published_with_file_upload_question, course: course)
-        submission = create(:course_assessment_submission, assessment: assessment, creator: user)
+        submission = create(:submission, assessment: assessment, creator: user)
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
 

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -24,11 +24,9 @@ RSpec.describe 'Course: Assessments: Attempt' do
     before { login_as(user, scope: :user) }
 
     let(:student) { create(:course_user, :approved, course: course).user }
-    let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, creator: student)
-    end
+    let(:submission) { create(:submission, assessment: assessment, creator: student) }
     let(:submitted_submission) do
-      create(:course_assessment_submission, :submitted, assessment: assessment, creator: student)
+      create(:submission, :submitted, assessment: assessment, creator: student)
     end
     let(:points_awarded) { 22 }
 

--- a/spec/features/course/assessment/assessment_viewing_spec.rb
+++ b/spec/features/course/assessment/assessment_viewing_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe 'Course: Assessments: Viewing' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) do
-      create(:course_assessment_assessment, :with_all_question_types, :published, course: course)
-    end
+    let(:assessment) { create(:assessment, :published_with_all_question_types, course: course) }
     before { login_as(user, scope: :user) }
 
     context 'As a Course Staff' do
@@ -54,7 +52,8 @@ RSpec.describe 'Course: Assessments: Viewing' do
       scenario 'I attempt the assessment from the show assessment page' do
         # Create a random submission which does not belong to the user.
         # The button should still be 'Attempt' with the random submission.
-        create(:course_assessment_submission, assessment: assessment)
+        student_user = create(:course_student, course: course).user
+        create(:submission, assessment: assessment, creator: student_user)
         visit course_assessment_path(course, assessment)
 
         expect(page).to have_link(

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:course_assessment_assessment, course: course) }
+    let(:assessment) { create(:assessment, course: course) }
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:course_assessment_assessment, course: course) }
+    let(:assessment) { create(:assessment, course: course) }
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:course_assessment_assessment, course: course) }
+    let(:assessment) { create(:assessment, course: course) }
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do

--- a/spec/features/course/assessment/submission/exam_spec.rb
+++ b/spec/features/course/assessment/submission/exam_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
     let(:mrq_questions) { assessment.reload.questions.map(&:specific) }
     let(:student) { create(:course_student, course: course).user }
     let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, creator: student)
+      create(:submission, assessment: assessment, creator: student)
     end
 
     before { login_as(user, scope: :user) }

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -16,14 +16,12 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
     before { login_as(user, scope: :user) }
 
     let(:student) { create(:course_user, :approved, course: course).user }
-    let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, creator: student)
-    end
+    let(:submission) { create(:submission, assessment: assessment, creator: student) }
     let(:programming_assessment) do
       create(:assessment, :guided, :published_with_programming_question, course: course)
     end
     let(:programming_assessment_submission) do
-      create(:course_assessment_submission, assessment: programming_assessment, creator: student)
+      create(:submission, assessment: programming_assessment, creator: student)
     end
 
     context 'As a Course Student' do

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, :published_with_programming_question, course: course) }
     let(:student) { create(:course_user, :approved, course: course).user }
-    let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, creator: student)
-    end
+    let(:submission) { create(:submission, assessment: assessment, creator: student) }
     before { login_as(user, scope: :user) }
 
     context 'As a course student' do

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -12,19 +12,16 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
     let(:students) { create_list(:course_student, 4, course: course) }
     let(:phantom_student) { create(:course_student, :phantom, course: course) }
     let!(:submitted_submission) do
-      create(:course_assessment_submission, :submitted, assessment: assessment,
-                                                        course: course,
-                                                        creator: students[0].user)
+      create(:submission, :submitted,
+             assessment: assessment, course: course, creator: students[0].user)
     end
     let!(:attempting_submission) do
-      create(:course_assessment_submission, :attempting, assessment: assessment,
-                                                         course: course,
-                                                         creator: students[1].user)
+      create(:submission, :attempting,
+             assessment: assessment, course: course, creator: students[1].user)
     end
     let!(:published_submission) do
-      create(:course_assessment_submission, :published, assessment: assessment,
-                                                     course: course,
-                                                     creator: students[2].user)
+      create(:submission, :published,
+             assessment: assessment, course: course, creator: students[2].user)
     end
     let!(:graded_submission) do
       create(:submission, :graded, assessment: assessment, course: course,

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -12,14 +12,12 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
     before { login_as(user, scope: :user) }
 
     let(:student) { create(:course_user, :approved, course: course).user }
-    let(:submission) do
-      create(:course_assessment_submission, assessment: assessment, creator: student)
-    end
+    let(:submission) { create(:submission, assessment: assessment, creator: student) }
     let(:programming_assessment) do
       create(:assessment, :worksheet, :published_with_programming_question, course: course)
     end
     let(:programming_assessment_submission) do
-      create(:course_assessment_submission, assessment: programming_assessment, creator: student)
+      create(:submission, assessment: programming_assessment, creator: student)
     end
 
     context 'As a Course Student' do

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Course: Submissions Viewing' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:course_assessment_assessment, course: course) }
+    let(:assessment) { create(:assessment, course: course) }
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
@@ -16,11 +16,10 @@ RSpec.describe 'Course: Submissions Viewing' do
         students = create_list(:course_student, 3, course: course)
         attempting_submission, submitted_submission, published_submission =
           students.zip([:attempting, :submitted, :published]).map do |student, trait|
-            create(:course_assessment_submission, trait,
-                   assessment: assessment, creator: student.user)
+            create(:submission, trait, assessment: assessment, creator: student.user)
           end
-        staff_submission = create(:course_assessment_submission, :submitted,
-                                  assessment: assessment, creator: course_manager.user)
+        staff_submission =
+          create(:submission, :submitted, assessment: assessment, creator: course_manager.user)
 
         visit course_submissions_path(course)
 
@@ -48,9 +47,8 @@ RSpec.describe 'Course: Submissions Viewing' do
         students = create_list(:course_student, 4, course: course)
         attempting_submission, submitted_submission1, submitted_submission2, published_submission =
           students.zip([:attempting, :submitted, :submitted, :published]).map do |student, trait|
-            create(:course_assessment_submission, trait,
-                   assessment: assessment, course: course,
-                   creator: student.user, course_user: student)
+            create(:submission, trait, assessment: assessment, course: course,
+                                       creator: student.user, course_user: student)
           end
 
         # Staff without group can view all pending submissions
@@ -96,8 +94,7 @@ RSpec.describe 'Course: Submissions Viewing' do
         assessments = create_list(:course_assessment_assessment, 3, course: course)
         attempting_submission, submitted_submission, published_submission =
           assessments.zip([:attempting, :submitted, :published]).map do |assessment, trait|
-            create(:course_assessment_submission, trait,
-                   assessment: assessment, creator: user)
+            create(:submission, trait, assessment: assessment, creator: user)
           end
 
         visit course_submissions_path(course)

--- a/spec/features/course/assessment_condition_management_spec.rb
+++ b/spec/features/course/assessment_condition_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Course: Assessments' do
 
     context 'As a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
-      let!(:assessment) { create(:course_assessment_assessment, course: course) }
+      let!(:assessment) { create(:assessment, course: course) }
       let(:other_assessment) { create(:assessment, course: course) }
       let!(:assessment_condition) do
         create(:assessment_condition,

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -7,9 +7,7 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_student) { create(:course_student, course: course) }
-    let(:submission) do
-      create(:course_assessment_submission, course: course, creator: course_student.user)
-    end
+    let(:submission) { create(:submission, course: course, creator: course_student.user) }
     let(:record) { submission.acting_as }
     let(:manual_record) { create(:course_experience_points_record, course_user: course_student) }
     let(:inactive_record) do

--- a/spec/features/course/staff_statistics_spec.rb
+++ b/spec/features/course/staff_statistics_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature 'Course: Statistics: Staff' do
       let!(:tutor1_submissions) do
         submitted_at = 1.day.ago
         published_at = submitted_at + 1.day + 1.hour + 1.minute + 1.second
-        assessment = create(:course_assessment_assessment, course: course)
-        submission = create(:course_assessment_submission, :published,
+        assessment = create(:assessment, course: course)
+        submission = create(:submission, :published,
                             assessment: assessment, course: course, publisher: tutor1.user,
                             published_at: published_at)
         create(:course_assessment_answer_multiple_response, :graded,
@@ -35,8 +35,8 @@ RSpec.feature 'Course: Statistics: Staff' do
       let!(:tutor2_submissions) do
         submitted_at = 2.days.ago
         published_at = submitted_at + 2.days
-        assessment = create(:course_assessment_assessment, course: course)
-        submission = create(:course_assessment_submission, :published,
+        assessment = create(:assessment, course: course)
+        submission = create(:submission, :published,
                             assessment: assessment, course: course, publisher: tutor2.user,
                             published_at: published_at)
         create(:course_assessment_answer_multiple_response, :graded,

--- a/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
@@ -5,7 +5,17 @@ RSpec.describe Course::Assessment::Answer::AutoGradingJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Assessment::Answer::AutoGradingJob }
-    let(:answer) { create(:course_assessment_answer_multiple_response, :submitted).answer }
+    let(:course) { create(:course) }
+    let(:student_user) { create(:course_student, course: course).user }
+    let(:assessment) do
+      create(:assessment, :published_with_mrq_question, course: course)
+    end
+    let(:question) { assessment.questions.first }
+    let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+    let(:answer) do
+      create(:course_assessment_answer_multiple_response, :submitted,
+             assessment: assessment, submission: submission, question: question).answer
+    end
     let!(:auto_grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
 
     it 'can be queued' do

--- a/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
@@ -5,9 +5,15 @@ RSpec.describe Course::Assessment::Submission::AutoGradingJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Assessment::Submission::AutoGradingJob }
-    let(:answer) { create(:course_assessment_answer_multiple_response, :submitted).answer }
-    let!(:submission) { answer.submission.tap { |submission| submission.answers.reload } }
-    let(:question) { answer.question.specific }
+    let(:course) { create(:course) }
+    let(:student_user) { create(:course_student, course: course).user }
+    let(:assessment) { create(:assessment, :published_with_mrq_question, course: course) }
+    let(:question) { assessment.questions.first.specific }
+    let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+    let(:answer) do
+      create(:course_assessment_answer_multiple_response, :submitted,
+             submission: submission, question: question.acting_as)
+    end
 
     it 'can be queued' do
       expect { subject.perform_later(submission) }.to \

--- a/spec/models/course/assessment/answer/programming_spec.rb
+++ b/spec/models/course/assessment/answer/programming_spec.rb
@@ -13,8 +13,18 @@ RSpec.describe Course::Assessment::Answer::Programming do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#reset_answer' do
-      let(:question) { create(:course_assessment_question_programming, template_file_count: 1) }
-      let(:answer) { create(:course_assessment_answer_programming, question: question.question) }
+      let(:course) { create(:course) }
+      let(:student_user) { create(:course_student, course: course).user }
+      let(:assessment) { create(:assessment, course: course) }
+      let(:question) do
+        create(:course_assessment_question_programming,
+               assessment: assessment, template_file_count: 1)
+      end
+      let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+      let(:answer) do
+        create(:course_assessment_answer_programming,
+               submission: submission, question: question.question)
+      end
       subject { answer.reset_answer }
 
       it 'replaces the answer with the original template files from the question' do

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Course::Assessment::Answer do
       describe '#submission' do
         context 'when the answer is being attempted' do
           it 'validates that the submission is being attempted' do
-            subject.submission = create(:course_assessment_submission, workflow_state: 'submitted')
+            subject.submission = create(:submission, workflow_state: 'submitted')
             expect(subject.valid?).to be(false)
             expect(subject.errors[:submission]).not_to be_empty
           end
@@ -149,11 +149,16 @@ RSpec.describe Course::Assessment::Answer do
     end
 
     describe '#auto_grade!' do
-      let(:question) { build(:course_assessment_question_multiple_response).question }
+      let(:course) { create(:course) }
+      let(:student_user) { create(:course_student, course: course).user }
+      let(:assessment) { create(:assessment, course: course) }
+      let(:question) do
+        build(:course_assessment_question_multiple_response, assessment: assessment).question
+      end
       let(:answer_traits) { :submitted }
       subject do
-        create(:course_assessment_answer_multiple_response, *answer_traits, question: question).
-          answer
+        create(:course_assessment_answer_multiple_response, *answer_traits,
+               question: question, creator: student_user).answer
       end
 
       it 'creates a new auto_grading' do

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -9,30 +9,26 @@ RSpec.describe Course::Assessment do
     let(:course_user) { create(:course_student, course: course) }
     let(:coursemate) { create(:course_student, course: course) }
     let(:draft_assessment) do
-      create(:course_assessment_assessment, :with_all_question_types, course: course, draft: true)
+      create(:assessment, :with_all_question_types, course: course, draft: true)
     end
     let(:published_assessment) do
-      create(:course_assessment_assessment, :with_all_question_types, :published, course: course)
+      create(:assessment, :published_with_all_question_types, course: course)
     end
     let(:published_assessment_with_attemping_submission) do
-      create(:course_assessment_assessment, :with_all_question_types, :published, course: course)
+      create(:assessment, :published_with_all_question_types, course: course)
     end
     let(:attempting_submission) do
-      create(:course_assessment_submission, :attempting,
-             assessment: published_assessment_with_attemping_submission,
-             creator: course_user.user)
+      create(:submission, :attempting,
+             assessment: published_assessment_with_attemping_submission, creator: course_user.user)
     end
     let(:submitted_submission) do
-      create(:course_assessment_submission, :submitted, assessment: published_assessment,
-                                                        creator: course_user.user)
+      create(:submission, :submitted, assessment: published_assessment, creator: course_user.user)
     end
     let(:coursemate_attempting_submission) do
-      create(:course_assessment_submission, :attempting, assessment: published_assessment,
-                                                         creator: coursemate.user)
+      create(:submission, :attempting, assessment: published_assessment, creator: coursemate.user)
     end
     let(:coursemate_submitted_submission) do
-      create(:course_assessment_submission, :submitted, assessment: published_assessment,
-                                                        creator: coursemate.user)
+      create(:submission, :submitted, assessment: published_assessment, creator: coursemate.user)
     end
 
     context 'when the user is a Course Student' do

--- a/spec/models/course/assessment/question/multiple_response_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_spec.rb
@@ -20,9 +20,14 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
     end
 
     describe '#attempt' do
-      subject { create(:course_assessment_question_multiple_response) }
-      let(:assessment) { subject.assessment }
-      let(:submission) { create(:course_assessment_submission, assessment: assessment) }
+      let(:course) { create(:course) }
+      let(:student_user) { create(:course_student, course: course).user }
+      let(:assessment) { create(:assessment, course: course) }
+      let(:question) do
+        create(:course_assessment_question_multiple_response, assessment: assessment)
+      end
+      let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+      subject { question }
 
       it 'returns an Answer' do
         expect(subject.attempt(submission)).to be_a(Course::Assessment::Answer)
@@ -35,9 +40,8 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
 
       context 'when last_attempt is given' do
         let(:last_attempt) do
-          create(:course_assessment_answer_multiple_response,
-                 :with_one_correct_option,
-                 question: subject.question, submission: submission)
+          build(:course_assessment_answer_multiple_response, :with_one_correct_option,
+                question: question.question)
         end
 
         it 'builds a new answer with old options' do

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -116,8 +116,10 @@ RSpec.describe Course::Assessment::Question::Programming do
 
     describe '#attempt' do
       subject { create(:course_assessment_question_programming, template_file_count: 1) }
+      let(:course) { assessment.course }
+      let(:student_user) { create(:course_student, course: course).user }
       let(:assessment) { subject.assessment }
-      let(:submission) { create(:course_assessment_submission, assessment: assessment) }
+      let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
 
       it 'returns an Answer' do
         expect(subject.attempt(submission)).to be_a(Course::Assessment::Answer)

--- a/spec/models/course/assessment/question/text_response_spec.rb
+++ b/spec/models/course/assessment/question/text_response_spec.rb
@@ -20,9 +20,12 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
     end
 
     describe '#attempt' do
-      subject { create(:course_assessment_question_text_response) }
-      let(:assessment) { subject.assessment }
-      let(:submission) { create(:course_assessment_submission, assessment: assessment) }
+      let(:course) { create(:course) }
+      let(:student_user) { create(:course_student, course: course).user }
+      let(:assessment) { create(:assessment, course: course) }
+      let(:question) { create(:course_assessment_question_text_response, assessment: assessment) }
+      let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+      subject { question }
 
       it 'returns an Answer' do
         expect(subject.attempt(submission)).to be_a(Course::Assessment::Answer)

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -117,12 +117,14 @@ RSpec.describe Course::Assessment::Question do
     end
 
     describe '#not_correctly_answered' do
+      let(:course) { assessment.course }
+      let(:student_user) { create(:course_student, course: course).user }
       let(:assessment) do
         assessment = build(:assessment)
         create_list(:course_assessment_question_multiple_response, 3, assessment: assessment)
         assessment
       end
-      let(:submission) { create(:course_assessment_submission, assessment: assessment) }
+      let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
 
       context 'when there is no answer' do
         it 'returns not correctly answered questions' do
@@ -145,7 +147,7 @@ RSpec.describe Course::Assessment::Question do
     end
 
     describe '.default_scope' do
-      let(:assessment) { create(:course_assessment_assessment) }
+      let(:assessment) { create(:assessment) }
       let!(:questions) { create_list(:course_assessment_question, 2, assessment: assessment) }
       it 'orders by ascending weight' do
         weights = assessment.questions.pluck(:weight)

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe Course::Assessment::Submission do
     let(:course_student1) { create(:course_student, course: course) }
     let(:user1) { course_student1.user }
     let(:submission1) do
-      create(:course_assessment_submission, *submission1_traits,
+      create(:submission, *submission1_traits,
              assessment: assessment, creator: user1, course_user: course_student1)
     end
     let(:submission1_traits) { [] }
     let(:course_student2) { create(:course_student, course: course) }
     let(:user2) { course_student2.user }
     let(:submission2) do
-      create(:course_assessment_submission, *submission2_traits,
+      create(:submission, *submission2_traits,
              assessment: assessment, creator: user2, course_user: course_student2)
     end
     let(:submission2_traits) { [] }
     let(:course_student3) { create(:course_student, course: course) }
     let(:user3) { course_student3.user }
     let(:submission3) do
-      create(:course_assessment_submission, *submission3_traits,
+      create(:submission, *submission3_traits,
              assessment: assessment, creator: user3, course_user: course_student3)
     end
     let(:submission3_traits) { [] }
@@ -119,9 +119,9 @@ RSpec.describe Course::Assessment::Submission do
     describe '.from_category' do
       let(:new_category) { create(:course_assessment_category, course: course) }
       let(:new_tab) { create(:course_assessment_tab, course: course, category: new_category) }
-      let(:new_assessment) { create(:course_assessment_assessment, course: course, tab: new_tab) }
-      let(:new_submission) { create(:course_assessment_submission, assessment: new_assessment) }
-      let!(:submissions) { [submission1, new_submission] }
+      let(:new_assessment) { create(:assessment, course: course, tab: new_tab) }
+      let!(:new_submission) { create(:submission, assessment: new_assessment, creator: user1) }
+      let(:submissions) { [submission1, new_submission] }
       subject { Course::Assessment::Submission.from_category(new_category) }
 
       it 'returns submissions from assessments in this category' do
@@ -131,8 +131,11 @@ RSpec.describe Course::Assessment::Submission do
 
     describe '.from_course' do
       let(:new_course) { create(:course) }
-      let(:new_assessment) { create(:course_assessment_assessment, course: new_course) }
-      let!(:new_submission) { create(:course_assessment_submission, assessment: new_assessment) }
+      let(:new_student) { create(:course_student, course: new_course) }
+      let(:new_assessment) { create(:assessment, course: new_course) }
+      let!(:new_submission) do
+        create(:submission, assessment: new_assessment, creator: new_student.user)
+      end
 
       it 'returns submissions from assessments in the specified course' do
         submission1
@@ -177,7 +180,7 @@ RSpec.describe Course::Assessment::Submission do
       let(:submission3_traits) { :published }
       let!(:submissions) { [submission1, submission2, submission3] }
 
-      it 'returns the submissions with submitted or publidhrf workflow state' do
+      it 'returns the submissions with submitted or published workflow state' do
         states = assessment.submissions.confirmed.map(&:workflow_state)
         expect(states).to contain_exactly('published', 'submitted')
       end
@@ -233,8 +236,8 @@ RSpec.describe Course::Assessment::Submission do
       context 'when category id is given' do
         let(:new_category) { create(:course_assessment_category, course: course) }
         let(:new_tab) { create(:course_assessment_tab, course: course, category: new_category) }
-        let(:new_assessment) { create(:course_assessment_assessment, course: course, tab: new_tab) }
-        let(:new_submission) { create(:course_assessment_submission, assessment: new_assessment) }
+        let(:new_assessment) { create(:assessment, course: course, tab: new_tab) }
+        let(:new_submission) { create(:submission, assessment: new_assessment, creator: user2) }
         let(:params) { { category_id: new_category.id } }
 
         it 'filters submissions by category' do

--- a/spec/models/course/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan_item_spec.rb
@@ -83,26 +83,10 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
         let(:actable) { create(:course_assessment_assessment, :with_mcq_question, course: course) }
         subject { actable.lesson_plan_item }
 
-        context 'when actable is a draft' do
-          it 'creates todos when the actable object changes to non-draft' do
-            expect do
-              subject.draft = false
-              subject.save
-            end.to change(Course::LessonPlan::Todo.all, :count).by(course.course_users.count)
-          end
-        end
-
-        context 'when actable is non-draft' do
-          before do
-            subject.draft = false
-            subject.save
-          end
-          it 'deletes associated todos when the actable object changes to draft' do
-            expect do
-              subject.draft = true
-              subject.save
-            end.to change(Course::LessonPlan::Todo.all, :count).by(-course.course_users.count)
-          end
+        it 'creates todos for newly created objects' do
+          expect do
+            create(:course_assessment_assessment, :published_with_mcq_question, course: course)
+          end.to change(Course::LessonPlan::Todo.all, :count).by(course.course_users.count)
         end
       end
     end

--- a/spec/models/course/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan_item_spec.rb
@@ -80,12 +80,12 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
 
         let(:course) { create(:course) }
         let!(:students) { create_list(:course_student, 3, course: course) }
-        let(:actable) { create(:course_assessment_assessment, :with_mcq_question, course: course) }
+        let(:actable) { create(:assessment, :with_mcq_question, course: course) }
         subject { actable.lesson_plan_item }
 
         it 'creates todos for newly created objects' do
           expect do
-            create(:course_assessment_assessment, :published_with_mcq_question, course: course)
+            create(:assessment, :published_with_mcq_question, course: course)
           end.to change(Course::LessonPlan::Todo.all, :count).by(course.course_users.count)
         end
       end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -348,10 +348,8 @@ RSpec.describe CourseUser, type: :model do
     end
 
     describe 'after_save callback for new course_user' do
-      context 'when there is a non-draft lesson_plan_items that have todos' do
-        let(:assessment) do
-          create(:course_assessment_assessment, :published_with_mcq_question, course: course)
-        end
+      context 'when there is a lesson_plan_items that have todos' do
+        let(:assessment) { create(:course_assessment_assessment, course: course) }
         subject { requested_course_user }
 
         before do
@@ -360,7 +358,7 @@ RSpec.describe CourseUser, type: :model do
           assessment
         end
 
-        it 'creates todos for the lesson_plan_items' do
+        it 'creates todos for the lesson_plan_item for course_user' do
           expect { subject }.to change(Course::LessonPlan::Todo.all, :count).by(1)
         end
       end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe CourseUser, type: :model do
 
     describe 'after_save callback for new course_user' do
       context 'when there is a lesson_plan_items that have todos' do
-        let(:assessment) { create(:course_assessment_assessment, course: course) }
+        let(:assessment) { create(:assessment, course: course) }
         subject { requested_course_user }
 
         before do

--- a/spec/notifiers/course/assessment_notifier.rb
+++ b/spec/notifiers/course/assessment_notifier.rb
@@ -7,7 +7,7 @@ RSpec.describe Course::AssessmentNotifier, type: :notifier do
   with_tenant(:instance) do
     describe '#assessment_attempted' do
       let(:course) { create(:course) }
-      let(:assessment) { create(:course_assessment_assessment, course: course) }
+      let(:assessment) { create(:assessment, course: course) }
       let(:user) { create(:course_user, course: course).user }
 
       subject { Course::AssessmentNotifier.assessment_attempted(user, assessment) }
@@ -19,9 +19,9 @@ RSpec.describe Course::AssessmentNotifier, type: :notifier do
 
     describe '#assessment_submitted' do
       let(:course) { create(:course) }
-      let(:submission) { create(:course_assessment_submission, course: course) }
       let(:course_user) { create(:course_user, course: course) }
       let(:user) { course_user.user }
+      let(:submission) { create(:submission, course: course, creator: user) }
 
       context 'when user do not belongs to any group' do
         subject { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }

--- a/spec/services/course/assessment/answer/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/auto_grading_service_spec.rb
@@ -4,9 +4,14 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Answer::AutoGradingService do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:student_user) { create(:course_student, course: course).user }
+    let(:assessment) { create(:assessment, :published_with_mrq_question, course: course) }
+    let(:question) { assessment.questions.first }
     let(:answer) do
+      submission = create(:submission, assessment: assessment, creator: student_user)
       create(:course_assessment_answer_multiple_response, :submitted,
-             submission_traits: [{ auto_grade: false }]).answer
+             question: question, submission: submission).answer
     end
     let!(:auto_grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
 

--- a/spec/services/course/assessment/submission/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/submission/auto_grading_service_spec.rb
@@ -4,20 +4,35 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Submission::AutoGradingService do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let(:answer) { create(:course_assessment_answer_multiple_response, :submitted).answer }
-    let(:submission) { answer.submission.tap { |submission| submission.answers.reload } }
-    let(:question) { answer.question.specific }
+    let(:course) { create(:course) }
+    let(:student_user) { create(:course_student, course: course).user }
+    let(:assessment) { create(:assessment, :published_with_mrq_question, course: course) }
+    let(:question) { assessment.questions.first.specific }
+    let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+    let(:answer) do
+      create(:course_assessment_answer_multiple_response, :submitted,
+             question: question.acting_as, submission: submission).answer
+    end
+    # let(:question) { answer.question.specific }
 
     describe '#grade' do
       it 'grades all answers' do
+        answer
         expect(subject.grade(submission)).to eq(true)
 
         expect(submission.answers.map(&:reload).all?(&:graded?)).to be(true)
       end
 
       context 'when given a non-auto gradable answer' do
-        let(:answer) { create(:course_assessment_answer_programming, :submitted).answer }
+        let(:non_autograded_question) do
+          create(:course_assessment_question_programming, assessment: assessment)
+        end
+        let!(:answer) do
+          create(:course_assessment_answer_programming, :submitted,
+                 question: non_autograded_question.acting_as, submission: submission).answer
+        end
         it 'does not grade the answer' do
+          answer
           expect(subject.grade(submission)).to eq(true)
 
           gradable_answers = submission.answers.reject { |answer| answer.question.auto_gradable? }
@@ -28,12 +43,10 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
 
       context 'when assessment is autograded' do
         let(:assessment) do
-          create(:course_assessment_assessment, :published_with_mcq_question, :autograded,
-                 question_count: 2)
+          create(:assessment, :published_with_mcq_question, :autograded,
+                 course: course, question_count: 2)
         end
-        let(:submission) do
-          create(:course_assessment_submission, assessment: assessment)
-        end
+        let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
         before do
           # Create one correct and one wrong answer.
           create(:course_assessment_answer_multiple_response, :with_all_correct_options,
@@ -69,6 +82,7 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
       end
 
       it 'fails with a SubJobError' do
+        answer
         expect { subject.grade(submission) }.to \
           raise_error(Course::Assessment::Submission::AutoGradingService::SubJobError, '0')
       end


### PR DESCRIPTION
Next step of #867.

This PR:
 - Fixes some of the default callbacks for todos: 
    - todos are created when `lesson_plan_items` are created, regardless of the draft status. 
 - Fixes some of the specs - when `submissions` are created, the factory does not automatically populate a course user for the `creator`, leading to errors. 
  - Implements the todo hooks for submissions workflow transitions 


After this: 
 - Implement todo views for students (with model scopes)
 - Controller action to ignore todos
 - `db migration` or rake task to populate todos for existing `courses`