### PR TITLE
Notification for starting and closing of assessment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :development, :test do
   gem 'yard', group: :doc
 
   # Use RSpec for Behaviour testing
+  gem 'email_spec'
   gem 'rspec-rails'
   gem 'rspec-html-matchers'
   gem 'should_not'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,10 @@ GEM
     edge (0.5.0)
       activerecord (>= 4.1.0)
     ejs (1.1.1)
+    email_spec (2.1.0)
+      htmlentities (~> 4.3.3)
+      launchy (~> 2.1)
+      mail (~> 2.6.3)
     erubis (2.7.0)
     execjs (2.7.0)
     exifr (1.2.5)
@@ -197,6 +201,7 @@ GEM
       activesupport
       html-pipeline (>= 1.11)
       rouge (~> 1.8)
+    htmlentities (4.3.4)
     http_accept_language (2.1.0)
     i18n (0.7.0)
     i18n-js (3.0.0.rc14)
@@ -238,6 +243,8 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     key_struct (0.4.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -562,6 +569,7 @@ DEPENDENCIES
   devise_masquerade
   edge
   ejs
+  email_spec
   factory_girl_rails
   filename
   font-awesome-rails

--- a/app/jobs/course/assessment/closing_reminder_job.rb
+++ b/app/jobs/course/assessment/closing_reminder_job.rb
@@ -1,0 +1,16 @@
+class Course::Assessment::ClosingReminderJob < ApplicationJob
+  include TrackableJob
+
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # Prevent the job from retrying due to deleted records
+  end
+
+  protected
+
+  def perform_tracked(user, assessment, end_at)
+    instance = Course.unscoped { assessment.course.instance }
+    ActsAsTenant.with_tenant(instance) do
+      Course::Assessment::ReminderService.closing_reminder(user, assessment, end_at)
+    end
+  end
+end

--- a/app/jobs/course/assessment/opening_reminder_job.rb
+++ b/app/jobs/course/assessment/opening_reminder_job.rb
@@ -1,0 +1,16 @@
+class Course::Assessment::OpeningReminderJob < ApplicationJob
+  include TrackableJob
+
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # Prevent the job from retrying due to deleted records
+  end
+
+  protected
+
+  def perform_tracked(user, assessment, start_at)
+    instance = Course.unscoped { assessment.course.instance }
+    ActsAsTenant.with_tenant(instance) do
+      Course::Assessment::ReminderService.opening_reminder(user, assessment, start_at)
+    end
+  end
+end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -13,6 +13,9 @@ class Course::Assessment < ActiveRecord::Base
   after_initialize :set_defaults, if: :new_record?
   before_validation :propagate_course
   before_validation :assign_folder_attributes
+  before_validation :prevent_reminder_duplication
+  before_save :setup_opening_reminders, if: :start_at_changed?
+  before_save :setup_closing_reminders, if: :end_at_changed?
 
   validate :validate_presence_of_questions, if: :published?
   validate :validate_only_autograded_questions, if: :autograded?
@@ -106,6 +109,33 @@ class Course::Assessment < ActiveRecord::Base
   def set_defaults
     self.published = false
     self.autograded ||= false
+  end
+
+  # Prevent duplicate reminder from being sent due to floating point changes
+  def prevent_reminder_duplication
+    self.start_at = start_at_was if start_at.to_f.floor == start_at_was.to_f.floor
+    self.end_at = end_at_was if end_at.to_f.floor == end_at_was.to_f.floor
+  end
+
+  def setup_opening_reminders
+    # Randomize the milliseconds of the reminders' datetime to prevent duplication
+    self.start_at += Random.rand(0...0.1).round(4)
+
+    execute_after_commit do
+      Course::Assessment::OpeningReminderJob.set(wait_until: start_at).
+        perform_later(creator, self, start_at.to_f)
+    end
+  end
+
+  def setup_closing_reminders
+    # Randomize the milliseconds of the reminders' datetime to prevent duplication
+    self.end_at += Random.rand(0...0.1).round(4)
+
+    execute_after_commit do
+      # Send notification one day before the closing date
+      Course::Assessment::ClosingReminderJob.set(wait_until: end_at - 1.day).
+        perform_later(creator, self, end_at.to_f)
+    end
   end
 
   def validate_presence_of_questions

--- a/app/services/course/assessment/reminder_service.rb
+++ b/app/services/course/assessment/reminder_service.rb
@@ -1,0 +1,18 @@
+class Course::Assessment::ReminderService
+  class << self
+    delegate :opening_reminder, to: :new
+    delegate :closing_reminder, to: :new
+  end
+
+  def opening_reminder(user, assessment, start_at)
+    return unless start_at.round(4) == assessment.start_at.to_f.round(4) && assessment.published?
+
+    Course::AssessmentNotifier.assessment_opening(user, assessment)
+  end
+
+  def closing_reminder(user, assessment, end_at)
+    return unless end_at.round(4) == assessment.end_at.to_f.round(4) && assessment.published?
+
+    Course::AssessmentNotifier.assessment_closing(user, assessment)
+  end
+end

--- a/app/views/notifiers/course/assessment_notifier/closing/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/closing/user_notifications/email.html.slim
@@ -1,0 +1,10 @@
+- assessment = @object
+- course = assessment.course
+- host = course.instance.host
+- time = Time.use_zone(@recipient.time_zone) { assessment.end_at.to_formatted_s(:long) }
+
+- message.subject = t('.subject', course: course.title, assessment: assessment.title)
+
+= simple_format(t('.message', time: time,
+                assessment: link_to(assessment.title,
+                                    course_assessment_url(course, assessment, host: host))))

--- a/app/views/notifiers/course/assessment_notifier/opening/course_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/opening/course_notifications/email.html.slim
@@ -1,0 +1,9 @@
+- assessment = @object
+- course = assessment.course
+- host = course.instance.host
+
+- message.subject = t('.subject', course: course.title, assessment: assessment.title)
+
+= simple_format(t('.message',
+                assessment: link_to(assessment.title,
+                                    course_assessment_url(course, assessment, host: host))))

--- a/config/locales/en/notifiers/course/assessment_notifier/closing/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment_notifier/closing/user_notifications/email.yml
@@ -1,0 +1,10 @@
+en:
+  notifiers:
+    course:
+      assessment_notifier:
+        closing:
+          user_notifications:
+            email:
+              subject: '%{course} Reminder for about %{assessment}'
+              message: >
+                Please be reminded that %{assessment} is due on %{time}

--- a/config/locales/en/notifiers/course/assessment_notifier/opening/course_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment_notifier/opening/course_notifications/email.yml
@@ -1,0 +1,10 @@
+en:
+  notifiers:
+    course:
+      assessment_notifier:
+        opening:
+          course_notifications:
+            email:
+              subject: '%{course} New Assessment Available'
+              message: >
+                New Assessment Available : %{assessment}

--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -38,7 +38,18 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
   end
 
   def self.enqueue_at(job, timestamp) #:nodoc:
-    @future_jobs << { job: job.serialize, at: timestamp }
+    @future_jobs << { job: job, at: timestamp }
+  end
+
+  # Add all future jobs into the pending jobs queue according to timestamp
+  def self.perform_enqueued_jobs
+    @future_jobs.sort_by { |job| -job[:at] }.each { |job| enqueue(job[:job]) }
+    clear_enqueued_jobs
+  end
+
+  # Clear all the enqueued jobs
+  def self.clear_enqueued_jobs
+    @future_jobs.clear
   end
 
   # Waits for all queued jobs to finish executing.

--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -21,6 +21,7 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
   # The maximum number of threads to maintain in the thread pool.
   MAX_THREAD_POOL_SIZE = 3
 
+  @future_jobs = []
   @pending_jobs = []
   @running_jobs = 0
   @finish_jobs_condition = ConditionVariable.new
@@ -34,6 +35,10 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
 
       payload.reverse_merge!(notification_statistics)
     end
+  end
+
+  def self.enqueue_at(job, timestamp) #:nodoc:
+    @future_jobs << { job: job.serialize, at: timestamp }
   end
 
   # Waits for all queued jobs to finish executing.

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -104,7 +104,6 @@ RSpec.feature 'Course: Achievements' do
         check course_user_id
         check phantom_user_id
 
-
         expect do
           click_button I18n.t('course.achievement.course_users.course_users_form.button')
         end.to change(manual_achievement.course_users, :count).by(2)

--- a/spec/jobs/course/assessment/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/closing_reminder_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::ClosingReminderJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let!(:now) { Time.zone.now }
+
+    let(:user) { create(:course_user).user }
+    let(:assessment) { create(:assessment) }
+    subject { Course::Assessment::ClosingReminderJob }
+
+    it 'can be queued' do
+      expect { subject.perform_later(user, assessment, now.to_i) }.
+        to have_enqueued_job(subject).exactly(:once)
+    end
+  end
+end

--- a/spec/jobs/course/assessment/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/opening_reminder_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::OpeningReminderJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let!(:now) { Time.zone.now }
+
+    let(:user) { create(:course_user).user }
+    let!(:assessment) { create(:assessment) }
+    subject { Course::Assessment::OpeningReminderJob }
+
+    it 'can be queued' do
+      expect { subject.perform_later(user, assessment, now.to_i) }.
+        to have_enqueued_job(subject).exactly(:once)
+    end
+  end
+end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Course::Assessment do
           expect(subject.folder.name).to eq(subject.title)
           expect(subject.folder.parent).to eq(subject.tab.category.folder)
           expect(subject.folder.course).to eq(subject.course)
-          expect(subject.folder.start_at).to eq(subject.start_at)
+          expect(subject.folder.start_at.round(0)).to eq(subject.start_at.round(0))
         end
       end
 

--- a/spec/services/course/assessment/reminder_service_spec.rb
+++ b/spec/services/course/assessment/reminder_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::ReminderService do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+
+    describe '#opening_reminder' do
+      let!(:now) { Time.zone.now }
+
+      let(:user) { create(:course_user, course: course).user }
+      let!(:assessment) { create(:assessment, start_at: now) }
+
+      context 'when assessment is published' do
+        it 'notify the users' do
+          assessment.published = true
+
+          expect_any_instance_of(Course::AssessmentNotifier).to receive(:assessment_opening).once
+          subject.opening_reminder(user, assessment, assessment.start_at.to_f)
+        end
+      end
+
+      context 'when assessment is a draft' do
+        it 'does not notify the users' do
+          expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_opening)
+          subject.opening_reminder(user, assessment, assessment.start_at.to_f)
+        end
+      end
+
+      context "when assessment's start_date was changed" do
+        it 'does not notify the users' do
+          start_at = assessment.start_at.to_f
+          assessment.start_at = now + 1.day
+
+          expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_opening)
+          subject.opening_reminder(user, assessment, start_at)
+        end
+      end
+    end
+
+    describe '#closing_reminder' do
+      let!(:now) { Time.zone.now }
+
+      let(:user) { create(:course_user, course: course).user }
+      let!(:assessment) { create(:assessment, end_at: now) }
+
+      context 'when assessment is published' do
+        it 'notify the users' do
+          assessment.published = true
+
+          expect_any_instance_of(Course::AssessmentNotifier).to receive(:assessment_closing).once
+          subject.closing_reminder(user, assessment, assessment.end_at.to_f)
+        end
+      end
+
+      context 'when assessment is a draft' do
+        it 'does not notify the users' do
+          expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_closing)
+          subject.closing_reminder(user, assessment, assessment.end_at.to_f)
+        end
+      end
+
+      context "when assessment's end_date was changed" do
+        it 'does not notify the users' do
+          end_at = assessment.end_at.to_f
+          assessment.end_at = now + 1.day
+
+          expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_closing)
+          subject.closing_reminder(user, assessment, end_at)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,11 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'coverage_helper'
-require 'should_not/rspec'
 require 'capybara/rspec'
