### PR TITLE
Fix bug in submissions where total-grade is not updated when each individual answer's grade is changed

### DIFF
--- a/app/assets/javascripts/course/assessment/submission/submission.js
+++ b/app/assets/javascripts/course/assessment/submission/submission.js
@@ -8,8 +8,8 @@
   var SUMMARY_GRADE_SELECTOR = '.submission-grades-summary-grade';
   var GRADE_INPUT_SELECTOR = 'input.grade';
   var POINTS_AWARDED_SELECTOR = 'input.submission-points-awarded';
-  var MAXIMUM_GRADE_SELECTOR = '#submission-statistics-maximum-grade';
-  var TOTAL_GRADE_SELECTOR = '#submission-statistics-total-grade';
+  var MAXIMUM_GRADE_SELECTOR = '.submission-statistics-maximum-grade';
+  var TOTAL_GRADE_SELECTOR = '.submission-statistics-total-grade';
 
   /**
    * Update the initial EXP points after page load.
@@ -116,7 +116,7 @@
   function getActualPoints(totalGrade) {
     var $pointsAwardedInput = $(POINTS_AWARDED_SELECTOR);
     var basePoints = $pointsAwardedInput.data('base-points');
-    var maximumGrade = $(MAXIMUM_GRADE_SELECTOR).text();
+    var maximumGrade = $(MAXIMUM_GRADE_SELECTOR).first().text();
 
     var actualPoints = 0;
     if (maximumGrade !== 0) {

--- a/app/views/course/assessment/submission/submissions/_progress.html.slim
+++ b/app/views/course/assessment/submission/submissions/_progress.html.slim
@@ -26,8 +26,8 @@ div.panel class=(panel_class)
           tr
             th = @submission.class.human_attribute_name(:grade)
             td
-              span#submission-statistics-total-grade>
+              span.submission-statistics-total-grade>
                 = @submission.grade
               ' /
-              span#submission-statistics-maximum-grade>
+              span.submission-statistics-maximum-grade>
                 = @submission.assessment.maximum_grade

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -24,10 +24,10 @@ div.panel.panel-default
           tr
             th = @submission.class.human_attribute_name(:grade)
             td
-              span#submission-statistics-total-grade>
+              span.submission-statistics-total-grade>
                 = @submission.grade
               ' /
-              span#submission-statistics-maximum-grade
+              span.submission-statistics-maximum-grade
                 = @submission.assessment.maximum_grade
           - if current_course.gamified?
             tr


### PR DESCRIPTION
- Bug is due to id selector only returning 1 element. Recently the submission progress pane was added, resulting in 2 elements with the same ID.
- This led to the submission progress pane being updated when grades were change, but not the statistics pane below.
- The fix changes this to a class-selector instead, and now both grades are updated.

cc: @fonglh @kxmbrian 