### PR TITLE
Change the behaviour of password protected exam assessments

### DIFF
--- a/app/controllers/course/assessment/sessions_controller.rb
+++ b/app/controllers/course/assessment/sessions_controller.rb
@@ -47,6 +47,7 @@ class Course::Assessment::SessionsController < Course::Assessment::Controller
   end
 
   def authentication_service
-    @service ||= Course::Assessment::SessionAuthenticationService.new(@assessment, session)
+    @service ||=
+      Course::Assessment::SessionAuthenticationService.new(@assessment, session, @submission)
   end
 end

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -23,7 +23,8 @@ class Course::Assessment::Submission::SubmissionsController < \
     raise IllegalStateError if @assessment.questions.empty?
     @submission.session_id = session[:session_id]
     if @submission.save
-      redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission)
+      redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission,
+                                                         new_submission: true)
     else
       redirect_to course_assessments_path(current_course),
                   danger: t('.failure', error: @submission.errors.full_messages.to_sentence)

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -6,7 +6,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   before_action :authorize_assessment!, only: :create
   skip_authorize_resource :submission, only: [:edit, :update, :auto_grade]
   before_action :authorize_submission!, only: [:edit, :update]
-  before_action :check_password, only: [:create, :edit]
+  before_action :check_password, only: [:edit, :update]
   before_action :load_or_create_answers, only: [:edit, :update]
 
   delegate_to_service(:update)
@@ -21,7 +21,7 @@ class Course::Assessment::Submission::SubmissionsController < \
 
   def create
     raise IllegalStateError if @assessment.questions.empty?
-    @submission.last_session_id = session[:session_id]
+    @submission.session_id = session[:session_id]
     if @submission.save
       redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission)
     else
@@ -93,9 +93,11 @@ class Course::Assessment::Submission::SubmissionsController < \
   end
 
   def check_password
+    return unless @submission.attempting?
     return if !@assessment.password_protected? || can?(:manage, @assessment)
 
-    service = Course::Assessment::SessionAuthenticationService.new(@assessment, session)
+    service =
+      Course::Assessment::SessionAuthenticationService.new(@assessment, session, @submission)
     unless service.authenticated?
       redirect_to new_course_assessment_session_path(
         current_course, @assessment, submission_id: @submission.id

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -21,6 +21,7 @@ class Course::Assessment::Submission::SubmissionsController < \
 
   def create
     raise IllegalStateError if @assessment.questions.empty?
+    @submission.last_session_id = session[:session_id]
     if @submission.save
       redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission)
     else

--- a/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
+++ b/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
@@ -10,12 +10,8 @@ div.btn-group
       = link_to(t('.view'), edit_course_assessment_submission_path(current_course,
           assessment, submitted_submission), class: ['btn', 'btn-info'])
     - elsif can?(:attempt, assessment)
-      - if assessment.password_protected?
-        = link_to t('.attempt'), new_course_assessment_session_path(current_course, assessment),
-                  class: ['btn', 'btn-info']
-      - else
-        = link_to t('.attempt'), course_assessment_submissions_path(current_course, assessment),
-                  class: ['btn','btn-info'], method: :post
+      = link_to t('.attempt'), course_assessment_submissions_path(current_course, assessment),
+                class: ['btn','btn-info'], method: :post
   - else
     = link_to(t('.attempt'), '#', class: ['btn', 'btn-info', 'disabled'])
 

--- a/app/views/course/assessment/sessions/new.html.slim
+++ b/app/views/course/assessment/sessions/new.html.slim
@@ -5,7 +5,7 @@
   p.text-center = t('.message')
 
   = simple_form_for :session, url: course_assessment_sessions_path(current_course, @assessment), method: :post do |f|
-    = f.input :password, as: :string, label: false, required: false, placeholder: t('.placeholder')
+    = f.input :password, label: false, required: false, placeholder: t('.placeholder')
     = f.hidden_field :submission_id, value: params[:submission_id]
 
     = f.submit t('.continue'), class: ['btn', 'btn-primary']

