### PR TITLE
Implement backend methods to allow reattempting questions in guided assessments

### DIFF
--- a/app/models/concerns/course/assessment/questions_concern.rb
+++ b/app/models/concerns/course/assessment/questions_concern.rb
@@ -11,14 +11,14 @@ module Course::Assessment::QuestionsConcern
   #   answers.
   # @return [Array<Course::Assessment::Answer>] The answers for the questions, in the same order
   #   specified. Newly initialized answers will not be persisted.
-  def attempt(submission)
+  def attempt(submission, reattempt = false)
     attempting_answers = submission.answers.latest_answers.
                          merge(submission.answers.with_attempting_state).
                          where(question: self).
                          map { |answer| [answer.question, answer] }.to_h
 
     map do |question|
-      attempting_answers.fetch(question) { question.attempt(submission) }
+      attempting_answers.fetch(question) { question.attempt(submission, reattempt: reattempt) }
     end
   end
 

--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -3,8 +3,11 @@ module Course::Assessment::Submission::AnswersConcern
   extend ActiveSupport::Concern
 
   # Scope to obtain the latest answers for each question for Course::Assessment::Submission.
+  # TODO: Remove this and use submission#latest_answers instead. Requires refactoring on
+  #         assessment.questions#attempt
   def latest_answers
-    unscope(:order).select('DISTINCT ON (question_id) *').order(:question_id, created_at: :desc)
+    unscope(:order).select('DISTINCT ON (question_id) *').order(:question_id, created_at: :desc).
+      without_reattempting_state
   end
 
   # Load the answers of specific question.

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -27,6 +27,8 @@ module Course::Assessment::Submission::WorkflowEventConcern
     end
     self.publisher = User.stamper || User.system
     self.published_at = Time.zone.now
+
+    assessment.questions.attempt(self, reattempt: true) if assessment.reattemptable?
   end
 
   # Handles the unsubmission of a submitted submission.
@@ -36,5 +38,15 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
     unsubmit_latest_answers
     self.points_awarded = nil
+
+    answers.select(&:reattempting?).map(&:mark_for_destruction) if assessment.reattemptable?
+  end
+
+  private
+
+  def unsubmit_latest_answers
+    latest_answers.each do |answer|
+      answer.unsubmit! if answer.submitted? || answer.graded?
+    end
   end
 end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -93,6 +93,10 @@ class Course::Assessment < ActiveRecord::Base
     password.present?
   end
 
+  def reattemptable?
+    guided?
+  end
+
   private
 
   # Sets the course of the lesson plan item to be the same as the one for the assessment.

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -205,10 +205,4 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
     Course::AssessmentNotifier.assessment_submitted(creator, course_user, self)
   end
-
-  def unsubmit_latest_answers
-    latest_answers.each do |answer|
-      answer.unsubmit! if answer.submitted? || answer.graded?
-    end
-  end
 end

--- a/app/services/course/assessment/answer/auto_grading_service.rb
+++ b/app/services/course/assessment/answer/auto_grading_service.rb
@@ -30,7 +30,7 @@ class Course::Assessment::Answer::AutoGradingService
       Course::Assessment::Answer.transaction do
         answer.save!
         if reattempt
-          new_answer = answer.question.attempt(answer.submission, answer)
+          new_answer = answer.question.attempt(answer.submission, last_attempt: answer)
           new_answer.save!
           # Move posts to the new answer.
           # TODO: Mount posts under a join table between submission and answer.

--- a/db/migrate/20161103141247_create_reattempting_answers_for_published_submissions.rb
+++ b/db/migrate/20161103141247_create_reattempting_answers_for_published_submissions.rb
@@ -1,0 +1,15 @@
+class CreateReattemptingAnswersForPublishedSubmissions < ActiveRecord::Migration
+  def up
+    guided_ids = Course::Assessment.guided.pluck(:id)
+    Course::Assessment::Submission.
+      where { id >> guided_ids }.
+      includes(assessment: :questions).
+      each do |submission|
+        submission.assessment.questions.attempt(submission, reattempt: true)
+      end
+  end
+
+  def down
+    Course::Assessment::Answer.with_reattempting_state.destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102022455) do
+ActiveRecord::Schema.define(version: 20161103141247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -113,6 +113,14 @@ RSpec.describe Course::Assessment::Question do
             expect { subject.attempt(nil) }.to raise_error(NotImplementedError)
           end
         end
+
+        context 'when reattempt is set to true' do
+          it 'sets the answer to reattempting state' do
+            answer = build_stubbed(:course_assessment_answer, question: question)
+            expect(question).to receive(:attempt).and_return(answer)
+            expect(subject.attempt(nil, reattempt: true).reattempting?).to be_truthy
+          end
+        end
       end
     end
 

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -350,6 +350,19 @@ RSpec.describe Course::Assessment::Submission do
           expect(submission.answers.all?(&:graded?)).to be(true)
         end
       end
+
+      context 'when the assessment is guided' do
+        let(:assessment_traits) { [:with_all_question_types, :guided] }
+        before do
+          submission.publish!
+          submission.save!
+        end
+
+        it 'createa reattempting answers for each question' do
+          expect(submission.reload.answers.with_reattempting_state.map(&:question)).
+            to contain_exactly(*assessment.questions)
+        end
+      end
     end
 
     describe '#auto_grade!' do
@@ -415,6 +428,14 @@ RSpec.describe Course::Assessment::Submission do
         it 'sets all latest answers in the submission to attempting' do
           expect(subject.latest_answers.all?(&:attempting?)).to be(true)
           expect(earlier_answer.reload).to be_graded
+        end
+
+        context 'when the assessment is guided' do
+          let(:assessment_traits) { [:with_all_question_types, :guided] }
+
+          it 'deletes all reattempting answers' do
+            expect(subject.answers.with_reattempting_state.count).to eq(0)
+          end
         end
       end
     end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -171,6 +171,19 @@ RSpec.describe Course::Assessment do
             expect(answers.all?(&:persisted?)).to be(false)
           end
         end
+
+        context 'when reattempt is true' do
+          before do
+            assessment.questions.attempt(submission, reattempt: true).tap do |answers|
+              answers.each(&:save)
+            end
+          end
+
+          it 'creates new answers with reattempting state' do
+            expect(submission.reload.answers.with_reattempting_state.count).
+              to eq(assessment.questions.count)
+          end
+        end
       end
 
       describe '#step' do


### PR DESCRIPTION
First part of #1313. This PR defines the design for reattempting questions in guided assessments. Specific tasks include:
 - Defining new workflow state `reattempting`
 - Modifying all current scopes/calculated attributes to not consider `reattempting` answers
 - Defining hooks to create/delete `reattempting` answers
 - DB migration to populate `reattempting` answers for existing submissions.

I'm not sure if the DB migration script is efficient; I'll probably need to try running this once on my local with a prod backup DB. Will update when I do that tomorrow. 

