### PR TITLE
Enable and populate todos (or pending tasks) for existing courses

### DIFF
--- a/app/models/concerns/course/lesson_plan/item_todo_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item_todo_concern.rb
@@ -16,9 +16,10 @@ module Course::LessonPlan::ItemTodoConcern
 
   protected
 
-  # Create todos for the given lesson_plan_item for all course_users in the course.
+  # Create todos for the given lesson_plan_item for all course_users in the course,
+  #   except invited course_users (ie. course_users who do not have a user record).
   def create_todos
-    course_users = CourseUser.where(course_id: course_id)
+    course_users = CourseUser.where(course_id: course_id).where.not(workflow_state: 'invited')
     Course::LessonPlan::Todo.create_for(self, course_users)
   end
 end

--- a/app/models/concerns/course_user/todo_concern.rb
+++ b/app/models/concerns/course_user/todo_concern.rb
@@ -6,7 +6,18 @@ module CourseUser::TodoConcern
     after_create :create_todos_for_course_user
   end
 
+  # Overrides #accept method, which is part of the workflow event transition handler
+  # Given the need to override this method, this concern has to be placed after the
+  #   event transition handlers defined in CourseUser class.
+  def accept(*args)
+    super(*args) if defined?(super)
+    create_todos_for_course_user
+  end
+
+  # Create todos for all course_users except those who are invited.
+  # Invited course_users do not have a user_id.
   def create_todos_for_course_user
+    return unless user
     items =
       Course::LessonPlan::Item.where(course_id: course_id).includes(:actable).select(&:has_todo?)
     Course::LessonPlan::Todo.create_for(items, self)

--- a/app/models/concerns/course_user/workflow_concern.rb
+++ b/app/models/concerns/course_user/workflow_concern.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module CourseUser::WorkflowConcern
+  # Transitions the user from the invited to the accepted state.
+  #
+  # @param [User] user The user which is accepting this invitation.
+  # @return [void]
+  def accept(user)
+    self.user = user
+  end
+
+  # Callback handler for workflow state change to the rejected state.
+  def on_rejected_entry(*)
+    destroy
+  end
+end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -3,10 +3,8 @@
 #
 # An assessment is a collection of questions that can be asked.
 class Course::Assessment < ActiveRecord::Base
-  # TODO: Remove when entire todo feature is ready
-  # include Course::Assessment::TodoConcern
-  # acts_as_lesson_plan_item has_todo: true
-  acts_as_lesson_plan_item
+  include Course::Assessment::TodoConcern
+  acts_as_lesson_plan_item has_todo: true
   acts_as_conditional
   has_one_folder
 

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -3,8 +3,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
   include Workflow
   # Workflow event transition logic must exist above Todo concern to allow for todo callbacks.
   include Course::Assessment::Submission::WorkflowEventConcern
-  # TODO: Remove when entire todo feature is ready
-  # include Course::Assessment::Submission::TodoConcern
+  include Course::Assessment::Submission::TodoConcern
 
   acts_as_experience_points_record
 

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -3,6 +3,8 @@ class CourseUser < ActiveRecord::Base
   include Workflow
   include CourseUser::StaffConcern
   include CourseUser::LevelProgressConcern
+  # Workflow event transition logic must exist above Todo concern to allow for todo callbacks.
+  include CourseUser::WorkflowConcern
   include CourseUser::TodoConcern
 
   after_initialize :set_defaults, if: :new_record?
@@ -128,19 +130,6 @@ class CourseUser < ActiveRecord::Base
   # @return [Boolean]
   def real_student?
     student? && !phantom
-  end
-
-  # Transitions the user from the invited to the accepted state.
-  #
-  # @param [User] user The user which is accepting this invitation.
-  # @return [void]
-  def accept(user)
-    self.user = user
-  end
-
-  # Callback handler for workflow state change to the rejected state.
-  def on_rejected_entry(*)
-    destroy
   end
 
   # Returns my students in the course.

