### PR TITLE
Fix a bug that EXP history breaks when the updater is not in the course

### DIFF
--- a/app/views/course/experience_points_records/_experience_points_record.html.slim
+++ b/app/views/course/experience_points_records/_experience_points_record.html.slim
@@ -8,8 +8,8 @@
 = content_tag_for(:tr, experience_points_record, row_options_hash)
   = simple_fields_for experience_points_record do |f|
     td
-      - updater = @course_user_preload_service.course_user_for(experience_points_record.updater)
-      = link_to_user(updater)
+      - updater_course_user = @course_user_preload_service.course_user_for(experience_points_record.updater)
+      = link_to_user(updater_course_user || experience_points_record.updater)
     td
       - if !experience_points_record.manually_awarded?
         = render partial: experience_points_record.specific, suffix: 'experience_points_reason'

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -9,7 +9,12 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
     let(:course_student) { create(:course_student, course: course) }
     let(:submission) { create(:submission, course: course, creator: course_student.user) }
     let(:record) { submission.acting_as }
-    let(:manual_record) { create(:course_experience_points_record, course_user: course_student) }
+    let(:manual_record) do
+      # Set the updater to a user not in the course to make sure the page still works in this case.
+      record = create(:course_experience_points_record, course_user: course_student)
+      record.update_column(:updater_id, create(:user).id)
+      record
+    end
     let(:inactive_record) do
       create(:course_experience_points_record, :inactive, course_user: course_student)
     end


### PR DESCRIPTION
* Use original updater if updater's course user is nil