### PR TITLE
Allow deletion of dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,7 +175,7 @@ gem 'themes_on_rails', '>= 0.3.1', github: 'lowjoel/themes_on_rails',
 
 # Forms made easy for Rails
 gem 'simple_form', '~> 3.2.1'
-gem 'simple_form-bootstrap'
+gem 'simple_form-bootstrap', github: 'allenwq/simple_form-bootstrap' 
 # Dynamic nested forms
 gem 'cocoon'
 gem 'momentjs-rails', '>= 2.8.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,17 @@ GIT
       warden (~> 1.2.3)
 
 GIT
+  remote: git://github.com/allenwq/simple_form-bootstrap.git
+  revision: a69ba245cf614323d97aef79ec950e84510d78b3
+  specs:
+    simple_form-bootstrap (1.4.0)
+      actionpack (~> 4.0)
+      activemodel (~> 4.0)
+      bootstrap-sass (~> 3)
+      railties (~> 4.0)
+      simple_form (>= 3.1.0)
+
+GIT
   remote: git://github.com/lowjoel/simple_token_authentication.git
   revision: 75cca3c0327e8ae9c8e2554e3d51b6f1b5db18a1
   branch: optional-params-headers
@@ -468,12 +479,6 @@ GEM
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
-    simple_form-bootstrap (1.4.0)
-      actionpack (~> 4.0)
-      activemodel (~> 4.0)
-      bootstrap-sass (~> 3)
-      railties (~> 4.0)
-      simple_form (>= 3.1.0)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -619,7 +624,7 @@ DEPENDENCIES
   should_not
   shoulda-matchers
   simple_form (~> 3.2.1)
-  simple_form-bootstrap
+  simple_form-bootstrap!
   simple_token_authentication!
   simplecov
   slim-rails

--- a/app/models/concerns/course/reminder_concern.rb
+++ b/app/models/concerns/course/reminder_concern.rb
@@ -38,8 +38,10 @@ module Course::ReminderConcern
     self.opening_reminder_token = Time.zone.now.to_f.round(5)
 
     execute_after_commit do
-      opening_reminder_job_class.set(wait_until: start_at).
-        perform_later(updater, self, opening_reminder_token)
+      if start_at
+        opening_reminder_job_class.set(wait_until: start_at).
+          perform_later(updater, self, opening_reminder_token)
+      end
     end
   end
 
@@ -49,7 +51,7 @@ module Course::ReminderConcern
 
     execute_after_commit do
       # Send notification one day before the closing date
-      if end_at > Time.zone.now
+      if end_at && end_at > Time.zone.now
         closing_reminder_job_class.set(wait_until: end_at - 1.day).
           perform_later(self, closing_reminder_token)
       end


### PR DESCRIPTION
This fixes #1581 

The `simple_form-bootstrap` library has some javascript issues that prevents the date from being deleted.

I have changed the gem to my fork and made a PR to the upstream.