--- a/db/migrate/20161020020353_add_todos_for_existing_lesson_plan_items.rb
+++ b/db/migrate/20161020020353_add_todos_for_existing_lesson_plan_items.rb
@@ -1,0 +1,50 @@
+class AddTodosForExistingLessonPlanItems < ActiveRecord::Migration
+  def up
+    Instance.all.each do |instance|
+      ActsAsTenant.current_tenant = instance
+      Course.all.each do |course|
+        create_todos_for(course)
+      end
+    end
+  end
+
+  def down
+    Course::LessonPlan::Todo.delete_all
+  end
+
+  def create_todos_for(course) # rubocop:disable Metrics/AbcSize
+    # Submissions hash from course with the following format:
+    #   { [submission.assessment.lesson_plan_item.id, creator_id]: '#{workflow_state}' }
+    submissions_hash =
+      Course::Assessment::Submission.
+      from_course(course).
+      includes(assessment: :lesson_plan_item).
+      map do |s|
+        [[s.assessment.lesson_plan_item.id, s.creator_id], s.workflow_state]
+      end.to_h
+
+    items = course.lesson_plan_items.where(actable_type: 'Course::Assessment').pluck(:id)
+    course_users = course.course_users.where.not(user_id: nil).pluck(:user_id)
+
+    # Populate an array of hashes with todo attributes for creation
+    items.product(course_users).map! do |ary|
+      workflow_state =
+        case submissions_hash[ary]
+        when nil
+          'not_started'
+        when 'attempting'
+          'in_progress'
+        when 'submitted', 'graded', 'published'
+          'completed'
+        end
+
+      Course::LessonPlan::Todo.
+        new(item_id: ary[0],
+            user_id: ary[1],
+            workflow_state: workflow_state,
+            creator: User.system,
+            updater: User.system).
+        save!(validate: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161013115452) do
+ActiveRecord::Schema.define(version: 20161020020353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -46,15 +46,6 @@ RSpec.feature 'Course: Homepage' do
       notifications
     end
 
-    # TODO: To remove when this declaration is done on the model itself
-    Course::Assessment.class_eval do
-      include Course::Assessment::TodoConcern
-      def self.has_todo?; true; end # rubocop:disable Style/SingleLineMethods
-    end
-    Course::Assessment::Submission.class_eval do
-      include Course::Assessment::Submission::TodoConcern
-    end
-
     let(:assessment_todos) do
       todos = {}
 

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -420,14 +420,6 @@ RSpec.describe Course::Assessment::Submission do
     end
 
     describe 'callbacks from Course::Assessment::Submission::TodoConcern' do
-      # TODO: To remove when this declaration is done on the model itself
-      Course::Assessment.class_eval do
-        def self.has_todo?; true; end # rubocop:disable Style/SingleLineMethods
-      end
-      Course::Assessment::Submission.class_eval do
-        include Course::Assessment::Submission::TodoConcern
-      end
-
       let(:assessment_traits) { [:published_with_mcq_question] }
       subject do
         Course::LessonPlan::Todo.

--- a/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
@@ -80,13 +80,16 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
 
         let(:course) { create(:course) }
         let!(:students) { create_list(:course_student, 3, course: course) }
+        let!(:invited_student) { create(:course_user, :invited, course: course, user: nil) }
         let(:actable) { create(:assessment, :with_mcq_question, course: course) }
         subject { actable.lesson_plan_item }
 
-        it 'creates todos for newly created objects' do
+        it 'creates todos for created objects for course_users (except those with invited status' do
           expect do
             create(:assessment, :published_with_mcq_question, course: course)
-          end.to change(Course::LessonPlan::Todo.all, :count).by(course.course_users.count)
+          end.
+            to change(Course::LessonPlan::Todo.all, :count).
+            by(course.course_users.where.not(workflow_state: 'invited').count)
         end
       end
     end

--- a/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
@@ -75,9 +75,6 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
 
     context 'when actable object is declared to have a todo' do
       describe 'callbacks from Course::LessonPlan::TodoConcern' do
-        # TODO: To remove when this declaration is done on the model itself
-        Course::Assessment.class_eval { def self.has_todo?; true; end } # rubocop:disable Style/SingleLineMethods
-
         let(:course) { create(:course) }
         let!(:students) { create_list(:course_student, 3, course: course) }
         let!(:invited_student) { create(:course_user, :invited, course: course, user: nil) }

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe CourseUser, type: :model do
       end
     end
 
-    describe 'after_save callback for new course_user' do
+    describe 'CourseUser::TodoConcern callbacks for new course_user' do
       context 'when there is a lesson_plan_items that have todos' do
         let(:assessment) { create(:assessment, course: course) }
         subject { requested_course_user }
@@ -360,6 +360,24 @@ RSpec.describe CourseUser, type: :model do
 
         it 'creates todos for the lesson_plan_item for course_user' do
           expect { subject }.to change(Course::LessonPlan::Todo.all, :count).by(1)
+        end
+
+        context 'when course_user is invited' do
+          subject { create(:course_user, :invited, course: course, user: nil) }
+
+          it 'does not creates todos for the lesson_plan_item for course_user' do
+            expect { subject }.not_to change(Course::LessonPlan::Todo.all, :count)
+          end
+
+          describe '.accept' do
+            it 'creates todos for the lesson_plan_item for course_user' do
+              expect do
+                user = create(:user)
+                subject.accept!(user)
+                subject.save
+              end.to change(Course::LessonPlan::Todo.all, :count).by(1)
+            end
+          end
         end
       end
     end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -351,12 +351,7 @@ RSpec.describe CourseUser, type: :model do
       context 'when there is a lesson_plan_items that have todos' do
         let(:assessment) { create(:assessment, course: course) }
         subject { requested_course_user }
-
-        before do
-          # TODO: To remove when this declaration is done on the model itself
-          Course::Assessment.class_eval { def self.has_todo?; true; end } # rubocop:disable Style/SingleLineMethods
-          assessment
-        end
+        before { assessment }
 
         it 'creates todos for the lesson_plan_item for course_user' do
           expect { subject }.to change(Course::LessonPlan::Todo.all, :count).by(1)


### PR DESCRIPTION
This PR:
 - Enables todos on assessments, and 
 - Populates todos in the database for existing courses and assessments. 

Fixes and finishes #867.
Depends on #1597.

I benchmarked the population of todos on my local machine (timing are in seconds):
```
CS1010X - Programming Methodology (AY2015/2016, Sem2)
Number of Records: 14592
Time Taken:        126.230316

CS1010S - Programming Methodology (AY2016/2017, Sem1)
Number of Records: 40256
Time Taken:        391.591406

FMC1206: Computing for a Better World
Number of Records: 324
Time Taken:        4.416828

Source Academy
Number of Records: 5032
Time Taken:        48.794754
```
In total, I think it takes around 10 minutes to create on my machine. I expect it to be around that region +- 5min to do on the actual production machine. 