### PR TITLE
Fix file input button not working in firefox

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -344,6 +344,7 @@ class ProgrammingQuestionForm extends React.Component {
           className={styles.fileInputButton}
           label={newPackageButton}
           labelPosition="before"
+          containerElement="label"
           primary
           disabled={this.props.data.get('is_loading')}
         >


### PR DESCRIPTION
One line fix to make the choose new file button in the programming question form work in firefox.