### PR TITLE
Fix race condition which results in unsynced submission and answer states

### DIFF
--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         click_button I18n.t('course.assessment.submission.submissions.buttons.unsubmit')
         expect(submission.reload.attempting?).to be_truthy
         expect(submission.points_awarded).to be_nil
-        expect(submission.latest_answers.all?(&:attempting?)).to be_truthy
+        expect(submission.reload.latest_answers.all?(&:attempting?)).to be_truthy
 
         # Published submission
         submission.finalise!

--- a/spec/services/course/assessment/submission/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/submission/auto_grading_service_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
         expect(submission.answers.map(&:reload).map(&:grade).all?(&:nil?)).to be(true)
       end
 
+      context 'when the submission has an answer in the attempting state' do
+        let(:answer) do
+          create(:course_assessment_answer_multiple_response,
+                 question: question.acting_as, submission: submission).answer
+        end
+
+        it 'submits and grades the answer' do
+          answer
+          expect(subject.grade(submission)).to eq(true)
+
+          expect(answer.reload.evaluated?).to be_truthy
+          expect(submission.answers.map(&:reload).all?(&:evaluated?)).to be(true)
+        end
+      end
+
       context 'when given a non-auto gradable answer' do
         let(:non_autograded_question) do
           create(:course_assessment_question_programming, assessment: assessment)


### PR DESCRIPTION
Fixes #2046 - please read that PR for more of the investigation. 

Problem: There are instances of submitted submissions with answers that are still in an attempting state.
Investigation into this surfaced a race condition - given that user has 2 tabs open, the user can send 2 requests to the coursemology server: (i) Finalise submission, (ii) Submit and evaluat the answer for the current programming question being worked on.

The race condition occurs because (ii) would recreate an attempting answer after autograding is done, but is unaware that the submission could be finalised during this process. This would result in (i) having a SubJobError where the job is unable to cope with the IllegalStateError raised.

The desync in states results in the course_staff being unable to grade the answers, requring some intervention.

Solution: Two fixes are done to ensure the following -
1. Answers are not created for reattempting if the submission is submitted
2. Submissions would auto-grade all answers, including those in attempting state (which could have been created after finalising the submission, but before the autograding job has run)

The solutions proposed greatly reduces the possibility of the race condition happening, but there is a very minute possibility (in a perfect world with 0 latency) that the race condition can still occur. Hence, the submission autograding job is implemented with retries to try to catch such cases.