### PR TITLE
Implement scaffold views for video

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -27,6 +27,7 @@ $course-discussion-post-shadow-color: $gray-lighter !default;
 $course-discussion-post-annotation-trigger-bg-color: $body-bg !default;
 $course-discussion-post-annotation-trigger-color: $brand-primary !default;
 $course-forum-unread-highlight: #f8e3e3 !default;
+$course-video-not-started-bg: $gray-lighter !default;
 
 
 //== Fonts

--- a/app/assets/stylesheets/course/video/videos.scss
+++ b/app/assets/stylesheets/course/video/videos.scss
@@ -1,0 +1,26 @@
+.course-video-videos {
+  &.show {
+    .details-table {
+      margin-top: 1.5em;
+    }
+  }
+
+  &.index {
+    .videos-list {
+      table-layout: fixed;
+
+      tr.not-started {
+        background-color: $course-video-not-started-bg;
+      }
+
+      td,
+      th {
+        vertical-align: middle;
+      }
+
+      .table-start-at {
+        @extend .text-center;
+      }
+    }
+  }
+}

--- a/app/controllers/components/course/videos_component.rb
+++ b/app/controllers/components/course/videos_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+class Course::VideosComponent < SimpleDelegator
+  include Course::ControllerComponentHost::Component
+
+  def self.display_name
+    I18n.t('components.video.name')
+  end
+
+  def self.enabled_by_default?
+    false
+  end
+
+  def sidebar_items
+    main_sidebar_items + settings_sidebar_items
+  end
+
+  def settings
+    @settings ||= Course::VideoSettings.new(current_course.settings(:video))
+  end
+
+  private
+
+  def main_sidebar_items
+    [
+      {
+        key: :videos,
+        icon: 'video-camera',
+        title: settings.title || t('course.video.videos.sidebar_title'),
+        weight: 4,
+        path: course_videos_path(current_course)
+      }
+    ]
+  end
+
+  def settings_sidebar_items
+    [
+      {
+        title: settings.title || t('course.video.videos.sidebar_title'),
+        type: :settings,
+        weight: 4,
+        path: course_admin_videos_path(current_course)
+      }
+    ]
+  end
+end

--- a/app/controllers/course/admin/video_settings_controller.rb
+++ b/app/controllers/course/admin/video_settings_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class Course::Admin::VideoSettingsController < Course::Admin::Controller
+  add_breadcrumb :edit, :course_admin_videos_path
+  before_action :load_settings
+
+  def edit; end
+
+  def update
+    if @settings.update(video_settings_params) && current_course.save
+      redirect_to course_admin_videos_path(current_course), success: t('.success')
+    else
+      render 'edit'
+    end
+  end
+
+  private
+
+  def video_settings_params #:nodoc:
+    params.require(:video_settings).permit(:title)
+  end
+
+  # Load our settings adapter to handle video settings
+  def load_settings
+    @settings ||= Course::VideoSettings.new(current_course.settings(:video))
+  end
+end

--- a/app/controllers/course/video/controller.rb
+++ b/app/controllers/course/video/controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class Course::Video::Controller < Course::ComponentController
+  load_and_authorize_resource :video, through: :course, class: Course::Video.name
+  before_action :add_videos_breadcrumb
+
+  private
+
+  def add_videos_breadcrumb
+    add_breadcrumb @settings.title || :index, :course_videos_path
+  end
+
+  # @return [Course::Video Component] The video component.
+  # @return [nil] If video component is disabled.
+  def component
+    current_component_host[:course_videos_component]
+  end
+end

--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -3,4 +3,41 @@ class Course::Video::VideosController < Course::Video::Controller
   def index #:nodoc:
     @videos = @videos.ordered_by_date
   end
+
+  def show; end
+
+  def new; end
+
+  def create
+    if @video.save
+      redirect_to course_videos_path(current_course), success: t('.success', title: @video.title)
+    else
+      render 'new'
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @video.update(video_params)
+      redirect_to course_videos_path(current_course), success: t('.success', title: @video.title)
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    if @video.destroy
+      redirect_to course_videos_path(current_course), success: t('.success', title: @video.title)
+    else
+      redirect_to course_videos_path(current_course),
+                  danger: t('.failure', error: @video.errors.full_messages.to_sentence)
+    end
+  end
+
+  private
+
+  def video_params
+    params.require(:video).permit(:title, :description, :start_at, :url, :published)
+  end
 end

