### PR TITLE
Add Roboto font to React Summernote

### DIFF
--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -140,6 +140,12 @@ class MaterialSummernote extends React.Component {
             options={{
               dialogsInBody: false,
               disabled: this.props.disabled,
+              fontNames: [
+                'Arial', 'Arial Black', 'Comic Sans MS', 'Courier New',
+                'Helvetica Neue', 'Helvetica', 'Impact', 'Lucida Grande',
+                'Roboto', 'Tahoma', 'Times New Roman', 'Verdana',
+              ],
+              fontNamesIgnoreCheck: ['Roboto'],
               toolbar: [
                 ['style', ['style']],
                 ['font', ['bold', 'underline', 'clear']],


### PR DESCRIPTION
Fixes #2116 

Adds Roboto to the list of fonts. Roboto is installed as a web font in Coursemology/coursemology-theme#23

Rails Summernote editors default to Helvetica Neue, not Roboto. Should we add Roboto there as well?