### PR TITLE
Don't use trackable job for email jobs

### DIFF
--- a/app/jobs/course/assessment/closing_reminder_job.rb
+++ b/app/jobs/course/assessment/closing_reminder_job.rb
@@ -1,13 +1,11 @@
 class Course::Assessment::ClosingReminderJob < ApplicationJob
-  include TrackableJob
-
   rescue_from(ActiveJob::DeserializationError) do |_|
     # Prevent the job from retrying due to deleted records
   end
 
   protected
 
-  def perform_tracked(user, assessment, token)
+  def perform(user, assessment, token)
     instance = Course.unscoped { assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
       Course::Assessment::ReminderService.closing_reminder(user, assessment, token)

--- a/app/jobs/course/assessment/opening_reminder_job.rb
+++ b/app/jobs/course/assessment/opening_reminder_job.rb
@@ -1,13 +1,11 @@
 class Course::Assessment::OpeningReminderJob < ApplicationJob
-  include TrackableJob
-
   rescue_from(ActiveJob::DeserializationError) do |_|
     # Prevent the job from retrying due to deleted records
   end
 
   protected
 
-  def perform_tracked(user, assessment, token)
+  def perform(user, assessment, token)
     instance = Course.unscoped { assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
       Course::Assessment::ReminderService.opening_reminder(user, assessment, token)

--- a/app/jobs/course/video/closing_reminder_job.rb
+++ b/app/jobs/course/video/closing_reminder_job.rb
@@ -1,13 +1,11 @@
 class Course::Video::ClosingReminderJob < ApplicationJob
-  include TrackableJob
-
   rescue_from(ActiveJob::DeserializationError) do |_|
     # Prevent the job from retrying due to deleted records
   end
 
   protected
 
-  def perform_tracked(user, video, token)
+  def perform(user, video, token)
     instance = Course.unscoped { video.course.instance }
     ActsAsTenant.with_tenant(instance) do
       Course::Video::ReminderService.closing_reminder(user, video, token)

--- a/app/jobs/course/video/opening_reminder_job.rb
+++ b/app/jobs/course/video/opening_reminder_job.rb
@@ -1,13 +1,11 @@
 class Course::Video::OpeningReminderJob < ApplicationJob
-  include TrackableJob
-
   rescue_from(ActiveJob::DeserializationError) do |_|
     # Prevent the job from retrying due to deleted records
   end
 
   protected
 
-  def perform_tracked(user, video, token)
+  def perform(user, video, token)
     instance = Course.unscoped { video.course.instance }
     ActsAsTenant.with_tenant(instance) do
       Course::Video::ReminderService.opening_reminder(user, video, token)


### PR DESCRIPTION
The purpose of trackable jobs is for tracking and redirection after job finished, not necessary for email. 

Extra records get created and errors get suppressed. 