### PR TITLE
Use 'ban' icon to denote item is a draft

### DIFF
--- a/app/views/course/achievement/achievements/_achievement.html.slim
+++ b/app/views/course/achievement/achievements/_achievement.html.slim
@@ -9,11 +9,12 @@
       = display_locked_achievement_badge
 
   th
+    - if achievement.draft?
+      span title=draft_message(achievement)
+        => fa_icon 'ban'.freeze
+
     = link_to format_inline_text(achievement.title),
               course_achievement_path(current_course, achievement)
-    - if achievement.draft?
-      small title=achievement
-        =< fa_icon 'eye-slash'.freeze
 
   td.table-description colspan=2
     div.description

--- a/app/views/course/assessment/assessments/_lesson_plan_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_lesson_plan_assessment.html.slim
@@ -13,11 +13,11 @@
       span.label.label-default
         = format_inline_text(assessment.tab.category.title.singularize)
 
-      =< format_inline_text(assessment.title)
-
       - if assessment.draft?
         span data-placement='top' title=draft_message(assessment)
-          =< fa_icon 'eye-slash'.freeze
+          =< fa_icon 'ban'.freeze
+
+      =< format_inline_text(assessment.title)
 
   .lesson-plan-item-body.panel-collapse.collapse.in id=item_body_id(assessment)
     li.list-group-item

--- a/app/views/course/lesson_plan/events/_lesson_plan_event.html.slim
+++ b/app/views/course/lesson_plan/events/_lesson_plan_event.html.slim
@@ -13,11 +13,11 @@
       span.label.label-default
         = event.event_type
 
-      =< format_inline_text(event.title)
-
       - if event.draft?
         span data-placement='top' title=draft_message(event)
-        =< fa_icon 'eye-slash'.freeze
+          =< fa_icon 'ban'.freeze
+
+      =< format_inline_text(event.title)
 
   .lesson-plan-item-body.panel-collapse.collapse.in id=item_body_id(event)
     li.list-group-item


### PR DESCRIPTION
Follows up on #1544.
- Standardize the use of 'ban' icon to denote that item is a draft. 
- Moves icon in front of the text.
- Use bigger icons.
- Fix `title` bugs.

#hacktoberfest