### PR TITLE
Implement resending of individual course_user_invitations

### DIFF
--- a/app/views/course/user_invitations/_course_user_invitation.html.slim
+++ b/app/views/course/user_invitations/_course_user_invitation.html.slim
@@ -1,0 +1,15 @@
+= content_tag_for(:tr, invitation) do
+  th = invitation.name
+  td = invitation.email
+  td = invitation.invitation_key
+  - if !invitation.confirmed?
+    td = t('course.users.status.invited')
+    td = format_datetime(invitation.sent_at, :short) if invitation.sent_at
+    td
+      = delete_button([current_course, invitation],
+        class: 'btn-xs', title: t('.delete_tooltip')) do
+        = fa_icon 'close'.freeze
+  - else
+    td = t('course.users.status.accepted')
+    td = format_datetime(invitation.confirmed_at, :short) if invitation.confirmed_at
+  td

--- a/app/views/course/user_invitations/_course_user_invitation.html.slim
+++ b/app/views/course/user_invitations/_course_user_invitation.html.slim
@@ -6,9 +6,14 @@
     td = t('course.users.status.invited')
     td = format_datetime(invitation.sent_at, :short) if invitation.sent_at
     td
-      = delete_button([current_course, invitation],
-        class: 'btn-xs', title: t('.delete_tooltip')) do
-        = fa_icon 'close'.freeze
+      div.btn-group
+        = link_to course_user_invitation_resend_invitation_path(current_course, invitation),
+                  remote: true, class: ['btn', 'btn-info', 'btn-sm'], method: :post,
+                  title: t('.resend_tooltip') do
+          = fa_icon 'envelope'.freeze
+        = delete_button([current_course, invitation],
+          class: 'btn-sm', title: t('.delete_tooltip')) do
+          = fa_icon 'close'.freeze
   - else
     td = t('course.users.status.accepted')
     td = format_datetime(invitation.confirmed_at, :short) if invitation.confirmed_at

--- a/app/views/course/user_invitations/_course_user_invitations.html.slim
+++ b/app/views/course/user_invitations/_course_user_invitations.html.slim
@@ -1,5 +1,5 @@
 - pending = !invitations.first.confirmed?
-table.table.table-striped.table-hover
+table.table.table-striped.table-hover class="#{pending ? 'pending' : 'confirmed'}"
   thead
     tr
       th = t('common.name')
@@ -8,25 +8,10 @@ table.table.table-striped.table-hover
       th = t('.status')
       - if pending
         th = t('.sent_at')
-        th
+      - else
+        th = t('.confirmed_at')
+      th
       th
 
   tbody
-    - invitations.each do |invitation|
-      = content_tag_for(:tr, invitation) do
-        th = invitation.name
-        td = invitation.email
-        td = invitation.invitation_key
-        - if pending
-          td = t('course.users.status.invited')
-          td
-            - if invitation.sent_at
-              = format_datetime(invitation.sent_at, :short)
-          td
-            = delete_button([current_course, invitation],
-                            class: 'btn-xs', title: t('.delete_tooltip')) do
-              = fa_icon 'close'.freeze
-          td
-        - else
-          td = t('course.users.status.accepted')
-          td
+    = render partial: 'course_user_invitation', collection: invitations, as: :invitation

--- a/app/views/course/user_invitations/reload_course_user_invitation.js.erb
+++ b/app/views/course/user_invitations/reload_course_user_invitation.js.erb
@@ -1,0 +1,10 @@
+<% if @invitation %>
+  $('<%= "#user_invitation_#{@invitation.id}"%>').replaceWith(
+    '<%= escape_javascript(render partial: 'course/user_invitations/course_user_invitation',
+                                  locals: { invitation: @invitation }) %>'
+  );
+<% end %>
+
+// Remove older flash messages, and show users the new flash message
+$('.course-layout').parents('.container-fluid:first').find('.alert').remove();
+$('.course-layout').parents('.container-fluid:first').prepend('<%= j(flash_messages) %>');

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -25,6 +25,7 @@ en:
         confirmed_at: 'Invitation Accepted At'
       course_user_invitation:
         delete_tooltip: 'Delete Invitation'
+        resend_tooltip: 'Resend Invitation'
       new:
         header: 'Invite Users'
         tabs:
@@ -52,6 +53,11 @@ en:
           success: 'Successfully invited users with the given details.'
       invitation_fields:
         remove: 'Remove'
+      resend_invitation:
+        success: >
+          The request to resend the email invitation to %{email}
+          is received, please wait while the email is sent out.
+        failure: 'The request to resend the email invitation failed.'
       resend_invitations:
         success: 'Email invitations were successfully resent.'
         failure: 'The resending of email invitations failed.'

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -22,6 +22,8 @@ en:
         invitation_code: 'Invitation Code'
         status: 'Status'
         sent_at: 'Invitation Sent At'
+        confirmed_at: 'Invitation Accepted At'
+      course_user_invitation:
         delete_tooltip: 'Delete Invitation'
       new:
         header: 'Invite Users'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,9 @@ Rails.application.routes.draw do
       resources :levels, except: [:show, :edit, :update]
       resource :duplication, only: [:show, :create]
 
-      resources :user_invitations, only: [:index, :new, :create, :destroy]
+      resources :user_invitations, only: [:index, :new, :create, :destroy] do
+        post 'resend_invitation'
+      end
 
       resources :enrol_requests, only: [:index, :destroy] do
         post 'approve', on: :member


### PR DESCRIPTION
Fixes #1813 and #1712. 

This PR: 
 - Adds a `Confirmed At` column for confirmed invitations. 
 - Allows for course_staff to resend individual user_invitation emails.