### PR TITLE
Enlarge and reposition announcement status icons

### DIFF
--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -1,16 +1,15 @@
 = div_for(announcement, class: time_period_class(announcement) + unread_class(announcement))
   h2.announcement-title
     - if announcement.unread?(current_user)
-      small => fa_icon 'envelope'.freeze
+      span => fa_icon 'envelope'.freeze
+    - if announcement.sticky?
+      span title=t('.sticky')
+        => fa_icon 'thumb-tack'.freeze
+    - unless announcement.currently_active?
+      span title=time_period_message(announcement)
+        => fa_icon 'calendar'.freeze
 
     = format_inline_text(announcement.title)
-
-    - if announcement.sticky?
-      small title=t('.sticky')
-        =< fa_icon 'thumb-tack'.freeze
-    - unless announcement.currently_active?
-      small title=time_period_message(announcement)
-        =< fa_icon 'calendar'.freeze
 
     div.pull-right
       div.btn-group


### PR DESCRIPTION
Similar to #1619

<img width="238" alt="screen shot 2017-01-06 at 4 07 11 pm" src="https://cloud.githubusercontent.com/assets/6252919/21711548/6652ad26-d42a-11e6-9bdb-2473bcb3d259.png">

