### PR TITLE
Support encoded base64 images for now

### DIFF
--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -11,8 +11,21 @@ module ApplicationHTMLFormattersHelper
                                          HTML::Pipeline::RougeFilter
                                        ], DefaultPipelineOptions)
 
+  # SanitizationFilter Custom Options
+  #
+  # - Allow whitelisting of base64 encoded images for HTML text.
+  # Link: https://github.com/jch/html-pipeline#2-how-do-i-customize-a-whitelist-for-sanitizationfilters
+  # TODO: Remove 'data' once we disable Base64 encoding
+  # TODO: Figure out how to whitelist 'style' as WYSIWYG editor adds that attribute.
+  SANITIZATION_FILTER_WHITELIST ||= begin
+    list = HTML::Pipeline::SanitizationFilter::WHITELIST
+    list[:protocols]['img']['src'] << 'data' unless list[:protocols]['img']['src'].include?('data')
+    list
+  end
+
   # The HTML sanitizer options to use.
   HTMLSanitizerOptions = {
+    whitelist: SANITIZATION_FILTER_WHITELIST
   }.freeze
 
   # The HTML sanitizer to use.

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe ApplicationFormattersHelper do
       it 'produces html_safe output' do
         expect(helper.format_html('')).to be_html_safe
       end
+
+      context 'when base64 images are included' do
+        it 'does not filter them out' do
+          html = '<img src="data:image/png;base64,foodata">'
+          expect(helper.format_html(html)).to include('data')
+        end
+      end
     end
 
     describe '#format_code_block' do


### PR DESCRIPTION
This is a temporary fix for #1557. 

Currently the WYISWYG editor encodes images into base64 images. They do not show up because our HTML filters does not acknowledge that format. This PR is a temporary fix to support image uploads in this manner. 

Important points: 
 - As discussed in #1557, this is an _interim solution_, we will eventually use attachments instead of encoded attachments. 
 - The WYSIWYG editor also applies some styling on the size of the image, which I require more time to fix, so images will be shown at 100% size (or the size of the container).  