### PR TITLE
Left align summernote material button

### DIFF
--- a/client/app/lib/styles/MaterialSummernote.scss
+++ b/client/app/lib/styles/MaterialSummernote.scss
@@ -1134,8 +1134,8 @@
     background: #ffffff;
     border-color: #e4e4e4;
     margin: 0;
-    padding: 10px 0 15px;
-    text-align: center;
+    padding: 10px 0 15px 15px;
+    text-align: left;
   }
 
   .note-editor .note-toolbar > .btn-group,


### PR DESCRIPTION
It was center aligned before.

<img width="990" alt="screen shot 2017-01-18 at 9 07 31 pm" src="https://cloud.githubusercontent.com/assets/4983239/22065228/447e9010-ddc2-11e6-8e5f-3f26cad52f60.png">
