### PR TITLE
Update simple-form_bootstrap.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: git://github.com/allenwq/simple_form-bootstrap.git
-  revision: a69ba245cf614323d97aef79ec950e84510d78b3
+  revision: 6fb3239ed7d306dd42c332c6e8cbed447c641277
   specs:
     simple_form-bootstrap (1.4.0)
       actionpack (~> 4.0)
@@ -115,7 +115,7 @@ GEM
     anbt-sql-formatter (0.0.5)
     arel (6.0.3)
     ast (2.3.0)
-    autoprefixer-rails (6.5.4)
+    autoprefixer-rails (6.7.1)
       execjs
     awesome_print (1.7.0)
     bcrypt (3.1.11)
@@ -128,7 +128,7 @@ GEM
     bootstrap3-datetimepicker-rails (4.17.43)
       momentjs-rails (>= 2.8.1)
     bootstrap_tokenfield_rails (0.12.1)
-    builder (3.2.2)
+    builder (3.2.3)
     bullet (5.4.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
@@ -250,7 +250,7 @@ GEM
     js-routes (1.3.2)
       railties (>= 3.2)
       sprockets-rails
-    json (1.8.3)
+    json (1.8.6)
     jwt (1.5.6)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
@@ -286,7 +286,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     nokogumbo (1.4.10)
       nokogiri
@@ -336,9 +336,9 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-flog (1.3.3)
       anbt-sql-formatter
@@ -643,4 +643,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.14.3


### PR DESCRIPTION
lowjoel/simple_form-bootstrap was updated so allenwq/simple_form-bootstrap
was rebased onto the changes, changing the commit SHA.

Update the Gemfile.lock file so the build script can find the revision
to check out.

This also caused some other gems to be updated.

@allenwq @weiqingtoh please check, this is urgent as we can't build/deploy as the old revision can't be found.