### PR TITLE
Fixes for Course Components and Settings

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -71,3 +71,7 @@ table.codehilite {
 .turbolinks-progress-bar {
   background-color: $red;
 }
+
+.nav-tabs {
+  margin-bottom: 1em;
+}

--- a/app/controllers/components/course/controller_component_host.rb
+++ b/app/controllers/components/course/controller_component_host.rb
@@ -133,7 +133,7 @@ class Course::ControllerComponentHost
   #
   # @return [Array<Class>] array of enabled components in Course
   def course_enabled_components
-    @course_enabled_components = begin
+    @course_enabled_components ||= begin
       if @context.current_course.gamified?
         instance_enabled_components
       else

--- a/app/controllers/components/course/controller_component_host.rb
+++ b/app/controllers/components/course/controller_component_host.rb
@@ -46,6 +46,12 @@ class Course::ControllerComponentHost
       def gamified?
         false
       end
+
+      # @return [Boolean] States whether a component can be disabled. Value is true by default.
+      #   Used to hide
+      def can_be_disabled?
+        true
+      end
     end
   end
 
@@ -134,6 +140,13 @@ class Course::ControllerComponentHost
         instance_enabled_components - instance_enabled_components.select(&:gamified?)
       end
     end
+  end
+
+  # Returns the components in Course which can be disabled.
+  #
+  # @return [Array<Class>] array of disable-able components in Course
+  def course_disableable_components
+    @course_disableable_components ||= course_enabled_components.select(&:can_be_disabled?)
   end
 
   # Gets the sidebar elements.

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -2,6 +2,10 @@
 class Course::CoursesComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.can_be_disabled?
+    false
+  end
+
   def sidebar_items
     admin_sidebar_items + settings_sidebar_items
   end

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -32,7 +32,7 @@ class Course::CoursesComponent < SimpleDelegator
 
   def settings_index_item
     {
-      title: t('layouts.course_admin.title'),
+      title: t('layouts.course_admin.course_settings.title'),
       type: :settings,
       weight: 1,
       path: course_admin_path(current_course)

--- a/app/controllers/components/course/points_disbursement_component.rb
+++ b/app/controllers/components/course/points_disbursement_component.rb
@@ -6,6 +6,10 @@ class Course::PointsDisbursementComponent < SimpleDelegator
     true
   end
 
+  def self.display_name
+    I18n.t('components.points_disbursement.name')
+  end
+
   def sidebar_items
     return [] unless can_create_experience_points_record?
 

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -2,6 +2,10 @@
 class Course::UsersComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
+  def self.can_be_disabled?
+    false
+  end
+
   def sidebar_items
     main_sidebar_items + admin_sidebar_items
   end

--- a/app/views/course/admin/component_settings/edit.html.slim
+++ b/app/views/course/admin/component_settings/edit.html.slim
@@ -6,8 +6,8 @@
         th = t('.name')
         th = t('.enabled')
     tbody
-      - course_enabled_components = current_component_host.course_enabled_components
-      - collection = course_enabled_components.map { |c| [c.display_name, c.key.to_s] }
+      - course_components = current_component_host.course_disableable_components
+      - collection = course_components.map { |c| [c.display_name, c.key.to_s] }
       = f.collection_check_boxes :enabled_component_ids, collection, :last, :first do |f|
         tr
           th = f.label

--- a/config/locales/en/components.yml
+++ b/config/locales/en/components.yml
@@ -23,3 +23,5 @@ en:
         name: 'Comments Center'
     statistics:
       name: 'Statistics'
+    points_disbursement:
+      name: 'Points Disbursement'

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -17,7 +17,9 @@ en:
     course:
       administration: :'system.admin.admin.index.header'
     course_admin:
-      title: 'Settings'
+      title: 'Course Settings'
+      course_settings:
+        title: 'General'
       announcement_settings:
         title: :'course.announcements.index.header'
       component_settings:

--- a/spec/components/course/controller_component_host_spec.rb
+++ b/spec/components/course/controller_component_host_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
     end
   end
 
+  class self::DummyCoreCourseModule
+    include Course::ControllerComponentHost::Component
+
+    def self.can_be_disabled?
+      false
+    end
+
+    def initialize(*)
+    end
+  end
+
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
@@ -202,6 +213,17 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
 
         it 'does not include gamified components' do
           expect(subject).not_to include(self.class::DummyGamifiedCourseModule)
+        end
+      end
+    end
+
+    describe '#course_disableable_components' do
+      subject { component_host.course_disableable_components }
+      context 'when the component cannot be disabled' do
+        let(:course) { create(:course, instance: instance) }
+
+        it 'does not include gamified components' do
+          expect(subject).not_to include(self.class::DummyCoreCourseModule)
         end
       end
     end

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Course: Administration: Components' do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:components) { Course::ControllerComponentHost.components }
+    let(:components) { Course::ControllerComponentHost.components.select(&:can_be_disabled?) }
     let(:sample_component_id) do
       "settings_effective_enabled_component_ids_#{components.sample.key}"
     end


### PR DESCRIPTION
This PR fixes a few things in course settings (and other small stuff):
 - Declare core course components - these components cannot be disabled
 - Added display titles for missing components
 - Fixed naming, styling issues. 

This also fixes #950