### PR TITLE
Stabilise specs

### DIFF
--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         fill_in 'maximum_grade', with: maximum_grade
         click_button I18n.t('helpers.buttons.update')
 
+        message = I18n.t('course.assessment.question.text_responses.update.success')
+        expect(page).to have_selector('div.alert', text: message)
         expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(question.reload.maximum_grade).to eq(maximum_grade)
 
@@ -114,8 +116,8 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         end
         click_button I18n.t('helpers.buttons.update')
 
-        expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).to have_selector('div.alert.alert-success')
+        expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(question.reload.solutions.count).to eq(0)
       end
 

--- a/spec/features/course/assessment/submission/autograded_spec.rb
+++ b/spec/features/course/assessment/submission/autograded_spec.rb
@@ -217,7 +217,9 @@ RSpec.describe 'Course: Assessment: Submissions: Autograded' do
         wait_for_ajax
 
         # Check that attached file is displayed
-        expect(page).to have_selector('a', text: 'text.txt')
+        # find is used here, so that an exception will be raised when fail and rspec will retry
+        # the test.
+        expect(find('a', text: 'text.txt')).to be_present
 
         # Check that attachment is uploaded
         expect(answer.specific.attachment).to be_present

--- a/spec/features/course/lesson_plan_event_management_spec.rb
+++ b/spec/features/course/lesson_plan_event_management_spec.rb
@@ -46,6 +46,7 @@ RSpec.feature 'Course: Events' do
         expect(page).to have_text(event_to_edit.title)
         find("#item-#{event_to_edit.acting_as.id} .admin-button button").click
         find_link(nil, href: edit_course_lesson_plan_event_path(course, event_to_edit)).click
+        expect(page).to have_selector('h1', text: I18n.t('course.lesson_plan.events.edit.header'))
         expect(current_path).to eq(edit_course_lesson_plan_event_path(course, event_to_edit))
       end
 


### PR DESCRIPTION
Addresses #2161

this PR will hopefully resolve the following failures:
```
1.1) Failure/Error: expect(current_path).to eq(course_assessment_path(course, assessment))
          
            expected: "/courses/102/assessments/19"
                 got: "/courses/102/assessments/19/question/text_responses/2/edit"
          
            (compared using ==)
          # ./spec/features/course/assessment/question/text_response_management_spec.rb:76:
```

```
  1) Course: Assessment: Submissions: Autograded with tenant :instance As a Course Student I can add an attachment to a file upload question
     Failure/Error: expect(page).to have_selector('a', text: 'text.txt')
       expected to find css "a" with text "text.txt" but there were no matches. Also found "layout.coursemology", "layout.navbar.courses", "", "", "", "layout.navbar.help", "user 33", "", "", "Course 149001790339", "activerecord.attributes.course/assessment/category/title.default", "Assessment 18", "", "student 10", "layouts.course_user_badge.achievements 0", "layouts.course_user_badge.levels 0", "course.announcements.sidebar_title", "activerecord.attributes.course/assessment/category/title.default", "course.assessment.submissions.sidebar_title", "course.achievement.achievements.sidebar_title", "course.discussion.topics.sidebar_title", "course.leaderboards.sidebar_title", "course.users.sidebar_title", "course.lesson_plan.items.sidebar_title", "course.material.sidebar_title", "course.forum.forums.sidebar_title", "1", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", which matched the selector but not all filters.
     # ./spec/features/course/assessment/submission/autograded_spec.rb:220:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in <top (required)>'
```