### PR TITLE
Ensure the Todos create/update callbacks are more robust

### DIFF
--- a/app/models/concerns/course/assessment/submission/todo_concern.rb
+++ b/app/models/concerns/course/assessment/submission/todo_concern.rb
@@ -22,9 +22,13 @@ module Course::Assessment::Submission::TodoConcern
     elsif submitted? || graded? || published?
       todo.update_column(:workflow_state, 'completed') unless todo.completed?
     end
+  rescue ActiveRecordError => error
+    raise ActiveRecord::Rollback, error.message
   end
 
   def restart_todo
     todo.update_column(:workflow_state, 'not_started') unless todo.not_started?
+  rescue ActiveRecordError => error
+    raise ActiveRecord::Rollback, error.message
   end
 end

--- a/app/models/concerns/course/lesson_plan/item_todo_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item_todo_concern.rb
@@ -14,12 +14,18 @@ module Course::LessonPlan::ItemTodoConcern
     actable && actable.can_user_start?(user)
   end
 
-  protected
-
   # Create todos for the given lesson_plan_item for all course_users in the course,
-  #   except invited course_users (ie. course_users who do not have a user record).
+  # except invited course_users (ie. course_users who do not have a user record).
+  #
+  # A rollback of the transaction (including saving of the actable lesson_plan_item)
+  # will be raised if the creation of the todo fails validations and cannot be created.
+  #
+  # @raise [ActiveRecord::Rollback] If the creation of the todo is invalid, the transaction will
+  #   be rolled back.
   def create_todos
     course_users = CourseUser.where(course_id: course_id).where.not(workflow_state: 'invited')
-    Course::LessonPlan::Todo.create_for(self, course_users)
+    Course::LessonPlan::Todo.create_for!(self, course_users)
+  rescue ActiveRecord::RecordInvalid => error
+    raise ActiveRecord::Rollback, error.message
   end
 end

--- a/app/models/concerns/course_user/todo_concern.rb
+++ b/app/models/concerns/course_user/todo_concern.rb
@@ -16,10 +16,15 @@ module CourseUser::TodoConcern
 
   # Create todos for all course_users except those who are invited.
   # Invited course_users do not have a user_id.
+  #
+  # @raise [ActiveRecord::Rollback] If the creation of the todo is invalid, the transaction will
+  #   be rolled back.
   def create_todos_for_course_user
     return unless user
     items =
       Course::LessonPlan::Item.where(course_id: course_id).includes(:actable).select(&:has_todo?)
-    Course::LessonPlan::Todo.create_for(items, self)
+    Course::LessonPlan::Todo.create_for!(items, self)
+  rescue ActiveRecord::RecordInvalid => error
+    raise ActiveRecord::Rollback, error.message
   end
 end

--- a/app/models/course/lesson_plan/todo.rb
+++ b/app/models/course/lesson_plan/todo.rb
@@ -36,12 +36,13 @@ class Course::LessonPlan::Todo < ActiveRecord::Base
     # @param [CourseUser|Array<CourseUser>] course_users
     #   The course_user, or array of course_users to create todos for.
     # @return [Array<Course::LessonPlan::Todo>|nil] Array of created todos, or nil if invalid params
-    def create_for(items, course_users)
+    # @raise [ActiveRecord::RecordInvalid] Raised if the validations to create todo fails.
+    def create_for!(items, course_users)
       return unless items && course_users
       items = [items] if items.is_a?(Course::LessonPlan::Item)
       course_users = [course_users] if course_users.is_a?(CourseUser)
       user_item_hash = items.product(course_users).map { |ary| { item: ary[0], user: ary[1].user } }
-      Course::LessonPlan::Todo.create(user_item_hash)
+      Course::LessonPlan::Todo.create!(user_item_hash)
     end
 
     # Destroy todos for the associated lesson_plan_item for specified course_users.

--- a/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
@@ -79,14 +79,19 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
         let!(:students) { create_list(:course_student, 3, course: course) }
         let!(:invited_student) { create(:course_user, :invited, course: course, user: nil) }
         let(:actable) { create(:assessment, :with_mcq_question, course: course) }
-        subject { actable.lesson_plan_item }
+        subject { create(:assessment, :published_with_mcq_question, course: course).acting_as }
 
-        it 'creates todos for created objects for course_users (except those with invited status' do
-          expect do
-            create(:assessment, :published_with_mcq_question, course: course)
-          end.
+        it 'creates todos for created objects for course_users (except those with invited state)' do
+          expect { subject }.
             to change(Course::LessonPlan::Todo.all, :count).
             by(course.course_users.where.not(workflow_state: 'invited').count)
+        end
+
+        context ' when the creation of todo fails' do
+          it 'raises an ActiveRecord::Rollback exception' do
+            subject
+            expect { subject.create_todos }.to raise_exception(ActiveRecord::Rollback)
+          end
         end
       end
     end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -374,6 +374,16 @@ RSpec.describe CourseUser, type: :model do
             end
           end
         end
+
+        context 'when the creation of the todo fails' do
+          before { subject }
+
+          it 'raises an ActiveRecord::Rollback exception' do
+            expect do
+              subject.create_todos_for_course_user
+            end.to raise_exception(ActiveRecord::Rollback)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Technically these updates should be done in the same transaction as the updating of the `LessonPlan::Item` or `Submission`, hence the PR.

Some Info: 
 - `The entire callback chain of a #save, #save!, or #destroy call runs within a transaction. That includes after_* hooks. If everything goes fine a COMMIT is executed once the chain has been completed.` [(Source)](http://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html)
 - `ActiveRecord::Base.transaction uses this exception to distinguish a deliberate rollback from other exceptional situations ... But if you raise an ActiveRecord::Rollback exception, then the database transaction will be rolled back, without passing on the exception.`[(Source)](http://api.rubyonrails.org/classes/ActiveRecord/Rollback.html)

