### PR TITLE
Scribing question models and controller

### DIFF
--- a/app/controllers/course/assessment/question/scribing_controller.rb
+++ b/app/controllers/course/assessment/question/scribing_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::ScribingController < \
+  Course::Assessment::QuestionsController
+  load_and_authorize_resource :scribing_question,
+                              class: Course::Assessment::Question::Scribing,
+                              through: :assessment, parent: false
+
+  def new
+    respond_to do |format|
+      format.html { render 'new' }
+    end
+  end
+
+  def show
+    respond_to do |format|
+      format.json { render_scribing_question_json }
+    end
+  end
+
+  def create
+    respond_to do |format|
+      if @scribing_question.save
+        format.json { render_scribing_question_json }
+      else
+        format.json { render_failure_json t('.failure') }
+      end
+    end
+  end
+
+  def edit
+    respond_to do |format|
+      format.html { render 'edit' }
+      format.json { render_scribing_question_json }
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @scribing_question.save
+        format.json { render_scribing_question_json }
+      else
+        format.json { render_failure_json t('.failure') }
+      end
+    end
+  end
+
+  def destroy
+    if @scribing_question.destroy
+      redirect_to course_assessment_path(current_course, @assessment),
+                  success: t('.success')
+    else
+      error = @scribing_question.errors.full_messages.to_sentence
+      redirect_to course_assessment_path(current_course, @assessment),
+                  danger: t('.failure', error: error)
+    end
+  end
+
+  private
+
+  def render_scribing_question_json
+    render partial: 'scribing_question', locals: { scribing_question: @scribing_question }
+  end
+
+  def scribing_question_params
+    params.require(:question_scribing).permit(
+      :title, :description, :staff_only_comments, :maximum_grade,
+      :attempt_limit,
+      skill_ids: []
+    )
+  end
+
+  def render_failure_json(message)
+    render json: { message: message, errors: @scribing_question.errors.full_messages },
+           status: :bad_request
+  end
+end

--- a/app/helpers/course/assessment/question/scribing_helper.rb
+++ b/app/helpers/course/assessment/question/scribing_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module Course::Assessment::Question::ScribingHelper
+  # Determines if the scribing question errors should be displayed.
+  #
+  # @return [Boolean]
+  def display_validation_errors?
+    @scribing_question.errors.present?
+  end
+
+  # Displays the validation errors alert for scribing question.
+  #
+  # @return [String] If there are validation errors for the question.
+  # @return [nil] If there are no validation errors for the question.
+  def validation_errors_alert
+    return nil if @scribing_question.errors.empty?
+
+    content_tag(:div, class: ['alert', 'alert-danger']) do
+      messages = @scribing_question.errors.full_messages.map do |message|
+        content_tag(:div, message)
+      end
+
+      safe_join messages
+    end
+  end
+end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -40,6 +40,9 @@ class Course::Assessment < ActiveRecord::Base
   has_many :programming_questions,
            through: :questions, inverse_through: :question, source: :actable,
            source_type: Course::Assessment::Question::Programming.name
+  has_many :scribing_questions,
+           through: :questions, inverse_through: :question, source: :actable,
+           source_type: Course::Assessment::Question::Scribing.name
   has_many :assessment_conditions, class_name: Course::Condition::Assessment.name,
                                    inverse_of: :assessment, dependent: :destroy
 

--- a/app/models/course/assessment/answer/scribing.rb
+++ b/app/models/course/assessment/answer/scribing.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class Course::Assessment::Answer::Scribing < ActiveRecord::Base
+  acts_as :answer, class_name: Course::Assessment::Answer.name
+
+  def to_partial_path
+    'course/assessment/answer/scribing/scribing'
+  end
+
+  MAX_ATTEMPTING_TIMES = 1000
+  # Returns the attempting times left for current answer.
+  # The max attempting times will be returned if question don't have the limit.
+  #
+  # @return [Integer]
+  def attempting_times_left
+    @times_left ||= begin
+      return MAX_ATTEMPTING_TIMES unless question.actable.attempt_limit
+
+      times = question.actable.attempt_limit - submission.evaluated_or_graded_answers(question).size
+      times = 0 if times < 0
+      times
+    end
+  end
+end

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -88,6 +88,8 @@ module Course::Assessment::AssessmentAbility
         question: { assessment: assessment_course_staff_hash }
     can :manage, Course::Assessment::Question::Programming,
         question: { assessment: assessment_course_staff_hash }
