### PR TITLE
Implement attempting limit for programming questions

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -53,7 +53,7 @@ class Course::Assessment::Question::ProgrammingController < \
   def programming_question_params
     params.require(:question_programming).permit(
       :title, :description, :staff_only_comments, :maximum_grade, :weight,
-      :language_id, :memory_limit, :time_limit,
+      :language_id, :memory_limit, :time_limit, :attempt_limit,
       *attachment_params,
       skill_ids: []
     )

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -58,4 +58,12 @@ module Course::Assessment::Submission::SubmissionsHelper
   def single_question_flag_class(assessment)
     assessment.questions.length > 1 ? 'multi-question' : 'single-question'
   end
+
+  def enable_submit_button?(answer)
+    if answer.attempting_times_left > 0
+      true
+    else
+      can?(:manage, answer.submission.assessment)
+    end
+  end
 end

--- a/app/models/course/assessment/answer/programming.rb
+++ b/app/models/course/assessment/answer/programming.rb
@@ -23,4 +23,19 @@ class Course::Assessment::Answer::Programming < ActiveRecord::Base
     end
     acting_as
   end
+
+  MAX_ATTEMPTING_TIMES = 1000
+  # Returns the attempting times left for current answer.
+  # The max attempting times will be returned if question don't have the limit.
+  #
+  # @return [Integer]
+  def attempting_times_left
+    @times_left ||= begin
+      return MAX_ATTEMPTING_TIMES unless question.actable.attempt_limit
+
+      times = question.actable.attempt_limit - submission.graded_answers(question).size
+      times = 0 if times < 0
+      times
+    end
+  end
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -160,6 +160,11 @@ class Course::Assessment::Submission < ActiveRecord::Base
     answers.group_by(&:question_id).map { |pair| pair[1].last }
   end
 
+  # Returns all graded answers of the question in current submission.
+  def graded_answers(question)
+    answers.select { |a| a.question_id == question.id &&  a.graded? }
+  end
+
   private
 
   # Queues the submission for auto grading, after the submission has changed to the submitted state.

--- a/app/services/course/assessment/submission/update_guided_assessment_service.rb
+++ b/app/services/course/assessment/submission/update_guided_assessment_service.rb
@@ -30,4 +30,10 @@ class Course::Assessment::Submission::UpdateGuidedAssessmentService <
         end
       end
   end
+
+  # Guided assessment will ignore the attempt limit, otherwise student cannot proceed to next step
+  # if exceeds the limit.
+  def valid_for_grade?
+    true
+  end
 end

--- a/app/views/course/assessment/answer/_worksheet.html.slim
+++ b/app/views/course/assessment/answer/_worksheet.html.slim
@@ -1,16 +1,22 @@
 - if answer.submission.attempting? && answer.specific.is_a?(Course::Assessment::Answer::Programming)
+  - programming_answer = answer.specific
+  - if answer.question.actable.attempt_limit
+    - button_text = t('.run_code_with_limit', limit: programming_answer.attempting_times_left)
+  - else
+    - button_text = t('.run_code')
+
   - if answer.attempting?
     div.btn-group
       = link_to_reset_answer(answer)
-      = base_answer_form.button :button, t('.run_code'), value: answer.id,
-        name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger']
+      = base_answer_form.button :button, button_text, value: answer.id,
+        name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger'], disabled: !enable_submit_button?(programming_answer)
   - elsif answer.submitted? && job = answer.try(:auto_grading).try(:job)
     - if job.errored?
       p.bg-danger = t('.error')
-      = base_answer_form.button :button, t('.run_code'), value: answer.id, name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger']
+      = base_answer_form.button :button, button_text, value: answer.id, name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger']
     - elsif job.submitted?
       = link_to '#', class: ['btn', 'btn-danger', 'submitted'], 'data-job-path': job_path(job), disabled: true do
