### PR TITLE
Fix lesson plan notification initial state

### DIFF
--- a/client/app/bundles/course/lesson_plan/reducers/lessonPlanReducer.jsx
+++ b/client/app/bundles/course/lesson_plan/reducers/lessonPlanReducer.jsx
@@ -3,7 +3,7 @@ import { combineReducers } from 'redux-immutable';
 import items, { initialState as itemsInitialState } from './items';
 import milestones, { initialState as milestonesInitialState } from './milestones';
 import hiddenItemTypes, { initialState as hiddenItemTypesInitialState } from './hiddenItemTypes';
-import notification, { notification as notificationInitialState } from './notification';
+import notification, { initialState as notificationInitialState } from './notification';
 
 export const initialState = Immutable.fromJS({
   items: itemsInitialState,

--- a/client/app/bundles/course/lesson_plan/reducers/notification.jsx
+++ b/client/app/bundles/course/lesson_plan/reducers/notification.jsx
@@ -1,6 +1,6 @@
 import actionTypes from '../constants';
 
-const initialState = '';
+export const initialState = '';
 
 export default function (state = initialState, action) {
   const { type } = action;


### PR DESCRIPTION
This will remove the webpack warning. 

Will be removing the combining of initial states in the root reducer when I clean up Lesson Plan as each reducer already specifies a default argument, so no need to pass the initial states to `createStore`.