### PR TITLE
Fix duplication permissions

### DIFF
--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -1,4 +1,6 @@
 class Course::DuplicationsController < Course::ComponentController
+  before_action :authorize_duplication
+
   def show
   end
 
@@ -8,6 +10,12 @@ class Course::DuplicationsController < Course::ComponentController
     else
       redirect_to course_duplication_path(current_course), danger: t('.failed')
     end
+  end
+
+  protected
+
+  def authorize_duplication
+    authorize!(:manage, current_course)
   end
 
   private

--- a/spec/features/course/duplication_spec.rb
+++ b/spec/features/course/duplication_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Course: Duplication' do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let!(:course) { create(:course) }
+
+    before do
+      login_as(user, scope: :user)
+    end
+
+    context 'As a System Administrator' do
+      let(:user) { create(:administrator) }
+
+      scenario 'I can view the Duplication Sidebar item' do
+        visit course_path(course)
+
+        expect(page).to have_selector('li', text: 'layouts.duplication.title')
+      end
+
+      scenario 'I can duplicate a course' do
+        visit course_duplication_path(course)
+
+        expect(page).to have_field('New course start date')
+        expect(page).to have_field('New course title')
+
+        expect { click_button I18n.t('course.duplications.show.duplicate') }.
+          to change { instance.courses.count }.by(1)
+      end
+    end
+
+    context 'As a Course Administrator' do
+      let(:user) { create(:course_manager, course: course).user }
+
+      scenario 'I cannot view the Duplication Sidebar item' do
+        visit course_path(course)
+
+        expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+      end
+    end
+
+    context 'As a Course Student' do
+      let(:user) { create(:course_student, course: course).user }
+
+      scenario 'I cannot view the Duplication Sidebar item' do
+        visit course_path(course)
+
+        expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+      end
+    end
+  end
+end

--- a/spec/features/course/duplication_spec.rb
+++ b/spec/features/course/duplication_spec.rb
@@ -34,20 +34,29 @@ RSpec.feature 'Course: Duplication' do
     context 'As a Course Administrator' do
       let(:user) { create(:course_manager, course: course).user }
 
-      scenario 'I cannot view the Duplication Sidebar item' do
+      scenario 'I cannot view the Duplication Sidebar item but can duplicate a course' do
         visit course_path(course)
 
         expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+
+        visit course_duplication_path(course)
+
+        expect(page).to have_field('New course start date')
+        expect(page).to have_field('New course title')
       end
     end
 
     context 'As a Course Student' do
       let(:user) { create(:course_student, course: course).user }
 
-      scenario 'I cannot view the Duplication Sidebar item' do
+      scenario 'I cannot view the Duplication Sidebar item and cannot duplicate a course' do
         visit course_path(course)
 
         expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+
+        visit course_duplication_path(course)
+
+        expect(page.status_code).to eq(403)
       end
     end
   end


### PR DESCRIPTION
Depends on #1742.

Allow course owners and administrators to duplicate a course.
Sidebar item is currently only visible to administrators as the UX of the duplication feature isn't ready for general use.