### PR TITLE
Add datetime format options that don't show the time.

### DIFF
--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -80,9 +80,19 @@ module ApplicationFormattersHelper
            locals: options
   end
 
+  # Custom datetime formats
+  Time::DATE_FORMATS[:date_only_long] = '%B %d, %Y'
+  Time::DATE_FORMATS[:date_only_short] = '%d %b'
+
   # Format the given datetime
   #
   # @param [DateTime] date The datetime to be formatted
+  # @param [Symbol] format The output format. Use Ruby's defaults or see above for
+  #   some predefined formats.
+  #   e.g. :long => "December 04, 2007 00:00"
+  #        :short => "04 Dec 00:00"
+  #        :date_only_long => "December 04, 2007"
+  #        :date_only_short => "04 Dec"
   # @return [String] the formatted datetime string
   def format_datetime(date, format = :long)
     user_zone = (current_user ? current_user.time_zone : nil) ||


### PR DESCRIPTION
Data is stored as datetime, but there are situations where we just
want to display the date.

For example, the course start date on the course duplication page. Or the assessment start column.