+require 'coverage_helper'
+require 'email_spec'
+require 'email_spec/rspec'
+require 'should_not/rspec'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -61,6 +61,18 @@ module TrackableJob::FeatureSpecHelpers
       ActiveJob::QueueAdapters::BackgroundThreadAdapter.wait_for_jobs
     end
   end
+
+  def perform_enqueued_jobs
+    if ActiveJob::Base.queue_adapter == ActiveJob::QueueAdapters::BackgroundThreadAdapter
+      ActiveJob::QueueAdapters::BackgroundThreadAdapter.perform_enqueued_jobs
+    end
+  end
+
+  def clear_enqueued_jobs
+    if ActiveJob::Base.queue_adapter == ActiveJob::QueueAdapters::BackgroundThreadAdapter
+      ActiveJob::QueueAdapters::BackgroundThreadAdapter.clear_enqueued_jobs
+    end
+  end
 end
 
 module TrackableJob::ModelSpecHelpers


### PR DESCRIPTION
Send an opening notification when an assessment is starting and a closing notification when an assessment is closing one day before the end day.

Notification will not be send out for draft assessment, and closing notification will not be send out if the assessment is guided (following the previous implementation).

In the event that the start date or end date is changed, notification will only be send on the latest start/end date. E.g. if assessment start date change from 1st nov to 3rd nov, opening notification will only be send out on 3rd nov.
