### PR TITLE
Fix random failures

### DIFF
--- a/spec/libraries/activity_wrapper_spec.rb
+++ b/spec/libraries/activity_wrapper_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe Notifier::Base::ActivityWrapper, type: :notifier do
           subject { activity.notify(course, :email).save }
 
           it 'sends emails to course users' do
-            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(2)
+            expect { subject }.
+              to change { ActionMailer::Base.deliveries.count }.by(course.course_users.count)
           end
         end
 

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Course::Assessment do
           expect(subject.folder.name).to eq(subject.title)
           expect(subject.folder.parent).to eq(subject.tab.category.folder)
           expect(subject.folder.course).to eq(subject.course)
-          expect(subject.folder.start_at.round(0)).to eq(subject.start_at.round(0))
+          expect(subject.folder.start_at).to be_within(0.5).of(subject.start_at)
         end
       end
 


### PR DESCRIPTION
* The delivery count should be based on course users count
* `round` will break in certain cases ( i.e. if we compare 0.99 with 1.01 )

Some logs:

```
  1) Course::Assessment with tenant :instance callbacks after assessment was saved sets the folder to have the same attributes as the assessment
     Failure/Error: expect(subject.folder.start_at.round(0)).to eq(subject.start_at.round(0))
     
       expected: 2016-12-27 09:44:59.000000000 +0000
            got: 2016-12-27 09:44:58.000000000 +0000
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1,2 @@
       -Tue, 27 Dec 2016 09:44:59 UTC +00:00
       +Tue, 27 Dec 2016 09:44:58 UTC +00:00```