### PR TITLE
Implement scopes and modify controller for todo

### DIFF
--- a/app/models/concerns/course/assessment/todo_concern.rb
+++ b/app/models/concerns/course/assessment/todo_concern.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Course::Assessment::TodoConcern
+  extend ActiveSupport::Concern
+
+  def can_user_start?(user)
+    course_user = user.course_users.find_by(course: course)
+    conditions_satisfied_by?(course_user)
+  end
+end

--- a/app/models/concerns/course/lesson_plan/item_todo_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item_todo_concern.rb
@@ -10,6 +10,10 @@ module Course::LessonPlan::ItemTodoConcern
     actable && actable.class.has_todo?
   end
 
+  def can_user_start?(user)
+    actable && actable.can_user_start?(user)
+  end
+
   protected
 
   # Create todos for the given lesson_plan_item for all course_users in the course.

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -4,6 +4,7 @@
 # An assessment is a collection of questions that can be asked.
 class Course::Assessment < ActiveRecord::Base
   # TODO: Remove when entire todo feature is ready
+  # include Course::Assessment::TodoConcern
   # acts_as_lesson_plan_item has_todo: true
   acts_as_lesson_plan_item
   acts_as_conditional

--- a/app/models/course/lesson_plan/todo.rb
+++ b/app/models/course/lesson_plan/todo.rb
@@ -66,6 +66,14 @@ class Course::LessonPlan::Todo < ActiveRecord::Base
     end
   end
 
+  # Checks if item can be started by user. #can_start? must be implemented by lesson_plan_item's
+  #   actable class, otherwise all item's are true by default.
+  #
+  # @return [Boolean] Whether the todo can be started or not.
+  def can_user_start?
+    item.can_user_start?(user)
+  end
+
   private
 
   # Sets default values

--- a/lib/extensions/acts_as_helpers/active_record/base.rb
+++ b/lib/extensions/acts_as_helpers/active_record/base.rb
@@ -18,6 +18,8 @@ module Extensions::ActsAsHelpers::ActiveRecord::Base
     # To declare that an actable model has todos:
     #   - Define has_todo as true when calling acts_as_lesson_plan_item
     #   - Define hooks to update todo's workflow_state (see Course::LessonPlan::Todo)
+    #   - For additional logic on whether a user can start an item, overwrite #can_user_start?
+    #       in the actable model.
     def acts_as_lesson_plan_item(has_todo: false)
       acts_as :lesson_plan_item, class_name: Course::LessonPlan::Item.name
 
@@ -26,6 +28,7 @@ module Extensions::ActsAsHelpers::ActiveRecord::Base
       end
       self.has_todo = has_todo ? true : false
       extend LessonPlanItemClassMethods
+      include LessonPlanItemInstanceMethods
     end
   end
 
@@ -38,6 +41,12 @@ module Extensions::ActsAsHelpers::ActiveRecord::Base
   module LessonPlanItemClassMethods
     def has_todo?
       has_todo
+    end
+  end
+
+  module LessonPlanItemInstanceMethods
+    def can_user_start?(_user = nil)
+      true
     end
   end
 end

--- a/spec/factories/course_lesson_plan_todos.rb
+++ b/spec/factories/course_lesson_plan_todos.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
   factory :course_lesson_plan_todo, class: Course::LessonPlan::Todo.name, aliases: [:todo] do
     transient do
       course { create(:course) }
-      draft false
+      draft true
     end
     item { create(:course_lesson_plan_item, course: course, base_exp: 1000, draft: draft) }
     add_attribute(:ignore) { false }
@@ -19,6 +19,20 @@ FactoryGirl.define do
 
     trait :completed do
       workflow_state :completed
+    end
+
+    trait :not_opened do
+      after(:build) do |todo|
+        todo.item.start_at = 2.days.from_now
+        todo.item.save!
+      end
+    end
+
+    trait :opened do
+      after(:build) do |todo|
+        todo.item.start_at = 2.days.ago
+        todo.item.save!
+      end
     end
 
     after(:build) do |_todo, evaluator|

--- a/spec/libraries/acts_as_lesson_plan_item_spec.rb
+++ b/spec/libraries/acts_as_lesson_plan_item_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe 'Extension: Acts as Lesson Plan Item' do
     acts_as_lesson_plan_item
   end
 
+  class self::DummyTodoClass < ActiveRecord::Base
+    def self.columns
+      []
+    end
+
+    acts_as_lesson_plan_item has_todo: true
+  end
+
   subject(:dummy) { self.class::DummyClass.new }
   it { is_expected.to respond_to(:base_exp) }
   it { is_expected.to respond_to(:time_bonus_exp) }
@@ -32,6 +40,18 @@ RSpec.describe 'Extension: Acts as Lesson Plan Item' do
       it 'has correct total EXP' do
         expect(subject.total_exp).to eq(subject.base_exp + subject.extra_bonus_exp)
       end
