### PR TITLE
Sync translation for 'file' on submissions edit and assessments show

### DIFF
--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -23,7 +23,7 @@ en:
             failure: 'Could not create submission: %{error}'
           edit:
             attempt: :'course.assessment.assessments.assessment.attempt'
-            files: 'Files'
+            files: :'course.assessment.assessments.show.files'
           publish_all:
             success: 'All graded submissions have been published.'
             notice: 'There are no graded submissions.'


### PR DESCRIPTION
Fix for [issue](https://github.com/Coursemology/coursemology2/pull/1851#pullrequestreview-16133396) in #1851.