### PR TITLE
Allow non-autograded questions to be added to autograded assessments

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,38 +1,27 @@
 {
-	// Default options
-	"boss": true,
+	"boss": false,
 	"browser": true,
+	"camelcase": true,
 	"curly": true,
 	"eqeqeq": true,
 	"eqnull": true,
 	"expr": true,
+	"forin": true,
+	"globals": {
+		"jQuery": true,
+		"$": true,
+		"ace": true
+	},
 	"immed": true,
 	"indent": 4,
 	"latedef": "nofunc",
+	"maxlen": 100,
 	"newcap": true,
 	"noarg": true,
+	"quotmark": "single",
+	"strict": true,
 	"sub": true,
 	"trailing": true,
 	"undef": true,
 	"unused": true,
-	"globals": {
-		"jQuery": true,
-		"$": true
-	},
-
-	// Project options: Default off
-	"camelcase": true,
-	"forin": true,
-	"quotmark": "single",
-	"strict": true,
-
-	// Project options: Default on
-	"boss": false,
-
-	// Other Project options:
-	"maxlen": 100,
-	"globals": {
-		"jQuery": true,
-		"ace": true
-	}
 }

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -20,7 +20,6 @@ class Course::Assessment < ActiveRecord::Base
   after_commit :clear_duplication_flag
 
   validate :validate_presence_of_questions, if: :published?
-  validate :validate_only_autograded_question_when_published
 
   belongs_to :tab, inverse_of: :assessments
 
@@ -135,17 +134,6 @@ class Course::Assessment < ActiveRecord::Base
 
   def validate_presence_of_questions
     errors.add(:published, :no_questions) unless questions.present?
-  end
-
-  def validate_only_autograded_question_when_published
-    return unless autograded? && published?
-
-    non_autograded_questions = questions.select { |q| !q.auto_gradable? }
-    return if non_autograded_questions.empty?
-
-    message = I18n.t('activerecord.errors.models.course/assessment.autograded',
-                     question: non_autograded_questions.first.display_title)
-    errors.add(:published, message)
   end
 
   def clear_duplication_flag

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -68,10 +68,8 @@ class Course::Assessment::Answer < ActiveRecord::Base
   #   finished.
   # @param [Boolean] reattempt Whether to create new answer based on current answer after grading.
   # @return [Course::Assessment::Answer::AutoGradingJob] The job instance.
-  # @raise [ArgumentError] When the question cannot be auto graded.
   # @raise [IllegalStateError] When the answer has not been submitted.
   def auto_grade!(redirect_to_path = nil, reattempt = false)
-    raise ArgumentError unless question.auto_gradable?
     raise IllegalStateError if attempting?
 
     ensure_auto_grading!

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -5,8 +5,6 @@ class Course::Assessment::Question < ActiveRecord::Base
 
   before_validation :set_defaults, if: :new_record?
 
-  validate :validate_assessment_is_not_autograded, unless: :auto_gradable?
-
   belongs_to :assessment, inverse_of: :questions
   has_many :answers, class_name: Course::Assessment::Answer.name, dependent: :destroy,
                      inverse_of: :question
@@ -85,11 +83,6 @@ class Course::Assessment::Question < ActiveRecord::Base
   end
 
   private
-
-  def validate_assessment_is_not_autograded
-    return unless assessment.autograded? && assessment.published?
-    errors.add(:base, :autograded_assessment)
-  end
 
   def set_defaults
     return if weight.present? || !assessment || assessment.new_record?

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -101,10 +101,7 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
   def non_autograded_template_files=(template_files)
     self.template_files.clear
     self.template_files = template_files
-
-    execute_after_commit do
-      test_cases.clear
-    end
+    test_cases.clear
   end
 
   private

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -33,7 +33,12 @@ class Course::Assessment::Question::TextResponse < ActiveRecord::Base
 
   def attempt(submission, last_attempt = nil)
     answer = submission.text_response_answers.build(submission: submission, question: question)
-    answer.answer_text = last_attempt.answer_text if last_attempt
+    if last_attempt
+      answer.answer_text = last_attempt.answer_text
+      if last_attempt.attachment_reference
+        answer.attachment_reference = last_attempt.attachment_reference.dup
+      end
+    end
     answer.acting_as
   end
 

--- a/app/services/course/assessment/question/programming/programming_package_service.rb
+++ b/app/services/course/assessment/question/programming/programming_package_service.rb
@@ -22,6 +22,7 @@ class Course::Assessment::Question::Programming::ProgrammingPackageService
     else
       templates = @language_package_service.submission_templates
       @question.imported_attachment = nil
