### PR TITLE
Implement backend package service for online editor

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -9,32 +9,18 @@ class Course::Assessment::Question::ProgrammingController < \
   end
 
   def create
-    if @programming_question.save
-      if @programming_question.import_job
-        redirect_to job_path(@programming_question.import_job)
-      else
-        redirect_to course_assessment_path(current_course, @assessment),
-                    success: t('.success')
-      end
-    else
-      render 'new'
-    end
+    @programming_question.package_type = :zip_upload
+
+    save_and_redirect('new', t('.success'))
   end
 
   def edit
   end
 
   def update
-    if @programming_question.update_attributes(programming_question_params)
-      if @programming_question.import_job
-        redirect_to job_path(@programming_question.import_job)
-      else
-        redirect_to course_assessment_path(current_course, @assessment),
-                    success: t('.success')
-      end
-    else
-      render 'edit'
-    end
+    @programming_question.assign_attributes programming_question_params
+
+    save_and_redirect('edit', t('.success'))
   end
 
   def destroy
@@ -57,5 +43,18 @@ class Course::Assessment::Question::ProgrammingController < \
       *attachment_params,
       skill_ids: []
     )
+  end
+
+  def save_and_redirect(template, message)
+    if @programming_question.save
+      if @programming_question.import_job
+        redirect_to job_path(@programming_question.import_job)
+      else
+        redirect_to course_assessment_path(current_course, @assessment),
+                    success: message
+      end
+    else
+      render template
+    end
   end
 end

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -57,4 +57,18 @@ class Course::Assessment::Question::ProgrammingController < \
       render template
     end
   end
+
+  def save_and_render_json
+    if @programming_question.save! && @programming_question.import_job
+      @redirect_url = job_path(@programming_question.import_job)
+    end
+
+    render '_props'
+  end
+
+  def programming_package_service(params = nil)
+    Course::Assessment::Question::Programming::ProgrammingPackageService.new(
+      @programming_question, params
+    )
+  end
 end

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::Question::Programming < ActiveRecord::Base
+  enum package_type: { zip_upload: 0, online_editor: 1 }
+
   # The table name for this model is singular.
   self.table_name = table_name.singularize
 
@@ -26,6 +28,10 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
 
   def auto_gradable?
     !test_cases.empty?
+  end
+
+  def edit_online?
+    package_type == 'online_editor'
   end
 
   def auto_grader

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -94,6 +94,16 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
     @duplicating = true
   end
 
+  # This specifies the template files generated from the online editor.
+  #
+  # This is used by the +Course::Assessment::Question::Programming::ProgrammingPackageService+ to
+  # set the template files for a non-autograded programming question.
+  def non_autograded_template_files=(template_files)
+    self.template_files.clear
+    self.template_files = template_files
+    @non_autograded_template_files = true
+  end
+
   private
 
   # Queues the new question package for processing.
@@ -117,7 +127,7 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
 
   # Removes the template files and test cases from the old package.
   def remove_old_package
-    template_files.clear
+    template_files.clear unless @non_autograded_template_files
     test_cases.clear
     self.import_job = nil
   end

