### PR TITLE
Add awarded_at and awarder to experience points record

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -62,10 +62,10 @@ class Course::Assessment::Submission::SubmissionsController < \
   def publish_all
     graded_submissions = @assessment.submissions.with_graded_state
     if !graded_submissions.empty?
-      graded_submissions.update_all(
-        workflow_state: 'published', publisher_id: current_user.id, published_at: Time.zone.now,
-        updated_at: Time.zone.now, updater_id: current_user.id
-      )
+      graded_submissions.each do |submission|
+        submission.publish!
+        submission.save!
+      end
       redirect_to course_assessment_submissions_path(current_course, @assessment),
                   success: t('.success')
     else

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -13,18 +13,15 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
   # Handles the marking of a submission. This will grade all the answers.
   def mark(_ = nil)
-    answers.each do |answer|
-      answer.publish! if answer.submitted? || answer.evaluated?
-    end
+    publish_answers
   end
 
   # Handles the publishing of a submission.
   #
   # This grades all the answers as well.
   def publish(_ = nil)
-    answers.each do |answer|
-      answer.publish! if answer.submitted? || answer.evaluated?
-    end
+    publish_answers
+
     self.publisher = User.stamper || User.system
     self.published_at = Time.zone.now
   end
@@ -36,5 +33,19 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
     unsubmit_latest_answers
     self.points_awarded = nil
+  end
+
+  private
+
+  def publish_answers
+    answers.each do |answer|
+      answer.publish! if answer.submitted? || answer.evaluated?
+    end
+  end
+
+  def unsubmit_latest_answers
+    latest_answers.each do |answer|
+      answer.unsubmit! unless answer.attempting?
+    end
   end
 end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -2,6 +2,10 @@
 module Course::Assessment::Submission::WorkflowEventConcern
   extend ActiveSupport::Concern
 
+  included do
+    before_validation :assign_experience_points, if: :workflow_state_changed?
+  end
+
   protected
 
   # Handles the finalisation of a submission.
@@ -11,7 +15,9 @@ module Course::Assessment::Submission::WorkflowEventConcern
     answers.select(&:attempting?).each(&:finalise!)
   end
 
-  # Handles the marking of a submission. This will grade all the answers.
+  # Handles the marking of a submission.
+  #
+  # This will grade all the answers, and set the points_awarded as a draft.
   def mark(_ = nil)
     publish_answers
   end
@@ -24,6 +30,8 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
     self.publisher = User.stamper || User.system
     self.published_at = Time.zone.now
+    self.awarder = User.stamper || User.system
+    self.awarded_at = Time.zone.now
   end
 
   # Handles the unsubmission of a submitted submission.
@@ -33,9 +41,27 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
     unsubmit_latest_answers
     self.points_awarded = nil
+    self.draft_points_awarded = nil
+    self.awarded_at = nil
+    self.awarder = nil
   end
 
   private
+
+  # Defined outside of the workflow transition as points_awarded and draft_points_awarded are
+  # not set during the event transition, hence they are not modifiable within the method itself.
+  def assign_experience_points
+    # publish event (from grade) - Deduce points awarded from draft or updated attribute.
+    if workflow_state_was == 'graded' && workflow_state == 'published'
+      self.points_awarded ||= draft_points_awarded
+      self.draft_points_awarded = nil
+
+    # grade event - If points are awarded, ignore draft_points, otherwise use draft_points_awarded.
+    elsif workflow_state_was == 'submitted' && workflow_state == 'graded'
+      self.draft_points_awarded = points_awarded
+      self.points_awarded = nil
+    end
+  end
 
   def publish_answers
     answers.each do |answer|

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -209,10 +209,4 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
     Course::AssessmentNotifier.assessment_submitted(creator, course_user, self)
   end
-
-  def unsubmit_latest_answers
-    latest_answers.each do |answer|
-      answer.unsubmit! unless answer.attempting?
-    end
-  end
 end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -170,6 +170,12 @@ class Course::Assessment::Submission < ActiveRecord::Base
     answers.select { |a| a.question_id == question.id &&  a.graded? }
   end
 
