### PR TITLE
Modify assessment helper function to #show_bonus_attributes?

### DIFF
--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -19,21 +19,18 @@ module Course::Assessment::AssessmentsHelper
       !assessment.conditions_satisfied_by?(current_course_user)
   end
 
-  def show_bonus_end_at?
+  def show_bonus_attributes?
     @show_bonus_end_at ||= begin
-      @assessments.any? { |assessment| assessment.bonus_end_at.present? }
+      return false unless current_course.gamified?
+      @assessments.any? do |assessment|
+        assessment.bonus_end_at.present? && assessment.time_bonus_exp > 0
+      end
     end
   end
 
   def show_end_at?
     @show_end_at ||= begin
       @assessments.any? { |assessment| assessment.end_at.present? }
-    end
-  end
-
-  def show_time_bonus_exp?
-    @show_time_bonus_exp ||= begin
-      @assessments.any? { |assessment| assessment.time_bonus_exp > 0 }
     end
   end
 end

--- a/app/services/course/assessment/submission/auto_grading_service.rb
+++ b/app/services/course/assessment/submission/auto_grading_service.rb
@@ -75,7 +75,7 @@ class Course::Assessment::Submission::AutoGradingService
     assessment = submission.assessment
     bonus_end_at = assessment.bonus_end_at
     total_exp = assessment.base_exp
-    if !bonus_end_at || submission.submitted_at <= bonus_end_at
+    if bonus_end_at && submission.submitted_at <= bonus_end_at
       total_exp += assessment.time_bonus_exp
     end
 

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -8,8 +8,12 @@
 
   - if current_course.gamified?
     td.table-base-exp = assessment.base_exp
-    - if show_time_bonus_exp?
-      td.table-time-bonus-exp = assessment.time_bonus_exp
+  - if show_bonus_attributes?
+    td.table-time-bonus-exp
+      - if assessment.bonus_end_at.present? && assessment.time_bonus_exp > 0
+        = assessment.time_bonus_exp
+      - else
+        = '-'
   - unless current_component_host[:course_achievements_component].nil?
     td.achievement-badge.table-requirement-for
       - achievement_conditionals = @conditional_service.achievement_conditional_for(assessment)
@@ -22,9 +26,12 @@
         = format_datetime(assessment.start_at, :short)
     - else
       = format_datetime(assessment.start_at, :short)
-  - if current_course.gamified? && show_bonus_end_at?
+  - if show_bonus_attributes?
     td.table-bonus-cut-off
-      = format_datetime(assessment.bonus_end_at, :short) if assessment.bonus_end_at.present?
+      - if assessment.bonus_end_at.present? && assessment.time_bonus_exp > 0
+        = format_datetime(assessment.bonus_end_at, :short)
+      - else
+        = '-'
   - if show_end_at?
     td.table-end-at
       = format_datetime(assessment.end_at, :short) if assessment.end_at.present?

--- a/app/views/course/assessment/assessments/index.html.slim
+++ b/app/views/course/assessment/assessments/index.html.slim
@@ -24,12 +24,12 @@ table.table.assessments-list.table-hover
       th
       - if current_course.gamified?
         th.table-base-exp = Course::LessonPlan::Item.human_attribute_name(:base_exp)
-        - if show_time_bonus_exp?
-          th.table-time-bonus-exp = Course::LessonPlan::Item.human_attribute_name(:time_bonus_exp)
+      - if show_bonus_attributes?
+        th.table-time-bonus-exp = Course::LessonPlan::Item.human_attribute_name(:time_bonus_exp)
       - unless current_component_host[:course_achievements_component].nil?
         th.table-requirement-for = t('.requirement_for')
       th.table-start-at = t('.start_at')
-      - if current_course.gamified? && show_bonus_end_at?
+      - if show_bonus_attributes?
         th.table-bonus-cut-off = t('.bonus_cut_off')
       - if show_end_at?
         th.table-end-at = t('.end_at')


### PR DESCRIPTION
Mainly this PR will show the bonus exp as a dash (`-`) if `bonus_end_at` does not exist.