### PR TITLE
Link pending comments directly to the question

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/submission.js
+++ b/app/assets/javascripts/course/assessment/submission/submission.js
@@ -1,4 +1,6 @@
-(function($) {
+//= require helpers/url_helpers
+
+(function($, URL_HELPERS) {
   'use strict';
   var DOCUMENT_SELECTOR = '.course-assessment-submission-submissions.edit ';
   var SINGLE_QUESTION_ASSESSMENT_SELECTOR = DOCUMENT_SELECTOR + '.single-question ';
@@ -164,8 +166,8 @@
       $('#' + identifier).find('textarea.code').ace();
     });
 
-    // Show the first tab on page load.
-    $(MULTI_QUESTION_ASSESSMENT_SELECTOR + '.tab-header a:first').tab('show');
+    var step = URL_HELPERS.getUrlParameter('step') || 1;
+    $(MULTI_QUESTION_ASSESSMENT_SELECTOR + '.tab-header a[step="' + step + '"]').tab('show');
   }
 
   function initializeAceEditor() {
@@ -180,4 +182,4 @@
   $(document).ready(updateInitialPoints);
   $(document).ready(initializeAnswerTabs);
   $(document).ready(initializeAceEditor);
-})(jQuery);
+})(jQuery, URL_HELPERS);

--- a/app/assets/javascripts/helpers/url_helpers.js
+++ b/app/assets/javascripts/helpers/url_helpers.js
@@ -1,0 +1,30 @@
+var URL_HELPERS = (function (){
+  'use strict';
+
+  /* Get the given parameter from the URL.
+   * e.g. With this URL -> http://dummy.com/?technology=jquery&blog=jquerybyexample
+   *
+   * var tech = getUrlParameter('technology');
+   * var blog = getUrlParameter('blog');
+   *
+   * Taken from http://stackoverflow.com/questions/19491336/get-url-parameter-jquery-or-how-to-get-query-string-values-in-js
+   */
+  function getUrlParameter(sParam) {
+    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
+        sURLVariables = sPageURL.split('&'),
+        sParameterName,
+        i;
+
+    for (i = 0; i < sURLVariables.length; i++) {
+      sParameterName = sURLVariables[i].split('=');
+
+      if (sParameterName[0] === sParam) {
+        return sParameterName[1] === undefined ? true : sParameterName[1];
+      }
+    }
+  }
+
+  return {
+    getUrlParameter: getUrlParameter
+  };
+}(jQuery));

--- a/app/views/course/assessment/answers/_discussion_topic_answer.html.slim
+++ b/app/views/course/assessment/answers/_discussion_topic_answer.html.slim
@@ -6,13 +6,12 @@
 
 = div_for(topic, 'data-topic-id' => topic.id) do
   h3
-    = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
+    - comment_title = "#{assessment.title}: #{question.display_title}"
+    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: assessment.questions.index(question) + 1)
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
   h4
     = t('.by_html', user: link_to_user(submission.creator))
-  h4
-    = t('.question', title: question.display_title)
 
   = display_topic answer.acting_as, post_partial: 'course/discussion/post',
                                     footer: 'course/discussion/posts/form'

--- a/app/views/course/assessment/submission/submissions/_manually_graded_answers_tabbed.html.slim
+++ b/app/views/course/assessment/submission/submissions/_manually_graded_answers_tabbed.html.slim
@@ -4,7 +4,7 @@
 ul.nav.nav-tabs.tab-header role="tab-list"
   - f.object.assessment.questions.each.with_index(1) do |question, index|
     li role="presentation"
-      a href="##{question.id}" aria-controls="#{question.id}" role="tab" data-toggle="tab"
+      a href="##{question.id}" aria-controls="#{question.id}" role="tab" data-toggle="tab" step="#{index}"
         = t('.question', number: index)
 
 div.tab-content

--- a/config/locales/en/course/assessment/answers.yml
+++ b/config/locales/en/course/assessment/answers.yml
@@ -4,4 +4,3 @@ en:
       answers:
         discussion_topic_answer:
           by_html: 'By: %{user}'
-          question: 'Question: %{title}'


### PR DESCRIPTION
Instead of linking to the assessment where the comment was made, link it directly to the question in the assessment.

Fixes #1797.