### PR TITLE
Implement signup with invitation

### DIFF
--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class User::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
+  before_action :load_invitation, only: [:new, :create]
   layout :select_layout
 
   # GET /resource/sign_up
@@ -68,5 +69,15 @@ class User::RegistrationsController < Devise::RegistrationsController
   # @return [nil]
   def select_layout
     'user_admin' if ['edit', 'update'].include?(params['action'])
+  end
+
+  def load_invitation
+    return unless invitation_param.present?
+
+    @invitation = Course::UserInvitation.unconfirmed.find_by(invitation_key: invitation_param)
+  end
+
+  def invitation_param
+    params.permit(:invitation)[:invitation]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,6 +93,17 @@ class User < ActiveRecord::Base
     default_email_record.update_attributes(primary: true)
   end
 
+  # Update the user using the info from invitation.
+  #
+  # @param [Course::UserInvitation]
+  def build_from_invitation(invitation)
+    self.name = invitation.name
+    self.email = invitation.email
+    skip_confirmation!
+    course_users.build(course: invitation.course, name: invitation.name,
+                       creator: self, updater: self)
+  end
+
   private
 
   # Gets the default email address record.

--- a/app/views/course/mailer/user_invitation_email.html.slim
+++ b/app/views/course/mailer/user_invitation_email.html.slim
@@ -1,7 +1,7 @@
 = simple_format(t('.message', course: link_to(@course.title, course_url(@course)),
                               coursemology: link_to(t('layout.coursemology'), root_url),
                               email: @invitation.email,
-                              sign_up: link_to(t('layout.navbar.register'), new_user_registration_url)))
+                              click_here: link_to(t('.click_here'), new_user_registration_url(invitation: @invitation.invitation_key))))
 
 pre
   code

--- a/app/views/course/mailer/user_invitation_email.text.erb
+++ b/app/views/course/mailer/user_invitation_email.text.erb
@@ -1,6 +1,6 @@
 <%= t('.message', course: plain_link_to(@course.title, course_url(@course)),
                   coursemology: plain_link_to(t('layout.coursemology'), root_url),
                   email: @invitation.email,
-                  sign_up: plain_link_to(t('layout.navbar.register'), new_user_registration_url)) %>
+                  click_here: plain_link_to(t('.click_here'), new_user_registration_url(invitation: @invitation.invitation_key))) %>
 
 <%= @invitation.invitation_key %>

--- a/app/views/user/registrations/new.html.slim
+++ b/app/views/user/registrations/new.html.slim
@@ -5,10 +5,14 @@
 
 = simple_form_for resource, as: resource_name, url: registration_path(resource_name) do |f|
   = f.error_notification
-
   .form-inputs
-    = f.input :name, required: true, autofocus: true
-    = f.input :email, required: true
+    - if @invitation
+      = hidden_field_tag :invitation, @invitation.invitation_key
+      = f.input :name, required: true, input_html: { value: @invitation.name }, disabled: true
+      = f.input :email, required: true, input_html: { value: @invitation.email }, disabled: true
+    - else
+      = f.input :name, required: true, autofocus: true
+      = f.input :email, required: true
     = f.input :password, required: true,
               hint: (t('.password_hint', length: @minimum_password_length) if @validatable)
     = f.input :password_confirmation, required: true

--- a/config/locales/en/course/mailer/user_invitation_email.yml
+++ b/config/locales/en/course/mailer/user_invitation_email.yml
@@ -3,11 +3,12 @@ en:
     mailer:
       user_invitation_email:
         subject: 'Invitation to Register for %{course}'
+        click_here: 'Click here'
         message: >
           You are invited to register for %{course} on %{coursemology}.
 
 
           You do not seem to have an account registered at this email address (%{email});
-          please %{sign_up} for an account before visiting %{course} to enrol for the course.
+          %{click_here} to create an account and accept the invitation.
           If you have an existing Coursemology account registered under a different email,
-          enrol with the following non-transferable registration code:
+          visit %{course} and enrol with the following non-transferable registration code:


### PR DESCRIPTION
When sign up using the invitation link:
- Name/Email are automatically filled in 
- User will be enrolled in the course after sign up
- User don't need to confirm email again