### PR TITLE
Add tests for survey forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 # Ignore generated code coverage information
 /spec/coverage/*
 /coverage/*
+/client/coverage/*
 
 # Ignore additional themes
 /app/themes/*

--- a/client/app/__test__/setup.js
+++ b/client/app/__test__/setup.js
@@ -1,5 +1,8 @@
 import { IntlProvider, intlShape } from 'react-intl';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import injectTapEventPlugin from 'lib/injectTapEventPlugin';
+
+injectTapEventPlugin();
 
 require('babel-polyfill');
 // Our jquery is from CDN and loaded at runtime, so this is required in test.

--- a/client/app/__test__/setup.js
+++ b/client/app/__test__/setup.js
@@ -7,7 +7,7 @@ const jQuery = require('jquery');
 
 const timeZone = "Asia/Singapore";
 const intlProvider = new IntlProvider({ locale: 'en', timeZone }, {});
-const courseId = 1;
+const courseId = "1";
 
 // Global variables
 global.courseId = courseId;

--- a/client/app/bundles/course/survey/components/FormDialogue.jsx
+++ b/client/app/bundles/course/survey/components/FormDialogue.jsx
@@ -57,6 +57,7 @@ class FormDialogue extends React.Component {
         {...{ disabled }}
       />,
       <FlatButton
+        ref={(button) => { this.submitButton = button; }}
         label={intl.formatMessage(formTranslations.submit)}
         primary
         keyboardFocused

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/index.jsx
@@ -33,7 +33,7 @@ const propTypes = {
   formValues: PropTypes.object,
 };
 
-const SurveyFormDialogue = ({
+const QuestionFormDialogue = ({
   dispatch,
   visible,
   disabled,
@@ -66,6 +66,6 @@ const SurveyFormDialogue = ({
   );
 };
 
-SurveyFormDialogue.propTypes = propTypes;
+QuestionFormDialogue.propTypes = propTypes;
 
-export default connect(mapStateToProps)(SurveyFormDialogue);
+export default connect(mapStateToProps)(QuestionFormDialogue);

--- a/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount, ReactWrapper } from 'enzyme';
+import ReactTestUtils from 'react-addons-test-utils';
+import CourseAPI from 'api/course';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+import storeCreator from '../../../store';
+import NewSurveyButton from '../NewSurveyButton';
+import SurveyFormDialogue from '../../../containers/SurveyFormDialogue';
+
+injectTapEventPlugin();
+
+describe('<NewSurveyButton />', () => {
+  it('injects handlers that allow surveys to be created', () => {
+    const spyCreate = jest.spyOn(CourseAPI.survey.surveys, 'create');
+    const store = storeCreator({ surveys: { surveysFlags: { canCreate: true } } });
+    const contextOptions = {
+      context: { intl, store, muiTheme },
+      childContextTypes: { muiTheme: React.PropTypes.object, intl: intlShape },
+    };
+
+    const newSurveyButton = mount(<NewSurveyButton />, contextOptions);
+    const surveyFormDialogue = mount(<SurveyFormDialogue />, contextOptions);
+
+    // Click 'new survey' button
+    const newSurveyButtonNode = ReactDOM.findDOMNode(newSurveyButton.find('button').node);
+    ReactTestUtils.Simulate.touchTap(newSurveyButtonNode);
+    expect(surveyFormDialogue.find('SurveyFormDialogue').first().props().visible).toBe(true);
+
+    // Fill survey form
+    const survey = {
+      base_exp: 0,
+      start_at: new Date('2016-12-31T16:00:00.000Z'),
+      end_at: new Date('2017-01-07T15:59:00.000Z'),
+      title: 'Funky survey title',
+    };
+    const startAt = '01-01-2017';
+    const dialogInline = surveyFormDialogue.find('RenderToLayer').first().node.layerElement;
+    const surveyForm = new ReactWrapper(dialogInline, true).find('form');
+    const titleInput = surveyForm.find('input[name="title"]');
+    titleInput.simulate('change', { target: { value: survey.title } });
+    const startAtDateInput = surveyForm.find('input[name="start_at"]').first();
+    startAtDateInput.simulate('change', { target: { value: startAt } });
+    startAtDateInput.simulate('blur');
+
+    // Submit survey form
+    const submitButton = surveyFormDialogue.find('FormDialogue').first().node.submitButton;
+    ReactTestUtils.Simulate.touchTap(ReactDOM.findDOMNode(submitButton));
+    expect(spyCreate).toHaveBeenCalledWith({ survey });
+  });
+});

--- a/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
@@ -3,12 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount, ReactWrapper } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import injectTapEventPlugin from 'react-tap-event-plugin';
 import storeCreator from '../../../store';
 import NewSurveyButton from '../NewSurveyButton';
 import SurveyFormDialogue from '../../../containers/SurveyFormDialogue';
-
-injectTapEventPlugin();
 
 describe('<NewSurveyButton />', () => {
   it('injects handlers that allow surveys to be created', () => {

--- a/client/app/bundles/course/survey/pages/SurveyIndex/__test__/index.test.js
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/__test__/index.test.js
@@ -8,7 +8,7 @@ describe('<SurveyIndex />', () => {
     const store = storeCreator({ surveys: {} });
 
     const indexPage = shallow(
-      <SurveyIndex params={{ courseId: courseId.toString() }} />,
+      <SurveyIndex params={{ courseId }} />,
       {
         context: { intl, store, muiTheme },
         childContextTypes: { muiTheme: React.PropTypes.object, intl: intlShape },

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/NewQuestionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/NewQuestionButton.test.jsx
@@ -3,12 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount, ReactWrapper } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import injectTapEventPlugin from 'react-tap-event-plugin';
 import storeCreator from '../../../../store';
 import NewQuestionButton from '../NewQuestionButton';
 import QuestionFormDialogue from '../../../../containers/QuestionFormDialogue';
-
-injectTapEventPlugin();
 
 describe('<NewQuestionButton />', () => {
   it('injects handlers that allow survey questions to be created', () => {
@@ -44,7 +41,9 @@ describe('<NewQuestionButton />', () => {
 
     expect(spyCreate).toHaveBeenCalled();
     const formData = spyCreate.mock.calls[0][0];
-    // Test one by one because jsdom does not support 'FormData#getAll' yet
+    // formData is an instance of FormData. To enumerate all the items, we should be able to use
+    // `#entries` or `#keys`, but jsdom doesn't seem to support these methods yet.
+    // See https://github.com/tmpvar/jsdom/issues/1671
     expect(formData.get('question[question_type]')).toBe('multiple_response');
     expect(formData.get('question[required]')).toBe('false');
     expect(formData.get('question[description]')).toBe(questionText);

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/NewQuestionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/NewQuestionButton.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount, ReactWrapper } from 'enzyme';
+import ReactTestUtils from 'react-addons-test-utils';
+import CourseAPI from 'api/course';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+import storeCreator from '../../../../store';
+import NewQuestionButton from '../NewQuestionButton';
+import QuestionFormDialogue from '../../../../containers/QuestionFormDialogue';
+
+injectTapEventPlugin();
+
+describe('<NewQuestionButton />', () => {
+  it('injects handlers that allow survey questions to be created', () => {
+    const spyCreate = jest.spyOn(CourseAPI.survey.questions, 'create');
+    const store = storeCreator({ surveys: {} });
+    const contextOptions = {
+      context: { intl, store, muiTheme },
+      childContextTypes: { muiTheme: React.PropTypes.object, intl: intlShape },
+    };
+
+    const sectionId = 7;
+    const newQuestionButton = mount(<NewQuestionButton sectionId={sectionId} />, contextOptions);
+    const questionFormDialogue = mount(<QuestionFormDialogue />, contextOptions);
+
+    // Click 'new question' button
+    const newQuestionButtonNode = ReactDOM.findDOMNode(newQuestionButton.find('button').node);
+    ReactTestUtils.Simulate.touchTap(newQuestionButtonNode);
+    expect(questionFormDialogue.find('QuestionFormDialogue').first().props().visible).toBe(true);
+
+    // Fill section form with title
+    const questionText = 'Question: Is it true?';
+    const optionText = 'Yes';
+    const dialogInline = questionFormDialogue.find('RenderToLayer').first().node.layerElement;
+    const questionForm = new ReactWrapper(dialogInline, true).find('form');
+    const descriptionInput = questionForm.find('textarea[name="description"]');
+    descriptionInput.simulate('change', { target: { value: questionText } });
+    const optionInput = questionForm.find('QuestionFormOption').first().find('textarea').last();
+    optionInput.simulate('change', { target: { value: optionText } });
+
+    // Submit question form
+    const submitButton = questionFormDialogue.find('FormDialogue').first().node.submitButton;
+    ReactTestUtils.Simulate.touchTap(ReactDOM.findDOMNode(submitButton));
+
+    expect(spyCreate).toHaveBeenCalled();
+    const formData = spyCreate.mock.calls[0][0];
+    // Test one by one because jsdom does not support 'FormData#getAll' yet
+    expect(formData.get('question[question_type]')).toBe('multiple_response');
+    expect(formData.get('question[required]')).toBe('false');
+    expect(formData.get('question[description]')).toBe(questionText);
+    expect(formData.get('question[options_attributes][0][option]')).toBe(optionText);
+  });
+});

--- a/client/app/bundles/course/survey/pages/SurveyShow/__test__/NewSectionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/__test__/NewSectionButton.test.jsx
@@ -3,12 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount, ReactWrapper } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import injectTapEventPlugin from 'react-tap-event-plugin';
 import storeCreator from '../../../store';
 import NewSectionButton from '../NewSectionButton';
 import SectionFormDialogue from '../../../containers/SectionFormDialogue';
-
-injectTapEventPlugin();
 
 describe('<NewSectionButton />', () => {
   it('injects handlers that allow survey sections to be created', () => {

--- a/client/app/bundles/course/survey/pages/SurveyShow/__test__/NewSectionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/__test__/NewSectionButton.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount, ReactWrapper } from 'enzyme';
+import ReactTestUtils from 'react-addons-test-utils';
+import CourseAPI from 'api/course';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+import storeCreator from '../../../store';
+import NewSectionButton from '../NewSectionButton';
+import SectionFormDialogue from '../../../containers/SectionFormDialogue';
+
+injectTapEventPlugin();
+
+describe('<NewSectionButton />', () => {
+  it('injects handlers that allow survey sections to be created', () => {
+    const spyCreate = jest.spyOn(CourseAPI.survey.sections, 'create');
+    const store = storeCreator({ surveys: {} });
+    const contextOptions = {
+      context: { intl, store, muiTheme },
+      childContextTypes: { muiTheme: React.PropTypes.object, intl: intlShape },
+    };
+    const newSectionButton = mount(<NewSectionButton />, contextOptions);
+    const sectionFormDialogue = mount(<SectionFormDialogue />, contextOptions);
+
+    // Click 'new section' button
+    const newSectionButtonNode = ReactDOM.findDOMNode(newSectionButton.find('button').node);
+    ReactTestUtils.Simulate.touchTap(newSectionButtonNode);
+    expect(sectionFormDialogue.find('SectionFormDialogue').first().props().visible).toBe(true);
+
+    // Fill section form with title
+    const section = { title: 'Funky section title' };
+    const dialogInline = sectionFormDialogue.find('RenderToLayer').first().node.layerElement;
+    const sectionForm = new ReactWrapper(dialogInline, true).find('form');
+    const titleInput = sectionForm.find('input[name="title"]');
+    titleInput.simulate('change', { target: { value: section.title } });
+
+    // Submit section form
+    const submitButton = sectionFormDialogue.find('FormDialogue').first().node.submitButton;
+    ReactTestUtils.Simulate.touchTap(ReactDOM.findDOMNode(submitButton));
+    expect(spyCreate).toHaveBeenCalledWith({ section });
+  });
+});

--- a/client/app/lib/components/ProviderWrapper.jsx
+++ b/client/app/lib/components/ProviderWrapper.jsx
@@ -3,13 +3,12 @@ import { Provider } from 'react-redux';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import { i18nLocale, timeZone } from 'lib/helpers/server-context';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import injectTapEventPlugin from 'react-tap-event-plugin';
+import injectTapEventPlugin from 'lib/injectTapEventPlugin';
 
 import zh from 'react-intl/locale-data/zh';
 
 import translations from '../../../build/locales/locales.json';
 
-// Needed for onTouchTap http://stackoverflow.com/a/34015469/988941
 injectTapEventPlugin();
 
 const propTypes = {

--- a/client/app/lib/injectTapEventPlugin.js
+++ b/client/app/lib/injectTapEventPlugin.js
@@ -1,0 +1,12 @@
+import injectTapEventPlugin from 'react-tap-event-plugin';
+import EventPluginRegistry from 'react-dom/lib/EventPluginRegistry';
+
+/**
+ * Injects tap event plugin if it has not already been injected.
+ */
+export default function () {
+  if (!EventPluginRegistry.registrationNameModules.onTouchTap) {
+    // Needed for onTouchTap http://stackoverflow.com/a/34015469/988941
+    injectTapEventPlugin();
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -13,8 +13,10 @@
     "build:development": "yarn run build:translations && webpack-dev-server",
     "build:translations": "babel-node scripts/aggregate-translations.js",
     "extract-translations": "yarn run build:production && babel-node scripts/extract-translations.js",
-    "lint": "eslint . --ext .js --ext .jsx --cache --ignore-pattern '**/__test__/**' && eslint . --ext .test.js --ext .test.jsx --cache -c .eslintrc.test",
-    "lint-fix": "eslint . --ext .js --ext .jsx --cache --fix --ignore-pattern '**/__test__/**' && eslint . --ext .test.js --ext .test.jsx --cache --fix -c .eslintrc.test"
+    "lint-src": "eslint . --ext .js --ext .jsx --cache --ignore-pattern '**/__test__/**' --ignore-pattern 'coverage/**'",
+    "lint-tests": "eslint . --ext .test.js --ext .test.jsx --cache -c .eslintrc.test",
+    "lint": "yarn run lint-src && yarn run lint-tests",
+    "lint-fix": "yarn run lint-src -- --fix && yarn run lint-tests -- --fix"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
Adds basic tests to check that survey, survey section and survey question forms fire off the appropriate request when submitted.

MaterialUI's `Dialog` does not render the dialog body directly, but instead renders a `RenderToLayer` component that appends the Dialog body to the end of the document body. ~In order to test forms nested in Dialog bodies, this PR manually looks for the forms in `document.body` and works with the HTML Dom Nodes directly instead of manipulating React Elements using Enzyme.~