--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Course::Video::VideosController < Course::Video::Controller
+  def index #:nodoc:
+    @videos = @videos.ordered_by_date
+  end
+end

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module Course::VideosAbilityComponent
+  include AbilityHost::Component
+
+  def define_permissions
+    if user
+      allow_student_show_video
+      allow_student_attempt_video
+      allow_staff_manage_video
+    end
+
+    super
+  end
+
+  private
+
+  def video_all_course_users_hash
+    { lesson_plan_item: course_all_course_users_hash }
+  end
+
+  def video_all_course_staff_hash
+    { lesson_plan_item: course_staff_hash }
+  end
+
+  def video_published_all_course_users_hash
+    { lesson_plan_item: { published: true } }.deep_merge(video_all_course_users_hash)
+  end
+
+  def allow_student_show_video
+    can :read, Course::Video, video_published_all_course_users_hash
+  end
+
+  def allow_student_attempt_video
+    can :attempt, Course::Video do |video|
+      video.started? && video.published?
+    end
+  end
+
+  def allow_staff_manage_video
+    can :manage, Course::Video, video_all_course_staff_hash
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -52,6 +52,7 @@ class Course < ActiveRecord::Base
   has_many :discussion_topics, class_name: Course::Discussion::Topic.name, inverse_of: :course
   has_many :forums, dependent: :destroy, inverse_of: :course
   has_many :surveys, through: :lesson_plan_items, source: :actable, source_type: Course::Survey.name
+  has_many :videos, through: :lesson_plan_items, source: :actable, source_type: Course::Video.name
 
   accepts_nested_attributes_for :invitations, :assessment_categories
 

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -9,6 +9,16 @@ class Course::Video < ActiveRecord::Base
   has_many :submissions, class_name: Course::Video::Submission.name,
                          inverse_of: :video, dependent: :destroy
 
+  # TODO: Refactor this together with assessments.
+  # @!method self.ordered_by_date
+  #   Orders the videos by the starting date.
+  scope :ordered_by_date, (lambda do
+    select('course_videos.*').
+      select('course_lesson_plan_items.start_at').
+      joins { lesson_plan_item }.
+      merge(Course::LessonPlan::Item.ordered_by_date)
+  end)
+
   def self.use_relative_model_naming?
     true
   end

--- a/app/models/course/video_settings.rb
+++ b/app/models/course/video_settings.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+class Course::VideoSettings
+  include ActiveModel::Model
+  include ActiveModel::Conversion
+  include ActiveModel::Validations
+
+  # Initialises the settings adapter
+  #
+  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
+  def initialize(settings)
+    @settings = settings
+  end
+
+  # Returns the title of video component
+  #
+  # @return [String] The custom or default title of video component
+  def title
+    @settings.title
+  end
+
+  # Sets the title of video component
+  #
+  # @param [String] title The new title
+  def title=(title)
+    title = nil unless title.present?
+    @settings.title = title
+  end
+
+  # Update settings with the hash attributes
+  #
+  # @param [Hash] attributes The hash who stores the new settings
+  def update(attributes)
+    attributes.each { |k, v| send("#{k}=", v) }
+    valid?
+  end
+
+  def persisted? #:nodoc:
+    true
+  end
+end

--- a/app/views/course/admin/video_settings/edit.html.slim
+++ b/app/views/course/admin/video_settings/edit.html.slim
@@ -1,0 +1,4 @@
+= simple_form_for @settings, url: course_admin_videos_path(current_course) do |f|
+  = f.error_notification
+  = f.input :title, as: :string, placeholder: t('.title_placeholder')
+  = f.button :submit

--- a/app/views/course/video/videos/_form.html.slim
+++ b/app/views/course/video/videos/_form.html.slim
@@ -1,0 +1,9 @@
+= simple_form_for [current_course, @video] do |f|
+  = f.error_notification
+  = f.input :title
+  = f.input :description
+  = f.input :url
+  = f.input :start_at
+  = f.input :published
+
+  = f.button :submit

