### PR TITLE
Add transaction when auto grade the answer

### DIFF
--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -116,9 +116,13 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   end
 
   def grade_and_reattempt_answer(answer)
-    answer.finalise! if answer.attempting?
-    answer.save!
-    answer.auto_grade!(edit_submission_path, true)
+    # The transaction is to make sure that auto grading and job are present when the answer is in
+    # the submitted state.
+    answer.class.transaction do
+      answer.finalise! if answer.attempting?
+      answer.save!
+      answer.auto_grade!(edit_submission_path, true)
+    end
   end
 
   def unsubmit?


### PR DESCRIPTION
There are some answers in the submitted state but don't have the auto grading job.

This transaction ensures that they are created together, need to keep monitoring. 