### PR TITLE
Use image_optim_rails to compress assets when precompiling.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ end
 # source files/image assets.
 group :assets do
   # Compress image assets
-  gem 'image_optim'
+  gem 'image_optim_rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       railties (>= 3.2, < 5.1)
     friendly_id (5.2.0)
       activerecord (>= 4.0.0)
-    fspath (3.0.1)
+    fspath (3.0.3)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.4.6)
@@ -235,6 +235,10 @@ GEM
       image_size (~> 1.5)
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
+    image_optim_rails (0.2.0)
+      image_optim (~> 0.24.0)
+      rails
+      sprockets
     image_size (1.5.0)
     in_threads (1.3.1)
     its-it (1.3.0)
@@ -317,7 +321,7 @@ GEM
       websocket-driver (>= 0.2.0)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
-    progress (3.2.2)
+    progress (3.3.0)
     public_suffix (2.0.4)
     puma (3.6.2)
     rack (1.6.5)
@@ -588,7 +592,7 @@ DEPENDENCIES
   http_accept_language
   i18n-js (>= 3.0.0.rc1)
   i18n-tasks
-  image_optim
+  image_optim_rails
   jbuilder
   jquery-cdn
   jquery-rails

--- a/config/image_optim.yml
+++ b/config/image_optim.yml
@@ -1,0 +1,1 @@
+skip_missing_workers: true


### PR DESCRIPTION
Skip missing workers so precompile doesn't fail for when built on
machines without the binaries.
Warning messages about the missing binaries will still be displayed.

`image_optim` on its own was not invoked during precompile.