### PR TITLE
Fix Comment Bugs

### DIFF
--- a/app/assets/javascripts/helpers/discussion/post_helpers.js
+++ b/app/assets/javascripts/helpers/discussion/post_helpers.js
@@ -14,7 +14,10 @@ var DISCUSSION_POST_HELPERS = (function($, EVENT_HELPERS,
    * @param element
    */
   function showCommentToolbar(element, selector) {
-    var $comments = $('.discussion_post', element).filter(selector + '*');
+    var $comments = $('.discussion_post', element).
+                    addBack('.discussion_post').
+                    filter(selector + '*');
+
     $comments.find('.toolbar').show();
   }
 

--- a/app/controllers/course/assessment/submission/answer/comments_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/comments_controller.rb
@@ -10,6 +10,11 @@ class Course::Assessment::Submission::Answer::CommentsController < \
   def create
     @answer.class.transaction do
       @post.title = @assessment.title
+      # Set parent as the topologically last pre-existing post, if it exists.
+      # @post is in @answer.posts, so we filter out @post, which has no id yet.
+      if @answer.posts.length > 1
+        @post.parent = @answer.posts.ordered_topologically.flatten.select(&:id).last
+      end
       if super && @answer.save
         send_created_notification(@post)
       else

--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -7,6 +7,11 @@ class Course::Discussion::PostsController < Course::ComponentController
   include Course::Discussion::PostsConcern
 
   def create
+    # Set parent as the topologically last pre-existing post, if it exists.
+    # @post is in @topic.posts, so we filter out @post, which has no id yet.
+    if @topic.posts.length > 1
+      @post.parent = @topic.posts.ordered_topologically.flatten.select(&:id).last
+    end
     if super
       send_created_notification(@post)
     else

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -12,17 +12,6 @@ module Course::Assessment::Submission::SubmissionsHelper
     "course_assessment_submission_answer_#{answer.id}_comments"
   end
 
-  # Finds the comment being created/edited, or constructs a new one in reply to the latest post.
-  #
-  # @param [Course::Discussion::Topic] topic The topic being replied to.
-  # @return [Course::Discussion::Post]
-  def new_comments_post(topic)
-    new_post = topic.posts.find(&:new_record?)
-    return new_post if new_post
-
-    topic.posts.build
-  end
-
   # Return the CSS class of the explanation based on the correctness of the answer.
   #
   # @return [String]

--- a/app/models/concerns/course/discussion/post/ordering_concern.rb
+++ b/app/models/concerns/course/discussion/post/ordering_concern.rb
@@ -9,6 +9,7 @@ module Course::Discussion::Post::OrderingConcern
     include Enumerable
     delegate :each, to: :@sorted
     delegate :length, to: :@sorted
+    delegate :flatten, to: :@sorted
     alias_method :size, :length
 
     # Constructor.

--- a/app/views/course/assessment/answer/_answer.html.slim
+++ b/app/views/course/assessment/answer/_answer.html.slim
@@ -30,6 +30,4 @@
 
       h3 = t('.comments')
       div.comments id=comments_container_id(answer)
-        - topic = answer.discussion_topic
-        = div_for(topic, 'data-topic-id' => topic.id)
-          = render partial: 'course/assessment/answer/comments', locals: { answer: answer }
+        = render partial: 'course/assessment/answer/comments', locals: { answer: answer }

--- a/app/views/course/assessment/answer/_comments.html.slim
+++ b/app/views/course/assessment/answer/_comments.html.slim
@@ -1,3 +1,5 @@
-= display_topic answer.discussion_topic,
-                post_partial: 'course/discussion/post',
-                footer: 'course/assessment/answer/comments_footer'
+- topic = answer.discussion_topic
+= div_for(topic, 'data-topic-id' => topic.id)
+  = display_topic topic,
+                  post_partial: 'course/discussion/post',
+                  footer: 'course/assessment/answer/comments_footer'

--- a/app/views/course/assessment/answer/_comments_footer.html.slim
+++ b/app/views/course/assessment/answer/_comments_footer.html.slim
@@ -5,7 +5,6 @@
 
 div.answer-comment-form data-action=answer_comment_path data-method="post" style='display: none'
   div.form-group.text
-    input name="discussion_post[parent_id]" type="hidden" value=new_comments_post(topic).parent_id
     textarea.form-control.text.airmode.comment name="discussion_post[text]"
   button.btn.btn-primary.reply-comment
     = t('.comment')

--- a/app/views/course/discussion/posts/_form.html.slim
+++ b/app/views/course/discussion/posts/_form.html.slim
@@ -1,6 +1,6 @@
 / Hide the form if the browser does not support javascript.
 div.post-form style='display: none'
-  = simple_form_for Course::Discussion::Post.new(parent_id: topic.post_ids.first), url: course_topic_posts_path(current_course, topic) do |f|
+  = simple_form_for Course::Discussion::Post.new, url: course_topic_posts_path(current_course, topic) do |f|
     = f.hidden_field :parent_id
     = f.input :text, label: false, input_html: { class: ['airmode'] }
     = f.button :submit, t('.comment')

--- a/lib/extensions/discussion_topic/active_record/base.rb
+++ b/lib/extensions/discussion_topic/active_record/base.rb
@@ -7,13 +7,10 @@ module Extensions::DiscussionTopic::ActiveRecord::Base
     # comments center.
     # @option options [Boolean] :touch Set to true if the topic need to be touched upon updating.
     def acts_as_discussion_topic(display_globally: false, touch: false)
-      acts_as :discussion_topic, class_name: Course::Discussion::Topic.name
+      acts_as :discussion_topic, class_name: Course::Discussion::Topic.name, touch: touch
       # For autoload to work correctly after class changed, we store the model name first and
       # constantize later.
       Course::Discussion::Topic.global_topic_model_names << name if display_globally
-
-      # This can be removed after https://github.com/hzamani/active_record-acts_as/pull/78
-      define_method(:touch_actable) {} unless touch
     end
   end
 end

--- a/spec/helpers/course/assessment/submission/submissions_helper_spec.rb
+++ b/spec/helpers/course/assessment/submission/submissions_helper_spec.rb
@@ -4,35 +4,6 @@ RSpec.describe Course::Assessment::Submission::SubmissionsHelper do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    describe '#new_comments_post' do
-      let(:topic) { build(:course_discussion_topic) }
-
-      context 'when the topic has no posts' do
-        it 'returns a new post' do
-          expect(helper.new_comments_post(topic)).to be_a_new_record
-        end
-      end
-
-      context 'when the topic has an unsaved post' do
-        let!(:post) do
-          build(:course_discussion_post, topic: topic).tap do |post|
-            topic.posts << post
-          end
-        end
-
-        it 'returns the unsaved post' do
-          expect(helper.new_comments_post(topic)).to eq(post)
-        end
-      end
-
-      context 'when the topic has all saved posts' do
-        let!(:post) { create(:course_discussion_post, topic: topic) }
-        it 'returns a new post' do
-          expect(helper.new_comments_post(topic)).to be_a_new_record
-        end
-      end
-    end
-
     describe '#max_step' do
       let(:assessment) { build(:assessment, :autograded, :published_with_mcq_question) }
       before { helper.instance_variable_set(:@assessment, assessment) }


### PR DESCRIPTION
Fixes #1896 and #891 

- Newly-added comments could not be edited because the updated list of comments sent back by the server after comment creation was not enclosed in a `div_for(topic)`, so the topic_id was missing and the edit form failed to render.
- `parent` for new comments is assigned to be `posts.order_topologically.last`. Since comments are now linear, this is the last post in the chain.
- Combined some of the `js: true` specs.
- After assessment answer comments are deleted, the root (topmost) comment's toolbar was not shown. Have fixed that.
- Previously, replies in the comments center get the first post in the thread as their parent. This breaks the linearity and the posts are displayed as nested (see #1879).