### PR TITLE
Only allow user to register in opened course

### DIFF
--- a/app/models/components/course/course_ability_component.rb
+++ b/app/models/components/course/course_ability_component.rb
@@ -23,11 +23,12 @@ module Course::CourseAbilityComponent
 
   def allow_showing_open_courses
     # TODO: Replace with just the symbols when Rails 5 is released.
-    can [:read, :register], Course, published_or_opened_course_hash
+    can [:read], Course, published_or_opened_course_hash
   end
 
   def allow_unregistered_users_registering_open_courses
-    can :create, Course::EnrolRequest, course: published_or_opened_course_hash, user: user
+    can [:register], Course, opened_course_hash
+    can :create, Course::EnrolRequest, course: opened_course_hash, user: user
     can :destroy, Course::EnrolRequest, user: user
   end
 
@@ -47,5 +48,9 @@ module Course::CourseAbilityComponent
 
   def published_or_opened_course_hash
     { status: [Course.statuses[:published], Course.statuses[:opened]] }
+  end
+
+  def opened_course_hash
+    { status: Course.statuses[:opened] }
   end
 end

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -1,7 +1,7 @@
 = div_for(current_course) do
   h1
     = format_inline_text(current_course.title)
-    - if !current_course.user?(current_user) && can?(:register, current_course)
+    - if current_course.opened? && !current_course.user?(current_user)
       div.register
         = render partial: 'course/user_registrations/registration'
 

--- a/spec/models/course_ability_spec.rb
+++ b/spec/models/course_ability_spec.rb
@@ -15,8 +15,13 @@ RSpec.describe Course, type: :model do
       let(:user) { create(:user) }
 
       it { is_expected.to be_able_to(:show, published_course) }
+      it { is_expected.not_to be_able_to(:register, published_course) }
+
       it { is_expected.to be_able_to(:show, opened_course) }
+      it { is_expected.to be_able_to(:register, opened_course) }
+
       it { is_expected.not_to be_able_to(:show, closed_course) }
+      it { is_expected.not_to be_able_to(:register, closed_course) }
       it { is_expected.not_to be_able_to(:participate, closed_course) }
 
       it 'sees the opened courses' do


### PR DESCRIPTION
Fixes a bug that user can register published course. 

Also implemented #1867, but it will require some discussion, will do it a separate RP instead. 