### PR TITLE
Split course status into independent options

### DIFF
--- a/app/assets/stylesheets/course/courses.scss
+++ b/app/assets/stylesheets/course/courses.scss
@@ -2,12 +2,8 @@
 
 .course-courses {
   &.show {
-    .course > h1 > .register {
-      @extend .pull-right;
-      @extend .col-lg-offset-9;
-      @extend .col-lg-3;
-      @extend .col-md-offset-8;
-      @extend .col-md-4;
+    .enrol-request {
+      margin-top: 10px;
     }
 
     .message-holder {

--- a/app/assets/stylesheets/course/registrations.scss
+++ b/app/assets/stylesheets/course/registrations.scss
@@ -1,0 +1,7 @@
+.course-user-registrations {
+  &.new {
+    span.input-group-btn {
+      vertical-align: top;
+    }
+  }
+}

--- a/app/controllers/course/admin/admin_controller.rb
+++ b/app/controllers/course/admin/admin_controller.rb
@@ -24,7 +24,7 @@ class Course::Admin::AdminController < Course::Admin::Controller
 
   def course_setting_params #:nodoc:
     params.require(:course).
-      permit(:title, :description, :status, :start_at, :end_at, :logo, :gamified)
+      permit(:title, :description, :published, :enrollable, :start_at, :end_at, :logo, :gamified)
   end
 
   def destroy_success #:nodoc:

--- a/app/controllers/course/component_controller.rb
+++ b/app/controllers/course/component_controller.rb
@@ -5,16 +5,8 @@ class Course::ComponentController < Course::Controller
   before_action :load_current_component_host
   before_action :check_component, if: :component_defined?
   before_action :load_settings, if: :component_defined?
-  before_action :check_user_participation, unless: :skip_participation_check?
 
   protected
-
-  # Check if the user can participate in the current course
-  #
-  # @raise [CanCan::AccessDenied] When the user cannot participate in the course.
-  def check_user_participation
-    authorize! :participate, current_course
-  end
 
   # Check if the component is enabled. We don't want to let user access the page through url if the
   # component is disabled.
@@ -43,13 +35,5 @@ class Course::ComponentController < Course::Controller
   # @return [Boolean]
   def component_defined?
     defined?(component)
-  end
-
-  # If child controller requires non course users to interact with it, it should override this
-  # and return true.
-  #
-  # @return [Boolean]
-  def skip_participation_check?
-    false
   end
 end

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -2,6 +2,7 @@
 class Course::CoursesController < Course::Controller
   include Course::ActivityFeedsConcern
 
+  skip_authorize_resource :course, only: [:show, :index]
   before_action :load_todos, only: [:show]
 
   def index # :nodoc:

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -40,7 +40,7 @@ class Course::EnrolRequestsController < Course::ComponentController
   end
 
   private
-  
+
   def create_course_user
     course_user = CourseUser.new(course_user_params.
       reverse_merge(course: current_course, user_id: @enrol_request.user_id))

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Course::EnrolRequestsController < Course::ComponentController
+  skip_authorize_resource :course, only: [:create, :destroy]
   load_and_authorize_resource :enrol_request, through: :course, class: Course::EnrolRequest.name
 
   def index
@@ -29,10 +30,6 @@ class Course::EnrolRequestsController < Course::ComponentController
   end
 
   private
-
-  def skip_participation_check?
-    return true if ['destroy'].include? action_name
-  end
 
   def create_course_user
     course_user = CourseUser.new(course_user_params.

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -7,6 +7,16 @@ class Course::EnrolRequestsController < Course::ComponentController
     @enrol_requests = @enrol_requests.includes(:user)
   end
 
+  def create
+    @enrol_request.user = current_user
+    if @enrol_request.save
+      redirect_to course_path(current_course), success: t('.success')
+    else
+      redirect_to course_path(current_course),
+                  danger: @enrol_request.errors.full_messages.to_sentence
+    end
+  end
+
   # Allow users to withdraw their requests to register for a course that are pending
   # approval/rejection.
   def destroy
@@ -30,7 +40,7 @@ class Course::EnrolRequestsController < Course::ComponentController
   end
 
   private
-
+  
   def create_course_user
     course_user = CourseUser.new(course_user_params.
       reverse_merge(course: current_course, user_id: @enrol_request.user_id))

--- a/app/controllers/course/user_registrations_controller.rb
+++ b/app/controllers/course/user_registrations_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Course::UserRegistrationsController < Course::ComponentController
   before_action :ensure_unregistered_user, only: [:create]
-  before_action :authorize_register!, only: [:create]
   before_action :load_registration
+  skip_authorize_resource :course, only: [:create]
 
   def create # :nodoc:
     @registration.update(registration_params.reverse_merge(course: current_course,
@@ -28,11 +28,6 @@ class Course::UserRegistrationsController < Course::ComponentController
     redirect_to course_path(current_course), info: message
   end
 
-  # Prevents registration to the course unless it is open for registration.
-  def authorize_register!
-    authorize!(:register, current_course)
-  end
-
   def load_registration
     @registration = Course::Registration.new
   end
@@ -54,9 +49,5 @@ class Course::UserRegistrationsController < Course::ComponentController
       end
 
     redirect_to course_path(current_course), success: success
-  end
-
-  def skip_participation_check?
-    return true if ['create'].include? action_name
   end
 end

--- a/app/models/components/course/course_ability_component.rb
+++ b/app/models/components/course/course_ability_component.rb
@@ -3,10 +3,9 @@ module Course::CourseAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_showing_open_courses
     if user
       allow_instructors_create_courses
-      allow_unregistered_users_registering_open_courses
+      allow_unregistered_users_registering_courses
       allow_registered_users_showing_course
       allow_owners_managing_course
       allow_staff_manage_users
@@ -21,19 +20,13 @@ module Course::CourseAbilityComponent
     can :create, Course if user.instance_users.instructor.present?
   end
 
-  def allow_showing_open_courses
-    # TODO: Replace with just the symbols when Rails 5 is released.
-    can [:read], Course, published_or_opened_course_hash
-  end
-
-  def allow_unregistered_users_registering_open_courses
-    can [:register], Course, opened_course_hash
-    can :create, Course::EnrolRequest, course: opened_course_hash, user: user
+  def allow_unregistered_users_registering_courses
+    can :create, Course::EnrolRequest, course: { enrollable: true }
     can :destroy, Course::EnrolRequest, user: user
   end
 
   def allow_registered_users_showing_course
-    can [:read, :participate], Course, course_user_hash
+    can :read, Course, course_user_hash
   end
 
   def allow_owners_managing_course
@@ -44,13 +37,5 @@ module Course::CourseAbilityComponent
 
   def allow_staff_manage_users
     can [:show_users, :manage_users], Course, course_user_hash(*CourseUser::STAFF_ROLES.to_a)
-  end
-
-  def published_or_opened_course_hash
-    { status: [Course.statuses[:published], Course.statuses[:opened]] }
-  end
-
-  def opened_course_hash
-    { status: Course.statuses[:opened] }
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,12 +10,6 @@ class Course < ActiveRecord::Base
   after_initialize :set_defaults, if: :new_record?
   before_validation :set_defaults, if: :new_record?
 
-  # closed: Closed for registering.
-  # published: Accessible in courses index page.
-  # opened: published + opened for registering.
-  enum status: { closed: 0, published: 1, opened: 2 }
-  PUBLIC_STATUSES = Set[:published, :opened].freeze
-
   belongs_to :instance, inverse_of: :courses
   has_many :enrol_requests, inverse_of: :course, dependent: :destroy
   has_many :course_users, inverse_of: :course, dependent: :destroy
@@ -59,7 +53,7 @@ class Course < ActiveRecord::Base
   scope :ordered_by_title, -> { order(:title) }
   scope :ordered_by_start_at, ->(direction = :desc) { order(start_at: direction) }
   scope :ordered_by_end_at, ->(direction = :desc) { order(end_at: direction) }
-  scope :publicly_accessible, -> { where(status: PUBLIC_STATUSES.map { |s| statuses[s] }) }
+  scope :publicly_accessible, -> { where(published: true) }
 
   # @!method containing_user
   #   Selects all the courses with user as one of its members

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -89,6 +89,10 @@ class Course < ActiveRecord::Base
     self.registration_key = 'C'.freeze + SecureRandom.base64(8)
   end
 
+  def code_registration_enabled?
+    registration_key.present?
+  end
+
   # Returns the root folder of the course.
   # @return [Course::Material::Folder] The root folder.
   def root_folder

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -15,7 +15,7 @@ class Course::UserInvitation < ActiveRecord::Base
   #
   # @param [User] user
   def self.for_user(user)
-    find_by(email: user.emails.select(:email))
+    find_by(email: user.emails.confirmed.select(:email))
   end
 
   def confirm!

--- a/app/models/user/email.rb
+++ b/app/models/user/email.rb
@@ -9,6 +9,8 @@ class User::Email < ActiveRecord::Base
 
   belongs_to :user, inverse_of: :emails
 
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
+
   # Set the email as primary. This method would cause the email record to be directly updated.
   #
   # @return [Boolean] True if transaction was done successfully, otherwise nil.

--- a/app/services/course/user_registration_service.rb
+++ b/app/services/course/user_registration_service.rb
@@ -34,24 +34,16 @@ class Course::UserRegistrationService
   # trigger acceptance of the invitation. Otherwise, proceed to do new course user registration.
   #
   # @param [Course::Registration] registration The registration object to be processed.
-  # @return [CourseUser] The Course User which was created or updated from the registration.
+  # @return [CourseUser|nil] The Course User which was created or updated from the registration,
+  #   nil will be returned if there's no existing invitation to the user.
   def register_without_registration_code(registration)
     invitation = registration.course.invitations.unconfirmed.for_user(registration.user)
     if invitation.nil?
-      find_or_create_enrol_request!(registration)
+      registration.errors.add(:code, :blank)
+      nil
     else
       accept_invitation(registration, invitation)
     end
-  end
-
-  # Find or create a enrol_request.
-  #
-  # @param [Course::Registration] registration The registration model containing the course and user
-  #   parameters.
-  # @return [CourseUser] The Course User object which was found or created.
-  def find_or_create_enrol_request!(registration)
-    registration.enrol_request =
-      Course::EnrolRequest.find_or_create_by!(course: registration.course, user: registration.user)
   end
 
   # Find or create a course_user.
@@ -80,6 +72,8 @@ class Course::UserRegistrationService
       claim_course_registration_code(registration)
     elsif code[0] == 'I'
       claim_course_invitation_code(registration)
+    else
+      invalid_code(registration)
     end
   end
 

--- a/app/views/course/admin/admin/index.html.slim
+++ b/app/views/course/admin/admin/index.html.slim
@@ -10,7 +10,8 @@
     div.course-logo = display_course_logo(current_course)
     = f.file_field :logo
 
-    = f.input :status, as: :radio_buttons, collection: Course.statuses.keys
+    = f.input :published, label: t('.publish_label'), hint: t('.publish_hint')
+    = f.input :enrollable, label: t('.enrollable_label')
     = f.input :start_at
     = f.input :end_at
     = f.label :gamified

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -15,7 +15,7 @@
                collection: current_course.managers.includes(:user).map(&:user)
 
   - if current_course.user?(current_user) || can?(:manage, current_course)
-    - if !@currently_active_announcements.empty?
+    - if @currently_active_announcements && !@currently_active_announcements.empty?
       h2 = t('.announcements')
       div.message-holder
         = render partial: @currently_active_announcements,
@@ -33,7 +33,7 @@
         tbody
           = render @todos
 
-    - if !@activity_feeds.empty?
+    - if @activity_feeds && !@activity_feeds.empty?
       h2 = t('.activities')
       div.message-holder
         - @activity_feeds.each do |notification|

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -1,9 +1,9 @@
 = div_for(current_course) do
   h1
     = format_inline_text(current_course.title)
-    - if current_course.opened? && !current_course.user?(current_user)
-      div.register
-        = render partial: 'course/user_registrations/registration'
+
+  - unless current_course_user
+    = render partial: 'course/user_registrations/registration'
 
   - unless current_course.user?(current_user)
     h2 = t('.description')

--- a/app/views/course/user_invitations/new.html.slim
+++ b/app/views/course/user_invitations/new.html.slim
@@ -54,7 +54,7 @@ div.methods role='tabpanel'
         = simple_format(t('.registration_code.explanation_warning'))
       = simple_form_for current_course, url: toggle_registration_course_users_path,
                                         method: :post do |f|
-        - if current_course.registration_key.present?
+        - if current_course.code_registration_enabled?
           div.registration-code
             pre
               code

--- a/app/views/course/user_registrations/_registration.html.slim
+++ b/app/views/course/user_registrations/_registration.html.slim
@@ -1,10 +1,9 @@
-- unless current_course_user
-  - if enrol_request = Course::EnrolRequest.find_by(course: current_course, user: current_user)
-    = delete_button([current_course, enrol_request]) do
-      = t('.deregister')
-  - else
+- display_code_form = current_course.code_registration_enabled? || current_course.invitations.unconfirmed.count > 0
+- invitation = current_course.invitations.unconfirmed.for_user(current_user)
+
+- if display_code_form
+  .col-lg-4.col-md-5.col-md-offset-7.col-lg-offset-8
     = simple_form_for @registration, url: course_register_path(current_course) do |f|
-      - invitation = current_course.invitations.unconfirmed.for_user(current_user)
       - if invitation.present?
         = f.hidden_field :code
         = f.button :submit, value: t('.enter_course')
@@ -14,3 +13,18 @@
           span.input-group-btn
             = f.button :submit, value: t('.register'), class: 'register'
 
+- if enrol_request = Course::EnrolRequest.find_by(course: current_course, user: current_user)
+  .col-lg-4.col-md-5.col-md-offset-7.col-lg-offset-8
+    .enrol-request.text-right
+      = link_to t('.deregister'), [current_course, enrol_request], method: :delete
+
+/ Use can directly press the enter course button is there's an invitation
+- elsif current_course.enrollable? && !invitation
+  - link = link_to t('common.click_here'), course_enrol_requests_path(current_course), method: :post
+  - if display_code_form
+    .enrol-request.col-md-5.col-md-offset-7.col-lg-4.col-lg-offset-8
+      p = t('.new_enrol_request_text_html', click_here: link)
+  - else
+    .pull-right
+      = link_to t('.new_enrol_request_button'), course_enrol_requests_path(current_course),
+                class: ['btn', 'btn-primary'], method: :post

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -7,14 +7,14 @@
         div.hidden-xs.text-center#course-sidebar-logo
           = link_to course_path(current_course) do
             = display_course_logo(current_course)
-        - if current_course_user.present? && can?(:participate, current_course)
+        - if current_course_user.present? && can?(:read, current_course)
           div.col-xs-12.user
             = display_user_image(current_user)
             span#user-sidebar = link_to_user(current_course_user || current_user)
           - if current_course_user.student? && current_course.gamified?
             = display_course_user_badge(current_course_user)
       nav.navbar-default role='navigation'
-        - if can?(:participate, current_course)
+        - if can?(:read, current_course)
           div.sidebar.collapse.navbar-collapse#course-navigation-sidebar
             = sidebar_items(controller.sidebar_items(type: :normal))
 

--- a/app/views/system/admin/courses/_course.html.slim
+++ b/app/views/system/admin/courses/_course.html.slim
@@ -3,7 +3,6 @@
   th
     = link_to format_inline_text(course.title),
               course_url(course, host: course.instance.host, port: nil)
-  td = course.status
   td = format_datetime(course.created_at)
   td
     = link_to format_inline_text(course.instance.name),

--- a/app/views/system/admin/courses/index.html.slim
+++ b/app/views/system/admin/courses/index.html.slim
@@ -13,7 +13,6 @@ table.table.table-middle-align.table-hover
     tr
       th = t('.serial_number')
       th = t('.title')
-      th = t('.status')
       th = t('.created_at')
       th = t('.instance')
       th = t('.owners')

--- a/app/views/system/admin/instance/courses/_course.html.slim
+++ b/app/views/system/admin/instance/courses/_course.html.slim
@@ -2,7 +2,6 @@
   td = (current_page - 1) * per_page + course_counter + 1
   th
     = link_to format_inline_text(course.title), course_path(course)
-  td = course.status
   td = format_datetime(course.created_at)
   td
     ul.list-unstyled

--- a/app/views/system/admin/instance/courses/index.html.slim
+++ b/app/views/system/admin/instance/courses/index.html.slim
@@ -13,7 +13,6 @@ table.table.table-middle-align.table-hover
     tr
       th = t('.serial_number')
       th = t('.title')
-      th = t('.status')
       th = t('.created_at')
       th = t('.owners')
       th

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -13,6 +13,7 @@ en:
     submit: 'Submit'
     show_more: 'See all'
     show_less: 'See less'
+    click_here: 'Click here'
   helpers:
     submit:
       condition_level:

--- a/config/locales/en/course/admin/admin.yml
+++ b/config/locales/en/course/admin/admin.yml
@@ -4,6 +4,10 @@ en:
       admin:
         index:
           header: 'Settings'
+          publish_label: 'Publish Course'
+          publish_hint: >
+            Published courses will show up in the list of courses publicly viewable by all users.
+          enrollable_label: 'Allow users to send an enrolment request'
           gamified_label: >
             If enabled, the course would show levels and experience points to all students.
             Course staff would be able to configure and award experience points to students.

--- a/config/locales/en/course/enrol_requests.yml
+++ b/config/locales/en/course/enrol_requests.yml
@@ -3,6 +3,8 @@ en:
     enrol_requests:
       index:
         header: 'User Requests'
+      create:
+        success: 'Your request was sent, please wait for the course owner to approve.'
       destroy:
         success: 'The registration request was deleted.'
       approve:

--- a/config/locales/en/course/user_registrations.yml
+++ b/config/locales/en/course/user_registrations.yml
@@ -2,11 +2,14 @@ en:
   course:
     user_registrations:
       registration:
-        registration_code: 'Registration code'
+        registration_code: 'Invitation code'
         register: 'Register'
-        deregister: 'Cancel Registration Request'
-        enter_course: 'Enter Course'
+        deregister: 'Cancel Enrolment Request'
+        enter_course: 'Accept Invitation'
+        new_enrol_request_text_html: >
+          If you don't have an invitation code, %{click_here} to request to enrol in this course
+        new_enrol_request_button: 'Request to enrol'
       create:
-        invalid_code: 'You have entered an invalid registration code.'
+        invalid_code: 'You have entered an invalid invitation code.'
         requested: 'You have submitted registration request to the course.'
         registered: 'You have been registered as a %{role}.'

--- a/config/locales/en/system/admin/courses.yml
+++ b/config/locales/en/system/admin/courses.yml
@@ -7,7 +7,6 @@ en:
           header_with_count: 'Courses (%{count})'
           serial_number: 'S/N'
           title: 'Title'
-          status: 'Status'
           created_at: 'Created At'
           instance: 'Instance'
           owners: 'Owners'

--- a/config/locales/en/system/admin/instance/courses.yml
+++ b/config/locales/en/system/admin/instance/courses.yml
@@ -8,7 +8,6 @@ en:
             header_with_count: 'Courses (%{count})'
             serial_number: 'S/N'
             title: 'Title'
-            status: 'Status'
             created_at: 'Created At'
             owners: 'Owners'
             search_placeholder: 'Search course title, description or related users'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,7 +208,7 @@ Rails.application.routes.draw do
         post 'resend_invitation'
       end
 
-      resources :enrol_requests, only: [:index, :destroy] do
+      resources :enrol_requests, only: [:index, :create, :destroy] do
         post 'approve', on: :member
       end
 

--- a/db/migrate/20170117145558_add_fields_to_courses.rb
+++ b/db/migrate/20170117145558_add_fields_to_courses.rb
@@ -1,0 +1,15 @@
+class AddFieldsToCourses < ActiveRecord::Migration
+  def up
+    add_column :courses, :published, :boolean, default: false, null: false
+    add_column :courses, :enrollable, :boolean, default: false, null: false
+
+    # Closed
+    Course.unscoped.where(status: 0).update_all(enrollable: false, published: false)
+    # Published
+    Course.unscoped.where(status: 1).update_all(enrollable: false, published: true)
+    # Opened
+    Course.unscoped.where(status: 2).update_all(enrollable: true, published: true)
+
+    remove_column :courses, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170116103602) do
+ActiveRecord::Schema.define(version: 20170117145558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,8 @@ ActiveRecord::Schema.define(version: 20170116103602) do
     t.string   "title",            :limit=>255, :null=>false
     t.text     "description"
     t.text     "logo"
-    t.integer  "status",           :default=>0, :null=>false
+    t.boolean  "published",        :default=>false, :null=>false
+    t.boolean  "enrollable",       :default=>false, :null=>false
     t.string   "registration_key", :limit=>16, :index=>{:name=>"index_courses_on_registration_key", :unique=>true}
     t.text     "settings"
     t.boolean  "gamified",         :default=>true, :null=>false

--- a/spec/controllers/course/controller_spec.rb
+++ b/spec/controllers/course/controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Course::Controller, type: :controller do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
-    let(:course) { create(:course, :opened) }
+    let(:course) { create(:course, :published) }
     before { sign_in(user) if user }
 
     describe '#current_course' do
@@ -28,9 +28,9 @@ RSpec.describe Course::Controller, type: :controller do
     describe '#current_course_user' do
       context 'when there is no user logged in' do
         let(:user) { nil }
-        it 'returns nil' do
-          get(:show, id: course.id)
-          expect(controller.current_course_user).to be_nil
+        subject { get(:show, id: course.id) }
+        it 'raises an error' do
+          expect { subject }.to raise_error(CanCan::AccessDenied)
         end
       end
 

--- a/spec/controllers/course/user_invitations_controller_spec.rb
+++ b/spec/controllers/course/user_invitations_controller_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Course::UserInvitationsController, type: :controller do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
-    let(:course) { create(:course, :opened) }
+    let(:course) { create(:course, :enrollable) }
     let(:erroneous_course) do
-      create(:course, :opened).tap do |course|
+      create(:course, :enrollable).tap do |course|
         user = create(:user)
         course.course_users.build(user: user).save
         course.course_users.build(user: user)

--- a/spec/controllers/course/user_registrations_controller_spec.rb
+++ b/spec/controllers/course/user_registrations_controller_spec.rb
@@ -5,33 +5,13 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
-    let(:course) { create(:course, :opened) }
+    let(:course) { create(:course, :enrollable) }
     describe '#create' do
       before { sign_in(user) }
       subject { post :create, course_id: course, registration: registration_params }
 
       context 'when no registration code is specified' do
         let(:registration_params) { { code: '' } }
-        context 'when the user is not in the course' do
-          context 'when the course is open' do
-            it 'creates a new request' do
-              expect { subject }.
-                to change { course.enrol_requests.count }.by(1)
-            end
-            it { is_expected.to redirect_to(course_path(course)) }
-            it 'sets the proper flash message' do
-              subject
-              expect(flash[:success]).to eq(I18n.t('course.user_registrations.create.requested'))
-            end
-          end
-
-          context 'when the course is closed' do
-            before { course.update_attributes!(status: :closed) }
-            it 'rejects the request' do
-              expect { subject }.to raise_exception(CanCan::AccessDenied)
-            end
-          end
-        end
 
         context 'when the user is already registered' do
           context 'when the user is a student of the course' do
@@ -67,8 +47,7 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
           context 'when the user is not in the course' do
             context 'when the course is open' do
               it 'registers the user' do
-                expect { subject }.
-                  to change { course.course_users.count }.by(1)
+                expect { subject }.to change { course.course_users.count }.by(1)
               end
               it { is_expected.to redirect_to(course_path(course)) }
               it 'sets the proper flash message' do
@@ -77,10 +56,10 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
               end
             end
 
-            context 'when the course is closed' do
-              before { course.update_attributes!(status: :closed) }
+            context 'when the course does not allow enrolment requests' do
+              before { course.update_attributes!(enrollable: false) }
               it 'rejects the request' do
-                expect { subject }.to raise_exception(CanCan::AccessDenied)
+                expect { subject }.to change { course.course_users.count }.by(1)
               end
             end
           end
@@ -110,8 +89,7 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
           context 'when the user is not in the course' do
             context 'when the course is open' do
               it 'registers the user' do
-                expect { subject }.
-                  to change { course.course_users.count }.by(1)
+                expect { subject }.to change { course.course_users.count }.by(1)
               end
               it { is_expected.to redirect_to(course_path(course)) }
               it 'sets the proper flash message' do
@@ -120,10 +98,10 @@ RSpec.describe Course::UserRegistrationsController, type: :controller do
               end
             end
 
-            context 'when the course is closed' do
-              before { course.update_attributes!(status: :closed) }
+            context 'when the course does not allow enrolment requests' do
+              before { course.update_attributes!(enrollable: false) }
               it 'rejects the request' do
-                expect { subject }.to raise_exception(CanCan::AccessDenied)
+                expect { subject }.to change { course.course_users.count }.by(1)
               end
             end
           end

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::UsersController, type: :controller do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:user) { create(:user) }
-    let(:course) { create(:course, :opened) }
+    let(:course) { create(:course, :enrollable) }
     let(:course_user_immutable_stub) do
       stub = CourseUser.new(course: course)
       allow(stub).to receive(:save).and_return(false)

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -9,17 +9,15 @@ FactoryGirl.define do
     start_at Time.zone.now
     end_at 7.days.from_now
     gamified true
-
-    trait :closed do
-      status :closed
-    end
+    published false
+    enrollable false
 
     trait :published do
-      status :published
+      published true
     end
 
-    trait :opened do
-      status :opened
+    trait :enrollable do
+      enrollable true
     end
 
     trait :with_video_component_enabled do

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Course: Homepage' do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    let(:course) { create(:course, :opened) }
+    let(:course) { create(:course, :enrollable) }
     let(:feed_notifications) do
       notifications = []
       # Achievement gained notification

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -128,7 +128,7 @@ RSpec.feature 'Courses: Invitations', js: true do
     end
 
     context 'As a User' do
-      let(:course) { create(:course, :opened) }
+      let(:course) { create(:course, :enrollable) }
       let(:instance_user) { create(:instance_user) }
       let(:user) { instance_user.user }
 
@@ -148,7 +148,7 @@ RSpec.feature 'Courses: Invitations', js: true do
       end
 
       context 'when I have an invitation code for another email address' do
-        let(:invitation) { create(:course_user_invitation, course: course) }
+        let!(:invitation) { create(:course_user_invitation, course: course) }
 
         scenario 'I can accept invitations' do
           visit course_path(course)

--- a/spec/features/course_management_spec.rb
+++ b/spec/features/course_management_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Courses' do
 
     scenario 'Users can see a list of published courses' do
       create(:course)
-      create(:course, [:published, :opened].sample)
+      create(:course, :published)
 
       visit courses_path
       expect(all('.course').count).to eq(1)

--- a/spec/models/course_ability_spec.rb
+++ b/spec/models/course_ability_spec.rb
@@ -7,34 +7,22 @@ RSpec.describe Course, type: :model do
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }
-    let!(:closed_course) { create(:course, :closed) }
+    let!(:closed_course) { create(:course, published: false, enrollable: false) }
     let!(:published_course) { create(:course, :published) }
-    let!(:opened_course) { create(:course, :opened) }
+    let!(:enrollable_course) { create(:course, :enrollable) }
 
     context 'when the user is a Normal User' do
       let(:user) { create(:user) }
 
-      it { is_expected.to be_able_to(:show, published_course) }
-      it { is_expected.not_to be_able_to(:register, published_course) }
-
-      it { is_expected.to be_able_to(:show, opened_course) }
-      it { is_expected.to be_able_to(:register, opened_course) }
-
+      it { is_expected.not_to be_able_to(:show, published_course) }
+      it { is_expected.not_to be_able_to(:show, enrollable_course) }
       it { is_expected.not_to be_able_to(:show, closed_course) }
-      it { is_expected.not_to be_able_to(:register, closed_course) }
-      it { is_expected.not_to be_able_to(:participate, closed_course) }
-
-      it 'sees the opened courses' do
-        expect(Course.accessible_by(subject)).
-          to contain_exactly(published_course, opened_course)
-      end
     end
 
     context 'when the user is a Course Student' do
       let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, course) }
-      it { is_expected.to be_able_to(:participate, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Course, type: :model do
       subject { Course.new(creator: owner, updater: owner) }
 
       it { is_expected.not_to be_published }
-      it { is_expected.not_to be_opened }
+      it { is_expected.not_to be_enrollable }
 
       it 'contains the provided user as the owner' do
         expect(subject.course_users.map(&:user)).to include(owner)

--- a/spec/services/course/user_registration_service_spec.rb
+++ b/spec/services/course/user_registration_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::UserRegistrationService, type: :service do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let(:course) { create(:course, :opened) }
+    let(:course) { create(:course, :enrollable) }
     let(:user) { create(:user) }
     let(:registration) { Course::Registration.new(course: course, user: user, code: '') }
     subject { Course::UserRegistrationService.new }
@@ -46,16 +46,8 @@ RSpec.describe Course::UserRegistrationService, type: :service do
       end
 
       context 'when the given registration does not have a registration code' do
-        it 'succeeds' do
-          expect do
-            expect(subject.register(registration)).to be_truthy
-          end.to change { course.enrol_requests.count }.by(1)
-        end
-
-        it 'emails the course staff' do
-          expect do
-            expect(subject.register(registration)).to be_truthy
-          end.to change { ActionMailer::Base.deliveries.count }.by(1)
+        it 'fails' do
+          expect(subject.register(registration)).to be_nil
         end
       end
     end


### PR DESCRIPTION
Fix #1867 and #1769 
This PR is a bit large because it has fundamental permissions changes and need modification to lots of tests.

Course statuses now become 2 independent options: "Publish Course" and "Allow Enrolment Request"

- Modified the permission to not allow normal users to access course, thus `participate` ability is not needed anymore
- As discussed, course #show page is public now. so that user can input invitation code even if the course does not accept enrol requests
- Refactor registration page
   - Split the register form to enrol request creation button and invitation code form
   - The invitation code button will only be shown if the course has any outstanding invitations or course level registration code is enabled


Screenshots:
1. "Allow enrol requests" with outstanding invitations 
![screen shot 2017-01-18 at 8 21 40 pm](https://cloud.githubusercontent.com/assets/4983239/22064041/b1c8a76a-ddbc-11e6-979b-fe62b30e9eb1.png)

2. "Allow enrol requests" without outstanding invitation:
![screen shot 2017-01-18 at 8 26 05 pm](https://cloud.githubusercontent.com/assets/4983239/22063993/821f2d4a-ddbc-11e6-8a30-8639112f1558.png)
( only the button is displayed )


3. if user's email is in the invitation list. The "Request to enrol" button will be hide and only the "Enter Course" is displayed.
![screen shot 2017-01-18 at 8 39 09 pm](https://cloud.githubusercontent.com/assets/4983239/22064367/34054b60-ddbe-11e6-92be-48bbd9739939.png)