### PR TITLE
Preserve order of MultipleResponseQuestion options.

### DIFF
--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -7,7 +7,7 @@ class Course::Assessment::Question::MultipleResponsesController < \
 
   def new
     @multiple_response_question.grading_scheme = :any_correct if params[:multiple_choice] == 'true'
-    @multiple_response_question.options.build if @multiple_response_question.options.empty?
+    @multiple_response_question.options.build(weight: 1) if @multiple_response_question.options.empty?
   end
 
   def create
@@ -48,7 +48,7 @@ class Course::Assessment::Question::MultipleResponsesController < \
     params.require(:question_multiple_response).permit(
       :title, :description, :staff_only_comments, :maximum_grade, :grading_scheme,
       skill_ids: [],
-      options_attributes: [:_destroy, :id, :correct, :option, :explanation]
+      options_attributes: [:_destroy, :id, :correct, :option, :explanation, :weight]
     )
   end
 end

--- a/app/models/course/assessment/question/multiple_response_option.rb
+++ b/app/models/course/assessment/question/multiple_response_option.rb
@@ -3,6 +3,8 @@ class Course::Assessment::Question::MultipleResponseOption < ActiveRecord::Base
   belongs_to :question, class_name: Course::Assessment::Question::MultipleResponse.name,
                         inverse_of: :options
 
+  default_scope { order(weight: :asc) }
+
   # @!method self.correct
   #   Gets the options which are marked as correct.
   scope :correct, ->() { where(correct: true) }

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -7,9 +7,10 @@
   div.has-error
     = f.full_error :options
 
-  table.table.table-striped.table-hover
+  table.table.table-striped.table-hover.multiple-response-options
     thead
       tr
+        th.reorder
         th = t('.correct')
         th = t('.option')
         th = t('.explanation')

--- a/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
@@ -1,6 +1,10 @@
 = content_tag_for(:tr, f.object, class: 'nested-fields') do
+  td.reorder.handle.weight
+    span = fa_icon 'reorder'.freeze
+    = f.hidden_field :weight
   td = f.input :correct, label: false
   td = f.input :option, label: false, input_html: { class: ['multiple-response-option', 'airmode'] }
-  td = f.input :explanation, label: false, placeholder: t('.explanation_hint'),
+  td
+    = f.input :explanation, label: false, placeholder: t('.explanation_hint'),
     input_html: { class: ['multiple-response-explanation', 'airmode'] }
   td = link_to_remove_association t('.remove'), f

--- a/client/app/bundles/course/assessment/question/multiple_responses.js
+++ b/client/app/bundles/course/assessment/question/multiple_responses.js
@@ -1,0 +1,26 @@
+require('jquery-ui/ui/widgets/sortable');
+
+$(document).ready(() => {
+  // When items are removed, there might be gaps in the weights.
+  function updateWeights() {
+    $('.weight input').val(index => index + 1);
+  }
+
+  $('.multiple-response-options tbody').on('cocoon:after-insert cocoon:after-remove', () => {
+    updateWeights();
+  });
+
+  $('.multiple-response-options tbody').sortable({
+    axis: 'y',
+    handle: '.handle',
+    helper(e, ui) {
+      ui.children().each(() => {
+        $(this).width($(this).width());
+      });
+      return ui;
+    },
+    stop() {
+      updateWeights();
+    },
+  });
+});

