### PR TITLE
Modify submissions to only finalise latest answers instead of finalising all answers

### DIFF
--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -10,10 +10,10 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
   # Handles the finalisation of a submission.
   #
-  # This finalises all the answers as well.
+  # This finalises all latest answers as well.
   def finalise(_ = nil)
     self.submitted_at = Time.zone.now
-    answers.select(&:attempting?).each(&:finalise!)
+    latest_answers.select(&:attempting?).each(&:finalise!)
   end
 
   # Handles the marking of a submission.

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -8,6 +8,7 @@ class Course::Assessment::Answer < ActiveRecord::Base
     state :attempting do
       event :finalise, transitions_to: :submitted
     end
+    # State where student officially indicates to submit the answer.
     state :submitted do
       event :unsubmit, transitions_to: :attempting
       event :evaluate, transitions_to: :evaluated


### PR DESCRIPTION
Given how the reattempting is done, users could trigger additional attempting answers through having multiple tabs open on the same question, and submitting at the same time. 

Before this fix, what happens is that the additional `attempting` answer gets `finalise!`, and `graded` without an auto_graded job. This PR fixes this by leaving these answers, and only we `finalise!` latest answers instead.

One side effect is for #1887 - where the attempting history should only show answers that have `submitted`, `evaluated` and `graded` states.