+    can :manage, Course::Assessment::Question::Scribing,
+        question: { assessment: assessment_course_staff_hash }
   end
 
   # Only managers are allowed to publish assessment submission grades

--- a/app/models/course/assessment/question/scribing.rb
+++ b/app/models/course/assessment/question/scribing.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::Scribing < ActiveRecord::Base
+  acts_as :question, class_name: Course::Assessment::Question.name
+
+  def to_partial_path
+    'course/assessment/question/scribing/scribing'
+  end
+
+  def attempt(submission, _last_attempt = nil)
+    answer = submission.scribing_answers.build(submission: submission, question: question)
+    answer.acting_as
+  end
+end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -52,6 +52,9 @@ class Course::Assessment::Submission < ActiveRecord::Base
   has_many :programming_answers,
            through: :answers, inverse_through: :answer, source: :actable,
            source_type: Course::Assessment::Answer::Programming.name
+  has_many :scribing_answers,
+           through: :answers, inverse_through: :answer, source: :actable,
+           source_type: Course::Assessment::Answer::Scribing.name
 
   # @!attribute [r] graders
   #   The graders associated with this submission.

--- a/app/views/course/assessment/answer/scribing/_scribing.html.slim
+++ b/app/views/course/assessment/answer/scribing/_scribing.html.slim
@@ -1,0 +1,1 @@
+- question = scribing.question.specific

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -80,6 +80,11 @@
             = link_to(t('.new_question.programming'),
                       new_course_assessment_question_programming_path(current_course, @assessment),
                       role: 'menuitem')
+          / Uncomment code to create scribing question
+          /li role='presentation'
+          /  = link_to(t('.new_question.scribing'),
+          /            new_course_assessment_question_scribing_path(current_course, @assessment),
+          /            role: 'menuitem')
 
     h3 = t('.questions')
     br

--- a/app/views/course/assessment/question/scribing/_scribing.html.slim
+++ b/app/views/course/assessment/question/scribing/_scribing.html.slim
@@ -1,0 +1,8 @@
+- edit_path = edit_course_assessment_question_scribing_path(current_course, @assessment,
+  scribing)
+- delete_path = course_assessment_question_scribing_path(current_course, @assessment,
+  scribing)
+= render partial: 'course/assessment/questions/question',
+  locals: { question: scribing,
+    edit_path: edit_path,
+    delete_path: delete_path }

--- a/app/views/course/assessment/question/scribing/_scribing_question.html.slim
+++ b/app/views/course/assessment/question/scribing/_scribing_question.html.slim
@@ -1,0 +1,4 @@
+- question = scribing_question.specific
+h3 = format_inline_text(question.display_title)
+= format_html(question.description)
+hr

--- a/app/views/course/assessment/question/scribing/_scribing_question.json.jbuilder
+++ b/app/views/course/assessment/question/scribing/_scribing_question.json.jbuilder
@@ -1,0 +1,11 @@
+json.question do
+  json.(@scribing_question, :id, :title, :description, :staff_only_comments, :maximum_grade,
+    :weight)
+  json.skill_ids @scribing_question.skills.order('LOWER(title) ASC').as_json(only: [:id, :title])
+  json.skills current_course.assessment_skills.order('LOWER(title) ASC') do |skill|
+    json.(skill, :id, :title)
+  end
+
+  json.published_assessment @assessment.published?
+  json.attempt_limit @scribing_question.attempt_limit
+end

--- a/app/views/course/assessment/question/scribing/edit.html.slim
+++ b/app/views/course/assessment/question/scribing/edit.html.slim
@@ -1,0 +1,3 @@
+- add_breadcrumb format_inline_text(@scribing_question.display_title)
+= page_header format_inline_text(@scribing_question.display_title)
+div#scribing-question

