### PR TITLE
Modify email input in invitation service to be case insensitive

### DIFF
--- a/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
@@ -97,10 +97,12 @@ module Course::UserInvitationService::EmailInvitationConcern
   # Invites the given users into the course.
   #
   # @param [Array<Hash{Symbol=>String}>] users A mutable array of users to add. Each hash must have
-  #   two attributes: the +:name+ and the +:email+ of the user to add.
+  #   two attributes: the +:name+ and the +:email+ of the user to add. The provided +emails+
+  #   are NOT case sensitive.
   # @return [Array<(Array<CourseUser>, Array<Course::UserInvitation>)>] A tuple containing the
   #   list of users who were immediately registered, and the users who were invited.
   def invite_users(users)
+    users = users.each { |user| user[:email] = user[:email].downcase }
     augment_user_objects(users)
     existing_users, new_users = users.partition { |user| user[:user].present? }
 

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -270,6 +270,20 @@ RSpec.describe Course::UserInvitationService, type: :service do
             expect(found_user).not_to be_nil
           end
         end
+
+        context 'when provided emails are capitalised' do
+          let(:modified_existing_user_attributes) do
+            existing_user_attributes.each { |attr| attr[:email] = attr[:email].upcase }
+          end
+
+          it 'adds the correct users' do
+            subject.send(:invite_users, modified_existing_user_attributes)
+            existing_users.each do |user|
+              found_user = course.course_users.find { |course_user| course_user.user == user }
+              expect(found_user).not_to be_nil
+            end
+          end
+        end
       end
 
       context 'when users do not exist in the current instance' do


### PR DESCRIPTION
- Service will downcase all emails when processing invitations.
- This fixes a bug where service recognises A@a.com differently from a@a.com, and proceeds to create a user, which then violates validations as the gem devise downcases all emails before persisting them in the database.

Fixes #1727 