### PR TITLE
Fix specs and reduce random failures  

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true

--- a/spec/services/course/assessment/submission/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/submission/auto_grading_service_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe Course::Assessment::Submission::AutoGradingService do
                  submission: submission)
         end
         before do
+          # Stub #auto_grade_submission so that job is not created upon save
+          allow(submission).to receive(:auto_grade_submission).and_return(true)
           submission.finalise!
           submission.save!
         end


### PR DESCRIPTION
Reference #2161 

Rails autoload is not threadsafe and it fails randomly in our background thread adapter in tests, related to exceptions like `Circular dependency detected while autoloading constant xxx`

REF: http://stackoverflow.com/questions/29439323/rails-4-2-autoloading-not-thread-safe