### PR TITLE
Define a more verbose association, also to circumvent circular dependency issue while loading in production

### DIFF
--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -6,7 +6,8 @@ class Course::Video < ActiveRecord::Base
 
   after_initialize :set_defaults, if: :new_record?
 
-  has_many :submissions, inverse_of: :video, dependent: :destroy
+  has_many :submissions, class_name: Course::Video::Submission.name,
+                         inverse_of: :video, dependent: :destroy
 
   def self.use_relative_model_naming?
     true


### PR DESCRIPTION
Verified this by loading `rails s -e production`. 