### PR TITLE
Do not send submission graded email for autograded assessments.

### DIFF
--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -32,7 +32,9 @@ module Course::Assessment::Submission::WorkflowEventConcern
     self.published_at = Time.zone.now
     self.awarder = User.stamper || User.system
     self.awarded_at = Time.zone.now
-    execute_after_commit { Course::Mailer.submission_graded_email(self).deliver_later } if persisted?
+    if persisted? && !assessment.autograded?
+      execute_after_commit { Course::Mailer.submission_graded_email(self).deliver_later }
+    end
   end
 
   # Handles the unsubmission of a submitted submission.

--- a/spec/features/course/assessment/submission/autograded_spec.rb
+++ b/spec/features/course/assessment/submission/autograded_spec.rb
@@ -162,7 +162,12 @@ RSpec.describe 'Course: Assessment: Submissions: Autograded' do
         visit current_path
         click_button I18n.t('course.assessment.submission.submissions.buttons.finalise')
 
+        perform_enqueued_jobs
         wait_for_job
+        # Check that student is NOT notified that his submission is graded
+        emails = unread_emails_for(student.email).map(&:subject)
+        expect(emails).not_to include('course.mailer.submission_graded_email.subject')
+
         visit current_path
         expect(page).to have_selector('td', text: 'published')
         expect(page).not_to have_selector('.btn.finalise')


### PR DESCRIPTION
Add spec to make sure email is not sent for autograded assessments.

Fixes #1977.