### PR TITLE
Speed up specs - Faster builds for everyone! 

### DIFF
--- a/spec/factories/course_assessment_question_multiple_response_options.rb
+++ b/spec/factories/course_assessment_question_multiple_response_options.rb
@@ -10,10 +10,12 @@ FactoryGirl.define do
     trait :correct do
       correct true
       option 'Correct'
+      explanation 'Correct because this is correct'
     end
     trait :wrong do
       correct false
       option 'Wrong'
+      explanation 'Wrong because this is wrong'
     end
   end
 end

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -69,8 +69,10 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         correct_option_attributes =
           attributes_for(:course_assessment_question_multiple_response_option, :correct)
         within find('#new_question_multiple_response_option') do
-          find('textarea.multiple-response-option').set correct_option_attributes[:option]
-          find('textarea.multiple-response-explanation').set correct_option_attributes[:explanation]
+          fill_in_rails_summernote '.question_multiple_response_options_option',
+                                   correct_option_attributes[:option]
+          fill_in_rails_summernote '.question_multiple_response_options_explanation',
+                                   correct_option_attributes[:explanation]
         end
 
         click_button I18n.t('helpers.buttons.create')
@@ -86,8 +88,10 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
 
         # Create a correct option
         within find('#new_question_multiple_response_option') do
-          find('textarea.multiple-response-option').set correct_option_attributes[:option]
-          find('textarea.multiple-response-explanation').set correct_option_attributes[:explanation]
+          fill_in_rails_summernote '.question_multiple_response_options_option',
+                                   correct_option_attributes[:option]
+          fill_in_rails_summernote '.question_multiple_response_options_explanation',
+                                   correct_option_attributes[:explanation]
           check find('input[type="checkbox"]')[:name]
         end
 
@@ -124,8 +128,13 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
           click_link I18n.t('course.assessment.question.multiple_responses.form.add_option')
           within all('.edit_question_multiple_response '\
             'tr.question_multiple_response_option')[i] do
-            find('textarea.multiple-response-option').set option[:option]
-            find('textarea.multiple-response-explanation').set option[:explanation]
+            # A custom css selector, :last is added here because +fill_in_rails_summernote+ doesn't
+            # acknowledge the scope defined by capabara.
+            # This works only if +click_link+ is executed before each option.
+            fill_in_rails_summernote '.question_multiple_response_options_option:last',
+                                     option[:option]
+            fill_in_rails_summernote '.question_multiple_response_options_explanation:last',
+                                     option[:explanation]
             if option[:correct]
               check find('input[type="checkbox"]')[:name]
             else

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -24,9 +24,12 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         expect(page).to have_xpath('//form[@id=\'programmming-question-form\']')
         question_attributes = attributes_for(:course_assessment_question_programming)
         fill_in 'question_programming[title]', with: question_attributes[:title]
-        fill_in 'question_programming[description]', with: question_attributes[:description]
-        fill_in 'question_programming[staff_only_comments]',
-                with: question_attributes[:staff_only_comments]
+
+        fill_in_react_summernote 'textarea#question_programming_description',
+                                 question_attributes[:description]
+        fill_in_react_summernote 'textarea#question_programming_staff_only_comments',
+                                 question_attributes[:staff_only_comments]
+
         fill_in 'question_programming[maximum_grade]', with: question_attributes[:maximum_grade]
         within find_field('question_programming[skill_ids][]', visible: false) do
           select skill.title, visible: false
@@ -38,8 +41,12 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         expect(page).to_not have_xpath('//form//*[contains(@class, \'fa-spinner\')]')
         expect(current_path).to eq(course_assessment_path(course, assessment))
 
-        question_created = assessment.questions.first.specific
+        question_created = assessment.questions.first.specific.reload
         expect(page).to have_content_tag_for(question_created)
+        expect(question_created.description).
+          to include(question_attributes[:description])
+        expect(question_created.staff_only_comments).
+          to include(question_attributes[:staff_only_comments])
         expect(question_created.skills).to contain_exactly(skill)
       end
 
@@ -116,7 +123,8 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         expect(page).to have_xpath('//form[@id=\'programmming-question-form\']')
         question_attributes = attributes_for(:course_assessment_question_programming)
         fill_in 'question_programming[title]', with: question_attributes[:title]
-        fill_in 'question_programming[description]', with: question_attributes[:description]
+        fill_in_react_summernote 'textarea#question_programming_description',
+                                 question_attributes[:description]
         fill_in 'question_programming[maximum_grade]', with: question_attributes[:maximum_grade]
         within find_field('question_programming[skill_ids][]', visible: false) do
           select skill.title, visible: false

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
         # Make a first comment
         answer_selector = content_tag_selector(comment_answer)
         comment_post_text = 'test comment'
-        fill_in_summernote answer_selector, comment_post_text
+        fill_in_rails_summernote answer_selector, comment_post_text
         within find(answer_selector) do
           find('.reply-comment').click
         end
@@ -139,7 +139,7 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
 
         # Reply to the first comment
         comment_reply_text = 'test reply'
-        fill_in_summernote answer_selector, comment_reply_text
+        fill_in_rails_summernote answer_selector, comment_reply_text
         within find(answer_selector) do
           find('.reply-comment').click
         end
@@ -155,7 +155,7 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
         find(content_tag_selector(comment_reply)).find('.edit').click
         updated_post_text = 'updated comment'
         edit_form_selector = '.edit-discussion-post-form'
-        fill_in_summernote edit_form_selector, updated_post_text
+        fill_in_rails_summernote edit_form_selector, updated_post_text
         within find(answer_selector).find('.edit-discussion-post-form') do
           click_button I18n.t('javascript.course.discussion.post.submit')
         end
