### PR TITLE
Order assessments by title if their dates are same

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   def index
-    @assessments = @assessments.ordered_by_date.with_submissions_by(current_user)
+    @assessments = @assessments.ordered_by_date_and_title.with_submissions_by(current_user)
     @conditional_service = Course::Assessment::AchievementPreloadService.new(@assessments)
   end
 

--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::Video::VideosController < Course::Video::Controller
   def index #:nodoc:
-    @videos = @videos.ordered_by_date.with_submissions_by(current_user)
+    @videos = @videos.ordered_by_date_and_title.with_submissions_by(current_user)
   end
 
   def show; end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -56,13 +56,13 @@ class Course::Assessment < ActiveRecord::Base
       where { course_assessment_questions.assessment_id == course_assessments.id }
   end)
 
-  # @!method self.ordered_by_date
-  #   Orders the assessments by the starting date.
-  scope :ordered_by_date, (lambda do
+  # @!method self.ordered_by_date_and_title
+  #   Orders the assessments by the starting date and title.
+  scope :ordered_by_date_and_title, (lambda do
     select('course_assessments.*').
-      select { lesson_plan_item.start_at }.
+      select { [lesson_plan_item.start_at, lesson_plan_item.title] }.
       joins { lesson_plan_item }.
-      merge(Course::LessonPlan::Item.ordered_by_date)
+      merge(Course::LessonPlan::Item.ordered_by_date_and_title)
   end)
 
   # @!method with_submissions_by(creator)

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -17,6 +17,10 @@ class Course::LessonPlan::Item < ActiveRecord::Base
     order { start_at }
   end)
 
+  scope :ordered_by_date_and_title, (lambda do
+    order(:start_at, :title)
+  end)
+
   belongs_to :course, inverse_of: :lesson_plan_items
   has_many :todos, class_name: Course::LessonPlan::Todo, inverse_of: :item, dependent: :destroy
 

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -9,13 +9,13 @@ class Course::Video < ActiveRecord::Base
                          inverse_of: :video, dependent: :destroy
 
   # TODO: Refactor this together with assessments.
-  # @!method self.ordered_by_date
-  #   Orders the videos by the starting date.
-  scope :ordered_by_date, (lambda do
+  # @!method self.ordered_by_date_and_title
+  #   Orders the videos by the starting date and title.
+  scope :ordered_by_date_and_title, (lambda do
     select('course_videos.*').
-      select('course_lesson_plan_items.start_at').
+      select('course_lesson_plan_items.start_at, course_lesson_plan_items.title').
       joins { lesson_plan_item }.
-      merge(Course::LessonPlan::Item.ordered_by_date)
+      merge(Course::LessonPlan::Item.ordered_by_date_and_title)
   end)
 
   # @!method with_submissions_by(creator)

--- a/app/views/course/assessment/submissions/_filter.html.slim
+++ b/app/views/course/assessment/submissions/_filter.html.slim
@@ -13,7 +13,7 @@ div.submissions-filter
         label: category.title.singularize,
         selected: lambda { |assessment| assessment[1] == assessment_id },
         include_blank: '',
-        collection: @category.assessments.ordered_by_date.published.map { |a| [a.title, a.id] }
+        collection: @category.assessments.ordered_by_date_and_title.published.map { |a| [a.title, a.id] }
     = f.input :group_id,
         as: :select,
         required: false,

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -268,15 +268,22 @@ RSpec.describe Course::Assessment do
       end
     end
 
-    describe '.ordered_by_date' do
-      let(:other_assessment) { create(:assessment, *assessment_traits, course: course) }
+    describe '.ordered_by_date_and_title' do
+      let(:course) { create(:course) }
+      let(:start_at) { DateTime.new(2017, 1, 1).utc }
+      let!(:assessment1) do
+        create(:assessment, title: 'A', course: course, start_at: start_at)
+      end
+      let!(:assessment2) do
+        create(:assessment, title: 'B', course: course, start_at: start_at)
+      end
+      let!(:assessment3) do
+        create(:assessment, title: 'A', course: course, start_at: start_at + 1.day)
+      end
 
-      it 'orders the assessments by date' do
-        assessment
-        other_assessment
-        consecutive = course.assessments.each_cons(2)
-        expect(consecutive.to_a).not_to be_empty
-        expect(consecutive.all? { |first, second| first.start_at <= second.start_at })
+      it 'orders the assessments by date and title' do
+        expect(course.assessments.ordered_by_date_and_title).
+          to eq([assessment1, assessment2, assessment3])
       end
     end
 

--- a/spec/models/course/video_spec.rb
+++ b/spec/models/course/video_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Course::Video, type: :model do
     let(:video1) { create(:video, course: course) }
     let(:video2) { create(:video, course: course, start_at: Time.zone.now - 1.month) }
 
-    describe '.ordered_by_date' do
-      it 'orders the videos by date' do
+    describe '.ordered_by_date_and_title' do
+      it 'orders the videos by date and title' do
         video1
         video2
-        consecutive = course.videos.each_cons(2)
+        consecutive = course.videos.ordered_by_date_and_title.each_cons(2)
         expect(consecutive.to_a).not_to be_empty
         expect(consecutive.all? { |first, second| first.start_at <= second.start_at })
       end


### PR DESCRIPTION
Fix #1812 

Should consider using a new column to store the hash, instead of the milliseconds part of the start/end_at