### PR TITLE
Send email notifications when submission is graded

### DIFF
--- a/app/mailers/course/mailer.rb
+++ b/app/mailers/course/mailer.rb
@@ -70,4 +70,19 @@ class Course::Mailer < ApplicationMailer
     mail(to: @recipient.email,
          subject: t('.subject', course: @course.title, assessment: @assessment.title))
   end
+
+  # Send an email to the submission's creator when it has been graded.
+  #
+  # @param [Course::Assessment::Submission] submission The submission which was graded.
+  def submission_graded_email(submission)
+    ActsAsTenant.without_tenant do
+      @course = submission.assessment.course
+    end
+    @recipient = submission.creator
+    @assessment = submission.assessment
+    @submission = submission
+
+    mail(to: @recipient.email,
+         subject: t('.subject', course: @course.title, assessment: @assessment.title))
+  end
 end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -32,6 +32,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
     self.published_at = Time.zone.now
     self.awarder = User.stamper || User.system
     self.awarded_at = Time.zone.now
+    execute_after_commit { Course::Mailer.submission_graded_email(self).deliver_later } if persisted?
   end
 
   # Handles the unsubmission of a submitted submission.

--- a/app/views/course/mailer/submission_graded_email.html.slim
+++ b/app/views/course/mailer/submission_graded_email.html.slim
@@ -1,0 +1,7 @@
+- host = @course.instance.host
+
+= simple_format(t('.message', submission: link_to(@assessment.title,
+                                                  edit_course_assessment_submission_url(@course,
+                                                                                        @assessment,
+                                                                                        @submission,
+                                                                                        host: host))))

--- a/app/views/course/mailer/submission_graded_email.text.erb
+++ b/app/views/course/mailer/submission_graded_email.text.erb
@@ -1,0 +1,6 @@
+<% host = @course.instance.host %>
+<%= t('.message', submission: plain_link_to(@assessment.title,
+                                            edit_course_assessment_submission_url(@course,
+                                                                                  @assessment,
+                                                                                  @submission,
+                                                                                  host: host))) %>

--- a/config/locales/en/course/mailer/submission_graded_email.yml
+++ b/config/locales/en/course/mailer/submission_graded_email.yml
@@ -1,0 +1,7 @@
+en:
+  course:
+    mailer:
+      submission_graded_email:
+        subject: '%{course}: Your submission for %{assessment} has been graded'
+        message: >
+          Click %{submission} to view your grade.

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -234,6 +234,14 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
         fill_in find('input.form-control.grade')[:name], with: 0
         click_button I18n.t('course.assessment.submission.submissions.buttons.publish')
 
+        # Send and wait for submission graded email
+        perform_enqueued_jobs
+        wait_for_job
+
+        # Check that student is notified that his submission is graded
+        emails = unread_emails_for(student.email).map(&:subject)
+        expect(emails).to include('course.mailer.submission_graded_email.subject')
+
         expect(current_path).
           to eq(edit_course_assessment_submission_path(course, assessment, submission))
         expect(submission.reload.published?).to be(true)


### PR DESCRIPTION
Fixes #1899.

Desired behaviour:
1. For normal manually graded assessments, notify student once his submission his graded.
2. For delayed publication assessments, notify student once all the grades are published.

Because both the above cases occur on the `publish` event, this should just work.