### PR TITLE
Patch bidirectional dependent destroy bug in rails

### DIFF
--- a/lib/extensions/destroy_callbacks/active_record/base.rb
+++ b/lib/extensions/destroy_callbacks/active_record/base.rb
@@ -23,7 +23,6 @@ module Extensions::DestroyCallbacks::ActiveRecord::Base
   private
 
   def update_status
-    return if destroying? # Works around Rails #13609
     @destroying = true
     yield
   ensure

--- a/lib/extensions/destroy_callbacks/active_record/callbacks.rb
+++ b/lib/extensions/destroy_callbacks/active_record/callbacks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Rails #13609 has been fixed in https://github.com/rails/rails/pull/18548, this files does the
+# patch for rails 4.2.
+module Extensions::DestroyCallbacks::ActiveRecord::Callbacks
+  def self.included(base)
+    base.module_eval do
+      def destroy
+        @_destroy_callback_already_called ||= false
+        return if @_destroy_callback_already_called
+        @_destroy_callback_already_called = true
+        _run_destroy_callbacks { super }
+      ensure
+        @_destroy_callback_already_called = false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails 5 have fixed this but not rails 4.

This will also fix the bug that `after_destroy` callback be called for multiple times.