### PR TITLE
Show assessment files in submission edit page

### DIFF
--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -108,6 +108,10 @@
     .tab-header {
       margin-bottom: 0;
     }
+
+    .files {
+      margin-bottom: 20px;
+    }
   }
 
   &.index {

--- a/app/views/course/assessment/submission/submissions/edit.html.slim
+++ b/app/views/course/assessment/submission/submissions/edit.html.slim
@@ -4,6 +4,11 @@
   div.well
     = format_html(@assessment.description)
 
+- unless @assessment.folder.materials.empty?
+  .files
+    h4 = t('.files')
+    = render partial: 'layouts/materials', locals: { folder: @assessment.folder }
+
 = div_for(@assessment, 'data-assessment-id' => @assessment.id,
                        class: single_question_flag_class(@assessment)) do
   = div_for(@submission, 'data-submission-id' => @submission.id) do

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -23,6 +23,7 @@ en:
             failure: 'Could not create submission: %{error}'
           edit:
             attempt: :'course.assessment.assessments.assessment.attempt'
+            files: 'Files'
           publish_all:
             success: 'All graded submissions have been published.'
             notice: 'There are no graded submissions.'


### PR DESCRIPTION
Related to #1790 

<img width="443" alt="screen shot 2017-01-11 at 8 13 44 pm" src="https://cloud.githubusercontent.com/assets/6252919/21848140/857fd444-d83a-11e6-9e28-70f531931870.png">

Would adding experience points details, start/end dates, and which assessments it unlocks clutter this page?