### PR TITLE
Implement frontend for online editor

### DIFF
--- a/app/helpers/course/assessment/question/programming_helper.rb
+++ b/app/helpers/course/assessment/question/programming_helper.rb
@@ -63,6 +63,10 @@ module Course::Assessment::Question::ProgrammingHelper
     end
   end
 
+  def check_import_job?
+    @programming_question.import_job && @programming_question.import_job.status != 'completed'
+  end
+
   def display_autograded_toggle?
     @programming_question.edit_online? || can_switch_package_type?
   end

--- a/app/helpers/course/assessment/question/programming_helper.rb
+++ b/app/helpers/course/assessment/question/programming_helper.rb
@@ -63,8 +63,12 @@ module Course::Assessment::Question::ProgrammingHelper
     end
   end
 
+  def display_autograded_toggle?
+    @programming_question.edit_online? || can_switch_package_type?
+  end
+
   def can_switch_package_type?
-    params[:action] == 'new'
+    params[:action] == 'new' || params[:action] == 'create'
   end
 
   def can_edit_online?

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -101,7 +101,10 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
   def non_autograded_template_files=(template_files)
     self.template_files.clear
     self.template_files = template_files
-    @non_autograded_template_files = true
+
+    execute_after_commit do
+      test_cases.clear
+    end
   end
 
   private
@@ -127,7 +130,7 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
 
   # Removes the template files and test cases from the old package.
   def remove_old_package
-    template_files.clear unless @non_autograded_template_files
+    template_files.clear
     test_cases.clear
     self.import_job = nil
   end

--- a/app/services/course/assessment/question/programming/programming_package_service.rb
+++ b/app/services/course/assessment/question/programming/programming_package_service.rb
@@ -9,7 +9,6 @@ class Course::Assessment::Question::Programming::ProgrammingPackageService
   def initialize(question, params)
     @question = question
     @language = question.language
-    @current_attachment = question.attachment
     @template_files = question.template_files
 
     init_language_package_service(params)
@@ -18,7 +17,7 @@ class Course::Assessment::Question::Programming::ProgrammingPackageService
   # Generates a programming package from the parameters which were passed to the controller.
   def generate_package
     if @language_package_service.autograded?
-      new_package = @language_package_service.generate_package(@current_attachment)
+      new_package = @language_package_service.generate_package(@question.attachment)
       @question.file = new_package if new_package.present?
     else
       templates = @language_package_service.submission_templates
@@ -33,7 +32,7 @@ class Course::Assessment::Question::Programming::ProgrammingPackageService
   #
   # @return [Hash]
   def extract_meta
-    data = @language_package_service.extract_meta(@current_attachment, @template_files)
+    data = @language_package_service.extract_meta(@question.attachment, @template_files)
     { editor_mode: @editor_mode, data: data } if data.present?
   end
 

--- a/app/services/course/assessment/question/programming/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming/python/python_package_service.rb
@@ -17,7 +17,7 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
     [
       {
         filename: 'template.py',
-        content: @test_params[:submission]
+        content: @test_params[:submission] || ''
       }
     ]
   end
@@ -50,6 +50,8 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
   end
 
   def extract_meta(attachment, template_files)
+    return @meta if @meta.present?
+
     # attachment will be nil if the question is not autograded, in that case the meta data will be
     # generated from the template files in the database.
     return generate_non_autograded_meta(template_files) if attachment.nil?
@@ -133,6 +135,7 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
       # Create tests directory with prepend, append and autograde files
       zip.put_next_entry 'tests/'
       zip.put_next_entry 'tests/append.py'
+      zip.print "\n"
       zip.print @test_params[:append]
       zip.print "\n"
 

