### PR TITLE
Use attachment instead of ImageUploader for survey question option images

### DIFF
--- a/app/controllers/course/survey/questions_controller.rb
+++ b/app/controllers/course/survey/questions_controller.rb
@@ -39,6 +39,6 @@ class Course::Survey::QuestionsController < Course::Survey::SurveysController
   def question_params
     params.require(:question).
       permit(:description, :question_type, :required, :max_options, :min_options, :grid_view,
-             options_attributes: [:id, :option, :weight, :image, :_destroy])
+             options_attributes: [:id, :option, :weight, :file, :_destroy])
   end
 end

--- a/app/models/course/survey/question_option.rb
+++ b/app/models/course/survey/question_option.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Course::Survey::QuestionOption < ActiveRecord::Base
-  mount_uploader :image, ImageUploader
+  has_one_attachment
 
   belongs_to :question, inverse_of: :options
   has_many :answer_options, class_name: Course::Survey::AnswerOption.name,

--- a/app/views/course/survey/questions/_option.json.jbuilder
+++ b/app/views/course/survey/questions/_option.json.jbuilder
@@ -1,5 +1,5 @@
 json.(option, :id, :option, :weight)
-unless option.image.file.nil?
-  json.image_url option.image.url
-  json.image_name option.image.file.original_filename
+unless option.attachment.nil?
+  json.image_url option.attachment.url
+  json.image_name option.attachment.name
 end

--- a/client/app/bundles/course/survey/components/QuestionForm.jsx
+++ b/client/app/bundles/course/survey/components/QuestionForm.jsx
@@ -95,7 +95,7 @@ const questionFormTranslations = defineMessages({
 });
 
 const countFilledOptions = options => (
-  options.filter(option => option && (option.option || option.image || option.image_url)).length
+  options.filter(option => option && (option.option || option.file || option.image_url)).length
 );
 
 const validate = (values) => {

--- a/client/app/bundles/course/survey/components/QuestionFormOption.jsx
+++ b/client/app/bundles/course/survey/components/QuestionFormOption.jsx
@@ -87,7 +87,7 @@ class QuestionFormOption extends React.Component {
   renderOptionBody() {
     const { intl, member, index, fields, disabled } = this.props;
     const fieldValue = fields.get(index);
-    const imageFile = fieldValue && fieldValue.image;
+    const imageFile = fieldValue && fieldValue.file;
 
     const fileOrSrc = {};
     let imageFileName = '';
@@ -150,7 +150,7 @@ class QuestionFormOption extends React.Component {
         { this.renderWidget() }
         { this.renderOptionBody() }
         <Field
-          name={`${member}.image`}
+          name={`${member}.file`}
           component={QuestionFormOption.renderImageField}
           {...{ index, disabled }}
         />

--- a/client/app/bundles/course/survey/components/QuestionFormOptions.jsx
+++ b/client/app/bundles/course/survey/components/QuestionFormOptions.jsx
@@ -42,13 +42,13 @@ class QuestionFormOptions extends React.Component {
     // eliminate blank options
     fields.removeAll();
     options.forEach((option) => {
-      if (option.option || option.image) {
+      if (option.option || option.file) {
         fields.push(option);
       }
     });
 
     for (let i = 0; i < files.length; i += 1) {
-      fields.push({ image: files[i] });
+      fields.push({ file: files[i] });
     }
   }
 

--- a/client/app/bundles/course/survey/utils.js
+++ b/client/app/bundles/course/survey/utils.js
@@ -5,7 +5,7 @@ export const sorts = {
 export const formatQuestionFormData = (data) => {
   const payload = new FormData();
   const filledOptions = data.options.filter(option =>
-    option && (option.option || option.image || option.image_url)
+    option && (option.option || option.file || option.image_url)
   );
   const filledOptionsCount = filledOptions.length;
 
@@ -18,7 +18,7 @@ export const formatQuestionFormData = (data) => {
   });
 
   filledOptions.forEach((option, index) => {
-    ['id', 'option', 'image'].forEach((field) => {
+    ['id', 'option', 'file'].forEach((field) => {
       if (option[field] !== undefined && option[field] !== null) {
         payload.append(`question[options_attributes][${index}][${field}]`, option[field]);
       }

--- a/db/migrate/20170220123952_remove_image_from_survey_question_option.rb
+++ b/db/migrate/20170220123952_remove_image_from_survey_question_option.rb
@@ -1,0 +1,5 @@
+class RemoveImageFromSurveyQuestionOption < ActiveRecord::Migration
+  def change
+    remove_column :course_survey_question_options, :image, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170217041431) do
+ActiveRecord::Schema.define(version: 20170220123952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -644,7 +644,6 @@ ActiveRecord::Schema.define(version: 20170217041431) do
   create_table "course_survey_question_options", force: :cascade do |t|
     t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_survey_question_options_question_id"}, :foreign_key=>{:references=>"course_survey_questions", :name=>"fk_course_survey_question_options_question_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.text    "option"
-    t.text    "image"
     t.integer "weight",      :null=>false
   end
 


### PR DESCRIPTION
This is so that we can easily track the image's original filename.