+  # Return the points awarded for the submission.
+  # If submission is 'graded', return the draft value, otherwise, the return the points awarded.
+  def current_points_awarded
+    graded? ? draft_points_awarded : points_awarded
+  end
+
   private
 
   # Queues the submission for auto grading, after the submission has changed to the submitted state.

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -30,6 +30,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
   schema_validations except: [:creator_id, :assessment_id]
   validate :validate_consistent_user, :validate_unique_submission, on: :create
+  validate :validate_awarded_attributes, if: :published?
 
   belongs_to :assessment, inverse_of: :submissions
 
@@ -195,6 +196,12 @@ class Course::Assessment::Submission < ActiveRecord::Base
     errors.clear
     errors[:base] << I18n.t('activerecord.errors.models.course/assessment/'\
                             'submission.submission_already_exists')
+  end
+
+  # Validate that the awarder and awarded_at is present for published submissions
+  def validate_awarded_attributes
+    return if awarded_at && awarder
+    errors.add(:experience_points_record, :absent_award_attributes)
   end
 
   def send_attempt_notification

--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -7,6 +7,8 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
   validates :reason, presence: true, if: :manually_awarded?
 
   belongs_to :course_user, inverse_of: :experience_points_records
+  # TODO: Add an optional: true when moving to Rails 5.
+  belongs_to :awarder, class_name: User.name, inverse_of: nil
 
   scope :active, -> { where { points_awarded != nil } } # rubocop:disable Style/NonNilCheck
 

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -36,8 +36,11 @@ div.panel.panel-default
                 / TODO: Factor in time-based experience points
                 td
                   = f.input :points_awarded, label: false,
-                            input_html: { class: 'submission-points-awarded',
-                                          'data-base-points' => @submission.assessment.base_exp },
+                            input_html: {\
+                              class: 'submission-points-awarded',
+                              'data-base-points' => @submission.assessment.base_exp,
+                              value: @submission.current_points_awarded
+                            },
                             wrapper_html: { class: 'form-inline points-awarded'}
                   span = ' / ' + @submission.assessment.base_exp.to_s
                   div.exp-multiplier.form-inline

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -36,11 +36,9 @@ div.panel.panel-default
                 / TODO: Factor in time-based experience points
                 td
                   = f.input :points_awarded, label: false,
-                            input_html: {\
-                              class: 'submission-points-awarded',
-                              'data-base-points' => @submission.assessment.base_exp,
-                              value: @submission.current_points_awarded
-                            },
+                            input_html: { class: 'submission-points-awarded',
+                                          'data-base-points' => @submission.assessment.base_exp,
+                                          value: @submission.current_points_awarded },
                             wrapper_html: { class: 'form-inline points-awarded'}
                   span = ' / ' + @submission.assessment.base_exp.to_s
                   div.exp-multiplier.form-inline

--- a/app/views/course/assessment/submission/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submission.html.slim
@@ -6,5 +6,9 @@
       = Course::Assessment::Submission.human_attribute_name(submission.workflow_state)
   td = submission.grade.to_s + ' / ' + submission.assessment.maximum_grade.to_s
   - if current_course.gamified?
-    td = submission.points_awarded.to_i.to_s
+    td
+      = submission.current_points_awarded.to_i.to_s
+      - if submission.graded?
+        span.text-danger title=t('.graded_not_published_warning')
+          =< fa_icon 'exclamation-circle'.freeze
   td

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -15,7 +15,7 @@
   - if submission.published?
     td = submission.grade.to_s + ' / ' + assessment.maximum_grade.to_s
     - if current_course.gamified?
-      td = submission.points_awarded
+      td = submission.current_points_awarded
   - else
     td = '-- / ' + assessment.maximum_grade.to_s
     - if current_course.gamified?

--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -16,6 +16,9 @@ en:
         course/assessment/submission:
           experience_points_record:
             inconsistent_user: 'the creator of the submission must be the same as the course user'
