### PR TITLE
Only apply autograded validation to published assessments 

### DIFF
--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -131,8 +131,13 @@ class Course::Assessment < ActiveRecord::Base
   end
 
   def validate_only_autograded_questions
-    return if questions.all?(&:auto_gradable?)
-    errors.add(:base, :autograded)
+    return unless published?
+    non_autograded_questions = questions.select { |q| !q.auto_gradable? }
+    return if non_autograded_questions.empty?
+
+    message = I18n.t('activerecord.errors.models.course/assessment.autograded',
+                     question: non_autograded_questions.first.display_title)
+    errors.add(:published, message)
   end
 
   def clear_duplication_flag

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -84,7 +84,7 @@ class Course::Assessment::Question < ActiveRecord::Base
   private
 
   def validate_assessment_is_not_autograded
-    return unless assessment.autograded
+    return unless assessment.autograded? && assessment.published?
     errors.add(:base, :autograded_assessment)
   end
 end

--- a/app/views/course/assessment/question/programming/_form.html.slim
+++ b/app/views/course/assessment/question/programming/_form.html.slim
@@ -1,7 +1,6 @@
-= import_result_alert
-
 = simple_form_for [current_course, @assessment, @programming_question] do |f|
   = f.error_notification
+  = import_result_alert
   = render partial: 'course/assessment/questions/form', locals: { f: f }
 
   = f.association :language

--- a/app/views/layouts/_attachment_uploader.html.slim
+++ b/app/views/layouts/_attachment_uploader.html.slim
@@ -9,11 +9,12 @@
     strong = t('.new_files')
     = f.file_field :files, multiple: true
 - else
-  - if f.object.attachment.present?
+  - if f.object.attachment.present? && f.object.attachment.persisted?
     strong => t('.uploaded_file')
     div
       span = link_to format_inline_text(f.object.attachment.name),
                                attachment_reference_path(f.object.attachment), target: "_blank"
       span.uploaded-by = t('.uploaded_by', name: f.object.attachment.creator.name)
+
   div
     = f.file_field :file

--- a/config/locales/en/activerecord/course/assessment.yml
+++ b/config/locales/en/activerecord/course/assessment.yml
@@ -7,4 +7,6 @@ en:
       models:
         course/assessment:
           no_questions: 'Assessment can only be published after adding questions'
-          autograded: 'Assessment can only be autograded if all questions are autograded'
+          autograded: >
+            Autograded Assessment can only be published if all questions are autograded:
+            %{question} is not autograded.

--- a/config/locales/en/activerecord/course/assessment/question.yml
+++ b/config/locales/en/activerecord/course/assessment/question.yml
@@ -4,7 +4,8 @@ en:
       models:
         course/assessment/question:
           autograded_assessment: >
-            A non-autograded question cannot be added to an autograded assessment.
+            A non-autograded question cannot be added to a published autograded assessment.
+            You might want to unpublish the assessment first.
     course/assessment/question:
       question_number: "Question %{index}"
       question_with_title: "%{question_number}: %{title}"

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Course::Assessment::Question do
     subject { build_stubbed(:course_assessment_question) }
 
     describe 'validations' do
-      context 'when assessment automatically releases grades' do
-        let(:assessment) { create(:assessment, :autograded) }
+      context 'when the assessment is published and autograded' do
+        let(:assessment) { create(:assessment, :published_with_mcq_question, :autograded) }
         let!(:question) { build(:course_assessment_question, assessment: assessment) }
         subject { question }
 

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -59,12 +59,13 @@ RSpec.describe Course::Assessment do
         end
       end
 
-      context 'when the assessment is set to be autograded' do
+      context 'when an autograded assessment is set to be published' do
+        let(:assessment_traits) { [:autograded] }
         let!(:question) do
           create(:course_assessment_question_programming, *question_traits, assessment: assessment)
         end
         subject do
-          assessment.autograded = true
+          assessment.published = true
           assessment
         end
 
@@ -73,7 +74,7 @@ RSpec.describe Course::Assessment do
 
           it 'is not valid' do
             expect(subject).not_to be_valid
-            expect(subject.errors['base']).
+            expect(subject.errors['published']).
               to include(I18n.t('activerecord.errors.models.course/assessment.autograded'))
           end
         end


### PR DESCRIPTION
Fix #1809 
- Fix validation
- Improve the validation message to further tell which question fails validate.
- Fix a uploader bug that it displays URL of non-persisted attachments  


Actually further thought about it, the validation for programming question part we need to redo, now it actually does not work as expected. e.g.

- If the question is already autograded (has test cases), and user wants to upload a package without any tests, he will success.

- If the question is not autograded, user simply cannot replace its package anymore, because the the question will fail to save. 

I will submit a separate issue regarding this.