### PR TITLE
Do not fill in grades if the assessment is manually graded

### DIFF
--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -15,6 +15,10 @@
       margin-top: 0.5em;
     }
 
+    .answer .grade-form {
+      margin-bottom: 0;
+    }
+
     .submission-buttons .btn {
       margin: 10px 20px 10px 0;
     }

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -14,7 +14,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
   # Handles the marking of a submission. This will grade all the answers.
   def mark(_ = nil)
     answers.each do |answer|
-      answer.publish! if answer.submitted?
+      answer.publish! if answer.submitted? || answer.evaluated?
     end
   end
 
@@ -23,7 +23,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
   # This grades all the answers as well.
   def publish(_ = nil)
     answers.each do |answer|
-      answer.publish! if answer.submitted?
+      answer.publish! if answer.submitted? || answer.evaluated?
     end
     self.publisher = User.stamper || User.system
     self.published_at = Time.zone.now

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -28,11 +28,10 @@ class Course::Assessment::Answer < ActiveRecord::Base
 
   validate :validate_consistent_assessment
   validate :validate_assessment_state, if: :attempting?
-  # TODO: Deal with grade in graded state.
   validates :submitted_at, presence: true, unless: :attempting?
   validates :submitted_at, :grade, :grader, :graded_at, absence: true, if: :attempting?
-  validates :grader, :graded_at, presence: true, if: :graded?
-  validate :validate_consistent_grade, unless: :attempting?
+  validates :grade, :grader, :graded_at, presence: true, if: :graded?
+  validate :validate_consistent_grade, if: :graded?
 
   belongs_to :submission, inverse_of: :answers
   belongs_to :question, class_name: Course::Assessment::Question.name, inverse_of: nil
@@ -90,11 +89,11 @@ class Course::Assessment::Answer < ActiveRecord::Base
   protected
 
   def finalise
-    self.grade = 0
     self.submitted_at = Time.zone.now
   end
 
   def publish
+    self.grade ||= 0
     self.grader = User.stamper || User.system
     self.graded_at = Time.zone.now
   end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -10,6 +10,14 @@ class Course::Assessment::Answer < ActiveRecord::Base
     end
     state :submitted do
       event :unsubmit, transitions_to: :attempting
+      event :evaluate, transitions_to: :evaluated
+      event :publish, transitions_to: :graded
+    end
+    # The state that has test case results but don't have a grade.
+    # For manually graded assessments, this should be the default state after auto-grading service
+    # is executed.
+    state :evaluated do
+      event :unsubmit, transitions_to: :attempting
       event :publish, transitions_to: :graded
     end
     state :graded do

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -214,7 +214,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
   def unsubmit_latest_answers
     latest_answers.each do |answer|
-      answer.unsubmit! if answer.submitted? || answer.graded?
+      answer.unsubmit! unless answer.attempting?
     end
   end
 end

--- a/app/services/course/assessment/answer/auto_grading_service.rb
+++ b/app/services/course/assessment/answer/auto_grading_service.rb
@@ -41,18 +41,30 @@ class Course::Assessment::Answer::AutoGradingService
     end
   end
 
-  # Grades into the given +Course::Assessment::Answer::AutoGrading+ object. This does not do
-  # anything, except mark the answer as having been graded.
-  #
-  # Subclasses should call this implementation after they are done to persist the changes to the
-  # database.
+  # Grades into the given +Course::Assessment::Answer::AutoGrading+ object. This assigns the grade
+  # and makes sure answer is in the correct state.
   #
   # @param [Course::Assessment::Answer] answer The answer to be graded.
   # @return [Course::Assessment::Answer] The graded answer. Note that this answer is not persisted
   #   yet.
   def grade(answer)
-    answer.publish!
-    answer.grader = User.system
+    grade = evaluate(answer)
+    answer.evaluate!
+
+    if answer.question.assessment.autograded?
+      answer.publish!
+      answer.grade = grade
+      answer.grader = User.system
+    end
     answer
+  end
+
+  # Evaluates and mark the answer as correct or not. This is supposed to be implemented by
+  # subclasses.
+  #
+  # @param [Course::Assessment::Answer] answer The answer to be evaluated.
+  # @return [Integer] grade The grade of the answer.
+  def evaluate(answer)
+    raise 'Not Implemented'
   end
 end

--- a/app/services/course/assessment/answer/multiple_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/multiple_response_auto_grading_service.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::MultipleResponseAutoGradingService < \
   Course::Assessment::Answer::AutoGradingService
-  def grade(answer)
-    answer.correct, answer.grade, messages = grade_answer(answer.actable)
+  def evaluate(answer)
+    answer.correct, grade, messages = evaluate_answer(answer.actable)
     answer.auto_grading.result = { messages: messages }