--- a/app/views/course/assessment/submission/submissions/_exam.html.slim
+++ b/app/views/course/assessment/submission/submissions/_exam.html.slim
@@ -15,3 +15,10 @@
       mark: @submission.submitted? && can_grade,
       unsubmit: !@submission.attempting? && can_grade\
      }
+
+/ Display a dialog after create the submission
+- if @assessment.password_protected? && params[:new_submission] == 'true'
+  javascript:
+    $(document).ready(function() {
+      alert(I18n.t('javascript.course.assessment.submission.submissions.exam.notice'));
+    });

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -61,7 +61,11 @@ en:
         form:
           autograded: 'Automatically assign grade and experience points after finalization'
           autograded_hint: 'Note that all the questions in the assessment must be auto-gradable'
-          password_hint: 'Students must input the correct password in order to attempt the assessment'
+          password_hint: >
+            When password protection is enabled, students are able to attempt the submission on the
+            first try. Further attempts at editing the submission requires the input of the
+            password (with the help of course staff). In addition, only one session is allowed to
+            access the submission at any given time.
           password_placeholder: 'Leave blank to disable password protection'
         assessment_management_buttons:
           attempt: 'Attempt'

--- a/config/locales/en/course/assessment/sessions.yml
+++ b/config/locales/en/course/assessment/sessions.yml
@@ -4,6 +4,6 @@ en:
       sessions:
         new:
           header: 'Input Password'
-          message: 'The assessment is locked, input the password to continue.'
+          message: 'The assessment is locked, please approach any course staff for assistance.'
           placeholder: 'Password'
           continue: 'Continue'

--- a/config/locales/en/javascript/course/assessment/submission/submissions.yml
+++ b/config/locales/en/javascript/course/assessment/submission/submissions.yml
@@ -1,0 +1,12 @@
+en:
+  javascript:
+    course:
+      assessment:
+        submission:
+          submissions:
+            exam:
+              notice: >
+                You are entering an exam.
+
+                Please do not sign out or close the browser, otherwise you will have trouble
+                continuing the exam.

--- a/db/migrate/20161027074807_add_session_id_to_submissions.rb
+++ b/db/migrate/20161027074807_add_session_id_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddSessionIdToSubmissions < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_submissions, :session_id, :string, foreign_key: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161020020353) do
+ActiveRecord::Schema.define(version: 20161027074807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,7 @@ ActiveRecord::Schema.define(version: 20161020020353) do
   create_table "course_assessment_submissions", force: :cascade do |t|
     t.integer  "assessment_id",  :null=>false, :index=>{:name=>"fk__course_assessment_submissions_assessment_id"}, :foreign_key=>{:references=>"course_assessments", :name=>"fk_course_assessment_submissions_assessment_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.string   "workflow_state", :limit=>255, :null=>false
+    t.string   "session_id",     :limit=>255
     t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_submissions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_submissions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at",     :null=>false

--- a/spec/features/course/assessment/submission/exam_spec.rb
+++ b/spec/features/course/assessment/submission/exam_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
     context 'As a Course Student' do
       let(:user) { student }
 
-      scenario 'I need to input the password before attempting exams', js: true do
+      scenario 'I need to input the password when using a different session ', js: true do
         assessment
         visit course_assessments_path(course)
 
@@ -29,6 +29,17 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
             I18n.t('course.assessment.assessments.assessment_management_buttons.attempt')
           ).trigger('click')
         end
+        # The user should be redirect to submission edit page
+        expect(page).to have_selector('h1', text: assessment.title)
+
+        submission = assessment.submissions.last
+
+        # Logout and login again and visit the same submission
+        logout
+        login_as(user)
+
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+
         expect(page).to have_selector('div.password-panel')
 
         fill_in 'session_password', with: 'wrong_password'
@@ -38,7 +49,6 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
         fill_in 'session_password', with: assessment.password
         click_button I18n.t('course.assessment.sessions.new.continue')
 
-        # The user should be redirect to submission edit page
         expect(page).to have_selector('h1', text: assessment.title)
       end
 


### PR DESCRIPTION
1. The password is not required when students attempt the assessment for the first time.
2. The password is required when students want to resume the submission in a different session.
3. At any given time, there's only one session can access the submission. Other sessions will be kicked out when there's a new session.
