### PR TITLE
Fix reset answer logic for tabbed assessments

### DIFF
--- a/app/views/course/assessment/submission/submissions/reload_answer.js.erb
+++ b/app/views/course/assessment/submission/submissions/reload_answer.js.erb
@@ -12,4 +12,10 @@ $('.expected').shorten({
   'lessText': I18n.t('common.show_less')
 });
 
-$('textarea.code').ace();
+// Reinitialise code editor window. To handle tabbed views differently from non-tabbed views,
+// as ACE editor initialises wrongly when element is hidden.
+<% if !@assessment.autograded? && @assessment.tabbed_view? %>
+  $('.tab-pane.active textarea.code').ace();
+<% else %>
+  $('textarea.code').ace();
+<% end %>

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
       end
 
       scenario 'I can reset my answer to a programming question', js: true do
+        assessment.tabbed_view = true
+        assessment.save!
         programming_question = programming_assessment.questions.first
         programming_answer = create(:course_assessment_answer_programming,
                                     assessment: programming_assessment,
@@ -89,6 +91,9 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
         # Check that answer has been reset to template files
         expect(programming_answer.reload.files.first.content).
           to eq(programming_question.specific.template_files.first.content)
+
+        # Check that ACE Editor has initialised correctly
+        expect(page).to have_css('.ace_editor')
       end
 
       scenario 'I can finalise my submission only once' do


### PR DESCRIPTION
Fixes #1939, which corrects #1938. This only happens on tabbed views for manually-graded assessments.

There is some context to this problem: 
 - We had an issue where ACE Editor cannot correctly initialised on tabbed views (see #1680). TL;DR, ACE editor observes current viewable area and decides on a height. If the textarea is hidden, the height is 0px. 
 - Hence, the solution then was to hook in the ACE initialisation when a tab is clicked (resulting in the content being shown). 
 - The PR fix initialises all textareas, so what happens is that if there are 6 tabbed questions, and if 3 were opened, reset answer would also initialise the remaining 3 questions (which then results in 'missing code editors'). 
 - The solution in this PR is then to only initialise the textarea in the `active` content pane. The rest of the answers that are not loaded will be correctly initialised when the user clicks on them later. 

Hence, the fix was to separately initialise ACE editors for tabbed assessments. 

cc: @fonglh 