### PR TITLE
Using params instead of http headers to set the format

### DIFF
--- a/client/app/lib/helpers/initializeComponent.jsx
+++ b/client/app/lib/helpers/initializeComponent.jsx
@@ -14,8 +14,8 @@ const initializeComponent = (Component, nodeId, storeCreator) => {
     , document.getElementById(nodeId));
   };
 
-  const headers = { Accept: 'application/json' };
-  axios.get('', { headers }).then((response) => {
+  const params = { format: 'json' };
+  axios.get('', { params }).then((response) => {
     $(document).ready(renderComponent(response.data));
   });
 };


### PR DESCRIPTION
Fix #1767

Using params instead of http headers to set the format. This will make the request url different from the page thus it's not displayed in the history.