### PR TITLE
Do not create instance_users for system admin after sign in

### DIFF
--- a/app/models/concerns/user_authentication_concern.rb
+++ b/app/models/concerns/user_authentication_concern.rb
@@ -9,7 +9,7 @@ module UserAuthenticationConcern
     devise :multi_email_authenticatable, :multi_email_confirmable, :multi_email_validatable,
            :registerable, :recoverable, :rememberable, :trackable, :masqueradable
 
-    before_sign_in :create_instance_user
+    before_sign_in :create_instance_user, unless: :administrator?
     after_create :create_instance_user
 
     include UserOmniauthConcern

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -3,22 +3,48 @@ require 'rails_helper'
 
 RSpec.feature 'Users: Sign In' do
   let(:instance) { Instance.default }
+  let(:other_instance) { create(:instance) }
+  let(:password) { '12345678' }
+
   with_tenant(:instance) do
-    scenario 'I can sign in if I am a user in another instance' do
-      other_instance = create(:instance)
-      password = 'abcdefghi'
-      user = nil
-      ActsAsTenant.with_tenant(other_instance) do
-        user = create(:user, password: password)
+    context 'As a user from another instance' do
+      let(:user) do
+        user = nil
+        ActsAsTenant.with_tenant(other_instance) do
+          user = create(:user, password: password)
+        end
+        user
       end
 
-      visit new_user_session_path
-      fill_in 'user_email', with: user.email
-      fill_in 'user_password', with: user.password
+      scenario 'I can sign in to current instance' do
+        visit new_user_session_path
+        fill_in 'user_email', with: user.email
+        fill_in 'user_password', with: user.password
 
-      expect do
-        click_button I18n.t('user.sessions.new.sign_in')
-      end.to change { instance.instance_users.exists?(user: user) }.from(false).to(true)
+        expect do
+          click_button I18n.t('user.sessions.new.sign_in')
+        end.to change { instance.instance_users.exists?(user: user) }.from(false).to(true)
+      end
+
+      context 'As a system administrator' do
+        let(:user) do
+          user = nil
+          ActsAsTenant.with_tenant(other_instance) do
+            user = create(:administrator, password: password)
+          end
+          user
+        end
+
+        scenario 'I can sign in to current instance' do
+          visit new_user_session_path
+          fill_in 'user_email', with: user.email
+          fill_in 'user_password', with: password
+
+          click_button I18n.t('user.sessions.new.sign_in')
+          expect(page).to have_selector('div.alert', text: I18n.t('user.signed_in'))
+          expect(instance.instance_users.exists?(user: user)).to be_falsy
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
For #1822

I don't have perfect solution for this problem yet. Because:

- If we want a single account to be able to login into every instance, the instance users must be created. 

- An option would be:  Do not allow users to directly login to other instances unless they have signed up in that instance
But for this option we need to implement a different sign up flow for the user who has an account in Coursemology, but not in the instance.

Based on those, I decided to disable instance_user creation for admin first. Instance users are only used for permission and user count tracking now, and admins are not affected by permissions because they can manage everything. 

Any thoughts ? 