### PR TITLE
Add uploader's name to materials and attachments form

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -71,3 +71,7 @@ table.codehilite {
 .nav-tabs {
   margin-bottom: 1em;
 }
+
+.uploaded-by {
+  padding-left: 1em;
+}

--- a/app/views/layouts/_attachment_uploader.html.slim
+++ b/app/views/layouts/_attachment_uploader.html.slim
@@ -2,14 +2,18 @@
   - unless f.object.attachments.empty?
     strong = t('.uploaded_files')
     - f.object.attachments.each do |attachment|
-      = link_to format_inline_text(attachment.name), '#'
+      div
+        span = link_to format_inline_text(attachment.name), '#'
+        span.uploaded-by = t('.uploaded_by', name: attachment.creator.name)
   div
     strong = t('.new_files')
     = f.file_field :files, multiple: true
 - else
   - if f.object.attachment.present?
     strong => t('.uploaded_file')
-    = link_to format_inline_text(f.object.attachment.name),
-              attachment_reference_path(f.object.attachment), target: "_blank"
+    div
+      span = link_to format_inline_text(f.object.attachment.name),
+                               attachment_reference_path(f.object.attachment), target: "_blank"
+      span.uploaded-by = t('.uploaded_by', name: f.object.attachment.creator.name)
   div
     = f.file_field :file

--- a/app/views/layouts/_materials_uploader.html.slim
+++ b/app/views/layouts/_materials_uploader.html.slim
@@ -2,7 +2,10 @@
   div
     strong = t('.uploaded_materials')
   - f.object.materials.each do |material|
-    div = link_to format_inline_text(material.name), '#'
+    div
+      span = link_to format_inline_text(material.name), '#'
+      span.uploaded-by = t('.uploaded_by', name: material.attachment.creator.name)
+
 div
   strong = t('.new_materials')
   = f.file_field :files_attributes, multiple: true

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -34,9 +34,11 @@ en:
       uploaded_files: 'Uploaded Files:'
       uploaded_file: 'Uploaded File:'
       new_files: 'Upload New Files'
+      uploaded_by: :'layouts.materials_uploader.uploaded_by'
     materials_uploader:
       uploaded_materials: 'Uploaded Materials:'
       new_materials: 'Upload New Materials'
+      uploaded_by: 'Uploaded By: %{name}'
     mailer:
       greeting: 'Hello, %{user}:'
       complimentary_close: 'Best Regards,'


### PR DESCRIPTION
Fixes #1729. 

This is an ugly hack to show the uploader's name of attachments for the edit forms for assessments and materials.

I am currently trying to reimplement the file uploader, so that will overwrite this in the future. 