### PR TITLE
Summernote editor changes

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -46,9 +46,21 @@
   //   Function applies config options to summernote based on CSS classes applied in 'textarea'.
   //   Currently supported options include `airmode` and `focus`.
   function initializeSummernote(element) {
-    var airmodeOptions = $.extend(true, { airMode: true },
-                                        { popover: $.summernote.options.popover });
-    airmodeOptions.popover.air.unshift(['style', ['style']]);
+    var airmodeOptions =
+      {
+        airMode: true,
+        popover: {
+          air: [
+            ['style', ['style']],
+            ['font', ['bold', 'underline', 'clear']],
+            ['script', ['superscript', 'subscript']],
+            ['color', ['color']],
+            ['para', ['ul', 'ol', 'paragraph']],
+            ['table', ['table']],
+            ['insert', ['link', 'picture']],
+          ]
+        }
+      };
 
     $('textarea.text').not('.summernote-initialised').each(function(){
       var $summernote = $(this);
@@ -60,15 +72,15 @@
 
       var options = {
         toolbar: [
-          ['paragraph-style', ['style']],
-          ['font-style', ['bold', 'underline', 'clear']],
-          ['font-script', ['superscript', 'subscript']],
-          ['font-name', ['fontname']],
+          ['style', ['style']],
+          ['font', ['bold', 'underline', 'clear']],
+          ['script', ['superscript', 'subscript']],
+          ['fontname', ['fontname']],
           ['color', ['color']],
-          ['paragraph', ['ul', 'ol', 'paragraph']],
+          ['para', ['ul', 'ol', 'paragraph']],
           ['table', ['table']],
           ['insert', ['link', 'picture', 'video']],
-          ['misc', ['fullscreen', 'codeview', 'help']],
+          ['view', ['fullscreen', 'codeview', 'help']],
         ],
         callbacks: {
           onImageUpload: function(files) {

--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -5,6 +5,43 @@
 (function($, EVENT_HELPERS) {
   'use strict';
 
+  function compressImage(image, onImageCompressed) {
+    // Maximum image size, images larger than this will be compressed
+    var IMAGE_MAX_WIDTH = 1920;
+    var IMAGE_MAX_HEIGHT = 1080;
+
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      var img = document.createElement('img');
+      var canvas = document.createElement('canvas');
+
+      img.src = e.target.result;
+      var width = img.width;
+      var height = img.height;
+
+      if (width <= IMAGE_MAX_WIDTH && height <= IMAGE_MAX_HEIGHT ) {
+       onImageCompressed(e.target.result);
+       return;
+      }
+      if (width > IMAGE_MAX_WIDTH) {
+        height *= IMAGE_MAX_WIDTH / width;
+        width = IMAGE_MAX_WIDTH;
+      }
+      if (height > IMAGE_MAX_HEIGHT) {
+        width *= IMAGE_MAX_HEIGHT / height;
+        height = IMAGE_MAX_HEIGHT;
+      }
+
+      canvas.width = width;
+      canvas.height = height;
+      var ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0, width, height);
+
+      onImageCompressed(canvas.toDataURL('image/jpeg'));
+    };
+    reader.readAsDataURL(image);
+  }
+
   // Initialises Summernote
   //   Function applies config options to summernote based on CSS classes applied in 'textarea'.
   //   Currently supported options include `airmode` and `focus`.
@@ -14,6 +51,13 @@
     airmodeOptions.popover.air.unshift(['style', ['style']]);
 
     $('textarea.text').not('.summernote-initialised').each(function(){
+      var $summernote = $(this);
+      function onImageCompressed(dataUrl) {
+        var img = document.createElement('img');
+        img.src = dataUrl;
+        $summernote.summernote('insertNode', img);
+      }
+
       var options = {
         toolbar: [
           ['paragraph-style', ['style']],
@@ -26,7 +70,15 @@
           ['insert', ['link', 'picture', 'video']],
           ['misc', ['fullscreen', 'codeview', 'help']],
         ],
+        callbacks: {
+          onImageUpload: function(files) {
+            for (var i = 0; i < files.length; i++) {
+              compressImage(files[i], onImageCompressed);
+            }
+          }
+        }
       };
+
       if ($(this).hasClass('airmode')) {
         options = $.extend(true, options, airmodeOptions);
       }

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHTMLFormattersHelper
 
     Sanitize.node!(node, elements: ['iframe'],
                          attributes: {
-                           'iframe' => %w(allowfullscreen frameborder height src width)
+                           'iframe' => ['allowfullscreen', 'frameborder', 'height', 'src', 'width']
                          })
 
     { node_whitelist: [node] }
@@ -51,10 +51,10 @@ module ApplicationHTMLFormattersHelper
     list[:attributes][:all] |= ['style']
     list[:attributes]['font'] = ['face']
     list[:attributes]['table'] = ['class']
-    list[:css] = { properties: %w(
-      background-color color float font-family height margin
-      margin-bottom margin-left margin-right margin-top text-align width
-    ) }
+    list[:css] = { properties: [
+      'background-color', 'color', 'float', 'font-family', 'height', 'margin',
+      'margin-bottom', 'margin-left', 'margin-right', 'margin-top', 'text-align', 'width'
+    ] }
     list[:transformers] |= [VIDEO_WHITELIST_TRANSFORMER]
     list
   end

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -34,6 +34,53 @@ class MaterialSummernote extends React.Component {
     }
   };
 
+  onImageUpload = (files) => {
+    for (let i = 0; i < files.length; i += 1) {
+      this.compressImage(files[i], (dataUrl) => {
+        const img = document.createElement('img');
+        img.src = dataUrl;
+        ReactSummernote.insertNode(img);
+      });
+    }
+  }
+
+  compressImage = (image, onImageCompressed) => {
+    // Maximum image size, images larger than this will be compressed
+    const IMAGE_MAX_WIDTH = 1920;
+    const IMAGE_MAX_HEIGHT = 1080;
+
+    const reader = new FileReader();
+    reader.onload = function (e) {
+      const img = document.createElement('img');
+      const canvas = document.createElement('canvas');
+
+      img.src = e.target.result;
+      let width = img.width;
+      let height = img.height;
+
+      if (width <= IMAGE_MAX_WIDTH && height <= IMAGE_MAX_HEIGHT) {
+        onImageCompressed(e.target.result);
+        return;
+      }
+      if (width > IMAGE_MAX_WIDTH) {
+        height *= IMAGE_MAX_WIDTH / width;
+        width = IMAGE_MAX_WIDTH;
+      }
+      if (height > IMAGE_MAX_HEIGHT) {
+        width *= IMAGE_MAX_HEIGHT / height;
+        height = IMAGE_MAX_HEIGHT;
+      }
+
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0, width, height);
+
+      onImageCompressed(canvas.toDataURL('image/jpeg'));
+    };
+    reader.readAsDataURL(image);
+  };
+
   render() {
     const {
       baseTheme,
@@ -103,6 +150,7 @@ class MaterialSummernote extends React.Component {
             onChange={this.props.onChange}
             onFocus={() => { this.setState({ isFocused: true }); }}
             onBlur={() => { this.setState({ isFocused: false }); }}
+            onImageUpload={this.onImageUpload}
           />
         </div>
       </div>

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -135,15 +135,15 @@ class MaterialSummernote extends React.Component {
               dialogsInBody: false,
               disabled: this.props.disabled,
               toolbar: [
-                ['paragraph-style', ['style']],
-                ['font-style', ['bold', 'underline', 'clear']],
-                ['font-script', ['superscript', 'subscript']],
-                ['font-name', ['fontname']],
+                ['style', ['style']],
+                ['font', ['bold', 'underline', 'clear']],
+                ['script', ['superscript', 'subscript']],
+                ['fontname', ['fontname']],
                 ['color', ['color']],
-                ['paragraph', ['ul', 'ol', 'paragraph']],
+                ['para', ['ul', 'ol', 'paragraph']],
                 ['table', ['table']],
                 ['insert', ['link', 'picture', 'video']],
-                ['misc', ['fullscreen', 'codeview', 'help']],
+                ['view', ['fullscreen', 'codeview', 'help']],
               ],
             }}
             value={this.props.value}


### PR DESCRIPTION
- Limit Summernote image uploads to 1920 * 1080 pixels. Larger images will be resized down on the client side.
- Add superscript and subscript buttons to air mode popover. Reorder buttons to match standard editor toolbar

Original air mode popover:
<img width="494" alt="screen shot 2017-02-20 at 3 45 24 pm" src="https://cloud.githubusercontent.com/assets/4056819/23116156/0cec0a48-f784-11e6-805c-447571ad4271.png">

New air mode popover:
![screen shot 2017-02-25 at 8 58 44 pm](https://cloud.githubusercontent.com/assets/4056819/23331259/3ef112f0-fb9d-11e6-8015-977a6a86c88c.png)