### PR TITLE
Fix bidirectional autosave bug which leads to multiple saves

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'calculated_attributes', '>= 0.1.3'
 gem 'squeel'
 # For multiple table inheritance
 #   TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
-gem 'active_record-acts_as', '>= 1.0.8', '<2.0.0'
+gem 'active_record-acts_as', github: 'Coursemology/active_record-acts_as' 
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Create pretty URLs and work with human-friendly strings

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: git://github.com/Coursemology/active_record-acts_as.git
+  revision: 098b5405c6d74275ba8035fa9e88b0f7cf6c422d
+  specs:
+    active_record-acts_as (2.0.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+
+GIT
   remote: git://github.com/ErwinM/acts_as_tenant.git
   revision: f87a619d79624e53342ab3c4a361607be1054334
   specs:
@@ -67,9 +75,6 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    active_record-acts_as (1.0.8)
-      activerecord (~> 4, >= 4.1.2)
-      activesupport (~> 4)
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
@@ -533,7 +538,7 @@ PLATFORMS
 
 DEPENDENCIES
   ace-rails-ap
-  active_record-acts_as (>= 1.0.8, < 2.0.0)
+  active_record-acts_as!
   activerecord-userstamp (>= 3.0.2)
   acts_as_tenant!
   after_commit_action

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -11,8 +11,8 @@ class Course::Assessment < ActiveRecord::Base
   include Course::Assessment::TodoConcern
 
   after_initialize :set_defaults, if: :new_record?
-  before_validation :assign_folder_attributes
   before_validation :propagate_course
+  before_validation :assign_folder_attributes
 
   validate :validate_presence_of_questions, unless: :draft?
   validate :validate_only_autograded_questions, if: :autograded?

--- a/app/models/course/assessment/answer/auto_grading.rb
+++ b/app/models/course/assessment/answer/auto_grading.rb
@@ -2,8 +2,7 @@
 class Course::Assessment::Answer::AutoGrading < ActiveRecord::Base
   actable
 
-  belongs_to :answer, class_name: Course::Assessment::Answer.name, touch: true, autosave: true,
-                      inverse_of: :auto_grading
+  belongs_to :answer, class_name: Course::Assessment::Answer.name, inverse_of: :auto_grading
   # @!attribute [r] job
   #   This might be null if the job has been cleared.
   belongs_to :job, class_name: TrackableJob::Job.name, inverse_of: nil

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -48,7 +48,7 @@ class Course::Condition::Assessment < ActiveRecord::Base
   end
 
   def self.on_dependent_status_change(submission)
-    return unless submission.previous_changes.key?(:workflow_state)
+    return unless submission.changes.key?(:workflow_state)
 
     submission.execute_after_commit do
       evaluate_conditional_for(submission.course_user) if submission.current_state >= :submitted

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -110,6 +110,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
 
   def grade_and_reattempt_answer(answer)
     answer.finalise! if answer.attempting?
+    answer.save!
     answer.auto_grade!(edit_submission_path, true)
   end
 

--- a/lib/extensions/destroy_callbacks/active_record/base.rb
+++ b/lib/extensions/destroy_callbacks/active_record/base.rb
@@ -23,7 +23,6 @@ module Extensions::DestroyCallbacks::ActiveRecord::Base
   private
 
   def update_status
-    return if destroying? # Works around Rails #13609
     @destroying = true
     yield
   ensure

--- a/lib/extensions/destroy_callbacks/active_record/callbacks.rb
+++ b/lib/extensions/destroy_callbacks/active_record/callbacks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Rails #13609 has been fixed in https://github.com/rails/rails/pull/18548, this files does the
+# patch for rails 4.2.
+module Extensions::DestroyCallbacks::ActiveRecord::Callbacks
+  def self.included(base)
+    base.module_eval do
+      def destroy
+        @_destroy_callback_already_called ||= false
+        return if @_destroy_callback_already_called
+        @_destroy_callback_already_called = true
+        _run_destroy_callbacks { super }
+      ensure
+        @_destroy_callback_already_called = false
+      end
+    end
+  end
+end

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
 
     trait :attempting do
       after(:build) do |submission|
-        submission.assessment.questions.attempt(submission).each(&:save!)
+        submission.answers = submission.assessment.questions.attempt(submission)
       end
     end
 

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -59,12 +59,16 @@ RSpec.feature 'Course: Homepage' do
         Course::LessonPlan::Todo.find_by(user: user, item: assessment.lesson_plan_item)
 
       assessment = create(:assessment, :published_with_mrq_question, course: course)
-      create(:submission, :submitted, assessment: assessment, creator: user)
+      submission2 = create(:submission, :attempting, assessment: assessment, creator: user)
+      submission2.finalise!
+      submission2.save!
       todos[:completed] =
         Course::LessonPlan::Todo.find_by(user: user, item: assessment.lesson_plan_item)
 
       assessment = create(:assessment, :with_mrq_question, draft: true, course: course)
-      create(:submission, :submitted, assessment: assessment, creator: user)
+      submission3 = create(:submission, :attempting, assessment: assessment, creator: user)
+      submission3.finalise!
+      submission3.save!
       todos[:unpublished] =
         Course::LessonPlan::Todo.find_by(user: user, item: assessment.lesson_plan_item)
 

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Course::Assessment do
 
           it 'is not valid' do
             expect(subject).not_to be_valid
-            expect(subject.errors['actable.base']).
+            expect(subject.errors['base']).
               to include(I18n.t('activerecord.errors.models.course/assessment.autograded'))
           end
         end


### PR DESCRIPTION
There is a bug( https://github.com/rails/rails/issues/23171 ) in rails that bidirectional `auto_save` will cause the record to be saved multiple times and  `after_save/update` callbacks get called for multiple times.  

This generates duplicate save queries on EVERY `save` or `update` of our main models (Assessment, Submission, LessonPlan, etc). This also leads to callbacks get called for multiple times, the code in the callbacks like notifications will be executed for multiple times too.

I managed to fix this case [in rails](https://github.com/allenwq/rails/tree/4-2-stable), but think it's not good to maintain our own rails. Looks like they want to fix the root cause here: https://github.com/rails/rails/pull/25337

Then I went to patch the `acts_as` gem to avoid use `autosave` instead. I forked the gem and fixed some other issues in the gem as well:
1. Make their latest version work with us
2. Fix a bug that unnecessary update query is generated when the model calls save but itself is not changed.
3. Use bidirectional `dependent: :destroy` on `actable` and `acting_as` model.  

I believe this PR will help to improve some of our performance and reduce the load on the database server.