+      @question.import_job_id = nil
       @question.non_autograded_template_files = templates.map do |template|
         Course::Assessment::Question::ProgrammingTemplateFile.new(template)
       end

--- a/app/services/course/assessment/submission/auto_grading_service.rb
+++ b/app/services/course/assessment/submission/auto_grading_service.rb
@@ -24,13 +24,9 @@ class Course::Assessment::Submission::AutoGradingService
 
   private
 
-  # Grades the answers in the provided submission which are auto gradable.
+  # Grades the answers in the provided submission.
   def grade_answers(submission)
-    auto_gradable_answers = submission.latest_answers.select do |answer|
-      answer.question.auto_gradable?
-    end
-    jobs = auto_gradable_answers.map { |answer| grade_answer(answer) }
-
+    jobs = submission.latest_answers.map { |answer| grade_answer(answer) }
     wait_for_jobs(jobs)
     aggregate_failures(jobs.map { |job| job.job.reload })
   end

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -7,7 +7,7 @@
 
 - if last_attempt && last_attempt.auto_grading && last_attempt.auto_grading.result
   = render partial: 'course/assessment/answer/explanation',
-           locals: { answer: f.object }
+           locals: { answer: last_attempt }
 
 - if question.auto_gradable? && can?(:grade, text_response.answer)
   = render partial: 'course/assessment/answer/text_responses/solution',

--- a/app/views/course/assessment/assessments/_form.html.slim
+++ b/app/views/course/assessment/assessments/_form.html.slim
@@ -16,7 +16,7 @@
   - if @assessment.autograded?
     = f.input :skippable, label: t('.skippable')
   - if @assessment.persisted?
-    = f.input :autograded, label: t('.autograded'), hint: t('.autograded_hint'), disabled: true
+    = f.input :autograded, label: t('.autograded'), disabled: true
   - else
     = f.hidden_field :autograded
   - unless @assessment.autograded?

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -82,5 +82,12 @@
                       role: 'menuitem')
 
     h3 = t('.questions')
+    br
+    - if @assessment.autograded?
+      - unless @assessment.questions.map(&:specific).all?(&:auto_gradable?)
+        div.alert.alert-warning
+          => fa_icon 'exclamation-triangle'
+          = t('.non_auto_gradable_questions')
+
     #sortable-questions
       = render @assessment.questions.map(&:specific)

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -12,6 +12,8 @@ json.question do
 
   json.autograded @programming_question.persisted? ?
     @programming_question.attachment.present? : @assessment.autograded?
+  json.has_auto_gradings @programming_question.auto_gradable? &&
+    @programming_question.answers.without_attempting_state.count > 0
   json.display_autograded_toggle display_autograded_toggle?
   json.autograded_assessment @assessment.autograded?
   json.published_assessment @assessment.published?

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -10,7 +10,8 @@ json.question do
     json.(skill, :id, :title)
   end
 
-  json.autograded @assessment.autograded? || @programming_question.attachment.present?
+  json.autograded @programming_question.persisted? ?
+    @programming_question.attachment.present? : @assessment.autograded?
   json.display_autograded_toggle display_autograded_toggle?
   json.autograded_assessment @assessment.autograded?
   json.published_assessment @assessment.published?

--- a/app/views/course/assessment/question/text_responses/_form.html.slim
+++ b/app/views/course/assessment/question/text_responses/_form.html.slim
@@ -21,6 +21,12 @@
       tbody
         = f.simple_fields_for :solutions do |solutions_form|
           = render 'solution_fields', f: solutions_form
+  - if f.object.assessment.autograded?
+    p
+      - if f.object.file_upload_question?
+        b = t('.file_upload_autograde')
+      - else
+        b = t('.text_response_autograde')
 
   - name = f.object.file_upload_question? ? t('.file_upload') : t('.text_response')
   - if f.object.persisted?

--- a/app/views/course/assessment/questions/_question.html.slim
+++ b/app/views/course/assessment/questions/_question.html.slim
@@ -3,6 +3,10 @@
     .panel-body
       = div_for(question, class: ['clearfix']) do
         div.pull-right
+          - if !question.auto_gradable? && question.assessment.autograded?
+            => fa_icon 'exclamation-triangle'.freeze,
+              title: t('.non_auto_gradable'),
+              class: 'text-warning'
           div.btn-group
             = edit_button(edit_path)
             = delete_button(delete_path)

