### PR TITLE
Implement confirmation dialog using react

### DIFF
--- a/app/views/course/discussion/_post.html.slim
+++ b/app/views/course/discussion/_post.html.slim
@@ -14,11 +14,12 @@
     div.toolbar.pull-right style='display: none'
       div.btn-group
         - if can?(:update, post)
-          => link_to('#', class: ['edit', 'btn', 'btn-default']) do
+          => link_to('#', class: ['edit', 'btn', 'btn-default'], remote: true) do
             = fa_icon 'edit'.freeze
         - if can?(:destroy, post)
           = link_to('#', class: ['delete', 'btn', 'btn-danger'],
-                         data: { confirm: t('.confirm-delete-post') }) do
+                         data: { confirm: t('.confirm-delete-post') },
+                         remote: true) do
             = fa_icon 'trash'.freeze
 
   div.content

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -27,13 +27,19 @@ function loadCurrentModule() {
   }
 }
 
+function loadModules() {
+  loadCurrentModule();
+  // Initializers
+  require('./lib/helpers/confirm_dialog');
+}
+
 if (!global.Intl) {
   require.ensure([], (require) => {
     require('intl');
     require('intl/locale-data/jsonp/en');
     require('intl/locale-data/jsonp/zh');
-    loadCurrentModule();
+    loadModules();
   }, 'intl');
 } else {
-  loadCurrentModule();
+  loadModules();
 }