+    end
+  end
+
+  context 'when declared to have a todo' do
+    subject { self.class::DummyTodoClass }
+
+    it 'sets the class to have_todo' do
+      expect(subject.has_todo?).to be_truthy
+    end
+
+    it 'sets all instances to respond with true to #can_start? by default' do
+      expect(subject.new.can_user_start?).to be_truthy
     end
   end
 end

--- a/spec/models/course/lesson_plan_todo_spec.rb
+++ b/spec/models/course/lesson_plan_todo_spec.rb
@@ -4,4 +4,107 @@ require 'rails_helper'
 RSpec.describe Course::LessonPlan::Todo, type: :model do
   it { is_expected.to belong_to(:item).inverse_of(:todos) }
   it { is_expected.to belong_to(:user).inverse_of(:todos) }
+
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let(:course) { create(:course) }
+    let(:student) { create(:course_student, course: course, user: user) }
+
+    describe '.opened' do
+      let!(:todo) { create(:course_lesson_plan_todo, *todo_traits, course: course, user: user) }
+      subject { user.todos.opened }
+
+      context 'when item has started' do
+        let(:todo_traits) { :opened }
+        it { is_expected.to contain_exactly(todo) }
+      end
+
+      context 'when item has not started' do
+        let(:todo_traits) { :not_opened }
+        it { is_expected.not_to include(todo) }
+      end
+    end
+
+    describe '.published' do
+      let!(:todo) { create(:course_lesson_plan_todo, draft: draft, course: course, user: user) }
+      subject { user.todos.published }
+
+      context 'when item is published' do
+        let(:draft) { false }
+        it { is_expected.to contain_exactly(todo) }
+      end
+
+      context 'when item is not published' do
+        let(:draft) { true }
+        it { is_expected.not_to include(todo) }
+      end
+    end
+
+    describe '.not_ignored' do
+      let!(:todo) { create(:course_lesson_plan_todo, ignore: ignore, course: course, user: user) }
+      subject { user.todos.not_ignored }
+
+      context 'when item is not ignored' do
+        let(:ignore) { false }
+        it { is_expected.to contain_exactly(todo) }
+      end
+
+      context 'when item is ignored' do
+        let(:ignore) { true }
+        it { is_expected.not_to include(todo) }
+      end
+    end
+
+    describe '.from_course' do
+      let(:other_course) { create(:course) }
+      let(:other_course_user) { create(:course_student, course: other_course, user: user) }
+      let!(:other_todo) { create(:course_lesson_plan_todo, course: other_course, user: user) }
+      let!(:todo) { create(:course_lesson_plan_todo, course: course, user: user) }
+      subject { user.todos.from_course(course) }
+
+      it { is_expected.to contain_exactly(todo) }
+    end
+
+    describe '.not_completed' do
+      let!(:todo_not_started) do
+        create(:course_lesson_plan_todo, :not_started, course: course, user: user)
+      end
+      let!(:todo_in_progress) do
+        create(:course_lesson_plan_todo, :in_progress, course: course, user: user)
+      end
+      let!(:todo_completed) do
+        create(:course_lesson_plan_todo, :completed, course: course, user: user)
+      end
+      subject { user.todos.not_completed }
+
+      it { is_expected.to contain_exactly(todo_not_started, todo_in_progress) }
+    end
+
+    describe '.pending_for' do
+      let(:other_course_user) { create(:course_student, course: course) }
+      let!(:todo) do
+        create(:course_lesson_plan_todo, :opened, draft: false, course: course, user: user)
+      end
+      let(:item) { todo.item }
+      let!(:other_todo) do
+        create(:course_lesson_plan_todo, item: item, course: course, user: other_course_user.user)
+      end
+      subject { Course::LessonPlan::Todo.pending_for(student) }
+
+      it 'returns the opened, not ignored and published todos from the correct user' do
+        expect(subject).to contain_exactly(todo)
+      end
+
+      context 'when todo is completed' do
+        let!(:completed_todo) do
+          create(:course_lesson_plan_todo, :opened, :completed,
+                 draft: false, course: course, user: user)
+        end
+        it 'is not included' do
+          expect(subject).not_to include(completed_todo)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/course/assessment/submission/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/submission/auto_grading_service_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
       create(:course_assessment_answer_multiple_response, :submitted,
              question: question.acting_as, submission: submission).answer
     end
-    # let(:question) { answer.question.specific }
 
     describe '#grade' do
       it 'grades all answers' do


### PR DESCRIPTION
Fixes part of #867. 

This PR: 
 - Defines scopes to allow loading in views.
 - Adds an additional method on the has_todo declaration to check whether the instance of `lesson_plan_item.actable` can be started
 - Load `@todos` in course homepage controller