### PR TITLE
Add and modify forum subscription button

### DIFF
--- a/app/assets/stylesheets/course/forum/forums.scss
+++ b/app/assets/stylesheets/course/forum/forums.scss
@@ -8,6 +8,21 @@
     }
   }
 
+  .forum-list {
+    .btn-subscribe {
+      @extend .btn-sm;
+      @extend .hidden-xs;
+
+      max-width: 110px;
+      width: 100%;
+    }
+
+    td,
+    th {
+      vertical-align: middle;
+    }
+  }
+
   .unread-controls.btn-group {
     margin-right: 20px;
   }

--- a/app/assets/stylesheets/course/forum/forums.scss
+++ b/app/assets/stylesheets/course/forum/forums.scss
@@ -1,4 +1,13 @@
 .course-forum-forums {
+  .btn-subscribe {
+    span {
+      @extend .hidden-xs;
+      @extend .hidden-sm;
+
+      margin-left: 5px;
+    }
+  }
+
   .unread-controls.btn-group {
     margin-right: 20px;
   }

--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -45,23 +45,21 @@ class Course::Forum::ForumsController < Course::Forum::Controller
   end
 
   def subscribe
-    redirect_path = course_forum_path(current_course, @forum)
     if @forum.subscriptions.create(user: current_user)
-      redirect_to redirect_path, success: t('.success', name: @forum.name)
+      flash.now[:success] = t('.success', name: @forum.name)
     else
-      redirect_to redirect_path,
-                  danger: t('.failure', error: @forum.errors.full_messages.to_sentence)
+      flash.now[:danger] = t('.failure', error: @forum.errors.full_messages.to_sentence)
     end
+    render 'update_subscribe_button'
   end
 
   def unsubscribe
-    redirect_path = course_forum_path(current_course, @forum)
-    if @forum.subscriptions.where(user: current_user).delete_all
-      redirect_to redirect_path, success: t('.success', name: @forum.name)
+    if @forum.subscriptions.where(user: current_user).delete_all > 0
+      flash.now[:success] = t('.success', name: @forum.name)
     else
-      redirect_to redirect_path,
-                  danger: t('.failure', error: @forum.errors.full_messages.to_sentence)
+      flash.now[:danger] = t('.failure')
     end
+    render 'update_subscribe_button'
   end
 
   def search

--- a/app/views/course/forum/forums/_controls.html.slim
+++ b/app/views/course/forum/forums/_controls.html.slim
@@ -6,16 +6,7 @@ span.pull-right
                                   class: ['btn', 'btn-default'], method: :patch
   .btn-group
     - if can?(:subscribe, @forum)
-      - if @forum.subscribed_by?(current_user)
-        = link_to unsubscribe_course_forum_path(current_course, @forum),
-                  title: t('course.forum.forums.unsubscribe.tag'), class: ['btn', 'btn-danger'],
-                  method: :delete do
-          = fa_icon 'heart-o'.freeze
-      - else
-        = link_to subscribe_course_forum_path(current_course, @forum),
-                  title: t('course.forum.forums.subscribe.tag'), class: ['btn', 'btn-success'], method: :post do
-          = fa_icon 'heart'.freeze
-
+      = render partial: 'subscribe_button', locals: { user: current_user, forum: @forum }
     = new_button([current_course, @forum, :topic]) if can?(:create, Course::Forum::Topic.new(forum: @forum))
     = edit_button([current_course, @forum]) if can?(:edit, @forum)
     = delete_button([current_course, @forum]) if can?(:destroy, @forum)

--- a/app/views/course/forum/forums/_forum.html.slim
+++ b/app/views/course/forum/forums/_forum.html.slim
@@ -7,3 +7,4 @@
   td = forum.topic_count
   td = forum.topic_post_count
   td = forum.topic_view_count
+  td = render partial: 'subscribe_button', locals: { user: current_user, forum: forum }

--- a/app/views/course/forum/forums/_subscribe_button.html.slim
+++ b/app/views/course/forum/forums/_subscribe_button.html.slim
@@ -1,12 +1,16 @@
 - if forum.subscribed_by?(user)
   = link_to unsubscribe_course_forum_path(forum.course, forum),
             title: t('course.forum.forums.unsubscribe.tag'),
-            class: ['btn', 'btn-danger', 'btn-subscribe'],
-            method: :delete do
-    = fa_icon 'envelope-o'.freeze
+            class: ['btn', 'btn-info', 'btn-subscribe'],
+            method: :delete,
+            remote: true do
+    = fa_icon 'envelope-open'.freeze, class: ['fa-fw']
+    span = t('.subscribed')
 - else
   = link_to subscribe_course_forum_path(forum.course, forum),
             title: t('course.forum.forums.subscribe.tag'),
-            class: ['btn', 'btn-success', 'btn-subscribe'],
-            method: :post do
-    = fa_icon 'envelope'.freeze
+            class: ['btn', 'btn-default', 'btn-subscribe'],
+            method: :post,
+            remote: true do
+    = fa_icon 'envelope-open-o'.freeze, class: ['fa-fw']
+    span = t('.subscribe')

--- a/app/views/course/forum/forums/_subscribe_button.html.slim
+++ b/app/views/course/forum/forums/_subscribe_button.html.slim
@@ -1,0 +1,12 @@
+- if forum.subscribed_by?(user)
+  = link_to unsubscribe_course_forum_path(forum.course, forum),
+            title: t('course.forum.forums.unsubscribe.tag'),
+            class: ['btn', 'btn-danger', 'btn-subscribe'],
+            method: :delete do
+    = fa_icon 'envelope-o'.freeze
+- else
+  = link_to subscribe_course_forum_path(forum.course, forum),
+            title: t('course.forum.forums.subscribe.tag'),
+            class: ['btn', 'btn-success', 'btn-subscribe'],
+            method: :post do
+    = fa_icon 'envelope'.freeze

--- a/app/views/course/forum/forums/index.html.slim
+++ b/app/views/course/forum/forums/index.html.slim
@@ -15,10 +15,11 @@ table.table.forum-list.table-hover
       th = t('.topics')
       th = t('.posts')
       th = t('.views')
+      th
   tbody
     - if @forums.empty?
       tr
-        td colspan="5" align="center"
+        td colspan="6" align="center"
           h3 = t('.no_forum')
     - else
       = render @forums

--- a/app/views/course/forum/forums/show.html.slim
+++ b/app/views/course/forum/forums/show.html.slim
@@ -1,21 +1,22 @@
-= page_header format_inline_text(@forum.name) do
-  = render 'controls'
+= content_tag_for(:div, @forum) do
+  = page_header format_inline_text(@forum.name) do
+    = render 'controls'
 
-table.table.forum-list.table-hover
-  thead
-    tr
-      th
-      th = t('.topics')
-      th = t('.votes')
-      th = t('.posts')
-      th = t('.views')
-      th = t('.latest_post')
-  tbody
-    - if @topics.empty?
+  table.table.forum-list.table-hover
+    thead
       tr
-        td colspan="6" align="center"
-        h3 = t('.no_topic')
-    - else
-      = render @topics
+        th
+        th = t('.topics')
+        th = t('.votes')
+        th = t('.posts')
+        th = t('.views')
+        th = t('.latest_post')
+    tbody
+      - if @topics.empty?
+        tr
+          td colspan="6" align="center"
+          h3 = t('.no_topic')
+      - else
+        = render @topics
 
-= paginate @topics
+  = paginate @topics

--- a/app/views/course/forum/forums/update_subscribe_button.js.erb
+++ b/app/views/course/forum/forums/update_subscribe_button.js.erb
@@ -1,0 +1,12 @@
+// Remove current tooltip, replace subscribe button, re-enable tooltip
+BUTTON_SELECTOR = '<%= "#forum_#{@forum.id} .btn-subscribe"%>';
+$(BUTTON_SELECTOR).tooltip('destroy');
+$(BUTTON_SELECTOR).replaceWith(
+    '<%= escape_javascript(render partial: 'course/forum/forums/subscribe_button', locals: { forum: @forum, user: current_user }) %>'
+);
+$(BUTTON_SELECTOR).tooltip();
+
+// Remove older flash messages, and show users the new flash message
+$('.course-layout').parents('.container-fluid:first').find('.alert').remove();
+$('.course-layout').parents('.container-fluid:first').prepend('<%= j(flash_messages) %>');
+window.scrollTo(0, 0);

--- a/config/locales/en/course/forum/forums.yml
+++ b/config/locales/en/course/forum/forums.yml
@@ -35,13 +35,13 @@ en:
           success: 'Forum %{name} was deleted.'
           failure: 'Failed to delete forum: %{error}'
         subscribe:
-          tag: 'Subscribe to email notification for this forum'
-          success: 'You have subscribed to Forum %{name}.'
-          failure: 'Fail to subscribe to Forum: %{error}'
+          tag: 'Subscribe to email notifications'
+          success: 'You are subscribed to %{name}.'
+          failure: 'Failed to subscribe to: %{error}'
         unsubscribe:
-          tag: 'Unsubscribe from email notification for this forum'
-          success: 'You have been unsubscribed from the Forum %{name}.'
-          failure: 'Fail to unsubscribe from Forum: %{error}'
+          tag: 'Unsubscribe from email notifications'
+          success: 'You have been unsubscribed from %{name}.'
+          failure: 'Failed to unsubscribe from : %{error}'
         search:
           header: 'Search Forums'
           search_panel_title: 'Forum Search'

--- a/config/locales/en/course/forum/forums.yml
+++ b/config/locales/en/course/forum/forums.yml
@@ -41,7 +41,11 @@ en:
         unsubscribe:
           tag: 'Unsubscribe from email notifications'
           success: 'You have been unsubscribed from %{name}.'
-          failure: 'Failed to unsubscribe from : %{error}'
+          failure: >
+            You are not subscribed to this forum, hence the unsubscription was unsuccessful.
+        subscribe_button:
+          subscribe: 'Subscribe'
+          subscribed: 'Subscribed'
         search:
           header: 'Search Forums'
           search_panel_title: 'Forum Search'

--- a/spec/controllers/course/forum/forums_controller_spec.rb
+++ b/spec/controllers/course/forum/forums_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Course::Forum::ForumsController, type: :controller do
       allow(stub).to receive(:save).and_return(false)
       allow(stub).to receive(:destroy).and_return(false)
       allow(stub.subscriptions).to receive(:create).and_return(false)
-      allow(stub.subscriptions).to receive_message_chain(:where, delete_all: false)
+      allow(stub.subscriptions).to receive_message_chain(:where, delete_all: 0)
       stub
     end
 
@@ -90,7 +90,7 @@ RSpec.describe Course::Forum::ForumsController, type: :controller do
     end
 
     describe '#subscribe' do
-      subject { post :subscribe, course_id: course, id: forum_stub }
+      subject { post :subscribe, course_id: course, id: forum_stub, format: 'js' }
 
       context 'when subscribe fails' do
         before do
@@ -98,20 +98,24 @@ RSpec.describe Course::Forum::ForumsController, type: :controller do
           subject
         end
 
-        it { is_expected.to redirect_to(course_forum_path(course, forum_stub)) }
+        it 'sets a failure flash message' do
+          expect(flash.now[:danger]).to eq(I18n.t('course.forum.forums.subscribe.failure'))
+        end
       end
     end
 
     describe '#unsubscribe' do
-      subject { delete :unsubscribe, course_id: course, id: forum_stub }
+      subject { delete :unsubscribe, course_id: course, id: forum_stub, format: 'js' }
 
-      context 'when unsubscribe fails' do
+      context 'when there is no subscription for the forum' do
         before do
           controller.instance_variable_set(:@forum, forum_stub)
           subject
         end
 
-        it { is_expected.to redirect_to(course_forum_path(course, forum_stub)) }
+        it 'sets a failure flash message' do
+          expect(flash.now[:danger]).to eq(I18n.t('course.forum.forums.unsubscribe.failure'))
+        end
       end
     end
   end

--- a/spec/features/course/forum_management_spec.rb
+++ b/spec/features/course/forum_management_spec.rb
@@ -81,10 +81,26 @@ RSpec.feature 'Course: Forum: Management' do
         expect(page).not_to have_content_tag_for(forum)
       end
 
-      scenario 'I can subscribe and unsubscribe to a forum', js: true do
+      scenario 'I can subscribe and unsubscribe to a forum ', js: true do
         forum = create(:forum, course: course)
-        visit course_forum_path(course, forum)
 
+        # Subscribe and unsubscribe at the specific forum page
+        visit course_forum_path(course, forum)
+        find_link(nil, href: subscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
+
+        expect(Course::Forum::Subscription.where(user: user, forum: forum).count).to eq(1)
+        expect(page).to have_selector('div.alert.alert-success')
+
+        find_link(nil, href: unsubscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
+
+        expect(page).to have_link(nil, href: subscribe_course_forum_path(course, forum))
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(Course::Forum::Subscription.where(user: user, forum: forum).empty?).to eq(true)
+
+        # Subscribe and unsubscribe at the course forums page
+        visit course_forums_path(course)
         find_link(nil, href: subscribe_course_forum_path(course, forum)).trigger('click')
         wait_for_ajax
 
@@ -111,10 +127,26 @@ RSpec.feature 'Course: Forum: Management' do
         end
       end
 
-      scenario 'I can subscribe and unsubscribe to a forum', js: true do
+      scenario 'I can subscribe and unsubscribe to a forum ', js: true do
         forum = create(:forum, course: course)
-        visit course_forum_path(course, forum)
 
+        # Subscribe and unsubscribe at the specific forum page
+        visit course_forum_path(course, forum)
+        find_link(nil, href: subscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
+
+        expect(Course::Forum::Subscription.where(user: user, forum: forum).count).to eq(1)
+        expect(page).to have_selector('div.alert.alert-success')
+
+        find_link(nil, href: unsubscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
+
+        expect(page).to have_link(nil, href: subscribe_course_forum_path(course, forum))
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(Course::Forum::Subscription.where(user: user, forum: forum).empty?).to eq(true)
+
+        # Subscribe and unsubscribe at the course forums page
+        visit course_forums_path(course)
         find_link(nil, href: subscribe_course_forum_path(course, forum)).trigger('click')
         wait_for_ajax
 

--- a/spec/features/course/forum_management_spec.rb
+++ b/spec/features/course/forum_management_spec.rb
@@ -81,28 +81,21 @@ RSpec.feature 'Course: Forum: Management' do
         expect(page).not_to have_content_tag_for(forum)
       end
 
-      scenario 'I can subscribe to a forum' do
+      scenario 'I can subscribe and unsubscribe to a forum', js: true do
         forum = create(:forum, course: course)
         visit course_forum_path(course, forum)
-        find_link(I18n.t('course.forum.forums.subscribe.tag'),
-                  href: subscribe_course_forum_path(course, forum)).click
 
-        expect(current_path).to eq(course_forum_path(course, forum))
-        expect(page).to have_link(I18n.t('course.forum.forums.unsubscribe.tag'),
-                                  href: unsubscribe_course_forum_path(course, forum))
+        find_link(nil, href: subscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
+
         expect(Course::Forum::Subscription.where(user: user, forum: forum).count).to eq(1)
-      end
+        expect(page).to have_selector('div.alert.alert-success')
 
-      scenario 'I can unsubscribe from a forum' do
-        forum = create(:forum, course: course)
-        Course::Forum::Subscription.create(forum: forum, user: user)
-        visit course_forum_path(course, forum)
-        find_link(I18n.t('course.forum.forums.unsubscribe.tag'),
-                  href: unsubscribe_course_forum_path(course, forum)).click
+        find_link(nil, href: unsubscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
 
-        expect(current_path).to eq(course_forum_path(course, forum))
-        expect(page).to have_link(I18n.t('course.forum.forums.subscribe.tag'),
-                                  href: subscribe_course_forum_path(course, forum))
+        expect(page).to have_link(nil, href: subscribe_course_forum_path(course, forum))
+        expect(page).to have_selector('div.alert.alert-success')
         expect(Course::Forum::Subscription.where(user: user, forum: forum).empty?).to eq(true)
       end
     end
@@ -118,28 +111,21 @@ RSpec.feature 'Course: Forum: Management' do
         end
       end
 
-      scenario 'I can subscribe to a forum' do
+      scenario 'I can subscribe and unsubscribe to a forum', js: true do
         forum = create(:forum, course: course)
         visit course_forum_path(course, forum)
-        find_link(I18n.t('course.forum.forums.subscribe.tag'),
-                  href: subscribe_course_forum_path(course, forum)).click
 
-        expect(current_path).to eq(course_forum_path(course, forum))
-        expect(page).to have_link(I18n.t('course.forum.forums.unsubscribe.tag'),
-                                  href: unsubscribe_course_forum_path(course, forum))
+        find_link(nil, href: subscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
+
         expect(Course::Forum::Subscription.where(user: user, forum: forum).count).to eq(1)
-      end
+        expect(page).to have_selector('div.alert.alert-success')
 
-      scenario 'I can unsubscribe from a forum' do
-        forum = create(:forum, course: course)
-        Course::Forum::Subscription.create(forum: forum, user: user)
-        visit course_forum_path(course, forum)
-        find_link(I18n.t('course.forum.forums.unsubscribe.tag'),
-                  href: unsubscribe_course_forum_path(course, forum)).click
+        find_link(nil, href: unsubscribe_course_forum_path(course, forum)).trigger('click')
+        wait_for_ajax
 
-        expect(current_path).to eq(course_forum_path(course, forum))
-        expect(page).to have_link(I18n.t('course.forum.forums.subscribe.tag'),
-                                  href: subscribe_course_forum_path(course, forum))
+        expect(page).to have_link(nil, href: subscribe_course_forum_path(course, forum))
+        expect(page).to have_selector('div.alert.alert-success')
         expect(Course::Forum::Subscription.where(user: user, forum: forum).empty?).to eq(true)
       end
 


### PR DESCRIPTION
This PR:
 - Modifies subscribe/unsubscribe forum action to an AJAX one. 
 - Modifies the styling of the subscribe/unsubscribe forum button.
 - Adds the forum subscription button to the forums page.

I'm not sure if rendering like that is the correct way, and the controllers seem a little duplicated. Should I combine them, or?

Screens:
![subscribe_1](https://cloud.githubusercontent.com/assets/4353853/20698740/1a07ae12-b63e-11e6-9afa-0582d5b70e70.gif)
![subscribe_2](https://cloud.githubusercontent.com/assets/4353853/20698741/1a081ae6-b63e-11e6-83fc-61bfff783a88.gif)
