### PR TITLE
Add grader name to submissions

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -164,7 +164,7 @@ class Course::UserInvitationsController < Course::ComponentController
   # @return [Array<String>]
   def invalid_course_user_errors
     invalid_course_users.map do |course_user|
-      user = self.class.helpers.display_user(course_user.user || course_user)
+      user = self.class.helpers.display_course_user(course_user)
       t('course.user_invitations.errors.duplicate_user', user: user)
     end
   end

--- a/app/helpers/course/controller_helper.rb
+++ b/app/helpers/course/controller_helper.rb
@@ -11,6 +11,23 @@ module Course::ControllerHelper
     user.name
   end
 
+  # Formats the given +User+ as a user-visible string. If the current user is a course_user in
+  # the course, the course_user.name would be used instead.
+  #
+  # @param [User|CourseUser] user The User to display.
+  # @return [String] The user-visible string to represent the User, suitable for rendering as
+  #   output.
+  def display_user(user)
+    return display_course_user(user) if user.is_a?(CourseUser)
+
+    course_user = user.course_users.find_by(course: controller.current_course)
+    if course_user
+      display_course_user(course_user)
+    else
+      super(user)
+    end
+  end
+
   # Links to the given +CourseUser+.
   #
   # @param [CourseUser] user The User to display.

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -1,4 +1,6 @@
 - display_grading_results = @submission.published? || can?(:grade, @submission)
+- show_graders = \
+    can?(:grade, @submission) && @submission.latest_answers.any? { |a| a.grader_id.present? }
 div.panel.panel-default
   div.panel-heading = t('.statistics')
   div.panel-body.statistics
@@ -63,7 +65,7 @@ div.panel.panel-default
         - if display_grading_results
           tr
             th = @submission.class.human_attribute_name(:grader)
-            td = display_course_user(@submission.publisher) if @submission.publisher
+            td = display_user(@submission.publisher) if @submission.publisher
           tr
             th = @submission.class.human_attribute_name(:graded_at)
             td = format_datetime(@submission.published_at) if @submission.published_at
@@ -74,13 +76,18 @@ div.panel.panel-default
         thead
           tr
             th = t('.question')
+            - if show_graders
+              th = t('.question_grader')
             th = @submission.class.human_attribute_name(:grade)
         tbody
-          - answer_by_question = @submission.latest_answers.group_by(&:question)
+          - answer_by_question = \
+              @submission.answers.latest_answers.includes(:grader).group_by(&:question)
           - @submission.assessment.questions.each do |question|
             - answer = answer_by_question[question].try(:first)
             tr
               th = format_inline_text(question.display_title)
+              - if show_graders
+                td = link_to_user(answer.grader) if answer&.grader
               td
                 - if answer
                   span.submission-grades-summary-grade> (id="submission-grades-summary-answer-#{answer.id}-grade")

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -59,6 +59,7 @@ en:
             statistics: 'Statistics'
             multiplier: 'Multiplier'
             question: 'Question'
+            question_grader: 'Grader'
             grade_summary: 'Grade Summary'
             publish_grade_hint: >
               The grades are currently not viewable to the student. You can publish the grades at

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -170,10 +170,10 @@ RSpec.feature 'Course: Homepage' do
         teaching_assistant = create(:course_teaching_assistant, course: course)
         visit course_path(course)
         course.course_users.owner.each do |course_user|
-          expect(page).to have_selector('span.name', text: course_user.user.name)
+          expect(page).to have_selector('span.name', text: course_user.name)
         end
-        expect(page).to have_selector('span.name', text: manager.user.name)
-        expect(page).not_to have_selector('span.name', text: teaching_assistant.user.name)
+        expect(page).to have_selector('span.name', text: manager.name)
+        expect(page).not_to have_selector('span.name', text: teaching_assistant.name)
       end
 
       scenario 'I am able to see the course description' do

--- a/spec/helpers/course/controller_helper_spec.rb
+++ b/spec/helpers/course/controller_helper_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe Course::ControllerHelper do
       end
     end
 
+    describe '#display_user' do
+      let(:user) { create(:user, name: 'user') }
+      let(:course_user) { create(:course_user, course: course, user: user, name: 'course_user') }
+      subject { helper.display_user(user) }
+
+      context 'when the given user is a course_user in the current course' do
+        it 'returns the name of the course user' do
+          course_user
+          expect(subject).to eq(course_user.name)
+        end
+      end
+
+      context 'when the given user is not a course_user in the current course' do
+        it 'returns the name of the user' do
+          user
+          expect(subject).to eq(user.name)
+        end
+      end
+    end
+
     describe '#link_to_course_user' do
       let(:user) { create(:course_student, course: course) }
       subject { helper.link_to_course_user(user) }


### PR DESCRIPTION
Fixes #2014.

This PR: 
 - Modifies the Submission Grader's name to use the `CourseUser` name (originally, the `User` name was stated, which was sometimes gibberish; 
 - Adds the Grader's `CourseUser` name to each question (only `course_staff` can see this). Also, this is a link to the grader's profile page in case there is a need to access the grader's email. 

There are 2 issues to note: 
 1. The Submission Grader is actually the person who published the submission. For assessments with no delayed grade publication, this is the TA who graded the submission. For assessments with delayed grade publication, this might be the `course_owner` or `course_manager` who clicked on the button to `Publish all grades`. 
 2. Currently because of how we implemented submissions, all the graders for each question are the same. So if A grades question 1-4 then saves, then B updates grades for question 3, the system would show B as the grader for all 4 questions. However, I recommend sticking with this implementation still, so when individual grading is implemented, there is no changes required. 



<img width="1030" alt="screen shot 2017-02-22 at 11 28 03 am" src="https://cloud.githubusercontent.com/assets/4353853/23196043/13cee9a6-f8f2-11e6-8791-33890d5832b5.png">