--- a/client/app/lib/components/ConfirmationDialog.jsx
+++ b/client/app/lib/components/ConfirmationDialog.jsx
@@ -19,6 +19,8 @@ const ConfirmationDialog = ({
   confirmDiscard,
   confirmDelete,
   confirmSubmit,
+  disableCancelButton,
+  disableConfirmButton,
 }) => {
   let confirmationButtonText = intl.formatMessage(formTranslations.continue);
   if (confirmButtonText) {
@@ -42,12 +44,14 @@ const ConfirmationDialog = ({
     <FlatButton
       primary
       keyboardFocused
+      disabled={disableCancelButton}
       onTouchTap={onCancel}
       style={buttonStyle}
       label={cancelButtonText || intl.formatMessage(formTranslations.cancel)}
     />,
     <FlatButton
       primary
+      disabled={disableConfirmButton}
       onTouchTap={onConfirm}
       style={buttonStyle}
       label={confirmationButtonText}
@@ -78,6 +82,8 @@ ConfirmationDialog.propTypes = {
   confirmDiscard: PropTypes.bool,
   confirmDelete: PropTypes.bool,
   confirmSubmit: PropTypes.bool,
+  disableCancelButton: PropTypes.bool,
+  disableConfirmButton: PropTypes.bool,
 };
 
 export default injectIntl(ConfirmationDialog);

--- a/client/app/lib/components/ConfirmationDialog.jsx
+++ b/client/app/lib/components/ConfirmationDialog.jsx
@@ -44,6 +44,7 @@ const ConfirmationDialog = ({
     <FlatButton
       primary
       keyboardFocused
+      className="cancel-btn"
       disabled={disableCancelButton}
       onTouchTap={onCancel}
       style={buttonStyle}
@@ -51,6 +52,7 @@ const ConfirmationDialog = ({
     />,
     <FlatButton
       primary
+      className="confirm-btn"
       disabled={disableConfirmButton}
       onTouchTap={onConfirm}
       style={buttonStyle}

--- a/client/app/lib/components/RailsConfirmationDialog.jsx
+++ b/client/app/lib/components/RailsConfirmationDialog.jsx
@@ -1,0 +1,36 @@
+import React, { PropTypes } from 'react';
+import ConfirmationDialog from 'lib/components/ConfirmationDialog';
+
+class RailsConfirmationDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: true, disableButtons: false };
+    this.onConfirm = this.onConfirm.bind(this);
+  }
+
+  // Disable buttons once the confirm button is clicked, then do confirm callback.
+  onConfirm() {
+    this.setState({ disableButtons: true });
+    this.props.onConfirmCallback();
+  }
+
+  render() {
+    return (
+      <ConfirmationDialog
+        open={this.state.open}
+        disableCancelButton={this.state.disableButtons}
+        disableConfirmButton={this.state.disableButtons}
+        onCancel={() => this.setState({ open: false })}
+        onConfirm={this.onConfirm}
+        message={this.props.message}
+      />
+    );
+  }
+}
+
+RailsConfirmationDialog.propTypes = {
+  onConfirmCallback: PropTypes.func,
+  message: PropTypes.string,
+};
+
+export default RailsConfirmationDialog;

--- a/client/app/lib/helpers/confirm_dialog.jsx
+++ b/client/app/lib/helpers/confirm_dialog.jsx
@@ -62,18 +62,19 @@ function overrideConfirmDialog() {
   function onConfirm(element) {
     element.removeAttr('data-confirm');
 
-    if (element.closest('body').length > 0 || element.closest('a').length === 0) {
-      // element is still visible in the page or element is not a link (button, etc).
+    if (element.is('a') && element.data('method') && !$.rails.isRemote(element)) {
+      // Manually handle and submit when the element is a link ( non-remote ).
+      // Because dialog is async now and the link could have already been removed, `trigger`
+      // might not work.
+      const httpMethod = element.data('method').toUpperCase();
+
+      if (['PUT', 'PATCH', 'DELETE'].indexOf(httpMethod) !== -1) { submitLink(element); }
+    } else {
+      // Element is a remote link, button, etc.
       element.trigger('click');
       if ($.rails.isRemote(element)) {
         $(document).ajaxComplete(() => unmountComponentAtNode(getOrCreateNode()));
       }
-    } else {
-      // element is a link and it is removed from the page (This could happen because the operation
-      // is Async now.
-      const httpMethod = element.data('method') && element.data('method').toUpperCase();
-
-      if (['PUT', 'PATCH', 'DELETE'].indexOf(httpMethod) !== -1) { submitLink(element); }
     }
   }
 

--- a/client/app/lib/helpers/confirm_dialog.jsx
+++ b/client/app/lib/helpers/confirm_dialog.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
+import RailsConfirmationDialog from 'lib/components/RailsConfirmationDialog';
+
+// Replaces Rail's UJS implementation of the Confirm Dialogue using a react component.
+// Code adapted from: http://lesseverything.com/blog/customizing-confirmation-dialog-in-rails/
+
+// Create a placeholder element to render the dialog.
+function getOrCreateNode() {
+  if (!document.getElementById('confirm-dialog')) {
+    const node = document.createElement('div');
+    node.setAttribute('id', 'confirm-dialog');
+    document.body.appendChild(node);
+  }
+  return document.getElementById('confirm-dialog');
+}
+
+// Loads the Dialog component.
+function loadDialogue(link, successCallback) {
+  const mountNode = getOrCreateNode();
+  // Remove existing hidden dialog, if any.
+  unmountComponentAtNode(mountNode);
+  render(
+    <ProviderWrapper>
+      <RailsConfirmationDialog
+        onConfirmCallback={() => successCallback(link)}
+        message={link.attr('data-confirm')}
+      />
+    </ProviderWrapper>
+    , mountNode
+  );
+}
+
+function overrideConfirmDialog() {
+  // Handler for elements with data-confirm attribute.
+  // This intercepts Rail's popup implementation and renders a dialog instead.
+  $.rails.allowAction = (link) => {
+    if (!link.attr('data-confirm')) { return true; }
+    loadDialogue(link, $.rails.onConfirm);
+    // Always stops the action since code runs asynchronously
+    return false;
+  };
+
+  // Success callback if dialog is confirmed.
+  $.rails.onConfirm = (link) => {
+    link.removeAttr('data-confirm');
+    link.trigger('click');
+    if ($.rails.isRemote(link)) {
+      $(document).ajaxComplete(() => unmountComponentAtNode(getOrCreateNode()));
+    }
+  };
+}
+
+$(document).ready(() => {
+  overrideConfirmDialog();
+});

--- a/spec/features/course/assessment/submission/autograded_spec.rb
+++ b/spec/features/course/assessment/submission/autograded_spec.rb
@@ -189,6 +189,9 @@ RSpec.describe 'Course: Assessment: Submissions: Autograded' do
         visit edit_course_assessment_submission_path(course, programming_assessment,
                                                      programming_submission)
         click_link I18n.t('course.assessment.answer.reset_answer.button')
+
+        expect(page).to have_selector('.confirm-btn')
+        accept_confirm_dialog
         wait_for_ajax
 
         # Check that answer has been reset to template files

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -83,9 +83,10 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
         visit edit_course_assessment_submission_path(course, programming_assessment,
                                                      programming_submission)
         expect(page).to have_selector('.btn.reset-answer', count: 1)
-        page.accept_alert I18n.t('course.assessment.answer.reset_answer.warning') do
-          click_link I18n.t('course.assessment.answer.reset_answer.button')
-        end
+        find('.btn.reset-answer').click
+
+        expect(page).to have_selector('.confirm-btn')
+        accept_confirm_dialog
         wait_for_ajax
 
         # Check that answer has been reset to template files
@@ -168,7 +169,10 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
           find('.delete').click
         end
 
+        expect(page).to have_selector('.confirm-btn')
+        accept_confirm_dialog
         wait_for_ajax
+
         expect(page).not_to have_content_tag_for(comment_reply)
         expect(comment_topic.reload.posts.count).to eq(1)
 

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
           find('textarea.code').set code
         end
         click_button I18n.t('course.assessment.submission.submissions.buttons.finalise')
+        expect(page).to have_selector('.confirm-btn')
+        accept_confirm_dialog
         wait_for_job
 
         annotation = 'test annotation text'
@@ -129,6 +131,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
         within find(content_tag_selector(post)) do
           find('.delete').click
         end
+        accept_confirm_dialog
 
         wait_for_ajax
         expect(page).not_to have_content_tag_for(post)

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -115,6 +115,8 @@ RSpec.feature 'Course: Topics: Management' do
 
         # Delete post
         find(content_tag_selector(post)).find('.delete').click
+        expect(page).to have_selector('.confirm-btn')
+        accept_confirm_dialog
         wait_for_ajax
         expect(page).not_to have_content_tag_for(post)
 

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -122,6 +122,8 @@ RSpec.feature 'Courses: Invitations', js: true do
 
         find_link(nil,
                   href: course_user_invitation_path(course, invitation_to_delete)).click
+        expect(page).to have_selector('.confirm-btn')
+        accept_confirm_dialog
         expect(current_path).to eq(course_user_invitations_path(course))
         expect(page).not_to have_content_tag_for(invitation_to_delete)
       end

--- a/spec/features/course/lesson_plan_event_management_spec.rb
+++ b/spec/features/course/lesson_plan_event_management_spec.rb
@@ -36,6 +36,8 @@ RSpec.feature 'Course: Events' do
         find("#item-#{event_to_delete.acting_as.id} .admin-button button").click
         expect do
           find_link(nil, href: course_lesson_plan_event_path(course, event_to_delete)).click
+          expect(page).to have_selector('.confirm-btn')
+          accept_confirm_dialog
         end.to change(course.lesson_plan_events, :count).by(-1)
 
         # Go to edit event page

--- a/spec/features/course/lesson_plan_event_management_spec.rb
+++ b/spec/features/course/lesson_plan_event_management_spec.rb
@@ -34,8 +34,10 @@ RSpec.feature 'Course: Events' do
         # Delete an event
         expect(page).to have_text(event_to_delete.title)
         find("#item-#{event_to_delete.acting_as.id} .admin-button button").click
+        deletion_path = course_lesson_plan_event_path(course, event_to_delete)
         expect do
-          find_link(nil, href: course_lesson_plan_event_path(course, event_to_delete)).click
+          find_link(nil, href: deletion_path).click
+          expect(page).not_to have_link(nil, href: deletion_path)
           expect(page).to have_selector('.confirm-btn')
           accept_confirm_dialog
         end.to change(course.lesson_plan_events, :count).by(-1)

--- a/spec/features/course/lesson_plan_milestone_management_spec.rb
+++ b/spec/features/course/lesson_plan_milestone_management_spec.rb
@@ -45,9 +45,10 @@ RSpec.feature 'Course: Lesson Plan Milestones' do
         # Delete a milestone
         expect(page).to have_text(milestone_to_delete.title)
         find("#milestone-#{milestone_to_delete.id} button").click
+        deletion_path = course_lesson_plan_milestone_path(course, milestone_to_delete)
         expect do
-          find_link(nil, href: course_lesson_plan_milestone_path(course, milestone_to_delete)).
-            click
+          find_link(nil, href: deletion_path).click
+          expect(page).not_to have_link(nil, href: deletion_path)
           expect(page).to have_selector('.confirm-btn')
           accept_confirm_dialog
         end.to change(course.lesson_plan_milestones, :count).by(-1)

--- a/spec/features/course/lesson_plan_milestone_management_spec.rb
+++ b/spec/features/course/lesson_plan_milestone_management_spec.rb
@@ -48,6 +48,8 @@ RSpec.feature 'Course: Lesson Plan Milestones' do
         expect do
           find_link(nil, href: course_lesson_plan_milestone_path(course, milestone_to_delete)).
             click
+          expect(page).to have_selector('.confirm-btn')
+          accept_confirm_dialog
         end.to change(course.lesson_plan_milestones, :count).by(-1)
 
         # Go to edit milestone page

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -33,6 +33,11 @@ module Capybara::TestGroupHelpers
       JS
       execute_script(script)
     end
+
+    def accept_confirm_dialog
+      find('.confirm-btn').click
+      find('.confirm-btn').click unless page.all('.confirm-btn').empty?
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #1878, which is to shift the focus of the confirmation window button from 'Ok' to 'Cancel'. Since Rails' implementation calls on `window.confirm()`, which then depends on browser implementation, we will need to implement our own confirm dialog. 

This PR does: 
 - Render a hidden `div` when needed, which acts as a node to render modals upon. 
 - Disable Rails' confirmation dialog logic, and inserted callbacks to interface with the react component.
 - Implemented Dialog react component, with a default focus on the cancel button instead.

@allenwq I'll need some help to check the implementation of this, this is my first react PR 😅 . I'm not sure if there are other ways of doing this as I'm still trying to get a hang of react. The situation here is a little tricky since:
 -  It is possible to have multiple buttons (non-react) trigger the same modal, and not to store state within this component. 
 - Hence, I chose not to have a parent component to manage state, and just rely on callbacks to unmount and re-render if necessary. 

A preview of the dialog:
![confirm-dialog](https://cloud.githubusercontent.com/assets/4353853/22341877/7939bf20-e42d-11e6-8c0f-7826f81ac36d.gif)
