### PR TITLE
Fix bug where deleting of option/solution did not work

### DIFF
--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -9,7 +9,7 @@ class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
   has_many :options, class_name: Course::Assessment::Question::MultipleResponseOption.name,
                      dependent: :destroy, foreign_key: :question_id, inverse_of: :question
 
-  accepts_nested_attributes_for :options
+  accepts_nested_attributes_for :options, allow_destroy: true
 
   # A Multiple Response Question is considered to be a Multiple Choice Question (MCQ)
   # if and only if it has an "any correct" grading scheme. The case where "any correct"

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -7,7 +7,7 @@ class Course::Assessment::Question::TextResponse < ActiveRecord::Base
   has_many :solutions, class_name: Course::Assessment::Question::TextResponseSolution.name,
                        dependent: :destroy, foreign_key: :question_id, inverse_of: :question
 
-  accepts_nested_attributes_for :solutions
+  accepts_nested_attributes_for :solutions, allow_destroy: true
 
   def auto_gradable?
     !solutions.empty?

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         expect(question_created.options).to be_present
       end
 
-      scenario 'I can edit a question', js: true do
+      scenario 'I can edit a question and delete an option', js: true do
         mrq = create(:course_assessment_question_multiple_response, assessment: assessment,
                                                                     options: [])
         options = [
@@ -141,6 +141,22 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).to have_selector('div.alert.alert-success')
+        expect(mrq.reload.options.count).to eq(options.count)
+
+        # Delete all MRQ options
+        visit edit_path
+        all('tr.question_multiple_response_option').each do |element|
+          within element do
+            click_link I18n.t('course.assessment.question.multiple_responses.option_fields.remove')
+          end
+        end
+        click_button I18n.t(
+          'course.assessment.question.multiple_responses.form.multiple_response_button'
+        )
+
+        expect(current_path).to eq(course_assessment_path(course, assessment))
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(mrq.reload.options.count).to eq(0)
       end
 
       scenario 'I can delete a question' do

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         expect(question_created.allow_attachment).to be_truthy
       end
 
-      scenario 'I can edit a text response question', js: true do
+      scenario 'I can edit a text response question and delete options', js: true do
         question = create(:course_assessment_question_text_response, assessment: assessment,
                                                                      solutions: [])
         solutions = [
@@ -98,6 +98,19 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         click_button I18n.t('helpers.buttons.update')
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).to have_selector('div.alert.alert-success')
+
+        # Delete all solutions from question
+        visit edit_path
+        all('tr.question_text_response_solution').each do |element|
+          within element do
+            click_link I18n.t('course.assessment.question.text_responses.solution_fields.remove')
+          end
+        end
+        click_button I18n.t('helpers.buttons.update')
+
+        expect(current_path).to eq(course_assessment_path(course, assessment))
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(question.reload.solutions.count).to eq(0)
       end
 
       scenario 'I can delete a text response question' do


### PR DESCRIPTION
This PR fixes #1750. The problem was just forgetting to set a flag within `accepts_nested_attributes_for`, together with the [cocoon gem](https://github.com/nathanvda/cocoon).

I've fixed it and also added specs to guard against this. 