### PR TITLE
Add My Students tab for Student Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ educators to increase student engagement and make learning fun.
 
 ### System Requirements
 
-1. Ruby (>= 2.2.0)
+1. Ruby (>= 2.3.1)
 2. Ruby on Rails
 3. PostgreSQL
 4. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick))
 5. Node.js
+6. Yarn
 
 Coursemology uses [Ruby on Rails](http://rubyonrails.org/).
 In addition, some front-end components use
@@ -62,7 +63,7 @@ GoRails should help you to get started on Ruby on Rails.
     ~~~
     Or start the rails server yourself and:
     ~~~sh
-    # Make sure you have  ran this command to compile the assets before running the test suite.
+    # Run this command to compile the assets before running the test suite.
     $ cd client/ && yarn build:development
     ~~~
 

--- a/app/views/course/statistics/_course_student_statistics.html.slim
+++ b/app/views/course/statistics/_course_student_statistics.html.slim
@@ -1,0 +1,5 @@
+= render 'table', students: students
+
+- if phantom_students.present?
+  h1 = t('.phantom_students')
+  = render 'table', students: phantom_students

--- a/app/views/course/statistics/student.html.slim
+++ b/app/views/course/statistics/student.html.slim
@@ -1,6 +1,17 @@
 = page_header
-= render 'table', students: @students
+- if current_course_user&.my_students.any?
+  ul.nav.nav-tabs.tab-header role="tab-list"
+    li role="presentation"
+      a href="#my-students" aria-controls="my-students" role="tab" data-toggle="tab"
+        = t('.my_students_tab')
+    li role="presentation"
+      a href="#all-students" aria-controls="all-students" role="tab" data-toggle="tab"
+        = t('.all_students_tab')
 
-- if @phantom_students.present?
-  h1 = t('.phantom_students')
-  = render 'table', students: @phantom_students
+  div.tab-content
+    div.tab-pane.fade role="tabpanel" id="my-students"
+      = render 'table', students: current_course_user.my_students
+    div.tab-pane.fade role="tabpanel" id="all-students"
+      = render 'course_student_statistics', students: @students, phantom_students: @phantom_students
+- else
+  = render 'course_student_statistics', students: @students, phantom_students: @phantom_students

--- a/client/app/bundles/course/statistics.js
+++ b/client/app/bundles/course/statistics.js
@@ -1,0 +1,7 @@
+const MY_STUDENT_SELECTOR = 'a[href="#my-students"]';
+
+function initializeTabs() {
+  $(MY_STUDENT_SELECTOR).tab('show');
+}
+
+$(document).ready(initializeTabs);

--- a/config/locales/en/course/statistics.yml
+++ b/config/locales/en/course/statistics.yml
@@ -4,6 +4,9 @@ en:
       serial_number: 'S/N'
       student:
         header: 'Student Statistics'
+        my_students_tab: 'My Students'
+        all_students_tab: 'All Students'
+      course_student_statistics:
         phantom_students: 'Phantom Students'
       table:
         serial_number: :'course.statistics.serial_number'

--- a/spec/features/course/student_statistics_spec.rb
+++ b/spec/features/course/student_statistics_spec.rb
@@ -15,19 +15,20 @@ RSpec.feature 'Course: Student Statistics' do
     end
 
     context 'As a Course Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
-      let(:group) { create(:course_group, course: course) }
-      let(:group_without_manager) { create(:course_group, :without_users, course: course) }
       let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
-      let!(:group_manager) do
+      let(:user) { teaching_assistant.user }
+      let(:group) { create(:course_group, course: course) }
+      let(:other_group) { create(:course_group, :without_users, course: course) }
+      let(:group_manager) do
         create(:course_group_manager, group: group, course_user: teaching_assistant)
       end
-      let!(:group_users) do
+      let(:group_users) do
         create(:course_group_user, group: group, course_user: students.first)
-        create(:course_group_user, group: group_without_manager, course_user: students.last)
+        create(:course_group_user, group: other_group, course_user: students.last)
       end
 
-      scenario 'I can view student statistics' do
+      scenario 'I can view student statistics', js: true do
+        students
         visit course_statistics_student_path(course)
 
         expect(page).to have_selector('li', text: I18n.t('course.statistics.student.header'))
@@ -35,18 +36,29 @@ RSpec.feature 'Course: Student Statistics' do
         students.each do |student|
           expect(page).to have_content_tag_for(student)
         end
-        expect(page).to have_text(group_manager.course_user.name)
-        expect(page).not_to have_text(I18n.t('course.statistics.student.phantom_students'))
+        expect(page).not_to have_text(I18n.t('course.statistics.student.my_students_tab'))
+        expect(page).
+          not_to have_text(I18n.t('course.statistics.course_student_statistics.phantom_students'))
 
-        panthom_student = students.first
-        panthom_student.phantom = true
-        panthom_student.save
+        # Test that phantom students are rendered only if they exist
+        phantom_student = students.first
+        phantom_student.phantom = true
+        phantom_student.save
         visit course_statistics_student_path(course)
 
         students.each do |student|
           expect(page).to have_content_tag_for(student)
         end
-        expect(page).to have_text(I18n.t('course.statistics.student.phantom_students'))
+        expect(page).
+          to have_text(I18n.t('course.statistics.course_student_statistics.phantom_students'))
+
+        # Test that My Students tab is present if user is group manager with students.
+        group_manager
+        group_users
+        visit course_statistics_student_path(course)
+
+        expect(page).to have_text(I18n.t('course.statistics.student.my_students_tab'))
+        expect(page).to have_text(group_manager.course_user.name)
       end
     end
 


### PR DESCRIPTION
Fixes #2029. Staff that has a group would get a tab listing `my_students`.

Also added a commit to update readme for yarn and ruby 2.3.

![student-statistics-tab](https://cloud.githubusercontent.com/assets/4353853/23252124/99e7d50e-f9ea-11e6-915d-ee178c204cc6.gif)
