### PR TITLE
Add privacy warning icon to output stream panels.

### DIFF
--- a/app/views/course/assessment/answer/programming/_output_streams.html.slim
+++ b/app/views/course/assessment/answer/programming/_output_streams.html.slim
@@ -7,6 +7,8 @@ div.panel.panel-default
         aria-controls="collapseStdout_#{auto_grading.id}"]
         i.fa.fa-chevron aria-hidden="true"
         =< t('.stdout')
+        span.text-danger title=t('.privacy_warning')
+          =< fa_icon 'exclamation-triangle'.freeze
   div.panel-collapse.collapse id="collapseStdout_#{auto_grading.id}"
     div.panel-body
       pre
@@ -21,6 +23,8 @@ div.panel.panel-default
         aria-controls="collapseStderr_#{auto_grading.id}"]
         i.fa.fa-chevron aria-hidden="true"
         =< t('.stderr')
+        span.text-danger title=t('.privacy_warning')
+          =< fa_icon 'exclamation-triangle'.freeze
   div.panel-collapse.collapse id="collapseStderr_#{auto_grading.id}"
     dir.panel-body
       pre

--- a/config/locales/en/course/assessment/answer/programming.yml
+++ b/config/locales/en/course/assessment/answer/programming.yml
@@ -28,3 +28,4 @@ en:
           output_streams:
             stdout: :'course.assessment.question.programming.form_build_log.stdout'
             stderr: :'course.assessment.question.programming.form_build_log.stderr'
+            privacy_warning: 'You can view the output streams because you are staff. Students will not be able to see them.'


### PR DESCRIPTION
Reassure staff that students cannot see the output streams from code
evaluation.

Fixes #1871.

<img width="509" alt="screen shot 2017-01-14 at 1 42 30 am" src="https://cloud.githubusercontent.com/assets/1902527/21939459/d090d4da-d9fa-11e6-9800-f65f69065cbd.png">
