### PR TITLE
Fix "Unused parameters passed to Capybara::Queries::SelectorQuery"

### DIFF
--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -73,14 +73,12 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
 
         click_link I18n.t('course.assessment.submission.submissions.index.publish')
         expect(graded_submission.reload).to be_published
-        expect(page).
-          to have_selector('div',
-                           I18n.t('course.assessment.submission.submissions.publish_all.success'))
+        message = I18n.t('course.assessment.submission.submissions.publish_all.success')
+        expect(page).to have_selector('div', text: message)
 
         click_link I18n.t('course.assessment.submission.submissions.index.publish')
-        expect(page).
-          to have_selector('div',
-                           I18n.t('course.assessment.submission.submissions.publish_all.notice'))
+        message = I18n.t('course.assessment.submission.submissions.publish_all.notice')
+        expect(page).to have_selector('div', text: message)
       end
     end
   end

--- a/spec/features/course/experience_points/forum_disbrusement_spec.rb
+++ b/spec/features/course/experience_points/forum_disbrusement_spec.rb
@@ -53,9 +53,8 @@ RSpec.feature 'Course: Experience Points: Forum Disbursement' do
         end
         within find(content_tag_selector(students[2])) do
           expect(find('.points_awarded').value).to eq('200')
+          expect(all('td a').last[:href]).to include(search_course_forums_path(course))
         end
-
-        expect(page).to have_link(nil, search_course_forums_path(course))
 
         expect { click_button I18n.t('course.experience_points.forum_disbursement.new.submit') }.
           to change { Course::ExperiencePointsRecord.count }.by(3)


### PR DESCRIPTION
This will help to get rid of that warning.

`text:` option must be specified in `have_selector`