### PR TITLE
Modify HTML pipeline to handle iframes without src attribute

### DIFF
--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHTMLFormattersHelper
     return if env[:is_whitelisted] || !node.element?
 
     return unless node_name == 'iframe'
-    return unless node['src'].match VIDEO_URL_WHITELIST
+    return unless node['src']&.match VIDEO_URL_WHITELIST
 
     Sanitize.node!(node, elements: ['iframe'],
                          attributes: {

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -95,6 +95,13 @@ RSpec.describe ApplicationFormattersHelper do
           expect(helper.format_html(html)).to include('data')
         end
       end
+
+      context 'when provided iframe does not have an src attribute' do
+        it 'removes the iframe tag' do
+          html = '<iframe></iframe>'
+          expect(helper.format_html(html)).to be_empty
+        end
+      end
     end
 
     describe '#format_code_block' do


### PR DESCRIPTION
To just use the safe navigation operator. Pipeline will remove all iframes without any src attribute. 

cc: @jeremyyap 