### PR TITLE
More fixes to submission statuses 

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -62,7 +62,10 @@ class Course::Assessment::Submission::SubmissionsController < \
   def publish_all
     graded_submissions = @assessment.submissions.with_graded_state
     if !graded_submissions.empty?
-      graded_submissions.update_all(workflow_state: 'published')
+      graded_submissions.update_all(
+        workflow_state: 'published', publisher_id: current_user.id, published_at: Time.zone.now,
+        updated_at: Time.zone.now, updater_id: current_user.id
+      )
       redirect_to course_assessment_submissions_path(current_course, @assessment),
                   success: t('.success')
     else

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -23,7 +23,8 @@
         = render partial: 'course/assessment/answer/manually_graded',
           locals: { base_answer_form: f, answer: answer, last_attempt: last_attempt }
 
-      - if !submission.attempting?
+      / Don't show grades to students if they are not published
+      - if submission.published? || !submission.attempting? && can?(:grade, submission)
         = render partial: 'course/assessment/answer/grading',
                  locals: { base_answer_form: f, answer: answer }
 

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -10,10 +10,16 @@ div.panel.panel-default
         tr
           th = t('.status')
           td
-            = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
             - if @submission.graded?
-              span.text-warning title=t('.publish_grade_hint')
-                =< fa_icon 'question-circle-o'.freeze
+              - if can?(:grade, @submission)
+                = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
+                span.text-warning title=t('.publish_grade_hint')
+                  =< fa_icon 'question-circle-o'.freeze
+              - else
+                / For graded submissions, still show as submitted for students
+                = Course::Assessment::Submission.human_attribute_name(:submitted)
+            - else
+              = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
         - if display_grading_results
           tr
             th = @submission.class.human_attribute_name(:grade)

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
         expect(page).
           not_to have_button(I18n.t('course.assessment.submission.submissions.buttons.finalise'))
+        expect(page).not_to have_selector('div.submission_answers_grade')
       end
 
       scenario 'I can comment on answers', js: true do

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -76,6 +76,9 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
 
         click_link I18n.t('course.assessment.submission.submissions.index.publish')
         expect(graded_submission.reload).to be_published
+        expect(graded_submission.publisher).to eq(user)
+        expect(graded_submission.published_at).to be_present
+
         message = I18n.t('course.assessment.submission.submissions.publish_all.success')
         expect(page).to have_selector('div', text: message)
 


### PR DESCRIPTION
When the submission is graded but not published:
- Display submission status as submitted to students 
- Hide answer grading panel

Publisher and time get set when the submission is published by publish_all. 