### PR TITLE
Sort instance listing by name in admin page

### DIFF
--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -4,7 +4,7 @@ class System::Admin::InstancesController < System::Admin::Controller
   add_breadcrumb :index, :admin_instances_path
 
   def index #:nodoc:
-    @instances = Instance.order_by_id.page(page_param).calculated(:course_count, :user_count)
+    @instances = Instance.order_for_display.page(page_param).calculated(:course_count, :user_count)
   end
 
   def new #:nodoc:

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -57,6 +57,14 @@ class Instance < ActiveRecord::Base
   #   Orders the instances by ID.
   scope :order_by_id, ->(direction = :asc) { order(id: direction) }
 
+  scope :order_by_name, ->(direction = :asc) { order(name: direction) }
+
+  # Custom ordering. Put default instance first, followed by the others, which are ordered by name.
+  # This is for listing all the instances on the index page.
+  scope :order_for_display, (lambda do
+    order("CASE \"id\" WHEN #{DEFAULT_INSTANCE_ID} THEN 0 ELSE 1 END").order_by_name
+  end)
+
   # @!attribute [r] course_count
   #   The number of courses in the instance.
   calculated :course_count, (lambda do

--- a/app/views/system/admin/instances/_instance.html.slim
+++ b/app/views/system/admin/instances/_instance.html.slim
@@ -1,4 +1,5 @@
 = content_tag_for(:tr, instance)
+  td = (current_page - 1) * per_page + instance_counter + 1
   th
     a
       = link_to format_inline_text(instance.name), \

--- a/app/views/system/admin/instances/index.html.slim
+++ b/app/views/system/admin/instances/index.html.slim
@@ -1,14 +1,20 @@
 = page_header do
   = new_button([:admin, :instance]) if can?(:create, Instance.new)
+
+= page_entries_info(@instances)
+
 table.table.table-middle-align.table-hover
   thead
     tr
+      th= t('.serial_number')
       th= t('.name')
       th= t('.host_name')
       th= t('.users')
       th= t('.courses')
 
   tbody
-    = render @instances
+    = render partial: 'instance', collection: @instances,
+                                  locals: { current_page: @instances.current_page,
+                                            per_page: @instances.default_per_page }
 
 = paginate @instances

--- a/config/locales/en/system/admin/instances.yml
+++ b/config/locales/en/system/admin/instances.yml
@@ -4,6 +4,7 @@ en:
       instances:
         index:
           header: 'Instance Management'
+          serial_number: 'S/N'
           name: 'Name'
           host_name: 'Host Name'
           users: 'Total Users'

--- a/spec/factories/instances.rb
+++ b/spec/factories/instances.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   end
 
   factory :instance do
-    sequence(:name) { |n| "Instance#{n}" }
+    sequence(:name) { |n| "Instance-#{base_time}-#{n}" }
     host
 
     trait :with_video_component_enabled do

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe Instance do
     end
   end
 
+  describe '.order_for_display' do
+    let(:instances) { create_list(:instance, 2) }
+    # Use a name that comes before 'Default'
+    let!(:instance) { create(:instance, name: 'Abc') }
+
+    it 'orders the default instance first, then alphabetically by name' do
+      listing = Instance.order_for_display
+      expect(listing.first).to eq Instance.default
+
+      # Drop the 'Default' instance.
+      listing = listing.drop(1)
+      # Check that the rest of the names are ordered alphabetically.
+      names = listing.map(&:name)
+      expect(names.length).to be > 1
+      expect(names.each_cons(2).all? { |a, b| a <= b }).to be_truthy
+    end
+  end
+
   describe '.find_tenant_by_host' do
     let(:instances) { create_list(:instance, 3) }
 


### PR DESCRIPTION
Keep the default instance as the first one.
Also add a serial number to the listing so it's consistent with the course listing.

<img width="507" alt="screen shot 2017-02-08 at 10 49 40 pm" src="https://cloud.githubusercontent.com/assets/1902527/22742223/e9e988c2-ee50-11e6-8908-600dc3e28502.png">

Fixes #1998.