### PR TITLE
Link programming annotations directly to the question.

### DIFF
--- a/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
+++ b/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
@@ -7,14 +7,13 @@
 
 = div_for(topic, 'data-topic-id' => topic.id) do
   h3
-    = link_to assessment.title, edit_course_assessment_submission_path(current_course, assessment, submission)
+    - comment_title = "#{assessment.title}: #{question.display_title}"
+    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: assessment.questions.index(question) +1)
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
 
   h4
     = t('.by_html', user: link_to_user(submission.creator))
-  h4
-    = t('.question', title: question.display_title)
 
   = display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
   = display_topic topic, post_partial: 'course/discussion/post',

--- a/config/locales/en/course/assessment/answer/programming_file_annotations.yml
+++ b/config/locales/en/course/assessment/answer/programming_file_annotations.yml
@@ -5,4 +5,3 @@ en:
         programming_file_annotations:
           discussion_topic_programming_file_annotation:
             by_html: 'By: %{user}'
-            question: 'Question: %{title}'


### PR DESCRIPTION
Instead of linking to the assessment, link it directly to the question
where the annotation was made.

Turns out programming annotations are displayed through a different partial.

Related to #1803, fixes #1797.