### PR TITLE
Handle published/unpublished states in conditional evaluation service 

### DIFF
--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -37,13 +37,20 @@ class Course::Achievement < ActiveRecord::Base
     specific_conditions.empty?
   end
 
+  # @override ConditionalInstanceMethods#permitted_for!
   def permitted_for!(course_user)
     return if conditions.empty?
     course_users << course_user unless course_users.exists?(course_user.id)
   end
 
+  # @override ConditionalInstanceMethods#precluded_for!
   def precluded_for!(course_user)
     course_users.delete(course_user) if course_users.exists?(course_user.id)
+  end
+
+  # @override ConditionalInstanceMethods#satisfiable?
+  def satisfiable?
+    published?
   end
 
   def initialize_duplicate(duplicator, other)

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -86,10 +86,17 @@ class Course::Assessment < ActiveRecord::Base
     'course/assessment/assessments/assessment'.freeze
   end
 
+  # @override ConditionalInstanceMethods#permitted_for!
   def permitted_for!(_course_user)
   end
 
+  # @override ConditionalInstanceMethods#precluded_for!
   def precluded_for!(_course_user)
+  end
+
+  # @override ConditionalInstanceMethods#satisfiable?
+  def satisfiable?
+    published?
   end
 
   def password_protected?

--- a/app/models/course/condition/achievement.rb
+++ b/app/models/course/condition/achievement.rb
@@ -28,6 +28,9 @@ class Course::Condition::Achievement < ActiveRecord::Base
   #   contains all achievements the subject has obtained.
   # @return [Boolean] true if the user has the required achievement and false otherwise.
   def satisfied_by?(course_user)
+    # Unpublished achievements are considered not satisfied.
+    return false unless achievement.published?
+
     course_user.achievements.exists?(achievement)
   end
 

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -33,6 +33,9 @@ class Course::Condition::Assessment < ActiveRecord::Base
   end
 
   def satisfied_by?(course_user)
+    # Unpublished assessments are considered not satisfied.
+    return false unless assessment.published?
+
     user = course_user.user
 
     if minimum_grade_percentage

--- a/lib/autoload/course/conditional/user_satisfiability_graph.rb
+++ b/lib/autoload/course/conditional/user_satisfiability_graph.rb
@@ -34,6 +34,12 @@ class Course::Conditional::UserSatisfiabilityGraph
 
     # Walk through the graph to find all the satisfied conditionals
     @graph.each do |conditional|
+      # Remove conditional if they are not available.
+      unless conditional.satisfiable?
+        conditional.precluded_for!(course_user)
+        next
+      end
+
       conditions = conditional.specific_conditions.select { |c| c.satisfied_by?(course_user) }
       satisfied_conditions.merge(Set.new(conditions))
 

--- a/lib/extensions/conditional/active_record/base.rb
+++ b/lib/extensions/conditional/active_record/base.rb
@@ -46,6 +46,12 @@ module Extensions::Conditional::ActiveRecord::Base
     def precluded_for!(_course_user)
       raise NotImplementedError, 'Subclasses must implement a precluded_for! method.'
     end
+
+    # Whether the conditional is satisfiable?.
+    # e.g. Unpublished achievements should not never be satisfied and give to users.
+    def satisfiable?
+      raise NotImplementedError, 'Subclasses must implement a #satisfiable? method.'
+    end
   end
 
   module ConditionInstanceMethods

--- a/spec/factories/course_achievements.rb
+++ b/spec/factories/course_achievements.rb
@@ -10,5 +10,11 @@ FactoryGirl.define do
     trait :with_badge do
       badge { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'minion.png')) }
     end
+
+    trait :with_level_condition do
+      after(:build) do |achievement|
+        achievement.conditions = [build(:level_condition, course: achievement.course)]
+      end
+    end
   end
 end

--- a/spec/libraries/course/conditional/user_satisfiability_graph_spec.rb
+++ b/spec/libraries/course/conditional/user_satisfiability_graph_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Course::Conditional::UserSatisfiabilityGraph do
       @satisfied = false
     end
 
+    def satisfiable?
+      true
+    end
+
     def inspect
       "<#{@id}>"
     end

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -152,6 +152,8 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         assessment = create(:assessment, course: course)
         create(:course_assessment_question_multiple_response,
                maximum_grade: 10, assessment: assessment)
+        assessment.published = true
+        assessment.save!
         assessment
       end
 

--- a/spec/services/course/conditional/conditional_satisfiability_evaluation_service_spec.rb
+++ b/spec/services/course/conditional/conditional_satisfiability_evaluation_service_spec.rb
@@ -8,25 +8,27 @@ RSpec.describe Course::Conditional::ConditionalSatisfiabilityEvaluationService d
 
     describe '#evaluate' do
       let(:course_user) { create(:course_user, course: course) }
-      let!(:level_condition) { create(:level_condition, course: course) }
       let!(:achievement) do
-        create(:course_achievement, course: course, conditions: [level_condition])
+        create(:course_achievement, :with_level_condition, course: course)
+      end
+      let!(:unpublished_achievement) do
+        create(:course_achievement, :with_level_condition, course: course, published: false)
       end
 
       context 'when course user satisfy the level condition' do
         it 'adds the satisfied achievement conditional to the course user' do
           allow(course_user).to receive(:level_number).and_return(2)
-          # TODO: Check that the achievement was added to the course user once achievement's API
-          # are added in
           subject.evaluate(course_user)
+          expect(course_user.achievements).to include(achievement)
+          expect(course_user.achievements).not_to include(unpublished_achievement)
         end
       end
 
       context 'when course user do not satisfy the level condition' do
         it 'does not adds the unsatisfied achievement conditional to the course user' do
-          # TODO: Check that course user do not have the achievement once achievement's API are
-          # added in
           subject.evaluate(course_user)
+
+          expect(course_user.achievements).not_to include(achievement)
         end
       end
     end


### PR DESCRIPTION
Fix #1841 

- Add  an abstract method `#available?` for conditional, conditional will be taken away if it's not published. 

- Change the behaviour that if the condition is not published, it will never be satisfied. 