### PR TITLE
Hide duplication sidebar item from non-administrators.

### DIFF
--- a/app/controllers/components/course/duplication_component.rb
+++ b/app/controllers/components/course/duplication_component.rb
@@ -2,7 +2,7 @@ class Course::DuplicationComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
   def sidebar_items
-    return [] unless can?(:manage, current_course)
+    return [] unless current_user.administrator?
     [
       {
         key: :duplication,


### PR DESCRIPTION
Duplication UX is not ready for end users yet.