### PR TITLE
Remove nesting from discussion posts - both assessment submissions and forums

### DIFF
--- a/app/assets/stylesheets/course/discussion/_post.scss
+++ b/app/assets/stylesheets/course/discussion/_post.scss
@@ -50,7 +50,8 @@
     }
   }
 
+  // TODO: Update with final decision on handling nesting. See Coursemology/coursemology2#1879
   .replies.nested {
-    margin-left: 5em;
+    //margin-left: 5em;
   }
 }

--- a/app/assets/stylesheets/course/forum/topics.scss
+++ b/app/assets/stylesheets/course/forum/topics.scss
@@ -12,8 +12,9 @@
       margin-bottom: 1em;
     }
 
+    // TODO: Update with final decision on handling nesting. See Coursemology/coursemology2#1879
     .replies.nested {
-      margin-left: 7em;
+      //margin-left: 7em;
     }
 
     .unread-controls.btn-group {


### PR DESCRIPTION
This is a temporary fix, have created a new issue to figure out how to resolve this #1879 