### PR TITLE
Use puma as the server in tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,3 +90,9 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+Capybara.register_server(:puma) do |app, port|
+  server = Puma::Server.new(app)
+  server.add_tcp_listener(Capybara.server_host, port)
+  server.run
+end


### PR DESCRIPTION
This could hopefully fix the random timeouts in the tests.

Don't merge first, need to run tests for a few times.
