### PR TITLE
Update forum topic when post is created

### DIFF
--- a/app/controllers/course/forum/posts_controller.rb
+++ b/app/controllers/course/forum/posts_controller.rb
@@ -8,6 +8,8 @@ class Course::Forum::PostsController < Course::Forum::ComponentController
 
   def create
     if super
+      # Update parent topic updated_at to invalidate all read marks
+      @topic.touch
       send_created_notification(@post)
       redirect_to course_forum_topic_path(current_course, @forum, @topic),
                   success: t('course.discussion.posts.create.success')

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -232,6 +232,26 @@ RSpec.feature 'Course: Forum: Post: Management' do
         visit course_forum_topic_path(course, forum, topic)
         expect(page).to have_selector(content_tag_selector(topic.posts.first, class: 'unread'))
       end
+
+      scenario 'I can see topics with unread posts' do
+        create_list(:course_discussion_post, 2, topic: topic.acting_as)
+        post = topic.posts.reload.sample
+
+        reader = create(:course_user, course: course).user
+
+        expect(topic.unread?(reader)).to be_falsy
+
+        visit course_forum_topic_path(course, forum, topic)
+
+        find_link(nil, href: reply_course_forum_topic_post_path(course, forum, topic, post)).click
+
+        within '#new_discussion_post' do
+          fill_in 'discussion_post_text', with: 'test'
+          click_button 'submit'
+        end
+
+        expect(topic.unread?(reader)).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #2019

Update parent forum topic updated_at when a new post is created. This sets the topic to unread for all users.