### PR TITLE
Use separate columns to store notification tokens 

### DIFF
--- a/app/jobs/course/assessment/closing_reminder_job.rb
+++ b/app/jobs/course/assessment/closing_reminder_job.rb
@@ -7,10 +7,10 @@ class Course::Assessment::ClosingReminderJob < ApplicationJob
 
   protected
 
-  def perform_tracked(user, assessment, end_at)
+  def perform_tracked(user, assessment, token)
     instance = Course.unscoped { assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
-      Course::Assessment::ReminderService.closing_reminder(user, assessment, end_at)
+      Course::Assessment::ReminderService.closing_reminder(user, assessment, token)
     end
   end
 end

--- a/app/jobs/course/assessment/opening_reminder_job.rb
+++ b/app/jobs/course/assessment/opening_reminder_job.rb
@@ -7,10 +7,10 @@ class Course::Assessment::OpeningReminderJob < ApplicationJob
 
   protected
 
-  def perform_tracked(user, assessment, start_at)
+  def perform_tracked(user, assessment, token)
     instance = Course.unscoped { assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
-      Course::Assessment::ReminderService.opening_reminder(user, assessment, start_at)
+      Course::Assessment::ReminderService.opening_reminder(user, assessment, token)
     end
   end
 end

--- a/app/jobs/course/video/closing_reminder_job.rb
+++ b/app/jobs/course/video/closing_reminder_job.rb
@@ -7,10 +7,10 @@ class Course::Video::ClosingReminderJob < ApplicationJob
 
   protected
 
-  def perform_tracked(user, video, end_at)
+  def perform_tracked(user, video, token)
     instance = Course.unscoped { video.course.instance }
     ActsAsTenant.with_tenant(instance) do
-      Course::Video::ReminderService.closing_reminder(user, video, end_at)
+      Course::Video::ReminderService.closing_reminder(user, video, token)
     end
   end
 end

--- a/app/jobs/course/video/opening_reminder_job.rb
+++ b/app/jobs/course/video/opening_reminder_job.rb
@@ -7,10 +7,10 @@ class Course::Video::OpeningReminderJob < ApplicationJob
 
   protected
 
-  def perform_tracked(user, video, start_at)
+  def perform_tracked(user, video, token)
     instance = Course.unscoped { video.course.instance }
     ActsAsTenant.with_tenant(instance) do
-      Course::Video::ReminderService.opening_reminder(user, video, start_at)
+      Course::Video::ReminderService.opening_reminder(user, video, token)
     end
   end
 end

--- a/app/services/course/assessment/reminder_service.rb
+++ b/app/services/course/assessment/reminder_service.rb
@@ -4,14 +4,14 @@ class Course::Assessment::ReminderService
     delegate :closing_reminder, to: :new
   end
 
-  def opening_reminder(user, assessment, start_at)
-    return unless start_at.round(4) == assessment.start_at.to_f.round(4) && assessment.published?
+  def opening_reminder(user, assessment, token)
+    return unless assessment.opening_reminder_token == token && assessment.published?
 
     Course::AssessmentNotifier.assessment_opening(user, assessment)
   end
 
-  def closing_reminder(user, assessment, end_at)
-    return unless end_at.round(4) == assessment.end_at.to_f.round(4) && assessment.published?
+  def closing_reminder(user, assessment, token)
+    return unless assessment.closing_reminder_token == token && assessment.published?
 
     Course::AssessmentNotifier.assessment_closing(user, assessment)
   end

--- a/app/services/course/video/reminder_service.rb
+++ b/app/services/course/video/reminder_service.rb
@@ -4,14 +4,14 @@ class Course::Video::ReminderService
     delegate :closing_reminder, to: :new
   end
 
-  def opening_reminder(user, video, start_at)
-    return unless start_at.round(4) == video.start_at.to_f.round(4) && video.published?
+  def opening_reminder(user, video, token)
+    return unless video.opening_reminder_token == token && video.published?
 
     Course::VideoNotifier.video_opening(user, video)
   end
 
-  def closing_reminder(user, video, end_at)
-    return unless end_at.round(4) == video.end_at.to_f.round(4) && video.published?
+  def closing_reminder(user, video, token)
+    return unless video.closing_reminder_token == token && video.published?
 
     Course::VideoNotifier.video_closing(user, video)
   end

--- a/db/migrate/20170116103602_add_tokens_to_course_lesson_plan_items.rb
+++ b/db/migrate/20170116103602_add_tokens_to_course_lesson_plan_items.rb
@@ -2,5 +2,29 @@ class AddTokensToCourseLessonPlanItems < ActiveRecord::Migration
   def change
     add_column :course_lesson_plan_items, :opening_reminder_token, :float
     add_column :course_lesson_plan_items, :closing_reminder_token, :float
+
+    Course::Assessment.joins(:lesson_plan_item).
+      where('course_lesson_plan_items.start_at > ?', Time.zone.now).find_each do |assessment|
+      # Remove milliseconds part of the assessment
+      assessment.lesson_plan_item.update_column(:start_at, assessment.start_at.change(usec: 0))
+
+      # Create the new reminder job
+      token = Time.zone.now.to_f.round(5)
+      assessment.lesson_plan_item.update_column(:opening_reminder_token, token)
+      Course::Assessment::OpeningReminderJob.set(wait_until: assessment.start_at).
+        perform_later(assessment.updater, assessment, token)
+    end
+
+    Course::Assessment.joins(:lesson_plan_item).
+      where('course_lesson_plan_items.end_at > ?', 1.day.from_now).find_each do |assessment|
+      # Remove milliseconds part of the assessment
+      assessment.lesson_plan_item.update_column(:end_at, assessment.end_at.change(usec: 0))
+
+      # Create the new reminder job
+      token = Time.zone.now.to_f.round(5)
+      assessment.lesson_plan_item.update_column(:closing_reminder_token, token)
+      Course::Assessment::ClosingReminderJob.set(wait_until: assessment.end_at - 1.day).
+        perform_later(assessment.updater, assessment, token)
+    end
   end
 end

--- a/db/migrate/20170116103602_add_tokens_to_course_lesson_plan_items.rb
+++ b/db/migrate/20170116103602_add_tokens_to_course_lesson_plan_items.rb
@@ -1,0 +1,6 @@
+class AddTokensToCourseLessonPlanItems < ActiveRecord::Migration
+  def change
+    add_column :course_lesson_plan_items, :opening_reminder_token, :float
+    add_column :course_lesson_plan_items, :closing_reminder_token, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170115105609) do
+ActiveRecord::Schema.define(version: 20170116103602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -507,20 +507,22 @@ ActiveRecord::Schema.define(version: 20170115105609) do
 
   create_table "course_lesson_plan_items", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_lesson_plan_items_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
-    t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_items_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",          :limit=>255, :null=>false
+    t.string   "actable_type",           :limit=>255, :index=>{:name=>"index_course_lesson_plan_items_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
+    t.integer  "course_id",              :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_items_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",                  :limit=>255, :null=>false
     t.text     "description"
-    t.boolean  "published",      :default=>false, :null=>false
-    t.integer  "base_exp",       :null=>false
-    t.integer  "time_bonus_exp", :null=>false
-    t.datetime "start_at",       :null=>false
+    t.boolean  "published",              :default=>false, :null=>false
+    t.integer  "base_exp",               :null=>false
+    t.integer  "time_bonus_exp",         :null=>false
+    t.datetime "start_at",               :null=>false
     t.datetime "bonus_end_at"
     t.datetime "end_at"
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",     :null=>false
-    t.datetime "updated_at",     :null=>false
+    t.float    "opening_reminder_token"
+    t.float    "closing_reminder_token"
+    t.integer  "creator_id",             :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",             :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",             :null=>false
+    t.datetime "updated_at",             :null=>false
   end
 
   create_table "course_lesson_plan_milestones", force: :cascade do |t|

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -78,20 +78,20 @@ RSpec.feature 'Course: Assessments: Management' do
       end
 
       scenario 'I can edit an assessment' do
-        assessment = create(:assessment, :published_with_mrq_question, course: course)
+        assessment = create(:assessment, :published_with_mrq_question,
+                            course: course, start_at: 1.day.from_now)
         visit course_assessment_path(course, assessment)
-        clear_enqueued_jobs
-
         find_link(nil, href: edit_course_assessment_path(course, assessment)).click
 
         new_text = 'zzzz'
         fill_in 'assessment_title', with: new_text
+        fill_in 'assessment_start_at', with: Time.zone.now
         click_button 'submit'
 
         perform_enqueued_jobs
         wait_for_job
-        expect(unread_emails_for(user.email).count).to eq(0)
 
+        expect(unread_emails_for(user.email)).to be_present
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).to have_selector('h1', text: new_text)
       end

--- a/spec/jobs/course/assessment/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/closing_reminder_job_spec.rb
@@ -4,15 +4,23 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::ClosingReminderJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let!(:now) { Time.zone.now }
-
-    let(:user) { create(:course_user).user }
     let(:assessment) { create(:assessment) }
-    subject { Course::Assessment::ClosingReminderJob }
 
-    it 'can be queued' do
-      expect { subject.perform_later(user, assessment, now.to_i) }.
-        to have_enqueued_job(subject).exactly(:once)
+    context 'when end_at of the assessment is changed' do
+      it 'creates a closing reminder job' do
+        assessment.end_at = 1.day.from_now
+
+        expect { assessment.save }.to have_enqueued_job(Course::Assessment::ClosingReminderJob)
+      end
+
+      context 'when end_at is a past time' do
+        it 'does not do anything' do
+          assessment.end_at = 1.day.ago
+
+          expect { assessment.save }.
+            not_to have_enqueued_job(Course::Assessment::ClosingReminderJob)
+        end
+      end
     end
   end
 end

--- a/spec/jobs/course/assessment/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/opening_reminder_job_spec.rb
@@ -4,15 +4,14 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::OpeningReminderJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let!(:now) { Time.zone.now }
+    let(:assessment) { create(:assessment) }
 
-    let(:user) { create(:course_user).user }
-    let!(:assessment) { create(:assessment) }
-    subject { Course::Assessment::OpeningReminderJob }
+    context 'when start_at of the assessment is changed' do
+      it 'creates a opening reminder job' do
+        assessment.start_at = Time.zone.now
 
-    it 'can be queued' do
-      expect { subject.perform_later(user, assessment, now.to_i) }.
-        to have_enqueued_job(subject).exactly(:once)
+        expect { assessment.save }.to have_enqueued_job(Course::Assessment::OpeningReminderJob)
+      end
     end
   end
 end

--- a/spec/jobs/course/video/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/video/closing_reminder_job_spec.rb
@@ -4,15 +4,22 @@ require 'rails_helper'
 RSpec.describe Course::Video::ClosingReminderJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let!(:now) { Time.zone.now }
-
-    let(:user) { create(:course_user).user }
     let!(:video) { create(:video) }
-    subject { Course::Video::ClosingReminderJob }
 
-    it 'can be queued' do
-      expect { subject.perform_later(user, video, now.to_i) }.
-        to have_enqueued_job(subject).exactly(:once)
+    context 'when end_at is changed' do
+      it 'creates a closing reminder job' do
+        video.end_at = 1.day.from_now
+
+        expect { video.save }.to have_enqueued_job(Course::Video::ClosingReminderJob)
+      end
+
+      context 'when end_at is a past time' do
+        it 'does not do create any jobs' do
+          video.end_at = 1.day.ago
+
+          expect { video.save }.not_to have_enqueued_job(Course::Video::ClosingReminderJob)
+        end
+      end
     end
   end
 end

--- a/spec/jobs/course/video/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/video/opening_reminder_job_spec.rb
@@ -4,15 +4,14 @@ require 'rails_helper'
 RSpec.describe Course::Video::OpeningReminderJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let!(:now) { Time.zone.now }
+    let(:video) { create(:video) }
 
-    let(:user) { create(:course_user).user }
-    let!(:video) { create(:video) }
-    subject { Course::Video::OpeningReminderJob }
+    context 'when start_at is changed' do
+      it 'creates a opening reminder job' do
+        video.start_at = Time.zone.now
 
-    it 'can be queued' do
-      expect { subject.perform_later(user, video, now.to_i) }.
-        to have_enqueued_job(subject).exactly(:once)
+        expect { video.save }.to have_enqueued_job(Course::Video::OpeningReminderJob)
+      end
     end
   end
 end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Course::Assessment do
           expect(subject.folder.name).to eq(subject.title)
           expect(subject.folder.parent).to eq(subject.tab.category.folder)
           expect(subject.folder.course).to eq(subject.course)
-          expect(subject.folder.start_at).to be_within(0.5).of(subject.start_at)
+          expect(subject.folder.start_at).to eq(subject.start_at)
         end
       end
 
@@ -119,8 +119,7 @@ RSpec.describe Course::Assessment do
           subject.save
 
           expect(subject.folder.name).to eq(new_title)
-          # Assessment reminders add a small time differential to prevent duplication
-          expect(subject.folder.start_at).to be_within(1).of(new_start_at)
+          expect(subject.folder.start_at).to eq(new_start_at)
         end
       end
     end

--- a/spec/services/course/assessment/reminder_service_spec.rb
+++ b/spec/services/course/assessment/reminder_service_spec.rb
@@ -17,24 +17,23 @@ RSpec.describe Course::Assessment::ReminderService do
           assessment.published = true
 
           expect_any_instance_of(Course::AssessmentNotifier).to receive(:assessment_opening).once
-          subject.opening_reminder(user, assessment, assessment.start_at.to_f)
+          subject.opening_reminder(user, assessment, assessment.opening_reminder_token)
         end
       end
 
       context 'when assessment is a draft' do
         it 'does not notify the users' do
           expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_opening)
-          subject.opening_reminder(user, assessment, assessment.start_at.to_f)
+          subject.opening_reminder(user, assessment, assessment.opening_reminder_token)
         end
-      end
 
-      context "when assessment's start_date was changed" do
-        it 'does not notify the users' do
-          start_at = assessment.start_at.to_f
-          assessment.start_at = now + 1.day
+        context "when assessment's start_date was changed" do
+          it 'does not notify the users' do
+            assessment.start_at = now + 1.day
 
-          expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_opening)
-          subject.opening_reminder(user, assessment, start_at)
+            expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_opening)
+            subject.opening_reminder(user, assessment, assessment.opening_reminder_token)
+          end
         end
       end
     end
