### PR TITLE
Allow for resending and deleting of user invitations

### DIFF
--- a/app/assets/stylesheets/course/users.scss
+++ b/app/assets/stylesheets/course/users.scss
@@ -7,6 +7,10 @@
         min-width: 12em;
       }
     }
+
+    h4 {
+      padding-top: 1em;
+    }
   }
 
   &.show {

--- a/app/controllers/concerns/course/users_controller_management_concern.rb
+++ b/app/controllers/concerns/course/users_controller_management_concern.rb
@@ -18,7 +18,7 @@ module Course::UsersControllerManagementConcern
   def destroy # :nodoc:
     if @course_user.destroy
       success = t('course.users.destroy.success', role: @course_user.role,
-                                                  email: @course_user.user.email)
+                                                  email: course_user_email)
       redirect_to delete_redirect_path, success: success
     else
       redirect_to delete_redirect_path, danger: @course_user.errors.full_messages.to_sentence
@@ -127,7 +127,9 @@ module Course::UsersControllerManagementConcern
 
   # Selects an appropriate redirect path depending on the user being deleted.
   def delete_redirect_path
-    if @course_user.staff?
+    if @course_user.invited?
+      course_users_invitations_path(current_course)
+    elsif @course_user.staff?
       course_users_staff_path(current_course)
     else
       course_users_students_path(current_course)
@@ -143,5 +145,15 @@ module Course::UsersControllerManagementConcern
   def upgrade_to_staff_failure # :nodoc:
     redirect_to course_users_staff_path(current_course),
                 danger: @course_user.errors.full_messages.to_sentence
+  end
+
+  # Returns the email of the course_user.
+  # This method handles invited course_users, which do not have a user object.
+  def course_user_email
+    if @course_user.invited?
+      @course_user.invitation.user_email.email
+    else
+      @course_user.user.email
+    end
   end
 end

--- a/app/views/course/users/_course_user_invitations.html.slim
+++ b/app/views/course/users/_course_user_invitations.html.slim
@@ -6,9 +6,10 @@ table.table.table-striped.table-hover
       th = t('common.email')
       th = t('.invitation_code')
       th = t('.status')
-      th
       - if invited
+        th = t('.sent_at')
         th
+      th
 
   tbody
     - course_users.each do |course_user|
@@ -18,6 +19,9 @@ table.table.table-striped.table-hover
         td = course_user.invitation.invitation_key
         - if invited
           td = t('course.users.status.invited')
+          td
+            - if course_user.invitation.sent_at
+              = format_datetime(course_user.invitation.sent_at, :short)
           td
             = delete_button([current_course, course_user],
                             class: 'btn-xs', title: t('.delete_tooltip')) do

--- a/app/views/course/users/_course_user_invitations.html.slim
+++ b/app/views/course/users/_course_user_invitations.html.slim
@@ -1,0 +1,28 @@
+- invited = course_users.first.invited?
+table.table.table-striped.table-hover
+  thead
+    tr
+      th = t('common.name')
+      th = t('common.email')
+      th = t('.invitation_code')
+      th = t('.status')
+      th
+      - if invited
+        th
+
+  tbody
+    - course_users.each do |course_user|
+      = content_tag_for(:tr, course_user) do
+        th = course_user.name
+        td = course_user.invitation.user_email.email
+        td = course_user.invitation.invitation_key
+        - if invited
+          td = t('course.users.status.invited')
+          td
+            = delete_button([current_course, course_user],
+                            class: 'btn-xs', title: t('.delete_tooltip')) do
+              = fa_icon 'close'.freeze
+          td
+        - else
+          td = t('course.users.status.accepted')
+          td

--- a/app/views/course/users/invitations.html.slim
+++ b/app/views/course/users/invitations.html.slim
@@ -3,26 +3,18 @@
 
 = render partial: 'tabs'
 
-- accepted_course_users = @course_users.each.select { |user| !user.invited? }.size
-- progress = accepted_course_users * 100 / [@course_users.length, 1].max
+- accepted_course_users = @course_users.each.select { |user| !user.invited? }
+- invited_course_users = @course_users - accepted_course_users
+- progress = accepted_course_users.size * 100 / [@course_users.length, 1].max
 = display_progress_bar(progress, []) do
