### PR TITLE
Remove "reply" button for forum posts that have parents

### DIFF
--- a/app/views/course/forum/posts/_post.html.slim
+++ b/app/views/course/forum/posts/_post.html.slim
@@ -19,9 +19,10 @@
       - if defined?(show_buttons)
         div.pull-right
           .btn-group
-            = link_to reply_course_forum_topic_post_path(current_course, @forum, @topic, post),
-                      title: t('.reply'), class: ['btn', 'btn-primary'] do
-              = fa_icon 'mail-reply'.freeze
+            - if post.parent_id.nil?
+              = link_to reply_course_forum_topic_post_path(current_course, @forum, @topic, post),
+                        title: t('.reply'), class: ['btn', 'btn-primary'] do
+                = fa_icon 'mail-reply'.freeze
             - if can? :edit, post
               = edit_button(edit_course_forum_topic_post_path(current_course, @forum, @topic, post))
             - if can? :destroy, post


### PR DESCRIPTION
[Updated screenshot] 

![screenshot 2017-02-08 14 38 20](https://cloud.githubusercontent.com/assets/7563985/22726077/4938caee-ee0c-11e6-85a1-0f348817ca3c.png)

Fixes #2003 