### PR TITLE
Raise CPU hard limit to 30 seconds.

### DIFF
--- a/app/models/course/assessment/programming_evaluation.rb
+++ b/app/models/course/assessment/programming_evaluation.rb
@@ -17,7 +17,7 @@ class Course::Assessment::ProgrammingEvaluation < ActiveRecord::Base
   TIMEOUT = 5.minutes
 
   # The maximum amount of CPU time a job can take before it gets killed.
-  CPU_TIMEOUT = 10.seconds
+  CPU_TIMEOUT = 30.seconds
 
   before_save :copy_package, if: :package_path_changed?
   after_destroy :delete_package, if: :package_path

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.intl.js
@@ -45,12 +45,12 @@ export default defineMessages({
   },
   memoryLimitFieldLabel: {
     id: 'course.assessment.question.programming.programmingQuestionForm.memoryLimitFieldLabel',
-    defaultMessage: 'Memory Limit',
+    defaultMessage: 'Memory Limit (MB)',
     description: 'Label for the memory limit input field.',
   },
   timeLimitFieldLabel: {
     id: 'course.assessment.question.programming.programmingQuestionForm.timeLimitFieldLabel',
-    defaultMessage: 'Time Limit',
+    defaultMessage: 'Time Limit (s)',
     description: 'Label for the time limit input field.',
   },
   attemptLimitFieldLabel: {
@@ -149,6 +149,6 @@ export default defineMessages({
   },
   timeLimitRangeValidationError: {
     id: 'course.assessment.question.programming.programmingQuestionForm.timeLimitRangeValidationError',
-    defaultMessage: 'Time limit must be within 1 to 10.',
+    defaultMessage: 'Time limit must be within 1 to 30.',
   },
 });

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -35,6 +35,9 @@ const propTypes = {
   intl: intlShape.isRequired,
 };
 
+const DEFAULT_TIME_LIMIT = 10;
+const HARD_TIME_LIMIT = 30;
+
 function validation(data, pathOfKeysToData, intl) {
   const errors = [];
   const questionErrors = {};
@@ -61,7 +64,7 @@ function validation(data, pathOfKeysToData, intl) {
 
   // Check time limit
   const timeLimit = data.get('time_limit');
-  if (timeLimit && (timeLimit > 10 || timeLimit <= 0)) {
+  if (timeLimit && (timeLimit > HARD_TIME_LIMIT || timeLimit <= 0)) {
     questionErrors.time_limit =
       intl.formatMessage(translations.timeLimitRangeValidationError);
     hasError = true;
@@ -577,7 +580,7 @@ class ProgrammingQuestionForm extends React.Component {
                   this.renderInputField(
                     this.props.intl.formatMessage(translations.timeLimitFieldLabel),
                     'time_limit', false, 'number',
-                    ProgrammingQuestionForm.convertNull(question.get('time_limit')),
+                    question.get('time_limit') === null ? DEFAULT_TIME_LIMIT : question.get('time_limit'),
                     this.props.data.getIn(['question', 'error', 'time_limit']))
                   :
                   null

--- a/db/migrate/20170307090147_add_time_limit_to_existing_programming_questions.rb
+++ b/db/migrate/20170307090147_add_time_limit_to_existing_programming_questions.rb
@@ -1,0 +1,9 @@
+class AddTimeLimitToExistingProgrammingQuestions < ActiveRecord::Migration
+  def change
+    add_lower_default_to_existing_programming_questions
+  end
+
+  def add_lower_default_to_existing_programming_questions
+    Course::Assessment::Question::Programming.where(time_limit: nil).update_all(time_limit: 10)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170307080839) do
+ActiveRecord::Schema.define(version: 20170307090147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Course::Assessment::Question::Programming do
       it { is_expected.to validate_numericality_of(:memory_limit).allow_nil }
       it 'validates time_limit' do
         expect(subject).to validate_numericality_of(:time_limit).is_greater_than(0).
-          is_less_than_or_equal_to(10)
+          is_less_than_or_equal_to(30)
       end
     end
 


### PR DESCRIPTION
Some assignments parse large data files so the test cases need more time to run.

Pre-populate the time limit field with the lower limit of 10 seconds.
Time limit existing questions with no time limits to the old default of 10 seconds.