### PR TITLE
Small fixes to assessment#show page

### DIFF
--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -12,6 +12,9 @@
 
   table.table.table-bordered.details-table
     tbody
+      tr.type
+        th = t('.type')
+        td = @assessment.autograded? ? t('.autograded') : t('.manually_graded')
       tr.base_exp
         th = t('.base_exp')
         td = @assessment.base_exp

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -7,8 +7,9 @@
       = delete_button([current_course, @assessment])
 
 = div_for(@assessment, 'data-assessment-id' => @assessment.id) do
-  h3 = t('.description')
-  = format_html(@assessment.description)
+  - unless @assessment.description.blank?
+    h3 = t('.description')
+    = format_html(@assessment.description)
 
   table.table.table-bordered.details-table
     tbody
@@ -40,10 +41,11 @@
       = content_tag_for(:li, condition) do
         = condition.title
 
-  h3 = t('.finish_to_unlock')
-  = render partial: @assessment.assessment_conditions.includes(:conditional), suffix: 'condition'
+  - if @assessment.assessment_conditions.present?
+    h3 = t('.finish_to_unlock')
+    = render partial: @assessment.assessment_conditions.includes(:conditional), suffix: 'condition'
 
-  - if can?(:attempt, @assessment)
+  - if can?(:attempt, @assessment) && @assessment.folder.materials.present?
     h3 = t('.files')
     = render partial: 'layouts/materials', locals: { folder: @assessment.folder }
 

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -15,12 +15,15 @@ en:
           end_at: 'End At'
           requirement_for: 'Requirement For'
           new_assessment:
-            autograded: 'Autograded Assessment'
-            manually_graded: 'Manually Graded Assessment'
+            autograded: :'course.assessment.assessments.show.autograded'
+            manually_graded: :'course.assessment.assessments.show.manually_graded'
         assessment:
           attempt: 'Attempt'
           condition_not_satisfied: 'You do not fulfill the requirements of the assessment'
         show:
+          type: 'Assessment Type'
+          autograded: 'Autograded Assessment'
+          manually_graded: 'Manually Graded Assessment'
           description: 'Description'
           start_at: :'course.assessment.assessments.index.start_at'
           bonus_cut_off: :'course.assessment.assessments.index.bonus_cut_off'


### PR DESCRIPTION
This PR fixes small issues on assessment#show page:
 - Lists whether assessment is autograded or manually graded;
 - Hides headers if there is no relevant content. 