### PR TITLE
Implement a "Self Directed Learning" mode to allow students to access unopened course contents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
    - 'db/seeds.rb'
    - 'db/schema.rb'
    - 'vendor/bundle/**/*'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics/LineLength:
   Max: 100
@@ -55,3 +55,6 @@ Style/WordArray:
 
 Style/RegexpLiteral:
   AllowInnerSlashes: true
+
+Style/NumericPredicate:
+  EnforcedStyle: comparison

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ branches:
   except:
     - /^bundle-update-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}+$/
 rvm:
-  - 2.2.5
   - 2.3.1
+  - 2.3.3
 matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
-    - rvm: 2.2.5
+    - rvm: 2.3.3
       env: GROUP="checks"
 addons:
   postgresql: "9.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     devise_masquerade (0.2.0)
       devise (>= 2.1.0)
       railties (>= 3.0)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.5)
     easy_translate (0.5.0)
       json
@@ -377,7 +377,7 @@ GEM
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
-    rspec-html-matchers (0.8.2)
+    rspec-html-matchers (0.9.1)
       nokogiri (~> 1)
       rspec (>= 3.0.0.a, < 4)
     rspec-mocks (3.5.0)

--- a/app/assets/stylesheets/course/admin/admin.scss
+++ b/app/assets/stylesheets/course/admin/admin.scss
@@ -1,5 +1,13 @@
 .course-admin-admin {
-  .edit-course {
+  &.index {
+    .advance-start-at-time {
+      display: inline-block;
+
+      input {
+        width: 80px;
+      }
+    }
+
     .course-logo {
       .image > img {
         height: $course-admin-form-logo;

--- a/app/controllers/course/admin/admin_controller.rb
+++ b/app/controllers/course/admin/admin_controller.rb
@@ -24,7 +24,8 @@ class Course::Admin::AdminController < Course::Admin::Controller
 
   def course_setting_params #:nodoc:
     params.require(:course).
-      permit(:title, :description, :published, :enrollable, :start_at, :end_at, :logo, :gamified)
+      permit(:title, :description, :published, :enrollable, :start_at, :end_at, :logo, :gamified,
+             :advance_start_at_duration_days)
   end
 
   def destroy_success #:nodoc:

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -43,6 +43,11 @@ class Course::Controller < ApplicationController
   end
   helper_method :current_component_host
 
+  # Override of Cancancan#current_ability to provide current course.
+  def current_ability
+    @current_ability ||= Ability.new(current_user, current_course)
+  end
+
   private
 
   # Selects sidebar items of the given type.

--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -3,6 +3,7 @@ class Course::Material::MaterialsController < Course::Material::Controller
   load_and_authorize_resource :material, through: :folder, class: Course::Material.name
 
   def show
+    authorize!(:read_owner, @material.folder)
     redirect_to @material.attachment.url(filename: @material.name)
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,8 +10,10 @@ class Ability
   # Initialize the ability of user.
   #
   # @param [User|nil] user The current user. This can be nil if the no user is logged in.
-  def initialize(user)
+  # @param [Course|nil] course The current course. This can be nil if not inside a course.
+  def initialize(user, course = nil)
     @user = user
+    @course = course
     can :manage, :all if user && user.administrator?
 
     define_permissions

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,6 +2,7 @@
 class Ability
   include CanCan::Ability
   attr_reader :user
+  attr_reader :course
 
   # Load all components which declare abilities.
   AbilityHost.components.each { |component| prepend(component) }

--- a/app/models/components/course/materials_ability_component.rb
+++ b/app/models/components/course/materials_ability_component.rb
@@ -31,6 +31,11 @@ module Course::MaterialsAbilityComponent
       can [:read, :download],
           Course::Material::Folder, course_all_course_users_hash.reverse_merge(properties)
     end
+
+    can :read_owner, Course::Material::Folder do |folder|
+      # Different types of owners should define their own versions of `read_material`.
+      folder.concrete? || can?(:read_material, folder.owner)
+    end
   end
 
   def allow_students_upload_materials

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -47,7 +47,7 @@ module Course::VideosAbilityComponent
 
   def allow_student_attempt_video
     can :attempt, Course::Video do |video|
-      video.started? && video.published?
+      video.published? && video.self_directed_started?
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -113,6 +113,29 @@ class Course < ActiveRecord::Base
     end
   end
 
+  # This is the max time span that the student can access a future assignment.
+  # Used in self directed mode, which will allow students to access course contents in advance
+  # before they have started.
+  #
+  # @return [ActiveSupport::Duration]
+  def advance_start_at_duration
+    settings(:course).advance_start_at_duration
+  end
+
+  def advance_start_at_duration=(time)
+    settings(:course).advance_start_at_duration = time
+  end
+
+  # Convert the days to time duration and store it.
+  def advance_start_at_duration_days=(value)
+    value = if value.present? && value.to_i > 0
+              value.to_i.days
+            else
+              nil
+            end
+    settings(:course).advance_start_at_duration = value
+  end
+
   def initialize_duplicate(duplicator, other)
     self.start_at += duplicator.time_shift
     self.end_at += duplicator.time_shift

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -54,11 +54,13 @@ module Course::Assessment::AssessmentAbility
   end
 
   def allow_students_show_assessments
+    can :read_material, Course::Assessment::Category, course_all_course_users_hash
+    can :read_material, Course::Assessment::Tab, category: course_all_course_users_hash
     can :read, Course::Assessment, assessment_published_all_course_users_hash
   end
 
   def allow_students_attempt_assessment
-    can :attempt, Course::Assessment do |assessment|
+    can [:attempt, :read_material], Course::Assessment do |assessment|
       assessment.published? && assessment.self_directed_started? &&
         assessment.conditions_satisfied_by?(
           user.course_users.find_by(course: assessment.course)

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -59,9 +59,10 @@ module Course::Assessment::AssessmentAbility
 
   def allow_students_attempt_assessment
     can :attempt, Course::Assessment do |assessment|
-      assessment.started? && assessment.published? && assessment.conditions_satisfied_by?(
-        user.course_users.find_by(course: assessment.course)
-      )
+      assessment.published? && assessment.self_directed_started? &&
+        assessment.conditions_satisfied_by?(
+          user.course_users.find_by(course: assessment.course)
+        )
     end
   end
 

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -40,6 +40,17 @@ class Course::LessonPlan::Item < ActiveRecord::Base
     self.end_at = other.end_at + time_shift if other.end_at
   end
 
+  # Test if the lesson plan item has started for self directed learning.
+  #
+  # @return [Boolean]
+  def self_directed_started?
+    if course&.advance_start_at_duration
+      !start_at.present? || start_at - course.advance_start_at_duration < Time.zone.now
+    else
+      started?
+    end
+  end
+
   private
 
   # Sets default EXP values

--- a/app/views/course/admin/admin/index.html.slim
+++ b/app/views/course/admin/admin/index.html.slim
@@ -14,8 +14,24 @@
     = f.input :enrollable, label: t('.enrollable_label')
     = f.input :start_at
     = f.input :end_at
-    = f.label :gamified
-    = f.input :gamified, label: t('.gamified_label')
+    = f.input :gamified, hint: t('.gamified_label')
+
+    - max_time = current_course.advance_start_at_duration
+    .form-group.boolean.optional
+      .checkbox
+          = label_tag 'self_directed_learning' do
+            = check_box_tag 'self_directed_learning', max_time.present?, max_time.present?,
+                class: 'self-directed-learning-checkbox'
+            = t('.self_directed_learning')
+      p.help-block = t('.self_directed_learning_label')
+
+    - input = f.input :advance_start_at_duration_days,
+                      as: :integer, label: false,
+                      input_html: { value: max_time.present? ? max_time / 1.day : nil },
+                      wrapper_html: { class: 'form-inline advance-start-at-time' }
+    div.advance-start-at-time style="#{ max_time.present? ? '' : 'display: none' }"
+      = t('.self_directed_learning_time_html', input: input)
+    br
     = f.button :submit
 
   div.delete-course

--- a/client/app/bundles/course/admin/admin.js
+++ b/client/app/bundles/course/admin/admin.js
@@ -1,0 +1,13 @@
+$(document).ready(() => {
+  $('input.self-directed-learning-checkbox:checkbox').change(
+    function () {
+      if ($(this).is(':checked')) {
+        $('div.advance-start-at-time').show();
+        $('.advance-start-at-time input').prop('required', true);
+      } else {
+        $('.advance-start-at-time input').prop('required', false);
+        $('.advance-start-at-time input').val('');
+        $('div.advance-start-at-time').hide();
+      }
+    });
+});

--- a/config/locales/en/course/admin/admin.yml
+++ b/config/locales/en/course/admin/admin.yml
@@ -15,6 +15,12 @@ en:
             Disabling gamification would hide these options, and students would not be able to
             see experience points either. This would also disable the following components -
             Achievements, Levels, Leaderboard and Points Disbursement.
+          self_directed_learning: 'Self Directed Learning'
+          self_directed_learning_label: >
+            Allow students to attempt the assessments that start at a future time provided they
+            have fulfilled the prerequisites.
+          self_directed_learning_time_html: >
+            Allow students to access course items %{input} days in advance of the item's start time.
           delete:
             header: 'Delete Course'
             button: 'Delete My Course'

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -38,12 +38,32 @@ RSpec.feature 'Course: Administration: Administration' do
         fill_in 'course_title',          with: new_title
         fill_in 'course_description',    with: new_description
         attach_file :course_logo, File.join(Rails.root, '/spec/fixtures/files/picture.jpg')
+
         click_button I18n.t('helpers.submit.course.update')
 
         expect(page).to have_selector('div.alert.alert-success')
         expect(page).to have_content(course.logo.medium.url)
         expect(course.reload.title).to eq(new_title)
         expect(course.reload.description).to eq(new_description)
+      end
+
+      scenario 'I can enable/disable self directed learning', js: true do
+        visit course_admin_path(course)
+
+        days = 10
+        check 'self_directed_learning'
+        fill_in 'course_advance_start_at_duration_days', with: days
+
+        click_button 'submit'
+
+        expect(page).to have_selector('div.alert-success')
+        expect(course.reload.advance_start_at_duration).to be_within(1.hour).of(days.days)
+
+        uncheck 'self_directed_learning'
+        click_button 'submit'
+
+        expect(page).to have_selector('div.alert-success')
+        expect(course.reload.advance_start_at_duration).to be_nil
       end
 
       scenario 'I can delete the course' do

--- a/spec/features/course/user_profile_spec.rb
+++ b/spec/features/course/user_profile_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 RSpec.feature 'Courses: CourseUser Profile' do
   let(:instance) { Instance.default }
 
+  def exp_text(course_user)
+    I18n.t('course.users.show.experience_points_earned_html',
+           points: course_user.experience_points)
+  end
+
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_student) { create(:course_student, course: course) }
@@ -20,8 +25,7 @@ RSpec.feature 'Courses: CourseUser Profile' do
         expect(page).to have_text(course_student.name)
         expect(page).to have_text(I18n.t('course.users.show.achievement_count'))
         expect(page).to have_link(nil, href: course_achievement_path(course, achievement))
-        expect(page).
-          to have_text(I18n.t('course.users.show.experience_points_earned_html'))
+        expect(page).to have_text(exp_text(course_student))
       end
     end
 
@@ -36,8 +40,7 @@ RSpec.feature 'Courses: CourseUser Profile' do
         expect(page).not_to have_text(I18n.t('course.users.show.achievement_count'))
         expect(page).
           not_to have_selector('h2', text: Course::Achievement.model_name.human.pluralize)
-        expect(page).
-          not_to have_text(I18n.t('course.users.show.experience_points_earned_html'))
+        expect(page).not_to have_text(exp_text(course_teaching_assistant))
       end
 
       scenario "I can view a coursemate's profile" do
@@ -48,8 +51,7 @@ RSpec.feature 'Courses: CourseUser Profile' do
         expect(page).to have_text(course_student.name)
         expect(page).to have_text(I18n.t('course.users.show.achievement_count'))
         expect(page).to have_link(nil, href: course_achievement_path(course, achievement))
-        expect(page).
-          not_to have_text(I18n.t('course.users.show.experience_points_earned_html'))
+        expect(page).not_to have_text(exp_text(course_student))
       end
 
       scenario 'I can view my own profile' do
@@ -60,8 +62,7 @@ RSpec.feature 'Courses: CourseUser Profile' do
         expect(page).to have_text(course_student.name)
         expect(page).to have_text(I18n.t('course.users.show.achievement_count'))
         expect(page).to have_link(nil, href: course_achievement_path(course, achievement))
-        expect(page).
-          to have_text(I18n.t('course.users.show.experience_points_earned_html'))
+        expect(page).to have_text(exp_text(course_student))
       end
     end
   end

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -8,11 +8,14 @@ RSpec.describe Course::Assessment do
     let(:course) { create(:course) }
     let(:course_user) { create(:course_student, course: course) }
     let(:coursemate) { create(:course_student, course: course) }
-    let(:draft_assessment) do
+    let(:unpublished_assessment) do
       create(:assessment, :with_all_question_types, course: course, published: false)
     end
-    let(:published_assessment) do
-      create(:assessment, :published_with_all_question_types, course: course)
+    let(:published_started_assessment) do
+      create(:assessment, :published_with_mcq_question, course: course)
+    end
+    let(:published_not_started_assessment) do
+      create(:assessment, :published_with_mcq_question, start_at: 1.day.from_now, course: course)
     end
     let(:published_assessment_with_attemping_submission) do
       create(:assessment, :published_with_all_question_types, course: course)
@@ -22,40 +25,58 @@ RSpec.describe Course::Assessment do
              assessment: published_assessment_with_attemping_submission, creator: course_user.user)
     end
     let(:submitted_submission) do
-      create(:submission, :submitted, assessment: published_assessment, creator: course_user.user)
+      create(:submission, :submitted,
+             assessment: published_started_assessment, creator: course_user.user)
     end
     let(:coursemate_attempting_submission) do
-      create(:submission, :attempting, assessment: published_assessment, creator: coursemate.user)
+      create(:submission, :attempting,
+             assessment: published_started_assessment, creator: coursemate.user)
     end
     let(:coursemate_submitted_submission) do
-      create(:submission, :submitted, assessment: published_assessment, creator: coursemate.user)
+      create(:submission, :submitted,
+             assessment: published_started_assessment, creator: coursemate.user)
     end
 
     context 'when the user is a Course Student' do
       let(:user) { course_user.user }
 
       # Course Assessments
-      it { is_expected.not_to be_able_to(:read, draft_assessment) }
-      it { is_expected.to be_able_to(:read, published_assessment) }
+      it { is_expected.not_to be_able_to(:read, unpublished_assessment) }
+      it { is_expected.to be_able_to(:read, published_started_assessment) }
+      it { is_expected.to be_able_to(:read, published_not_started_assessment) }
 
       # Course Assessment Submissions
-      it { is_expected.not_to be_able_to(:attempt, draft_assessment) }
-      it { is_expected.to be_able_to(:attempt, published_assessment) }
+      it { is_expected.not_to be_able_to(:attempt, unpublished_assessment) }
+      it { is_expected.not_to be_able_to(:attempt, published_not_started_assessment) }
+      it { is_expected.to be_able_to(:attempt, published_started_assessment) }
       it { is_expected.to be_able_to(:create, attempting_submission) }
       it { is_expected.to be_able_to(:update, attempting_submission) }
       it { is_expected.to be_able_to(:read, submitted_submission) }
       it { is_expected.not_to be_able_to(:update, coursemate_attempting_submission) }
       it { is_expected.not_to be_able_to(:read, coursemate_submitted_submission) }
+
+      context 'when the course is self directed' do
+        let(:course) { create(:course, advance_start_at_duration_days: 3) }
+        let(:published_not_started_assessment2) do
+          create(:assessment, :published_with_mcq_question,
+                 start_at: 7.days.from_now, course: course)
+        end
+
+        it { is_expected.to be_able_to(:attempt, published_not_started_assessment) }
+
+        # This duration to this assessment's starting date is long that the max self directed time.
+        it { is_expected.not_to be_able_to(:attempt, published_not_started_assessment2) }
+      end
     end
 
     context 'when the user is a Course Staff' do
       let(:user) { create(:course_manager, course: course).user }
 
       # Course Assessments
-      it { is_expected.to be_able_to(:manage, draft_assessment) }
-      it { is_expected.to be_able_to(:manage, published_assessment) }
+      it { is_expected.to be_able_to(:manage, unpublished_assessment) }
+      it { is_expected.to be_able_to(:manage, published_started_assessment) }
       it 'can manage all questions in the assessment' do
-        draft_assessment.questions.each do |question|
+        unpublished_assessment.questions.each do |question|
           expect(subject).to be_able_to(:manage, question.specific)
         end
       end
@@ -71,7 +92,7 @@ RSpec.describe Course::Assessment do
       end
 
       it 'sees submitted submission for a given assessment' do
-        expect(published_assessment.submissions.accessible_by(subject)).
+        expect(published_started_assessment.submissions.accessible_by(subject)).
           to contain_exactly(submitted_submission)
       end
     end

--- a/spec/models/course/material/folder_ability_spec.rb
+++ b/spec/models/course/material/folder_ability_spec.rb
@@ -16,7 +16,13 @@ RSpec.describe Course::Material::Folder, type: :model do
     let(:not_started_linked_folder) do
       create(:assessment, course: course, start_at: 1.day.from_now).folder
     end
-
+    let(:started_published_linked_folder) do
+      create(:assessment, :published_with_mcq_question, course: course, start_at: 1.day.ago).folder
+    end
+    let(:not_started_published_linked_folder) do
+      create(:assessment, :published_with_mcq_question,
+             course: course, start_at: 1.day.from_now).folder
+    end
     context 'when the user is a Course Student' do
       let(:user) { create(:course_student, course: course).user }
 
@@ -25,6 +31,11 @@ RSpec.describe Course::Material::Folder, type: :model do
       it { is_expected.not_to be_able_to(:show, ended_folder) }
       it { is_expected.to be_able_to(:show, started_linked_folder) }
       it { is_expected.not_to be_able_to(:show, not_started_linked_folder) }
+
+      it { is_expected.not_to be_able_to(:read_owner, started_linked_folder) }
+      it { is_expected.not_to be_able_to(:read_owner, not_started_linked_folder) }
+      it { is_expected.to be_able_to(:read_owner, started_published_linked_folder) }
+      it { is_expected.not_to be_able_to(:read_owner, not_started_published_linked_folder) }
     end
 
     context 'when the user is a Course Staff' do
@@ -36,6 +47,11 @@ RSpec.describe Course::Material::Folder, type: :model do
       it { is_expected.not_to be_able_to(:manage, started_linked_folder) }
       it { is_expected.to be_able_to(:show, started_linked_folder) }
       it { is_expected.to be_able_to(:show, not_started_linked_folder) }
+
+      it { is_expected.to be_able_to(:read_owner, started_linked_folder) }
+      it { is_expected.to be_able_to(:read_owner, not_started_linked_folder) }
+      it { is_expected.to be_able_to(:read_owner, started_published_linked_folder) }
+      it { is_expected.to be_able_to(:read_owner, not_started_published_linked_folder) }
     end
 
     context 'when the user is a System Administrator' do

--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -34,7 +34,10 @@ RSpec.configure do |config|
       # @param [String] key The key to check.
       # @return [Boolean]
       def always_return_actual?(key)
-        key.start_with?('errors.', 'support.', 'number.', 'javascript.')
+        key.start_with?('errors.', 'support.', 'number.', 'javascript.', 'date.formats.',
+                        'time.formats.') ||
+          # The html passed to the key should always be returned.
+          key.end_with?('_html')
       end
     end
     I18n.backend = StubbedI18nBackend.new


### PR DESCRIPTION
Fixes #2002 

![screen shot 2017-02-14 at 6 01 45 pm](https://cloud.githubusercontent.com/assets/4983239/22924356/be60e84c-f2df-11e6-9e86-5e250a8295f4.png)

- Add a course setting to allow enable and change the max time of the mode
- Redefine permissions to allow user to access unopened materials
- Update and further fix material permission. Before the material was accessible as long as the owner is started ( regardless of whether published or not )