-    super(answer)
+    grade
   end
 
   private
@@ -15,7 +15,7 @@ class Course::Assessment::Answer::MultipleResponseAutoGradingService < \
   #   student.
   # @return [Array<(Boolean, Integer, Object)>] The correct status, grade and the messages to be
   #   assigned to the grading.
-  def grade_answer(answer)
+  def evaluate_answer(answer)
     question = answer.question.actable
 
     if question.any_correct?

--- a/app/services/course/assessment/answer/programming_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_auto_grading_service.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::ProgrammingAutoGradingService < \
   Course::Assessment::Answer::AutoGradingService
-  def grade(answer)
-    answer.correct, new_grade, programming_auto_grading = grade_answer(answer.actable)
+  def evaluate(answer)
+    answer.correct, grade, programming_auto_grading = evaluate_answer(answer.actable)
     programming_auto_grading.auto_grading = answer.auto_grading
-    answer.grade = new_grade if answer.question.assessment.autograded?
-    super(answer)
+    grade
   end
 
   private
@@ -15,7 +14,7 @@ class Course::Assessment::Answer::ProgrammingAutoGradingService < \
   # @param [Course::Assessment::Answer::Programming] answer The answer specified by the student.
   # @return [Array<(Boolean, Integer, Course::Assessment::Answer::ProgrammingAutoGrading)>] The
   #   correct status, grade and the programming auto grading record.
-  def grade_answer(answer)
+  def evaluate_answer(answer)
     question = answer.question.actable
     question.attachment.open(binmode: true) do |temporary_file|
       package = Course::Assessment::ProgrammingPackage.new(temporary_file)

--- a/app/services/course/assessment/answer/text_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_auto_grading_service.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::TextResponseAutoGradingService < \
   Course::Assessment::Answer::AutoGradingService
-  def grade(answer)
-    answer.correct, answer.grade, messages = grade_answer(answer.actable)
+  def evaluate(answer)
+    answer.correct, grade, messages = evaluate_answer(answer.actable)
     answer.auto_grading.result = { messages: messages }
-    super(answer)
+    grade
   end
 
   private
@@ -15,7 +15,7 @@ class Course::Assessment::Answer::TextResponseAutoGradingService < \
   #   student.
   # @return [Array<(Boolean, Integer, Object)>] The correct status, grade and the messages to be
   #   assigned to the grading.
-  def grade_answer(answer)
+  def evaluate_answer(answer)
     question = answer.question.actable
     answer_text = answer.answer_text
     exact_matches, keywords = question.solutions.partition(&:exact_match?)

--- a/app/views/course/assessment/answer/_grading.slim
+++ b/app/views/course/assessment/answer/_grading.slim
@@ -5,9 +5,10 @@ div.grading-panel
       div.panel-body
         div.form-group.submission_answers_grade.row
           div.col-lg-3.col-md-6.col-sm-6.col-xs-6
-            = base_answer_form.input :grade, label: false, input_html: { class: 'grade' },
-                                             wrapper_html: { class: 'grade-form' },
-                                             'data-answer-id' => answer.id
+            = base_answer_form.input :grade, label: false,
+                                             input_html: { class: 'grade', 'data-answer-id' => answer.id },
+                                             wrapper_html: { class: 'grade-form' }
+
           div.col-lg-3.col-md-6.col-sm-6.col-xs-6
             = t('.maximum_grade', maximum_grade: answer.question.maximum_grade)
   - elsif answer.graded?

--- a/app/views/course/assessment/answer/_grading.slim
+++ b/app/views/course/assessment/answer/_grading.slim
@@ -5,8 +5,9 @@ div.grading-panel
       div.panel-body
         div.form-group.submission_answers_grade.row
           div.col-lg-3.col-md-6.col-sm-6.col-xs-6
-            = base_answer_form.input_field :grade, class: ['form-control', 'grade'],
-                                                   'data-answer-id' => answer.id
+            = base_answer_form.input :grade, label: false, input_html: { class: 'grade' },
+                                             wrapper_html: { class: 'grade-form' },
+                                             'data-answer-id' => answer.id
           div.col-lg-3.col-md-6.col-sm-6.col-xs-6
             = t('.maximum_grade', maximum_grade: answer.question.maximum_grade)
   - elsif answer.graded?

--- a/app/views/course/assessment/submission/submissions/_buttons.html.slim
+++ b/app/views/course/assessment/submission/submissions/_buttons.html.slim
@@ -15,7 +15,8 @@ div.submission-buttons
                                       style: local_assigns[:finalise] ? '' : 'display: none'
 
   - if local_assigns[:auto_grade]
