### PR TITLE
Do not send activity emails for nil objects

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -13,6 +13,7 @@ class ActivityMailer < ApplicationMailer
     ActsAsTenant.without_tenant do
       @recipient = recipient
       @object = notification.activity.object
+      return unless @object # Object could be deleted already
       mail(to: recipient.email, template: view_path)
     end
   end


### PR DESCRIPTION
We have a lots of exceptions of `ActionView::Template::Error: undefined method `topic' for nil:NilClass `

I thought it was some sort of serialization issue initially. However, after debugging for a while I realized that It's actually because the post is deleted before the email is sent. 

For verification purpose, I checked the last 1000 forum activities in db, around 4.5% of them don't have the `object`.