@@ -50,24 +49,23 @@ RSpec.describe Course::Assessment::ReminderService do
           assessment.published = true
 
           expect_any_instance_of(Course::AssessmentNotifier).to receive(:assessment_closing).once
-          subject.closing_reminder(user, assessment, assessment.end_at.to_f)
+          subject.closing_reminder(user, assessment, assessment.closing_reminder_token)
         end
       end
 
       context 'when assessment is a draft' do
         it 'does not notify the users' do
           expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_closing)
-          subject.closing_reminder(user, assessment, assessment.end_at.to_f)
+          subject.closing_reminder(user, assessment, assessment.closing_reminder_token)
         end
-      end
 
-      context "when assessment's end_date was changed" do
-        it 'does not notify the users' do
-          end_at = assessment.end_at.to_f
-          assessment.end_at = now + 1.day
+        context "when assessment's end_date was changed" do
+          it 'does not notify the users' do
+            assessment.end_at = now + 1.day
 
-          expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_closing)
-          subject.closing_reminder(user, assessment, end_at)
+            expect_any_instance_of(Course::AssessmentNotifier).to_not receive(:assessment_closing)
+            subject.closing_reminder(user, assessment, assessment.closing_reminder_token)
+          end
         end
       end
     end

--- a/spec/services/course/video/reminder_service_spec.rb
+++ b/spec/services/course/video/reminder_service_spec.rb
@@ -17,24 +17,23 @@ RSpec.describe Course::Video::ReminderService do
           video.published = true
 
           expect_any_instance_of(Course::VideoNotifier).to receive(:video_opening).once
