### PR TITLE
Re-run the tests after the package is changed

### DIFF
--- a/app/jobs/course/assessment/question/answers_evaluation_job.rb
+++ b/app/jobs/course/assessment/question/answers_evaluation_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::AnswersEvaluationJob < ApplicationJob
+  def perform(question)
+    instance = Course.unscoped { question.assessment.course.instance }
+    ActsAsTenant.with_tenant(instance) do
+      Course::Assessment::Question::AnswersEvaluationService.new(question).call
+    end
+  end
+end

--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -26,6 +26,8 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   # @param [Attachment] attachment The attachment containing the package.
   def perform_import(question, attachment)
     Course::Assessment::Question::ProgrammingImportService.import(question, attachment)
+    # Re-run the tests since the test results are deleted with the old package.
+    Course::Assessment::Question::AnswersEvaluationJob.perform_later(question)
   ensure
     redirect_to edit_course_assessment_question_programming_path(question.assessment.course,
                                                                  question.assessment, question)

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -48,6 +48,8 @@ class Course::Assessment::Answer < ActiveRecord::Base
       joins { discussion_topic }.select { discussion_topic.id }
   end)
 
+  scope :without_attempting_state, -> { where.not(workflow_state: :attempting) }
+
   # Creates an Auto Grading job for this answer. This saves the answer if there are pending changes.
   #
   # @param [String|nil] redirect_to_path The path to be redirected after auto grading job was

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -6,6 +6,7 @@ class Course::Assessment::Question < ActiveRecord::Base
   validate :validate_assessment_is_not_autograded, unless: :auto_gradable?
 
   belongs_to :assessment, inverse_of: :questions
+  has_many :answers, class_name: Course::Assessment::Answer.name, inverse_of: :question
   has_and_belongs_to_many :skills
 
   default_scope { order(weight: :asc) }

--- a/app/services/course/assessment/question/answers_evaluation_service.rb
+++ b/app/services/course/assessment/question/answers_evaluation_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Evaluates all answers associated with the given question.
+# Call this service after the package of the question is updated.
+class Course::Assessment::Question::AnswersEvaluationService
+  # @param [Course::Assessment::Question] question The programming question.
+  def initialize(question)
+    @question = question
+  end
+
+  def call
+    @question.answers.without_attempting_state.each(&:auto_grade!)
+  end
+end

--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -4,6 +4,11 @@
 / Test case results table
 h3 = t('.test_cases')
 
+- if !@submission.attempting? && auto_grading.try(:job).try(:submitted?)
+  div.alert.alert-warning
+    => fa_icon 'exclamation'
+    = t('.evaluation_warning')
+
 - if test_cases_and_results.key?('public_test')
   = render partial: 'course/assessment/answer/programming/test_cases_of_type',
     locals: { test_cases_and_results: test_cases_and_results['public_test'],

--- a/config/locales/en/course/assessment/answer/programming.yml
+++ b/config/locales/en/course/assessment/answer/programming.yml
@@ -10,6 +10,8 @@ en:
           file_fields:
             expand_comments: 'Expand all comments'
           test_cases:
+            evaluation_warning:
+              The answer is still being evaluated, come back after a while to see the latest results.
             private: :'course.assessment.question.programming.form_test_cases.private'
             public: :'course.assessment.question.programming.form_test_cases.public'
             evaluation: :'course.assessment.question.programming.form_test_cases.evaluation'

--- a/spec/services/course/assessment/question/answers_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/question/answers_evaluation_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::AnswersEvaluationService do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    # Used MCQ question here because we are not able to run programming auto grading in tests
+    let(:question) { create(:course_assessment_question_multiple_response) }
+    let(:student) { create(:course_user, :approved, course: question.assessment.course).user }
+    let!(:submission) do
+      create(:submission, :graded, assessment: question.assessment, creator: student)
+    end
+    let!(:answers) { submission.answers }
+    subject { Course::Assessment::Question::AnswersEvaluationService.new(question) }
+
+    describe '#call' do
+      before { subject.call }
+
+      it 'auto grades the associated answers' do
+        expect(answers.map { |a| a.auto_grading.job }.all?(&:present?)).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix #1663 

- Re-run tests after a new package is successfully imported
- Display a warning for those answers which are still being evaluated