### PR TITLE
Fix nesting of course_user badge

### DIFF
--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -11,8 +11,8 @@
           div.col-xs-12.user
             = display_user_image(current_user)
             span#user-sidebar = link_to_user(current_course_user || current_user)
-            - if current_course_user.student? && current_course.gamified?
-              = display_course_user_badge(current_course_user)
+          - if current_course_user.student? && current_course.gamified?
+            = display_course_user_badge(current_course_user)
       nav.navbar-default role='navigation'
         - if can?(:participate, current_course)
           div.sidebar.collapse.navbar-collapse#course-navigation-sidebar


### PR DESCRIPTION
## Before:
<img width="419" alt="screen shot 2017-01-07 at 12 08 20 am" src="https://cloud.githubusercontent.com/assets/4353853/21724011/9e3814cc-d46d-11e6-8773-df9dc700fe1a.png">

## After:
<img width="423" alt="screen shot 2017-01-07 at 12 07 34 am" src="https://cloud.githubusercontent.com/assets/4353853/21724007/9a793424-d46d-11e6-898f-e44bbeb07976.png">
