### PR TITLE
Only restart job for attempting submissions

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -124,6 +124,8 @@ class Course::Assessment::Submission::SubmissionsController < \
   # Check for zombie jobs, create new grading jobs if there's any zombie jobs.
   # TODO: Remove this method after found the cause of the dead jobs.
   def check_zombie_jobs # rubocop:disable MethodLength, Metrics/AbcSize
+    return unless @submission.attempting?
+
     submitted_answers = @submission.latest_answers.select(&:submitted?)
     return if submitted_answers.empty?
 


### PR DESCRIPTION
submission auto-grading job will retry for submitted submissions, and we also don't want to create attempting answers for submitted submissions. 