### PR TITLE
Use course_users instead of users for reminder emails.

### DIFF
--- a/app/services/course/assessment/reminder_service.rb
+++ b/app/services/course/assessment/reminder_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Course::Assessment::ReminderService
   class << self
     delegate :opening_reminder, to: :new
@@ -16,11 +17,12 @@ class Course::Assessment::ReminderService
     # Send reminder emails to each student who hasn't submitted.
     recipients = uncompleted_students(assessment)
     recipients.each do |recipient|
-      Course::Mailer.assessment_closing_reminder_email(assessment, recipient).deliver_later
+      # Need to get the User model from the Course User because we need the email address.
+      Course::Mailer.assessment_closing_reminder_email(assessment, recipient.user).deliver_later
     end
 
     # Send an email to each instructor with a list of students who haven't submitted.
-    course_instructors = assessment.course.instructors.map(&:user)
+    course_instructors = assessment.course.instructors.includes(:user).map(&:user)
     course_instructors.each do |instructor|
       Course::Mailer.assessment_closing_summary_email(
         instructor, assessment, uncompleted_students_list(recipients)
@@ -30,11 +32,17 @@ class Course::Assessment::ReminderService
 
   private
 
+  # Returns a Set of students who have not completed the given assessment.
+  #
+  # @param [Course::Assessment] assessment The assessment to query.
+  # @return [Set<CourseUser>] Set of CourseUsers who have not finished the assessment.
   def uncompleted_students(assessment)
     course_users = assessment.course.course_users
-    students = course_users.student.includes(:user).map(&:user)
+    # Eager load :user as it's needed for the recipient email.
+    students = course_users.student.includes(:user)
     submitted =
-      assessment.submissions.confirmed.includes([course_user: :user]).map { |s| s.course_user.user }
+      assessment.submissions.confirmed.includes(experience_points_record: { course_user: :user }).
+      map(&:course_user)
     Set.new(students) - Set.new(submitted)
   end
 


### PR DESCRIPTION
Instructors see course_user name, so the names in the closing reminder
summary email should also be from the course user.

Some users have improperly set names in user, but their names in
course_user are fine.

Fixes #2045.