### PR TITLE
Fixes to Course Page - styling and latest course first

### DIFF
--- a/app/assets/stylesheets/course/courses.scss
+++ b/app/assets/stylesheets/course/courses.scss
@@ -42,14 +42,25 @@
   }
 
   &.index {
-    .thumbnail {
-      .image > img {
-        @include no-stretch;
+    .caption {
+      margin: 5px 0;
 
-        height: $course-course-listing-logo;
-        margin-top: 1em;
-        width: $course-course-listing-logo;
+      h4 {
+        height: 50px;
       }
+
+      .description {
+        height: 60px;
+        overflow-y: scroll;
+      }
+    }
+
+    .image > img {
+      @include no-stretch;
+
+      height: $course-course-listing-logo;
+      margin-top: 1em;
+      width: $course-course-listing-logo;
     }
   }
 }

--- a/app/assets/stylesheets/mixins/_bootstrap_grid_equal_height.scss
+++ b/app/assets/stylesheets/mixins/_bootstrap_grid_equal_height.scss
@@ -1,0 +1,25 @@
+// Solution to ensure equal height on bootstrap grids. Adapted from:
+// https://scotch.io/bar-talk/different-tricks-on-how-to-make-bootstrap-columns-all-the-same-height
+//
+// To use, add .is-flex to the row class, and .box after each grid.
+
+.row.is-flex {
+  display: flex;
+  flex-wrap: wrap;
+
+  > [class*='col-'] {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.is-flex {
+  .box {
+    background: none;
+    position: static;
+  }
+
+  [class*="col-"] {
+    background: $white;
+  }
+}

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -5,7 +5,7 @@ class Course::CoursesController < Course::Controller
   before_action :load_todos, only: [:show]
 
   def index # :nodoc:
-    @courses = Course.publicly_accessible.page(page_param)
+    @courses = Course.publicly_accessible.ordered_by_start_at.page(page_param)
   end
 
   def show # :nodoc:

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -56,6 +56,7 @@ class Course < ActiveRecord::Base
   accepts_nested_attributes_for :invitations, :assessment_categories
 
   scope :ordered_by_title, -> { order(:title) }
+  scope :ordered_by_start_at, ->(direction = :desc) { order(start_at: direction) }
   scope :ordered_by_end_at, ->(direction = :desc) { order(end_at: direction) }
   scope :publicly_accessible, -> { where(status: PUBLIC_STATUSES.map { |s| statuses[s] }) }
 

--- a/app/views/course/courses/_course.html.slim
+++ b/app/views/course/courses/_course.html.slim
@@ -1,9 +1,11 @@
-= div_for(course, class: ['col-sm-6', 'col-md-4', 'col-lg-3']) do
-  = link_to course_path(course) do
-    div.thumbnail.text-center
+= div_for(course, class: ['col-xs-12', 'col-sm-6', 'col-md-4', 'col-lg-3']) do
+  div.box.text-center.thumbnail
+    = link_to course_path(course) do
       div.course-logo
         = display_course_logo(course)
       div.caption
         / TODO: Truncate text when text truncator is implemented for HTML pipeline
-        h3 = format_inline_text(course.title)
-        p = format_html(course.description)
+        h4 = format_inline_text(course.title)
+        - unless course.description.blank?
+          div.description
+            = format_html(course.description)

--- a/app/views/course/courses/index.html.slim
+++ b/app/views/course/courses/index.html.slim
@@ -1,6 +1,7 @@
 = page_header do
   = new_button([:course]) if can?(:create, Course)
 
-= render @courses
+div.row.is-flex
+  = render @courses
 
 = paginate @courses


### PR DESCRIPTION
This PR does the following:
 - Display the latest Course first (rather than at the end); and
 - Fixes styling in the course listing page.

#### Preview
![courses](https://cloud.githubusercontent.com/assets/4353853/21584838/dc95dd7c-d0ed-11e6-9c9f-fa106f458117.gif)