--- a/db/migrate/20170203020915_add_weight_to_course_assessment_question_multiple_response_options.rb
+++ b/db/migrate/20170203020915_add_weight_to_course_assessment_question_multiple_response_options.rb
@@ -1,0 +1,18 @@
+class AddWeightToCourseAssessmentQuestionMultipleResponseOptions < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_question_multiple_response_options, :weight, :integer
+    populate_default_weights
+    change_column_null :course_assessment_question_multiple_response_options, :weight, false
+  end
+
+  def populate_default_weights
+    Course::Assessment::Question::MultipleResponse.includes(:options).find_each do |question|
+      options = question.options.sort_by(&:id)
+      first_id = options.first.id
+      options.each do |option|
+        # Start numbering the weights from 1
+        option.update_column(:weight, option.id - first_id + 1)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170128041649) do
+ActiveRecord::Schema.define(version: 20170203020915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,6 +219,7 @@ ActiveRecord::Schema.define(version: 20170128041649) do
     t.boolean "correct",     :null=>false
     t.text    "option",      :null=>false
     t.text    "explanation"
+    t.integer "weight",      :null=>false
   end
 
   create_table "course_assessment_answer_multiple_response_options", force: :cascade do |t|

--- a/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
@@ -51,6 +51,40 @@ RSpec.describe Course::Assessment::Question::MultipleResponsesController do
       it do
         is_expected.to render_template('edit')
       end
+
+      context 'when weight is updated' do
+        # Mutable multiple response question
+        let(:weight) { 5 }
+        let!(:multiple_response) do
+          create(:course_assessment_question_multiple_response, assessment: assessment)
+        end
+        subject do
+          question_multiple_response_attributes =
+            {
+              'options_attributes' =>
+                {
+                  '0' =>
+                    {
+                      id: multiple_response.options.first.id,
+                      weight: weight
+                    },
+                  '1' =>
+                    {
+                      id: multiple_response.options.second.id,
+                      weight: multiple_response.options.second.weight
+                    }
+                }
+            }
+          patch :update, course_id: course, assessment_id: assessment, id: multiple_response,
+                         question_multiple_response: question_multiple_response_attributes
+        end
+
+        it 'updates a valid weight' do
+          subject
+          saved_weight = multiple_response.reload.options.first.weight
+          expect(saved_weight).to eq(weight)
+        end
+      end
     end
 
     describe '#destroy' do

--- a/spec/factories/course_assessment_question_multiple_response_options.rb
+++ b/spec/factories/course_assessment_question_multiple_response_options.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     question { build(:course_assessment_question_multiple_response) }
     correct false
     option 'Option'
+    sequence(:weight)
 
     trait :correct do
       correct true

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         expect(question_created.options).to be_present
       end
 
-      scenario 'I can create a new multiple choice question' do
+      scenario 'I can create a new multiple choice question', js: true do
         visit course_assessment_path(course, assessment)
         click_on I18n.t('common.new')
         click_link I18n.t('course.assessment.assessments.show.new_question.multiple_choice')
@@ -66,6 +66,15 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         question_attributes = attributes_for(:course_assessment_question_multiple_response)
         fill_in 'title', with: question_attributes[:title]
         fill_in 'maximum_grade', with: question_attributes[:maximum_grade]
+
+        # Fill in the option and explanation first or form can't be submitted when js is on.
+        correct_option_attributes =
+          attributes_for(:course_assessment_question_multiple_response_option, :correct)
+        within find('#new_question_multiple_response_option') do
+          find('textarea.multiple-response-option').set correct_option_attributes[:option]
+          find('textarea.multiple-response-explanation').set correct_option_attributes[:explanation]
+        end
+
         click_button I18n.t(
           'course.assessment.question.multiple_responses.form.multiple_choice_button'
         )
@@ -80,8 +89,6 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         )
 
         # Create a correct option
-        correct_option_attributes =
-          attributes_for(:course_assessment_question_multiple_response_option, :correct)
         within find('#new_question_multiple_response_option') do
           find('textarea.multiple-response-option').set correct_option_attributes[:option]
           find('textarea.multiple-response-explanation').set correct_option_attributes[:explanation]

--- a/spec/models/course/assessment/question/multiple_response_option_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_option_spec.rb
@@ -17,5 +17,15 @@ RSpec.describe Course::Assessment::Question::MultipleResponseOption do
         expect(subject.all?(&:correct?)).to eq(true)
       end
     end
+
+    describe '.default_scope' do
+      let(:question) { create(:course_assessment_question_multiple_response) }
+
+      it 'orders by ascending weight' do
+        weights = question.options.pluck(:weight)
+        expect(weights.length).to be > 1
+        expect(weights.each_cons(2).all? { |a, b| a <= b }).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1791.

Add a weight field. Update weight field through the views.

Use option model default scope to get options in ascending order by weight.