### PR TITLE
Hide 'Run Code' button for programming questions in manually-graded assessments unless necessary

### DIFF
--- a/app/views/course/assessment/answer/_manually_graded.html.slim
+++ b/app/views/course/assessment/answer/_manually_graded.html.slim
@@ -8,8 +8,25 @@
   - if answer.attempting?
     div.btn-group
       = link_to_reset_answer(answer)
-      = base_answer_form.button :button, button_text, value: answer.id,
-        name: 'attempting_answer_id', class: ['submit-answer', 'btn-danger'], disabled: !enable_submit_button?(programming_answer)
+      / TODO: Consider refactor of whether to show the `Run Code` button
+      - if answer.question.auto_gradable?
+        - has_public_or_private_tests = !answer.question.specific.test_cases. \
+            select { |t| t.public_test? || t.private_test? }.blank?
+        - if has_public_or_private_tests
+          = base_answer_form.button :button, button_text,
+                                    value: answer.id,
+                                    name: 'attempting_answer_id',
+                                    class: ['submit-answer', 'btn-danger'],
+                                    disabled: !enable_submit_button?(programming_answer)
+        / If autograded programming question has no public or private tests,
+        / then it must have evaluation tests.
+        - elsif can?(:manage, answer.question.specific)
+          = base_answer_form.button :button, button_text,
+                                             value: answer.id,
+                                             name: 'attempting_answer_id',
+                                             class: ['submit-answer', 'btn-danger'],
+                                             title: t('.run_code_evaluation_warning'),
+                                             disabled: !enable_submit_button?(programming_answer)
   - elsif answer.submitted? && job = answer.try(:auto_grading).try(:job)
     - if job.errored?
       p.bg-danger = t('.error')

--- a/config/locales/en/course/assessment/answer/answers.yml
+++ b/config/locales/en/course/assessment/answer/answers.yml
@@ -10,6 +10,9 @@ en:
         manually_graded:
           run_code: 'Run Code'
           run_code_with_limit: 'Run ( %{limit} times left )'
+          run_code_evaluation_warning: >
+            You are able to see this because you are a staff and can view evaluation tests.
+            Students cannot see these tests nor this button.
           error: :'course.assessment.answer.error'
         comments_footer:
           comment: 'Comment'

--- a/spec/factories/course_assessment_question_programming.rb
+++ b/spec/factories/course_assessment_question_programming.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
       template_file_count 1
       test_case_count 0
       private_test_case_count 0
+      evaluation_test_case_count 0
     end
 
     memory_limit 32
@@ -33,7 +34,11 @@ FactoryGirl.define do
         build(:course_assessment_question_programming_test_case, :private, question: nil)
       end
 
-      public_test_cases + private_test_cases
+      evaluation_test_cases = evaluation_test_case_count.downto(1).map do
+        build(:course_assessment_question_programming_test_case, :evaluation, question: nil)
+      end
+
+      public_test_cases + private_test_cases + evaluation_test_cases
     end
 
     after(:build) do |question, evaluator|


### PR DESCRIPTION
This PR introduces the following behavior for programming questions in manually-graded assessments:
 - Students see the button only if there are public or private test cases
 - Staff see the button if there are any test cases
 - Added a tooltip warning for staff (as they see the button, but not the student) when question only has evaluation test cases
 - Added feature specs to test for students and staff

Fixes #1793.