### PR TITLE
Don't display stdout and stderr boxes if there's no exit code.

### DIFF
--- a/app/views/course/assessment/answer/programming/_programming.html.slim
+++ b/app/views/course/assessment/answer/programming/_programming.html.slim
@@ -13,6 +13,6 @@ div.files
 = render partial: 'course/assessment/answer/programming/test_cases',
          locals: { question: question, auto_grading: auto_grading, is_grader: is_grader }
 / Show stdout and stderr to graders when evaluation is unsuccessful.
-- if is_grader && auto_grading && auto_grading.exit_code != 0
+- if is_grader && auto_grading && auto_grading.exit_code && auto_grading.exit_code != 0
   = render partial: 'course/assessment/answer/programming/output_streams',
            locals: { auto_grading: auto_grading }


### PR DESCRIPTION
Hides empty stderr and stdout boxes for old auto gradings which do not
have this data.
Use the presence of exit code as a proxy for whether the other 2 values
are set.

If exit code is present but stdout and stderr somehow aren't set, it's better to be alerted so we can investigate, as that should not be the case.

References #1630. Minor UI fix.