### PR TITLE
Refactor frontend and use redux-immutable

### DIFF
--- a/client/app/bundles/course/lesson_plan/components/LessonPlanMilestone.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanMilestone.jsx
@@ -79,7 +79,7 @@ class LessonPlanMilestone extends React.Component {
             />
           </p>
         </div>
-        <div className={styles.milestoneContent}>
+        <div className={styles.spaceBetween}>
           <div>
             <p><span dangerouslySetInnerHTML={{ __html: milestone.get('description') }} /></p>
           </div>

--- a/client/app/bundles/course/lesson_plan/containers/LessonPlanContainer.jsx
+++ b/client/app/bundles/course/lesson_plan/containers/LessonPlanContainer.jsx
@@ -6,12 +6,7 @@ import LessonPlan from '../components/LessonPlan';
 import * as actionCreators from '../actions';
 
 function mapStateToProps(state) {
-  const lessonPlan = state.lessonPlan;
-  const items = lessonPlan.get('items');
-  const milestones = lessonPlan.get('milestones');
-  const hiddenItemTypes = lessonPlan.get('hiddenItemTypes');
-
-  return { milestones, items, hiddenItemTypes };
+  return state.get('lessonPlan').toObject();
 }
 
 const propTypes = {

--- a/client/app/bundles/course/lesson_plan/items.jsx
+++ b/client/app/bundles/course/lesson_plan/items.jsx
@@ -1,46 +1,5 @@
-import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-import { IntlProvider, addLocaleData } from 'react-intl';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import injectTapEventPlugin from 'react-tap-event-plugin';
-
-import zh from 'react-intl/locale-data/zh';
-
-import createStore from './store';
+import initializeComponent from 'lib/helpers/initializeComponent';
+import storeCreator from './store';
 import LessonPlanContainer from './containers/LessonPlanContainer';
-import translations from '../../../../build/locales/locales.json';
 
-// Needed for onTouchTap
-// http://stackoverflow.com/a/34015469/988941
-injectTapEventPlugin();
-
-function renderLessonPlan(props) {
-  const i18nLocale = $("meta[name='server-context']").data('i18n-locale');
-  const availableForeignLocales = { zh };
-  const localeWithoutRegionCode = i18nLocale.toLowerCase().split(/[_-]+/)[0];
-
-  let messages;
-  if (localeWithoutRegionCode !== 'en' && availableForeignLocales[localeWithoutRegionCode]) {
-    addLocaleData(availableForeignLocales[localeWithoutRegionCode]);
-    messages = translations[localeWithoutRegionCode] || translations[i18nLocale];
-  }
-
-  const store = createStore(props);
-
-  render(
-    <Provider store={store}>
-      <IntlProvider locale={i18nLocale} messages={messages}>
-        <MuiThemeProvider>
-          <LessonPlanContainer />
-        </MuiThemeProvider>
-      </IntlProvider>
-    </Provider>
-  , $('#lesson-plan-items')[0]);
-}
-
-$.getJSON('', (data) => {
-  $(document).ready(() => {
-    renderLessonPlan(data);
-  });
-});
+initializeComponent(LessonPlanContainer, 'lesson-plan-items', storeCreator);

--- a/client/app/bundles/course/lesson_plan/reducers/hiddenItemTypes.jsx
+++ b/client/app/bundles/course/lesson_plan/reducers/hiddenItemTypes.jsx
@@ -1,0 +1,19 @@
+import Immutable from 'immutable';
+import actionTypes from '../constants';
+
+export const initialState = Immutable.fromJS([]);
+
+export default function (state = initialState, action) {
+  const { type, itemType } = action;
+
+  switch (type) {
+    case actionTypes.TOGGLE_LESSON_PLAN_ITEM_TYPE_VISIBILITY: {
+      const updatedList = state.includes(itemType) ?
+        state.filter(hiddenType => hiddenType !== itemType) :
+        state.push(itemType);
+      return updatedList;
+    }
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/lesson_plan/reducers/index.jsx
+++ b/client/app/bundles/course/lesson_plan/reducers/index.jsx
@@ -1,10 +1,12 @@
+import Immutable from 'immutable';
+import { combineReducers } from 'redux-immutable';
 import lessonPlanReducer, { initialState as lessonPlanInitialState } from './lessonPlanReducer';
 
 // Redux expects to initialize the store using an Object, not an Immutable.Map
-export const initialStates = {
+export const initialStates = Immutable.fromJS({
   lessonPlan: lessonPlanInitialState,
-};
+});
 
-export default {
+export default combineReducers({
   lessonPlan: lessonPlanReducer,
-};
+});

--- a/client/app/bundles/course/lesson_plan/reducers/items.jsx
+++ b/client/app/bundles/course/lesson_plan/reducers/items.jsx
@@ -1,0 +1,12 @@
+import Immutable from 'immutable';
+
+export const initialState = Immutable.fromJS([]);
+
+export default function (state = initialState, action) {
+  const { type } = action;
+
+  switch (type) {
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/lesson_plan/reducers/lessonPlanReducer.jsx
+++ b/client/app/bundles/course/lesson_plan/reducers/lessonPlanReducer.jsx
@@ -1,24 +1,17 @@
 import Immutable from 'immutable';
-import actionTypes from '../constants';
+import { combineReducers } from 'redux-immutable';
+import items, { initialState as itemsInitialState } from './items';
+import milestones, { initialState as milestonesInitialState } from './milestones';
+import hiddenItemTypes, { initialState as hiddenItemTypesInitialState } from './hiddenItemTypes';
 
 export const initialState = Immutable.fromJS({
-  items: [],
-  milestones: [],
-  hiddenItemTypes: [],
+  items: itemsInitialState,
+  milestones: milestonesInitialState,
+  hiddenItemTypes: hiddenItemTypesInitialState,
 });
 
-export default function (state = initialState, action) {
-  const { type, itemType } = action;
-
-  switch (type) {
-    case actionTypes.TOGGLE_LESSON_PLAN_ITEM_TYPE_VISIBILITY: {
-      const hiddenItemTypes = state.get('hiddenItemTypes');
-      const updatedList = hiddenItemTypes.includes(itemType) ?
-        hiddenItemTypes.filter(hiddenType => hiddenType !== itemType) :
-        hiddenItemTypes.push(itemType);
-      return state.set('hiddenItemTypes', updatedList);
-    }
-    default:
-      return state;
-  }
-}
+export default combineReducers({
+  items,
+  milestones,
+  hiddenItemTypes,
+});

--- a/client/app/bundles/course/lesson_plan/reducers/milestones.jsx
+++ b/client/app/bundles/course/lesson_plan/reducers/milestones.jsx
@@ -1,0 +1,12 @@
+import Immutable from 'immutable';
+
+export const initialState = Immutable.fromJS([]);
+
+export default function (state = initialState, action) {
+  const { type } = action;
+
+  switch (type) {
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/lesson_plan/store.jsx
+++ b/client/app/bundles/course/lesson_plan/store.jsx
@@ -1,22 +1,12 @@
-import { compose, createStore, applyMiddleware, combineReducers } from 'redux';
-
-// Import thunkMiddleware for asynchronous actions
+import { compose, createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-
-import reducers, { initialStates } from './reducers';
+import rootReducer, { initialStates as defaultInitialStates } from './reducers';
 
 export default (props) => {
-  const { lessonPlan } = initialStates;
-
-  const initialState = {
-    lessonPlan: lessonPlan.merge(props),
-  };
-
-  const reducer = combineReducers(reducers);
-
+  const initialStates = defaultInitialStates.mergeDeep({ lessonPlan: props });
   const storeCreator = compose(
     applyMiddleware(thunkMiddleware)
   )(createStore);
 
-  return storeCreator(reducer, initialState);
+  return storeCreator(rootReducer, initialStates);
 };

--- a/client/app/lib/components/ProviderWrapper.jsx
+++ b/client/app/lib/components/ProviderWrapper.jsx
@@ -1,0 +1,48 @@
+import React, { PropTypes } from 'react';
+import { Provider } from 'react-redux';
+import { IntlProvider, addLocaleData } from 'react-intl';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+
+import zh from 'react-intl/locale-data/zh';
+
+import translations from '../../../build/locales/locales.json';
+
+// Needed for onTouchTap http://stackoverflow.com/a/34015469/988941
+injectTapEventPlugin();
+
+const propTypes = {
+  store: PropTypes.shape({
+    subscribe: PropTypes.func.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    getState: PropTypes.func.isRequired,
+  }),
+  children: React.PropTypes.element.isRequired,
+};
+
+const ProviderWrapper = ({ store, children }) => {
+  const i18nLocale =
+    document.querySelector("meta[name='server-context']").getAttribute('data-i18n-locale');
+  const availableForeignLocales = { zh };
+  const localeWithoutRegionCode = i18nLocale.toLowerCase().split(/[_-]+/)[0];
+
+  let messages;
+  if (localeWithoutRegionCode !== 'en' && availableForeignLocales[localeWithoutRegionCode]) {
+    addLocaleData(availableForeignLocales[localeWithoutRegionCode]);
+    messages = translations[localeWithoutRegionCode] || translations[i18nLocale];
+  }
+
+  return (
+    <Provider store={store}>
+      <IntlProvider locale={i18nLocale} messages={messages}>
+        <MuiThemeProvider>
+          { children }
+        </MuiThemeProvider>
+      </IntlProvider>
+    </Provider>
+  );
+};
+
+ProviderWrapper.propTypes = propTypes;
+
+export default ProviderWrapper;

--- a/client/app/lib/helpers/initializeComponent.jsx
+++ b/client/app/lib/helpers/initializeComponent.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
+
+const initializeComponent = (Component, nodeId, storeCreator) => {
+  const renderComponent = (props) => {
+    const store = storeCreator(props);
+
+    render(
+      <ProviderWrapper {...{ store }}>
+        <Component />
+      </ProviderWrapper>
+    , document.getElementById(nodeId));
+  };
+
+  $.getJSON('', (data) => {
+    $(document).ready(renderComponent(data));
+  });
+};
+
+export default initializeComponent;

--- a/client/package.json
+++ b/client/package.json
@@ -46,6 +46,7 @@
     "react-scroll": "^1.4.4",
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.3.1",
+    "redux-immutable": "^3.0.9",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.0.1",
     "sass-loader": "^4.0.2",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,6 +13,7 @@ const config = {
       'material-ui',
       'react',
       'react-dom',
+      'redux-immutable',
       'react-intl',
       'react-redux',
       'react-scroll',


### PR DESCRIPTION
In this PR:
- Minor UI fix for milestone
- Use redux-immutable, which is needed for `combineReducers` to work, since we are using Immutable.js.
- Factor out some boilerplate code, which can be shared by #1732 
