### PR TITLE
Fix todo callbacks for invited course_users

### DIFF
--- a/app/models/concerns/course/lesson_plan/item_todo_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item_todo_concern.rb
@@ -16,9 +16,10 @@ module Course::LessonPlan::ItemTodoConcern
 
   protected
 
-  # Create todos for the given lesson_plan_item for all course_users in the course.
+  # Create todos for the given lesson_plan_item for all course_users in the course,
+  #   except invited course_users (ie. course_users who do not have a user record).
   def create_todos
-    course_users = CourseUser.where(course_id: course_id)
+    course_users = CourseUser.where(course_id: course_id).where.not(workflow_state: 'invited')
     Course::LessonPlan::Todo.create_for(self, course_users)
   end
 end

--- a/app/models/concerns/course_user/todo_concern.rb
+++ b/app/models/concerns/course_user/todo_concern.rb
@@ -6,7 +6,18 @@ module CourseUser::TodoConcern
     after_create :create_todos_for_course_user
   end
 
+  # Overrides #accept method, which is part of the workflow event transition handler
+  # Given the need to override this method, this concern has to be placed after the
+  #   event transition handlers defined in CourseUser class.
+  def accept(*args)
+    super(*args) if defined?(super)
+    create_todos_for_course_user
+  end
+
+  # Create todos for all course_users except those who are invited.
+  # Invited course_users do not have a user_id.
   def create_todos_for_course_user
+    return unless user
     items =
       Course::LessonPlan::Item.where(course_id: course_id).includes(:actable).select(&:has_todo?)
     Course::LessonPlan::Todo.create_for(items, self)

--- a/app/models/concerns/course_user/workflow_concern.rb
+++ b/app/models/concerns/course_user/workflow_concern.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module CourseUser::WorkflowConcern
+  # Transitions the user from the invited to the accepted state.
+  #
+  # @param [User] user The user which is accepting this invitation.
+  # @return [void]
+  def accept(user)
+    self.user = user
+  end
+
+  # Callback handler for workflow state change to the rejected state.
+  def on_rejected_entry(*)
+    destroy
+  end
+end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -3,6 +3,8 @@ class CourseUser < ActiveRecord::Base
   include Workflow
   include CourseUser::StaffConcern
   include CourseUser::LevelProgressConcern
+  # Workflow event transition logic must exist above Todo concern to allow for todo callbacks.
+  include CourseUser::WorkflowConcern
   include CourseUser::TodoConcern
 
   after_initialize :set_defaults, if: :new_record?
@@ -128,19 +130,6 @@ class CourseUser < ActiveRecord::Base
   # @return [Boolean]
   def real_student?
     student? && !phantom
-  end
-
-  # Transitions the user from the invited to the accepted state.
-  #
-  # @param [User] user The user which is accepting this invitation.
-  # @return [void]
-  def accept(user)
-    self.user = user
-  end
-
-  # Callback handler for workflow state change to the rejected state.
-  def on_rejected_entry(*)
-    destroy
   end
 
   # Returns my students in the course.

--- a/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
@@ -80,13 +80,16 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
 
         let(:course) { create(:course) }
         let!(:students) { create_list(:course_student, 3, course: course) }
+        let!(:invited_student) { create(:course_user, :invited, course: course, user: nil) }
         let(:actable) { create(:assessment, :with_mcq_question, course: course) }
         subject { actable.lesson_plan_item }
 
-        it 'creates todos for newly created objects' do
+        it 'creates todos for created objects for course_users (except those with invited status' do
           expect do
             create(:assessment, :published_with_mcq_question, course: course)
-          end.to change(Course::LessonPlan::Todo.all, :count).by(course.course_users.count)
+          end.
+            to change(Course::LessonPlan::Todo.all, :count).
+            by(course.course_users.where.not(workflow_state: 'invited').count)
         end
       end
     end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe CourseUser, type: :model do
       end
     end
 
-    describe 'after_save callback for new course_user' do
+    describe 'CourseUser::TodoConcern callbacks for new course_user' do
       context 'when there is a lesson_plan_items that have todos' do
         let(:assessment) { create(:assessment, course: course) }
         subject { requested_course_user }
@@ -360,6 +360,24 @@ RSpec.describe CourseUser, type: :model do
 
         it 'creates todos for the lesson_plan_item for course_user' do
           expect { subject }.to change(Course::LessonPlan::Todo.all, :count).by(1)
+        end
+
+        context 'when course_user is invited' do
+          subject { create(:course_user, :invited, course: course, user: nil) }
+
+          it 'does not creates todos for the lesson_plan_item for course_user' do
+            expect { subject }.not_to change(Course::LessonPlan::Todo.all, :count)
+          end
+
+          describe '.accept' do
+            it 'creates todos for the lesson_plan_item for course_user' do
+              expect do
+                user = create(:user)
+                subject.accept!(user)
+                subject.save
+              end.to change(Course::LessonPlan::Todo.all, :count).by(1)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Ideally todos should be created only when course_user has a user record. 

This PR defines the todo callbacks more clearly:
 - Todos are created for all course_users that do not have the `invited` workflow_state.
 - Todos are created for course_users who are accepted and transition from `invited` to `approved` state.

Related to #867