### PR TITLE
Rename tutor to a more general name (instructors) for student statistics

### DIFF
--- a/app/views/course/statistics/_table.html.slim
+++ b/app/views/course/statistics/_table.html.slim
@@ -6,7 +6,7 @@ table.table.table-hover
       = CourseUser.human_attribute_name(:name)
     - unless @service.no_group_managers?
       th
-        = t('.tutor')
+        = t('.instructors')
     th.text-center
       = Course::Level.model_name.human
     th.text-center

--- a/config/locales/en/course/statistics.yml
+++ b/config/locales/en/course/statistics.yml
@@ -7,7 +7,7 @@ en:
         phantom_students: 'Phantom Students'
       table:
         serial_number: :'course.statistics.serial_number'
-        tutor: 'Tutor'
+        instructors: 'Instructor(s)'
         experience_points: 'Experience Points'
       staff:
         header: 'Staff Statistics'


### PR DESCRIPTION
Minor fix to make the terms used a little more generic.