-  = t('.progress', accepted: accepted_course_users, total: @course_users.size)
+  = t('.progress', accepted: accepted_course_users.size, total: @course_users.size)
 
 = simple_format t('.manual_acceptance')
 
-table.table.table-striped
-  thead
-    tr
-      th = t('common.name')
-      th = t('common.email')
-      th = t('.invitation_code')
-      th = t('.status')
-      th
-  tbody
-    - @course_users.each do |course_user|
-      = content_tag_for(:tr, course_user)
-        th = course_user.name
-        td = course_user.invitation.user_email.email
-        td = course_user.invitation.invitation_key
-        td = course_user.invited? ? t('course.users.status.invited') : t('course.users.status.accepted')
-        td
+- unless invited_course_users.blank?
+  h4 = t('.invited_header')
+  = render partial: 'course_user_invitations', locals: { course_users: invited_course_users }
+
+- unless accepted_course_users.blank?
+  h4 = t('.accepted_header')
+  = render partial: 'course_user_invitations', locals: { course_users: accepted_course_users }

--- a/app/views/course/users/invitations.html.slim
+++ b/app/views/course/users/invitations.html.slim
@@ -12,6 +12,9 @@
 = simple_format t('.manual_acceptance')
 
 - unless invited_course_users.blank?
+  span.pull-right
+    = link_to t('.resend_button'), resend_invitations_course_users_path(current_course),
+              method: :post, class: ['btn', 'btn-info']
   h4 = t('.invited_header')
   = render partial: 'course_user_invitations', locals: { course_users: invited_course_users }
 

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -28,3 +28,6 @@ en:
         remove: 'Remove'
       create:
         success: 'Successfully invited users from the uploaded file.'
+      resend_invitations:
+        success: 'Email invitations were successfully resent.'
+        failure: 'The resending of email invitations failed.'

--- a/config/locales/en/course/users.yml
+++ b/config/locales/en/course/users.yml
@@ -44,8 +44,12 @@ en:
 
           Users can key in their associated invitation code into the course registration page to
           register into this course.
+        invited_header: 'Pending Invitations'
+        accepted_header: 'Accepted Invitations'
+      course_user_invitations:
         invitation_code: 'Invitation Code'
         status: 'Status'
+        delete_tooltip: 'Delete Invitation'
       show:
         header: 'Profile'
         role: 'Role: %{role}'

--- a/config/locales/en/course/users.yml
+++ b/config/locales/en/course/users.yml
@@ -46,6 +46,7 @@ en:
           register into this course.
         invited_header: 'Pending Invitations'
         accepted_header: 'Accepted Invitations'
+        resend_button: 'Resend All Invitations'
       course_user_invitations:
         invitation_code: 'Invitation Code'
         status: 'Status'

--- a/config/locales/en/course/users.yml
+++ b/config/locales/en/course/users.yml
@@ -49,6 +49,7 @@ en:
       course_user_invitations:
         invitation_code: 'Invitation Code'
         status: 'Status'
+        sent_at: 'Invitation Sent At'
         delete_tooltip: 'Delete Invitation'
       show:
         header: 'Profile'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,6 +238,7 @@ Rails.application.routes.draw do
         resources :experience_points_records, only: [:index, :update, :destroy]
         get 'invite' => 'user_invitations#new', on: :collection
         post 'invite' => 'user_invitations#create', on: :collection
+        post 'resend_invitations' => 'user_invitations#resend_invitations', on: :collection
         get 'disburse_experience_points' => 'experience_points/disbursement#new', on: :collection
         post 'disburse_experience_points' => 'experience_points/disbursement#create',
              on: :collection