@@ -178,7 +178,7 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
 
         # Should still be able to reply when last comment is deleted
         comment_reply_text = 'another reply'
-        fill_in_summernote answer_selector, comment_reply_text
+        fill_in_rails_summernote answer_selector, comment_reply_text
         within find(answer_selector) do
           find('.reply-comment').click
         end

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
                               'annotation_form.reset'), match: :first
           expect(page).to have_tag('.annotation-form', count: 1)
 
-          fill_in_summernote answer_selector, annotation
+          fill_in_rails_summernote answer_selector, annotation
           click_button I18n.t('javascript.course.assessment.submission.answer.programming.'\
                               'annotation_form.submit')
           wait_for_ajax
@@ -91,7 +91,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
         find(content_tag_selector(annotation.discussion_topic)).find('.reply-annotation').click
 
         annotation_text = 'annotation'
-        fill_in_summernote '.annotation-form', annotation_text
+        fill_in_rails_summernote '.annotation-form', annotation_text
         within find_form('.annotation-form') do
           click_button I18n.t('javascript.course.assessment.submission.answer.programming.'\
                               'annotation_form.submit')
@@ -112,7 +112,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
         find(content_tag_selector(post)).find('.edit').click
 
         annotation_text = 'updated annotation'
-        fill_in_summernote '.edit-discussion-post-form', annotation_text
+        fill_in_rails_summernote '.edit-discussion-post-form', annotation_text
         within find_form('.edit-discussion-post-form') do
           click_button I18n.t('javascript.course.discussion.post.submit')
         end

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Course: Topics: Management' do
         visit course_topics_path(course)
 
         comment = 'GOOD WORK!'
-        fill_in_summernote '.post-form', comment
+        fill_in_rails_summernote '.post-form', comment
         within find('.post-form') do
           click_button 'course.discussion.posts.form.comment'
         end
@@ -100,7 +100,7 @@ RSpec.feature 'Course: Topics: Management' do
         visit course_topics_path(course)
 
         comment = 'THANKS !'
-        fill_in_summernote '.post-form', comment
+        fill_in_rails_summernote '.post-form', comment
         within find('.post-form') do
           click_button I18n.t('course.discussion.posts.form.comment')
         end
@@ -122,7 +122,7 @@ RSpec.feature 'Course: Topics: Management' do
 
         # Reply when last post of topic has just been deleted
         reply_text = 'WELCOME (:'
-        fill_in_summernote '.post-form', reply_text
+        fill_in_rails_summernote '.post-form', reply_text
         within find('.post-form') do
           click_button I18n.t('course.discussion.posts.form.comment')
         end
@@ -148,7 +148,7 @@ RSpec.feature 'Course: Topics: Management' do
 
         new_post_text = 'new post text'
         find(content_tag_selector(my_comment_post)).find('.edit').click
-        fill_in_summernote '.edit-discussion-post-form', new_post_text
+        fill_in_rails_summernote '.edit-discussion-post-form', new_post_text
         within find('.edit-discussion-post-form') do
           click_button I18n.t('javascript.course.discussion.post.submit')
         end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -25,18 +25,39 @@ module Capybara::TestGroupHelpers
       end
     end
 
+    def accept_confirm_dialog
+      find('.confirm-btn').click
+      find('.confirm-btn').click unless page.all('.confirm-btn').empty?
+    end
+
+    # Helper to fill in summernote textareas. Only to be used where javascript is enabled.
+    #
+    # The method provides an alternative method to fill up the textarea, which would
+    # otherwise be very slow if capybara's +find+ and +set+ were used.
     def fill_in_summernote(selector, text)
       script = <<-JS
-      var editorSelector = '#{selector} textarea';
+      var editorSelector = '#{selector}';
       $(editorSelector).summernote('reset');
       $(editorSelector).summernote('editor.insertText', '#{text}');
       JS
       execute_script(script)
     end
 
-    def accept_confirm_dialog
-      find('.confirm-btn').click
-      find('.confirm-btn').click unless page.all('.confirm-btn').empty?
+    # Special helper to fill in summernote textarea defined by react.
+    #
+    # Selector should specify the class of the target +textarea+, and method targets the +div+
+    # within. This should change when the internals of the summernote react component is changed.
+    def fill_in_react_summernote(selector, text)
+      react_selector = ' + div.material-summernote > div[id^="react-summernote-"]'
+      fill_in_summernote(selector + react_selector, text)
+    end
+
+    # Special helper to fill in summernote textarea defined in rails.
+    #
+    # Selector should specify the class of the target +div+, and method targets the textarea within.
+    def fill_in_rails_summernote(selector, text)
+      rails_selector = ' textarea'
+      fill_in_summernote(selector + rails_selector, text)
     end
   end
 end


### PR DESCRIPTION
So I looked into the specs that were taking a long time to run, and most of them came to the same problem, where we were using capybara to fill in textareas where summernote was present. This is slow cause capybara enters character by character, which fired callbacks for each change in character in summernote (learnt this from @jeremyyap 👍 ).

This PR changes those lines to use a helper which speeds tests up quickly. I'm not sure how much of an impact that is on our CI since we have parallelised tests. I've also modified the helper a little as the implementation of rails and react summernote is slightly different. 

Timings for the tests which were fixed: 
```
# Before
Finished in 3 minutes 1.4 seconds (files took 6.35 seconds to load)
5 examples, 0 failures
# After
Finished in 27.59 seconds (files took 5.33 seconds to load)
5 examples, 0 failures
```