--- a/app/views/course/video/videos/_video.html.slim
+++ b/app/views/course/video/videos/_video.html.slim
@@ -1,0 +1,14 @@
+= content_tag_for(:tr, video, class: time_period_class(video) + draft_class(video))
+  th colspan=2
+    - unless video.published?
+      span title=draft_message(video)
+        => fa_icon 'ban'.freeze
+    = link_to(format_inline_text(video.title),
+      course_video_path(current_course, video))
+  td.table-start-at
+    = format_datetime(video.start_at, :short)
+  td.table-buttons colspan=2
+    - if can?(:manage, video)
+      div.btn-group
+        = edit_button([current_course, video])
+        = delete_button([current_course, video])

--- a/app/views/course/video/videos/edit.html.slim
+++ b/app/views/course/video/videos/edit.html.slim
@@ -1,0 +1,3 @@
+- add_breadcrumb format_inline_text(@video.title)
+= page_header
+= render 'form'

--- a/app/views/course/video/videos/index.html.slim
+++ b/app/views/course/video/videos/index.html.slim
@@ -1,1 +1,14 @@
-= page_header
+= page_header do
+  - if can?(:manage, Course::Video.new(course: current_course))
+    = new_button([current_course, :video])
+
+table.table.videos-list.table-hover
+  thead
+    tr
+      th = t('.title')
+      th
+      th.table-start-at = t('.start_at')
+      th
+      th
+  tbody
+    = render partial: 'video', collection: @videos

--- a/app/views/course/video/videos/index.html.slim
+++ b/app/views/course/video/videos/index.html.slim
@@ -1,0 +1,1 @@
+= page_header

--- a/app/views/course/video/videos/new.html.slim
+++ b/app/views/course/video/videos/new.html.slim
@@ -1,0 +1,3 @@
+- add_breadcrumb :new
+= page_header
+= render 'form'

--- a/app/views/course/video/videos/show.html.slim
+++ b/app/views/course/video/videos/show.html.slim
@@ -1,0 +1,6 @@
+- add_breadcrumb format_inline_text(@video.title)
+= page_header format_inline_text(@video.title) do
+
+= div_for(@video) do
+  h3 = t('.description')
+  = format_html(@video.description)

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -37,7 +37,8 @@ en:
         discussion:
           topic_settings:
             edit: :'course.discussion.topics.index.header'
-
+        video_settings:
+          edit: :'course.video.videos.index.header'
       users:
         index: 'Users'
         students: :'course.users.students.header'
@@ -129,6 +130,9 @@ en:
       discussion:
         topics:
           index: :'course.discussion.topics.index.header'
+      video:
+        videos:
+          index: :'course.video.videos.index.header'
     system:
       admin:
         controller:

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -133,6 +133,7 @@ en:
       video:
         videos:
           index: :'course.video.videos.index.header'
+          new: :'course.video.videos.new.header'
     system:
       admin:
         controller:

--- a/config/locales/en/components.yml
+++ b/config/locales/en/components.yml
@@ -27,3 +27,5 @@ en:
       name: 'Points Disbursement'
     duplication:
       name: 'Duplication'
+    video:
+      name: :'course.video.videos.index.header'

--- a/config/locales/en/course/admin/video_settings.yml
+++ b/config/locales/en/course/admin/video_settings.yml
@@ -1,0 +1,8 @@
+en:
+  course:
+    admin:
+      video_settings:
+        edit:
+          title_placeholder: 'Leave blank to use default title'
+        update:
+          success: 'Video settings updated.'

--- a/config/locales/en/course/video/videos.yml
+++ b/config/locales/en/course/video/videos.yml
@@ -1,0 +1,7 @@
+en:
+  course:
+    video:
+      videos:
+        sidebar_title: :'course.video.videos.index.header'
+        index:
+          header: 'Videos'

--- a/config/locales/en/course/video/videos.yml
+++ b/config/locales/en/course/video/videos.yml
@@ -5,3 +5,18 @@ en:
         sidebar_title: :'course.video.videos.index.header'
         index:
           header: 'Videos'
+          title: 'Title'
+          start_at: 'Start At'
+        new:
+          header: 'New Video'
+        create:
+          success: '%{title} was created.'
+        show:
+          description: 'Description'
+        edit:
+          header: 'Edit Video'
+        update:
+          success: 'Video %{title} was updated.'
+        destroy:
+          success: '%{title} was deleted.'
+          failure: 'Could not delete video: %{error}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,8 +114,10 @@ Rails.application.routes.draw do
 
         get 'components' => 'component_settings#edit'
         patch 'components' => 'component_settings#update'
