### PR TITLE
Implement tabbed view for worksheet assessments, standardize assessment views

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/submission.js
+++ b/app/assets/javascripts/course/assessment/submission/submission.js
@@ -152,10 +152,32 @@
     return multiplier;
   }
 
+  function initializeAnswerTabs() {
+    $(MULTI_QUESTION_ASSESSMENT_SELECTOR + '.answers-tab a').click(function (e) {
+      e.preventDefault();
+      $(this).tab('show');
+    });
+
+    // Initialize Ace Editor when tab is shown.
+    $(MULTI_QUESTION_ASSESSMENT_SELECTOR + '.tab-header a').on('shown.bs.tab', function (e) {
+      var identifier = e.target.getAttribute('aria-controls');
+      $('#' + identifier).find('textarea.code').ace();
+    });
+
+    // Show the first tab on page load.
+    $(MULTI_QUESTION_ASSESSMENT_SELECTOR + '.tab-header a:first').tab('show');
+  }
+
+  function initializeAceEditor() {
+    $(DOCUMENT_SELECTOR + 'textarea.code').not('.tab-content textarea.code').ace();
+  }
+
   $(document).on('change', MULTI_QUESTION_ASSESSMENT_SELECTOR + GRADE_INPUT_SELECTOR,
                            updateGradesAndPoints);
   $(document).on('change', SINGLE_QUESTION_ASSESSMENT_SELECTOR + GRADE_INPUT_SELECTOR,
                            updateGradesAndPointsSingleQuestion);
   $(document).on('change', DOCUMENT_SELECTOR + '.exp-multiplier input', onMultiplierChange);
   $(document).on('turbolinks:load', updateInitialPoints);
+  $(document).on('turbolinks:load', initializeAnswerTabs);
+  $(document).on('turbolinks:load', initializeAceEditor);
 })(jQuery);

--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -32,7 +32,6 @@
     // See https://github.com/Coursemology/coursemology-theme/pull/5
     $('[title]', element).not('.fb-like *').tooltip();
     $('input.toggle-all[type="checkbox"]', element).checkboxToggleAll();
-    $('textarea.code', element).ace();
     initializeSummernote(element);
   }
 

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -7,6 +7,7 @@
 $grey: #808080 !default;
 $red: #ff0000 !default;
 $white: #ffffff !default;
+$grey-light: #cccccc !default;
 
 //## Variables for colors used in Coursemology.
 $course-achievement-granted-bg: $state-success-bg !default;
@@ -62,5 +63,6 @@ $course-course-listing-logo: $picture-medium !default;
 //== Others
 
 // Shadows
-$course-assessment-question-card-shadow: rgba(0, 0, 0, 0.12);
-$course-assessment-question-card-hover-shadow: rgba(0, 0, 0, 0.25);
+$course-assessment-question-card-shadow: rgba(0, 0, 0, 0.12) !default;
+$course-assessment-question-card-hover-shadow: rgba(0, 0, 0, 0.25) !default;
+$course-assessment-submission-shadow: rgba(0, 0, 0, 0.2) !default;

--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -24,6 +24,14 @@
       margin-bottom: 0;
     }
 
+    .answer-panel {
+      border: 1px solid $grey-light;
+      border-radius: 3px;
+      box-shadow: 0 0 4px 0 $course-assessment-submission-shadow;
+      margin-bottom: 1.5em;
+      padding: 1.5em 1.5em 0.5em;
+    }
+
     .completed > .navigation-pills {
       background-color: $course-assessment-navigation-circle-completed;
     }
@@ -32,10 +40,6 @@
       background-color: lighten($gray, 50%);
       color: $white;
       pointer-events: none;
-    }
-
-    .submission-buttons .btn {
-      margin: 10px 20px 10px 0;
     }
 
     .exp-multiplier,
@@ -65,6 +69,26 @@
       padding-left: 0;
       padding-right: 0;
       padding-top: 13px;