-          subject.opening_reminder(user, video, video.start_at.to_f)
+          subject.opening_reminder(user, video, video.opening_reminder_token)
         end
       end
 
       context 'when video is a draft' do
         it 'does not notify the users' do
           expect_any_instance_of(Course::VideoNotifier).to_not receive(:video_opening)
-          subject.opening_reminder(user, video, video.start_at.to_f)
+          subject.opening_reminder(user, video, video.opening_reminder_token)
         end
-      end
 
-      context "when video's start_date was changed" do
-        it 'does not notify the users' do
-          start_at = video.start_at.to_f
-          video.start_at = now + 1.day
+        context "when video's start_date was changed" do
+          it 'does not notify the users' do
+            video.start_at = now + 1.day
 
-          expect_any_instance_of(Course::VideoNotifier).to_not receive(:video_opening)
-          subject.opening_reminder(user, video, start_at)
+            expect_any_instance_of(Course::VideoNotifier).to_not receive(:video_opening)
+            subject.opening_reminder(user, video, video.opening_reminder_token)
+          end
         end
       end
     end
@@ -50,24 +49,23 @@ RSpec.describe Course::Video::ReminderService do
           video.published = true
 
           expect_any_instance_of(Course::VideoNotifier).to receive(:video_closing).once
-          subject.closing_reminder(user, video, video.end_at.to_f)
+          subject.closing_reminder(user, video, video.closing_reminder_token)
         end
       end
 
       context 'when video is a draft' do
         it 'does not notify the users' do
           expect_any_instance_of(Course::VideoNotifier).to_not receive(:video_closing)
-          subject.closing_reminder(user, video, video.end_at.to_f)
+          subject.closing_reminder(user, video, video.closing_reminder_token)
         end
-      end
 
-      context "when video's end_date was changed" do
-        it 'does not notify the users' do
-          end_at = video.end_at.to_f
-          video.end_at = now + 1.day
+        context "when video's end_date was changed" do
+          it 'does not notify the users' do
+            video.end_at = now + 1.day
 
-          expect_any_instance_of(Course::VideoNotifier).to_not receive(:video_closing)
-          subject.closing_reminder(user, video, end_at)
+            expect_any_instance_of(Course::VideoNotifier).to_not receive(:video_closing)
+            subject.closing_reminder(user, video, video.closing_reminder_token)
+          end
         end
       end
     end


### PR DESCRIPTION
Reference #1812

The old implementation affects the order of assessment.

Used an new implementation here and stores them in separate columns, also refactored part of the tests and did the migration to create new reminder jobs. 

The old reminder job will automatically become invalid because the implementation changed. 