### PR TITLE
Undo and allow forum nesting

### DIFF
--- a/app/assets/stylesheets/course/forum/topics.scss
+++ b/app/assets/stylesheets/course/forum/topics.scss
@@ -14,7 +14,7 @@
 
     // TODO: Update with final decision on handling nesting. See Coursemology/coursemology2#1879
     .replies.nested {
-      //margin-left: 7em;
+      margin-left: 3em;
     }
 
     .unread-controls.btn-group {


### PR DESCRIPTION
Enabled it again. Reduced the nesting to allow for more readability. 