### PR TITLE
Remove auto_grader role from user management views.

### DIFF
--- a/app/views/course/users/requests.html.slim
+++ b/app/views/course/users/requests.html.slim
@@ -24,7 +24,7 @@ div.users
             = simple_fields_for user, resource: :course_user, wrapper: :inline_form do |f|
               th = f.input :name
               td = f.object.user.email
-              td = f.input :role, as: :select, collection: CourseUser.roles.keys
+              td = f.input :role, as: :select, collection: CourseUser.roles.keys - ['auto_grader']
               td = f.input :phantom, label: false
               td.course_user_workflow_state
                 = f.radio_button :workflow_state, 'approved', checked: true

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -34,7 +34,7 @@ div.users
             = simple_fields_for user, resource: :course_user do |f|
               th = f.input :name, label: false
               td = f.object.user.email
-              td = f.input :role, as: :select, collection: CourseUser.roles.keys, label: false
+              td = f.input :role, as: :select, collection: CourseUser.roles.keys - ['auto_grader'], label: false
               td = f.input :phantom
               td
                 = f.button :submit, id: 'update' do

--- a/app/views/system/admin/instance/users/_instance_user.html.slim
+++ b/app/views/system/admin/instance/users/_instance_user.html.slim
@@ -7,7 +7,8 @@
     td = user.email
     / TODO: Add links after user public profile page was implemented
     td = link_to user.courses.length, '#'
-    td = f.input :role, as: :select, collection: InstanceUser.roles.keys, label: false
+    td = f.input :role, as: :select, collection: InstanceUser.roles.keys - ['auto_grader'],
+                 label: false
     td
       = f.button :submit, id: 'update' do
         = fa_icon 'check'.freeze

--- a/app/views/system/admin/users/_user.html.slim
+++ b/app/views/system/admin/users/_user.html.slim
@@ -4,8 +4,7 @@
     td = f.input :name, label: false
     td = user.email
     / TODO: implement after rails #13775 was closed.
-    td
-    td = f.input :role, as: :select, collection: User.roles.keys, label: false
+    td = f.input :role, as: :select, collection: User.roles.keys - ['auto_grader'], label: false
     td
       = f.button :submit, id: 'update' do
         = fa_icon 'check'.freeze

--- a/spec/features/course/staff_management_spec.rb
+++ b/spec/features/course/staff_management_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Courses: Staff Management' do
         within find(content_tag_selector(staff_to_change)) do
           fill_in 'course_user_name', with: new_name
           find('.dropdown-toggle').click
-          find('ul.dropdown-menu.inner').find('span', text: 'owner').click
+          find('ul.dropdown-menu.inner').find('span', text: 'owner').trigger('click')
           click_button 'update'
         end
 

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'System: Administration: Users' do
 
         user_to_change = users.sample
         within find(content_tag_selector(user_to_change)) do
-          find('.dropdown-toggle').click
+          find('.dropdown-toggle').trigger('click')
           find('ul.dropdown-menu.inner').find('span', text: /^$/).trigger('click')
           click_button 'update'
         end
@@ -38,7 +38,7 @@ RSpec.feature 'System: Administration: Users' do
         new_name = 'updated user name'
         within find(content_tag_selector(user_to_change)) do
           fill_in 'user_name', with: new_name
-          find('.dropdown-toggle').click
+          find('.dropdown-toggle').trigger('click')
           find('ul.dropdown-menu.inner').find('span', text: 'administrator').click
           click_button 'update'
         end


### PR DESCRIPTION
Prevent the role from displaying in the role selection dropdowns in
course user management and instance user management.