--- a/app/views/course/assessment/question/scribing/new.html.slim
+++ b/app/views/course/assessment/question/scribing/new.html.slim
@@ -1,0 +1,3 @@
+- add_breadcrumb :new
+= page_header
+div#scribing-question

--- a/config/locales/en/course/assessment/question/scribing.yml
+++ b/config/locales/en/course/assessment/question/scribing.yml
@@ -1,0 +1,16 @@
+en:
+  course:
+    assessment:
+      question:
+        scribing:
+          new:
+            header: 'New Scribing Question'
+          create:
+            success: 'The scribing question was created.'
+            failure: 'Could not create scribing question.'
+          update:
+            success: 'The scribing question was updated.'
+            failure: 'Could not update scribing question.'
+          destroy:
+            success: 'The scribing question was deleted.'
+            failure: 'Could not delete scribing question: %{error}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,6 +182,7 @@ Rails.application.routes.draw do
             resources :multiple_responses, only: [:new, :create, :edit, :update, :destroy]
             resources :text_responses, only: [:new, :create, :edit, :update, :destroy]
             resources :programming, only: [:new, :create, :edit, :update, :destroy]
+            resources :scribing, only: [:new, :create, :edit, :update, :destroy]
           end
           scope module: :submission do
             resources :submissions, only: [:index, :create, :edit, :update] do

--- a/db/migrate/20170224033224_create_course_assessment_question_scribings.rb
+++ b/db/migrate/20170224033224_create_course_assessment_question_scribings.rb
@@ -1,0 +1,8 @@
+class CreateCourseAssessmentQuestionScribings < ActiveRecord::Migration
+  def change
+    create_table :course_assessment_question_scribings do |t|
+      t.timestamps null: false
+      t.integer :attempt_limit
+    end
+  end
+end

