### PR TITLE
Set creator of duplicated course to be user that duplicates the course

### DIFF
--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -39,6 +39,7 @@ class Course::DuplicationsController < Course::ComponentController
     # and selected_objects
     @duplication_service ||= Course::DuplicationService.new(
       current_course,
+      current_user,
       create_duplication_params
     )
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -141,6 +141,7 @@ class Course < ActiveRecord::Base
     self.start_at += duplicator.time_shift
     self.end_at += duplicator.time_shift
     self.title = duplicator.new_course_title
+    self.creator = duplicator.current_user
     self.registration_key = nil
     logo.duplicate_from(other.logo) if other.logo_url
 

--- a/app/services/course/duplication_service.rb
+++ b/app/services/course/duplication_service.rb
@@ -5,11 +5,14 @@ class Course::DuplicationService
   # Constructor for the duplication service object.
   #
   # @param [Course] current_course The current course.
+  # @param [User] current_user The user that initiated the duplication service.
   # @param [Hash] duplication_params A hash of duplication parameters.
   # @param [Array] all_objects All the objects in the course.
   # @param [Array] selected_objects The objects to duplicate.
-  def initialize(current_course, duplication_params = {}, all_objects = [], selected_objects = [])
+  def initialize(current_course, current_user,
+                 duplication_params = {}, all_objects = [], selected_objects = [])
     @current_course = current_course
+    @current_user = current_user
     @all_objects = all_objects.append(current_course)
     @selected_objects = selected_objects.append(current_course)
     @duplication_params = duplication_params
@@ -35,7 +38,8 @@ class Course::DuplicationService
   #
   # @return [Duplicator]
   def duplicator
-    @duplicator ||= Duplicator.new(@all_objects - @selected_objects, time_shift, new_course_title)
+    @duplicator ||=
+      Duplicator.new(@all_objects - @selected_objects, time_shift, new_course_title, @current_user)
   end
 
   # Calculate the amount of time the objects in the new course have to be shifted by

--- a/lib/autoload/duplicator.rb
+++ b/lib/autoload/duplicator.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 class Duplicator
-  attr_reader :time_shift, :new_course_title
+  attr_reader :time_shift, :new_course_title, :current_user
+
   # Create an instance of Duplicator to track duplicated objects.
   #
   # @param [Enumerable] excluded_objects An Enumerable of objects to be excluded from duplication
   # @param [DateTime] time_shift The amount of time to shift dates by
-  def initialize(excluded_objects = [], time_shift = 0, new_course_title = 'Duplicated')
+  # @param [String] new_course_title The new course title
+  # @param [User] current_user Current user who initiated the duplication of the objects
+  def initialize(excluded_objects = [], time_shift = 0, new_course_title = 'Duplicated',
+                 current_user = User.system)
     @duplicated_objects = {} # hash to check what has been duplicated
     @exclusion_set = excluded_objects.to_set # set to check what should be excluded
     @time_shift = time_shift
     @new_course_title = new_course_title
+    @current_user = current_user
   end
 
   # Deep copy the arguments to this function. Objects must provide an +initialize_duplicate+


### PR DESCRIPTION
Fixes #2066. 

I considered just using `User.stamper`, which was a 1 line fix, but thought it might be more helpful (and more readable) to pass this information through the duplicator object. Any objections to this @fonglh?