### PR TITLE
Format datetimes using user-set timezone for React pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,10 +65,15 @@ module ApplicationHelper
     data = {
       name: 'server-context',
       'data-controller-name': controller.class.name.sub(/Controller$/, '').underscore,
-      'data-i18n-locale': I18n.locale
+      'data-i18n-locale': I18n.locale,
+      'data-time-zone': ActiveSupport::TimeZone::MAPPING[user_time_zone]
     }
 
     tag(:meta, data)
+  end
+
+  def user_time_zone
+    user_signed_in? ? current_user.time_zone : nil
   end
 
   # This helper will includes all webpack assets

--- a/client/app/api/Base.js
+++ b/client/app/api/Base.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { csrfToken } from 'lib/helpers/serverContext';
 
 export default class BaseAPI {
   constructor() {
@@ -9,13 +10,7 @@ export default class BaseAPI {
   getClient() {
     if (this.client) return this.client;
 
-    let token;
-    const tag = document.querySelector('meta[name="csrf-token"]');
-    if (tag) {
-      token = tag.getAttribute('content');
-    }
-
-    const headers = { Accept: 'application/json', 'X-CSRF-Token': token };
+    const headers = { Accept: 'application/json', 'X-CSRF-Token': csrfToken };
 
     this.client = axios.create({ headers });
     return this.client;

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanEdit.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanEdit.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';
-import moment from 'moment';
+import moment from 'lib/moment';
 import Snackbar from 'material-ui/Snackbar';
 import DateTimePicker from 'lib/components/form/DateTimePicker';
 import LessonPlanFilter from '../containers/LessonPlanFilter';

--- a/client/app/bundles/course/lesson_plan/components/LessonPlanItemEdit.jsx
+++ b/client/app/bundles/course/lesson_plan/components/LessonPlanItemEdit.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-danger */
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
-import moment from 'moment';
+import moment from 'lib/moment';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import Toggle from 'material-ui/Toggle';
 import DateTimePicker from 'lib/components/form/DateTimePicker';

--- a/client/app/bundles/course/survey/containers/RespondButton.jsx
+++ b/client/app/bundles/course/survey/containers/RespondButton.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
-import moment from 'moment';
+import moment from 'lib/moment';
 import { browserHistory } from 'react-router';
 import RaisedButton from 'material-ui/RaisedButton';
 import { surveyShape } from '../propTypes';

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -13,8 +13,7 @@
 
 
 function loadCurrentModule() {
-  const modulePath = document.head.querySelector("[name='server-context']")
-                       .getAttribute('data-controller-name');
+  const { modulePath } = require('./lib/helpers/serverContext');
   try {
     require(`../app/bundles/${modulePath}`);
   } catch (e) {

--- a/client/app/lib/axios.js
+++ b/client/app/lib/axios.js
@@ -1,12 +1,7 @@
 import originAxios from 'axios';
+import { csrfToken } from 'lib/helpers/serverContext';
 
-let token;
-const tag = document.querySelector('meta[name="csrf-token"]');
-if (tag) {
-  token = tag.getAttribute('content');
-}
-
-const headers = { Accept: 'application/json', 'X-CSRF-Token': token };
+const headers = { Accept: 'application/json', 'X-CSRF-Token': csrfToken };
 
 const axios = originAxios.create({ headers });
 export default axios;

--- a/client/app/lib/components/ProviderWrapper.jsx
+++ b/client/app/lib/components/ProviderWrapper.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Provider } from 'react-redux';
 import { IntlProvider, addLocaleData } from 'react-intl';
+import { i18nLocale, timeZone } from 'lib/helpers/serverContext';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 
@@ -21,8 +22,6 @@ const propTypes = {
 };
 
 const ProviderWrapper = ({ store, children }) => {
-  const i18nLocale =
-    document.querySelector("meta[name='server-context']").getAttribute('data-i18n-locale');
   const availableForeignLocales = { zh };
   const localeWithoutRegionCode = i18nLocale.toLowerCase().split(/[_-]+/)[0];
 
@@ -36,7 +35,7 @@ const ProviderWrapper = ({ store, children }) => {
   if (store) {
     providers =
       (<Provider store={store}>
-        <IntlProvider locale={i18nLocale} messages={messages}>
+        <IntlProvider locale={i18nLocale} messages={messages} timeZone={timeZone}>
           <MuiThemeProvider>
             { children }
           </MuiThemeProvider>

--- a/client/app/lib/components/form/DateTimePicker.jsx
+++ b/client/app/lib/components/form/DateTimePicker.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';
-import moment from 'moment';
+import moment from 'lib/moment';
 import TextField from 'material-ui/TextField';
 import DatePicker from 'material-ui/DatePicker';
 import TimePicker from 'material-ui/TimePicker';

--- a/client/app/lib/dateTimeDefaults.js
+++ b/client/app/lib/dateTimeDefaults.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'lib/moment';
 
 export const shortDateFormat = {
   year: 'numeric',

--- a/client/app/lib/helpers/serverContext.js
+++ b/client/app/lib/helpers/serverContext.js
@@ -1,0 +1,14 @@
+const serverContext = document.querySelector("meta[name='server-context']");
+
+function getServerContextAttribute(attributeName) {
+  return serverContext ? serverContext.getAttribute(attributeName) : null;
+}
+
+const modulePath = getServerContextAttribute('data-controller-name');
+const i18nLocale = getServerContextAttribute('data-i18n-locale');
+const timeZone = getServerContextAttribute('data-time-zone');
+
+const csrfTag = document.querySelector('meta[name="csrf-token"]');
+const csrfToken = csrfTag ? csrfTag.getAttribute('content') : null;
+
+export { modulePath, i18nLocale, timeZone, csrfToken };

--- a/client/app/lib/moment.js
+++ b/client/app/lib/moment.js
@@ -1,0 +1,5 @@
+import moment from 'moment-timezone';
+import { timeZone } from 'lib/helpers/serverContext';
+
+moment.tz.setDefault(timeZone);
+export default moment;

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "client/node_modules"
   ],
   "dependencies": {
+    "@types/moment-timezone": "^0.2.34",
     "axios": "^0.15.3",
     "babel": "^6.5.2",
     "babel-cli": "^6.6.5",
@@ -42,11 +43,12 @@
     "mirror-creator": "1.1.0",
     "mkdirp": "^0.5.1",
     "moment": "^2.17.1",
+    "moment-timezone": "^0.5.11",
     "node-sass": "^4.5.0",
     "react": "^0.14.8 || ^15.0.0",
     "react-ace": "^4.1.1",
     "react-dom": "^0.14.8 || ^15.0.0",
-    "react-intl": "^2.1.5",
+    "react-intl": "jeremyyap/react-intl#build",
     "react-redux": "^5.0.3",
     "react-router": "^3.0.0",
     "react-scroll": "^1.4.7",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@types/moment-timezone@^0.2.34":
+  version "0.2.34"
+  resolved "https://registry.yarnpkg.com/@types/moment-timezone/-/moment-timezone-0.2.34.tgz#948e0aff82742a31dd63714d1aac9616bc375053"
+  dependencies:
+    moment ">=2.14.0"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -3257,7 +3263,13 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@^2.17.1:
+moment-timezone@^0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.11.tgz#9b76c03d8ef514c7e4249a7bbce649eed39ef29f"
+  dependencies:
+    moment ">= 2.6.0"
+
+"moment@>= 2.6.0", moment@>=2.14.0, moment@^2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 
@@ -4077,9 +4089,9 @@ react-event-listener@^0.4.0:
     react-addons-shallow-compare "^15.4.2"
     warning "^3.0.0"
 
-react-intl@^2.1.5:
+react-intl@jeremyyap/react-intl#build:
   version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.2.3.tgz#8eebb03cddc38b337ed22fab78037ab53a594270"
+  resolved "https://codeload.github.com/jeremyyap/react-intl/tar.gz/a681ca76c33745781ae2dd2c20241b83a9f658c8"
   dependencies:
     intl-format-cache "^2.0.5"
     intl-messageformat "^1.3.0"


### PR DESCRIPTION
Fixes #1755 

- Use `moment-timezone` which extends `moment` and allows setting of a default timezone
- Patch `react-intl` to allow setting of global timezone in the provider - [Link to Patch](https://github.com/jeremyyap/react-intl/commit/5446f2cfcf7c0ab25bd4d2c412d07075958d4684)