### PR TITLE
Fixed a bug that multiple html editor areas are displayed when goes back

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -9,8 +9,13 @@
     var airmodeOptions = $.extend(true, { airMode: true },
                                         { popover: $.summernote.options.popover });
     airmodeOptions.popover.air.unshift(['style', ['style']]);
-    $('textarea.text.airmode', element).summernote(airmodeOptions);
-    $('textarea.text', element).summernote();
+    var airmodeTextareas = $('textarea.text.airmode', element).not('.summernote-initialised');
+    airmodeTextareas.summernote(airmodeOptions);
+    airmodeTextareas.addClass('summernote-initialised');
+
+    var textareas = $('textarea.text', element).not('.airmode').not('.summernote-initialised');
+    textareas.summernote();
+    textareas.addClass('summernote-initialised');
   }
 
   function initializeComponents(element) {


### PR DESCRIPTION
Fix #1374 

Forum, Comments, and all description textareas has this issue:
![screen shot 2016-10-26 at 2 57 13 pm](https://cloud.githubusercontent.com/assets/4983239/19716132/92a75ec0-9b8c-11e6-9988-e333dd85712c.png)

This is due to summernote get initialised multiple times.
