### PR TITLE
Add explanations to the python online editor

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.intl.js
@@ -6,15 +6,30 @@ export default defineMessages({
     defaultMessage: 'Prepend',
     description: 'Title for prepend code block.',
   },
+  prependSubtitle: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.prependSubtitle',
+    defaultMessage: '(optional, hidden, inserted before student\'s code)',
+    description: 'Subtitle for prepend code block.',
+  },
   appendTitle: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.appendTitle',
     defaultMessage: 'Append',
     description: 'Title for append code block.',
   },
+  appendSubtitle: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.appendSubtitle',
+    defaultMessage: '(optional, hidden, appended after student\'s code)',
+    description: 'Subtitle for append code block.',
+  },
   solutionTitle: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.solutionTitle',
     defaultMessage: 'Solution Template',
     description: 'Title for solution template code block.',
+  },
+  solutionSubtitle: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.solutionSubtitle',
+    defaultMessage: '(optional, hidden, stores solution for future reference)',
+    description: 'Subtitle for solution template code block.',
   },
   submissionTitle: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.submissionTitle',
@@ -44,17 +59,32 @@ export default defineMessages({
   fileNameHeader: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.fileNameHeader',
     defaultMessage: 'File Name',
-    description: 'Header for file name column in current data files paenl.',
+    description: 'Header for file name column in current data files panel.',
   },
   fileSizeHeader: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.fileSizeHeader',
     defaultMessage: 'File Size',
-    description: 'Header for file size column in current data files paenl.',
+    description: 'Header for file size column in current data files panel.',
   },
   newDataFilesHeader: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.newDataFilesHeader',
     defaultMessage: 'New Data Files',
     description: 'Header for the new data files panel.',
+  },
+  testCaseDescriptionNote: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.testCaseDescriptionNote',
+    defaultMessage: 'NOTE',
+    description: 'Value of the note key that is passed into the test case description.',
+  },
+  testCaseDescriptionPrint: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.testCaseDescriptionPrint',
+    defaultMessage: 'print()',
+    description: 'Value of the print key that is passed into the test case description.',
+  },
+  testCaseDescriptionNone: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.testCaseDescriptionNone',
+    defaultMessage: 'None',
+    description: 'Value of the none key that is passed into the test case description.',
   },
   addNewTestButton: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.addNewTestButton',

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
@@ -2,7 +2,7 @@ import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';
 import AceEditor from 'react-ace';
-import { injectIntl } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import { Card, CardHeader, CardText } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
@@ -370,12 +370,13 @@ class OnlineEditorPythonView extends React.Component {
     );
   }
 
-  renderEditorCard(header, field) {
+  renderEditorCard(header, subtitle, field) {
     return (
       <Card containerStyle={{ paddingBottom: 0 }} initiallyExpanded>
         <CardHeader
           title={header}
           textStyle={{ fontWeight: 'bold' }}
+          subtitle={subtitle}
           actAsExpander
           showExpandableButton
         />
@@ -424,14 +425,50 @@ class OnlineEditorPythonView extends React.Component {
     return (
       <div>
         <div style={{ marginBottom: '1em' }}>
-          { this.renderEditorCard(intl.formatMessage(translations.solutionTitle), 'solution') }
-          { this.renderEditorCard(intl.formatMessage(translations.prependTitle), 'prepend') }
-          { this.renderEditorCard(intl.formatMessage(translations.appendTitle), 'append') }
+          {
+            this.renderEditorCard(
+              intl.formatMessage(translations.solutionTitle),
+              intl.formatMessage(translations.solutionSubtitle),
+              'solution'
+            )
+          }
+          {
+            this.renderEditorCard(
+              intl.formatMessage(translations.prependTitle),
+              intl.formatMessage(translations.prependSubtitle),
+              'prepend'
+            )
+          }
+          {
+            this.renderEditorCard(
+              intl.formatMessage(translations.appendTitle),
+              intl.formatMessage(translations.appendSubtitle),
+              'append'
+            )
+          }
         </div>
         <h3>{ intl.formatMessage(translations.dataFilesHeader) }</h3>
         { this.renderExistingDataFiles() }
         { this.renderNewDataFiles() }
         <h3>{ intl.formatMessage(translations.testCasesHeader) }</h3>
+        <div style={{ marginBottom: '0.5em' }}>
+          <FormattedMessage
+            id="course.assessment.question.programming.onlineEditorPythonView.testCasesDescription"
+            defaultMessage={
+              '{note}: The expression in the {expression} column will be compared with the ' +
+              'expression in the {expected} column using the equality operator. The return value ' +
+              'of {print} is {none} and the printed output should not be confused with the ' +
+              'return value.'
+            }
+            values={{
+              note: <b>{intl.formatMessage(translations.testCaseDescriptionNote)}</b>,
+              expression: <b>{intl.formatMessage(translations.expressionHeader)}</b>,
+              expected: <b>{intl.formatMessage(translations.expectedHeader)}</b>,
+              print: <code>{intl.formatMessage(translations.testCaseDescriptionPrint)}</code>,
+              none: <code>{intl.formatMessage(translations.testCaseDescriptionNone)}</code>,
+            }}
+          />
+        </div>
         { errorTextElement }
         {
           this.renderTestCases(intl.formatMessage(translations.publicTestCases),
@@ -455,7 +492,13 @@ class OnlineEditorPythonView extends React.Component {
 
     return (
       <div id="python-online-editor">
-        { this.renderEditorCard(intl.formatMessage(translations.submissionTitle), 'submission') }
+        {
+          this.renderEditorCard(
+            intl.formatMessage(translations.submissionTitle),
+            null,
+            'submission'
+          )
+        }
         { autograded ? this.renderAutogradedFields() : null }
       </div>
     );


### PR DESCRIPTION
Use the same explanations as v1 for the prepend and append code blocks as well as the test cases.