--- a/app/services/course/assessment/question/programming/language_package_service.rb
+++ b/app/services/course/assessment/question/programming/language_package_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+# In charge of the programming package of the question when using the online editor. This will
+# generate a package based on the parameters from the online editor for autograded questions, or
+# extract the template files from the parameters for non-autograded questions.
+#
+# This also extracts the meta details of the programming question, the meta is a JSON used by the
+# online editor for rendering. This meta will be stored in the package for autograded questions, or
+# generated using the existing template files and the default meta for non-autograded questions.
+class Course::Assessment::Question::Programming::LanguagePackageService
+  # A concrete language package service will be initalized with the request parameters from the
+  # controller when creating/updating the programming question, the language package service
+  # will use the parameters to create/update the package.
+  #
+  # When using the service only to retrieve the meta for a programming question, the params
+  # argument can be nil.
+  #
+  # @param [ActionController::Parameters] params The parameters containing the data for package
+  #   generation.
+  def initialize(params)
+    @test_params = test_params params if params.present?
+  end
+
+  # Checks whether the programming question should be autograded.
+  #
+  # @return [Boolean]
+  def autograded?
+    raise NotImplementedError, 'You must implement this'
+  end
+
+  # Array of arguments used to create template files for non-autograded programming question.
+  #
+  # @return [Array]
+  def submission_templates
+    raise NotImplementedError, 'You must implement this'
+  end
+
+  # Generates a new package with the meta file.
+  #
+  # @param [AttachmentReference] Previous package, may contain files that the new package uses.
+  # @return [Tempfile]
+  def generate_package(old_attachment) # rubocop:disable UnusedMethodArgument
+    raise NotImplementedError, 'You must implement this'
+  end
+
+  # Defines the default meta to be used by the online editor for rendering.
+  #
+  # @return [Hash]
+  def default_meta
+    raise NotImplementedError, 'You must implement this'
+  end
+
+  # Retrieves the meta details from the programming package, or the template files if the package
+  # does not exist for non-autograded questions.
+  #
+  # @param [AttachmentReference] Package containing the meta details.
+  # @param [Array<Course::Assessment::Question::ProgrammingTemplateFile>] An Array of template
+  #   files used to generate meta for non-autograded questions.
+  # @return [Hash]
+  def extract_meta(attachment, template_files) # rubocop:disable UnusedMethodArgument
+    raise NotImplementedError, 'You must implement this'
+  end
+
+  private
+
+  # Permits the fields that are used to generate a the package for the language.
+  #
+  # @param [ActionController::Parameters] params The parameters containing the data for package
+  #   generation.
+  def test_params(params) # rubocop:disable UnusedMethodArgument
+    raise NotImplementedError, 'You must implement this'
+  end
+
+  # Checks that the test case field is meant to be a string.
+  #
+  # @param [String]
+  # @return [Boolean]
+  def string?(text)
+    text.first == '\'' && text.last == '\'' ||
+      text.first == '"' && text.last == '"'
+  end
+end

--- a/app/services/course/assessment/question/programming/programming_package_service.rb
+++ b/app/services/course/assessment/question/programming/programming_package_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+# Generates the package and extracts the meta for the programming question based on the language
+# of the programming question.
+class Course::Assessment::Question::Programming::ProgrammingPackageService
+  # Creates a new programming package service object.
+  #
+  # @param [Course::Assessment::Question::Programming] question The programming question with the
+  #   programming package.
+  def initialize(question, params)
+    @question = question
+    @language = question.language
+    @current_attachment = question.attachment
+    @template_files = question.template_files
+
+    init_language_package_service(params)
+  end
+
+  # Generates a programming package from the parameters which were passed to the controller.
+  def generate_package
+    if @language_package_service.autograded?
+      new_package = @language_package_service.generate_package(@current_attachment)
+      @question.file = new_package if new_package.present?
+    else
+      templates = @language_package_service.submission_templates
+      @question.imported_attachment = nil
+      @question.non_autograded_template_files = templates.map do |template|
+        Course::Assessment::Question::ProgrammingTemplateFile.new(template)
+      end
+    end
+  end
+
+  # Retrieves the meta details from the programming package.
+  #
+  # @return [Hash]
+  def extract_meta
+    data = @language_package_service.extract_meta(@current_attachment, @template_files)
+    { editor_mode: @editor_mode, data: data } if data.present?
+  end
+
+  private
+
+  def init_language_package_service(params)
+    if python_language
+      @language_package_service =
+        Course::Assessment::Question::Programming::Python::PythonPackageService.new params
+      @editor_mode = 'python'
+    elsif javascript_language
+      raise NotImplementedError
+    else
+      raise NotImplementedError
+    end
+  end
+
+  # Checks that the language is Python, regardless of Python2 or Python3
+  #
+  # @return [Boolean]
+  def python_language
+    @language.is_a?(Coursemology::Polyglot::Language::Python)
+  end
+
+  # Checks that the language is Javascript
+  #
+  # @return [Boolean]
+  def javascript_language
+    @language.is_a?(Coursemology::Polyglot::Language::JavaScript)
+  end
+end

--- a/app/services/course/assessment/question/programming/python/python_autograde_post.py
+++ b/app/services/course/assessment/question/programming/python/python_autograde_post.py
@@ -1,0 +1,8 @@
+
+# Do not modify beyond this line
+if __name__ == '__main__':
+    unittest.main(
+            testRunner=xmlrunner.XMLTestRunner(open('report.xml', 'wb'), outsuffix = ''),
+            failfast=False,
+            buffer=False,
+            catchbreak=False)

