### PR TITLE
Add an `api` folder that groups the frontend API

### DIFF
--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -29,7 +29,7 @@ class Course::Material::MaterialsController < Course::Material::Controller
       end
     else
       redirect_to course_material_folder_path(current_course, @folder),
-                  danger: t('.failure', error: @material.errors.full_messages.to_sentence)
+                  danger: t('.failure', message: @material.errors.full_messages.to_sentence)
     end
   end
 

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -18,6 +18,8 @@
         "functions": "never",
     }],
     "no-multi-str": 0,
+    // Use `_` to indicate that the method is private
+    "no-underscore-dangle": 0,
   },
   "globals": {
     "window": true,

--- a/client/app/api/Base.js
+++ b/client/app/api/Base.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+export default class BaseAPI {
+  constructor() {
+    this.client = null;
+  }
+
+  /** Returns the API client */
+  getClient() {
+    if (this.client) return this.client;
+
+    let token;
+    const tag = document.querySelector('meta[name="csrf-token"]');
+    if (tag) {
+      token = tag.getAttribute('content');
+    }
+
+    const headers = { Accept: 'application/json', 'X-CSRF-Token': token };
+
+    this.client = axios.create({ headers });
+    return this.client;
+  }
+}

--- a/client/app/api/course/Base.js
+++ b/client/app/api/course/Base.js
@@ -1,0 +1,11 @@
+/* eslint class-methods-use-this: "off" */
+import BaseAPI from '../Base';
+
+/** Course level Api helpers should be defined here */
+export default class BaseCourseAPI extends BaseAPI {
+  getCourseId() {
+    // TODO: Read the id from redux state or server context
+    const match = window.location.pathname.match(/^\/courses\/(\d+)/);
+    return match && match[1];
+  }
+}

--- a/client/app/api/course/MaterialFolders.js
+++ b/client/app/api/course/MaterialFolders.js
@@ -1,0 +1,26 @@
+import BaseCourseAPI from './Base';
+
+export default class MaterialFoldersAPI extends BaseCourseAPI {
+  /**
+  * Upload files to the specified folder.
+  *
+  * @param {number} folderId
+  * @param {array} files - A list of files from file input.
+  * @return {Promise}
+  * success response: { materials: Array.<{id:number, name:string, url:string, updated_at:string}> }
+      - A list of materials that has been created.
+  * error response: { message:string }
+  */
+  upload(folderId, files) {
+    const formData = new FormData();
+    for (let i = 0; i < files.length; i += 1) {
+      formData.append('material_folder[files_attributes][]', files[i]);
+    }
+
+    return this.getClient().put(`${this._getUrlPrefix()}/${folderId}/upload_materials`, formData);
+  }
+
+  _getUrlPrefix() {
+    return `/courses/${this.getCourseId()}/materials/folders`;
+  }
+}

--- a/client/app/api/course/Materials.js
+++ b/client/app/api/course/Materials.js
@@ -1,0 +1,20 @@
+import BaseCourseAPI from './Base';
+
+export default class MaterialsAPI extends BaseCourseAPI {
+  /**
+  * Destroy the material.
+  *
+  * @param {number} folderId
+  * @param {numbrt} materialId
+  * @return {Promise}
+  * success response: {}
+  * error response: { message:string }
+  */
+  destroy(folderId, materialId) {
+    return this.getClient().delete(`${this._getUrlPrefix()}/${folderId}/files/${materialId}`);
+  }
+
+  _getUrlPrefix() {
+    return `/courses/${this.getCourseId()}/materials/folders`;
+  }
+}

--- a/client/app/api/course/index.js
+++ b/client/app/api/course/index.js
@@ -1,0 +1,11 @@
+import MaterialsAPI from './Materials';
+import MaterialFoldersAPI from './MaterialFolders';
+
+const CourseAPI = {
+  materials: new MaterialsAPI(),
+  materialFolders: new MaterialFoldersAPI(),
+};
+
+Object.freeze(CourseAPI);
+
+export default CourseAPI;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -41,6 +41,7 @@ const config = {
     extensions: ['.js', '.jsx'],
     alias: {
       lib: path.resolve('./app/lib'),
+      api: path.resolve('./app/api'),
     },
   },
 


### PR DESCRIPTION
- This will serve as a middleware layer between client and server ( so that if later the server API changes, we only need to take care of this place ) 
- The courseId will be inferred by the `CourseAPIBase`, so that we don't need to pass `courseId` everywhere in the components. 
- My later PR will depend on this, puy here for discussion first. 

The usage will be like:
```javascript
import CourseAPI from 'api/course';

CourseAPI.materials.destroy(this.props.folderId, id)
.then(repsonse)
.catch(error)
```

Let me know your concerns about the naming conventions and the documentation convention of the APIs.