### PR TITLE
Rename 'Weight' field in question form to 'Order'.

### DIFF
--- a/app/views/course/admin/assessment_settings/edit.html.slim
+++ b/app/views/course/admin/assessment_settings/edit.html.slim
@@ -12,7 +12,7 @@ h2
       th
       th
       th = t('.title')
-      th = t('.weight')
+      th = Course::Assessment::Category.human_attribute_name(:weight)
       th = t('.parent_category')
       th
     tbody

--- a/app/views/course/admin/assessments/categories/new.html.slim
+++ b/app/views/course/admin/assessments/categories/new.html.slim
@@ -4,5 +4,5 @@
                   url: course_admin_assessments_categories_path(current_course) do |f|
   = f.error_notification
   = f.input :title
-  = f.input :weight
+  = f.input :weight, label: Course::Assessment::Category.human_attribute_name(:weight)
   = f.button :submit

--- a/app/views/course/admin/assessments/tabs/new.html.slim
+++ b/app/views/course/admin/assessments/tabs/new.html.slim
@@ -4,5 +4,5 @@
                   url: course_admin_assessments_category_tabs_path(current_course, @category) do |f|
   = f.error_notification
   = f.input :title
-  = f.input :weight
+  = f.input :weight, label: Course::Assessment::Tab.human_attribute_name(:weight)
   = f.button :submit

--- a/app/views/course/assessment/questions/_form.html.slim
+++ b/app/views/course/assessment/questions/_form.html.slim
@@ -2,5 +2,5 @@
 = f.input :description
 = f.input :staff_only_comments
 = f.input :maximum_grade
-= f.input :weight
+= f.input :weight, label: Course::Assessment::Question.human_attribute_name(:weight)
 = f.association :skills, as: :token, collection: current_course.assessment_skills, multiple: true

--- a/config/locales/en/activerecord/course/assessment/category.yml
+++ b/config/locales/en/activerecord/course/assessment/category.yml
@@ -3,6 +3,8 @@ en:
     attributes:
       course/assessment/category/title:
         default: :'course.assessment.assessments.index.header'
+      course/assessment/category:
+        weight: 'Order'
     errors:
       models:
         course/assessment/category:

--- a/config/locales/en/activerecord/course/assessment/question.yml
+++ b/config/locales/en/activerecord/course/assessment/question.yml
@@ -8,3 +8,6 @@ en:
     course/assessment/question:
       question_number: "Question %{index}"
       question_with_title: "%{question_number}: %{title}"
+    attributes:
+      course/assessment/question:
+        weight: 'Order'

--- a/config/locales/en/activerecord/course/assessment/tab.yml
+++ b/config/locales/en/activerecord/course/assessment/tab.yml
@@ -3,6 +3,8 @@ en:
     attributes:
       course/assessment/tab/title:
         default: 'Default'
+      course/assessment/tab:
+        weight: 'Order'
     errors:
       models:
         course/assessment/tab:

--- a/config/locales/en/course/admin/assessment_settings.yml
+++ b/config/locales/en/course/admin/assessment_settings.yml
@@ -9,5 +9,4 @@ en:
           categories_and_tabs: 'Categories and Tabs'
           submit: 'Update Assessment Settings'
           title: 'Title'
-          weight: 'Weight'
           parent_category: 'Category'


### PR DESCRIPTION
Fixes #1611.

In response to user feedback. Will be made obsolete by drag and drop reordering.