### PR TITLE
Show experience points breakdown for assessment index

### DIFF
--- a/app/assets/stylesheets/course/assessment/assessments.scss
+++ b/app/assets/stylesheets/course/assessment/assessments.scss
@@ -69,7 +69,8 @@
         @extend .text-center;
       }
 
-      .table-experience-points {
+      .table-base-exp,
+      .table-time-bonus-exp {
         @extend .hidden-xs;
         @extend .hidden-sm;
         @extend .text-center;

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -72,7 +72,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
 
   def assessment_params
     params.require(:assessment).permit(:title, :description, :base_exp, :time_bonus_exp,
-                                       :extra_bonus_exp, :start_at, :end_at, :bonus_end_at,
+                                       :start_at, :end_at, :bonus_end_at,
                                        :published, :mode, :autograded, :password, :tabbed_view,
                                        :skippable, folder_params)
   end

--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -30,4 +30,10 @@ module Course::Assessment::AssessmentsHelper
       @assessments.any? { |assessment| assessment.end_at.present? }
     end
   end
+
+  def show_time_bonus_exp?
+    @show_time_bonus_exp ||= begin
+      @assessments.any? { |assessment| assessment.time_bonus_exp > 0 }
+    end
+  end
 end

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -19,14 +19,6 @@ class Course::LessonPlan::Item < ActiveRecord::Base
   belongs_to :course, inverse_of: :lesson_plan_items
   has_many :todos, class_name: Course::LessonPlan::Todo, inverse_of: :item, dependent: :destroy
 
-  # Gives the maximum number of EXP Points that an EXP-awarding item
-  # is allocated to give, which is the sum of base and bonus EXPs.
-  #
-  # @return [Integer] Maximum EXP awardable.
-  def total_exp
-    base_exp + time_bonus_exp + extra_bonus_exp
-  end
-
   # Copy attributes for lesson plan item from the object being duplicated.
   # Shift the time related fields.
   #

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -30,7 +30,6 @@ class Course::LessonPlan::Item < ActiveRecord::Base
     self.published = other.published
     self.base_exp = other.base_exp
     self.time_bonus_exp = other.time_bonus_exp
-    self.extra_bonus_exp = other.extra_bonus_exp
     self.start_at = other.start_at + time_shift
     self.bonus_end_at = other.bonus_end_at + time_shift if other.bonus_end_at
     self.end_at = other.end_at + time_shift if other.end_at
@@ -42,7 +41,6 @@ class Course::LessonPlan::Item < ActiveRecord::Base
   def set_default_values
     self.base_exp ||= 0
     self.time_bonus_exp ||= 0
-    self.extra_bonus_exp ||= 0
   end
 
   # User must set bonus_end_at if there's bonus exp

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -7,7 +7,9 @@
               course_assessment_path(current_course, assessment))
 
   - if current_course.gamified?
-    td.table-experience-points = assessment.total_exp
+    td.table-base-exp = assessment.base_exp
+    - if show_time_bonus_exp?
+      td.table-time-bonus-exp = assessment.time_bonus_exp
   - unless current_component_host[:course_achievements_component].nil?
     td.achievement-badge.table-requirement-for
       - achievement_conditionals = @conditional_service.achievement_conditional_for(assessment)

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -5,7 +5,6 @@
   - if current_course.gamified?
     = f.input :base_exp
     = f.input :time_bonus_exp
-    = f.input :extra_bonus_exp
   = f.input :start_at
   = f.input :end_at
   - if current_course.gamified?

--- a/app/views/course/assessment/assessments/index.html.slim
+++ b/app/views/course/assessment/assessments/index.html.slim
@@ -23,7 +23,9 @@ table.table.assessments-list.table-hover
       th = t('.title')
       th
       - if current_course.gamified?
-        th.table-experience-points = t('.maximum_experience_points')
+        th.table-base-exp = Course::LessonPlan::Item.human_attribute_name(:base_exp)
+        - if show_time_bonus_exp?
+          th.table-time-bonus-exp = Course::LessonPlan::Item.human_attribute_name(:time_bonus_exp)
       - unless current_component_host[:course_achievements_component].nil?
         th.table-requirement-for = t('.requirement_for')
       th.table-start-at = t('.start_at')

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -17,7 +17,7 @@
         td = @assessment.base_exp
       tr.bonus_exp
         th = t('.bonus_exp')
-        td = @assessment.time_bonus_exp + @assessment.extra_bonus_exp
+        td = @assessment.time_bonus_exp
       tr.start_at
         th = t('.start_at')
         td = format_datetime(@assessment.start_at)

--- a/config/locales/en/activerecord/course/lesson_plan.yml
+++ b/config/locales/en/activerecord/course/lesson_plan.yml
@@ -8,3 +8,7 @@ en:
               required: 'cannot be blank if time bonus exp is set'
             start_at:
               cannot_be_after_end_at: 'cannot be after end at'
+    attributes:
+      course/lesson_plan/item:
+        base_exp: 'Experience Points'
+        time_bonus_exp: 'Bonus Experience Points'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -13,7 +13,6 @@ en:
           start_at: 'Start At'
           bonus_cut_off: 'Bonus Cut Off'
           end_at: 'End At'
-          maximum_experience_points: 'Maximum Experience Points'
           requirement_for: 'Requirement For'
           new_assessment:
             autograded: 'Autograded Assessment'

--- a/db/migrate/20170110022335_remove_extra_bonus_exp_from_lesson_plan.rb
+++ b/db/migrate/20170110022335_remove_extra_bonus_exp_from_lesson_plan.rb
@@ -1,0 +1,5 @@
+class RemoveExtraBonusExpFromLessonPlan < ActiveRecord::Migration
+  def change
+    remove_column :course_lesson_plan_items, :extra_bonus_exp, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170102053335) do
+ActiveRecord::Schema.define(version: 20170110022335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -513,7 +513,6 @@ ActiveRecord::Schema.define(version: 20170102053335) do
     t.boolean  "published",       :default=>false, :null=>false
     t.integer  "base_exp",        :null=>false
     t.integer  "time_bonus_exp",  :null=>false
-    t.integer  "extra_bonus_exp", :null=>false
     t.datetime "start_at",        :null=>false
     t.datetime "bonus_end_at"
     t.datetime "end_at"

--- a/spec/factories/course_lesson_plan_items.rb
+++ b/spec/factories/course_lesson_plan_items.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     course
     base_exp          { rand(1..10) * 100 }
     time_bonus_exp    { rand(1..10) * 100 }
-    extra_bonus_exp   { rand(1..10) * 100 }
     start_at { 1.day.ago }
     bonus_end_at { 1.day.from_now }
     end_at { nil }

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature 'Course: Assessments: Management' do
         fill_in 'assessment_description', with: assessment.description
         fill_in 'assessment_base_exp', with: assessment.base_exp
         fill_in 'assessment_time_bonus_exp', with: assessment.time_bonus_exp
-        fill_in 'assessment_extra_bonus_exp', with: assessment.extra_bonus_exp
         fill_in 'assessment_start_at', with: assessment.start_at
         fill_in 'assessment_end_at', with: assessment.end_at
         fill_in 'assessment_bonus_end_at', with: assessment.bonus_end_at
@@ -63,7 +62,6 @@ RSpec.feature 'Course: Assessments: Management' do
         fill_in 'assessment_description', with: assessment.description
         fill_in 'assessment_base_exp', with: assessment.base_exp
         fill_in 'assessment_time_bonus_exp', with: assessment.time_bonus_exp
-        fill_in 'assessment_extra_bonus_exp', with: assessment.extra_bonus_exp
         fill_in 'assessment_start_at', with: assessment.start_at
         fill_in 'assessment_end_at', with: assessment.end_at
         fill_in 'assessment_bonus_end_at', with: assessment.bonus_end_at

--- a/spec/libraries/acts_as_lesson_plan_item_spec.rb
+++ b/spec/libraries/acts_as_lesson_plan_item_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'Extension: Acts as Lesson Plan Item' do
   subject(:dummy) { self.class::DummyClass.new }
   it { is_expected.to respond_to(:base_exp) }
   it { is_expected.to respond_to(:time_bonus_exp) }
-  it { is_expected.to respond_to(:extra_bonus_exp) }
   it { is_expected.to respond_to(:start_at) }
   it { is_expected.to respond_to(:end_at) }
   it { is_expected.to respond_to(:bonus_end_at) }

--- a/spec/libraries/acts_as_lesson_plan_item_spec.rb
+++ b/spec/libraries/acts_as_lesson_plan_item_spec.rb
@@ -25,23 +25,8 @@ RSpec.describe 'Extension: Acts as Lesson Plan Item' do
   it { is_expected.to respond_to(:start_at) }
   it { is_expected.to respond_to(:end_at) }
   it { is_expected.to respond_to(:bonus_end_at) }
-  it { is_expected.to respond_to(:total_exp) }
   it { is_expected.to respond_to(:acting_as) }
   it { expect(dummy.acting_as).to respond_to(:specific) }
-
-  context 'when functioning as an EXP Source' do
-    describe 'sets and sums EXP correctly' do
-      subject do
-        dummy.tap do |d|
-          d.base_exp = rand(1..10)
-          d.extra_bonus_exp = rand(1..10)
-        end
-      end
-      it 'has correct total EXP' do
-        expect(subject.total_exp).to eq(subject.base_exp + subject.extra_bonus_exp)
-      end
-    end
-  end
 
   context 'when declared to have a todo' do
     subject { self.class::DummyTodoClass }

--- a/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
@@ -22,17 +22,12 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
       end
     end
 
-    describe '#total_exp' do
-      it 'equals base exp plus bonuses' do
-        sum = lesson_plan_item.base_exp +
-              lesson_plan_item.time_bonus_exp +
-              lesson_plan_item.extra_bonus_exp
-        expect(lesson_plan_item.total_exp).to eq sum
-      end
-    end
-
     describe '#set_default_values' do
-      subject { Course::LessonPlan::Item.new.total_exp }
+      subject do
+        item = Course::LessonPlan::Item.new
+        item.base_exp + item.time_bonus_exp
+      end
+
       it { is_expected.to eq 0 }
     end
 

--- a/spec/services/course/duplication_service_spec.rb
+++ b/spec/services/course/duplication_service_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe Course::DuplicationService, type: :service do
           expect(new_assessment.description).to eq assessment.description
           expect(new_assessment.base_exp).to eq assessment.base_exp
           expect(new_assessment.time_bonus_exp).to eq assessment.time_bonus_exp
-          expect(new_assessment.extra_bonus_exp).to eq assessment.extra_bonus_exp
           expect(new_assessment.published).to eq assessment.published
           expect(new_assessment.start_at).to be_within(1.second).of assessment.start_at + 1.day
           expect(new_assessment.bonus_end_at).to be_within(1.second).


### PR DESCRIPTION
`extra_bonus_exp` is also removed because it is unused.

Fixes #1826. Fixes #1825.