### PR TITLE
Modify navigational bar for assessments in guided mode

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -4,14 +4,16 @@
 
 //== Colors
 //
-$red: #ff0000 !default;
 $grey: #808080 !default;
-$forum-unread-highlight: #f8e3e3 !default;
+$red: #ff0000 !default;
+$white: #ffffff !default;
 
 //## Variables for colors used in Coursemology.
 $course-achievement-granted-bg: $state-success-bg !default;
 $course-achievement-locked-bg: $gray-lighter !default;
 $course-assessment-not-started-bg: $gray-lighter !default;
+$course-assessment-navigation-circle-active: $brand-info !default;
+$course-assessment-navigation-circle-completed: #d9edf7 !default;
 $course-assessment-submission-answer-correct-border-color: $state-success-border !default;
 $course-assessment-submission-answer-correct-border-radius: $border-radius-base !default;
 $course-assessment-submission-answer-correct-bg: $state-success-bg !default;
@@ -23,6 +25,7 @@ $course-discussion-post-border-radius: $border-radius-base !default;
 $course-discussion-post-shadow-color: $gray-lighter !default;
 $course-discussion-post-annotation-trigger-bg-color: $body-bg !default;
 $course-discussion-post-annotation-trigger-color: $brand-primary !default;
+$course-forum-unread-highlight: #f8e3e3 !default;
 
 
 //== Fonts

--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -1,5 +1,10 @@
 .course-assessment-submission-submissions {
   &.edit {
+    .active > .navigation-pills {
+      background-color: $course-assessment-navigation-circle-active;
+      color: $white;
+    }
+
     .answer .correct {
       background-color: $course-assessment-submission-answer-correct-bg;
 
@@ -19,6 +24,16 @@
       margin-bottom: 0;
     }
 
+    .completed > .navigation-pills {
+      background-color: $course-assessment-navigation-circle-completed;
+    }
+
+    .disabled > .navigation-pills {
+      background-color: lighten($gray, 50%);
+      color: $white;
+      pointer-events: none;
+    }
+
     .submission-buttons .btn {
       margin: 10px 20px 10px 0;
     }
@@ -30,6 +45,26 @@
 
     .exp-multiplier {
       margin-left: 1em;
+    }
+
+    .navigation {
+      display: inline-block;
+
+      > li {
+        height: 60px;
+        width: 60px;
+      }
+    }
+
+    .navigation-pills {
+      border: 1px solid lighten($gray, 50%);
+      border-radius: 50px;
+      color: $gray;
+      font-size: 120%;
+      margin: 5px;
+      padding-left: 0;
+      padding-right: 0;
+      padding-top: 13px;
     }
   }
 

--- a/app/assets/stylesheets/course/forum/_post.scss
+++ b/app/assets/stylesheets/course/forum/_post.scss
@@ -36,6 +36,6 @@
   }
 
   &.unread > .contents {
-    background-color: $forum-unread-highlight;
+    background-color: $course-forum-unread-highlight;
   }
 }

--- a/app/helpers/course/assessment/submission/submissions_guided_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_guided_helper.rb
@@ -28,8 +28,7 @@ module Course::Assessment::Submission::SubmissionsGuidedHelper
   def guided_nav_class(step)
     return 'active' if step == guided_current_step
     return 'disabled' if step > guided_max_step
-
-    ''
+    return 'completed' if step <= guided_max_step
   end
 
   def guided_current_answer

--- a/app/views/course/assessment/submission/submissions/_guided.html.slim
+++ b/app/views/course/assessment/submission/submissions/_guided.html.slim
@@ -1,8 +1,11 @@
-nav
-  ul.pagination
+div.text-center
+  ul.nav.nav-pills.navigation
     - (1..@assessment.questions.length).each do |i|
       li class="#{guided_nav_class(i)}"
-        = link_to i, [:edit, current_course, @assessment, @submission, step: i], class: ['btn', 'btn-default']
+        = link_to [:edit, current_course, @assessment, @submission, step: i], class: 'navigation-pills'
+          = i
+
+hr
 
 = simple_form_for [current_course, @assessment, @submission] do |f|
   = f.error_notification


### PR DESCRIPTION
This PR improves the navigational bar for assessments in guided mode. Opening the PR to review code/UI first.

To sum up: (See gif for more info)
 - For students, current question they are in (or Active tabs) will be colored in bootstrap's `$brand-info`
 - Questions that students have completed will be colored in a lighter version of `$brand-info`.
 - Disabled tabs will be colored in a lighter version of `grey`. I have also disabled pointer-events for disabled tabs.
 - Staff will see all tabs as completed, regardless of whether they have completed the question or not. 

To wait for #1680 to be merged, and I will rebase off master before merging this as there will be conflicts. 

![training-circles](https://cloud.githubusercontent.com/assets/4353853/20463489/3e1888b0-af6f-11e6-8ae1-4fa6f1f2fdbe.gif)
