### PR TITLE
Log session details for password-protected assessments

### DIFF
--- a/app/controllers/course/assessment/sessions_controller.rb
+++ b/app/controllers/course/assessment/sessions_controller.rb
@@ -34,6 +34,7 @@ class Course::Assessment::SessionsController < Course::Assessment::Controller
 
   def redirect_or_create_submission
     if @submission
+      log_service.log_submission_access(request)
       url = edit_course_assessment_submission_path(current_course, @assessment, @submission)
       render json: { success: true, submission_url: url }
     else
@@ -47,7 +48,12 @@ class Course::Assessment::SessionsController < Course::Assessment::Controller
   end
 
   def authentication_service
-    @service ||=
+    @auth_service ||=
       Course::Assessment::SessionAuthenticationService.new(@assessment, session, @submission)
+  end
+
+  def log_service
+    @log_service ||=
+      Course::Assessment::SessionLogService.new(@assessment, session, @submission)
   end
 end

--- a/app/controllers/course/assessment/submission/logs_controller.rb
+++ b/app/controllers/course/assessment/submission/logs_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Course::Assessment::Submission::LogsController < \
+  Course::Assessment::Submission::Controller
+
+  add_breadcrumb :submissions, :course_assessment_submissions_path
+  add_breadcrumb :index, :course_assessment_submission_logs_path
+
+  def index
+    authorize!(:manage, @assessment)
+  end
+end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -59,6 +59,9 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
   belongs_to :publisher, class_name: User.name, inverse_of: nil
 
+  has_many :logs, class_name: Course::Assessment::Submission::Log.name,
+                  inverse_of: :submission, dependent: :destroy
+
   accepts_nested_attributes_for :answers
 
   # @!attribute [r] graded_at

--- a/app/models/course/assessment/submission/log.rb
+++ b/app/models/course/assessment/submission/log.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class Course::Assessment::Submission::Log < ActiveRecord::Base
+  belongs_to :submission, class_name: Course::Assessment::Submission.name,
+                          inverse_of: :logs
+
+  scope :ordered_by_date, ->(direction = :desc) { order(created_at: direction) }
+
+  def ip_address
+    request['REMOTE_ADDR']
+  end
+
+  def user_agent
+    request['HTTP_USER_AGENT']
+  end
+
+  def user_session_id
+    request['USER_SESSION_ID']
+  end
+
+  def submission_session_id
+    request['SUBMISSION_SESSION_ID']
+  end
+end

--- a/app/models/course/assessment/submission/log.rb
+++ b/app/models/course/assessment/submission/log.rb
@@ -20,4 +20,8 @@ class Course::Assessment::Submission::Log < ActiveRecord::Base
   def submission_session_id
     request['SUBMISSION_SESSION_ID']
   end
+
+  def valid_attempt?
+    user_session_id == submission_session_id
+  end
 end

--- a/app/services/course/assessment/session_log_service.rb
+++ b/app/services/course/assessment/session_log_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# Authenticate the assessment and update the session_id in submission.
+class Course::Assessment::SessionLogService
+  # @param [Course::Assessment] assessment The password protected assessment.
+  # @param [ActionDispatch::Request::Session] session The current session.
+  # @param [Course::Assessment::Submission] submission The current submission.
+  def initialize(assessment, session, submission)
+    @assessment = assessment
+    @session = session
+    @submission = submission
+  end
+
+  # Log submission access attempts for password-protected assessments.
+  def log_submission_access(request)
+    request_headers = request.headers.env.select do |k, _|
+      k.in?(ActionDispatch::Http::Headers::CGI_VARIABLES) || k =~ /^HTTP_/
+    end
+
+    request_headers['USER_SESSION_ID'] = current_authentication_token
+    request_headers['SUBMISSION_SESSION_ID'] = @submission.session_id
+
+    @submission.logs.create(request: request_headers.to_json)
+  end
+
+  private
+
+  def current_authentication_token
+    @session[session_key]
+  end
+
+  def session_key
+    "assessment_#{@assessment.id}_authentication_token"
+  end
+end

--- a/app/views/course/assessment/submission/logs/index.html.slim
+++ b/app/views/course/assessment/submission/logs/index.html.slim
@@ -24,7 +24,7 @@ table.table
       th = t('.submission_session_id')
   tbody
     - @submission.logs.ordered_by_date.each do |log|
-      tr
+      tr class=('danger' unless log.valid_attempt?)
         td = format_datetime(log.created_at)
         td = log.ip_address
         td = log.user_agent

