### PR TITLE
Add delayed grade publication option

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -74,7 +74,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
     params.require(:assessment).permit(:title, :description, :base_exp, :time_bonus_exp,
                                        :start_at, :end_at, :bonus_end_at,
                                        :published, :mode, :autograded, :password, :tabbed_view,
-                                       :skippable, folder_params)
+                                       :skippable, :delayed_grade_publication, folder_params)
   end
 
   # Merges the parameters for category and tab IDs from either the assessment parameter or the

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -20,6 +20,8 @@
   - else
     = f.hidden_field :autograded
   - unless @assessment.autograded?
+    = f.input :delayed_grade_publication, label: t('.delayed_grade_publication'),
+                                          hint: t('.delayed_grade_publication_hint')
     = f.input :password, placeholder: t('.password_placeholder'), hint: t('.password_hint'),
                          input_html: { value: @assessment.password, onfocus: "this.type='text'", onblur: "this.type='password'" }
   = f.folder

--- a/app/views/course/assessment/submission/submissions/_manually_graded.html.slim
+++ b/app/views/course/assessment/submission/submissions/_manually_graded.html.slim
@@ -16,7 +16,7 @@
         save: @submission.attempting? || can_grade,
         finalise: @submission.attempting? && can?(:update, @submission),
         auto_grade: @submission.submitted? && can_grade,
-        mark: @submission.submitted? && can_grade,
-        publish: @submission.submitted? && can_grade,
+        mark: @submission.submitted? && @assessment.delayed_grade_publication? && can_grade,
+        publish: @submission.submitted? && !@assessment.delayed_grade_publication? && can_grade,
         unsubmit: !@submission.attempting? && can_grade\
       }

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -9,7 +9,11 @@ div.panel.panel-default
           td = display_course_user(@submission.course_user)
         tr
           th = t('.status')
-          td = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
+          td
+            = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
+            - if @submission.graded?
+              span.text-warning title=t('.publish_grade_hint')
+                =< fa_icon 'question-circle-o'.freeze
         - if display_grading_results
           tr
             th = @submission.class.human_attribute_name(:grade)

--- a/app/views/course/assessment/submission/submissions/index.html.slim
+++ b/app/views/course/assessment/submission/submissions/index.html.slim
@@ -1,6 +1,7 @@
 - add_breadcrumb t('.submissions')
 = page_header format_inline_text(@assessment.title) do
-  - if can?(:publish_all, Course::Assessment::Submission.new(assessment: @assessment))
+  - can_publish_grades = can?(:publish_all, Course::Assessment::Submission.new(assessment: @assessment))
+  - if can_publish_grades && @assessment.delayed_grade_publication?
     = link_to t('.publish'), publish_all_course_assessment_submissions_path(current_course, @assessment),
         class: ['btn', 'btn-danger'], method: :patch, data: { confirm: t('.confirm_publish') }
 

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -60,6 +60,11 @@ en:
             password (with the help of course staff). In addition, only one session is allowed to
             access the submission at any given time.
           password_placeholder: 'Leave blank to disable password protection'
+          delayed_grade_publication: 'Enable Delayed Grade Publication'
+          delayed_grade_publication_hint: >
+            With this enabled, gradings done by course staff will not automatically be published. To
+            publish all the gradings for this assessment, you can do so at a later time at the
+            submissions page.
         assessment_management_buttons:
           attempt: 'Attempt'
           resume: 'Resume'

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -55,6 +55,9 @@ en:
             multiplier: 'Multiplier'
             question: 'Question'
             grade_summary: 'Grade Summary'
+            publish_grade_hint: >
+              The grades are currently not viewable to the student. You can publish the grades at
+              the submissions page of current assessment.
           update:
             success: 'Submission was updated.'
             finalise: 'Your submission is being graded, please visit this page again later.'