--- a/app/views/course/assessment/submission/submissions/_autograded.html.slim
+++ b/app/views/course/assessment/submission/submissions/_autograded.html.slim
@@ -6,7 +6,7 @@ div.text-center
           = i
 
 div.answer-panel
-  = simple_form_for [current_course, @assessment, @submission] do |f|
+  = simple_form_for [current_course, @assessment, @submission], html: { multipart: true } do |f|
     = f.error_notification
     = hidden_field_tag :step, current_step
     div.answer-content

--- a/client/app/bundles/course/assessment/containers/AssessmentForm.intl.js
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm.intl.js
@@ -36,7 +36,7 @@ const translations = defineMessages({
   autogradedHint: {
     id: 'course.assessment.form.autogradedHint',
     defaultMessage: 'Automatically assign grade and experience points after assessment is \
-      submitted. Note that all the questions in the assessment must be auto-gradable.',
+      submitted. Answers that are not auto-gradable will always receive the maximum grade.',
   },
   skippable: {
     id: 'course.assessment.form.skippable',

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
@@ -9,6 +9,10 @@ export default defineMessages({
     id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedAssessment',
     defaultMessage: 'Non-autograded programming submissions will always receive the maximum grade',
   },
+  autogradedToggleDisabled: {
+    id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedToggleDisabled',
+    defaultMessage: 'This question cannot be switched to non-autograded as some answers have already been submitted',
+  },
   titleFieldLabel: {
     id: 'course.assessment.question.programming.programmingQuestionForm.titleFieldLabel',
     defaultMessage: 'Title',

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
@@ -7,7 +7,7 @@ export default defineMessages({
   },
   autogradedAssessment: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedAssessment',
-    defaultMessage: 'Autograded assessment cannot have non-autograded questions',
+    defaultMessage: 'Non-autograded programming submissions will always receive the maximum grade',
   },
   titleFieldLabel: {
     id: 'course.assessment.question.programming.programmingQuestionForm.titleFieldLabel',

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
@@ -7,7 +7,7 @@ export default defineMessages({
   },
   autogradedAssessment: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedAssessment',
-    defaultMessage: 'Non-autograded programming submissions will always receive the maximum grade',
+    defaultMessage: 'Answers to non-autograded programming questions will always receive the maximum grade',
   },
   autogradedToggleDisabled: {
     id: 'course.assessment.question.programming.onlineEditorPythonView.autogradedToggleDisabled',

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -456,9 +456,9 @@ class ProgrammingQuestionForm extends React.Component {
     languageOptions.unshift({ id: null, name: null });
 
     const autogradedAssessment = question.get('autograded_assessment');
-    const autograded = autogradedAssessment || question.get('autograded');
+    const autograded = question.get('autograded');
     let autogradedLabel = this.props.intl.formatMessage(translations.autograded);
-    if (autogradedAssessment) {
+    if (autogradedAssessment && !autograded) {
       autogradedLabel += ` (${this.props.intl.formatMessage(translations.autogradedAssessment)})`;
     }
 
@@ -544,10 +544,8 @@ class ProgrammingQuestionForm extends React.Component {
                     labelPosition="right"
                     toggled={autograded}
                     onToggle={(e) => {
-                      if (autogradedAssessment) return;
                       this.handleChange('autograded', e.target.checked);
                     }}
-                    readOnly={autogradedAssessment}
                     disabled={this.props.data.get('is_loading')}
                     style={{ margin: '1em 0' }}
                     name="question_programming[autograded]"

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -460,6 +460,8 @@ class ProgrammingQuestionForm extends React.Component {
     let autogradedLabel = this.props.intl.formatMessage(translations.autograded);
     if (autogradedAssessment && !autograded) {
       autogradedLabel += ` (${this.props.intl.formatMessage(translations.autogradedAssessment)})`;
+    } else if (question.get('has_auto_gradings')) {
+      autogradedLabel = ` (${this.props.intl.formatMessage(translations.autogradedToggleDisabled)})`;
     }
 
     const showEditOnline = question.get('edit_online');
@@ -546,7 +548,7 @@ class ProgrammingQuestionForm extends React.Component {
                     onToggle={(e) => {
                       this.handleChange('autograded', e.target.checked);
                     }}
-                    disabled={this.props.data.get('is_loading')}
+                    disabled={this.props.data.get('is_loading') || question.get('has_auto_gradings')}
                     style={{ margin: '1em 0' }}
                     name="question_programming[autograded]"
                   />

--- a/config/locales/en/activerecord/course/assessment.yml
+++ b/config/locales/en/activerecord/course/assessment.yml
@@ -7,6 +7,3 @@ en:
       models:
         course/assessment:
           no_questions: 'Assessment can only be published after adding questions'
-          autograded: >
-            Autograded Assessment can only be published if all questions are autograded:
-            %{question} is not autograded.

--- a/config/locales/en/activerecord/course/assessment/question.yml
+++ b/config/locales/en/activerecord/course/assessment/question.yml
@@ -1,11 +1,5 @@
 en:
   activerecord:
-    errors:
-      models:
-        course/assessment/question:
-          autograded_assessment: >
-            A non-autograded question cannot be added to a published autograded assessment.
-            You might want to unpublish the assessment first.
     course/assessment/question:
       question_number: "Question %{index}"
       question_with_title: "%{question_number}: %{title}"

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -39,6 +39,9 @@ en:
             text_response: 'Text Response'
             file_upload: 'File Upload'
             programming: 'Programming'
+          non_auto_gradable_questions: >
+            Some of the questions in this assessment are not auto-gradable.
+            The autograder will always award the maximum grade for these questions.
         new:
           header: 'New Assessment'
         edit:
@@ -50,7 +53,6 @@ en:
           failure: 'Could not delete assessment: %{error}'
         form:
           autograded: 'Automatically assign grade and experience points after finalization'
-          autograded_hint: 'Note that all the questions in the assessment must be auto-gradable'
           skippable: 'Allow students to skip steps'
           password_hint: >
             When password protection is enabled, students are allowed to access their submission once.

--- a/config/locales/en/course/assessment/question/text_response.yml
+++ b/config/locales/en/course/assessment/question/text_response.yml
@@ -22,6 +22,8 @@ en:
             add_solution: 'Add Solution'
             file_upload: 'File Upload Question'
             text_response: 'Text Response Question'
+            text_response_autograde: 'Note: If no solutions are provided, the autograder will always award the maximum grade.'
+            file_upload_autograde: 'Note: File upload question is not auto-gradable. The autograder will always award the maximum grade.'
           solution_fields:
             explanation_hint: 'The explanation to show after the student submits his answer.'
             remove: 'Remove'

--- a/config/locales/en/course/assessment/questions.yml
+++ b/config/locales/en/course/assessment/questions.yml
@@ -1,0 +1,6 @@
+en:
+  course:
+    assessment:
+      questions:
+        question:
+          non_auto_gradable: 'This question is not auto-gradable'

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -32,12 +32,7 @@ RSpec.describe Course::Assessment::Question do
 
         context 'when question is not autograded' do
           before { allow(question).to receive(:auto_gradable?).and_return(false) }
-
-          it 'is not valid' do
-            expect(subject).not_to be_valid
-            expect(subject.errors[:base]).to include(I18n.t('activerecord.errors.models.' \
-            'course/assessment/question.autograded_assessment'))
-          end
+          it { is_expected.to be_valid }
         end
       end
     end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -71,12 +71,7 @@ RSpec.describe Course::Assessment do
 
         context 'when the assessment has a non-autograded question' do
           let(:question_traits) { nil }
-
-          it 'is not valid' do
-            expect(subject).not_to be_valid
-            expect(subject.errors['published']).
-              to include(I18n.t('activerecord.errors.models.course/assessment.autograded'))
-          end
+          it { is_expected.to be_valid }
         end
 
         context 'when the assessment only has autograded questions' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,3 +99,5 @@ Capybara.register_server(:puma) do |app, port|
   server.add_tcp_listener(Capybara.server_host, port)
   server.run
 end
+
+Capybara.default_max_wait_time = 5


### PR DESCRIPTION
- Non-autograded questions (file upload, text response and programming) can now be added to autograded assessments
- Submissions to non-autograded questions in autograded assessments will be awarded the maximum grade by the autograder
- Fixed a bug with text response questions where the question could not be viewed after submitting an answer

- Question creation forms explain what is required for the question to be auto-gradable:
<img width="635" alt="screen shot 2017-02-16 at 3 16 28 pm" src="https://cloud.githubusercontent.com/assets/4056819/23011290/2261f238-f45b-11e6-9f96-763095911fad.png">

- Assessment page shows which questions are not auto-gradable and explains that those questions will automatically be assigned the maximum grade:
<img width="1012" alt="screen shot 2017-02-16 at 2 14 33 pm" src="https://cloud.githubusercontent.com/assets/4056819/23011169/605d5d94-f45a-11e6-8847-fe6984cc3232.png">

- Fixed a bug affecting text response questions that prevented reattempting a question after submitting an answer

Closes #1941 and #1811