### PR TITLE
Strip HTML tags from text response answers & solutions

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -63,7 +63,7 @@
         }
       };
 
-    $('textarea.text').not('.summernote-initialised').each(function(){
+    $('textarea.text').not('.summernote-initialised').each(function() {
       var $summernote = $(this);
       function onImageCompressed(dataUrl) {
         var img = document.createElement('img');

--- a/app/models/course/assessment/answer/text_response.rb
+++ b/app/models/course/assessment/answer/text_response.rb
@@ -13,6 +13,10 @@ class Course::Assessment::Answer::TextResponse < ActiveRecord::Base
     acting_as
   end
 
+  def sanitized_answer_text
+    Sanitize.fragment(answer_text).strip
+  end
+
   def download(dir)
     download_answer(dir) unless question.actable.file_upload_question?
     download_attachment(dir) if attachment
@@ -21,7 +25,7 @@ class Course::Assessment::Answer::TextResponse < ActiveRecord::Base
   def download_answer(dir)
     answer_path = File.join(dir, 'answer.txt')
     File.open(answer_path, 'w') do |file|
-      file.write(answer_text)
+      file.write(sanitized_answer_text)
     end
   end
 

--- a/app/services/course/assessment/answer/text_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_auto_grading_service.rb
@@ -17,7 +17,7 @@ class Course::Assessment::Answer::TextResponseAutoGradingService < \
   #   assigned to the grading.
   def evaluate_answer(answer)
     question = answer.question.actable
-    answer_text = answer.answer_text
+    answer_text = answer.sanitized_answer_text
     exact_matches, keywords = question.solutions.partition(&:exact_match?)
 
     solutions = find_exact_match(answer_text, exact_matches)

--- a/app/services/course/assessment/submission/zip_download_service.rb
+++ b/app/services/course/assessment/submission/zip_download_service.rb
@@ -78,9 +78,9 @@ class Course::Assessment::Submission::ZipDownloadService
       when STUDENTS[:my]
         @course_user.my_students
       when STUDENTS[:phantom]
-        @course_user.course.course_users.students.phantom
+        @assessment.course.course_users.students.phantom
       else
-        @course_user.course.course_users.students.without_phantom_users
+        @assessment.course.course_users.students.without_phantom_users
       end.select(:user_id)
   end
 end

--- a/app/views/course/assessment/question/text_responses/_solution_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_solution_fields.html.slim
@@ -3,8 +3,8 @@
                collection: Course::Assessment::Question::TextResponseSolution.solution_types.keys,
                input_html: { class: ['text-response-solution-type'] },
                label: false
-  td = f.input :solution, label: false, input_html: { class: ['text-response-solution'] }
+  td = f.input :solution, as: :string, label: false, input_html: { class: ['text-response-solution'] }
   td = f.input :grade, label: false, input_html: { class: ['text-response-grade'] }
   td = f.input :explanation, label: false, placeholder: t('.explanation_hint'),
-               input_html: { class: ['text-response-explanation'] }
+               input_html: { class: ['text-response-explanation', 'airmode'] }
   td = link_to_remove_association t('.remove'), f

--- a/spec/factories/course_assessment_answer_text_responses.rb
+++ b/spec/factories/course_assessment_answer_text_responses.rb
@@ -12,14 +12,14 @@ FactoryGirl.define do
             assessment: assessment).question
     end
 
-    answer_text 'xxx'
+    answer_text '<p>xxx</p>'
 
     trait :exact_match do
-      answer_text 'exact match'
+      answer_text '<p>exact match</p>'
     end
 
     trait :keyword do
-      answer_text 'my answer contains keyword match'
+      answer_text '<p>my answer contains keyword match</p>'
     end
 
     trait :no_match do

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -83,13 +83,10 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
           find('a.add_fields', text: link).trigger('click')
           within all('.edit_question_text_response '\
             'tr.question_text_response_solution')[i] do
-            # A custom css selector, :last is added here because +fill_in_rails_summernote+ doesn't
-            # acknowledge the scope defined by capabara.
-            # This works only if +click_link+ is executed before each option.
-            fill_in_rails_summernote '.question_text_response_solutions_solution:last',
-                                     solution[:solution]
+            find('input.text-response-solution').set solution[:solution]
             fill_in_rails_summernote '.question_text_response_solutions_explanation:last',
                                      solution[:explanation]
+
             solution_type = find('select.text-response-solution-type', visible: :all)
             # Twitter Bootstrap hides <select> element and creates a div.
             # The usual #select method is broken as it does not seem to work with hidden elements.


### PR DESCRIPTION
Fixes #2130 

Also includes some fixes for bugs introduced by #2165 
- Instance admins could not download submissions because there was no `course_user`
- HTML tags and base64 images were not stripped from downloaded answers