### PR TITLE
Remove turbolinks workaround from lesson plan

### DIFF
--- a/client/app/bundles/course/lesson_plan/components/LessonPlanNav.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanNav.jsx
@@ -7,8 +7,6 @@ const propTypes = {
   milestones: PropTypes.instanceOf(Immutable.List).isRequired,
 };
 
-// Need `data-turbolinks="false"` because of this issue:
-//     https://github.com/turbolinks/turbolinks/issues/75
 const LessonPlanNav = ({ milestones }) => (
   <Affix offsetTop={173} affixStyle={{ top: '70px' }} >
     <ul className="nav nav-pills nav-stacked">
@@ -17,7 +15,6 @@ const LessonPlanNav = ({ milestones }) => (
           <a
             href={`#lesson-plan-milestone-${milestone.get('id')}`}
             className="lesson-plan-nav-link"
-            data-turbolinks="false"
           >
             { milestone.get('title') }
           </a>


### PR DESCRIPTION
Follow up from #1687 