### PR TITLE
Fix rake assets:precompile failing in production environment

### DIFF
--- a/lib/tasks/coursemology/seed.rake
+++ b/lib/tasks/coursemology/seed.rake
@@ -1,7 +1,4 @@
-
 # frozen_string_literal: true
-require 'factory_girl_rails'
-require 'coursemology/polyglot'
 
 test_case_properties = [
   {
@@ -29,6 +26,9 @@ test_case_properties = [
 
 namespace :coursemology do
   task seed: 'db:seed' do
+    require 'factory_girl_rails'
+    require 'coursemology/polyglot'
+
     ActsAsTenant.with_tenant(Instance.default) do
       # Get the admin user
       admin = User::Email.find_by_email('test@example.org').user


### PR DESCRIPTION
As factory_girl is not installed in production environment but the rake task file is still loaded without being called, delay loading of factory_girl until rake task is called.