### PR TITLE
Fix ACE editor initialisation when there are multiple textareas

### DIFF
--- a/client/app/lib/layout_ace_editor.js
+++ b/client/app/lib/layout_ace_editor.js
@@ -107,11 +107,10 @@ function reassignLabelsToAce($from, $editor) {
 
 $.fn.ace = function (opt) {
   const options = $.extend({}, $.fn.ace.defaults, opt);
-
-  return this.each(() => {
+  return this.each(function () {
     const $this = $(this);
     const elementOptions = $.extend({}, options,
-      { lang: $this[0].lang,
+      { lang: this.lang,
         readOnly: $this[0].readOnly });
     const $editor = findOrBuildEditorContainer($this, elementOptions);
 


### PR DESCRIPTION
In #2142, the arrow notation was used to define the function that binds the ace editor to each textarea matching the given selector. However, using the arrow notation changes the semantics of the function as arrow functions do not have their own binding of `this`
This messes up the initialization when more than 1 textarea in the DOM matches the given selector, resulting in only the first editor being rendered.