--- a/app/services/course/assessment/question/programming/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming/python/python_package_service.rb
@@ -39,7 +39,7 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
 
   def default_meta
     {
-      submission: '', solution: '', prepend: '', append: '', autograded: false,
+      submission: '', solution: '', prepend: '', append: '',
       data_files: [],
       test_cases: {
         public: [],

--- a/app/views/course/assessment/question/programming/_import_result.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_import_result.json.jbuilder
@@ -8,4 +8,6 @@ json.import_result do
       json.stderr log['stderr']
     end
   end
+
+  json.import_errored import_errored?
 end

--- a/app/views/course/assessment/question/programming/_props.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_props.json.jbuilder
@@ -3,6 +3,6 @@ json.partial! 'package_ui'
 json.partial! 'test_ui'
 json.partial! 'import_result'
 
-if @redirect_url
-  json.redirect_url @redirect_url
+if @response
+  json.partial! 'response', locals: { response: @response }
 end

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -19,6 +19,8 @@ json.question do
   json.memory_limit @programming_question.memory_limit
   json.time_limit @programming_question.time_limit
 
+  json.autograded @assessment.autograded? || @programming_question.attachment.present?
+  json.display_autograded_toggle display_autograded_toggle?
   json.autograded_assessment @assessment.autograded?
   json.published_assessment @assessment.published?
   json.attempt_limit @programming_question.attempt_limit

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -27,6 +27,7 @@ json.question do
     json.package do
       json.name @programming_question.attachment.name
       json.path attachment_reference_path(@programming_question.attachment)
+      json.updater_name @programming_question.attachment.updater.name
     end
   else
     json.package nil

--- a/app/views/course/assessment/question/programming/_response.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_response.json.jbuilder
@@ -1,0 +1,14 @@
+if check_import_job?
+  json.import_job_url job_path(@programming_question.import_job)
+
+  if response[:redirect_to_edit]
+    json.redirect_edit do
+      json.url edit_course_assessment_question_programming_path(current_course, @assessment, @programming_question)
+      json.page_header @programming_question.display_title
+      json.page_title @programming_question.display_title + ' - ' + page_title
+    end
+  end
+end
+
+json.redirect_assessment course_assessment_path(current_course, @assessment)
+json.message response[:message]

--- a/app/views/course/assessment/question/programming/edit.json.jbuilder
+++ b/app/views/course/assessment/question/programming/edit.json.jbuilder
@@ -2,7 +2,6 @@ json.form_data do
   json.method 'PATCH'
   json.auth_token form_authenticity_token
   json.path course_assessment_question_programming_path(current_course, @assessment, @programming_question)
-  json.async true
 end
 
 json.partial! 'props'

--- a/app/views/course/assessment/question/programming/new.json.jbuilder
+++ b/app/views/course/assessment/question/programming/new.json.jbuilder
@@ -2,7 +2,6 @@ json.form_data do
   json.method 'POST'
   json.auth_token form_authenticity_token
   json.path course_assessment_question_programming_index_path(current_course, @assessment)
-  json.async false
 end
 
 json.partial! 'props'

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -5,7 +5,8 @@
   },
   "rules": {
     # See https://github.com/yannickcr/eslint-plugin-react/issues/847
-    "react/no-unused-prop-types": ["warn", { "skipShapeProps": true }]
+    "react/no-unused-prop-types": ["warn", { "skipShapeProps": true }],
+    "new-cap": [2, { "capIsNewExceptions": ["Set"] }],
   },
   "globals": {
     "window": true,

--- a/client/app/bundles/course/assessment/question/programming/ProgrammingQuestion.jsx
+++ b/client/app/bundles/course/assessment/question/programming/ProgrammingQuestion.jsx
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 import Immutable from 'immutable';
 
 import ProgrammingQuestionForm from './components/ProgrammingQuestionForm';
+import * as onlineEditorActionCreators from './actions/onlineEditorActionCreators';
 import * as programmingQuestionActionCreators from './actions/programmingQuestionActionCreators';
 
 
@@ -19,12 +20,14 @@ const propTypes = {
 const ProgrammingQuestion = (props) => {
   const { dispatch, programmingQuestion } = props;
   const actions = bindActionCreators(programmingQuestionActionCreators, dispatch);
+  const onlineEditorActions = bindActionCreators(onlineEditorActionCreators, dispatch);
 
   return (
     <ProgrammingQuestionForm
       {...{
         actions,
         data: programmingQuestion,
+        onlineEditorActions,
       }}
     />
   );

--- a/client/app/bundles/course/assessment/question/programming/actions/onlineEditorActionCreators.jsx
+++ b/client/app/bundles/course/assessment/question/programming/actions/onlineEditorActionCreators.jsx
@@ -1,0 +1,34 @@
+import actionTypes from '../constants/onlineEditorConstants';
+
+export function updatePythonCodeBlock(field, newValue) {
+  return {
+    type: actionTypes.PYTHON_CODE_BLOCK_UPDATE,
+    field,
+    newValue,
+  };
+}
+
+export function createPythonTestCase(testType) {
+  return {
+    type: actionTypes.PYTHON_TEST_CASE_CREATE,
+    testType,
+  };
+}
+
+export function updatePythonTestCase(testType, index, field, newValue) {
+  return {
+    type: actionTypes.PYTHON_TEST_CASE_UPDATE,
+    testType,
+    index,
+    field,
+    newValue,
+  };
+}
+
+export function deletePythonTestCase(testType, index) {
+  return {
+    type: actionTypes.PYTHON_TEST_CASE_DELETE,
+    testType,
+    index,
+  };
+}

--- a/client/app/bundles/course/assessment/question/programming/actions/onlineEditorActionCreators.jsx
+++ b/client/app/bundles/course/assessment/question/programming/actions/onlineEditorActionCreators.jsx
@@ -32,3 +32,26 @@ export function deletePythonTestCase(testType, index) {
     index,
   };
 }
+
+export function updateNewDataFile(filename, index) {
+  return {
+    type: actionTypes.PYTHON_NEW_DATA_FILE_UPDATE,
+    index,
+    filename,
+  };
+}
+
+export function deleteNewDataFile(index) {
+  return {
+    type: actionTypes.PYTHON_NEW_DATA_FILE_DELETE,
+    index,
+  };
+}
+
+export function deleteExistingDataFile(filename, toDelete) {
+  return {
+    type: actionTypes.PYTHON_EXISTING_DATA_FILE_DELETE,
+    filename,
+    toDelete,
+  };
+}

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
@@ -20,6 +20,8 @@ const translations = defineMessages({
 const propTypes = {
   data: PropTypes.instanceOf(Immutable.Map).isRequired,
   actions: PropTypes.object.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  autograded: PropTypes.bool.isRequired,
   autogradedAssessment: PropTypes.bool.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
@@ -27,13 +29,13 @@ const propTypes = {
 };
 
 export function validation(data, pathOfKeysToData, intl) {
-  const mode = data.get('mode');
+  const mode = data.getIn(pathOfKeysToData).get('mode');
   const errors = [];
 
   switch (mode) {
     case 'python':
       return errors.concat(
-        pythonValidation(data.get('python'), pathOfKeysToData.concat(['python']), intl)
+        pythonValidation(data, pathOfKeysToData.concat(['python']), intl)
       );
     default:
       return errors;
@@ -41,19 +43,18 @@ export function validation(data, pathOfKeysToData, intl) {
 }
 
 const OnlineEditor = (props) => {
-  const { data, actions, intl, autogradedAssessment } = props;
-  const testUI = data.get('test_ui');
-  const mode = testUI.get('mode');
-  const isLoading = data.get('is_loading');
+  const { data, actions, intl, isLoading, autograded, autogradedAssessment } = props;
+  const mode = data.get('mode');
 
   switch (mode) {
     case 'python':
       return (<OnlineEditorPythonView
         {...{
           actions,
-          data: testUI.get('python'),
-          dataFiles: testUI.get('data_files'),
+          data: data.get('python'),
+          dataFiles: data.get('data_files'),
           isLoading,
+          autograded,
           autogradedAssessment,
         }}
       />);

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
@@ -49,7 +49,7 @@ const OnlineEditor = (props) => {
     case 'python':
       return (<OnlineEditorPythonView
         {...{
-          actions, data: testUI.get('python'), isLoading }}
+          actions, data: testUI.get('python'), dataFiles: testUI.get('data_files'), isLoading }}
       />);
 
     case null:

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
@@ -20,6 +20,7 @@ const translations = defineMessages({
 const propTypes = {
   data: PropTypes.instanceOf(Immutable.Map).isRequired,
   actions: PropTypes.object.isRequired,
+  autogradedAssessment: PropTypes.bool.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
@@ -40,7 +41,7 @@ export function validation(data, pathOfKeysToData, intl) {
 }
 
 const OnlineEditor = (props) => {
-  const { data, actions, intl } = props;
+  const { data, actions, intl, autogradedAssessment } = props;
   const testUI = data.get('test_ui');
   const mode = testUI.get('mode');
   const isLoading = data.get('is_loading');
@@ -49,7 +50,12 @@ const OnlineEditor = (props) => {
     case 'python':
       return (<OnlineEditorPythonView
         {...{
-          actions, data: testUI.get('python'), dataFiles: testUI.get('data_files'), isLoading }}
+          actions,
+          data: testUI.get('python'),
+          dataFiles: testUI.get('data_files'),
+          isLoading,
+          autogradedAssessment,
+        }}
       />);
 
     case null:

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
@@ -1,0 +1,73 @@
+import Immutable from 'immutable';
+
+import React, { PropTypes } from 'react';
+import { injectIntl, defineMessages } from 'react-intl';
+import OnlineEditorPythonView, { validation as pythonValidation } from './OnlineEditorPythonView';
+
+const translations = defineMessages({
+  selectLanguageAlert: {
+    id: 'course.assessment.question.programming.onlineEditor.selectLanguageAlert',
+    defaultMessage: 'Please select a language.',
+    description: 'Alert message to be displayed when no language is selected.',
+  },
+  notYetImplementedAlert: {
+    id: 'course.assessment.question.programming.onlineEditor.notYetImplementedAlert',
+    defaultMessage: 'Not yet implemented :(',
+    description: 'Alert message to be displayed when selected language does not have an online editor.',
+  },
+});
+
+const propTypes = {
+  data: PropTypes.instanceOf(Immutable.Map).isRequired,
+  actions: PropTypes.object.isRequired,
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+export function validation(data, pathOfKeysToData, intl) {
+  const mode = data.get('mode');
+  const errors = [];
+
+  switch (mode) {
+    case 'python':
+      return errors.concat(
+        pythonValidation(data.get('python'), pathOfKeysToData.concat(['python']), intl)
+      );
+    default:
+      return errors;
+  }
+}
+
+const OnlineEditor = (props) => {
+  const { data, actions, intl } = props;
+  const testUI = data.get('test_ui');
+  const mode = testUI.get('mode');
+  const isLoading = data.get('is_loading');
+
+  switch (mode) {
+    case 'python':
+      return (<OnlineEditorPythonView
+        {...{
+          actions, data: testUI.get('python'), isLoading }}
+      />);
+
+    case null:
+      return (
+        <div className="alert alert-warning">
+          {intl.formatMessage(translations.selectLanguageAlert)}
+        </div>
+      );
+
+    default:
+      return (
+        <div className="alert alert-info">
+          {intl.formatMessage(translations.notYetImplementedAlert)}
+        </div>
+      );
+  }
+};
+
+OnlineEditor.propTypes = propTypes;
+
+export default injectIntl(OnlineEditor);

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
@@ -1,0 +1,81 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  autograded: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.autograded',
+    defaultMessage: 'Autograded',
+  },
+  prependTitle: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.prependTitle',
+    defaultMessage: 'Prepend',
+    description: 'Title for prepend code block.',
+  },
+  appendTitle: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.appendTitle',
+    defaultMessage: 'Append',
+    description: 'Title for append code block.',
+  },
+  solutionTitle: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.solutionTitle',
+    defaultMessage: 'Solution Template',
+    description: 'Title for solution template code block.',
+  },
+  submissionTitle: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.submissionTitle',
+    defaultMessage: 'Submission Template',
+    description: 'Title for submission template code block.',
+  },
+  testCasesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.testCasesHeader',
+    defaultMessage: 'Test Cases',
+    description: 'Header for the test cases of the online editor.',
+  },
+  addNewTestButton: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.addNewTestButton',
+    defaultMessage: 'Add new test',
+    description: 'Button for adding new test case.',
+  },
+  publicTestCases: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.publicTestCases',
+    defaultMessage: 'Public Test Cases',
+    description: 'Title for public test cases panel.',
+  },
+  privateTestCases: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.privateTestCases',
+    defaultMessage: 'Private Test Cases',
+    description: 'Title for private test cases panel.',
+  },
+  evaluationTestCases: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.evaluationTestCases',
+    defaultMessage: 'Evaluation Test Cases',
+    description: 'Title for evaluation test cases panel.',
+  },
+  identifierHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.identifierHeader',
+    defaultMessage: 'Identifier',
+    description: 'Header for identifier column of test cases panel.',
+  },
+  expressionHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.expressionHeader',
+    defaultMessage: 'Expression',
+    description: 'Header for expression column of test cases panel.',
+  },
+  expectedHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.expectedHeader',
+    defaultMessage: 'Expected',
+    description: 'Header for expected column of test cases panel.',
+  },
+  hintHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.hintHeader',
+    defaultMessage: 'Hint',
+    description: 'Header for hint column of test cases panel.',
+  },
+  noTestCaseErrorAlert: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.noTestCaseErrorAlert',
+    defaultMessage: 'At least 1 test case is required for autograded programming question.',
+  },
+  cannotBeBlankValidationError: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.cannotBeBlankValidationError',
+    defaultMessage: 'Cannot be blank.',
+  },
+});

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
@@ -30,6 +30,36 @@ export default defineMessages({
     defaultMessage: 'Test Cases',
     description: 'Header for the test cases of the online editor.',
   },
+  dataFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.dataFilesHeader',
+    defaultMessage: 'Data Files',
+    description: 'Header for the data files of the online editor.',
+  },
+  currentDataFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.currentDataFilesHeader',
+    defaultMessage: 'Current Data Files',
+    description: 'Header for the current data files panel.',
+  },
+  addDataFileButton: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.addDataFileButton',
+    defaultMessage: 'Add Data File',
+    description: 'Button for adding a new data file.',
+  },
+  fileNameHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.fileNameHeader',
+    defaultMessage: 'File Name',
+    description: 'Header for file name column in current data files paenl.',
+  },
+  fileSizeHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.fileSizeHeader',
+    defaultMessage: 'File Size',
+    description: 'Header for file size column in current data files paenl.',
+  },
+  newDataFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.newDataFilesHeader',
+    defaultMessage: 'New Data Files',
+    description: 'Header for the new data files panel.',
+  },
   addNewTestButton: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.addNewTestButton',
     defaultMessage: 'Add new test',

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
@@ -1,14 +1,6 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  autograded: {
-    id: 'course.assessment.question.programming.onlineEditorPythonView.autograded',
-    defaultMessage: 'Autograded',
-  },
-  autogradedAssessment: {
-    id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedAssessment',
-    defaultMessage: 'Autograded assessment cannot have non-autograded questions',
-  },
   prependTitle: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.prependTitle',
     defaultMessage: 'Prepend',

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
@@ -5,6 +5,10 @@ export default defineMessages({
     id: 'course.assessment.question.programming.onlineEditorPythonView.autograded',
     defaultMessage: 'Autograded',
   },
+  autogradedAssessment: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedAssessment',
+    defaultMessage: 'Autograded assessment cannot have non-autograded questions',
+  },
   prependTitle: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.prependTitle',
     defaultMessage: 'Prepend',

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
@@ -7,7 +7,6 @@ import { Card, CardHeader, CardText } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
-import Toggle from 'material-ui/Toggle';
 import { Table, TableBody, TableFooter, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import transitions from 'material-ui/styles/transitions';
 import { grey100, grey300, white } from 'material-ui/styles/colors';
@@ -31,7 +30,7 @@ const propTypes = {
     deleteExistingDataFile: PropTypes.func.isRequired,
   }),
   isLoading: PropTypes.bool.isRequired,