+    }
+
+    .submission-buttons .btn {
+      margin-bottom: 10px;
+      margin-left: 0;
+      margin-right: 20px;
+      margin-top: 20px;
+    }
+
+    .tab-content {
+      border-bottom: 1px solid $gray-lighter;
+      border-bottom-left-radius: 3px;
+      border-bottom-right-radius: 3px;
+      border-left: 1px solid $gray-lighter;
+      border-right: 1px solid $gray-lighter;
+      padding: 1.5em;
+    }
+
+    .tab-header {
+      margin-bottom: 0;
     }
   }
 

--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -1,8 +1,12 @@
+@mixin active-navigation-pill {
+  background-color: $course-assessment-navigation-circle-active;
+  color: $white;
+}
+
 .course-assessment-submission-submissions {
   &.edit {
     .active > .navigation-pills {
-      background-color: $course-assessment-navigation-circle-active;
-      color: $white;
+      @include active-navigation-pill;
     }
 
     .answer .correct {
@@ -24,6 +28,16 @@
       margin-bottom: 0;
     }
 
+    .answer-content {
+      border-bottom: 1px solid $gray-lighter;
+      border-radius: 3px;
+    }
+
+    .answer-content,
+    .tab-content {
+      padding: 1.5em;
+    }
+
     .answer-panel {
       border: 1px solid $grey-light;
       border-radius: 3px;
@@ -34,6 +48,10 @@
 
     .completed > .navigation-pills {
       background-color: $course-assessment-navigation-circle-completed;
+
+      &:hover {
+        @include active-navigation-pill;
+      }
     }
 
     .disabled > .navigation-pills {
@@ -53,6 +71,7 @@
 
     .navigation {
       display: inline-block;
+      margin-bottom: 12px;
 
       > li {
         height: 60px;
@@ -84,7 +103,6 @@
       border-bottom-right-radius: 3px;
       border-left: 1px solid $gray-lighter;
       border-right: 1px solid $gray-lighter;
-      padding: 1.5em;
     }
 
     .tab-header {

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -73,7 +73,8 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   def assessment_params
     params.require(:assessment).permit(:title, :description, :base_exp, :time_bonus_exp,
                                        :extra_bonus_exp, :start_at, :end_at, :bonus_end_at,
-                                       :draft, :mode, :autograded, :password, folder_params)
+                                       :draft, :mode, :autograded, :password, :tabbed_view,
+                                       folder_params)
   end
 
   # Merges the parameters for category and tab IDs from either the assessment parameter or the

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -12,6 +12,8 @@
     = f.input :bonus_end_at
   - unless @assessment.new_record?
     = f.input :draft
+  - if @assessment.worksheet?
+    = f.input :tabbed_view
   - if @assessment.guided? || @assessment.worksheet?
     = f.input :autograded, label: t('.autograded'), hint: t('.autograded_hint')
   - if @assessment.exam?

--- a/app/views/course/assessment/submission/submissions/_buttons.html.slim
+++ b/app/views/course/assessment/submission/submissions/_buttons.html.slim
@@ -6,7 +6,7 @@
 - submission = f.object
 div.submission-buttons
   - if local_assigns[:save]
-    = f.button :submit, t('common.save')
+    = f.button :submit, t('.save')
 
   // The button is displayed as hidden (instead of not displaying at all) because there are frontend
   // code will show/hide the button in some cases.

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -5,26 +5,26 @@ div.text-center
         = link_to [:edit, current_course, @assessment, @submission, step: i], class: 'navigation-pills'
           = i
 
-hr
+div.answer-panel
+  = simple_form_for [current_course, @assessment, @submission] do |f|
+    = f.error_notification
+    = hidden_field_tag :step, guided_current_step
+    = f.simple_fields_for :answers, guided_current_answer do |base_answer_form|
+      div.answer-content
+        - answer = base_answer_form.object
+        = render partial: answer.question, suffix: 'question'
+        = render partial: 'course/assessment/answer/answer', object: answer,
+                 locals: { base_answer_form: base_answer_form }
 
-= simple_form_for [current_course, @assessment, @submission] do |f|
-  = f.error_notification
-  = hidden_field_tag :step, guided_current_step
-  = f.simple_fields_for :answers, guided_current_answer do |base_answer_form|
-    - answer = base_answer_form.object
-    = render partial: answer.question, suffix: 'question'
-    = render partial: 'course/assessment/answer/answer', object: answer,
-             locals: { base_answer_form: base_answer_form }
+      - unless @submission.attempting?
+        = render 'statistics', f: f
 
-    - unless @submission.attempting?
-      = render 'statistics', f: f
-
-    - can_grade = can?(:grade, @submission)
-    = render 'buttons', {\
-        f: f,
-        save: answer.attempting? || (!@submission.attempting? && can_grade),
-        finalise: @submission.attempting? && guided_next_unanswered_question.nil?,
-        auto_grade: @submission.submitted? && can_grade,
-        publish: @submission.submitted? && can_grade,
-        unsubmit: !@submission.attempting? && can_grade\
-      }
+      - can_grade = can?(:grade, @submission)
+      = render 'buttons', {\
+          f: f,
+          save: answer.attempting? || (!@submission.attempting? && can_grade),
+          finalise: @submission.attempting? && guided_next_unanswered_question.nil?,
+          auto_grade: @submission.submitted? && can_grade,
+          publish: @submission.submitted? && can_grade,
+          unsubmit: !@submission.attempting? && can_grade\
+        }

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -10,12 +10,12 @@
     - unless @submission.attempting?
       = render 'statistics', f: f
 
-  - can_grade = can?(:grade, @submission)
-  = render 'buttons', {\
-      f: f,
-      save: @submission.attempting? || can_grade,
-      finalise: @submission.attempting? && can?(:update, @submission),
-      auto_grade: @submission.submitted? && can_grade,
-      publish: @submission.submitted? && can_grade,
-      unsubmit: !@submission.attempting? && can_grade\
-    }
+    - can_grade = can?(:grade, @submission)
+    = render 'buttons', {\
+        f: f,
+        save: @submission.attempting? || can_grade,
+        finalise: @submission.attempting? && can?(:update, @submission),
+        auto_grade: @submission.submitted? && can_grade,
+        publish: @submission.submitted? && can_grade,
+        unsubmit: !@submission.attempting? && can_grade\
+      }

--- a/app/views/course/assessment/submission/submissions/_worksheet.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet.html.slim
@@ -1,10 +1,14 @@
 = simple_form_for [current_course, @assessment, @submission], html: { multipart: true } do |f|
   = f.error_notification
 
-  = render 'worksheet_answers', f: f
+  div.answer-panel
+    - if @assessment.tabbed_view? && @assessment.questions.count > 1
+      = render 'worksheet_answers_tabbed', f: f
+    - else
+      = render 'worksheet_answers', f: f
 
-  - unless @submission.attempting?
-    = render 'statistics', f: f
+    - unless @submission.attempting?
+      = render 'statistics', f: f
 
   - can_grade = can?(:grade, @submission)
   = render 'buttons', {\

--- a/app/views/course/assessment/submission/submissions/_worksheet_answers.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet_answers.html.slim
@@ -1,6 +1,8 @@
 / TODO: Implement flag to display all answers, or only latest answers.
+
 - answers_by_question = f.object.latest_answers.group_by(&:question)
 - f.object.assessment.questions.each do |question|
-  = render partial: question, suffix: 'question'
-  - answer = answers_by_question[question].last
-  = render partial: 'course/assessment/answer/answer', object: answer
+  div.answer-content
+    = render partial: question, suffix: 'question'
+    - answer = answers_by_question[question].last
+    = render partial: 'course/assessment/answer/answer', object: answer

--- a/app/views/course/assessment/submission/submissions/_worksheet_answers_tabbed.html.slim
+++ b/app/views/course/assessment/submission/submissions/_worksheet_answers_tabbed.html.slim
@@ -1,0 +1,15 @@
+/ TODO: Implement flag to display all answers, or only latest answers.
+- answers_by_question = f.object.latest_answers.group_by(&:question)
+
+ul.nav.nav-tabs.tab-header role="tab-list"
+  - f.object.assessment.questions.each.with_index(1) do |question, index|
+    li role="presentation"
+      a href="##{question.id}" aria-controls="#{question.id}" role="tab" data-toggle="tab"
+        = t('.question', number: index)
+
+div.tab-content
+  - f.object.assessment.questions.each do |question|
+    div.tab-pane.fade role="tabpanel" id="#{question.id}"
+      = render partial: question, suffix: 'question'
+      - answer = answers_by_question[question].last
+      = render partial: 'course/assessment/answer/answer', object: answer

--- a/app/views/course/assessment/submission/submissions/edit.html.slim
+++ b/app/views/course/assessment/submission/submissions/edit.html.slim
@@ -3,7 +3,6 @@
 - unless @assessment.description.blank?
   div.well
     = format_html(@assessment.description)
-  hr
 
 = div_for(@assessment, 'data-assessment-id' => @assessment.id,
                        class: single_question_flag_class(@assessment)) do

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -9,7 +9,6 @@ en:
     plain_text_link: '%{text} (%{url})'
     time_range: '%{from} to %{to}'
     draft: 'Draft'
-    save: 'Save'
     search: 'Search'
     submit: 'Submit'
     show_more: 'See all'

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -24,7 +24,7 @@ en:
           correct: 'Correct!'
           wrong: 'Wrong!'
         reset_answer:
-          button: 'Reset'
+          button: 'Reset Answer'
           tooltip: 'Reset your current answer to the template'
           warning: >
             Are you sure you want to reset your answer? This action is irreversible and you will

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -24,6 +24,7 @@ en:
             success: 'All graded submissions have been published.'
             notice: 'There are no graded submissions.'
           buttons:
+            save: 'Save Draft'
             finalise: 'Finalise Submission'
             publish: 'Publish Grade'
             mark: 'Submit for publishing'

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -59,3 +59,5 @@ en:
             experience_points: 'Experience Points'
           no_submission:
             not_started: 'Not Started'
+          worksheet_answers_tabbed:
+            question: 'Q%{number}'

--- a/db/migrate/20161116075305_add_tabbed_view_to_course_assessments.rb
+++ b/db/migrate/20161116075305_add_tabbed_view_to_course_assessments.rb
@@ -1,0 +1,5 @@
+class AddTabbedViewToCourseAssessments < ActiveRecord::Migration
+  def change
+    add_column :course_assessments, :tabbed_view, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161108030759) do
+ActiveRecord::Schema.define(version: 20161116075305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 20161108030759) do
   create_table "course_assessments", force: :cascade do |t|
     t.integer  "tab_id",     :null=>false, :index=>{:name=>"fk__course_assessments_tab_id"}, :foreign_key=>{:references=>"course_assessment_tabs", :name=>"fk_course_assessments_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "mode",       :default=>0, :null=>false
+    t.boolean  "tabbed_view", :default=>false, :null=>false
     t.boolean  "autograded", :null=>false
     t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessments_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_assessments_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_updater_id", :on_update=>:no_action, :on_delete=>:no_action}

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     base_exp 1000
     autograded false
     draft true
+    tabbed_view false
 
     trait :unopened do
       start_at { 1.day.from_now }

--- a/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/multiple_response_answer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
 
           choose correct_option
 
-          click_button I18n.t('common.save')
+          click_button I18n.t('course.assessment.submission.submissions.buttons.save')
           expect(current_path).to eq(
             edit_course_assessment_submission_path(course, assessment, submission)
           )
@@ -42,7 +42,7 @@ RSpec.describe 'Course: Assessments: Submissions: Multiple Response Answers' do
 
           check correct_option
 
-          click_button I18n.t('common.save')
+          click_button I18n.t('course.assessment.submission.submissions.buttons.save')
           expect(current_path).to eq(
             edit_course_assessment_submission_path(course, assessment, submission)
           )

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
           end
         end
 
-        click_button I18n.t('common.save')
+        click_button I18n.t('course.assessment.submission.submissions.buttons.save')
         expect(current_path).to eq(
           edit_course_assessment_submission_path(course, assessment, submission)
         )
@@ -53,7 +53,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
             fill_in 'filename', with: new_file_name
           end
         end
-        click_button I18n.t('common.save')
+        click_button I18n.t('course.assessment.submission.submissions.buttons.save')
 
         expected_files.each do |file|
           expect(page).to have_field('filename', with: file)
@@ -64,7 +64,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
           all(:link, I18n.t('course.assessment.answer.programming.file_fields.delete')).
             each(&:click)
         end
-        click_button I18n.t('common.save')
+        click_button I18n.t('course.assessment.submission.submissions.buttons.save')
 
         expect(page).not_to have_field('filename')
       end

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
         attach_file "submission_answers_attributes_#{answer.id}_actable_attributes_file",
                     File.join(Rails.root, '/spec/fixtures/files/text.txt')
 
-        click_button I18n.t('common.save')
+        click_button I18n.t('course.assessment.submission.submissions.buttons.save')
 
         expect(answer.specific.attachment).to be_present
       end

--- a/spec/features/course/assessment/submission/exam_spec.rb
+++ b/spec/features/course/assessment/submission/exam_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
 
         option = assessment.questions.first.actable.options.first.option
         check option
-        click_button I18n.t('common.save')
+        click_button I18n.t('course.assessment.submission.submissions.buttons.save')
 
         expect(current_path).to eq(
           edit_course_assessment_submission_path(course, assessment, submission)
@@ -89,7 +89,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
         fill_in find('input.form-control.grade')[:name], with: 0
 
         click_button I18n.t('course.assessment.submission.submissions.buttons.mark')
-        expect(page).to have_button(I18n.t('common.save'))
+        expect(page).to have_button(I18n.t('course.assessment.submission.submissions.buttons.save'))
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))
         expect(submission.reload.graded?).to be_truthy

--- a/spec/features/course/assessment/submission/guided_spec.rb
+++ b/spec/features/course/assessment/submission/guided_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         option = mrq_questions.first.options.first.option
         check option
-        click_button I18n.t('common.save')
+        click_button I18n.t('course.assessment.submission.submissions.buttons.save')
 
         expect(page).to have_selector('div.alert-success',
                                       text: 'course.assessment.submission.submissions.update.'\
@@ -192,7 +192,7 @@ RSpec.describe 'Course: Assessment: Submissions: Guided' do
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
-        expect(page).to have_button(I18n.t('common.save'))
+        expect(page).to have_button(I18n.t('course.assessment.submission.submissions.buttons.save'))
         click_link I18n.t('course.assessment.submission.submissions.buttons.evaluate_answers')
         wait_for_job
 

--- a/spec/features/course/assessment/submission/worksheet_spec.rb
+++ b/spec/features/course/assessment/submission/worksheet_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
 
         option = assessment.questions.first.actable.options.first.option
         check option
-        click_button I18n.t('common.save')
+        click_button I18n.t('course.assessment.submission.submissions.buttons.save')
 
         expect(current_path).to eq(
           edit_course_assessment_submission_path(course, assessment, submission)
@@ -81,7 +81,8 @@ RSpec.describe 'Course: Assessment: Submissions: Worksheet' do
           edit_course_assessment_submission_path(course, assessment, submission)
         )
         expect(submission.reload).to be_submitted
-        expect(page).not_to have_button(I18n.t('common.save'))
+        expect(page).
+          not_to have_button(I18n.t('course.assessment.submission.submissions.buttons.save'))
 
         visit edit_course_assessment_submission_path(course, assessment, submission)
         expect(page).


### PR DESCRIPTION
This PR fixes #1652: 
 - Added a column on assessment, configurable for manually graded assessments (ie. worksheet mode for now) 
 - Shows tabbed views for submissions if assessment is manually graded and tabbed view is enabled. 
 - Standardises views across autograded, manual-graded (tabbed and non-tabbed) assessments.

Sample views: 
### Tabbed manual-graded assessments
![tabbed](https://cloud.githubusercontent.com/assets/4353853/20475619/bb4f9560-b007-11e6-8d94-b3b1ae812cbb.gif)

### Non-Tabbed manual-graded assessments
![non-tabbed](https://cloud.githubusercontent.com/assets/4353853/20475657/d8da8432-b007-11e6-93d3-1035a3e687f3.gif)

### Autograded
![autograded](https://cloud.githubusercontent.com/assets/4353853/20475661/db1904bc-b007-11e6-8aa7-a80c12954c92.gif)

