### PR TITLE
Do not use session_id and manually generate authentication token

### DIFF
--- a/app/services/course/assessment/session_authentication_service.rb
+++ b/app/services/course/assessment/session_authentication_service.rb
@@ -28,20 +28,33 @@ class Course::Assessment::SessionAuthenticationService
     end
   end
 
+  # Generates a new authentication token and stores it in current session.
+  #
+  # @return [String] the new authentication token.
+  def generate_authentication_token!
+    new_id = SecureRandom.hex(8)
+    @session[session_key] = new_id
+    new_id
+  end
+
   # Check whether current session is the same session that created the submission or not.
   #
   # @return [Boolean]
   def authenticated?
-    current_session_id == @submission.session_id
+    current_authentication_token && current_authentication_token == @submission.session_id
   end
 
   private
 
   def update_session_id
-    @submission.update_column(:session_id, current_session_id)
+    @submission.update_column(:session_id, generate_authentication_token!)
   end
 
-  def current_session_id
-    @session[:session_id]
+  def current_authentication_token
+    @session[session_key]
+  end
+
+  def session_key
+    "assessment_#{@assessment.id}_authentication_token"
   end
 end


### PR DESCRIPTION
Just realized that production server uses Redis as the session store.

Due to the store implementation, the `:session_id` is not available and password authentication is not working properly.  This id seems only accessible in cookie store, which is the development/test environment. 

This PR changes the implementation and manually generates the token instead of relying on the session_id.