### PR TITLE
Fix updating exp bug when grading submissions

### DIFF
--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -37,7 +37,7 @@ class Course::Assessment::Answer < ActiveRecord::Base
   validates :submitted_at, presence: true, unless: :attempting?
   validates :submitted_at, :grade, :grader, :graded_at, absence: true, if: :attempting?
   validates :grade, :grader, :graded_at, presence: true, if: :graded?
-  validate :validate_consistent_grade, if: :graded?
+  validate :validate_grade, unless: :attempting?
 
   belongs_to :submission, inverse_of: :answers
   belongs_to :question, class_name: Course::Assessment::Question.name, inverse_of: nil
@@ -135,8 +135,9 @@ class Course::Assessment::Answer < ActiveRecord::Base
     end
   end
 
-  def validate_consistent_grade
+  def validate_grade
     errors.add(:grade, :consistent_grade) if grade.present? && grade > question.maximum_grade
+    errors.add(:grade, :non_negative_grade) if grade.present? && grade < 0
   end
 
   # Ensures that an auto grading record exists for this answer.

--- a/client/app/bundles/course/assessment/submission/calculate-grade-exp.js
+++ b/client/app/bundles/course/assessment/submission/calculate-grade-exp.js
@@ -13,14 +13,17 @@ const MAXIMUM_GRADE_SELECTOR = '.submission-statistics-maximum-grade';
 const TOTAL_GRADE_SELECTOR = '.submission-statistics-total-grade';
 
 /**
-* Update the initial EXP points after page load.
+* Update the initial grade and EXP points after page ready.
 */
-function updateInitialPoints() {
-  const totalGrade = Number($(TOTAL_GRADE_SELECTOR).text());
-  if (isNaN(totalGrade)) { return; }
+function updateInitialGradesAndPoints() {
+  const allGrades = $(GRADE_INPUT_SELECTOR);
+  for (let i = 0, len = allGrades.length; i < len; i++) {
+    updateGradesSummary(allGrades[i].getAttribute('data-answer-id'), allGrades[i].value);
+  }
 
+  const totalGrade = Number($(TOTAL_GRADE_SELECTOR).text());
   const assignedExp = $(POINTS_AWARDED_SELECTOR).val();
-  if (!assignedExp) {
+  if (!isNaN(totalGrade) && !assignedExp) {
     updateExperiencePointsAwarded(totalGrade);
   }
 }
@@ -154,7 +157,7 @@ function getMultiplier() {
   return multiplier;
 }
 
-$(document).ready(updateInitialPoints);
+$(document).ready(updateInitialGradesAndPoints);
 $(document).on('change', MULTI_QUESTION_ASSESSMENT_SELECTOR + GRADE_INPUT_SELECTOR, updateGradesAndPoints);
 $(document).on('change', SINGLE_QUESTION_ASSESSMENT_SELECTOR + GRADE_INPUT_SELECTOR, updateGradesAndPointsSingleQuestion);
 $(document).on('change', '.exp-multiplier input', onMultiplierChange);

--- a/config/locales/en/activerecord/course/assessment/answer.yml
+++ b/config/locales/en/activerecord/course/assessment/answer.yml
@@ -16,3 +16,4 @@ en:
               attemptable_state: 'must be in the attempting state'
             grade:
               consistent_grade: 'must be less than question maximum grade'
+              non_negative_grade: 'cannot be negative'

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -76,11 +76,29 @@ RSpec.describe Course::Assessment::Answer do
             expect(subject).not_to be_valid
             expect(subject.errors[:grade]).not_to be_empty
           end
+        end
+
+        context 'when the answer has a grade' do
+          let(:answers) do
+            ['submitted', 'evaluated', 'graded'].map do |workflow_state|
+              build_stubbed(:course_assessment_answer, workflow_state: workflow_state)
+            end
+          end
 
           it 'must be less than or equal to the question maximum grade' do
-            subject.grade = subject.question.maximum_grade + 1
-            expect(subject).not_to be_valid
-            expect(subject.errors[:grade]).not_to be_empty
+            answers.each do |answer|
+              answer.grade = answer.question.maximum_grade + 1
+              expect(answer).not_to be_valid
+              expect(answer.errors[:grade]).not_to be_empty
+            end
+          end
+
+          it 'cannot be negative' do
+            answers.each do |answer|
+              answer.grade = -1
+              expect(answer).not_to be_valid
+              expect(answer.errors[:grade]).not_to be_empty
+            end
           end
         end
       end


### PR DESCRIPTION
Fixes #2131. 

This PR does 2 things: 
 - Ensure that grades are non-negative (grades cannot be less than 0); 
 - Fix a bug when grading submissions where updating grades after a validation error doesn't lead to an automatic update in the total EXP.

The bug happens because the summary grades were not updated when there are validation failures, hence the calculation of total grade (and hence the total experience points) is not correct. The change does a initialisation of this logic to populate the summary grades when the page is ready. 