### PR TITLE
Raise an error if instance not found

### DIFF
--- a/app/controllers/concerns/application_multitenancy_concern.rb
+++ b/app/controllers/concerns/application_multitenancy_concern.rb
@@ -20,7 +20,14 @@ module ApplicationMultitenancyConcern
   # @return [nil] If there is no current tenant.
   def deduce_tenant
     tenant_host = deduce_tenant_host
-    Instance.find_tenant_by_host_or_default(tenant_host)
+    instance = Instance.find_tenant_by_host_or_default(tenant_host)
+
+    if Rails.env.production? && instance && instance.default? &&
+       instance.host.casecmp(tenant_host) != 0
+      raise ActionController::RoutingError, 'Instance Not Found'
+    end
+
+    instance
   end
 
   # Deduces the current host. We strip any leading www from the host.


### PR DESCRIPTION
Raise an error and do not use default instance if the host does not much the host of default instance in production.

Development and Test will still need the old behaviour to work.