### PR TITLE
Shorten both expected and actual output of test case display.

### DIFF
--- a/app/assets/javascripts/course/assessment/test_case.js
+++ b/app/assets/javascripts/course/assessment/test_case.js
@@ -4,12 +4,13 @@
   'use strict';
   var QUESTION_SELECTOR = '.course-assessment-question-programming.edit';
   var SUBMISSION_SELECTOR = '.course-assessment-submission-submissions.edit';
-  var EXPECTED_VALUE_SELECTOR = QUESTION_SELECTOR + ' .expected' +
-                                ', ' +
-                                SUBMISSION_SELECTOR + ' .expected';
+  var TEST_CASE_SELECTOR = QUESTION_SELECTOR + ' .expected' + ', ' +
+                           SUBMISSION_SELECTOR + ' .expected' + ', ' +
+                           QUESTION_SELECTOR + ' .output' + ', ' +
+                           SUBMISSION_SELECTOR + ' .output';
 
-  function shortenExpectedText() {
-    $(EXPECTED_VALUE_SELECTOR).shorten({
+  function shortenTestCaseText() {
+    $(TEST_CASE_SELECTOR).shorten({
       'showChars': 140,
       'moreText': I18n.t('common.show_more'),
       'lessText': I18n.t('common.show_less')
@@ -17,6 +18,6 @@
   }
 
   $(document).ready(function() {
-    shortenExpectedText();
+    shortenTestCaseText();
   });
 })(jQuery);

--- a/app/views/course/assessment/answer/programming/_test_cases_of_type.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases_of_type.html.slim
@@ -9,10 +9,12 @@ div.panel.panel-default
   table.table
     thead
       tr
-        th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier) if is_grader
+        - if is_grader
+          th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:identifier)
         th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expression)
         th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:expected)
-        th = t('.output') if is_grader
+        - if is_grader
+          th = t('.output')
         - if @submission.attempting?
           th = Course::Assessment::Question::ProgrammingTestCase.human_attribute_name(:hint)
         th = t('.passed')
@@ -20,11 +22,14 @@ div.panel.panel-default
       tr
       - test_cases_and_results.each do |test_case, test_case_result|
         = content_tag_for(:tr, test_case, class: test_result_class(test_case_result)) do
-          th = format_html(test_case.identifier) if is_grader
+          - if is_grader
+            th = format_html(test_case.identifier)
           td = format_html(test_case.expression)
           td
             div.expected = format_html(test_case.expected)
-          td = simple_format(get_output(test_case_result)) if is_grader
+          - if is_grader
+            td
+              div.output = simple_format(get_output(test_case_result))
           - if @submission.attempting?
             td
               - unless test_case_result && test_case_result.passed?


### PR DESCRIPTION
This occurs when showing individual answers on the submission edit page.

Fixes #1924.

This is for instructors, students do not see output.

The programming question edit page is now in React and doesn't respond to this. @kxmbrian will look into it.

![screen shot 2017-01-19 at 11 17 18 am](https://cloud.githubusercontent.com/assets/1902527/22092562/6b0170e6-de39-11e6-9c64-81d16a4901fc.png)