+
         get 'sidebar' => 'sidebar_settings#edit'
         patch 'sidebar' => 'sidebar_settings#update'
+
         get 'announcements' => 'announcement_settings#edit'
         patch 'announcements' => 'announcement_settings#update'
 
@@ -133,6 +135,9 @@ Rails.application.routes.draw do
 
         get 'topics' => 'discussion/topic_settings#edit', path: 'comments'
         patch 'topics' => 'discussion/topic_settings#update', path: 'comments'
+
+        get'videos' => 'video_settings#edit'
+        patch 'videos' => 'video_settings#update'
 
         namespace 'assessments' do
           resources :categories, only: [:new, :create, :destroy] do
@@ -289,6 +294,10 @@ Rails.application.routes.draw do
 
       get 'statistics/student'
       get 'statistics/staff'
+
+      scope module: :video do
+        resources :videos, only: [:index]
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,7 +296,7 @@ Rails.application.routes.draw do
       get 'statistics/staff'
 
       scope module: :video do
-        resources :videos, only: [:index]
+        resources :videos
       end
     end
   end

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     published false
     tabbed_view false
 
-    trait :unopened do
+    trait :not_started do
       start_at { 1.day.from_now }
     end
 

--- a/spec/factories/course_video_videos.rb
+++ b/spec/factories/course_video_videos.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   sequence(:course_video_title) { |n| "Video #{n}" }
+  sequence(:course_video_description) { |n| "Video Description #{n}" }
   factory :course_video, class: Course::Video.name, aliases: [:video],
                          parent: :course_lesson_plan_item do
     course
     title { generate(:course_video_title) }
+    description { generate(:course_video_description) }
     url 'https://www.youtube.com/watch?v=i_YiovUyMds'
     published false
 

--- a/spec/factories/course_video_videos.rb
+++ b/spec/factories/course_video_videos.rb
@@ -6,5 +6,14 @@ FactoryGirl.define do
     course
     title { generate(:course_video_title) }
     url 'https://www.youtube.com/watch?v=i_YiovUyMds'
+    published false
+
+    trait :not_started do
+      start_at { 1.day.from_now }
+    end
+
+    trait :published do
+      published true
+    end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -21,5 +21,11 @@ FactoryGirl.define do
     trait :opened do
       status :opened
     end
+
+    trait :with_video_component_enabled do
+      after(:build) do |course|
+        course.settings(:components, :course_videos_component).enabled = true
+      end
+    end
   end
 end

--- a/spec/factories/instances.rb
+++ b/spec/factories/instances.rb
@@ -8,5 +8,11 @@ FactoryGirl.define do
   factory :instance do
     sequence(:name) { |n| "Instance#{n}" }
     host
+
+    trait :with_video_component_enabled do
+      after(:build) do |instance|
+        instance.settings(:components, :course_videos_component).enabled = true
+      end
+    end
   end
 end

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -2,10 +2,10 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Components' do
-  let!(:instance) { Instance.default }
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
 
   with_tenant(:instance) do
-    let(:course) { create(:course) }
+    let(:course) { create(:course, :with_video_component_enabled) }
     let(:components) { Course::ControllerComponentHost.components.select(&:can_be_disabled?) }
     let(:sample_component_id) do
       "settings_effective_enabled_component_ids_#{components.sample.key}"

--- a/spec/features/course/admin/video_settings_spec.rb
+++ b/spec/features/course/admin/video_settings_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Course: Administration: Videos' do
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course, :with_video_component_enabled) }
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Manager' do
+      let(:user) { create(:course_manager, course: course).user }
+
+      scenario 'I can change the videos title' do
+        visit course_admin_videos_path(course)
+
+        new_title = 'New Title'
+        empty_title = ''
+
+        fill_in 'video_settings_title', with: new_title
+        click_button 'update'
+        expect(page).
+          to have_selector('div', text: I18n.t('course.admin.video_settings.update.success'))
+        expect(page).to have_field('video_settings_title', with: new_title)
+        expect(page).to have_selector('li a', text: new_title)
+
+        fill_in 'video_settings_title', with: empty_title
+        click_button 'update'
+        expect(page).
+          to have_selector('div', text: I18n.t('course.admin.video_settings.update.success'))
+        expect(page).to have_selector('li a', text: I18n.t('course.video.videos.sidebar_title'))
+      end
+    end
+  end
+end

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'Course: Assessments: Attempt' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:empty_assessment) { create(:assessment, course: course, published: false) }
-    let(:unopened_assessment) do
-      create(:assessment, :published_with_all_question_types, :unopened, course: course)
+    let(:not_started_assessment) do
+      create(:assessment, :published_with_all_question_types, :not_started, course: course)
     end
     let(:assessment) { create(:assessment, :published_with_all_question_types, course: course) }
     let(:assessment_tabbed_single_question) do