--- a/app/views/course/assessment/submission/logs/index.html.slim
+++ b/app/views/course/assessment/submission/logs/index.html.slim
@@ -1,0 +1,32 @@
+h1 = t('.header')
+
+table.table.table-bordered.details-table
+  tbody
+    tr
+      th = t('.assessment_title')
+      td = link_to @assessment.title, course_assessment_path(current_course, @assessment)
+    tr
+      th = t('.student_name')
+      td = link_to_user @submission.course_user
+    tr
+      th = t('.status')
+      td = link_to edit_course_assessment_submission_path(current_course, @submission.assessment,
+                                                          @submission) do
+          = Course::Assessment::Submission.human_attribute_name(@submission.workflow_state)
+
+table.table
+  thead
+    tr
+      th = t('.timestamp')
+      th = t('.ip_address')
+      th = t('.user_agent')
+      th = t('.user_session_id')
+      th = t('.submission_session_id')
+  tbody
+    - @submission.logs.ordered_by_date.each do |log|
+      tr
+        td = format_datetime(log.created_at)
+        td = log.ip_address
+        td = log.user_agent
+        td = log.user_session_id
+        td = log.submission_session_id

--- a/app/views/course/assessment/submission/submissions/_no_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_no_submission.html.slim
@@ -4,5 +4,6 @@ tr.no-submission
   td.col-md-3.col-xs-3
     strong = t('.not_started')
   td -
-  td -
+  - if current_course.gamified?
+    td -
   td

--- a/app/views/course/assessment/submission/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submission.html.slim
@@ -12,3 +12,7 @@
   - if current_course.gamified?
     td = submission.current_points_awarded.to_i.to_s
   td
+    - if @assessment.password_protected?
+      = link_to course_assessment_submission_logs_path(current_course, submission.assessment,
+                                                       submission), class: ['btn', 'btn-primary'] do
+        = t('.logs')

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -96,6 +96,10 @@ en:
         skill_branches:
           index: :'breadcrumbs.course.assessment.skills.index'
           new: :'course.assessment.skill_branches.new.header'
+        submission:
+          logs:
+            index: :'course.assessment.submission.logs.index.header'
+            submissions: :'course.assessment.submissions.index.header'
         submissions:
           index: :'course.assessment.submissions.index.header'
           pending: :'course.assessment.submissions.pending.header'

--- a/config/locales/en/course/assessment/submission/logs.yml
+++ b/config/locales/en/course/assessment/submission/logs.yml
@@ -1,0 +1,15 @@
+en:
+  course:
+    assessment:
+      submission:
+        logs:
+          index:
+            assessment_title: 'Assessment Title'
+            header: 'Access Logs'
+            ip_address: 'IP Address'
+            student_name: :'course.assessment.submission.submissions.submissions.student_name'
+            submission_session_id: 'Submission Session Token'
+            status: :'course.assessment.submission.submissions.submissions.status'
+            timestamp: 'Timestamp'
+            user_agent: 'User Agent'
+            user_session_id: 'User Session Token'

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -76,6 +76,7 @@ en:
               The grade and experience points are in a draft state and cannot be seen by
               the student. Publish all grades by clicking the 'Publish Grades' button on
               the top right side of the page.
+            logs: 'View Access Logs'
           no_submission:
             not_started: 'Not Started'
           manually_graded_answers_tabbed:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,7 @@ Rails.application.routes.draw do
               post :auto_grade, on: :member
               post :reload_answer, on: :member
               patch :publish_all, on: :collection
+              resources :logs, only: [:index]
               scope module: :answer do
                 resources :answers, only: [] do
                   resources :comments, only: [:create]

