### PR TITLE
Reassign parent folder if category changed

### DIFF
--- a/app/models/course/assessment/tab.rb
+++ b/app/models/course/assessment/tab.rb
@@ -2,7 +2,10 @@
 class Course::Assessment::Tab < ActiveRecord::Base
   belongs_to :category, class_name: Course::Assessment::Category.name, inverse_of: :tabs
   has_many :assessments, class_name: Course::Assessment.name, dependent: :destroy, inverse_of: :tab
+  has_many :folders, class_name: Course::Material::Folder.name, through: :assessments,
+                     inverse_of: nil
 
+  before_save :reassign_folders, if: :category_id_changed?
   before_destroy :validate_before_destroy
 
   default_scope { order(:weight) }
@@ -26,5 +29,16 @@ class Course::Assessment::Tab < ActiveRecord::Base
     safe = other_tabs_remaining?
     errors.add(:base, :deletion) unless safe
     safe
+  end
+
+  # Reassign the assessment folders to new category if the category changed.
+  def reassign_folders
+    # Category association might not be updated when category_id changed
+    new_parent_folder = Course::Assessment::Category.find(category_id).folder
+
+    folders.each do |folder|
+      folder.parent = new_parent_folder
+      return false unless folder.save
+    end
   end
 end

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -126,7 +126,8 @@ class Course::Material::Folder < ActiveRecord::Base
   end
 
   def assign_valid_name
-    return unless name_changed? && owner
+    return if owner_id.nil? && owner.nil?
+    return if !name_changed? && !parent_id_changed?
 
     self.name = next_valid_name
   end

--- a/spec/features/course/category_management_spec.rb
+++ b/spec/features/course/category_management_spec.rb
@@ -66,6 +66,25 @@ RSpec.feature 'Course: Category: Management' do
         expect(page).to have_selector('div.alert.alert-danger')
         expect(page).to have_content_tag_for(category)
       end
+
+      scenario 'I can move tab to another category' do
+        default_category = course.assessment_categories.first
+        tab = create(:course_assessment_tab, course: course)
+        assessment = create(:assessment, course: course, tab: tab)
+
+        visit course_admin_assessments_path(course)
+
+        expect(assessment.folder.parent).not_to eq(default_category.folder)
+
+        # Move tab from its owne category to default category.
+        find("#tab_#{tab.id}").
+          find('#course_assessment_categories_attributes_1_tabs_attributes_1_category_id').
+          find(:xpath, 'option[2]').select_option
+
+        click_button 'submit'
+        expect(tab.reload.category).to eq(default_category)
+        expect(assessment.reload.folder.parent).to eq(default_category.folder)
+      end
     end
   end
 end


### PR DESCRIPTION
Fix #1801

This fixes a bug that assessment folders get wrong parents if tabs get reassigned. 