@@ -91,11 +91,11 @@ RSpec.describe 'Course: Assessments: Attempt' do
           to eq(edit_course_assessment_submission_path(course, assessment, created_submission))
       end
 
-      scenario 'I cannot attempt unopened assessments' do
-        unopened_assessment
+      scenario 'I cannot attempt assessments that have not started' do
+        not_started_assessment
         visit course_assessments_path(course)
 
-        within find(content_tag_selector(unopened_assessment)) do
+        within find(content_tag_selector(not_started_assessment)) do
           expect(page).not_to have_button(
             I18n.t('course.assessment.assessments.assessment_management_buttons.attempt')
           )
@@ -188,18 +188,18 @@ RSpec.describe 'Course: Assessments: Attempt' do
         ))
       end
 
-      scenario 'I can attempt unopened assessments' do
-        unopened_assessment
+      scenario 'I can attempt assessments that have not started' do
+        not_started_assessment
         visit course_assessments_path(course)
 
-        within find(content_tag_selector(unopened_assessment)) do
+        within find(content_tag_selector(not_started_assessment)) do
           find_link(I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-                    href: course_assessment_submissions_path(course, unopened_assessment)).click
+                    href: course_assessment_submissions_path(course, not_started_assessment)).click
         end
 
-        created_submission = unopened_assessment.submissions.last
+        created_submission = not_started_assessment.submissions.last
         expect(current_path).to eq(
-          edit_course_assessment_submission_path(course, unopened_assessment, created_submission)
+          edit_course_assessment_submission_path(course, not_started_assessment, created_submission)
         )
       end
 

--- a/spec/features/course/video/video_management_spec.rb
+++ b/spec/features/course/video/video_management_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Course: Videos: Management' do
+  let(:instance) { create(:instance, :with_video_component_enabled) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course, :with_video_component_enabled) }
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Teaching Assistant' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
+
+      scenario 'I can create a video' do
+        video = build_stubbed(:video)
+        visit course_videos_path(course)
+
+        click_link(nil, href: new_course_video_path(course))
+        expect(page).to have_selector('h1', text: I18n.t('course.video.videos.new.header'))
+
+        fill_in 'video_title', with: video.title
+        fill_in 'video_description', with: video.description
+        fill_in 'video_start_at', with: video.start_at
+        fill_in 'video_url', with: video.url
+
+        click_button 'submit'
+
+        expect(current_path).to eq(course_videos_path(course))
+        expect(page).to have_selector('div.alert.alert-success')
+
+        video_created = course.videos.last
+        expect(page).to have_content_tag_for(video_created)
+      end
+
+      scenario 'I can edit or delete a video from the videos page' do
+        unpublished_video = create(:video, course: course)
+        edit_path = edit_course_video_path(course, unpublished_video)
+
+        # Edit video Page
+        visit course_videos_path(course)
+        within find(content_tag_selector(unpublished_video)) do
+          find('.btn.btn-default.edit').click
+        end
+        expect(current_path).to eq(edit_path)
+        new_title = 'zzz'
+
+        fill_in 'video_title', with: new_title
+        click_button 'submit'
+
+        expect(unpublished_video.reload.title).to eq(new_title)
+        expect(current_path).to eq(course_videos_path(course))
+
+        # Delete video
+        expect do
+          within find(content_tag_selector(unpublished_video)) do
+            find('.btn.btn-danger.delete').click
+          end
+        end.to change { course.videos.count }.by(-1)
+      end
+    end
+  end
+end

