### PR TITLE
Modify behavior for submissions page (to show/not to show) grades and exp

### DIFF
--- a/app/views/course/assessment/submission/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submission.html.slim
@@ -4,11 +4,11 @@
     = link_to edit_course_assessment_submission_path(current_course, submission.assessment,
                                                      submission) do
       = Course::Assessment::Submission.human_attribute_name(submission.workflow_state)
-  td = submission.grade.to_s + ' / ' + submission.assessment.maximum_grade.to_s
+  td
+    = submission.grade.to_s + ' / ' + submission.assessment.maximum_grade.to_s
+    - if submission.graded?
+      span.text-danger title=t('.graded_not_published_warning')
+        =< fa_icon 'exclamation-circle'.freeze
   - if current_course.gamified?
-    td
-      = submission.current_points_awarded.to_i.to_s
-      - if submission.graded?
-        span.text-danger title=t('.graded_not_published_warning')
-          =< fa_icon 'exclamation-circle'.freeze
+    td = submission.current_points_awarded.to_i.to_s
   td

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -12,8 +12,12 @@
           = link_to_course_user(manager) do |course_user|
             = format_inline_text(course_user.name)
 
-  - if submission.published?
-    td = submission.grade.to_s + ' / ' + assessment.maximum_grade.to_s
+  - if submission.published? || submission.graded?
+    td
+      = submission.grade.to_s + ' / ' + assessment.maximum_grade.to_s
+      - if submission.graded?
+        span.text-danger title=t('.graded_not_published_warning')
+          =< fa_icon 'exclamation-circle'.freeze
     - if current_course.gamified?
       td = submission.current_points_awarded
   - else

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -12,7 +12,9 @@
           = link_to_course_user(manager) do |course_user|
             = format_inline_text(course_user.name)
 
-  - if submission.published? || submission.graded?
+  - can_see_grades = \
+      submission.published? || (submission.graded? && can?(:grade, submission.assessment))
+  - if can_see_grades
     td
       = submission.grade.to_s + ' / ' + assessment.maximum_grade.to_s
       - if submission.graded?

--- a/config/locales/en/course/assessment/submissions.yml
+++ b/config/locales/en/course/assessment/submissions.yml
@@ -10,6 +10,8 @@ en:
         submission:
           grade: 'Grade'
           view: 'View'
+          graded_not_published_warning:
+            :'course.assessment.submission.submissions.submission.graded_not_published_warning'
         tabs:
           my_students_pending: 'My Students'
           all_pending: 'All Pending Submissions'

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe 'Course: Submissions Viewing' do
       let(:user) { course_manager.user }
 
       scenario 'I can view all submitted and published submissions' do
-        students = create_list(:course_student, 3, course: course)
-        attempting_submission, submitted_submission, published_submission =
-          students.zip([:attempting, :submitted, :published]).map do |student, trait|
+        students = create_list(:course_student, 4, course: course)
+        attempting_submission, submitted_submission, graded_submission, published_submission =
+          students.zip([:attempting, :submitted, :graded, :published]).map do |student, trait|
             create(:submission, trait, assessment: assessment, creator: student.user)
           end
         staff_submission =
@@ -26,7 +26,7 @@ RSpec.describe 'Course: Submissions Viewing' do
 
         expect(page).to have_selector('div.submissions-filter')
 
-        # Submissions page should not have show attempting submissions or staff submissions.
+        # Submissions page should not show attempting submissions or staff submissions.
         expect(page).not_to have_content_tag_for(attempting_submission)
         expect(page).not_to have_content_tag_for(staff_submission)
 
@@ -36,11 +36,13 @@ RSpec.describe 'Course: Submissions Viewing' do
             href: edit_course_assessment_submission_path(course, assessment, submitted_submission)
           )
         end
-        within find(content_tag_selector(published_submission)) do
-          expect(page).to have_link(
-            I18n.t('course.assessment.submissions.submission.view'),
-            href: edit_course_assessment_submission_path(course, assessment, published_submission)
-          )
+        [graded_submission, published_submission].each do |submission|
+          within find(content_tag_selector(submission)) do
+            expect(page).to have_link(
+              I18n.t('course.assessment.submissions.submission.view'),
+              href: edit_course_assessment_submission_path(course, assessment, submission)
+            )
+          end
         end
       end
 

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -130,11 +130,11 @@ RSpec.describe 'Course: Submissions Viewing' do
     context 'As a Course Student' do
       let(:user) { create(:course_student, course: course).user }
 
-      scenario 'I can view my submitted and published submissions' do
+      scenario 'I can view my submitted, graded and published submissions' do
         # Attach a submission of each trait to a unique assessment
-        assessments = create_list(:course_assessment_assessment, 3, course: course)
-        attempting_submission, submitted_submission, published_submission =
-          assessments.zip([:attempting, :submitted, :published]).map do |assessment, trait|
+        assessments = create_list(:course_assessment_assessment, 4, course: course)
+        attempting_submission, submitted_submission, graded_submission, published_submission =
+          assessments.zip([:attempting, :submitted, :graded, :published]).map do |assessment, trait|
             create(:submission, trait, assessment: assessment, creator: user)
           end
 
@@ -143,13 +143,15 @@ RSpec.describe 'Course: Submissions Viewing' do
         expect(page).not_to have_content_tag_for(attempting_submission)
         expect(page).not_to have_selector('div.submissions-filter')
 
-        [submitted_submission, published_submission].each do |submission|
+        [submitted_submission, graded_submission, published_submission].each do |submission|
           within find(content_tag_selector(submission)) do
             expect(page).to have_link(
               I18n.t('course.assessment.submissions.submission.view'),
               href: edit_course_assessment_submission_path(course, submission.assessment,
                                                            submission)
             )
+            # Cannot see grades for graded submission
+            expect(page).to have_text('--') if submission.graded?
           end
         end
       end


### PR DESCRIPTION
This PR fixes #1988. 

Basically: 
 - Staff gets to see draft grades and experience points awarded for 'graded but not published' state.
 - Student does not see draft grades and experience points until the submission is published. 

I've also shifted the warning tooltip from the experience points column to the points awarded column. This is because there are cases where an ungamified course might result in a hidden EXP column, which won't be useful for users. 

### Screenshots

__Admin View__
<img width="1283" alt="screen shot 2017-02-03 at 11 42 17 am" src="https://cloud.githubusercontent.com/assets/4353853/22578826/91b432cc-ea06-11e6-9ee6-f985dfe9c862.png">

<img width="1298" alt="screen shot 2017-02-03 at 11 50 17 am" src="https://cloud.githubusercontent.com/assets/4353853/22578890/ff19b710-ea06-11e6-8690-ce77378df97f.png">

__Student View__
<img width="1253" alt="screen shot 2017-02-03 at 11 41 44 am" src="https://cloud.githubusercontent.com/assets/4353853/22578824/8ec1a6b2-ea06-11e6-8fe1-31f53d5d5d9a.png">