### PR TITLE
Fix a bug in unread count when the current_course_user is not present

### DIFF
--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -25,10 +25,13 @@ module Course::Discussion::TopicsHelper
   end
 
   def my_students_unread_count
-    @my_students_unread ||= begin
+    @my_students_unread ||=
+      if current_course_user
         my_student_ids = current_course_user.my_students.select(:user_id)
         current_course.discussion_topics.globally_displayed.
           from_user(my_student_ids).pending_staff_reply.distinct.count
+      else
+        0
       end
   end
 

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -143,5 +143,17 @@ RSpec.feature 'Course: Topics: Management' do
         expect(page).not_to have_content_tag_for(my_comment_post)
       end
     end
+
+    context 'As a system administrator' do
+      let(:user) { create(:administrator) }
+
+      scenario 'I can visit the comments page' do
+        answer_comment
+        visit course_topics_path(course)
+
+        expect(page).to have_selector('.nav.nav-tabs')
+        expect(page).to have_selector('div', text: answer_comment.question.assessment.title)
+      end
+    end
   end
 end


### PR DESCRIPTION
The current_course_user is not present when an admin visits the page