### PR TITLE
Subscribe group manager when a comment/annotation is made

### DIFF
--- a/app/controllers/course/assessment/submission/answer/comments_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/comments_controller.rb
@@ -29,6 +29,12 @@ class Course::Assessment::Submission::Answer::CommentsController < \
     @discussion_topic.ensure_subscribed_by(current_user)
     # Ensure answer's creator gets a notification when someone comments on this answer
     @discussion_topic.ensure_subscribed_by(@answer.submission.creator)
+
+    # Ensure all group managers get a notification when someone comments on this answer
+    answer_course_user = @answer.submission.course_user
+    answer_course_user.my_managers.each do |manager|
+      @discussion_topic.ensure_subscribed_by(manager.user)
+    end
   end
 
   def send_created_notification(post)

--- a/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
@@ -35,6 +35,13 @@ class Course::Assessment::Submission::Answer::Programming::AnnotationsController
     @discussion_topic.ensure_subscribed_by(current_user)
     # Ensure the student who wrote the code gets notified when someone comments on his code
     @discussion_topic.ensure_subscribed_by(@answer.submission.creator)
+
+    # Ensure all group managers get a notification when someone adds a programming annotation
+    # to the answer.
+    answer_course_user = @answer.submission.course_user
+    answer_course_user.my_managers.each do |manager|
+      @discussion_topic.ensure_subscribed_by(manager.user)
+    end
   end
 
   def send_created_notification(post)

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -124,6 +124,15 @@ class CourseUser < ActiveRecord::Base
       where { group_users.group.id >> my_groups }
   end
 
+  # Returns the managers of the groups I belong to in the course.
+  #
+  # @return[Array<CourseUser>]
+  def my_managers
+    my_groups = group_users.select(:group_id)
+    CourseUser.joins { group_users.group }.merge(Course::GroupUser.manager).
+      where { group_users.group.id >> my_groups }
+  end
+
   private
 
   def set_defaults # :nodoc:

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -292,15 +292,23 @@ RSpec.describe CourseUser, type: :model do
       end
     end
 
-    describe '#my_students' do
+    context 'when there are students in groups' do
       let(:group_owner) { create(:course_manager, course: course) }
       before do
         group = create(:course_group, course: course, creator: group_owner.user)
         create(:course_group_user, course: course, group: group, course_user: student)
       end
 
-      it 'returns all the normal users in the group' do
-        expect(group_owner.my_students).to contain_exactly(student)
+      describe '#my_students' do
+        it 'returns all the normal users in the group' do
+          expect(group_owner.my_students).to contain_exactly(student)
+        end
+      end
+
+      describe '#my_managers' do
+        it 'returns the managers of the student' do
+          expect(student.my_managers).to contain_exactly(group_owner)
+        end
       end
     end
 


### PR DESCRIPTION
Add function to get group managers of `CourseUser`.

Subscribe the managers of the student when a comment/annotation is made on the answer.

Fixes #1898.