### PR TITLE
Allow staff to view test cases of submissions in attempting state

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -26,6 +26,7 @@ module Course::Assessment::AssessmentAbility
     allow_staff_manage_annotations
     allow_staff_read_answers
     allow_manager_publish_submissions
+    allow_staff_read_tests
   end
 
   def define_auto_grader_permissions
@@ -109,6 +110,10 @@ module Course::Assessment::AssessmentAbility
     can :grade, Course::Assessment::Answer, submission: submissions_without_attempting_hash.merge(
       assessment: assessment_course_staff_hash
     )
+  end
+
+  def allow_staff_read_tests
+    can :read_tests, Course::Assessment::Submission, assessment: assessment_course_staff_hash
   end
 
   def allow_auto_grader_programming_evaluations

--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -1,5 +1,5 @@
 - auto_grading = answer.auto_grading ? answer.auto_grading.actable : nil
-- is_grader = can?(:grade, answer.answer)
+- is_grader = can?(:read_tests, @submission)
 - test_cases_by_type = question.test_cases_by_type
 - test_cases_and_results = get_test_cases_and_results(test_cases_by_type, auto_grading)
 

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, :published_with_programming_question, course: course) }
+    let(:assessment_2) { create(:assessment, :published_with_programming_question, course: course) }
     let(:submission) do
       create(:submission, *submission_traits, assessment: assessment, creator: user)
     end
+    let(:submission_2) do
+      create(:submission, *submission_traits_2, assessment: assessment_2, creator: user)
+    end
     let(:submission_traits) { nil }
+    let(:submission_traits_2) { nil }
 
     before { login_as(user, scope: :user) }
 
@@ -79,12 +84,23 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
     context 'As Course Staff' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
       let(:submission_traits) { :submitted }
+      let(:submission_traits_2) { :attempting }
 
       scenario 'I can view the test cases' do
+        # View test cases for submitted submission
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
         within find(content_tag_selector(submission.answers.first)) do
           assessment.questions.first.actable.test_cases.each do |solution|
+            expect(page).to have_content_tag_for(solution)
+          end
+        end
+
+        # View test cases for attempting submission
+        visit edit_course_assessment_submission_path(course, assessment_2, submission_2)
+
+        within find(content_tag_selector(submission_2.answers.first)) do
+          assessment_2.questions.first.actable.test_cases.each do |solution|
             expect(page).to have_content_tag_for(solution)
           end
         end


### PR DESCRIPTION
Fixes #1617.

Allows staff to view private and evaluation tests of submissions in attempting state. This will help staff render assistance to students who can't pass the private tests.