### PR TITLE
Fix submission filter (query not constructed correctly)

### DIFF
--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -98,8 +98,8 @@ class Course::Assessment::Submission < ActiveRecord::Base
   end)
 
   scope :from_group, (lambda do |group_id|
-    joins { experience_points_record.course_user.groups }.
-      where { experience_points_record.course_user.groups.id >> group_id }
+    joins(experience_points_record: [course_user: :groups]).
+      where('course_groups.id IN (?)', group_id)
   end)
 
   # @!method self.ordered_by_date
@@ -115,7 +115,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
   # @!method self.confirmed
   #   Returns submissions which have been submitted (which may or may not be graded).
-  scope :confirmed, -> { where.not(workflow_state: :attempting) }
+  scope :confirmed, -> { where(workflow_state: [:submitted, :graded, :published]) }
 
   scope :pending_for_grading, (lambda do
     where(workflow_state: [:submitted, :graded]).


### PR DESCRIPTION
Submission filter is not working after various of refactoring, this PR fixes it and added a feature spec.  Our model test doesn't detect the breakage because the scope `filter` is still working. 

The query constructed wrongly only when chain with other scopes:

- `where.not` does not work well when chaining, I inverted it and didn't dig deep to find the reason though.
- Course::Group table name is interpreted as `groups` by squeel when chaining...


