### PR TITLE
Duplication spec, only allow owners to duplicate

### DIFF
--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -1,4 +1,6 @@
 class Course::DuplicationsController < Course::ComponentController
+  before_action :authorize_duplication
+
   def show
   end
 
@@ -8,6 +10,12 @@ class Course::DuplicationsController < Course::ComponentController
     else
       redirect_to course_duplication_path(current_course), danger: t('.failed')
     end
+  end
+
+  protected
+
+  def authorize_duplication
+    authorize!(:duplicate, current_course)
   end
 
   private

--- a/app/models/components/course/duplication_ability_component.rb
+++ b/app/models/components/course/duplication_ability_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Course::DuplicationAbilityComponent
+  include AbilityHost::Component
+
+  def define_permissions
+    allow_owner_duplicate_course if user
+
+    super
+  end
+
+  private
+
+  def allow_owner_duplicate_course
+    # Actually unnecessary because course managers can :manage courses.
+    # This is for consistency if more fine grained permissions need to be defined when
+    # duplication cherry picking is supported.
+    can :duplicate, Course, course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
+  end
+end

--- a/spec/features/course/duplication_spec.rb
+++ b/spec/features/course/duplication_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Course: Duplication' do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let!(:course) { create(:course) }
+
+    before do
+      login_as(user, scope: :user)
+    end
+
+    context 'As a System Administrator' do
+      let(:user) { create(:administrator) }
+
+      scenario 'I can view the Duplication Sidebar item' do
+        visit course_path(course)
+
+        expect(page).to have_selector('li', text: 'layouts.duplication.title')
+      end
+
+      scenario 'I can duplicate a course' do
+        visit course_duplication_path(course)
+
+        expect(page).to have_field('New course start date')
+        expect(page).to have_field('New course title')
+
+        expect { click_button I18n.t('course.duplications.show.duplicate') }.
+          to change { instance.courses.count }.by(1)
+        # After duplicating, go back to the duplication page
+        expect(current_path).to eq(course_duplication_path(course))
+      end
+    end
+
+    context 'As a Course Administrator' do
+      let(:user) { create(:course_manager, course: course).user }
+
+      scenario 'I cannot view the Duplication Sidebar item but can duplicate a course' do
+        visit course_path(course)
+
+        expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+
+        visit course_duplication_path(course)
+
+        # Just test that the Duplicate form can be seen since the actual duplication is already
+        # tested under the System Administrator context.
+        expect(page).to have_field('New course start date')
+        expect(page).to have_field('New course title')
+      end
+    end
+
+    context 'As a Course Student' do
+      let(:user) { create(:course_student, course: course).user }
+
+      scenario 'I cannot view the Duplication Sidebar item and cannot duplicate a course' do
+        visit course_path(course)
+
+        expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+
+        visit course_duplication_path(course)
+
+        expect(page.status_code).to eq(403)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1718.

Only allow course owners and system administrators to duplicate courses.