### PR TITLE
Add separator in comment/annotation email notification.

### DIFF
--- a/config/locales/en/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.yml
@@ -7,7 +7,7 @@ en:
             annotated:
               user_notifications:
                 email:
-                  subject: '%{course} New annotation on %{topic}'
+                  subject: '%{course}: New annotation on %{topic}'
                   message: >
                     %{post_author} added an annotation, %{post}
 

--- a/config/locales/en/notifiers/course/assessment/answer/comment_notifier/replied/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment/answer/comment_notifier/replied/user_notifications/email.yml
@@ -7,7 +7,7 @@ en:
             replied:
               user_notifications:
                 email:
-                  subject: '%{course} New comment on %{topic}'
+                  subject: '%{course}: New comment on %{topic}'
                   message: >
                     %{post_author} commented, %{post}
 


### PR DESCRIPTION
Add a colon after the course title in the answer comment and programming
annotation notification emails.

[ci skip]