### PR TITLE
Sync todo status in after_save callback

### DIFF
--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Course::Assessment::Submission < ActiveRecord::Base
   include Workflow
-  # Workflow event transition logic must exist above Todo concern to allow for todo callbacks.
   include Course::Assessment::Submission::WorkflowEventConcern
   include Course::Assessment::Submission::TodoConcern
 

--- a/app/models/course/lesson_plan/todo.rb
+++ b/app/models/course/lesson_plan/todo.rb
@@ -3,17 +3,9 @@ class Course::LessonPlan::Todo < ActiveRecord::Base
   include Workflow
 
   workflow do
-    state :not_started do
-      event :start, transitions_to: :in_progress
-    end
-    state :in_progress do
-      event :complete, transitions_to: :completed
-      event :restart, transitions_to: :not_started
-    end
-    state :completed do
-      event :uncomplete, transitions_to: :in_progress
-      event :restart, transitions_to: :not_started
-    end
+    state :not_started
+    state :in_progress
+    state :completed
   end
 
   after_initialize :set_default_values, if: :new_record?

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -59,16 +59,12 @@ RSpec.feature 'Course: Homepage' do
         Course::LessonPlan::Todo.find_by(user: user, item: assessment.lesson_plan_item)
 
       assessment = create(:assessment, :published_with_mrq_question, course: course)
-      submission2 = create(:submission, :attempting, assessment: assessment, creator: user)
-      submission2.finalise!
-      submission2.save!
+      create(:submission, :submitted, assessment: assessment, creator: user)
       todos[:completed] =
         Course::LessonPlan::Todo.find_by(user: user, item: assessment.lesson_plan_item)
 
       assessment = create(:assessment, :with_mrq_question, draft: true, course: course)
-      submission3 = create(:submission, :attempting, assessment: assessment, creator: user)
-      submission3.finalise!
-      submission3.save!
+      create(:submission, :submitted, assessment: assessment, creator: user)
       todos[:unpublished] =
         Course::LessonPlan::Todo.find_by(user: user, item: assessment.lesson_plan_item)
 


### PR DESCRIPTION
TODO status was updated when the submission is finalized or unsubmitted, but that time the submission is not saved yet. TODO could go to the wrong state when submission fails to save, though  I would not expect this to happen.

This PR updates the todo status in the `after_save` callback.  

And after this I think it's good to just use enum to indicate the status instead of workflow library, we don't benefit from it anymore.

@weiqingtoh Any comments ? 