### PR TITLE
Survey Thumbnail tweaks

### DIFF
--- a/client/app/bundles/course/survey/components/OptionsListItem.jsx
+++ b/client/app/bundles/course/survey/components/OptionsListItem.jsx
@@ -13,6 +13,9 @@ const styles = {
     maxHeight: 150,
     maxWidth: 400,
   },
+  imageContainer: {
+    height: 150,
+  },
   gridCard: {
     margin: 10,
     padding: 10,
@@ -33,6 +36,10 @@ const styles = {
     maxHeight: 150,
     maxWidth: 150,
   },
+  tiledImageContainer: {
+    height: 150,
+    width: 150,
+  },
 };
 
 class OptionsListItem extends React.PureComponent {
@@ -50,7 +57,12 @@ class OptionsListItem extends React.PureComponent {
         style={styles.gridCard}
         containerStyle={styles.gridOption}
       >
-        { imageUrl ? <Thumbnail src={imageUrl} style={styles.tiledImage} /> : [] }
+        { imageUrl ?
+          <Thumbnail
+            src={imageUrl}
+            style={styles.tiledImage}
+            containerStyle={styles.tiledImageContainer}
+          /> : [] }
         <div style={styles.gridOptionBody}>
           { optionText ? <CardText>{optionText}</CardText> : null }
           { widget }
@@ -65,7 +77,12 @@ class OptionsListItem extends React.PureComponent {
       <div style={styles.option}>
         { widget }
         <div>
-          { imageUrl ? <Thumbnail src={imageUrl} style={styles.image} /> : [] }
+          { imageUrl ?
+            <Thumbnail
+              src={imageUrl}
+              style={styles.image}
+              containerStyle={styles.imageContainer}
+            /> : [] }
           { optionText || null }
         </div>
       </div>

--- a/client/app/bundles/course/survey/components/Thumbnail.jsx
+++ b/client/app/bundles/course/survey/components/Thumbnail.jsx
@@ -49,7 +49,7 @@ class Thumbnail extends React.PureComponent {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const { src, alt, file, onTouchTap, style, ...props } = this.props;
+    const { src, alt, file, onTouchTap, style, containerStyle, ...props } = this.props;
     const source = src || this.state.src;
     const altText = alt || this.state.alt || src;
 
@@ -84,13 +84,15 @@ class Thumbnail extends React.PureComponent {
 
     return (
       <div>
-        <img
-          src={source}
-          alt={altText}
-          onTouchTap={onThumbnailTouchTap}
-          style={thumbnailStyle}
-          {...props}
-        />
+        <div style={containerStyle}>
+          <img
+            src={source}
+            alt={altText}
+            onTouchTap={onThumbnailTouchTap}
+            style={thumbnailStyle}
+            {...props}
+          />
+        </div>
         <Dialog
           actions={actions}
           modal={false}
@@ -117,6 +119,7 @@ Thumbnail.propTypes = {
   file: PropTypes.instanceOf(File),
   onTouchTap: PropTypes.func,
   style: PropTypes.shape(),
+  containerStyle: PropTypes.shape(),
 };
 
 export default Thumbnail;

--- a/client/app/bundles/course/survey/components/Thumbnail.jsx
+++ b/client/app/bundles/course/survey/components/Thumbnail.jsx
@@ -15,7 +15,7 @@ const styles = {
   },
 };
 
-class Thumbnail extends React.Component {
+class Thumbnail extends React.PureComponent {
   constructor(props) {
     super(props);
     const { src, file } = props;

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormDeletedOptions.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormDeletedOptions.jsx
@@ -21,7 +21,11 @@ const styles = {
   image: {
     maxHeight: 48,
     maxWidth: 48,
+  },
+  imageContainer: {
     marginRight: 24,
+    height: 48,
+    width: 48,
   },
   imageSpacer: {
     width: 72,
@@ -62,7 +66,11 @@ class QuestionFormDeletedOptions extends React.Component {
               {this.renderWidget()}
               {
                 option.image_url ?
-                  <Thumbnail style={styles.image} src={option.image_url} /> :
+                  <Thumbnail
+                    src={option.image_url}
+                    style={styles.image}
+                    containerStyle={styles.imageContainer}
+                  /> :
                   <div style={styles.imageSpacer} />
               }
               <span style={styles.optionBody}>{option.option}</span>

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormOption.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormOption.jsx
@@ -54,9 +54,12 @@ const styles = {
     opacity: 0,
   },
   image: {
-    marginTop: 50,
     maxHeight: 150,
     maxWidth: 400,
+  },
+  imageContainer: {
+    marginTop: 50,
+    height: 150,
   },
 };
 
@@ -107,7 +110,11 @@ class QuestionFormOption extends React.Component {
       <div style={styles.optionBody}>
         {
           fileOrSrc.file || fileOrSrc.src ?
-            <Thumbnail style={styles.image} {...fileOrSrc} /> : null
+            <Thumbnail
+              {...fileOrSrc}
+              style={styles.image}
+              containerStyle={styles.imageContainer}
+            /> : null
         }
         <small>{imageFileName}</small>
         <Field

--- a/client/app/bundles/course/survey/pages/SurveyResults/QuestionResults.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/QuestionResults.jsx
@@ -18,7 +18,11 @@ const styles = {
   image: {
     maxHeight: 80,
     maxWidth: 80,
+  },
+  imageContainer: {
     margin: 10,
+    height: 80,
+    width: 80,
   },
   bar: {
     display: 'flex',
@@ -136,7 +140,12 @@ class QuestionResults extends React.Component {
         {
           hasImage ?
             <TableRowColumn>
-              { imageUrl ? <Thumbnail src={imageUrl} style={styles.image} /> : [] }
+              { imageUrl ?
+                <Thumbnail
+                  src={imageUrl}
+                  style={styles.image}
+                  containerStyle={styles.imageContainer}
+                /> : [] }
             </TableRowColumn> : null
         }
         <TableRowColumn colSpan={3}>


### PR DESCRIPTION
Depends on #2115 

In this PR:
- Avoid redundant re-rendering of images.
- Allow thumbnails to maintain their size before and after the image is loaded instead of having the thumbnail expand when the image is loaded.