--- a/app/services/course/assessment/question/programming/python/python_autograde_pre.py
+++ b/app/services/course/assessment/question/programming/python/python_autograde_pre.py
@@ -1,0 +1,11 @@
+import unittest
+# Needs xmlrunner: pip install unittest-xml-reporting
+import xmlrunner
+import sys
+
+class AutoGrader(unittest.TestCase):
+    def setUp(self):
+        # clears the dictionary containing meta data for each test
+        self.meta = { 'expression': '', 'expected': '', 'hint': '' }
+
+# Do not modify above this line, unless you know what you are doing

--- a/app/services/course/assessment/question/programming/python/python_makefile
+++ b/app/services/course/assessment/question/programming/python/python_makefile
@@ -1,0 +1,20 @@
+prepare:
+
+compile:
+
+test:	answer.py
+	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" python3 answer.py
+
+answer.py:	tests/autograde.py submission/template.py tests/prepend.py tests/append.py
+	cat tests/prepend.py submission/template.py tests/append.py tests/autograde.py > answer.py
+
+solution:	solution.py
+	PYTHONPATH="$(shell pwd)/solution":"$(shell pwd)/tests" python3 solution.py
+
+solution.py:	tests/autograde.py solution/template.py tests/prepend.py tests/append.py
+	cat tests/prepend.py solution/template.py tests/append.py tests/autograde.py > solution.py
+
+clean:
+	rm -f answer.py
+	rm -f report.xml
+	rm -f solution.py

