### PR TITLE
Modify simplecov-lcov to be required only in CI environment

### DIFF
--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 require 'simplecov'
-require 'simplecov-lcov'
 
 if ENV['CI']
+  require 'simplecov-lcov'
+
   SimpleCov::Formatter::LcovFormatter.report_with_single_file = true
   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 


### PR DESCRIPTION
There will be issues with `require 'simplecov-lcov'` when we test locally because bundle only installs that in `:ci` group.