-        => t('.run_code')
+        => button_text
         = fa_icon 'spinner lg spin'
 
 h3 = t('.comments')

--- a/app/views/course/assessment/question/programming/_form.html.slim
+++ b/app/views/course/assessment/question/programming/_form.html.slim
@@ -7,6 +7,8 @@
   = f.association :language
   = f.input :memory_limit
   = f.input :time_limit
+  - unless @assessment.guided?
+    = f.input :attempt_limit, placeholder: t('.attempt_limit_placeholder')
   = f.label :template_package
   = f.attachment
 

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -8,6 +8,7 @@ en:
         worksheet:
           comments: 'Comments'
           run_code: 'Run Code'
+          run_code_with_limit: 'Run ( %{limit} times left )'
           error: :'course.assessment.answer.error'
         comments_footer:
           comment: 'Comment'

--- a/config/locales/en/course/assessment/question/programming.yml
+++ b/config/locales/en/course/assessment/question/programming.yml
@@ -13,6 +13,7 @@ en:
             success: 'The programming question was deleted.'
             failure: 'Could not delete programming question: %{error}'
           form:
+            attempt_limit_placeholder: 'The maximum times that students can test their answers ( does not apply to staff )'
             import_result:
               success: 'The package was successfully imported.'
               error: 'The package could not be imported: %{error}'

--- a/db/migrate/20161107023238_add_attempt_limit_to_programming_questions.rb
+++ b/db/migrate/20161107023238_add_attempt_limit_to_programming_questions.rb
@@ -1,0 +1,5 @@
+class AddAttemptLimitToProgrammingQuestions < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_question_programming, :attempt_limit, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102022455) do
+ActiveRecord::Schema.define(version: 20161107023238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -242,6 +242,7 @@ ActiveRecord::Schema.define(version: 20161102022455) do
     t.integer "language_id",   :null=>false, :index=>{:name=>"fk__course_assessment_question_programming_language_id"}, :foreign_key=>{:references=>"polyglot_languages", :name=>"fk_course_assessment_question_programming_language_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer "memory_limit",  :comment=>"Memory limit, in MiB"
     t.integer "time_limit",    :comment=>"Time limit, in seconds"
+    t.integer "attempt_limit"
     t.uuid    "import_job_id", :comment=>"The ID of the importing job", :index=>{:name=>"index_course_assessment_question_programming_on_import_job_id", :unique=>true}, :foreign_key=>{:references=>"jobs", :name=>"fk_course_assessment_question_programming_import_job_id", :on_update=>:no_action, :on_delete=>:nullify}
   end
 

--- a/spec/factories/course_assessment_question_programming.rb
+++ b/spec/factories/course_assessment_question_programming.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
 
     memory_limit 32
     time_limit 10
+    attempt_limit 3
     language { Coursemology::Polyglot::Language::Python::Python2Point7.instance }
     template_files do
       template_file_count.downto(1).map do

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         select question_attributes[:language].name, from: 'language'
         fill_in 'memory_limit', with: question_attributes[:memory_limit]
         fill_in 'time_limit', with: question_attributes[:time_limit]
+        fill_in 'attempt_limit', with: question_attributes[:attempt_limit]
         click_button 'submit'
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
@@ -40,6 +41,9 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         expect(page).to have_content_tag_for(question_created)
         expect(question_created.skills).to contain_exactly(skill)
         expect(question_created.weight).to eq(question_attributes[:weight])
+        expect(question_created.memory_limit).to eq(question_attributes[:memory_limit])
+        expect(question_created.time_limit).to eq(question_attributes[:time_limit])
+        expect(question_created.attempt_limit).to eq(question_attributes[:attempt_limit])
       end
 
       scenario 'I can upload a template package' do


### PR DESCRIPTION
This will fix #1633

- Allow an attempt limit to be set for programming questions, students won't be able to submit the code after the limit is reached.
- Staff won't be affected by the limit
- The limit is also not valid in guided assessment