-    = link_to t('.auto_grade'),
+    - auto_grade_text = @assessment.autograded? ? t('.auto_grade') : t('.evaluate_answers')
+    = link_to auto_grade_text,
       auto_grade_course_assessment_submission_path(current_course, submission.assessment, submission),
       method: :post, class: ['btn', 'btn-info']
 

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -28,6 +28,7 @@ en:
             publish: 'Publish Grade'
             mark: 'Submit for publishing'
             auto_grade: 'Auto Grade Submission'
+            evaluate_answers: 'Evaluate Answers'
             unsubmit: 'Unsubmit Submission'
             confirm_finalise: |+
               THIS ACTION IS IRREVERSIBLE

--- a/spec/factories/course_assessment_answers.rb
+++ b/spec/factories/course_assessment_answers.rb
@@ -34,6 +34,7 @@ FactoryGirl.define do
     end
 
     trait :graded do
+      grade 0
       submitted
       submission_traits :graded
       after(:build) do |answer| # rubocop:disable Style/SymbolProc

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
 
       scenario 'I can view the auto grading results' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        click_link I18n.t('course.assessment.submission.submissions.buttons.auto_grade')
+        click_link I18n.t('course.assessment.submission.submissions.buttons.evaluate_answers')
         wait_for_job
 
         expect(page).

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
 
       scenario 'I can view the grading scheme' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        click_link I18n.t('course.assessment.submission.submissions.buttons.auto_grade')
+        click_link I18n.t('course.assessment.submission.submissions.buttons.evaluate_answers')
         wait_for_job
 
         expect(page).

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         )
       end
 
-      scenario "I can grade the student's work", js: true do
+      scenario "I can evaluate the student's work", js: true do
         assessment.questions.attempt(submission).each(&:save!)
         submission.points_awarded = nil
         submission.finalise!
@@ -169,7 +169,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         click_link I18n.t('course.assessment.submission.submissions.buttons.auto_grade')
         wait_for_job
 
-        expect(submission.answers.map(&:reload).all?(&:graded?)).to be(true)
+        expect(submission.answers.map(&:reload).all?(&:evaluated?)).to be(true)
 
         # This field should be filled when page loads
         correct_exp = (assessment.base_exp * submission.grade /

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
         # Auto grade where possible. There's one MRQ so it should be gradable.
-        click_link I18n.t('course.assessment.submission.submissions.buttons.auto_grade')
+        click_link I18n.t('course.assessment.submission.submissions.buttons.evaluate_answers')
         wait_for_job
 
         expect(submission.answers.map(&:reload).all?(&:evaluated?)).to be(true)

--- a/spec/features/course/assessment/submission/exam_spec.rb
+++ b/spec/features/course/assessment/submission/exam_spec.rb
@@ -81,8 +81,9 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
-        expect(page).to have_button(I18n.t('common.save'))
+        fill_in find('input.form-control.grade')[:name], with: 0
 
+        expect(page).to have_button(I18n.t('common.save'))
         click_button I18n.t('course.assessment.submission.submissions.buttons.mark')
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
         expect(page).to have_button(I18n.t('common.save'))
-        click_link I18n.t('course.assessment.submission.submissions.buttons.auto_grade')
+        click_link I18n.t('course.assessment.submission.submissions.buttons.evaluate_answers')
         wait_for_job
 
         fill_in find('input.form-control.grade')[:name], with: 0

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         click_link I18n.t('course.assessment.submission.submissions.buttons.auto_grade')
         wait_for_job
 
+        fill_in find('input.form-control.grade')[:name], with: 0
         click_button I18n.t('course.assessment.submission.submissions.buttons.publish')
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))

--- a/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Course::Assessment::Answer::AutoGradingJob do
         have_enqueued_job(subject).exactly(:once)
     end
 
-    it 'grades answers' do
+    it 'evaluates answers' do
       subject.perform_now(answer)
-      expect(answer).to be_graded
+      expect(answer).to be_evaluated
     end
   end
 end

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -68,22 +68,11 @@ RSpec.describe Course::Assessment::Answer do
           end
         end
 
-        context 'when the answer is submitted' do
-          let(:workflow_state) { 'submitted' }
-
-          it 'must have a grade' do
-            expect(subject).not_to be_valid
-            pending 'add back validation'
-            expect(subject.errors[:grade]).not_to be_empty
-          end
-        end
-
         context 'when the answer is graded' do
           let(:workflow_state) { 'graded' }
 
           it 'must have a grade' do
             expect(subject).not_to be_valid
-            pending 'add back validation'
             expect(subject.errors[:grade]).not_to be_empty
           end
 
@@ -116,11 +105,6 @@ RSpec.describe Course::Assessment::Answer do
     end
 
     describe '#finalise!' do
