### PR TITLE
Modify pending submissions not to show submissions from guided assessments

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -10,7 +10,7 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   end
 
   def pending
-    @submissions = pending_submissions.from_course(current_course).pending_for_grading
+    @submissions = pending_submissions.from_course(current_course)
   end
 
   private
@@ -55,9 +55,9 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   def pending_submissions
     if pending_submission_params[:my_students] == 'true'
       my_student_ids = current_course_user ? current_course_user.my_students.select(:user_id) : []
-      @submissions.by_users(my_student_ids)
+      @submissions.by_users(my_student_ids).pending_for_grading
     else
-      @submissions
+      @submissions.pending_for_grading
     end
   end
 

--- a/app/helpers/course/assessment/submissions_helper.rb
+++ b/app/helpers/course/assessment/submissions_helper.rb
@@ -6,8 +6,7 @@ module Course::Assessment::SubmissionsHelper
   def pending_submissions_count
     @pending_submissions_count ||= begin
       student_ids = current_course.course_users.students.select(:user_id)
-      Course::Assessment::Submission.from_course(current_course).by_users(student_ids).
-        with_submitted_state.count
+      pending_submission_count_for(student_ids)
     end
   end
 
@@ -17,8 +16,19 @@ module Course::Assessment::SubmissionsHelper
   def my_students_pending_submissions_count
     @my_student_pending_submissions ||= begin
       my_student_ids = current_course_user ? current_course_user.my_students.select(:user_id) : []
-      Course::Assessment::Submission.from_course(current_course).with_submitted_state.
-        by_users(my_student_ids).count
+      pending_submission_count_for(my_student_ids)
     end
+  end
+
+  private
+
+  # Returns the count of submissions given the student ids
+  #
+  # @param [Array<Fixnum>] student_ids The submissions for the given user_ids of student
+  # @return [Integer] The required count
+  def pending_submission_count_for(student_ids)
+    return 0 if student_ids.blank?
+    Course::Assessment::Submission.
+      from_course(current_course).by_users(student_ids).pending_for_grading.count
   end
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -117,7 +117,11 @@ class Course::Assessment::Submission < ActiveRecord::Base
   #   Returns submissions which have been submitted (which may or may not be graded).
   scope :confirmed, -> { where.not(workflow_state: :attempting) }
 
-  scope :pending_for_grading, -> { where(workflow_state: [:submitted, :graded]) }
+  scope :pending_for_grading, (lambda do
+    where(workflow_state: [:submitted, :graded]).
+      joins { assessment }.
+      where { assessment.autograded == false }
+  end)
 
   # Filter submissions by category_id, assessment_id, group_id and/or user_id (creator)
   scope :filter, (lambda do |filter_params|


### PR DESCRIPTION
Fixes #1421.

This PR modifies pending submissions to only show submissions from assessments that are not guided (ie. worksheet and exam). 