+            absent_award_attributes: >
+              there is no award attributes for your submission, please try again
+              or contact the Coursemology team
           submission_already_exists: "Looks like you have already created a submission. Try again?"
         course/assessment/category:
           deletion: 'the last category cannot be deleted'

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -70,6 +70,11 @@ en:
             status: 'Submission Status'
             grade: 'Grade'
             experience_points: 'Experience Points'
+          submission:
+            graded_not_published_warning: >
+              The grading and experience points are in a draft state, and is currently not viewable
+              by the student. You can publish all draft grades by clicking the 'Publish Grades'
+              button at the top of this page.
           no_submission:
             not_started: 'Not Started'
           manually_graded_answers_tabbed:

--- a/db/migrate/20170117164747_add_awarded_at_and_draft_exp_to_course_experience_points_records.rb
+++ b/db/migrate/20170117164747_add_awarded_at_and_draft_exp_to_course_experience_points_records.rb
@@ -1,0 +1,29 @@
+class AddAwardedAtAndDraftExpToCourseExperiencePointsRecords < ActiveRecord::Migration
+  def change
+    add_column :course_experience_points_records, :draft_points_awarded, :integer
+    add_column :course_experience_points_records, :awarded_at, :datetime
+    add_column :course_experience_points_records, :awarder_id, :integer,
+               foreign_key: { references: :users }
+
+    Course::Assessment::Submission.joins(:experience_points_record).
+      where(workflow_state: ['attempting', 'submitted', 'graded']).find_each do |submission|
+
+      # Shift exp to draft exp
+      points_awarded = submission.points_awarded
+      submission.experience_points_record.update_columns(
+        draft_points_awarded: points_awarded, points_awarded: nil
+      )
+    end
+
+    Course::Assessment::Submission.joins(:experience_points_record).
+      where(workflow_state: 'published').find_each do |submission|
+
+      # Update awarded_at and awarder_id
+      awarded_at = submission.experience_points_record.updated_at
+      awarder_id = submission.experience_points_record.updater_id
+      submission.experience_points_record.update_columns(
+        awarded_at: awarded_at, awarder_id: awarder_id
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170117145558) do
+ActiveRecord::Schema.define(version: 20170117164747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -431,14 +431,17 @@ ActiveRecord::Schema.define(version: 20170117145558) do
 
   create_table "course_experience_points_records", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_experience_points_records_on_actable", :with=>["actable_id"], :unique=>true}
+    t.string   "actable_type",         :limit=>255, :index=>{:name=>"index_course_experience_points_records_on_actable", :with=>["actable_id"], :unique=>true}
+    t.integer  "draft_points_awarded"
     t.integer  "points_awarded"
-    t.integer  "course_user_id", :null=>false, :index=>{:name=>"fk__course_experience_points_records_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_experience_points_records_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "reason",         :limit=>255
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_experience_points_records_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_experience_points_records_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",     :null=>false
-    t.datetime "updated_at",     :null=>false
+    t.integer  "course_user_id",       :null=>false, :index=>{:name=>"fk__course_experience_points_records_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_experience_points_records_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "reason",               :limit=>255
+    t.integer  "creator_id",           :null=>false, :index=>{:name=>"fk__course_experience_points_records_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",           :null=>false, :index=>{:name=>"fk__course_experience_points_records_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",           :null=>false
+    t.datetime "updated_at",           :null=>false
+    t.integer  "awarder_id",           :index=>{:name=>"fk__course_experience_points_records_awarder_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_awarder_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "awarded_at"
   end
 
   create_table "course_forums", force: :cascade do |t|

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -16,6 +16,11 @@ FactoryGirl.define do
     autograded false
     published false
     tabbed_view false
+    delayed_grade_publication false
+
+    trait :delay_grade_publication do
+      delayed_grade_publication true
+    end
 
     trait :not_started do
       start_at { 1.day.from_now }

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -34,6 +34,8 @@ FactoryGirl.define do
 
         # Revert publisher and published at if given.
         submission.mark!
+        submission.draft_points_awarded = submission.points_awarded
+        submission.points_awarded = nil
       end
     end
 

--- a/spec/factories/course_experience_points_records.rb
+++ b/spec/factories/course_experience_points_records.rb
@@ -13,6 +13,9 @@ FactoryGirl.define do
         create(:course_user, course: course, user: creator)
     end
     points_awarded { rand(1..20) * 100 }
+    draft_points_awarded nil
+    awarded_at nil
+    awarder nil
     reason { 'Reason for manually-awarded experience points' if manually_awarded? }
 
     trait :inactive do

--- a/spec/features/course/assessment/submission/password_protected_and_deplayed_publishing_spec.rb
+++ b/spec/features/course/assessment/submission/password_protected_and_deplayed_publishing_spec.rb
@@ -88,12 +88,16 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
         expect(page).to have_button(I18n.t('course.assessment.submission.submissions.buttons.mark'))
 
         fill_in find('input.form-control.grade')[:name], with: 0
+        fill_in 'submission[points_awarded]', with: 50
 
         click_button I18n.t('course.assessment.submission.submissions.buttons.mark')
         expect(page).to have_button(I18n.t('course.assessment.submission.submissions.buttons.save'))
+
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))
         expect(submission.reload.graded?).to be_truthy
+        expect(submission.points_awarded).to be_nil
+        expect(submission.draft_points_awarded).to eq(50)
       end
     end
   end

--- a/spec/features/course/assessment/submission/password_protected_spec.rb
+++ b/spec/features/course/assessment/submission/password_protected_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) do
-      create(:assessment, :published_with_mrq_question,
-             course: course, password: 'super_secret', delayed_grade_publication: true)
+      create(:assessment, :published_with_mrq_question, :delay_grade_publication,
+             course: course, password: 'super_secret')
     end
     let(:mrq_questions) { assessment.reload.questions.map(&:specific) }
     let(:student) { create(:course_student, course: course).user }

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -66,8 +66,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
 
     context 'As a Course Manager' do
       let(:assessment) do
-        create(:assessment, :with_all_question_types,
-               course: course, delayed_grade_publication: true)
+        create(:assessment, :with_all_question_types, :delay_grade_publication, course: course)
       end
       let(:user) { create(:course_manager, course: course).user }
 
@@ -78,6 +77,10 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
         expect(graded_submission.reload).to be_published
         expect(graded_submission.publisher).to eq(user)
         expect(graded_submission.published_at).to be_present
+        expect(graded_submission.awarder).to be_present
+        expect(graded_submission.awarded_at).to be_present
+        expect(graded_submission.draft_points_awarded).to be_nil
+        expect(graded_submission.points_awarded).not_to be_nil
 
         message = I18n.t('course.assessment.submission.submissions.publish_all.success')
         expect(page).to have_selector('div', text: message)

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -512,6 +512,32 @@ RSpec.describe Course::Assessment::Submission do
       end
     end
 
+    describe '#current_points_awarded' do
+      let(:assessment_traits) { [:published_with_mcq_question] }
+      let(:submission1_traits) { [:submitted] }
+      let(:points_awarded) { 100 }
+      let(:draft_points_awarded) { 50 }
+      subject { submission1.current_points_awarded }
+      before do
+        submission1.points_awarded = points_awarded
+        submission1.draft_points_awarded = draft_points_awarded
+      end
+
+      context 'when submission is published' do
+        it 'returns the correct value' do
+          submission1.publish!
+          expect(subject).to eq(points_awarded)
+        end
+      end
+
+      context 'when submission is graded' do
+        it 'returns the correct value' do
+          submission1.mark!
+          expect(subject).to eq(draft_points_awarded)
+        end
+      end
+    end
+
     describe 'callbacks from Course::Assessment::Submission::TodoConcern' do
       let(:assessment_traits) { [:published_with_mcq_question] }
       subject do

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -70,6 +70,34 @@ RSpec.describe Course::Assessment::Submission do
                 'submission_already_exists'))
         end
       end
+
+      context 'when submission is published' do
+        let(:submission1_traits) { :published }
+        subject { submission1 }
+        before { subject }
+
+        context 'when awarded_at is nil' do
+          it 'is not valid' do
+            subject.awarded_at = nil
+            expect(subject).not_to be_valid
+            expect(subject.errors.messages[:experience_points_record]).
+              to include(I18n.
+                t('activerecord.errors.models.course/assessment/submission.'\
+                'attributes.experience_points_record.absent_award_attributes'))
+          end
+        end
+
+        context 'when awarder is nil' do
+          it 'is not valid' do
+            subject.awarder = nil
+            expect(subject).not_to be_valid
+            expect(subject.errors.messages[:experience_points_record]).
+              to include(I18n.
+                t('activerecord.errors.models.course/assessment/submission.'\
+                'attributes.experience_points_record.absent_award_attributes'))
+          end
+        end
+      end
     end
 
     describe '.answers' do
@@ -317,6 +345,34 @@ RSpec.describe Course::Assessment::Submission do
       end
     end
 
+    describe '#mark!' do
+      let(:assessment_traits) { [:with_all_question_types] }
+      let(:submission) { submission1 }
+      let(:submission1_traits) { :submitted }
+
+      it 'propagates the graded state to its answers' do
+        expect(submission.answers.all?(&:submitted?)).to be(true)
+        submission.mark!
+        expect(submission.answers.all?(&:graded?)).to be(true)
+      end
+
+      context 'when assessment enables delayed_grade_publication' do
+        let(:assessment_traits) { [:with_all_question_types, :delay_grade_publication] }
+        let(:points_awarded) { 50 }
+        before do
+          submission1.points_awarded = points_awarded
+          submission1.mark!
+          submission1.save!
+        end
+        subject { submission1 }
+
+        it 'sets the draft_points_awarded to points_awarded, and points_awarded to nil' do
+          expect(subject.points_awarded).to be_nil
+          expect(subject.draft_points_awarded).to eq(points_awarded)
+        end
+      end
+    end
+
     describe '#publish!' do
       let(:assessment_traits) { [:with_all_question_types] }
       let(:submission) { submission1 }
@@ -328,12 +384,16 @@ RSpec.describe Course::Assessment::Submission do
         expect(submission.answers.all?(&:graded?)).to be(true)
       end
 
-      it 'sets the publisher and published_at time' do
+      it 'sets the publisher, awarder, awarded_at and published_at time' do
         expect(submission.publisher).to be_nil
         expect(submission.published_at).to be_nil
+        expect(submission.awarder).to be_nil
+        expect(submission.awarded_at).to be_nil
         submission.publish!
         expect(submission.publisher).not_to be_nil
         expect(submission.published_at).not_to be_nil
+        expect(submission.awarder).not_to be_nil
+        expect(submission.awarded_at).not_to be_nil
       end
 
       context 'when some of the answers are already graded' do
@@ -349,6 +409,38 @@ RSpec.describe Course::Assessment::Submission do
         it 'propagates the graded state to its answers' do
           submission.publish!
           expect(submission.answers.all?(&:graded?)).to be(true)
+        end
+      end
+
+      context 'when assessment enables delayed_grade_publication and when submission is graded' do
+        let(:assessment_traits) { [:with_all_question_types, :delay_grade_publication] }
+        let(:submission1_traits) { :graded }
+
+        context 'when draft_points are set' do
+          let(:draft_points) { 50 }
+          let(:points_awarded) { nil }
+          before do
+            submission1.draft_points_awarded = draft_points
+            submission1.save!
+            submission1.points_awarded = points_awarded
+            submission1.publish!
+            submission1.save!
+          end
+
+          subject { submission1 }
+
+          it 'sets draft_points_awarded to nil and points_awarded to draft_points_awarded' do
+            expect(subject.draft_points_awarded).to be_nil
+            expect(subject.points_awarded).to eq(draft_points)
+          end
+
+          context 'when points_awarded is provided' do
+            let(:points_awarded) { 100 }
+
+            it 'updates submission with the given points_awarded' do
+              expect(subject.points_awarded).to eq(points_awarded)
+            end
+          end
         end
       end
     end

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -168,24 +168,21 @@ RSpec.describe Course::Condition::Assessment, type: :model do
 
         context 'when the submission is attempted' do
           it 'returns false' do
-            create(:submission, workflow_state: :attempting, assessment: assessment,
-                                creator: course_user.user)
+            create(:submission, :attempting, assessment: assessment, creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_falsey
           end
         end
 
         context 'when the submission is submitted' do
           it 'returns true' do
-            create(:submission, workflow_state: :submitted, assessment: assessment,
-                                creator: course_user.user)
+            create(:submission, :submitted, assessment: assessment, creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_truthy
           end
         end
 
         context 'when the submission is published' do
           it 'returns true' do
-            create(:submission, workflow_state: :published, assessment: assessment,
-                                creator: course_user.user)
+            create(:submission, :published, assessment: assessment, creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_truthy
           end
         end
@@ -200,16 +197,14 @@ RSpec.describe Course::Condition::Assessment, type: :model do
 
         context 'when there are submitted submissions' do
           it 'returns false' do
-            create(:submission, workflow_state: :submitted, assessment: assessment,
-                                creator: course_user.user)
+            create(:submission, :submitted, assessment: assessment, creator: course_user.user)
             expect(subject.satisfied_by?(course_user)).to be_falsey
           end
         end
 
         context 'when there are published submissions' do
           let(:submission) do
-            create(:submission, workflow_state: :published, assessment: assessment,
-                                creator: course_user.user)
+            create(:submission, :published, assessment: assessment, creator: course_user.user)
           end
 
           context 'when there is no answer' do
@@ -218,11 +213,10 @@ RSpec.describe Course::Condition::Assessment, type: :model do
             end
           end
 
-          context 'when all published submissions are below the minimum grade percentage' do
+          context 'when the published submission is below the minimum grade percentage' do
             it 'returns false' do
-              answers = assessment.questions.attempt(submission)
+              answers = submission.answers
               answers.each do |answer|
-                answer.finalise!
                 answer.grade = 5
                 answer.save!
               end
@@ -231,11 +225,10 @@ RSpec.describe Course::Condition::Assessment, type: :model do
             end
           end
 
-          context 'when at least one submission is at least the minimum grade percentage' do
+          context 'when the submission is at least the minimum grade percentage' do
             it 'returns true' do
-              answers = assessment.questions.attempt(submission)
+              answers = submission.answers
               answers.each do |answer|
-                answer.finalise!
                 answer.grade = 6
                 answer.save!
               end


### PR DESCRIPTION
This PR is necessary to fix #1908 , which then solves #1888. 

Presently, `experience_points_record` is implemented as an `acts_as`, for models like assessment submissions. However, we have no way of determining when the EXP was awarded - the `created_at` flag indicates the submission creation time, while the `updated_at` flag indicates when the submission was last edited (which could even include changes to other meta-data). 

Hence, this PR introduces `draft_points_awarded`, `awarded_at` and `awarder_id` to the experience_points_record model. Elaboration of work: 
 - DB Migration, which add columns, but also updates `awarded_at` and `awarder_id` for published submissions (inferring from `updated_at` and `updater_id` fields - this is probably the best field we have for now), and shifts `points_awarded` to `draft_points_awarded` for `graded` submissions. 
 -  Implement model methods such that when submission: i) `submitted -> graded`: `points_awarded` will be updated to `draft_points_awarded`, ii) `submitted -> published` or `graded -> published`: `points_awarded` will be updated either from the provided attribute or `draft_points_awarded`.
 - Do some specs cleanup, and changed factories. 
 - Added some front end elements to indicate graded but not published submissions.

Issues: 
 - To implement the logic for `awarder` for `experience_points_record` for video submissions and survey responses. 
 - Should we validate presence of `awarded_at` and `awarder` for `published?` submissions?