-      it 'sets the grade to 0' do
-        subject.finalise!
-        expect(subject.grade).to eq(0)
-      end
-
       it 'sets submitted_at to the current time' do
         time = Time.zone.now
         subject.finalise!

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -264,7 +264,8 @@ RSpec.describe Course::Assessment::Submission do
       end
 
       it 'sums the grade of all answers' do
-        expect(submission.grade).to eq(submission.answers.map(&:grade).sum - earlier_answer.grade)
+        grade = submission.answers.map(&:grade).compact.sum - earlier_answer.grade
+        expect(submission.grade).to eq(grade)
       end
     end
 

--- a/spec/services/course/assessment/answer/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/auto_grading_service_spec.rb
@@ -18,22 +18,26 @@ RSpec.describe Course::Assessment::Answer::AutoGradingService do
     describe '.grade' do
       subject { Course::Assessment::Answer::AutoGradingService.grade(answer) }
 
-      it 'grades the answer' do
-        subject
+      context 'when the assessment is not autograded' do
+        it 'evaluates the answer' do
+          subject
 
-        expect(auto_grading.answer).to be_graded
-      end
-    end
-
-    describe '#grade' do
-      it "sets the answer's status to graded" do
-        result = subject.grade(answer)
-        expect(result).to be_graded
+          expect(answer).to be_evaluated
+          expect(answer.grader).to be_nil
+          expect(answer.grade).to be_nil
+        end
       end
 
-      it "sets the answer's grader to the system account" do
-        result = subject.grade(answer)
-        expect(result.grader).to eq(User.system)
+      context 'when the assessment is autograded' do
+        before { allow(assessment).to receive(:autograded?).and_return(true) }
+
+        it 'grades the answer' do
+          subject
+
+          expect(answer).to be_graded
+          expect(answer.grade).to be_present
+          expect(answer.grader).to be_present
+        end
       end
     end
   end

--- a/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Course::Assessment::Answer::MultipleResponseAutoGradingService do
     end
 
     describe '#grade' do
+      before { allow(answer.question.assessment).to receive(:autograded?).and_return(true) }
+
       context 'when the question requires all correct options' do
         context 'when only the correct answer is selected' do
           let(:answer_traits) { :with_all_correct_options }

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
           subject { super().grade(answer) }
           let(:answer_contents) { 'test code ' + SecureRandom.hex }
           let(:answer_traits) { [{ file_contents: [answer_contents] }] }
+          before { allow(answer.question.assessment).to receive(:autograded?).and_return(true) }
 
           it 'creates a new package with the correct file contents' do
             expect(Course::Assessment::ProgrammingEvaluationService).to \
@@ -74,7 +75,6 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
             it 'marks the answer correct' do
               subject
               expect(answer).to be_correct
-              pending 'Discuss when to change the grade'
               expect(answer.grade).to eq(question.maximum_grade)
             end
 
@@ -99,7 +99,6 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
             it 'gives a grade proportional to the number of test cases' do
               subject
               test_case_count = answer.question.actable.test_cases.count
-              pending 'Discuss when to change the grade'
               expect(answer.grade).to eq(answer.question.maximum_grade / test_case_count)
             end
           end
@@ -134,6 +133,8 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
         end
 
         describe '#grade' do
+          before { allow(answer.question.assessment).to receive(:autograded?).and_return(true) }
+
           subject { super().grade(answer) }
 
           it 'sets grade to 0' do

--- a/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Course::Assessment::Answer::TextResponseAutoGradingService do
     end
 
     describe '#grade' do
+      before { allow(answer.question.assessment).to receive(:autograded?).and_return(true) }
+
       context 'when an exact match is present' do
         let(:answer_traits) { :exact_match }
 

--- a/spec/services/course/assessment/submission/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/submission/auto_grading_service_spec.rb
@@ -15,11 +15,12 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
     end
 
     describe '#grade' do
-      it 'grades all answers' do
+      it 'evaluates all answers' do
         answer
         expect(subject.grade(submission)).to eq(true)
 
-        expect(submission.answers.map(&:reload).all?(&:graded?)).to be(true)
+        expect(submission.answers.map(&:reload).all?(&:evaluated?)).to be(true)
+        expect(submission.answers.map(&:reload).map(&:grade).all?(&:nil?)).to be(true)
       end
 
       context 'when given a non-auto gradable answer' do
@@ -64,6 +65,10 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
 
           correct_exp = (assessment.time_bonus_exp + assessment.base_exp).to_f / 2
           expect(submission.points_awarded).to eq(correct_exp.to_i)
+        end
+
+        it 'grades all answers' do
+          expect(submission.answers.map(&:reload).all?(&:graded?)).to be(true)
         end
       end
     end


### PR DESCRIPTION
This is the first part of assessment refactoring (#1640)

Added a new state to answers and refactored the auto grading service so that for manually graded assessments grades are not filled in when auto grading service is executed.