### PR TITLE
Update material permissions

### DIFF
--- a/app/models/components/course/materials_ability_component.rb
+++ b/app/models/components/course/materials_ability_component.rb
@@ -48,7 +48,7 @@ module Course::MaterialsAbilityComponent
   def allow_staff_manage_materials
     can :manage, Course::Material, material_course_staff_hash
 
-    can :read, Course::Material::Folder, course_staff_hash
+    can [:read, :upload], Course::Material::Folder, course_staff_hash
     can :manage, Course::Material::Folder, course_staff_hash.reverse_merge(concrete_folder_hash)
     # Do not allow admin to edit linked folders
     cannot [:update, :destroy], Course::Material::Folder do |folder|

--- a/app/views/course/material/folders/_folder_controls.html.slim
+++ b/app/views/course/material/folders/_folder_controls.html.slim
@@ -1,8 +1,8 @@
 span.pull-right.btn-group
-  - if can?(:new_subfolder, @folder)
+  - if @folder.concrete? && can?(:new_subfolder, @folder)
     = new_button(new_subfolder_course_material_folder_path(current_course, @folder), title: t('.new')) do
       = fa_icon 'folder'.freeze
-  - if can?(:upload, @folder)
+  - if @folder.concrete? && can?(:upload, @folder)
     = link_to new_materials_course_material_folder_path(current_course, @folder),
               title: t('.upload'), class: ['btn', 'btn-primary'] do
       = fa_icon 'upload'.freeze
@@ -10,5 +10,5 @@ span.pull-right.btn-group
             title: t('.download'), class: ['btn', 'btn-primary'] do
     = fa_icon 'download'.freeze
 
-  - if can?(:edit, @folder)
+  - if @folder.concrete? && can?(:edit, @folder)
     = edit_button([current_course, @folder])

--- a/spec/models/course/material/folder_ability_spec.rb
+++ b/spec/models/course/material/folder_ability_spec.rb
@@ -44,9 +44,11 @@ RSpec.describe Course::Material::Folder, type: :model do
       it { is_expected.to be_able_to(:manage, valid_folder) }
       it { is_expected.to be_able_to(:manage, not_started_folder) }
       it { is_expected.to be_able_to(:manage, ended_folder) }
-      it { is_expected.not_to be_able_to(:manage, started_linked_folder) }
-      it { is_expected.to be_able_to(:show, started_linked_folder) }
-      it { is_expected.to be_able_to(:show, not_started_linked_folder) }
+      it { is_expected.to be_able_to(:upload_materials, started_linked_folder) }
+      it { is_expected.to be_able_to(:upload_materials, started_linked_folder) }
+      it { is_expected.to be_able_to(:upload_materials, not_started_linked_folder) }
+      it { is_expected.not_to be_able_to(:destroy, started_linked_folder) }
+      it { is_expected.not_to be_able_to(:destroy, not_started_linked_folder) }
 
       it { is_expected.to be_able_to(:read_owner, started_linked_folder) }
       it { is_expected.to be_able_to(:read_owner, not_started_linked_folder) }


### PR DESCRIPTION
Fixes a permission issue that course staff are not able to upload to linked folders

This happens after we used remote calls for upload materials, It works before because the uploading goes through assessment and the permission is not checked.