### PR TITLE
Modify publish_all submissions into a job

### DIFF
--- a/app/jobs/course/assessment/submission/publishing_job.rb
+++ b/app/jobs/course/assessment/submission/publishing_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+class Course::Assessment::Submission::PublishingJob < ApplicationJob
+  include TrackableJob
+  include Rails.application.routes.url_helpers
+
+  protected
+
+  def perform_tracked(assessment, publisher)
+    instance = Course.unscoped { assessment.course.instance }
+    ActsAsTenant.with_tenant(instance) do
+      publish_submissions(assessment, publisher)
+    end
+
+    redirect_to course_assessment_submissions_path(assessment.course, assessment,
+                                                   published_success: true)
+  end
+
+  private
+
+  # Publishes all graded submissions for a given assessment.
+  #
+  # @param [Course::Assessment] assessment The assessment for which the submissions' grades are
+  # to be published for.
+  # @param [User] publisher The user object who would be publishing the submission.
+  def publish_submissions(assessment, publisher)
+    User.with_stamper(publisher) do
+      assessment.submissions.with_graded_state.each do |submission|
+        submission.publish!
+        submission.save!
+      end
+    end
+  end
+end

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
         visit course_assessment_submissions_path(course, assessment)
 
         click_link I18n.t('course.assessment.submission.submissions.index.publish')
+
+        wait_for_job
+        expect(current_path).to eq(course_assessment_submissions_path(course, assessment))
         expect(graded_submission.reload).to be_published
         expect(graded_submission.publisher).to eq(user)
         expect(graded_submission.published_at).to be_present


### PR DESCRIPTION
- Publishing more than 50 submissions might take a long time, so it is better to switch it to a job to avoid a timeout.

Fixes #1949.