### PR TITLE
Modify staff statistics to exclude submissions from staff and phanton students

### DIFF
--- a/app/models/concerns/course_user/staff_concern.rb
+++ b/app/models/concerns/course_user/staff_concern.rb
@@ -19,10 +19,15 @@ module CourseUser::StaffConcern
     end)
   end
 
+  # Returns the published submissions for the purpose of calculating marking statistics.
+  #
+  # This inlcudes only submissions from non-phantom, student course_users.
   def published_submissions # rubocop:disable Metrics/AbcSize
     @published_submissions ||=
       Course::Assessment::Submission.
       joins { experience_points_record.course_user }.
+      where { experience_points_record.course_user.role == CourseUser.roles[:student] }.
+      where { experience_points_record.course_user.phantom == false  }.
       where { experience_points_record.course_user.course_id == my { course_id } }.
       where { publisher_id == my { user_id } }
   end

--- a/spec/features/course/staff_statistics_spec.rb
+++ b/spec/features/course/staff_statistics_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature 'Course: Statistics: Staff' do
       let(:tutor1) { create(:course_teaching_assistant, course: course) }
       let(:tutor2) { create(:course_teaching_assistant, course: course) }
       let!(:tutor3) { create(:course_teaching_assistant, course: course) }
+      let(:student) { create(:course_student, course: course) }
       let(:user) { tutor1.user }
 
       # Create submissions for tutors, with given submitted at and published_at
@@ -44,6 +45,18 @@ RSpec.feature 'Course: Statistics: Staff' do
         [submission]
       end
 
+      let!(:tutor3_submissions) do
+        submitted_at, published_at = 2.days.ago, 2.days.ago
+        assessment = create(:assessment, course: course)
+        submission = create(:submission, :published,
+                            assessment: assessment, course: course, publisher: tutor3.user,
+                            published_at: published_at, submitted_at: submitted_at,
+                            creator: tutor3.user)
+        create(:course_assessment_answer_multiple_response, :graded,
+               assessment: assessment, submission: submission, submitted_at: submitted_at)
+        [submission]
+      end
+
       scenario 'I can view staff summary' do
         visit course_statistics_staff_path(course)
 
@@ -63,6 +76,7 @@ RSpec.feature 'Course: Statistics: Staff' do
           expect(page).to have_selector('td', text: "2 #{I18n.t('time.day')} 00:00:00")
         end
 
+        # Do not show reflect staff submissions as part of staff statistics.
         within find(content_tag_selector(tutor3)) do
           expect(page).to have_selector('td', text: '3')
           expect(page).to have_selector('td', text: tutor3.name)


### PR DESCRIPTION
To make the calculation more accurate, since I've noticed that users do look at this page. 