--- a/db/migrate/20170115105609_add_delayed_grade_publication_to_course_assessments.rb
+++ b/db/migrate/20170115105609_add_delayed_grade_publication_to_course_assessments.rb
@@ -1,0 +1,5 @@
+class AddDelayedGradePublicationToCourseAssessments < ActiveRecord::Migration
+  def change
+    add_column :course_assessments, :delayed_grade_publication, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170110022335) do
+ActiveRecord::Schema.define(version: 20170115105609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,15 +135,16 @@ ActiveRecord::Schema.define(version: 20170110022335) do
   end
 
   create_table "course_assessments", force: :cascade do |t|
-    t.integer  "tab_id",      :null=>false, :index=>{:name=>"fk__course_assessments_tab_id"}, :foreign_key=>{:references=>"course_assessment_tabs", :name=>"fk_course_assessments_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.boolean  "tabbed_view", :default=>false, :null=>false
-    t.boolean  "autograded",  :null=>false
-    t.boolean  "skippable",   :default=>false
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessments_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessments_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",  :null=>false
-    t.datetime "updated_at",  :null=>false
-    t.string   "password",    :limit=>255
+    t.integer  "tab_id",                    :null=>false, :index=>{:name=>"fk__course_assessments_tab_id"}, :foreign_key=>{:references=>"course_assessment_tabs", :name=>"fk_course_assessments_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.boolean  "tabbed_view",               :default=>false, :null=>false
+    t.boolean  "autograded",                :null=>false
+    t.boolean  "skippable",                 :default=>false
+    t.boolean  "delayed_grade_publication", :default=>false
+    t.string   "password",                  :limit=>255
+    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_assessments_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_assessments_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",                :null=>false
+    t.datetime "updated_at",                :null=>false
   end
 
   create_table "course_assessment_questions", force: :cascade do |t|
@@ -506,20 +507,20 @@ ActiveRecord::Schema.define(version: 20170110022335) do
 
   create_table "course_lesson_plan_items", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",    :limit=>255, :index=>{:name=>"index_course_lesson_plan_items_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
-    t.integer  "course_id",       :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_items_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",           :limit=>255, :null=>false
+    t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_lesson_plan_items_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
+    t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_items_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",          :limit=>255, :null=>false
     t.text     "description"
-    t.boolean  "published",       :default=>false, :null=>false
-    t.integer  "base_exp",        :null=>false
-    t.integer  "time_bonus_exp",  :null=>false
-    t.datetime "start_at",        :null=>false
+    t.boolean  "published",      :default=>false, :null=>false
+    t.integer  "base_exp",       :null=>false
+    t.integer  "time_bonus_exp", :null=>false
+    t.datetime "start_at",       :null=>false
     t.datetime "bonus_end_at"
     t.datetime "end_at"
-    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",      :null=>false
-    t.datetime "updated_at",      :null=>false
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
   end
 
   create_table "course_lesson_plan_milestones", force: :cascade do |t|

--- a/spec/features/course/assessment/submission/password_protected_spec.rb
+++ b/spec/features/course/assessment/submission/password_protected_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) do
-      create(:assessment, :published_with_mrq_question, course: course, password: 'super_secret')
+      create(:assessment, :published_with_mrq_question,
+             course: course, password: 'super_secret', delayed_grade_publication: true)
     end
     let(:mrq_questions) { assessment.reload.questions.map(&:specific) }
     let(:student) { create(:course_student, course: course).user }

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -65,7 +65,10 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
     end
 
     context 'As a Course Manager' do
-      let(:assessment) { create(:assessment, :with_all_question_types, course: course) }
+      let(:assessment) do
+        create(:assessment, :with_all_question_types,
+               course: course, delayed_grade_publication: true)
+      end
       let(:user) { create(:course_manager, course: course).user }
 
       scenario 'I can publish all graded exams' do

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'Course: Assessments: Management' do
         fill_in 'assessment_start_at', with: assessment.start_at
         fill_in 'assessment_end_at', with: assessment.end_at
         fill_in 'assessment_bonus_end_at', with: assessment.bonus_end_at
+        check 'assessment_delayed_grade_publication'
 
         click_button 'submit'
 
@@ -46,6 +47,7 @@ RSpec.feature 'Course: Assessments: Management' do
         expect(assessment_created.tab).to eq(assessment_tab)
         expect(page).to have_content_tag_for(assessment_created)
         expect(assessment_created.folder.materials).to be_present
+        expect(assessment_created.delayed_grade_publication?).to be_truthy
         expect(assessment_created).not_to be_autograded
       end
 


### PR DESCRIPTION
- Add an option to assessment to allow delayed grade publication 
- The 'Submit for publishing' Button will only show if the option is checked
