### PR TITLE
Modify the attachment API 

### DIFF
--- a/app/views/attachments/create.json.jbuilder
+++ b/app/views/attachments/create.json.jbuilder
@@ -2,5 +2,5 @@ json.success !@attachment.nil?
 
 if @attachment
   json.url @attachment.url
-  json.name @attachment.name
+  json.id @attachment.id
 end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -35,9 +35,8 @@ RSpec.describe AttachmentsController, type: :controller do
           expect(json['success']).to be_truthy
         end
 
-        it 'returns the url and name of the attachment' do
+        it 'returns the url of the attachment' do
           expect(json['url']).to eq(attachment.url)
-          expect(json['name']).to eq(attachment.name)
         end
       end
     end


### PR DESCRIPTION
As I work on the file uploader, I will make modifications to the create attachment API. Submitting this in a smaller PR first .

This PR adds 2 fields to the JSON response for the create attachment API: 
 - `original_filename`: as the attachment name will be hashed and unreadable to the user, it is necessary that we retain the original filename when we eventually save this. The original filename will be stored under `attachment_references`.
 - `attachment.id`: This will be used to uniquely identify the attachment that has been uploaded and persisted, to be used to create the `attachment_references` (and in the case of assessments, `material`). 

URL is retained in the response because we will use it to display a preview of the attachment. 

There might be future changes, but would like some other inputs now if any! 