### PR TITLE
Allow graded and evaluated answers to be re-evaluated.

### DIFF
--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -19,10 +19,15 @@ class Course::Assessment::Answer < ActiveRecord::Base
     state :evaluated do
       event :unsubmit, transitions_to: :attempting
       event :publish, transitions_to: :graded
+      # Allows re-evaluations.
+      event :evaluate, transitions_to: :evaluated
     end
     state :graded do
       event :unsubmit, transitions_to: :attempting
       event :publish, transitions_to: :graded # To re-grade an answer.
+      # Allows answers to be re-evaluated even after being graded. Useful if programming questions
+      # get additional test cases.
+      event :evaluate, transitions_to: :graded
     end
   end
 

--- a/app/services/course/assessment/submission/auto_grading_service.rb
+++ b/app/services/course/assessment/submission/auto_grading_service.rb
@@ -24,20 +24,15 @@ class Course::Assessment::Submission::AutoGradingService
 
   private
 
-  # Grades the answers in the provided submission which has not yet been graded and auto gradable.
+  # Grades the answers in the provided submission which are auto gradable.
   def grade_answers(submission)
-    auto_gradable_answers = ungraded_answers(submission).select do |answer|
+    auto_gradable_answers = submission.latest_answers.select do |answer|
       answer.question.auto_gradable?
     end
     jobs = auto_gradable_answers.map { |answer| grade_answer(answer) }
 
     wait_for_jobs(jobs)
     aggregate_failures(jobs.map { |job| job.job.reload })
-  end
-
-  # Gets the ungraded answers for the given submission
-  def ungraded_answers(submission)
-    submission.answers.select(&:submitted?)
   end
 
   # Grades the provided answer

--- a/spec/factories/course_assessment_answers.rb
+++ b/spec/factories/course_assessment_answers.rb
@@ -26,10 +26,18 @@ FactoryGirl.define do
 
     trait :submitted do
       submission_traits :submitted
-      after(:build) do |answer, evaluator| # rubocop:disable Style/SymbolProc
+      after(:build) do |answer, evaluator|
         answer.finalise!
         # Revert submitted at if given.
         answer.submitted_at = evaluator.submitted_at if evaluator.submitted_at
+      end
+    end
+
+    trait :evaluated do
+      submission_traits :submitted
+      submitted
+      after(:build) do |answer, _evaluator|
+        answer.evaluate!
       end
     end
 


### PR DESCRIPTION
Gives instructors the flexibility to re-evaluate an answer with the
"Evaluate Answers" button on the submission edit page.

Will also allow answers to be automatically re-evaluated when
programming question test cases are modified after answer submission.

Fixes #1931, needed for #1923.