--- a/db/migrate/20170315023554_create_course_assessment_answer_scribings.rb
+++ b/db/migrate/20170315023554_create_course_assessment_answer_scribings.rb
@@ -1,0 +1,6 @@
+class CreateCourseAssessmentAnswerScribings < ActiveRecord::Migration
+  def change
+    create_table :course_assessment_answer_scribings do |t|
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170309094211) do
+ActiveRecord::Schema.define(version: 20170315023554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -283,6 +283,9 @@ ActiveRecord::Schema.define(version: 20170309094211) do
     t.integer "line",    :null=>false
   end
 
+  create_table "course_assessment_answer_scribings", force: :cascade do |t|
+  end
+
   create_table "course_assessment_answer_text_responses", force: :cascade do |t|
     t.text "answer_text"
   end
@@ -310,6 +313,12 @@ ActiveRecord::Schema.define(version: 20170309094211) do
     t.text    "content",     :null=>false
   end
   add_index "course_assessment_question_programming_template_files", ["question_id", "filename"], :name=>"index_course_assessment_question_programming_template_filenames", :unique=>true, :case_sensitive=>false
+
+  create_table "course_assessment_question_scribings", force: :cascade do |t|
+    t.datetime "created_at",    :null=>false
+    t.datetime "updated_at",    :null=>false
+    t.integer  "attempt_limit"
+  end
 
   create_table "course_assessment_question_text_responses", force: :cascade do |t|
     t.boolean "allow_attachment", :default=>false

--- a/spec/controllers/course/assessment/question/scribing_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/scribing_controller_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::ScribingController do
+  render_views
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:scribing_question) { nil }
+    let(:user) { create(:user) }
+    let(:course) { create(:course, creator: user) }
+    let(:assessment) { create(:assessment, course: course) }
+    let(:question_scribing_attributes) do
+      attributes_for(:course_assessment_question_scribings).
+        slice(:title, :description, :staff_only_comments, :maximum_grade,
+              :attempt_limit)
+    end
+    let(:immutable_scribing_question) do
+      create(:course_assessment_question_scribings, assessment: assessment).tap do |question|
+        allow(question).to receive(:save).and_return(false)
+        allow(question).to receive(:destroy).and_return(false)
+      end
+    end
+
+    before do
+      sign_in(user)
+      return unless scribing_question
+      controller.instance_variable_set(:@scribing_question, scribing_question)
+    end
+
+    describe '#create' do
+      subject do
+        request.accept = 'application/json'
+        post :create, course_id: course, assessment_id: assessment,
+                      question_scribing: question_scribing_attributes
+      end
+
+      context 'when saving fails' do
+        let(:scribing_question) { immutable_scribing_question }
+
+        it 'returns the correct status' do
+          subject
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'returns the correct failure message' do
+          subject
+          body = JSON.parse(response.body)
+          # rubocop:disable LineLength
+          expect(body['message']).to eq(I18n.t('course.assessment.question.scribing.create.failure'))
+          # rubocop:enable LineLength
+        end
+      end
+    end
+
+    describe '#update' do
+      subject do
+        request.accept = 'application/json'
+        patch :update, course_id: course, assessment_id: assessment, id: scribing_question,
+                       question_scribing: question_scribing_attributes
+      end
+
+      context 'when the question cannot be saved' do
+        let(:scribing_question) { immutable_scribing_question }
+
+        it 'returns the correct status' do
+          subject
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'returns the correct failure message' do
+          subject
+          body = JSON.parse(response.body)
+          # rubocop:disable LineLength
+          expect(body['message']).to eq(I18n.t('course.assessment.question.scribing.update.failure'))
+          # rubocop:enable LineLength
+        end
+      end
+    end
+
+    describe '#destroy' do
+      let(:scribing_question) { immutable_scribing_question }
+      subject do
+        post :destroy, course_id: course, assessment_id: assessment, id: scribing_question
+      end
+
+      context 'when the question cannot be destroyed' do
+        let(:scribing_question) { immutable_scribing_question }
+
+        it { is_expected.to redirect_to(course_assessment_path(course, assessment)) }
+        it 'sets the correct flash message' do
+          subject
+          expect(flash[:danger]).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/course_assessment_answer_scribings.rb
+++ b/spec/factories/course_assessment_answer_scribings.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_answer_scribings,
+          class: Course::Assessment::Answer::Scribing,
+          parent: :course_assessment_answer do
+    transient do
+      question_traits nil
+    end
+
+    question do
+      build(:course_assessment_question_scribings, *question_traits,
+            assessment: assessment).question
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_scribings.rb
+++ b/spec/factories/course_assessment_question_scribings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_question_scribings,
+          class: Course::Assessment::Question::Scribing,
+          parent: :course_assessment_question do
+    attempt_limit 3
+  end
+end

--- a/spec/models/course/assessment/answer/scribing_spec.rb
+++ b/spec/models/course/assessment/answer/scribing_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Answer::Scribing, type: :model do
+  it { is_expected.to act_as(Course::Assessment::Answer) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+  end
+end

--- a/spec/models/course/assessment/question/scribing_spec.rb
+++ b/spec/models/course/assessment/question/scribing_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::Scribing, type: :model do
+  it { is_expected.to act_as(Course::Assessment::Question) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#attempt' do
+      let(:course) { create(:course) }
+      let(:student_user) { create(:course_student, course: course).user }
+      let(:assessment) { create(:assessment, course: course) }
+      let(:question) { create(:course_assessment_question_scribings, assessment: assessment) }
+      let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+      subject { question }
+
+      it 'returns an Answer' do
+        expect(subject.attempt(submission)).to be_a(Course::Assessment::Answer)
+      end
+
+      it 'associates the answer with the submission' do
+        answer = subject.attempt(submission)
+        expect(submission.scribing_answers).to include(answer.actable)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Models and controller for scribing question creation. 

- Scribing features are still incomplete at this stage.
- PR for frontend is kept separate as it still needs to be changed to redux-form and remove the use of immutable.js

Needs to be merged before #2172 (frontend)