### PR TITLE
Whitelist WYSIWYG editor attributes and styles

### DIFF
--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -16,10 +16,17 @@ module ApplicationHTMLFormattersHelper
   # - Allow whitelisting of base64 encoded images for HTML text.
   # Link: https://github.com/jch/html-pipeline#2-how-do-i-customize-a-whitelist-for-sanitizationfilters
   # TODO: Remove 'data' once we disable Base64 encoding
-  # TODO: Figure out how to whitelist 'style' as WYSIWYG editor adds that attribute.
   SANITIZATION_FILTER_WHITELIST ||= begin
     list = HTML::Pipeline::SanitizationFilter::WHITELIST
-    list[:protocols]['img']['src'] << 'data' unless list[:protocols]['img']['src'].include?('data')
+    list[:protocols]['img']['src'] |= ['data']
+    list[:elements] |= ['span', 'font']
+    list[:attributes][:all] |= ['style']
+    list[:attributes]['font'] = ['face']
+    list[:attributes]['table'] = ['class']
+    list[:css] = { properties: %w(
+      background-color color float font-family height margin
+      margin-bottom margin-left margin-right margin-top text-align width
+    ) }
     list
   end
 

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -11,12 +11,40 @@ module ApplicationHTMLFormattersHelper
                                          HTML::Pipeline::RougeFilter
                                        ], DefaultPipelineOptions)
 
+  # List of video hosting site URLs to allow
+  VIDEO_URL_WHITELIST = Regexp.union(
+    /\A(?:https?:)?\/\/(?:www\.)?youtube\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?youtu.be\//,
+    /\A(?:https?:)?\/\/(?:www\.)?vimeo\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?vine\.co\//,
+    /\A(?:https?:)?\/\/(?:www\.)?instagram\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?dailymotion\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?youku\.com\//
+  )
+
+  # Transformer to whitelist iframes containing embedded video content
+  VIDEO_WHITELIST_TRANSFORMER = lambda do |env|
+    node, node_name = env[:node], env[:node_name]
+
+    return if env[:is_whitelisted] || !node.element?
+
+    return unless node_name == 'iframe'
+    return unless node['src'].match VIDEO_URL_WHITELIST
+
+    Sanitize.node!(node, elements: ['iframe'],
+                         attributes: {
+                           'iframe' => %w(allowfullscreen frameborder height src width)
+                         })
+
+    { node_whitelist: [node] }
+  end
+
   # SanitizationFilter Custom Options
   #
   # - Allow whitelisting of base64 encoded images for HTML text.
   # Link: https://github.com/jch/html-pipeline#2-how-do-i-customize-a-whitelist-for-sanitizationfilters
   # TODO: Remove 'data' once we disable Base64 encoding
-  SANITIZATION_FILTER_WHITELIST ||= begin
+  SANITIZATION_FILTER_WHITELIST = begin
     list = HTML::Pipeline::SanitizationFilter::WHITELIST
     list[:protocols]['img']['src'] |= ['data']
     list[:elements] |= ['span', 'font']
@@ -27,6 +55,7 @@ module ApplicationHTMLFormattersHelper
       background-color color float font-family height margin
       margin-bottom margin-left margin-right margin-top text-align width
     ) }
+    list[:transformers] |= [VIDEO_WHITELIST_TRANSFORMER]
     list
   end
 

--- a/app/views/course/forum/posts/_post.html.slim
+++ b/app/views/course/forum/posts/_post.html.slim
@@ -14,6 +14,7 @@
           => format_datetime(post.created_at)
 
     = format_html(post.text)
+    div.clearfix
 
     div.info
       - if defined?(show_buttons)

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe ApplicationFormattersHelper do
         expect(helper.format_html('<script/>')).to eq('')
       end
 
+      it 'does not remove span tags' do
+        html = '<span>Hello World!</span>'
+        expect(helper.format_html(html)).to eq(html)
+      end
+
+      it 'does not remove font tags' do
+        html = '<font face="Arial">Hello World!</font>'
+        expect(helper.format_html(html)).to eq(html)
+      end
+
+      it 'does not remove table styling' do
+        html = '<table class="table-bordered"></table>'
+        expect(helper.format_html(html)).to eq(html)
+      end
+
+      it 'does not remove image styling' do
+        html = '<img src="hello.jpg" style="float:right; width: 50%">'
+        expect(helper.format_html(html)).to eq(html)
+      end
+
+      it 'removes forbidden css properties' do
+        html = '<div style="position: fixed; top: 0; left: 0;"></div>'
+        expect(helper.format_html(html)).not_to include('position')
+        expect(helper.format_html(html)).not_to include('top')
+        expect(helper.format_html(html)).not_to include('left')
+      end
+
       it 'formats code' do
         html = <<-HTML
           <pre lang="python"><code>

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -51,6 +51,30 @@ RSpec.describe ApplicationFormattersHelper do
         expect(helper.format_html(html)).not_to include('left')
       end
 
+      it 'does not remove embedded videos from allowed sources' do
+        html = <<-HTML
+          <iframe src="//youtube.com/video1"></iframe>
+          <iframe src="//instagram.com/video2"></iframe>
+          <iframe src="//vimeo.com/video3"></iframe>
+          <iframe src="//vine.co/video4"></iframe>
+          <iframe src="//dailymotion.com/video5"></iframe>
+          <iframe src="//youku.com/video6"></iframe>
+        HTML
+        expect(helper.format_html(html)).to eq(html)
+      end
+
+      it 'removes forbidden embedded content' do
+        html = <<-HTML
+          <iframe src="//beta.coursemology.org"></iframe>
+          <iframe src="//www.youtubeXcom.com"></iframe>
+          <iframe src="//wwwXinstagram.com"></iframe>
+          <iframe src="//vine.com"></iframe>
+          <iframe src="//dailymotion.co"></iframe>
+          <iframe src="//vimeo.org"></iframe>
+        HTML
+        expect(helper.format_html(html)).not_to include('iframe')
+      end
+
       it 'formats code' do
         html = <<-HTML
           <pre lang="python"><code>


### PR DESCRIPTION
Fixes #1868 and #2018 

Whitelist a limited set of tags, attributes and CSS properties used by Summernote for proper display of comments and forum posts.

This fixes the following issues:
- missing table cell borders
- paragraph, font and text styling not applied
- image not resized and position not changed

But if image is at the bottom and set to float then...

<img width="1004" alt="screen shot 2017-02-21 at 1 53 25 pm" src="https://cloud.githubusercontent.com/assets/4056819/23152687/ac9de2f4-f83e-11e6-87bf-be885265e7e1.png">

Update: added clearfix div:
<img width="834" alt="screen shot 2017-02-21 at 5 30 46 pm" src="https://cloud.githubusercontent.com/assets/4056819/23158939/e0378904-f85b-11e6-8276-544f10e18bcc.png">