--- a/db/migrate/20170308073855_create_course_assessment_submission_logs.rb
+++ b/db/migrate/20170308073855_create_course_assessment_submission_logs.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class CreateCourseAssessmentSubmissionLogs < ActiveRecord::Migration
+  def change
+    create_table :course_assessment_submission_logs do |t|
+      t.references :submission, null: false,
+                                foreign_key: { references: :course_assessment_submissions }
+      t.jsonb :request
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -350,6 +350,12 @@ ActiveRecord::Schema.define(version: 20170309094211) do
     t.integer "skill_id",    :null=>false, :index=>{:name=>"course_assessment_question_skills_skill_index"}, :foreign_key=>{:references=>"course_assessment_skills", :name=>"fk_course_assessment_questions_skills_skill_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
 
+  create_table "course_assessment_submission_logs", force: :cascade do |t|
+    t.integer  "submission_id", :null=>false, :index=>{:name=>"fk__course_assessment_submission_logs_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_submission_logs_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.jsonb    "request"
+    t.datetime "created_at",    :null=>false
+  end
+
   create_table "course_condition_achievements", force: :cascade do |t|
     t.integer "achievement_id", :null=>false, :index=>{:name=>"fk__course_condition_achievements_achievement_id"}, :foreign_key=>{:references=>"course_achievements", :name=>"fk_course_condition_achievements_achievement_id", :on_update=>:no_action, :on_delete=>:no_action}
   end

--- a/spec/factories/course_assessment_submission_logs.rb
+++ b/spec/factories/course_assessment_submission_logs.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_submission_log, class: Course::Assessment::Submission::Log do
+    transient do
+      course { build(:course) }
+      assessment { build(:assessment, course: course) }
+    end
+
+    submission { build(:submission, assessment: assessment, course: course) }
+    request do
+      {
+        'REMOTE_ADDR': '192.168.123.45',
+        'HTTP_USER_AGENT': 'Internet Explorer',
+        'USER_SESSION_ID': SecureRandom.hex(8),
+        'SUBMISSION_SESSION_ID': SecureRandom.hex(8)
+      }.to_json
+    end
+  end
+end

--- a/spec/features/course/assessment/submission/log_spec.rb
+++ b/spec/features/course/assessment/submission/log_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Course: Assessment: Submissions: Logs' do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:assessment, :published_with_mrq_question, course: course) }
+    let(:protected_assessment) do
+      create(:assessment, :published_with_mrq_question,
+             course: course, password: 'super_secret')
+    end
+    let(:student) { create(:course_student, course: course).user }
+    let(:submission) do
+      create(:submission, assessment: protected_assessment, creator: student)
+    end
+    let(:submission_logs) do
+      create_list(:course_assessment_submission_log, 5, submission: submission)
+    end
+
+    before { login_as(user, scope: :user) }
+
+    context 'As a Course Student' do
+      let(:user) { student }
+
+      scenario 'My access to the password-protected assessment is logged' do
+        protected_assessment
+        visit course_assessments_path(course)
+
+        within find(content_tag_selector(protected_assessment)) do
+          find_link(
+            I18n.t('course.assessment.assessments.assessment_management_buttons.attempt')
+          ).click
+        end
+
+        submission = protected_assessment.submissions.last
+        expect(submission.logs.count).to equal(1)
+
+        expect do
+          visit edit_course_assessment_submission_path(course, protected_assessment, submission)
+        end.not_to change { submission.logs.count }
+
+        # Logout and login again and visit the same submission
+        logout
+        login_as(user)
+
+        expect do
+          visit edit_course_assessment_submission_path(course, protected_assessment, submission)
+        end.to change { submission.logs.count }.by(1)
+
+        expect do
+          fill_in 'session_password', with: protected_assessment.password
+          click_button I18n.t('course.assessment.sessions.new.continue')
+        end.to change { submission.logs.count }.by(1)
+      end
+
+      scenario 'My access to the unprotected assessment is not logged' do
+        assessment
+        visit course_assessments_path(course)
+
+        within find(content_tag_selector(assessment)) do
+          find_link(
+            I18n.t('course.assessment.assessments.assessment_management_buttons.attempt')
+          ).click
+        end
+
+        submission = assessment.submissions.last
+        expect(submission.logs.count).to equal(0)
+
+        expect do
+          visit edit_course_assessment_submission_path(course, assessment, submission)
+        end.not_to change { submission.logs.count }
+      end
+    end
+
+    context 'As a Course Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
+
+      scenario 'I can view the access logs for a submission' do
+        protected_assessment
+        submission
+        submission_logs
+
+        visit course_assessment_submission_logs_path(course, protected_assessment, submission)
+
+        expect(page).
+          to have_selector('h1', text: I18n.t('course.assessment.submission.logs.index.header'))
+      end
+    end
+  end
+end

--- a/spec/features/course/assessment/submission/log_spec.rb
+++ b/spec/features/course/assessment/submission/log_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'Course: Assessment: Submissions: Logs' do
 
         submission = protected_assessment.submissions.last
         expect(submission.logs.count).to equal(1)
+        expect(submission.logs.last.valid_attempt?).to be(true)
 
         expect do
           visit edit_course_assessment_submission_path(course, protected_assessment, submission)
@@ -48,11 +49,13 @@ RSpec.describe 'Course: Assessment: Submissions: Logs' do
         expect do
           visit edit_course_assessment_submission_path(course, protected_assessment, submission)
         end.to change { submission.logs.count }.by(1)
+        expect(submission.logs.last.valid_attempt?).to be(false)
 
         expect do
           fill_in 'session_password', with: protected_assessment.password
           click_button I18n.t('course.assessment.sessions.new.continue')
         end.to change { submission.logs.count }.by(1)
+        expect(submission.logs.last.valid_attempt?).to be(true)
       end
 
       scenario 'My access to the unprotected assessment is not logged' do

--- a/spec/models/course/assessment/submission/log_spec.rb
+++ b/spec/models/course/assessment/submission/log_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Submission::Log, type: :model do
+  it { is_expected.to belong_to(:submission) }
+end


### PR DESCRIPTION
Implements #1660

![screen shot 2017-03-11 at 4 50 09 pm](https://cloud.githubusercontent.com/assets/4056819/23821893/d9dec1d0-067a-11e7-8c82-2b87005d2084.png)

![screen shot 2017-03-11 at 9 04 42 pm](https://cloud.githubusercontent.com/assets/4056819/23823474/7da13938-069e-11e7-9ac6-2f17961ee7e9.png)

Access will be logged in the following cases:
- When the assessment is opened
- When the assessment is accessed from a different session than the initial one
- When the correct password is entered to unlock the assessment