### PR TITLE
Optimise the performance of pending comments count query

### DIFF
--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -27,7 +27,7 @@ module Course::Discussion::TopicsHelper
   def my_students_unread_count
     @my_students_unread ||=
       if current_course_user
-        my_student_ids = current_course_user.my_students.select(:user_id)
+        my_student_ids = current_course_user.my_students.pluck(:user_id)
         current_course.discussion_topics.globally_displayed.
           from_user(my_student_ids).pending_staff_reply.distinct.count
       else


### PR DESCRIPTION
Fix #2043 

Used `pluck` instead of `select` and split the giant query into two small queries. Although it's one more query now, the total time is much shorter. 

Before:
```SQL
SELECT DISTINCT COUNT(DISTINCT "course_discussion_topics"."id") FROM "course_discussion_topics" INNER JOIN "course_discussion_posts" ON "course_discussion_posts"."topic_id" = "course_discussion_topics"."id" WHERE "course_discussion_topics"."course_id" = $1 AND "course_discussion_topics"."actable_type" IN ('Course::Assessment::Answer', 'Course::Assessment::Answer::ProgrammingFileAnnotation') AND "course_discussion_topics"."pending_staff_reply" = $2 AND (course_discussion_topics.id IN (SELECT "course_discussion_topics"."id" FROM "course_assessment_answers" INNER JOIN "course_assessment_submissions" ON "course_assessment_submissions"."id" = "course_assessment_answers"."submission_id" INNER JOIN "course_discussion_topics" ON "course_discussion_topics"."actable_id" = "course_assessment_answers"."id" AND "course_discussion_topics"."actable_type" = 'Course::Assessment::Answer' WHERE "course_assessment_submissions"."creator_id" IN (SELECT "course_users"."user_id" FROM "course_users" INNER JOIN "course_group_users" ON "course_group_users"."course_user_id" = "course_users"."id" INNER JOIN "course_groups" ON "course_groups"."id" = "course_group_users"."group_id" WHERE "course_group_users"."role" = 0 AND "course_groups"."id" IN (SELECT "course_group_users"."group_id" FROM "course_group_users" WHERE "course_group_users"."course_user_id" = 673 AND "course_group_users"."role" = 1))  ORDER BY "course_assessment_answers"."created_at" ASC) OR course_discussion_topics.id IN (SELECT "course_discussion_topics"."id" FROM "course_assessment_answer_programming_file_annotations" INNER JOIN "course_assessment_answer_programming_files" ON "course_assessment_answer_programming_files"."id" = "course_assessment_answer_programming_file_annotations"."file_id" INNER JOIN "course_assessment_answer_programming" ON "course_assessment_answer_programming"."id" = "course_assessment_answer_programming_files"."answer_id" INNER JOIN "course_assessment_answers" ON "course_assessment_answers"."actable_id" = "course_assessment_answer_programming"."id" AND "course_assessment_answers"."actable_type" = 'Course::Assessment::Answer::Programming' INNER JOIN "course_assessment_submissions" ON "course_assessment_submissions"."id" = "course_assessment_answers"."submission_id" INNER JOIN "course_discussion_topics" ON "course_discussion_topics"."actable_id" = "course_assessment_answer_programming_file_annotations"."id" AND "course_discussion_topics"."actable_type" = 'Course::Assessment::Answer::ProgrammingFileAnnotation' WHERE "course_assessment_submissions"."creator_id" IN (SELECT "course_users"."user_id" FROM "course_users" INNER JOIN "course_group_users" ON "course_group_users"."course_user_id" = "course_users"."id" INNER JOIN "course_groups" ON "course_groups"."id" = "course_group_users"."group_id" WHERE "course_group_users"."role" = 0 AND "course_groups"."id" IN (SELECT "course_group_users"."group_id" FROM "course_group_users" WHERE "course_group_users"."course_user_id" = 673 AND "course_group_users"."role" = 1))))
(701ms)
```

Now:
```SQL
SELECT "course_users"."user_id" FROM "course_users" INNER JOIN "course_group_users" ON "course_group_users"."course_user_id" = "course_users"."id" INNER JOIN "course_groups" ON "course_groups"."id" = "course_group_users"."group_id" WHERE "course_group_users"."role" = $1 AND "course_groups"."id" IN (SELECT "course_group_users"."group_id" FROM "course_group_users" WHERE "course_group_users"."course_user_id" = $2 AND "course_group_users"."role" = $3)
(1ms)

SELECT DISTINCT COUNT(DISTINCT "course_discussion_topics"."id") FROM "course_discussion_topics" INNER JOIN "course_discussion_posts" ON "course_discussion_posts"."topic_id" = "course_discussion_topics"."id" WHERE "course_discussion_topics"."course_id" = $1 AND "course_discussion_topics"."actable_type" IN ('Course::Assessment::Answer', 'Course::Assessment::Answer::ProgrammingFileAnnotation') AND "course_discussion_topics"."pending_staff_reply" = $2 AND (course_discussion_topics.id IN (SELECT "course_discussion_topics"."id" FROM "course_assessment_answers" INNER JOIN "course_assessment_submissions" ON "course_assessment_submissions"."id" = "course_assessment_answers"."submission_id" INNER JOIN "course_discussion_topics" ON "course_discussion_topics"."actable_id" = "course_assessment_answers"."id" AND "course_discussion_topics"."actable_type" = 'Course::Assessment::Answer' WHERE "course_assessment_submissions"."creator_id" IN (4616, 11085)  ORDER BY "course_assessment_answers"."created_at" ASC) OR course_discussion_topics.id IN (SELECT "course_discussion_topics"."id" FROM "course_assessment_answer_programming_file_annotations" INNER JOIN "course_assessment_answer_programming_files" ON "course_assessment_answer_programming_files"."id" = "course_assessment_answer_programming_file_annotations"."file_id" INNER JOIN "course_assessment_answer_programming" ON "course_assessment_answer_programming"."id" = "course_assessment_answer_programming_files"."answer_id" INNER JOIN "course_assessment_answers" ON "course_assessment_answers"."actable_id" = "course_assessment_answer_programming"."id" AND "course_assessment_answers"."actable_type" = 'Course::Assessment::Answer::Programming' INNER JOIN "course_assessment_submissions" ON "course_assessment_submissions"."id" = "course_assessment_answers"."submission_id" INNER JOIN "course_discussion_topics" ON "course_discussion_topics"."actable_id" = "course_assessment_answer_programming_file_annotations"."id" AND "course_discussion_topics"."actable_type" = 'Course::Assessment::Answer::ProgrammingFileAnnotation' WHERE "course_assessment_submissions"."creator_id" IN (4616, 11085)))
(33ms)
```