--- a/spec/features/course/video/video_viewing_spec.rb
+++ b/spec/features/course/video/video_viewing_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Course: Videos: Viewing' do
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
+
+  with_tenant(:instance) do
+    let!(:course) { create(:course, :with_video_component_enabled) }
+    let(:unpublished_video) { create(:video, course: course) }
+    let(:published_video) { create(:video, :published, course: course) }
+    let(:published_not_started_video) { create(:video, :published, :not_started, course: course) }
+    let(:videos) { [unpublished_video, published_video, published_not_started_video] }
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Student' do
+      let(:user) { create(:course_student, course: course).user }
+
+      scenario 'I can view all published videos on the videos page' do
+        videos
+        visit course_videos_path(course)
+
+        [published_video, published_not_started_video].each do |video|
+          expect(page).to have_content_tag_for(video)
+        end
+
+        expect(page).not_to have_content_tag_for(unpublished_video)
+      end
+    end
+  end
+end

--- a/spec/models/course/condition/assessment_ability_spec.rb
+++ b/spec/models/course/condition/assessment_ability_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Course::Condition::Assessment do
       let(:user) { create(:course_student, course: course).user }
 
       context 'when the assessment is published but has not started' do
-        let(:unopened_assessment) do
-          create(:assessment, :published_with_mrq_question, :unopened, course: course)
+        let(:not_started_assessment) do
+          create(:assessment, :published_with_mrq_question, :not_started, course: course)
         end
 
-        it { is_expected.to_not be_able_to(:attempt, unopened_assessment) }
+        it { is_expected.to_not be_able_to(:attempt, not_started_assessment) }
       end
 
       context 'when the assessment has started' do

--- a/spec/models/course/video/video_ability_spec.rb
+++ b/spec/models/course/video/video_ability_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Video do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    subject { Ability.new(user) }
+    let(:course) { create(:course) }
+    let(:course_user) { create(:course_student, course: course) }
+    let(:draft_video) { create(:video, course: course) }
+    let(:published_video) { create(:video, :published, course: course) }
+    let(:published_video_not_started) { create(:video, :not_started, :published, course: course) }
+    let(:other_course) { create(:course) }
+    let(:other_video) { create(:video, :published, course: other_course) }
+
+    context 'when the user is a Course Student' do
+      let(:user) { course_user.user }
+
+      # Course Video
+      it { is_expected.not_to be_able_to(:read, other_video) }
+      it { is_expected.not_to be_able_to(:read, draft_video) }
+      it { is_expected.to be_able_to(:read, published_video) }
+      it { is_expected.to be_able_to(:read, published_video_not_started) }
+
+      # Course Video Submissions
+      it { is_expected.not_to be_able_to(:attempt, draft_video) }
+      it { is_expected.not_to be_able_to(:attempt, published_video_not_started) }
+      it { is_expected.to be_able_to(:attempt, published_video) }
+    end
+
+    context 'when the user is a Course Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
+
+      # Course Video
+      it { is_expected.to be_able_to(:manage, draft_video) }
+      it { is_expected.to be_able_to(:manage, published_video) }
+    end
+  end
+end

--- a/spec/models/course/video_spec.rb
+++ b/spec/models/course/video_spec.rb
@@ -4,4 +4,21 @@ require 'rails_helper'
 RSpec.describe Course::Video, type: :model do
   it { is_expected.to act_as(Course::LessonPlan::Item) }
   it { is_expected.to have_many(:submissions).inverse_of(:video).dependent(:destroy) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:video1) { create(:video, course: course) }
+    let(:video2) { create(:video, course: course) }
+
+    describe '.ordered_by_date' do
+      it 'orders the videos by date' do
+        video1
+        video2
+        consecutive = course.videos.each_cons(2)
+        expect(consecutive.to_a).not_to be_empty
+        expect(consecutive.all? { |first, second| first.start_at <= second.start_at })
+      end
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Course, type: :model do
     it { is_expected.to have_many(:lesson_plan_items).dependent(:destroy) }
     it { is_expected.to have_many(:lesson_plan_milestones).dependent(:destroy) }
     it { is_expected.to have_many(:material_folders).dependent(:destroy) }
+    it { is_expected.to have_many(:surveys).through(:lesson_plan_items) }
+    it { is_expected.to have_many(:videos).through(:lesson_plan_items) }
 
     it { is_expected.to validate_presence_of(:title) }
 


### PR DESCRIPTION
This PR implements the following:
 - Basic views for videos: index, show, edit, new. Also implemented update and destroy actions as well.
 - Permissions for videos
 - Settings for videos
 - Video component

Next steps: 
 - Implement views and controllers for video submissions
 - Implement URL validator at the model level (only whitelist youtube?)