### PR TITLE
Pass delayed_grade_publication status to frontend

### DIFF
--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -1,6 +1,6 @@
 json.attributes do
   json.(@assessment, :id, :title, :description, :start_at, :end_at, :bonus_end_at, :base_exp,
-    :time_bonus_exp, :published, :autograded, :skippable, :tabbed_view, :password)
+    :time_bonus_exp, :published, :autograded, :skippable, :tabbed_view, :password, :delayed_grade_publication)
 end
 
 json.mode_switching @assessment.allow_mode_switching?


### PR DESCRIPTION
My bad, from the testing on staging, the `delayed_grade_publication` status is always false cause the data is not passed to the frontend.