### PR TITLE
Add evaluation id to result struct for instrumentation purposes

### DIFF
--- a/app/services/course/assessment/answer/programming_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_auto_grading_service.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::Answer::ProgrammingAutoGradingService < \
   Course::Assessment::Answer::AutoGradingService
   def evaluate(answer)
-    answer.correct, grade, programming_auto_grading = evaluate_answer(answer.actable)
+    answer.correct, grade, programming_auto_grading, = evaluate_answer(answer.actable)
     programming_auto_grading.auto_grading = answer.auto_grading
     grade
   end
@@ -66,7 +66,7 @@ class Course::Assessment::Answer::ProgrammingAutoGradingService < \
 
     all_correct = number_correct == test_count
     grade = question.maximum_grade * number_correct / test_count
-    [all_correct, grade, auto_grading]
+    [all_correct, grade, auto_grading, evaluation_result.evaluation_id]
   end
 
   # Checks presence of test report and builds the test case records.

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -6,7 +6,7 @@ class Course::Assessment::ProgrammingEvaluationService
   CPU_TIMEOUT = Course::Assessment::ProgrammingEvaluation::CPU_TIMEOUT
 
   # Represents a result of evaluating a package.
-  Result = Struct.new(:stdout, :stderr, :test_report, :exit_code) do
+  Result = Struct.new(:stdout, :stderr, :test_report, :exit_code, :evaluation_id) do
     # Checks if the evaluation errored.
     #
     # This does not count failing test cases as an error, although the exit code is nonzero.
@@ -96,7 +96,8 @@ class Course::Assessment::ProgrammingEvaluationService
   def execute
     evaluation = create_evaluation
     wait_for_evaluation(evaluation)
-    Result.new(evaluation.stdout, evaluation.stderr, evaluation.test_report, evaluation.exit_code)
+    Result.new(evaluation.stdout, evaluation.stderr, evaluation.test_report,
+               evaluation.exit_code, evaluation.id)
   ensure
     evaluation.destroy! if evaluation
   end


### PR DESCRIPTION
This will allow linking of programming answer and evaluation instrumentation logs