### PR TITLE
Warn graders of late submissions

### DIFF
--- a/app/views/course/assessment/submission/submissions/_progress.html.slim
+++ b/app/views/course/assessment/submission/submissions/_progress.html.slim
@@ -31,3 +31,7 @@ div.panel class=(panel_class)
               ' /
               span.submission-statistics-maximum-grade>
                 = @submission.assessment.maximum_grade
+    - if @submission.assessment.end_at && @submission.submitted? && @submission.submitted_at > @submission.assessment.end_at
+      div.alert.alert-danger
+        span.glyphicon.glyphicon-exclamation-sign
+        =< t('.late_submission_warning')

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -54,7 +54,12 @@ div.panel.panel-default
           td = format_datetime(@submission.created_at)
         tr
           th = @submission.class.human_attribute_name(:submitted_at)
-          td = format_datetime(@submission.submitted_at)
+          - if @assessment.end_at && @submission.submitted_at > @assessment.end_at
+            td.text-danger
+              strong => format_datetime(@submission.submitted_at)
+              span.text-danger.glyphicon.glyphicon-exclamation-sign title=t('.late_submission_warning')
+          - else
+            td = format_datetime(@submission.submitted_at)
         - if display_grading_results
           tr
             th = @submission.class.human_attribute_name(:grader)

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -63,6 +63,7 @@ en:
             publish_grade_hint: >
               The grades are currently not viewable to the student. You can publish the grades at
               the submissions page of current assessment.
+            late_submission_warning: :'course.assessment.submission.submissions.progress.late_submission_warning'
           update:
             success: 'Submission was updated.'
             finalise: 'Your submission is being graded, please visit this page again later.'

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -50,6 +50,7 @@ en:
             student: :'course.users.role.student'
             attempted_at: :'course.assessment.submission.submissions.statistics.attempted_at'
             submitted_at: 'Submitted At'
+            late_submission_warning: 'This submission is LATE! You may want to penalize the student for late submission.'
           statistics:
             student: :'course.users.role.student'
             status: 'Status'

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -192,6 +192,26 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
         submission.finalise!
         submission.save!
 
+        # Check that there is NO late submission warning.
+        late_submission_text = I18n.t('course.assessment.submission.submissions.progress.'\
+                                      'late_submission_warning')
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+        # Submission progress panel
+        expect(page).not_to have_selector('div.alert.alert-danger', text: late_submission_text)
+        # Statistics panel
+        expect(page).not_to have_selector('td.text-danger')
+
+        # Create a late submission
+        assessment.end_at = Time.zone.now - 1.day
+        assessment.save!
+
+        # Refresh and check for the late submission warning.
+        visit edit_course_assessment_submission_path(course, assessment, submission)
+        # Submission progress panel
+        expect(page).to have_selector('div.alert.alert-danger', text: late_submission_text)
+        # Statistics panel
+        expect(page).to have_selector('td.text-danger')
+
         # Create an extra question after submission is submitted, user should still be able to
         # grade the submission in this case.
         create(:course_assessment_question_multiple_response, assessment: assessment)


### PR DESCRIPTION
Fixes #1961.

### Submission Progress Panel
![screen shot 2017-01-26 at 8 59 12 am](https://cloud.githubusercontent.com/assets/1902527/22316982/dd70e9fa-e3ab-11e6-9f38-807b1d095f49.png)

### Statistics Panel
![screen shot 2017-01-26 at 9 38 42 am](https://cloud.githubusercontent.com/assets/1902527/22316983/dd75a53a-e3ab-11e6-9124-5cb1b4ac15d3.png)

Statistics panel has a tooltip over the exclamation mark with the same late submission message as shown in the progress panel.