--- a/db/migrate/20161214050848_add_sent_at_to_course_user_invitations.rb
+++ b/db/migrate/20161214050848_add_sent_at_to_course_user_invitations.rb
@@ -1,0 +1,5 @@
+class AddSentAtToCourseUserInvitations < ActiveRecord::Migration
+  def change
+    add_column :course_user_invitations, :sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161207013914) do
+ActiveRecord::Schema.define(version: 20161214050848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -650,6 +650,7 @@ ActiveRecord::Schema.define(version: 20161207013914) do
     t.integer  "course_user_id", :null=>false, :index=>{:name=>"index_course_user_invitations_on_course_user_id", :unique=>true}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_user_invitations_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "user_email_id",  :null=>false, :index=>{:name=>"fk__course_user_invitations_user_email_id"}, :foreign_key=>{:references=>"user_emails", :name=>"fk_course_user_invitations_user_email_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.string   "invitation_key", :limit=>16, :null=>false, :index=>{:name=>"index_course_user_invitations_on_invitation_key", :unique=>true}
+    t.datetime "sent_at"
     t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at",     :null=>false

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Course::UsersController, type: :controller do
       before { sign_in(user) }
       subject { delete :destroy, course_id: course, id: course_user_to_delete }
 
-      let!(:course_user_to_delete) { create(:course_user, course: course, user: create(:user)) }
+      let!(:course_user_to_delete) { create(:course_user, course: course) }
 
       context 'when the user is a manager' do
         let!(:course_user) { create(:course_manager, course: course, user: user) }
@@ -140,6 +140,14 @@ RSpec.describe Course::UsersController, type: :controller do
           it 'sets an error flash message' do
             expect(flash[:danger]).to eq('')
           end
+        end
+
+        context 'when the user is invited' do
+          let!(:course_user_to_delete) do
+            create(:course_user_invitation, course: course).course_user
+          end
+
+          it { is_expected.to redirect_to(course_users_invitations_path(course)) }
         end
       end
 

--- a/spec/factories/course_users.rb
+++ b/spec/factories/course_users.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     end
     trait :invited do
       workflow_state :invited
+      user nil
     end
     trait :rejected do
       workflow_state :rejected

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -81,12 +81,13 @@ RSpec.feature 'Courses: Invitations', js: true do
         expect(course.registration_key).to be_nil
       end
 
-      scenario 'I can track the status of invites' do
+      scenario 'I can track the status of invites and delete invites' do
         visit course_users_invitations_path(course)
 
         invitations = create_list(:course_user_invitation, 3, course: course)
         invitations.first.course_user.accept!(create(:instance_user).user)
         invitations.first.course_user.save!
+        invitation_to_delete = invitations.second
         visit course_users_invitations_path(course)
 
         expect(page).to have_selector('div.progress')
@@ -102,6 +103,11 @@ RSpec.feature 'Courses: Invitations', js: true do
             end
           end
         end
+
+        find_link(nil,
+                  href: course_user_path(course, invitation_to_delete.course_user)).click
+        expect(current_path).to eq(course_users_invitations_path(course))
+        expect(page).not_to have_content_tag_for(invitation_to_delete.course_user)
       end
     end
 

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -81,10 +81,11 @@ RSpec.feature 'Courses: Invitations', js: true do
         expect(course.registration_key).to be_nil
       end
 
-      scenario 'I can track the status of invites and delete invites' do
+      scenario 'I can track the status of invites, resend invites and delete invites' do
         visit course_users_invitations_path(course)
 
-        invitations = create_list(:course_user_invitation, 3, course: course)
+        old_time = 1.day.ago
+        invitations = create_list(:course_user_invitation, 3, course: course, sent_at: old_time)
         invitations.first.course_user.accept!(create(:instance_user).user)
         invitations.first.course_user.save!
         invitation_to_delete = invitations.second
@@ -103,6 +104,11 @@ RSpec.feature 'Courses: Invitations', js: true do
             end
           end
         end
+
+        find_link(I18n.t('course.users.invitations.resend_button'),
+                  href: resend_invitations_course_users_path(course)).click
+        expect(current_path).to eq(course_users_invitations_path(course))
+        expect(invitation_to_delete.reload.sent_at).not_to eq(old_time)
 
         find_link(nil,
                   href: course_user_path(course, invitation_to_delete.course_user)).click

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'capybara/rspec'
 require 'coverage_helper'
+require 'action_mailer'
 require 'email_spec'
 require 'email_spec/rspec'
 require 'should_not/rspec'


### PR DESCRIPTION
This PR: 
 - Creates the `sent_at` column for invitations to be tracked when the last email was sent. 
 - Allows for the deletion of any pending invitations. 
 - Allows for the resending of all pending invitations

There is one other missing part from this, which is to selectively resend invitations. I've accounted for this in the controllers, but I will try react for that since there are some dynamic components. Will open up another issue for that. 

![invitations](https://cloud.githubusercontent.com/assets/4353853/21215157/4860273c-c2da-11e6-9433-4d2a5aca3aa5.gif)

