### PR TITLE
Fix a bug that buttons are missing if submission fails to update

### DIFF
--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -6,6 +6,8 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
     elsif @submission.update_attributes(update_params)
       redirect_to_edit
     else
+      # The management buttons depends on the state of the submission
+      @submission.workflow_state = @submission.workflow_state_was
       render 'edit'
     end
   end

--- a/spec/features/course/assessment/submission/exam_spec.rb
+++ b/spec/features/course/assessment/submission/exam_spec.rb
@@ -81,10 +81,15 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
+        # Grade the submission with empty answer grade
+        click_button I18n.t('course.assessment.submission.submissions.buttons.mark')
+        expect(page).to have_selector('div.alert-danger')
+        expect(page).to have_button(I18n.t('course.assessment.submission.submissions.buttons.mark'))
+
         fill_in find('input.form-control.grade')[:name], with: 0
 
-        expect(page).to have_button(I18n.t('common.save'))
         click_button I18n.t('course.assessment.submission.submissions.buttons.mark')
+        expect(page).to have_button(I18n.t('common.save'))
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))
         expect(submission.reload.graded?).to be_truthy

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -196,8 +196,16 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
         click_link I18n.t('course.assessment.submission.submissions.buttons.evaluate_answers')
         wait_for_job
 
+        # Publish the submission with empty answer grade
+        click_button I18n.t('course.assessment.submission.submissions.buttons.publish')
+
+        expect(page).to have_selector('div.alert-danger')
+        expect(page).
+          to have_button(I18n.t('course.assessment.submission.submissions.buttons.publish'))
+
         fill_in find('input.form-control.grade')[:name], with: 0
         click_button I18n.t('course.assessment.submission.submissions.buttons.publish')
+
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))
         expect(submission.reload.published?).to be(true)


### PR DESCRIPTION
Fix #1676

Some buttons are missing if submission fails to update due to validation ( e.g. set grade to nil )