--- a/app/services/course/assessment/question/programming/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming/python/python_package_service.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::Programming::Python::PythonPackageService < \
+  Course::Assessment::Question::Programming::LanguagePackageService
+  AUTOGRADE_PRE_PATH = File.join(File.expand_path(File.dirname(__FILE__)),
+                                 'python_autograde_pre.py').freeze
+
+  AUTOGRADE_POST_PATH = File.join(File.expand_path(File.dirname(__FILE__)),
+                                  'python_autograde_post.py').freeze
+
+  MAKEFILE_PATH = File.join(File.expand_path(File.dirname(__FILE__)), 'python_makefile').freeze
+
+  def autograded?
+    @test_params.key?(:autograded)
+  end
+
+  def submission_templates
+    [
+      {
+        filename: 'template.py',
+        content: @test_params[:submission]
+      }
+    ]
+  end
+
+  def generate_package(old_attachment)
+    return nil if @test_params.blank?
+
+    @tmp_dir = Dir.mktmpdir
+    @old_meta = old_attachment.present? ? extract_meta(old_attachment, nil) : nil
+    data_files_to_keep = old_attachment.present? ? find_data_files_to_keep(old_attachment) : []
+    @meta = generate_meta(data_files_to_keep)
+
+    return nil if @meta == @old_meta
+
+    file = generate_zip_file(data_files_to_keep)
+    FileUtils.remove_entry @tmp_dir if @tmp_dir.present?
+    file
+  end
+
+  def default_meta
+    {
+      submission: '', solution: '', prepend: '', append: '', autograded: false,
+      data_files: [],
+      test_cases: {
+        public: [],
+        private: [],
+        evaluation: []
+      }
+    }
+  end
+
+  def extract_meta(attachment, template_files)
+    # attachment will be nil if the question is not autograded, in that case the meta data will be
+    # generated from the template files in the database.
+    return generate_non_autograded_meta(template_files) if attachment.nil?
+
+    extract_autograded_meta(attachment)
+  end
+
+  private
+
+  def extract_autograded_meta(attachment)
+    attachment.open(binmode: true) do |temporary_file|
+      begin
+        package = Course::Assessment::ProgrammingPackage.new(temporary_file)
+        meta = package.meta_file
+        @old_meta = meta.present? ? JSON.parse(meta) : nil
+      ensure
+        next unless package
+        temporary_file.close
+      end
+    end
+  end
+
+  def generate_non_autograded_meta(template_files)
+    meta = default_meta
+
+    return meta if template_files.blank?
+
+    # For python editor, there is only a single submission template file.
+    meta[:submission] = template_files.first.content
+
+    meta
+  end
+
+  def extract_from_package(package, new_data_filenames, data_files_to_delete)
+    data_files_to_keep = []
+
+    if @old_meta.present?
+      package.unzip_file @tmp_dir
+
+      @old_meta['data_files'].try(:each) do |file|
+        next if data_files_to_delete.try(:include?, (file['filename']))
+        # new files overrides old ones
+        next if new_data_filenames.include?(file['filename'])
+        data_files_to_keep.append(File.new(File.join(@tmp_dir, file['filename'])))
+      end
+    end
+
+    data_files_to_keep
+  end
+
+  def find_data_files_to_keep(attachment)
+    new_filenames = (@test_params[:data_files] || []).reject(&:nil?).map(&:original_filename)
+
+    attachment.open(binmode: true) do |temporary_file|
+      begin
+        package = Course::Assessment::ProgrammingPackage.new(temporary_file)
+        return extract_from_package(package, new_filenames, @test_params[:data_files_to_delete])
+      ensure
+        next unless package
+        temporary_file.close
+      end
+    end
+  end
+
+  def generate_zip_file(data_files_to_keep)
+    tmp = Tempfile.new(['package', '.zip'])
+
+    Zip::OutputStream.open(tmp.path) do |zip|
+      # Create solution directory with template file
+      zip.put_next_entry 'solution/'
+      zip.put_next_entry 'solution/template.py'
+      zip.print @test_params[:solution]
+      zip.print "\n"
+
+      # Create submission directory with template file
+      zip.put_next_entry 'submission/'
+      zip.put_next_entry 'submission/template.py'
+      zip.print @test_params[:submission]
+      zip.print "\n"
+
+      # Create tests directory with prepend, append and autograde files
+      zip.put_next_entry 'tests/'
+      zip.put_next_entry 'tests/append.py'
+      zip.print @test_params[:append]
+      zip.print "\n"
+
+      zip.put_next_entry 'tests/prepend.py'
+      zip.print @test_params[:prepend]
+      zip.print "\n"
+
+      zip.put_next_entry 'tests/autograde.py'
+      zip.print File.read(AUTOGRADE_PRE_PATH)
+
+      tests = @test_params[:test_cases]
+
+      index = 1
+      [:public, :private, :evaluation].each do |test_type|
+        tests[test_type].try(:each) do |test|
+          test_fn = "    def test_#{test_type}_#{index}(self):\n"\
+                    "        self.meta['expression'] = #{test[:expression].inspect}\n"\
+
+          # String types should be displayed with quotes, other types will be converted to string
+          # with the str method.
+          expected = string?(test[:expected]) ? test[:expected].inspect : "str(#{test[:expected]})"
+          test_fn += "        self.meta['expected'] = #{expected}\n"
+
+          unless test[:hint].blank?
+            test_fn += "        self.meta['hint'] = #{test[:hint].inspect}\n"
+          end
+
+          test_fn += "        _out = #{test[:expression]}\n"\
+                     "        self.meta['output'] = _out\n"\
+                     "        self.assertEqual(_out, #{test[:expected]})\n"\
+                     "\n"
+
+          zip.print test_fn
+
+          index += 1
+        end
+      end
+
+      zip.print File.read(AUTOGRADE_POST_PATH)
+
+      # Creates Makefile
+      zip.put_next_entry 'Makefile'
+      zip.print File.read(MAKEFILE_PATH)
+
+      zip.put_next_entry '.meta'
+      zip.print @meta.to_json
+    end
+
+    Zip::File.open(tmp.path) do |zip|
+      @test_params[:data_files].try(:each) do |file|
+        next if file.nil?
+        zip.add(file.original_filename, file.tempfile.path)
+      end
+
+      data_files_to_keep.each do |file|
+        zip.add(File.basename(file.path), file.path)
+      end
+    end
+
+    tmp
+  end
+
+  def get_data_files_meta(data_files_to_keep, new_data_files)
+    data_files = []
+
+    new_data_files.each do |file|
+      sha256 = Digest::SHA256.file(file.tempfile).hexdigest
+      data_files.append(filename: file.original_filename, size: file.tempfile.size, hash: sha256)
+    end
+
+    data_files_to_keep.each do |file|
+      sha256 = Digest::SHA256.file(file).hexdigest
+      data_files.append(filename: File.basename(file.path), size: file.size, hash: sha256)
+    end
+
+    data_files
+  end
+
+  def generate_meta(data_files_to_keep)
+    meta = default_meta
+
+    [:submission, :solution, :prepend, :append].each { |field| meta[field] = @test_params[field] }
+
+    meta[:autograded] = autograded?
+
+    new_data_files = (@test_params[:data_files] || []).reject(&:nil?)
+    meta[:data_files] = get_data_files_meta(data_files_to_keep, new_data_files)
+
+    [:public, :private, :evaluation].each do |test_type|
+      meta[:test_cases][test_type] = @test_params[:test_cases][test_type] || []
+    end
+
+    meta
+  end
+
+  def test_params(params)
+    test_params = params.require(:question_programming).permit(
+      :prepend, :append, :solution, :submission, :autograded,
+      data_files: [],
+      test_cases: {
+        public: [:expression, :expected, :hint],
+        private: [:expression, :expected, :hint],
+        evaluation: [:expression, :expected, :hint]
+      }
+    )
+    whitelist(params, test_params)
+  end
+
+  def whitelist(params, test_params)
+    test_params.tap do |whitelisted|
+      whitelisted[:data_files_to_delete] = params['question_programming']['data_files_to_delete']
+    end
+  end
+end

