### PR TITLE
Fix Summernote image upload bugs

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -10,17 +10,19 @@
     var IMAGE_MAX_WIDTH = 1920;
     var IMAGE_MAX_HEIGHT = 1080;
 
+    var img = document.createElement('img');
+    var canvas = document.createElement('canvas');
+
     var reader = new FileReader();
     reader.onload = function(e) {
-      var img = document.createElement('img');
-      var canvas = document.createElement('canvas');
-
       img.src = e.target.result;
+    };
+    img.onload = function() {
       var width = img.width;
       var height = img.height;
 
       if (width <= IMAGE_MAX_WIDTH && height <= IMAGE_MAX_HEIGHT ) {
-       onImageCompressed(e.target.result);
+       onImageCompressed(img.src);
        return;
       }
       if (width > IMAGE_MAX_WIDTH) {

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -26,6 +26,7 @@ class MaterialSummernote extends React.Component {
   constructor(props) {
     super(props);
     this.state = { isFocused: false };
+    this.reactSummernote = null;
   }
 
   onChange = (e) => {
@@ -39,7 +40,9 @@ class MaterialSummernote extends React.Component {
       this.compressImage(files[i], (dataUrl) => {
         const img = document.createElement('img');
         img.src = dataUrl;
-        ReactSummernote.insertNode(img);
+        if (this.reactSummernote != null) {
+          this.reactSummernote.editor.summernote('insertNode', img);
+        }
       });
     }
   }
@@ -50,7 +53,7 @@ class MaterialSummernote extends React.Component {
     const IMAGE_MAX_HEIGHT = 1080;
 
     const reader = new FileReader();
-    reader.onload = function (e) {
+    reader.onload = function onload(e) {
       const img = document.createElement('img');
       const canvas = document.createElement('canvas');
 
@@ -131,6 +134,7 @@ class MaterialSummernote extends React.Component {
         />
         <div className="material-summernote">
           <ReactSummernote
+            ref={(ref) => { this.reactSummernote = ref; }}
             options={{
               dialogsInBody: false,
               disabled: this.props.disabled,

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -52,17 +52,19 @@ class MaterialSummernote extends React.Component {
     const IMAGE_MAX_WIDTH = 1920;
     const IMAGE_MAX_HEIGHT = 1080;
 
+    const img = document.createElement('img');
+    const canvas = document.createElement('canvas');
+
     const reader = new FileReader();
     reader.onload = function onload(e) {
-      const img = document.createElement('img');
-      const canvas = document.createElement('canvas');
-
       img.src = e.target.result;
+    };
+    img.onload = function onload() {
       let width = img.width;
       let height = img.height;
 
       if (width <= IMAGE_MAX_WIDTH && height <= IMAGE_MAX_HEIGHT) {
-        onImageCompressed(e.target.result);
+        onImageCompressed(img.src);
         return;
       }
       if (width > IMAGE_MAX_WIDTH) {


### PR DESCRIPTION
Fixes multiple bugs introduced by #2058 

1. If there are multiple React Summernote components on one page, inserting an
image into the second one inserted it into the first one instead.

1. Oversized images are not properly detected to require resizing.