### PR TITLE
Fix forum styling

### DIFF
--- a/app/assets/stylesheets/course/forum/_post.scss
+++ b/app/assets/stylesheets/course/forum/_post.scss
@@ -1,9 +1,7 @@
 @mixin course-forum-post {
   .user {
     float: left;
-    margin-right: 1em;
     text-align: right;
-    width: 7em;
 
     .image {
       float: right;

--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -53,15 +53,13 @@
 
   #users-container {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .user {
     align-items: center;
+    margin: 0.5em;
     display: flex;
-    flex: 1;
-    margin: 0.5em 0;
-    max-width: 200px;
-    min-width: 100px;
 
     #user-sidebar {
       font-size: 18px;

--- a/app/views/course/forum/forums/_controls.html.slim
+++ b/app/views/course/forum/forums/_controls.html.slim
@@ -1,12 +1,11 @@
-span.pull-right
-  .unread-controls.btn-group
-    = link_to_next_unread
-    = link_to t('.mark_as_read'), mark_as_read_course_forum_path(current_course, @forum),
-                                  title: t('.mark_forum_description'),
-                                  class: ['btn', 'btn-default'], method: :patch
-  .btn-group
-    - if can?(:subscribe, @forum)
-      = render partial: 'subscribe_button', locals: { user: current_user, forum: @forum }
-    = new_button([current_course, @forum, :topic]) if can?(:create, Course::Forum::Topic.new(forum: @forum))
-    = edit_button([current_course, @forum]) if can?(:edit, @forum)
-    = delete_button([current_course, @forum]) if can?(:destroy, @forum)
+.unread-controls.btn-group
+  = link_to_next_unread
+  = link_to t('.mark_as_read'), mark_as_read_course_forum_path(current_course, @forum),
+                                title: t('.mark_forum_description'),
+                                class: ['btn', 'btn-default'], method: :patch
+.btn-group
+  - if can?(:subscribe, @forum)
+    = render partial: 'subscribe_button', locals: { user: current_user, forum: @forum }
+  = new_button([current_course, @forum, :topic]) if can?(:create, Course::Forum::Topic.new(forum: @forum))
+  = edit_button([current_course, @forum]) if can?(:edit, @forum)
+  = delete_button([current_course, @forum]) if can?(:destroy, @forum)

--- a/app/views/course/forum/forums/show.html.slim
+++ b/app/views/course/forum/forums/show.html.slim
@@ -7,9 +7,9 @@
       tr
         th
         th = t('.topics')
-        th = t('.votes')
-        th = t('.posts')
-        th = t('.views')
+        th.hidden-xs = t('.votes')
+        th.hidden-xs = t('.posts')
+        th.hidden-xs = t('.views')
         th = t('.latest_post')
     tbody
       - if @topics.empty?

--- a/app/views/course/forum/posts/_post.html.slim
+++ b/app/views/course/forum/posts/_post.html.slim
@@ -3,18 +3,22 @@
 = div_for(post, class: post_class) do
   = div_for(post.creator) do
     = display_user_image(post.creator)
-    span.name = link_to_user(post.creator)
 
   div.contents
     h4.title
-      - if post.unread?(current_user)
-        => fa_icon 'envelope'.freeze
-      div.pull-right
-        .timestamp
+      span.name
+        = link_to_user(post.creator)
+      span.pull-right
+        - if post.unread?(current_user)
+          => fa_icon 'envelope'.freeze, title: 'Unread'
+        span.timestamp
           => format_datetime(post.created_at)
 
-    = format_html(post.text)
+    hr
+    div.body
+      = format_html(post.text)
 
+    hr
     div.info
       - if defined?(show_buttons)
         div.pull-right

--- a/app/views/course/forum/topics/_controls.html.slim
+++ b/app/views/course/forum/topics/_controls.html.slim
@@ -1,42 +1,41 @@
-span.pull-right
-  .unread-controls.btn-group
-    = link_to_next_unread
-  .btn-group
-    - if can?(:subscribe, @topic)
-      - if @topic.subscribed_by?(current_user)
-        = link_to subscribe_course_forum_topic_path(current_course, @forum, @topic, subscribe: false),
-                  title: t('course.forum.topics.unsubscribe.tag'), class: ['btn', 'btn-danger'],
-                  method: :delete do
-          = fa_icon 'heart-o'.freeze
-      - else
-        = link_to subscribe_course_forum_topic_path(current_course, @forum, @topic, subscribe: true),
-                  title: t('course.forum.topics.subscribe.tag'), class: ['btn', 'btn-success'],
-                  method: :post, role: 'button' do
-          = fa_icon 'heart'.freeze
+.unread-controls.btn-group
+  = link_to_next_unread
+.btn-group
+  - if can?(:subscribe, @topic)
+    - if @topic.subscribed_by?(current_user)
+      = link_to subscribe_course_forum_topic_path(current_course, @forum, @topic, subscribe: false),
+                title: t('course.forum.topics.unsubscribe.tag'), class: ['btn', 'btn-danger'],
+                method: :delete do
+        = fa_icon 'heart-o'.freeze
+    - else
+      = link_to subscribe_course_forum_topic_path(current_course, @forum, @topic, subscribe: true),
+                title: t('course.forum.topics.subscribe.tag'), class: ['btn', 'btn-success'],
+                method: :post, role: 'button' do
+        = fa_icon 'heart'.freeze
 
-    - if can?(:set_hidden, @topic)
-      - if @topic.hidden
-        = link_to hidden_course_forum_topic_path(current_course, @forum, @topic, hidden: false),
-                  title: t('course.forum.topics.shown.tag'), class: ['btn', 'btn-info'],
-                  method: :put do
-          = fa_icon 'eye'.freeze
-      - else
-        = link_to hidden_course_forum_topic_path(current_course, @forum, @topic, hidden: true),
-                  title: t('course.forum.topics.hidden.tag'), class: ['btn', 'btn-primary'],
-                  method: :put do
-          = fa_icon 'eye-slash'.freeze
+  - if can?(:set_hidden, @topic)
+    - if @topic.hidden
+      = link_to hidden_course_forum_topic_path(current_course, @forum, @topic, hidden: false),
+                title: t('course.forum.topics.shown.tag'), class: ['btn', 'btn-info'],
+                method: :put do
+        = fa_icon 'eye'.freeze
+    - else
+      = link_to hidden_course_forum_topic_path(current_course, @forum, @topic, hidden: true),
+                title: t('course.forum.topics.hidden.tag'), class: ['btn', 'btn-primary'],
+                method: :put do
+        = fa_icon 'eye-slash'.freeze
 
-    - if can?(:set_locked, @topic)
-      - if @topic.locked
-        = link_to locked_course_forum_topic_path(current_course, @forum, @topic, locked: false),
-                  title: t('course.forum.topics.unlocked.tag'), class: ['btn', 'btn-success'],
-                  method: :put do
-          = fa_icon 'unlock'.freeze
-      - else
-        = link_to locked_course_forum_topic_path(current_course, @forum, @topic, locked: true),
-                  title: t('course.forum.topics.locked.tag'), class: ['btn', 'btn-warning'],
-                  method: :put do
-          = fa_icon 'lock'.freeze
+  - if can?(:set_locked, @topic)
+    - if @topic.locked
+      = link_to locked_course_forum_topic_path(current_course, @forum, @topic, locked: false),
+                title: t('course.forum.topics.unlocked.tag'), class: ['btn', 'btn-success'],
+                method: :put do
+        = fa_icon 'unlock'.freeze
+    - else
+      = link_to locked_course_forum_topic_path(current_course, @forum, @topic, locked: true),
+                title: t('course.forum.topics.locked.tag'), class: ['btn', 'btn-warning'],
+                method: :put do
+        = fa_icon 'lock'.freeze
 
-    = edit_button(edit_course_forum_topic_path(current_course, @forum, @topic)) if can?(:edit, @topic)
-    = delete_button(course_forum_topic_path(current_course, @forum, @topic)) if can?(:destroy, @topic)
+  = edit_button(edit_course_forum_topic_path(current_course, @forum, @topic)) if can?(:edit, @topic)
+  = delete_button(course_forum_topic_path(current_course, @forum, @topic)) if can?(:destroy, @topic)

--- a/app/views/course/forum/topics/_topic.html.slim
+++ b/app/views/course/forum/topics/_topic.html.slim
@@ -7,9 +7,9 @@
               course_forum_topic_path(current_course, @forum, topic))
     div.started-by
       = t('.started_by_html', user: link_to_user(topic.creator))
-  td = topic.vote_count
-  td = topic.post_count
-  td = topic.view_count
+  td.hidden-xs = topic.vote_count
+  td.hidden-xs = topic.post_count
+  td.hidden-xs = topic.view_count
   td.latest-post
     - last_post = topic.posts.last
     - if last_post


### PR DESCRIPTION
- Fixes #1942 styling of forum posts
<img width="750" alt="screen shot 2017-02-20 at 11 35 50 am" src="https://cloud.githubusercontent.com/assets/4056819/23111026/c97f2d8a-f760-11e6-91f1-5c49309a0cc6.png">

- Hide forum topic vote, post and view counts on small screens
<img width="650" alt="screen shot 2017-02-20 at 11 37 36 am" src="https://cloud.githubusercontent.com/assets/4056819/23111081/20feeef6-f761-11e6-9e14-ce7f720ebfcf.png">

- Allow list of instructors on course page to overflow to multiple rows
<img width="712" alt="screen shot 2017-02-20 at 11 33 13 am" src="https://cloud.githubusercontent.com/assets/4056819/23110999/90044892-f760-11e6-8efb-353fc00553fc.png">