--- a/db/migrate/20161027020646_add_package_type_to_course_assessment_question_programming.rb
+++ b/db/migrate/20161027020646_add_package_type_to_course_assessment_question_programming.rb
@@ -1,0 +1,6 @@
+class AddPackageTypeToCourseAssessmentQuestionProgramming < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_question_programming, :package_type, :integer,
+               default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,6 +246,7 @@ ActiveRecord::Schema.define(version: 20170102053335) do
     t.integer "time_limit",    :comment=>"Time limit, in seconds"
     t.integer "attempt_limit"
     t.uuid    "import_job_id", :comment=>"The ID of the importing job", :index=>{:name=>"index_course_assessment_question_programming_on_import_job_id", :unique=>true}, :foreign_key=>{:references=>"jobs", :name=>"fk_course_assessment_question_programming_import_job_id", :on_update=>:no_action, :on_delete=>:nullify}
+    t.integer "package_type",  :default=>0, :null=>false
   end
 
   create_table "course_assessment_question_programming_test_cases", force: :cascade do |t|

--- a/lib/autoload/course/assessment/programming_package.rb
+++ b/lib/autoload/course/assessment/programming_package.rb
@@ -31,6 +31,9 @@
 # changes to disk. Duplicate the file before modifying if you do not want to modify the original
 # file -- changes are made in-place.
 class Course::Assessment::ProgrammingPackage
+  # The path to the .meta file.
+  META_PATH = Pathname.new('.meta').freeze
+
   # The path to the Makefile.
   MAKEFILE_PATH = Pathname.new('Makefile').freeze
 
@@ -99,6 +102,15 @@ class Course::Assessment::ProgrammingPackage
     ['Makefile', 'submission/', 'tests/'].all? { |entry| @file.find_entry(entry).present? }
   end
 
+  # Gets the .meta file.
+  #
+  # @return [String] Contents of the .meta file.
+  def meta_file
+    get_file(META_PATH)
+  rescue
+    nil
+  end
+
   # Gets the contents of all submission files.
   #
   # @return [Hash<Pathname, String>] A hash mapping the file path to the file contents of each
@@ -149,6 +161,18 @@ class Course::Assessment::ProgrammingPackage
     self.submission_files = files
   end
 
+  # Unzips the contents of the file to the destination folder.
+  #
+  # @param [String] Path to folder.
+  def unzip_file(destination)
+    ensure_file_open!
+    @file.each do |entry|
+      entry_path = File.join(destination, entry.name)
+      FileUtils.mkdir_p(File.dirname(entry_path))
+      @file.extract(entry, entry_path) unless File.exist?(entry_path)
+    end
+  end
+
   private
 
   # Ensures that the zip file is open.
@@ -187,5 +211,14 @@ class Course::Assessment::ProgrammingPackage
       file_name = entry_file_name.relative_path_from(folder_path)
       [file_name, entry.get_input_stream(&:read)]
     end.to_h
+  end
+
+  # Get the contents of a file.
+  #
+  # @param [String] Path to file.
+  # @return [String]
+  def get_file(file_path)
+    ensure_file_open!
+    @file.read(file_path)
   end
 end


### PR DESCRIPTION
First step of #1568

This PR:

- Adds the backend service for python packages.
- Migration to add `package_type` to programming questions.
  - Controller will set the `package_type` to `zip_upload` in `create`.

After this:

- Implement frontend in react and material-ui.
- Make edit asynchronous.