### PR TITLE
Fix bug where deletion of assessment/video/survey cannot be done

### DIFF
--- a/app/models/concerns/course/assessment/submission/todo_concern.rb
+++ b/app/models/concerns/course/assessment/submission/todo_concern.rb
@@ -18,17 +18,19 @@ module Course::Assessment::Submission::TodoConcern
 
   def update_todo
     if attempting?
-      todo.update_column(:workflow_state, 'in_progress') unless todo.in_progress?
+      todo.update_attribute(:workflow_state, 'in_progress') unless todo.in_progress?
     elsif submitted? || graded? || published?
-      todo.update_column(:workflow_state, 'completed') unless todo.completed?
+      todo.update_attribute(:workflow_state, 'completed') unless todo.completed?
     end
-  rescue ActiveRecordError => error
+  rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message
   end
 
+  # Skip callback if assessment is deleted as todo will be deleted.
   def restart_todo
-    todo.update_column(:workflow_state, 'not_started') unless todo.not_started?
-  rescue ActiveRecordError => error
+    return if assessment.destroying?
+    todo.update_attribute(:workflow_state, 'not_started') unless todo.not_started?
+  rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message
   end
 end

--- a/app/models/concerns/course/survey/response/todo_concern.rb
+++ b/app/models/concerns/course/survey/response/todo_concern.rb
@@ -18,17 +18,19 @@ module Course::Survey::Response::TodoConcern
 
   def update_todo
     if submitted?
-      todo.update_column(:workflow_state, 'completed') unless todo.completed?
+      todo.update_attribute(:workflow_state, 'completed') unless todo.completed?
     else
-      todo.update_column(:workflow_state, 'in_progress') unless todo.in_progress?
+      todo.update_attribute(:workflow_state, 'in_progress') unless todo.in_progress?
     end
-  rescue ActiveRecordError => error
+  rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message
   end
 
+  # Skip callback if survey is deleted as todo will be deleted.
   def restart_todo
-    todo.update_column(:workflow_state, 'not_started') unless todo.not_started?
-  rescue ActiveRecordError => error
+    return if survey.destroying?
+    todo.update_attribute(:workflow_state, 'not_started') unless todo.not_started?
+  rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message
   end
 end

--- a/app/models/concerns/course/video/submission/todo_concern.rb
+++ b/app/models/concerns/course/video/submission/todo_concern.rb
@@ -18,9 +18,15 @@ module Course::Video::Submission::TodoConcern
 
   def complete_todo
     todo.update_attribute(:workflow_state, 'completed') unless todo.completed?
+  rescue ActiveRecord::ActiveRecordError => error
+    raise ActiveRecord::Rollback, error.message
   end
 
+  # Skip callback if video is deleted as todo will be deleted.
   def restart_todo
+    return if video.destroying?
     todo.update_attribute(:workflow_state, 'not_started') unless todo.not_started?
+  rescue ActiveRecord::ActiveRecordError => error
+    raise ActiveRecord::Rollback, error.message
   end
 end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -578,6 +578,20 @@ RSpec.describe Course::Assessment::Submission do
           expect(subject.not_started?).to be_truthy
         end
       end
+
+      context 'when assessment is destroyed' do
+        let!(:submission1_traits) { [:published] }
+        let!(:submission2_traits) { [:graded] }
+        let!(:submission3_traits) { [:submitted] }
+
+        it 'deletes all todos' do
+          item_id = assessment.lesson_plan_item.id
+          assessment.destroy
+          expect(Course::LessonPlan::Todo.find_by(item_id: item_id, user_id: user1.id)).to be_nil
+          expect(Course::LessonPlan::Todo.find_by(item_id: item_id, user_id: user2.id)).to be_nil
+          expect(Course::LessonPlan::Todo.find_by(item_id: item_id, user_id: user3.id)).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/models/course/survey/response_spec.rb
+++ b/spec/models/course/survey/response_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe Course::Survey::Response do
           expect(subject.not_started?).to be_truthy
         end
       end
+
+      context 'when survey is destroyed' do
+        it 'deletes the todo' do
+          survey.destroy
+          expect(subject).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/models/course/video/submission_spec.rb
+++ b/spec/models/course/video/submission_spec.rb
@@ -5,14 +5,19 @@ RSpec.describe Course::Video::Submission do
   it { is_expected.to act_as(Course::ExperiencePointsRecord) }
   it { is_expected.to belong_to(:video).inverse_of(:submissions) }
 
-  let!(:instance) { Instance.default }
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
   with_tenant(:instance) do
-    let(:course) { create(:course) }
+    let(:course) { create(:course, :with_video_component_enabled) }
     let!(:student) { create(:course_student, course: course) }
     let!(:other_student) { create(:course_student, course: course) }
-    let(:video) { create(:video, course: course) }
-    let(:submission1) { create(:video_submission, video: video, creator: student.user) }
-    let(:submission2) { create(:video_submission, video: video, creator: other_student.user) }
+    let(:video) { create(:video, :published, course: course) }
+    let(:submission1) do
+      create(:video_submission, video: video, creator: student.user, course_user: student)
+    end
+    let(:submission2) do
+      create(:video_submission, video: video, creator: other_student.user,
+                                course_user: other_student)
+    end
 
     describe 'validations' do
       context 'when the course user is different from the submission creator' do
@@ -59,21 +64,28 @@ RSpec.describe Course::Video::Submission do
 
     describe 'callbacks from Course::Video::Submission::TodoConcern' do
       before { submission1 }
-      let(:todo) do
+      subject do
         Course::LessonPlan::Todo.
           find_by(item_id: video.lesson_plan_item.id, user_id: student.user.id)
       end
 
       context 'when the submission is created' do
         it 'sets the todo to completed' do
-          expect(todo.completed?).to be_truthy
+          expect(subject.completed?).to be_truthy
         end
       end
 
       context 'when the submission is destroyed' do
         it 'sets the todo state to not started' do
           submission1.destroy
-          expect(todo.not_started?).to be_truthy
+          expect(subject.not_started?).to be_truthy
+        end
+      end
+
+      context 'when the video is destroyed' do
+        it 'deletes the todo' do
+          video.destroy
+          expect(subject).to be_nil
         end
       end
     end


### PR DESCRIPTION
- Todos had repeated delete callbacks on the lesson_plan_item, as well as the submissions/response models: eg. Assessment `acts_as` `lesson_plan_item`, which `has_many` `todos` with `dependent: destroy`. Also, deletion of submissions triggers a `restart_todo` to update the `workflow_state` of the submission. 
- Fixed naming of incorrect error.

I face a weird issue, which I can fix in the code, but I'm not sure whether it is correct. Placing the code up here first for discussion. 