### PR TITLE
Housekeeping and DateTimePicker bugfix

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "extends": "airbnb",
   "settings": {
     import/resolver: "webpack"

--- a/client/app/bundles/course/assessment/components/Material.jsx
+++ b/client/app/bundles/course/assessment/components/Material.jsx
@@ -23,12 +23,7 @@ const propTypes = {
 };
 
 class Material extends React.Component {
-  constructor(props) {
-    super(props);
-    this.onDelete = this.onDelete.bind(this);
-  }
-
-  onDelete(e) {
+  onDelete = (e) => {
     e.preventDefault();
     const { url, onMaterialDelete } = this.props;
     onMaterialDelete(url);

--- a/client/app/bundles/course/assessment/containers/MaterialListContainer.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialListContainer.jsx
@@ -11,10 +11,9 @@ class MaterialListContainer extends React.Component {
   constructor(props) {
     super(props);
     this.state = { materials: props.materials };
-    this.onMaterialDelete = this.onMaterialDelete.bind(this);
   }
 
-  onMaterialDelete(url) {
+  onMaterialDelete = (url) => {
     const originMaterials = this.state.materials;
     // Update UI to show the loader.
     const [index, material] = originMaterials.findEntry(m => m.get('url') === url);

--- a/client/app/bundles/course/assessment/question/programming/components/BuildLog.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/BuildLog.jsx
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 
 const translations = defineMessages({
   header: {
@@ -23,9 +23,7 @@ const translations = defineMessages({
 
 const propTypes = {
   data: PropTypes.instanceOf(Immutable.Map).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const BuildLog = (props) => {

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditor.jsx
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import OnlineEditorPythonView, { validation as pythonValidation } from './OnlineEditorPythonView';
 
 const translations = defineMessages({
@@ -23,9 +23,7 @@ const propTypes = {
   isLoading: PropTypes.bool.isRequired,
   autograded: PropTypes.bool.isRequired,
   autogradedAssessment: PropTypes.bool.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 export function validation(data, pathOfKeysToData, intl) {

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
@@ -96,11 +96,6 @@ class OnlineEditorPythonView extends React.Component {
     return `question_programming[test_cases][${type}][][${field}]`;
   }
 
-  constructor(props) {
-    super(props);
-    this.renderExistingDataFiles = this.renderExistingDataFiles.bind(this);
-  }
-
   codeChangeHandler(field) {
     return e => this.props.actions.updatePythonCodeBlock(field, e);
   }
@@ -133,7 +128,7 @@ class OnlineEditorPythonView extends React.Component {
     };
   }
 
-  renderExistingDataFiles() {
+  renderExistingDataFiles = () => {
     if (this.props.data.get('data_files').size === 0) {
       return null;
     }

--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditorPythonView.jsx
@@ -2,7 +2,7 @@ import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';
 import AceEditor from 'react-ace';
-import { injectIntl, FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage, intlShape } from 'react-intl';
 import { Card, CardHeader, CardText } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
@@ -31,9 +31,7 @@ const propTypes = {
   }),
   isLoading: PropTypes.bool.isRequired,
   autograded: PropTypes.bool.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const contextTypes = {

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -112,13 +112,6 @@ class ProgrammingQuestionForm extends React.Component {
     return value === null ? '' : value;
   }
 
-  constructor(props) {
-    super(props);
-    this.onSubmit = this.onSubmit.bind(this);
-    this.onSelectSkills = this.onSelectSkills.bind(this);
-    this.onPackageUploadFileChange = this.onPackageUploadFileChange.bind(this);
-  }
-
   componentDidMount() {
     this.summernoteEditors = $('#programmming-question-form .note-editor .note-editable');
   }
@@ -127,7 +120,7 @@ class ProgrammingQuestionForm extends React.Component {
     this.summernoteEditors.attr('contenteditable', !nextProps.data.get('is_loading'));
   }
 
-  onSelectSkills(id) {
+  onSelectSkills = (id) => {
     const currentSkills = this.props.data.getIn(['question', 'skill_ids']);
     const currentSkillsWithoutId = currentSkills.filterNot(v => v.get('id') === id);
 
@@ -145,13 +138,13 @@ class ProgrammingQuestionForm extends React.Component {
     }
   }
 
-  onPackageUploadFileChange(e) {
+  onPackageUploadFileChange = (e) => {
     const files = e.target.files;
     const filename = files.length === 0 ? null : files[0].name;
     this.handleChange('package_filename', filename);
   }
 
-  onSubmit(e) {
+  onSubmit = (e) => {
     e.preventDefault();
     if (!this.validationCheck()) return;
 

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';
-import { injectIntl } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
@@ -32,9 +32,7 @@ const propTypes = {
     clearSubmissionMessage: PropTypes.func.isRequired,
   }),
   onlineEditorActions: PropTypes.instanceOf(Object).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 function validation(data, pathOfKeysToData, intl) {

--- a/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { Card, CardHeader } from 'material-ui/Card';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import ExpandableText from 'lib/components/ExpandableText';
@@ -8,9 +8,7 @@ import styles from './UploadedPackageTestCaseView.scss';
 
 const propTypes = {
   testCases: PropTypes.object.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const translations = defineMessages({

--- a/client/app/bundles/course/assessment/question/programming/components/UploadedPackageView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/UploadedPackageView.jsx
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import UploadedPackageTemplateView from './UploadedPackageTemplateView';
 import UploadedPackageTestCaseView from './UploadedPackageTestCaseView';
 
@@ -20,9 +20,7 @@ const translations = defineMessages({
 
 const propTypes = {
   data: PropTypes.instanceOf(Immutable.Map).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 class UploadedPackageView extends React.Component {

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanEdit.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanEdit.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import moment from 'moment';
 import Toggle from 'material-ui/Toggle';
 import Snackbar from 'material-ui/Snackbar';
@@ -48,9 +48,7 @@ const propTypes = {
   updateItem: PropTypes.func,
   updateMilestone: PropTypes.func,
   notification: PropTypes.string,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const styles = {

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanEmpty.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanEmpty.jsx
@@ -1,5 +1,5 @@
-import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import React from 'react';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { grey600 } from 'material-ui/styles/colors';
 
 const translations = defineMessages({
@@ -17,9 +17,7 @@ const inlineStyles = {
 };
 
 const propTypes = {
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const LessonPlanEmpty = ({ intl }) => (

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanFilterButton.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanFilterButton.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import RaisedButton from 'material-ui/RaisedButton';
 import Popover from 'material-ui/Popover';
 import Menu from 'material-ui/Menu';
@@ -13,9 +13,7 @@ const propTypes = {
   toggleItemTypeVisibility: PropTypes.func.isRequired,
   hiddenItemTypes: PropTypes.instanceOf(Immutable.List).isRequired,
   items: PropTypes.instanceOf(Immutable.List).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const translations = defineMessages({

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanFilterButton.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanFilterButton.jsx
@@ -32,12 +32,9 @@ class LessonPlanFilterButton extends React.Component {
     this.state = {
       open: false,
     };
-
-    this.handleTouchTap = this.handleTouchTap.bind(this);
-    this.handleRequestClose = this.handleRequestClose.bind(this);
   }
 
-  handleTouchTap(event) {
+  handleTouchTap = (event) => {
     // This prevents ghost click.
     event.preventDefault();
 
@@ -47,7 +44,7 @@ class LessonPlanFilterButton extends React.Component {
     });
   }
 
-  handleRequestClose() {
+  handleRequestClose = () => {
     this.setState({
       open: false,
     });

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanItem.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanItem.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-danger */
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { CardText, CardTitle } from 'material-ui/Card';
 import Avatar from 'material-ui/Avatar';
 import Chip from 'material-ui/Chip';
@@ -20,10 +20,8 @@ import { red700, grey700 } from 'material-ui/styles/colors';
 import { shortDateFormat, standardDateFormat, shortTimeFormat } from 'lib/date_time_defaults';
 
 const propTypes = {
-  item: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  item: PropTypes.instanceOf(Immutable.Map).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const translations = defineMessages({

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanMilestone.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanMilestone.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-danger */
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
-import { FormattedDate, injectIntl, defineMessages } from 'react-intl';
+import { FormattedDate, injectIntl, defineMessages, intlShape } from 'react-intl';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
 import IconButton from 'material-ui/IconButton';
@@ -26,9 +26,7 @@ const translations = defineMessages({
 
 const propTypes = {
   milestone: PropTypes.instanceOf(Immutable.Map).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 class LessonPlanMilestone extends React.Component {

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanNav.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanNav.jsx
@@ -36,12 +36,9 @@ class LessonPlanNav extends React.Component {
       open: false,
       text: props.intl.formatMessage(translations.goto),
     };
-
-    this.handleTouchTap = this.handleTouchTap.bind(this);
-    this.handleRequestClose = this.handleRequestClose.bind(this);
   }
 
-  handleTouchTap(event) {
+  handleTouchTap = (event) => {
     // This prevents ghost click.
     event.preventDefault();
 
@@ -51,7 +48,7 @@ class LessonPlanNav extends React.Component {
     });
   }
 
-  handleRequestClose() {
+  handleRequestClose = () => {
     this.setState({
       open: false,
     });

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanNav.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanNav.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import RaisedButton from 'material-ui/RaisedButton';
 import Popover from 'material-ui/Popover';
 import Menu from 'material-ui/Menu';
@@ -10,9 +10,7 @@ import { scroller, Helpers } from 'react-scroll';
 
 const propTypes = {
   milestones: PropTypes.instanceOf(Immutable.List).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const translations = defineMessages({

--- a/client/app/bundles/course/lesson_plan/containers/LessonPlanContainer.jsx
+++ b/client/app/bundles/course/lesson_plan/containers/LessonPlanContainer.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import * as actionCreators from '../actions';
 import lessonPlanItemTypeKey from '../utils';
 import { constants } from '../constants';
@@ -20,9 +20,7 @@ const propTypes = {
   items: PropTypes.instanceOf(Immutable.List).isRequired,
   hiddenItemTypes: PropTypes.instanceOf(Immutable.List).isRequired,
   dispatch: PropTypes.func.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   children: PropTypes.element.isRequired,
 };
 

--- a/client/app/bundles/course/survey/components/FormDialogue.jsx
+++ b/client/app/bundles/course/survey/components/FormDialogue.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import formTranslations from 'lib/translations/form';
@@ -12,9 +12,7 @@ const propTypes = {
   skipConfirmation: PropTypes.bool.isRequired,
   disabled: PropTypes.bool.isRequired,
   open: PropTypes.bool.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   children: PropTypes.node,
 };
 

--- a/client/app/bundles/course/survey/components/QuestionForm.jsx
+++ b/client/app/bundles/course/survey/components/QuestionForm.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { reduxForm, Field, FieldArray, Form } from 'redux-form';
 import TextField from 'lib/components/redux-form/TextField';
 import SelectField from 'lib/components/redux-form/SelectField';
@@ -255,9 +255,7 @@ QuestionForm.propTypes = {
   }),
   handleSubmit: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape,
   disabled: PropTypes.bool,
 };
 

--- a/client/app/bundles/course/survey/components/QuestionFormOption.jsx
+++ b/client/app/bundles/course/survey/components/QuestionFormOption.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { Field } from 'redux-form';
 import IconButton from 'material-ui/IconButton';
 import Checkbox from 'material-ui/Checkbox';
@@ -172,9 +172,7 @@ class QuestionFormOption extends React.Component {
 }
 
 QuestionFormOption.propTypes = {
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   disabled: PropTypes.bool,
   multipleChoice: PropTypes.bool,
   multipleResponse: PropTypes.bool,

--- a/client/app/bundles/course/survey/components/QuestionFormOptions.jsx
+++ b/client/app/bundles/course/survey/components/QuestionFormOptions.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import FlatButton from 'material-ui/FlatButton';
 import QuestionFormOption from './QuestionFormOption';
 
@@ -96,9 +96,7 @@ class QuestionFormOptions extends React.Component {
 }
 
 QuestionFormOptions.propTypes = {
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   disabled: PropTypes.bool,
   fields: PropTypes.shape({
     map: PropTypes.func.isRequired,

--- a/client/app/bundles/course/survey/components/SurveyDetails.jsx
+++ b/client/app/bundles/course/survey/components/SurveyDetails.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { browserHistory } from 'react-router';
 import { Table, TableBody, TableRow, TableRowColumn } from 'material-ui/Table';
 import { Card, CardText } from 'material-ui/Card';
@@ -99,9 +99,7 @@ class SurveyDetails extends React.Component {
 }
 
 SurveyDetails.propTypes = {
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   survey: PropTypes.shape({
     title: PropTypes.string,
     description: PropTypes.string,

--- a/client/app/bundles/course/survey/components/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/components/SurveyForm.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { reduxForm, Field, Form } from 'redux-form';
 import TextField from 'lib/components/redux-form/TextField';
 import DateTimePicker from 'lib/components/redux-form/DateTimePicker';
@@ -54,9 +54,7 @@ const propTypes = {
   shiftEndDate: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   disabled: PropTypes.bool,
 };
 

--- a/client/app/bundles/course/survey/components/SurveyQuestions.jsx
+++ b/client/app/bundles/course/survey/components/SurveyQuestions.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { Card, CardText } from 'material-ui/Card';
 import Checkbox from 'material-ui/Checkbox';
 import RadioButton from 'material-ui/RadioButton';
@@ -115,9 +115,7 @@ SurveyQuestions.propTypes = {
       image: PropTypes.string,
     })),
   })),
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(SurveyQuestions);

--- a/client/app/bundles/course/survey/components/SurveysEmpty.jsx
+++ b/client/app/bundles/course/survey/components/SurveysEmpty.jsx
@@ -1,5 +1,5 @@
-import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import React from 'react';
+import { FormattedMessage, defineMessages } from 'react-intl';
 import { grey600 } from 'material-ui/styles/colors';
 
 const translations = defineMessages({
@@ -16,18 +16,10 @@ const inlineStyles = {
   },
 };
 
-const propTypes = {
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
-};
-
-const SurveysEmpty = ({ intl }) => (
+const SurveysEmpty = () => (
   <h4 style={inlineStyles.noSurveys}>
-    {intl.formatMessage(translations.noSurveys)}
+    {<FormattedMessage {...translations.noSurveys} />}
   </h4>
 );
 
-SurveysEmpty.propTypes = propTypes;
-
-export default injectIntl(SurveysEmpty);
+export default SurveysEmpty;

--- a/client/app/bundles/course/survey/components/SurveysTable.jsx
+++ b/client/app/bundles/course/survey/components/SurveysTable.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import { Link } from 'react-router';
 import { standardDateFormat } from 'lib/date_time_defaults';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
@@ -15,9 +15,7 @@ const styles = {
 const propTypes = {
   surveys: PropTypes.array.isRequired,
   courseId: PropTypes.string.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 const SurveysTable = ({ intl, surveys, courseId }) => (

--- a/client/app/bundles/course/survey/components/Thumbnail.jsx
+++ b/client/app/bundles/course/survey/components/Thumbnail.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import formTranslations from 'lib/translations/form';
@@ -36,7 +36,7 @@ class Thumbnail extends React.Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const { intl, src, alt, file, onTouchTap, style, ...props } = this.props;
+    const { src, alt, file, onTouchTap, style, ...props } = this.props;
     const source = src || this.state.src;
     const altText = alt || this.state.alt || src;
 
@@ -63,7 +63,7 @@ class Thumbnail extends React.Component {
 
     const actions = [
       <FlatButton
-        label={intl.formatMessage(formTranslations.close)}
+        label={<FormattedMessage {...formTranslations.close} />}
         primary
         onTouchTap={() => this.setState({ open: false })}
       />,
@@ -99,9 +99,6 @@ class Thumbnail extends React.Component {
 }
 
 Thumbnail.propTypes = {
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
   src: PropTypes.string,
   alt: PropTypes.string,
   file: PropTypes.instanceOf(File),
@@ -109,4 +106,4 @@ Thumbnail.propTypes = {
   style: PropTypes.shape(),
 };
 
-export default injectIntl(Thumbnail);
+export default Thumbnail;

--- a/client/app/bundles/course/survey/containers/NewQuestionButton.jsx
+++ b/client/app/bundles/course/survey/containers/NewQuestionButton.jsx
@@ -41,14 +41,7 @@ class NewQuestionButton extends React.Component {
     return payload;
   }
 
-  constructor(props) {
-    super(props);
-
-    this.createQuestionHandler = this.createQuestionHandler.bind(this);
-    this.showNewQuestionForm = this.showNewQuestionForm.bind(this);
-  }
-
-  createQuestionHandler(data) {
+  createQuestionHandler = (data) => {
     const { dispatch, intl, courseId, surveyId } = this.props;
     const { createSurveyQuestion } = actionCreators;
 
@@ -60,7 +53,7 @@ class NewQuestionButton extends React.Component {
     );
   }
 
-  showNewQuestionForm() {
+  showNewQuestionForm = () => {
     const { dispatch, intl } = this.props;
     const { showQuestionForm } = actionCreators;
 

--- a/client/app/bundles/course/survey/containers/NewQuestionButton.jsx
+++ b/client/app/bundles/course/survey/containers/NewQuestionButton.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import * as actionCreators from '../actions';
 import { questionTypes } from '../constants';
 import AddButton from '../components/AddButton';
@@ -80,9 +80,7 @@ NewQuestionButton.propTypes = {
   dispatch: PropTypes.func.isRequired,
   courseId: PropTypes.string.isRequired,
   surveyId: PropTypes.string.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default connect(state => state)(injectIntl(NewQuestionButton));

--- a/client/app/bundles/course/survey/containers/NewSurveyButton.jsx
+++ b/client/app/bundles/course/survey/containers/NewSurveyButton.jsx
@@ -30,14 +30,7 @@ const propTypes = {
 };
 
 class NewSurveyButton extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.createSurveyHandler = this.createSurveyHandler.bind(this);
-    this.showNewSurveyForm = this.showNewSurveyForm.bind(this);
-  }
-
-  createSurveyHandler(data) {
+  createSurveyHandler = (data) => {
     const { dispatch, intl, courseId } = this.props;
     const { createSurvey } = actionCreators;
 
@@ -47,7 +40,7 @@ class NewSurveyButton extends React.Component {
     return dispatch(createSurvey(courseId, payload, successMessage, failureMessage));
   }
 
-  showNewSurveyForm() {
+  showNewSurveyForm = () => {
     const { dispatch, intl } = this.props;
     const { showSurveyForm } = actionCreators;
 

--- a/client/app/bundles/course/survey/containers/NewSurveyButton.jsx
+++ b/client/app/bundles/course/survey/containers/NewSurveyButton.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { aWeekStartingTomorrow } from 'lib/date_time_defaults';
 import * as actionCreators from '../actions';
 import AddButton from '../components/AddButton';
@@ -24,9 +24,7 @@ const propTypes = {
   dispatch: PropTypes.func.isRequired,
   canCreate: PropTypes.bool.isRequired,
   courseId: PropTypes.string.isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 class NewSurveyButton extends React.Component {

--- a/client/app/bundles/course/survey/containers/ShowSurvey.jsx
+++ b/client/app/bundles/course/survey/containers/ShowSurvey.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import * as actionCreators from '../actions';
 import SurveyDetails from '../components/SurveyDetails';
 import SurveyQuestions from '../components/SurveyQuestions';
@@ -133,9 +133,7 @@ ShowSurvey.propTypes = {
     surveyId: PropTypes.string.isRequired,
   }).isRequired,
   surveys: PropTypes.arrayOf(PropTypes.object).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default connect(state => state)(injectIntl(ShowSurvey));

--- a/client/app/bundles/course/survey/containers/Surveys.jsx
+++ b/client/app/bundles/course/survey/containers/Surveys.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import TitleBar from 'lib/components/TitleBar';
 import * as actionCreators from '../actions';
 import SurveysEmpty from '../components/SurveysEmpty';
@@ -14,9 +14,6 @@ const propTypes = {
   params: PropTypes.shape({
     courseId: PropTypes.string.isRequired,
   }),
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
 };
 
 class Surveys extends React.Component {
@@ -26,7 +23,7 @@ class Surveys extends React.Component {
   }
 
   render() {
-    const { intl, surveys, params: { courseId } } = this.props;
+    const { surveys, params: { courseId } } = this.props;
     surveys.sort((a, b) => {
       const dateOrder = new Date(a.start_at) - new Date(b.start_at);
       return dateOrder === 0 ? a.title.localeCompare(b.title) : dateOrder;
@@ -34,7 +31,7 @@ class Surveys extends React.Component {
     return (
       <div>
         <TitleBar
-          title={intl.formatMessage(translations.surveys)}
+          title={<FormattedMessage {...translations.surveys} />}
         />
         { surveys.length > 0 ? <SurveysTable {...{ surveys, courseId }} /> : <SurveysEmpty /> }
         <NewSurveyButton {...{ courseId }} />
@@ -45,4 +42,4 @@ class Surveys extends React.Component {
 
 Surveys.propTypes = propTypes;
 
-export default connect(state => state)(injectIntl(Surveys));
+export default connect(state => state)(Surveys);

--- a/client/app/lib/components/ChipInput.jsx
+++ b/client/app/lib/components/ChipInput.jsx
@@ -167,11 +167,6 @@ class ChipInput extends React.Component {
       focusedChip: null,
       inputValue: '',
     };
-
-    this.handleInputBlur = this.handleInputBlur.bind(this);
-    this.handleInputFocus = this.handleInputFocus.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleKeyUp = this.handleKeyUp.bind(this);
   }
 
   componentWillMount() {
@@ -261,7 +256,7 @@ class ChipInput extends React.Component {
     if (this.input) this.getInputNode().select();
   }
 
-  handleInputBlur(event) {
+  handleInputBlur = (event) => {
     if (!this.autoComplete) return;
     setTimeout(() => {
       if (!this.autoComplete.state.open || this.autoComplete.requestsList.length === 0) {
@@ -275,7 +270,7 @@ class ChipInput extends React.Component {
     }, 1);
   }
 
-  handleInputFocus(event) {
+  handleInputFocus = (event) => {
     if (this.props.disabled) {
       return;
     }
@@ -285,7 +280,7 @@ class ChipInput extends React.Component {
     }
   }
 
-  handleKeyDown(event) {
+  handleKeyDown = (event) => {
     if (event.keyCode === 8 || event.keyCode === 46) { // Backspace and Delete
       if (event.target.value === '') {
         const chips = this.props.value;
@@ -334,7 +329,7 @@ class ChipInput extends React.Component {
     }
   }
 
-  handleKeyUp(event) {
+  handleKeyUp = (event) => {
     if (this.props.newChipKeyCodes.indexOf(event.keyCode) < 0) {
       this.setState({ inputValue: event.target.value });
     } else {

--- a/client/app/lib/components/ConfirmationDialog.jsx
+++ b/client/app/lib/components/ConfirmationDialog.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import formTranslations from 'lib/translations/form';
@@ -68,9 +68,7 @@ const ConfirmationDialog = ({
 };
 
 ConfirmationDialog.propTypes = {
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   open: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,

--- a/client/app/lib/components/ExpandableText.jsx
+++ b/client/app/lib/components/ExpandableText.jsx
@@ -28,17 +28,14 @@ class ExpandableText extends React.Component {
     this.state = {
       expanded: false,
     };
-
-    this.handleShowAll = this.handleShowAll.bind(this);
-    this.handleShowLess = this.handleShowLess.bind(this);
   }
 
-  handleShowAll(e) {
+  handleShowAll = (e) => {
     e.preventDefault();
     this.setState({ expanded: true });
   }
 
-  handleShowLess(e) {
+  handleShowLess = (e) => {
     e.preventDefault();
     this.setState({ expanded: false });
   }

--- a/client/app/lib/components/ExpandableText.jsx
+++ b/client/app/lib/components/ExpandableText.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 
 const translations = defineMessages({
   showAll: {
@@ -15,9 +15,7 @@ const translations = defineMessages({
 const propTypes = {
   text: PropTypes.string.isRequired,
   maxChars: PropTypes.number,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
 };
 
 class ExpandableText extends React.Component {

--- a/client/app/lib/components/form/DateTimePicker.jsx
+++ b/client/app/lib/components/form/DateTimePicker.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import moment from 'moment';
 import TextField from 'material-ui/TextField';
 import DatePicker from 'material-ui/DatePicker';
@@ -62,9 +62,7 @@ const propTypes = {
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   style: PropTypes.object,
 };
 

--- a/client/app/lib/components/form/DateTimePicker.jsx
+++ b/client/app/lib/components/form/DateTimePicker.jsx
@@ -97,13 +97,17 @@ class DateTimePicker extends React.Component {
 
   updateDate = (_, newDate) => {
     const { date, months, years } = moment(newDate).toObject();
-    const newDateTime = moment(this.props.value).set({ date, months, years });
+    const newDateTime = this.props.value ?
+      moment(this.props.value).set({ date, months, years }) :
+      moment({ date, months, years });
     this.updateDateTime(newDateTime.toDate());
   }
 
   updateTime = (_, newTime) => {
     const { hours, minutes } = moment(newTime).toObject();
-    const newDateTime = moment(this.props.value).set({ hours, minutes });
+    const newDateTime = this.props.value ?
+      moment(this.props.value).set({ hours, minutes }) :
+      moment({ hours, minutes });
     this.updateDateTime(newDateTime.toDate());
   }
 

--- a/client/app/lib/components/form/DateTimePicker.jsx
+++ b/client/app/lib/components/form/DateTimePicker.jsx
@@ -82,11 +82,6 @@ class DateTimePicker extends React.Component {
     super(props);
 
     this.state = DateTimePicker.displayState(props.value);
-    this.updateDate = this.updateDate.bind(this);
-    this.updateTime = this.updateTime.bind(this);
-    this.updateDateTime = this.updateDateTime.bind(this);
-    this.handleDateFieldBlur = this.handleDateFieldBlur.bind(this);
-    this.handleTimeFieldBlur = this.handleTimeFieldBlur.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -94,7 +89,7 @@ class DateTimePicker extends React.Component {
     this.state = DateTimePicker.displayState(dateTime);
   }
 
-  updateDateTime(newDateTime) {
+  updateDateTime = (newDateTime) => {
     const { onBlur, onChange } = this.props;
     this.setState(DateTimePicker.displayState(newDateTime));
     // Marks redux-form field as 'touched' so that validation errors are shown, if any.
@@ -102,19 +97,19 @@ class DateTimePicker extends React.Component {
     if (onChange) { onChange(null, newDateTime); }
   }
 
-  updateDate(_, newDate) {
+  updateDate = (_, newDate) => {
     const { date, months, years } = moment(newDate).toObject();
     const newDateTime = moment(this.props.value).set({ date, months, years });
     this.updateDateTime(newDateTime.toDate());
   }
 
-  updateTime(_, newTime) {
+  updateTime = (_, newTime) => {
     const { hours, minutes } = moment(newTime).toObject();
     const newDateTime = moment(this.props.value).set({ hours, minutes });
     this.updateDateTime(newDateTime.toDate());
   }
 
-  handleDateFieldBlur() {
+  handleDateFieldBlur = () => {
     // Blanking out the date blanks out the whole field
     if (this.state.displayedDate === '') {
       this.updateDateTime(null, null);
@@ -129,7 +124,7 @@ class DateTimePicker extends React.Component {
     }
   }
 
-  handleTimeFieldBlur() {
+  handleTimeFieldBlur = () => {
     // Blanking out the time also blanks out the whole field
     if (this.state.displayedTime === '') {
       this.updateDateTime(null, null);

--- a/client/package.json
+++ b/client/package.json
@@ -61,6 +61,7 @@
     "webpack": "^1.13.3"
   },
   "devDependencies": {
+    "babel-eslint": "^6.1.2",
     "babel-plugin-react-intl": "^2.2.0",
     "eslint": "^3.9.1",
     "eslint-config-airbnb": "^12.0.0",


### PR DESCRIPTION
- Use propType supplied by react-intl instead of manually rolling our own
- Change the eslint parser to permit fat arrow syntax for defining class methods
- Fix error when dateTime is blanked out before a new date is selected via the datePicker or timePicker.