### PR TITLE
Update webpack config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,13 +78,11 @@ module ApplicationHelper
 
   # This helper will includes all webpack assets
   def webpack_assets_tag
-    capture do
-      concat "\n"
-      concat javascript_include_tag(*webpack_asset_paths('manifest', extension: 'js'))
-      concat "\n"
-      concat javascript_include_tag(*webpack_asset_paths('vendor', extension: 'js'))
-      concat "\n"
-      concat javascript_include_tag(*webpack_asset_paths('coursemology', extension: 'js'))
-    end
+    javascript_include_tag(
+      *webpack_asset_paths('manifest', extension: 'js'),
+      *webpack_asset_paths('lib', extension: 'js'),
+      *webpack_asset_paths('vendor', extension: 'js'),
+      *webpack_asset_paths('coursemology', extension: 'js')
+    )
   end
 end

--- a/client/package.json
+++ b/client/package.json
@@ -85,8 +85,7 @@
     "sass-loader": "^6.0.2",
     "stats-webpack-plugin": "^0.4.3",
     "style-loader": "^0.13.2",
-    "webpack": "^2.2.1",
-    "webpack-md5-hash": "^0.0.5"
+    "webpack": "^2.2.1"
   },
   "devDependencies": {
     "axios-mock-adapter": "^1.7.1",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,6 +1,5 @@
 const webpack = require('webpack');
 const path = require('path');
-const WebpackMd5Hash = require('webpack-md5-hash');
 const StatsPlugin = require('stats-webpack-plugin');
 
 const env = process.env.NODE_ENV || 'development';
@@ -13,12 +12,10 @@ const devServerPort = 8080;
 const config = {
   entry: {
     coursemology: ['babel-polyfill', './app/index'],
-    vendor: [
+    lib: [
       'axios',
       'brace',
       'immutable',
-      'jquery-ui',
-      'material-ui',
       'moment',
       'react',
       'react-ace',
@@ -34,6 +31,12 @@ const config = {
       'redux-immutable',
       'redux-promise',
       'redux-thunk',
+    ],
+    // Vendor contains the libraries that are not in a single bundle (size could change depends on
+    // application code)
+    vendor: [
+      'jquery-ui',
+      'material-ui',
     ],
   },
 
@@ -61,13 +64,15 @@ const config = {
 
   plugins: [
     new webpack.IgnorePlugin(/__test__/),
-    new WebpackMd5Hash(),
+    new webpack.HashedModuleIdsPlugin(),
     new webpack.optimize.CommonsChunkPlugin({
-      names: ['vendor', 'manifest'],
+      names: ['vendor', 'lib', 'manifest'], // `vendor` depends on `lib` depends on `manifest`
     }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(env),
     }),
+    // Do not require all locles in moment
+    new webpack.ContextReplacementPlugin(/moment\/locale$/, /^\.\/(en-.*|zh-.*)$/),
     // must match config.webpack.manifest_filename
     new StatsPlugin('manifest.json', {
       chunkModules: false,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1233,10 +1233,6 @@ change-emitter@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.2.tgz#6b88ca4d5d864e516f913421b11899a860aee8db"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-
 cheerio@^0.22.0:
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
@@ -1529,10 +1525,6 @@ cross-spawn@^3.0.0:
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -2926,7 +2918,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2, is-buffer@~1.1.1:
+is-buffer@^1.0.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
 
@@ -3841,14 +3833,6 @@ material-ui@^0.17.0:
 math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
-
-md5@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5947,12 +5931,6 @@ webpack-dev-server@^2.4.1:
     supports-color "^3.1.1"
     webpack-dev-middleware "^1.9.0"
     yargs "^6.0.0"
-
-webpack-md5-hash@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/webpack-md5-hash/-/webpack-md5-hash-0.0.5.tgz#d9f1899ead664459dd8b6b0c926ac71cfbd7bc7a"
-  dependencies:
-    md5 "^2.0.0"
 
 webpack-sources@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
webpack-md5-hash ensures that the vendor hash does not change when app code changes, however, it has some known issues that result in our manifest (webpack entry file) hash not changing when app code changes. 

This further leads to the manifest file not updated in user's browser and caused some caching issues.

This PR removes it and use `webpack.HashedModuleIdsPlugin`, it achieves the same purpose but less aggressive. 

A `lib` bundle is introduced and most our libraries are moved there, `vendor` now contains the libraries whose size are dynamic and could change more fequently.

Let moment only require en/zh locales (reduces the bundle size by abt 200KB)


REFS:
https://webpack.js.org/guides/caching/#deterministic-hashes
https://sebastianblade.com/using-webpack-to-achieve-long-term-cache
http://stackoverflow.com/questions/25384360/how-to-prevent-moment-js-from-loading-locales-with-webpack