-  autogradedAssessment: PropTypes.bool.isRequired,
+  autograded: PropTypes.bool.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
@@ -43,12 +42,13 @@ const contextTypes = {
 
 export function validation(data, pathOfKeysToData, intl) {
   const errors = [];
+  const pythonData = data.getIn(pathOfKeysToData);
 
-  if (data.get('autograded')) {
+  if (data.getIn(['question', 'autograded'])) {
     let testsCount = 0;
 
     ['public', 'private', 'evaluation'].forEach((type) => {
-      const testCases = data.getIn(['test_cases', type]);
+      const testCases = pythonData.getIn(['test_cases', type]);
       testsCount += testCases.size;
 
       testCases.forEach((testCase, index) => {
@@ -98,18 +98,7 @@ class OnlineEditorPythonView extends React.Component {
 
   constructor(props) {
     super(props);
-    this.onAutogradedChange = this.onAutogradedChange.bind(this);
     this.renderExistingDataFiles = this.renderExistingDataFiles.bind(this);
-  }
-
-  componentWillMount() {
-    if (this.props.autogradedAssessment) {
-      this.props.actions.updatePythonCodeBlock('autograded', true);
-    }
-  }
-
-  onAutogradedChange(e) {
-    this.props.actions.updatePythonCodeBlock('autograded', e.target.checked);
   }
 
   codeChangeHandler(field) {
@@ -166,7 +155,7 @@ class OnlineEditorPythonView extends React.Component {
       const buttonClass = toDelete ? 'fa fa-undo' : 'fa fa-trash';
       const buttonColor = toDelete ? white : grey300;
       const rowStyle = toDelete ?
-        {textDecoration: 'line-through', backgroundColor: grey100}
+        { textDecoration: 'line-through', backgroundColor: grey100 }
         :
         {};
 
@@ -182,7 +171,7 @@ class OnlineEditorPythonView extends React.Component {
             />
             <input
               type="checkbox"
-              hidden={true}
+              hidden
               name={`question_programming[data_files_to_delete][${filename}]`}
               checked={toDelete}
             />
@@ -228,7 +217,7 @@ class OnlineEditorPythonView extends React.Component {
       const key = fileData.get('key');
 
       let deleteButton = null;
-      let addFileButtonStyle = {};
+      const addFileButtonStyle = {};
 
       if (this.props.dataFiles.get('key') !== key) {
         // Do not show for last row
@@ -462,24 +451,10 @@ class OnlineEditorPythonView extends React.Component {
   }
 
   render() {
-    const { intl, data, autogradedAssessment } = this.props;
-    const autograded = autogradedAssessment || data.get('autograded');
-    let autogradedLabel = intl.formatMessage(translations.autograded);
-    if (autogradedAssessment) {
-      autogradedLabel += ` (${intl.formatMessage(translations.autogradedAssessment)})`;
-    }
+    const { intl, autograded } = this.props;
 
     return (
       <div id="python-online-editor">
-        <Toggle
-          label={autogradedLabel}
-          labelPosition="right"
-          toggled={autograded}
-          onToggle={this.onAutogradedChange}
-          disabled={autogradedAssessment || this.props.isLoading}
-          style={{ margin: '1em 0' }}
-          name="question_programming[autograded]"
-        />
         { this.renderEditorCard(intl.formatMessage(translations.submissionTitle), 'submission') }
         { autograded ? this.renderAutogradedFields() : null }
       </div>

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
@@ -1,0 +1,309 @@
+import Immutable from 'immutable';
+
+import React, { PropTypes } from 'react';
+import AceEditor from 'react-ace';
+import { injectIntl } from 'react-intl';
+import { Card, CardHeader, CardText } from 'material-ui/Card';
+import FlatButton from 'material-ui/FlatButton';
+import TextField from 'material-ui/TextField';
+import Toggle from 'material-ui/Toggle';
+import { Table, TableBody, TableFooter, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
+import transitions from 'material-ui/styles/transitions';
+import { red500 } from 'material-ui/styles/colors';
+
+import 'brace/mode/python';
+import 'brace/theme/monokai';
+
+import styles from './OnlineEditorPythonView.scss';
+import translations from './OnlineEditorPythonView.intl';
+
+const propTypes = {
+  data: PropTypes.instanceOf(Immutable.Map).isRequired,
+  actions: React.PropTypes.shape({
+    updatePythonCodeBlock: PropTypes.func.isRequired,
+    createPythonTestCase: PropTypes.func.isRequired,
+    updatePythonTestCase: PropTypes.func.isRequired,
+    deletePythonTestCase: PropTypes.func.isRequired,
+  }),
+  isLoading: PropTypes.bool.isRequired,
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+const contextTypes = {
+  muiTheme: React.PropTypes.object.isRequired,
+};
+
+export function validation(data, pathOfKeysToData, intl) {
+  const errors = [];
+
+  if (data.get('autograded')) {
+    let testsCount = 0;
+
+    ['public', 'private', 'evaluation'].forEach((type) => {
+      const testCases = data.getIn(['test_cases', type]);
+      testsCount += testCases.size;
+
+      testCases.forEach((testCase, index) => {
+        const testCaseError = {};
+        let hasError = false;
+
+        if (testCase.get('expression').trim() === '') {
+          testCaseError.expression =
+            intl.formatMessage(translations.cannotBeBlankValidationError);
+          hasError = true;
+        }
+        if (testCase.get('expected').trim() === '') {
+          testCaseError.expected =
+            intl.formatMessage(translations.cannotBeBlankValidationError);
+          hasError = true;
+        }
+
+        if (hasError) {
+          errors.push({
+            path: pathOfKeysToData.concat(['test_cases', type, index, 'error']),
+            error: testCaseError,
+          });
+        }
+      });
+    });
+
+    if (testsCount === 0) {
+      errors.push({
+        path: pathOfKeysToData.concat(['test_cases', 'error']),
+        error: intl.formatMessage(translations.noTestCaseErrorAlert),
+      });
+    }
+  }
+
+  return errors;
+}
+
+class OnlineEditorPythonView extends React.Component {
+
+  static getInputName(field) {
+    return `question_programming[${field}]`;
+  }
+
+  static getTestInputName(type, field) {
+    return `question_programming[test_cases][${type}][][${field}]`;
+  }
+
+  constructor(props) {
+    super(props);
+    this.onAutogradedChange = this.onAutogradedChange.bind(this);
+  }
+
+  onAutogradedChange(e) {
+    this.props.actions.updatePythonCodeBlock('autograded', e.target.checked);
+  }
+
+  codeChangeHandler(field) {
+    return e => this.props.actions.updatePythonCodeBlock(field, e);
+  }
+
+  testCaseDeleteHandler(type, index) {
+    return (e) => {
+      e.preventDefault();
+
+      if (!this.props.isLoading) {
+        this.props.actions.deletePythonTestCase(type, index);
+      }
+    };
+  }
+
+  testCaseCreateHandler(type) {
+    return (e) => {
+      e.preventDefault();
+
+      if (!this.props.isLoading) {
+        this.props.actions.createPythonTestCase(type);
+      }
+    };
+  }
+
+  renderTestCases(header, testCases, type, startIndex = 0) {
+    const renderInput = (test, field, placeholder, index) => (
+      <TextField
+        type="text"
+        name={OnlineEditorPythonView.getTestInputName(type, field)}
+        onChange={(e, newValue) => {
+          this.props.actions.updatePythonTestCase(type, index, field, newValue);
+        }}
+        hintText={placeholder}
+        errorText={test.getIn(['error', field])}
+        disabled={this.props.isLoading}
+        value={test.get(field)}
+        fullWidth
+        multiLine
+      />
+    );
+
+    const identifier = this.props.intl.formatMessage(translations.identifierHeader);
+    const expression = this.props.intl.formatMessage(translations.expressionHeader);
+    const expected = this.props.intl.formatMessage(translations.expectedHeader);
+    const hint = this.props.intl.formatMessage(translations.hintHeader);
+
+    const rows = [...testCases.get(type).entries()].map(([index, test]) => (
+      <TableRow key={index}>
+        <TableHeaderColumn className={styles.deleteButtonCell}>
+          <RaisedButton
+            backgroundColor={red500}
+            icon={<i className="fa fa-minus" />}
+            disabled={this.props.isLoading}
+            onClick={this.testCaseDeleteHandler(type, index)}
+            style={{ minWidth: '40px', width: '40px' }}
+          />
+        </TableHeaderColumn>
+        <TableRowColumn className={styles.testCell}>
+          test_{type}_{startIndex + index + 1}
+        </TableRowColumn>
+        <TableRowColumn className={styles.testCell}>
+          { renderInput(test, 'expression', expression, index) }
+        </TableRowColumn>
+        <TableRowColumn className={styles.testCell}>
+          { renderInput(test, 'expected', expected, index) }
+        </TableRowColumn>
+        <TableRowColumn className={styles.testCell}>
+          { renderInput(test, 'hint', hint, index) }
+        </TableRowColumn>
+      </TableRow>
+    ));
+
+    return (
+      <Card initiallyExpanded>
+        <CardHeader
+          title={header}
+          textStyle={{ fontWeight: 'bold' }}
+          actAsExpander
+          showExpandableButton
+        />
+        <CardText expandable style={{ padding: 0 }}>
+          <Table selectable={false}>
+            <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
+              <TableRow>
+                <TableHeaderColumn className={styles.deleteButtonCell} />
+                <TableHeaderColumn>{identifier}</TableHeaderColumn>
+                <TableHeaderColumn>{expression}</TableHeaderColumn>
+                <TableHeaderColumn>{expected}</TableHeaderColumn>
+                <TableHeaderColumn>{hint}</TableHeaderColumn>
+              </TableRow>
+            </TableHeader>
+            <TableBody displayRowCheckbox={false}>
+              {rows}
+            </TableBody>
+            <TableFooter adjustForCheckbox={false}>
+              <TableRow>
+                <TableRowColumn colSpan="5" style={{ textAlign: 'center' }}>
+                  <FlatButton
+                    label={this.props.intl.formatMessage(translations.addNewTestButton)}
+                    icon={<i className="fa fa-plus" />}
+                    disabled={this.props.isLoading}
+                    onClick={this.testCaseCreateHandler(type)}
+                  />
+                </TableRowColumn>
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </CardText>
+      </Card>
+    );
+  }
+
+  renderEditorCard(header, field) {
+    return (
+      <Card containerStyle={{ paddingBottom: 0 }} initiallyExpanded>
+        <CardHeader
+          title={header}
+          textStyle={{ fontWeight: 'bold' }}
+          actAsExpander
+          showExpandableButton
+        />
+        <CardText expandable style={{ padding: 0 }}>
+          <textarea
+            name={OnlineEditorPythonView.getInputName(field)}
+            value={this.props.data.get(field)}
+            style={{ display: 'none' }}
+            readOnly="true"
+          />
+          <AceEditor
+            mode="python"
+            theme="monokai"
+            width="100%"
+            minLines={10}
+            maxLines={Math.max(20, this.props.data.get(field).split(/\r\n|\r|\n/).length)}
+            name={OnlineEditorPythonView.getInputName(field)}
+            value={this.props.data.get(field)}
+            onChange={this.codeChangeHandler(field)}
+            editorProps={{ $blockScrolling: true }}
+            setOptions={{ useSoftTabs: true, readOnly: this.props.isLoading }}
+          />
+        </CardText>
+      </Card>
+    );
+  }
+
+  renderAutogradedFields() {
+    const { intl, data } = this.props;
+    const testCases = data.get('test_cases');
+    const testCaseError = data.getIn(['test_cases', 'error']);
+    const errorTextElement = testCaseError && (
+    <div
+      style={{
+        fontSize: 12,
+        lineHeight: '12px',
+        color: this.context.muiTheme.textField.errorColor,
+        transition: transitions.easeOut(),
+        marginBottom: '1em',
+      }}
+    >
+      {testCaseError}
+    </div>
+      );
+
+    return (
+      <div>
+        <div style={{ marginBottom: '1em' }}>
+          { this.renderEditorCard(intl.formatMessage(translations.solutionTitle), 'solution') }
+          { this.renderEditorCard(intl.formatMessage(translations.prependTitle), 'prepend') }
+          { this.renderEditorCard(intl.formatMessage(translations.appendTitle), 'append') }
+        </div>
+        <h3>{ intl.formatMessage(translations.testCasesHeader) }</h3>
+        { errorTextElement }
+        {this.renderTestCases(intl.formatMessage(translations.publicTestCases),
+          testCases, 'public')}
+        {this.renderTestCases(intl.formatMessage(translations.privateTestCases),
+          testCases, 'private', testCases.get('public').size)}
+        {this.renderTestCases(intl.formatMessage(translations.evaluationTestCases),
+          testCases, 'evaluation',
+          testCases.get('public').size + testCases.get('private').size)}
+      </div>
+    );
+  }
+
+  render() {
+    const { intl, data } = this.props;
+    const autograded = data.get('autograded');
+
+    return (
+      <div id="python-online-editor">
+        <Toggle
+          label={intl.formatMessage(translations.autograded)}
+          labelPosition="right"
+          toggled={autograded}
+          onToggle={this.onAutogradedChange}
+          disabled={this.props.isLoading}
+          style={{ margin: '1em 0' }}
+        />
+        { this.renderEditorCard(intl.formatMessage(translations.submissionTitle), 'submission') }
+        { autograded ? this.renderAutogradedFields() : null }
+      </div>
+    );
+  }
+}
+
+OnlineEditorPythonView.propTypes = propTypes;
+OnlineEditorPythonView.contextTypes = contextTypes;
+
+export default injectIntl(OnlineEditorPythonView);

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
@@ -31,6 +31,7 @@ const propTypes = {
     deleteExistingDataFile: PropTypes.func.isRequired,
   }),
   isLoading: PropTypes.bool.isRequired,
+  autogradedAssessment: PropTypes.bool.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
@@ -99,6 +100,12 @@ class OnlineEditorPythonView extends React.Component {
     super(props);
     this.onAutogradedChange = this.onAutogradedChange.bind(this);
     this.renderExistingDataFiles = this.renderExistingDataFiles.bind(this);
+  }
+
+  componentWillMount() {
+    if (this.props.autogradedAssessment) {
+      this.props.actions.updatePythonCodeBlock('autograded', true);
+    }
   }
 
   onAutogradedChange(e) {
@@ -455,17 +462,21 @@ class OnlineEditorPythonView extends React.Component {
   }
 
   render() {
-    const { intl, data } = this.props;
-    const autograded = data.get('autograded');
+    const { intl, data, autogradedAssessment } = this.props;
+    const autograded = autogradedAssessment || data.get('autograded');
+    let autogradedLabel = intl.formatMessage(translations.autograded);
+    if (autogradedAssessment) {
+      autogradedLabel += ` (${intl.formatMessage(translations.autogradedAssessment)})`;
+    }
 
     return (
       <div id="python-online-editor">
         <Toggle
-          label={intl.formatMessage(translations.autograded)}
+          label={autogradedLabel}
           labelPosition="right"
           toggled={autograded}
           onToggle={this.onAutogradedChange}
-          disabled={this.props.isLoading}
+          disabled={autogradedAssessment || this.props.isLoading}
           style={{ margin: '1em 0' }}
           name="question_programming[autograded]"
         />

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.scss
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.scss
@@ -1,0 +1,14 @@
+// scss-lint:disable ImportantRule
+.deleteButtonCell {
+  padding-left: 12px !important;
+  text-align: center;
+  vertical-align: middle !important;
+  width: 50px;
+}
+
+.testCell {
+  text-overflow: initial !important;
+  white-space: normal !important;
+  word-break: break-word;
+}
+// scss-lint:enable ImportantRule

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.scss
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.scss
@@ -11,4 +11,20 @@
   white-space: normal !important;
   word-break: break-word;
 }
+
+.fileInputButton {
+  cursor: pointer;
+  margin-right: 1em;
+}
+
+.uploadInput {
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+}
 // scss-lint:enable ImportantRule

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
@@ -1,6 +1,14 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
+  autograded: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.autograded',
+    defaultMessage: 'Autograded',
+  },
+  autogradedAssessment: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedAssessment',
+    defaultMessage: 'Autograded assessment cannot have non-autograded questions',
+  },
   titleFieldLabel: {
     id: 'course.assessment.question.programming.programmingQuestionForm.titleFieldLabel',
     defaultMessage: 'Title',

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
@@ -61,6 +61,21 @@ export default defineMessages({
     defaultMessage: 'Uploaded package',
     description: 'Label for the existing uploaded zip package.',
   },
+  downloadPackageLabel: {
+    id: 'course.assessment.question.programming.programmingQuestionForm.downloadPackageLabel',
+    defaultMessage: 'Download package',
+    description: 'Label for the downloading generated zip package.',
+  },
+  packageUpdatedBy: {
+    id: 'course.assessment.question.programming.programmingQuestionForm.packageUpdatedBy',
+    defaultMessage: 'Updated by: {name}',
+    description: 'Shows the author who last modified the package through the online editor.',
+  },
+  packageUploadedBy: {
+    id: 'course.assessment.question.programming.programmingQuestionForm.packageUploadedBy',
+    defaultMessage: 'Uploaded by: {name}',
+    description: 'Shows the author who last uploaded the zip package.',
+  },
   newPackageButton: {
     id: 'course.assessment.question.programming.programmingQuestionForm.newPackageButton',
     defaultMessage: 'Choose new package',

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
@@ -109,12 +109,8 @@ export default defineMessages({
     defaultMessage: 'Submit',
     description: 'Button for submitting the form.',
   },
-  updateSuccessMessage: {
-    id: 'course.assessment.question.programming.programmingQuestionForm.updateSuccessMessage',
-    defaultMessage: 'The question was successfully updated.',
-  },
-  updateFailureMessage: {
-    id: 'course.assessment.question.programming.programmingQuestionForm.updateFailureMessage',
+  submitFailureMessage: {
+    id: 'course.assessment.question.programming.programmingQuestionForm.submitFailureMessage',
     defaultMessage: 'An error occurred, please try again.',
   },
   evaluatingMessage: {

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -366,22 +366,34 @@ class ProgrammingQuestionForm extends React.Component {
   }
 
   renderPackageField(label, field, pkg, newFilename, showEditOnline) {
-    const uploadedPackageLabel = this.props.intl.formatMessage(translations.uploadedPackageLabel);
-    const downloadNode = (
-      pkg ?
-        (<div className={styles.downloadPackageContainer}>
-          <span className={styles.uploadedPackageLabel}>{uploadedPackageLabel}:</span>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href={pkg.get('path')}
-          >
-            {pkg.get('name')}
-          </a>
-        </div>)
+    let downloadNode = null;
+
+    if (pkg) {
+      const uploadedPackageLabel = showEditOnline ?
+        this.props.intl.formatMessage(translations.downloadPackageLabel)
         :
-        null
-    );
+        this.props.intl.formatMessage(translations.uploadedPackageLabel);
+      const name = pkg.get('updater_name');
+      const author = showEditOnline ?
+        this.props.intl.formatMessage(translations.packageUpdatedBy, { name })
+        :
+        this.props.intl.formatMessage(translations.packageUploadedBy, { name });
+      downloadNode = (
+        <div className={styles.downloadPackageContainer}>
+          <div>
+            <span className={styles.uploadedPackageLabel}>{uploadedPackageLabel}:</span>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={pkg.get('path')}
+            >
+              {pkg.get('name')}
+            </a>
+          </div>
+          <div>{author}</div>
+        </div>
+      );
+    }
 
     if (showEditOnline) {
       return downloadNode;

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -152,24 +152,16 @@ class ProgrammingQuestionForm extends React.Component {
   }
 
   onSubmit(e) {
-    if (!this.validationCheck()) {
-      e.preventDefault();
-      return;
-    }
-    const async = this.props.data.getIn(['form_data', 'async']);
+    e.preventDefault();
+    if (!this.validationCheck()) return;
 
-    if (async) {
-      e.preventDefault();
+    const url = this.props.data.getIn(['form_data', 'path']);
+    const method = this.props.data.getIn(['form_data', 'method']);
+    const formData = new FormData(this.form);
 
-      const url = this.props.data.getIn(['form_data', 'path']);
-      const method = this.props.data.getIn(['form_data', 'method']);
-      const formData = new FormData(this.form);
+    const failureMessage = this.props.intl.formatMessage(translations.submitFailureMessage);
 
-      const successMessage = this.props.intl.formatMessage(translations.updateSuccessMessage);
-      const failureMessage = this.props.intl.formatMessage(translations.updateFailureMessage);
-
-      this.props.actions.submitForm(url, method, formData, successMessage, failureMessage);
-    }
+    this.props.actions.submitForm(url, method, formData, failureMessage);
   }
 
   validationCheck() {
@@ -484,6 +476,16 @@ class ProgrammingQuestionForm extends React.Component {
     return (
       <div>
         { this.renderImportAlertView() }
+        {
+          this.props.data.get('save_errors') ?
+            <div className="alert alert-danger">
+              {
+                this.props.data.get('save_errors').map((errorMessage, index) => <div key={index}>{errorMessage}</div>)
+              }
+            </div>
+            :
+            null
+        }
         <form
           id="programmming-question-form"
           action={formData.get('path')}
@@ -551,10 +553,12 @@ class ProgrammingQuestionForm extends React.Component {
                     labelPosition="right"
                     toggled={autograded}
                     onToggle={(e) => {
+                      if (autogradedAssessment) return;
                       this.handleChange('autograded', e.target.checked);
                     }}
-                    disabled={autogradedAssessment || this.props.data.get('is_loading')}
-                    style={{margin: '1em 0'}}
+                    readOnly={autogradedAssessment}
+                    disabled={this.props.data.get('is_loading')}
+                    style={{ margin: '1em 0' }}
                     name="question_programming[autograded]"
                   />
                   :

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -437,6 +437,7 @@ class ProgrammingQuestionForm extends React.Component {
           {...{
             actions: this.props.onlineEditorActions,
             data: this.props.data,
+            autogradedAssessment: this.props.data.getIn(['question', 'autograded_assessment']),
           }}
         />
       );

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.scss
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.scss
@@ -8,6 +8,7 @@
 .staffCommentsInput,
 .skillsInput,
 .maximumGradeInput,
+.autogradeToggle,
 .languageInput,
 .memoryLimitInput,
 .timeLimitInput,

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.scss
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.scss
@@ -63,6 +63,10 @@
   width: 100%;
 }
 
+.downloadPackageContainer {
+  margin-top: 0.5em;
+}
+
 .submitButton {
   margin-bottom: 1em;
   margin-top: 1em;

--- a/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
@@ -83,7 +83,7 @@ class UploadedPackageTestCaseView extends React.Component {
 
       return (
         <Table selectable={false}>
-          <TableHeader displaySelectAll={false}>
+          <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
             <TableRow>
               <TableHeaderColumn>
                 { this.props.intl.formatMessage(translations.identifierHeader) }

--- a/client/app/bundles/course/assessment/question/programming/constants/onlineEditorConstants.jsx
+++ b/client/app/bundles/course/assessment/question/programming/constants/onlineEditorConstants.jsx
@@ -7,6 +7,9 @@ const editorActionTypes = mirrorCreator([
   'PYTHON_TEST_CASE_CREATE',
   'PYTHON_TEST_CASE_UPDATE',
   'PYTHON_TEST_CASE_DELETE',
+  'PYTHON_NEW_DATA_FILE_UPDATE',
+  'PYTHON_NEW_DATA_FILE_DELETE',
+  'PYTHON_EXISTING_DATA_FILE_DELETE',
 ]);
 
 export default editorActionTypes;

--- a/client/app/bundles/course/assessment/question/programming/constants/onlineEditorConstants.jsx
+++ b/client/app/bundles/course/assessment/question/programming/constants/onlineEditorConstants.jsx
@@ -1,0 +1,12 @@
+// See https://www.npmjs.com/package/mirror-creator
+// Allows us to set up constants in a slightly more concise syntax.
+import mirrorCreator from 'mirror-creator';
+
+const editorActionTypes = mirrorCreator([
+  'PYTHON_CODE_BLOCK_UPDATE',
+  'PYTHON_TEST_CASE_CREATE',
+  'PYTHON_TEST_CASE_UPDATE',
+  'PYTHON_TEST_CASE_DELETE',
+]);
+
+export default editorActionTypes;

--- a/client/app/bundles/course/assessment/question/programming/reducers/programmingQuestionReducer.jsx
+++ b/client/app/bundles/course/assessment/question/programming/reducers/programmingQuestionReducer.jsx
@@ -49,6 +49,14 @@ export const initialState = Immutable.fromJS({
         private: [],
         public: [],
       },
+      data_files: [],
+    },
+    data_files: {
+      to_delete: Immutable.Set(),
+      new: [
+        { key: 0, filename: null },
+      ],
+      key: 0,
     },
   },
   import_result: {
@@ -123,6 +131,44 @@ function pythonTestReducer(state, action) {
   }
 }
 
+function dataFilesReducer(state, action) {
+  const { type } = action;
+
+  switch (type) {
+    case editorActionTypes.PYTHON_NEW_DATA_FILE_UPDATE: {
+      const { index, filename } = action;
+      let newFiles = state.get('new')
+        .update(index, fileData => Immutable.fromJS({ key: fileData.get('key'), filename }));
+
+      // Adds a new entry if there are no more empty non-deleted files.
+      if (newFiles.last().get('filename') !== null) {
+        const newKey = state.get('new') + 1;
+        newFiles = newFiles.push(Immutable.fromJS({ key: newKey, filename: null }));
+        return state.set('key', newKey).set('new', newFiles);
+      }
+
+      return state.set('new', newFiles);
+    }
+    case editorActionTypes.PYTHON_NEW_DATA_FILE_DELETE: {
+      const { index } = action;
+      return state.set('new', state.get('new').delete(index));
+    }
+    case editorActionTypes.PYTHON_EXISTING_DATA_FILE_DELETE: {
+      const { filename, toDelete } = action;
+      const currentFilesToDelete = state.get('to_delete');
+
+      if (toDelete) {
+        return state.set('to_delete', currentFilesToDelete.add(filename));
+      }
+
+      return state.set('to_delete', currentFilesToDelete.delete(filename));
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
 function apiReducer(state, action) {
   const { type } = action;
 
@@ -136,12 +182,21 @@ function apiReducer(state, action) {
 
       if (data) {
         const { question, package_ui, test_ui, import_result } = data;
+        const key = state.getIn(['test_ui', 'data_files', 'key']);
+        let newState = state;
+        const editorMode = test_ui.mode;
 
-        return state
+        if (editorMode && test_ui[editorMode] !== undefined) {
+          newState = newState.setIn(['test_ui', editorMode], Immutable.fromJS(test_ui[editorMode]));
+        }
+
+        return newState
           .set('is_evaluating', isEvaluating)
           .mergeDeep({ question })
           .setIn(['question', 'package_filename'], null)
-          .merge({ test_ui, package_ui, import_result });
+          .merge({ package_ui, import_result })
+          .setIn(['test_ui', 'data_files', 'to_delete'], Immutable.Set())
+          .setIn(['test_ui', 'data_files', 'new'], Immutable.fromJS([{ key, filename: null }]));
       }
 
       return state
@@ -151,10 +206,16 @@ function apiReducer(state, action) {
     case actionTypes.SUBMIT_FORM_SUCCESS: {
       const { data } = action;
       const { question, package_ui, test_ui, import_result } = data;
+      let newState = state;
+      const editorMode = test_ui.mode;
 
-      return state
+      if (editorMode && test_ui[editorMode] !== undefined) {
+        newState = newState.setIn(['test_ui', editorMode], Immutable.fromJS(test_ui[editorMode]));
+      }
+
+      return newState
         .mergeDeep({ question })
-        .merge({ test_ui, package_ui, import_result });
+        .merge({ package_ui, import_result });
     }
     case actionTypes.SUBMIT_FORM_FAILURE: {
       return state;
@@ -183,6 +244,12 @@ export default function programmingQuestionReducer(state = initialState, action)
     case editorActionTypes.PYTHON_CODE_BLOCK_UPDATE: {
       const pythonTest = state.get('test_ui').get('python');
       return state.setIn(['test_ui', 'python'], pythonTestReducer(pythonTest, action));
+    }
+    case editorActionTypes.PYTHON_NEW_DATA_FILE_UPDATE:
+    case editorActionTypes.PYTHON_NEW_DATA_FILE_DELETE:
+    case editorActionTypes.PYTHON_EXISTING_DATA_FILE_DELETE: {
+      const dataFiles = state.get('test_ui').get('data_files');
+      return state.setIn(['test_ui', 'data_files'], dataFilesReducer(dataFiles, action));
     }
     case actionTypes.SUBMIT_FORM_EVALUATING:
     case actionTypes.SUBMIT_FORM_LOADING:

--- a/client/app/bundles/course/assessment/question/programming/reducers/programmingQuestionReducer.jsx
+++ b/client/app/bundles/course/assessment/question/programming/reducers/programmingQuestionReducer.jsx
@@ -19,6 +19,8 @@ export const initialState = Immutable.fromJS({
     skills: [],
     memory_limit: null,
     time_limit: null,
+    autograded: false,
+    display_autograded_toggle: false,
     autograded_assessment: false,
     published_assessment: false,
     attempt_limit: null,
@@ -39,7 +41,6 @@ export const initialState = Immutable.fromJS({
   test_ui: {
     mode: null,
     python: {
-      autograded: false,
       prepend: '',
       append: '',
       solution: '',
@@ -82,6 +83,11 @@ function questionReducer(state, action) {
   switch (type) {
     case actionTypes.PROGRAMMING_QUESTION_UPDATE: {
       const { field, newValue } = action;
+
+      if (field === 'autograded' && newValue === false) {
+        return state.set(field, newValue).set('edit_online', true);
+      }
+
       return state.set(field, newValue).deleteIn(['error', field]);
     }
     case actionTypes.SKILLS_UPDATE: {

--- a/config/locales/en/course/assessment/question/programming.yml
+++ b/config/locales/en/course/assessment/question/programming.yml
@@ -7,8 +7,10 @@ en:
             header: 'New Programming Question'
           create:
             success: 'The programming question was created.'
+            failure: 'Could not create programming question.'
           update:
             success: 'The programming question was updated.'
+            failure: 'Could not update programming question.'
           destroy:
             success: 'The programming question was deleted.'
             failure: 'Could not delete programming question: %{error}'

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::ProgrammingController do
+  render_views
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:programming_question) { nil }
@@ -29,13 +30,26 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
 
     describe '#create' do
       subject do
+        request.accept = 'application/json'
         post :create, course_id: course, assessment_id: assessment,
                       question_programming: question_programming_attributes
       end
 
       context 'when saving fails' do
         let(:programming_question) { immutable_programming_question }
-        it { is_expected.to render_template('new') }
+
+        it 'returns the correct status' do
+          subject
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'returns the correct failure message' do
+          subject
+          body = JSON.parse(response.body)
+          expect(body['message']).to eq(
+            I18n.t('course.assessment.question.programming.create.failure')
+          )
+        end
       end
 
       context 'when attaching a template package' do
@@ -50,9 +64,10 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
           end
         end
 
-        it 'redirects to job progress page' do
+        it 'returns the correct import job url' do
           subject
-          expect(subject).to redirect_to(
+          body = JSON.parse(response.body)
+          expect(body['import_job_url']).to eq(
             job_path(controller.instance_variable_get(:@programming_question).import_job)
           )
         end
@@ -61,13 +76,26 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
 
     describe '#update' do
       subject do
+        request.accept = 'application/json'
         patch :update, course_id: course, assessment_id: assessment, id: programming_question,
                        question_programming: question_programming_attributes
       end
 
       context 'when the question cannot be saved' do
         let(:programming_question) { immutable_programming_question }
-        it { is_expected.to render_template('edit') }
+
+        it 'returns the correct status' do
+          subject
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'returns the correct failure message' do
+          subject
+          body = JSON.parse(response.body)
+          expect(body['message']).to eq(
+            I18n.t('course.assessment.question.programming.update.failure')
+          )
+        end
       end
 
       context 'when attaching a template package' do
@@ -86,9 +114,10 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
           end
         end
 
-        it 'redirects to job progress page' do
+        it 'returns the correct import job url' do
           subject
-          expect(subject).to redirect_to(
+          body = JSON.parse(response.body)
+          expect(body['import_job_url']).to eq(
             job_path(controller.instance_variable_get(:@programming_question).import_job)
           )
         end

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
         include Rails.application.routes.url_helpers
 
         let(:programming_question) do
-          create(:course_assessment_question_programming, assessment: assessment)
+          create(:course_assessment_question_programming,
+                 assessment: assessment, template_package: true)
         end
         let(:question_programming_attributes) do
           attributes_for(:course_assessment_question_programming, template_package: true).

--- a/spec/factories/course_assessment_question_programming.rb
+++ b/spec/factories/course_assessment_question_programming.rb
@@ -25,6 +25,9 @@ FactoryGirl.define do
       File.new(File.join(Rails.root, 'spec/fixtures/course/'\
                          'programming_question_template.zip'), 'rb') if template_package
     end
+    package_type do
+      template_package ? :zip_upload : :online_editor
+    end
     test_cases do
       public_test_cases = test_case_count.downto(1).map do
         build(:course_assessment_question_programming_test_case, question: nil)

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -33,19 +33,14 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         end
         select question_attributes[:language].name,
                from: 'question_programming[language_id]', visible: false
-        fill_in 'question_programming[memory_limit]', with: question_attributes[:memory_limit]
-        fill_in 'question_programming[time_limit]', with: question_attributes[:time_limit]
-        fill_in 'question_programming[attempt_limit]', with: question_attributes[:attempt_limit]
         page.find('#programmming-question-form-submit').click
 
+        expect(page).to_not have_xpath('//form//*[contains(@class, \'fa-spinner\')]')
         expect(current_path).to eq(course_assessment_path(course, assessment))
 
         question_created = assessment.questions.first.specific
         expect(page).to have_content_tag_for(question_created)
         expect(question_created.skills).to contain_exactly(skill)
-        expect(question_created.memory_limit).to eq(question_attributes[:memory_limit])
-        expect(question_created.time_limit).to eq(question_attributes[:time_limit])
-        expect(question_created.attempt_limit).to eq(question_attributes[:attempt_limit])
       end
 
       scenario 'I can upload a template package', js: true do
@@ -71,8 +66,9 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         page.find('#programmming-question-form-submit').click
         wait_for_job
 
-        expect(current_path).to \
-          start_with(course_assessment_path(course, assessment))
+        expect(page).to_not have_xpath('//form//*[contains(@class, \'fa-spinner\')]')
+        expect(current_path).to eq(course_assessment_path(course, assessment))
+        visit edit_course_assessment_question_programming_path(course, assessment, question)
 
         expect(page).to have_selector('div.alert.alert-success')
         question.template_files.reload.each do |template|
@@ -99,7 +95,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         page.find('#programmming-question-form-submit').click
 
         expect(page).to_not have_xpath('//form//*[contains(@class, \'fa-spinner\')]')
-        expect(current_path).to eq(edit_path)
+        expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(question.reload.maximum_grade).to eq(maximum_grade)
       end
 
@@ -127,8 +123,10 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         end
         select question_attributes[:language].name,
                from: 'question_programming[language_id]', visible: false
+        page.check('question_programming[autograded]', visible: false)
         fill_in 'question_programming[memory_limit]', with: question_attributes[:memory_limit]
         fill_in 'question_programming[time_limit]', with: question_attributes[:time_limit]
+        fill_in 'question_programming[attempt_limit]', with: question_attributes[:attempt_limit]
 
         page.find('#upload-package-tab').click
         page.find('#question_programming_file', visible: false).click
@@ -140,8 +138,14 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         page.find('#programmming-question-form-submit').click
         wait_for_job
 
+        expect(page).to_not have_xpath('//form//*[contains(@class, \'fa-spinner\')]')
         expect(current_path).to \
           start_with(course_assessment_path(course, assessment))
+
+        question_created = assessment.questions.first.specific
+        expect(question_created.memory_limit).to eq(question_attributes[:memory_limit])
+        expect(question_created.time_limit).to eq(question_attributes[:time_limit])
+        expect(question_created.attempt_limit).to eq(question_attributes[:attempt_limit])
       end
     end
 

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
 
       scenario 'I can upload a template package', js: true do
         question = create(:course_assessment_question_programming,
-                          assessment: assessment, template_file_count: 0)
+                          assessment: assessment, template_file_count: 0, template_package: true)
         visit edit_course_assessment_question_programming_path(course, assessment, question)
         expect(page).to have_xpath('//form[@id=\'programmming-question-form\']')
 
@@ -130,6 +130,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         fill_in 'question_programming[memory_limit]', with: question_attributes[:memory_limit]
         fill_in 'question_programming[time_limit]', with: question_attributes[:time_limit]
 
+        page.find('#upload-package-tab').click
         page.find('#question_programming_file', visible: false).click
         attach_file 'question_programming[file]',
                     File.join(ActionController::TestCase.fixture_path,


### PR DESCRIPTION
Last step of #1568
Depends on #1834 

This PR:

- Implements the python editor using ReactJS and material-ui.
  + Validates the presence of at least 1 test case when autograded is checked.
  + When the assessment is autograded, the question cannot be set to non-autograded.
- Implements adding and deleting data files for python editor.
  + If the user adds a new file with the exact same filename as an existing file, the new file will automatically replace the existing file even if the user did not mark the existing file for deletion.
- Display the user who last modified the package file/last edited the python editor.
