### PR TITLE
Display total number of courses in course listing headers

### DIFF
--- a/app/views/system/admin/courses/index.html.slim
+++ b/app/views/system/admin/courses/index.html.slim
@@ -1,6 +1,13 @@
-= page_header
+/ Show total number of courses when search field is blank (nil or empty string)
+- if params['search'].blank?
+  = page_header t('.header_with_count', count: Course.unscoped.all.count)
+- else
+  = page_header
 
 = render partial: 'layouts/search_form', locals: { url: admin_courses_path, placeholder: t('.search_placeholder') }
+
+- unless params['search'].blank?
+  h4 = t('.search_count', count: @courses.size)
 
 table.table.table-middle-align.table-hover
   thead

--- a/app/views/system/admin/instance/courses/index.html.slim
+++ b/app/views/system/admin/instance/courses/index.html.slim
@@ -1,6 +1,13 @@
-= page_header
+/ Show  number of courses in instance when search field is blank (nil or empty string)
+- if params['search'].blank?
+  = page_header t('.header_with_count', count: @courses.size)
+- else
+  = page_header
 
 = render partial: 'layouts/search_form', locals: { url: admin_instance_courses_path, placeholder: t('.search_placeholder') }
+
+- unless params['search'].blank?
+  h4 = t('.search_count', count: @courses.size)
 
 table.table.table-middle-align.table-hover
   thead

--- a/config/locales/en/system/admin/courses.yml
+++ b/config/locales/en/system/admin/courses.yml
@@ -4,6 +4,8 @@ en:
       courses:
         index:
           header: 'Courses'
+          header_with_count: 'Courses (%{count})'
+          search_count: '%{count} courses found'
           title: 'Title'
           status: 'Status'
           created_at: 'Created At'

--- a/config/locales/en/system/admin/instance/courses.yml
+++ b/config/locales/en/system/admin/instance/courses.yml
@@ -5,6 +5,8 @@ en:
         courses:
           index:
             header: 'Courses'
+            header_with_count: 'Courses (%{count})'
+            search_count: '%{count} courses found'
             title: 'Title'
             status: 'Status'
             created_at: 'Created At'


### PR DESCRIPTION
Show total number of courses in the header for both system course listing and instance course listing.

When search is used, show the number of search results instead.

References #1815. Partial fix, serial number yet to be discussed.