### PR TITLE
Modify todo#create_for! to use bulk inserts for todo creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -200,6 +200,8 @@ gem 'nokogiri', '>= 1.6.8'
 # Polyglot support
 gem 'coursemology-polyglot', '>= 0.1.0'
 
+# To assist with bulk inserts into database
+gem 'activerecord-import', '>= 0.2.0'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       activemodel (= 4.2.7.1)
       activesupport (= 4.2.7.1)
       arel (~> 6.0)
+    activerecord-import (0.16.2)
+      activerecord (>= 3.2)
     activerecord-userstamp (3.0.4)
       activerecord (~> 4.2)
       activesupport (~> 4.2)
@@ -543,6 +545,7 @@ PLATFORMS
 DEPENDENCIES
   ace-rails-ap
   active_record-acts_as!
+  activerecord-import (>= 0.2.0)
   activerecord-userstamp (>= 3.0.2)
   acts_as_tenant!
   after_commit_action

--- a/app/models/concerns/course/lesson_plan/item_todo_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item_todo_concern.rb
@@ -16,16 +16,8 @@ module Course::LessonPlan::ItemTodoConcern
 
   # Create todos for the given lesson_plan_item for all course_users in the course,
   # except invited course_users (ie. course_users who do not have a user record).
-  #
-  # A rollback of the transaction (including saving of the actable lesson_plan_item)
-  # will be raised if the creation of the todo fails validations and cannot be created.
-  #
-  # @raise [ActiveRecord::Rollback] If the creation of the todo is invalid, the transaction will
-  #   be rolled back.
   def create_todos
     course_users = CourseUser.where(course_id: course_id).where.not(workflow_state: 'invited')
     Course::LessonPlan::Todo.create_for!(self, course_users)
-  rescue ActiveRecord::RecordInvalid => error
-    raise ActiveRecord::Rollback, error.message
   end
 end

--- a/app/models/concerns/course_user/todo_concern.rb
+++ b/app/models/concerns/course_user/todo_concern.rb
@@ -16,15 +16,10 @@ module CourseUser::TodoConcern
 
   # Create todos for all course_users except those who are invited.
   # Invited course_users do not have a user_id.
-  #
-  # @raise [ActiveRecord::Rollback] If the creation of the todo is invalid, the transaction will
-  #   be rolled back.
   def create_todos_for_course_user
     return unless user
     items =
       Course::LessonPlan::Item.where(course_id: course_id).includes(:actable).select(&:has_todo?)
     Course::LessonPlan::Todo.create_for!(items, self)
-  rescue ActiveRecord::RecordInvalid => error
-    raise ActiveRecord::Rollback, error.message
   end
 end

--- a/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
@@ -86,13 +86,6 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
             to change(Course::LessonPlan::Todo.all, :count).
             by(course.course_users.where.not(workflow_state: 'invited').count)
         end
-
-        context ' when the creation of todo fails' do
-          it 'raises an ActiveRecord::Rollback exception' do
-            subject
-            expect { subject.create_todos }.to raise_exception(ActiveRecord::Rollback)
-          end
-        end
       end
     end
   end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -374,16 +374,6 @@ RSpec.describe CourseUser, type: :model do
             end
           end
         end
-
-        context 'when the creation of the todo fails' do
-          before { subject }
-
-          it 'raises an ActiveRecord::Rollback exception' do
-            expect do
-              subject.create_todos_for_course_user
-            end.to raise_exception(ActiveRecord::Rollback)
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
In #1728 - the problem is that when there is a bulk import of `course_users` through the `course_user_invitations`, the creation can be slow as the creation of todos is not efficient. 

This PR fixes that by using activerecord-import gem to assist with the bulk creation. Overall, using this has some overhead, but for a large number of records this makes it faster.

I suspect there is still some time spent in constructing the hash, so maybe I can work on optimising that later one as well. 

### Benchmarks

#### Summary
Basically I recorded the time it took to create todos in a course of (10, 100, and 200) students by creating 3 assessments (todo creation is implemented as an assessment creation callback). 

| Number of Users - Bulk/Old  | Todo Creation for Ass. 1 | Todo Creation for Ass. 2 | Todo Creation for Ass. 3 |
|----------------------|-------------------------|-------------------------|-------------------------|
| 10 Users - Bulk | 0.120338                        | 0.047167                        | 0.050220                        |
| 10 Users - Old  | 0.086091                        | 0.057012                        | 0.055717                        |
| 100 Users - Bulk| 0.551820                        | 0.442304                        | 0.418337                        |
| 100 Users - Old | 0.658688                        | 0.600826                        | 0.655925                        |
| 200 Users - Bulk| 0.915618                        | 0.779372                        | 0.832880                        |
| 200 Users - Old | 1.203331                        | 1.166382                        | 1.229744                        |


#### Test Code

Rails Console Commands
```
c = FactoryGirl.create(:course)
FactoryGirl.create_list(:course_student, 100, course: c)
# 1st time
FactoryGirl.create(:assessment, course: c) 
# 2nd time
FactoryGirl.create(:assessment, course: c)
# 3rd time
FactoryGirl.create(:assessment, course: c)
```

```ruby
# Old Code
def create_for!(items, course_users)   
  return unless items && course_users   
  items = [items] if items.is_a?(Course::LessonPlan::Item)   
  course_users = [course_users] if course_users.is_a?(CourseUser)   
  b = Benchmark.measure do     
    user_item_hash = items.product(course_users).map { |ary| { item: ary[0], user: ary[1].user } }     
    Course::LessonPlan::Todo.create!(user_item_hash)   
  end    
  puts b
 end

# Bulk Insert
def create_for!(items, course_users)   
  return unless items && course_users   
  items = [items] if items.is_a?(Course::LessonPlan::Item)   
  course_users = [course_users] if course_users.is_a?(CourseUser)       
  b = Benchmark.measure do     
    Course::LessonPlan::Todo.import *build_attribute_hash_for(items, course_users)   
  end   
  puts b
 end

```