### PR TITLE
Display forum post text in notification email.

### DIFF
--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -9,7 +9,9 @@
 
 = simple_format(t('.message',
                 topic: link_to(topic.title,
-                               course_forum_topic_url(course, topic.forum, topic, host: host))))
+                               course_forum_topic_url(course, topic.forum, topic, host: host)),
+                post: post.text,
+                post_author: post.creator.name))
 
 = simple_format(t('.unsubscribe.message',
                 unsubscribe_link: link_to(t('.unsubscribe.tag'), unsubscribe_url)))

--- a/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
@@ -8,10 +8,11 @@ en:
               email:
                 subject: '%{course} New reply for forum topic: %{topic}'
                 message: >
-                  You can view the new reply here:
+                  %{post_author} replied,
+                  %{post}
 
-                  %{topic}
+                  You can respond here: %{topic}
 
                 unsubscribe:
                   tag: 'Unsubscribe'
-                  message: '%{unsubscribe_link} from email notification for this topic'
+                  message: '%{unsubscribe_link} from email notifications for this topic'


### PR DESCRIPTION
Fixes #1856.

Have also checked the rest of the notifiers to make sure they have useful text.