### PR TITLE
Show submission counts grouped by submission state

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -19,7 +19,7 @@ $course-assessment-submission-answer-correct-border-color: $state-success-border
 $course-assessment-submission-answer-correct-border-radius: $border-radius-base !default;
 $course-assessment-submission-answer-correct-bg: $state-success-bg !default;
 $course-assessment-submission-answer-correct-border-text: $state-success-text !default;
-$course-assessment-submission-not-started: $red !default;
+$course-assessment-submission-not-started-text: $red !default;
 $course-discussion-post-border: 1px solid $panel-default-border !default;
 $course-discussion-post-border-color: $panel-default-border !default;
 $course-discussion-post-border-radius: $border-radius-base !default;
@@ -30,6 +30,13 @@ $course-forum-unread-highlight: #f8e3e3 !default;
 $course-video-not-started-bg: $gray-lighter !default;
 $course-video-submission-not-started: $red !default;
 
+$course-assessment-submission-state-colors: (
+  not-started: #ffaaaa,
+  attempting: #fffbaa,
+  submitted: #dddddd,
+  graded: #aaeeff,
+  published: #adffaa
+);
 
 //== Fonts
 //

--- a/app/assets/stylesheets/course/assessment/submission/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submission/submissions.scss
@@ -118,7 +118,21 @@
     .submissions {
       .no-submission {
         strong {
-          color: $course-assessment-submission-not-started;
+          color: $course-assessment-submission-not-started-text;
+        }
+      }
+    }
+
+    .submission-state-histogram {
+      border-radius: 10px;
+      display: flex;
+      overflow: hidden;
+      text-align: center;
+
+      @each $submission-state, $color in $course-assessment-submission-state-colors {
+        .#{$submission-state} {
+          background-color: $color;
+          min-width: 50px;
         }
       }
     }

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -15,7 +15,8 @@ class Course::Assessment::Submission::SubmissionsController < \
 
   def index
     authorize!(:manage, @assessment)
-    @submissions = @submissions.includes(:answers, experience_points_record: :course_user)
+    @assessment = @assessment.calculated(:maximum_grade)
+    @submissions = @submissions.includes(:answers)
     @my_students = current_course_user.try(:my_students) || []
     @course_students = current_course.course_users.students.order_alphabetically
     if params[:published_success]

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Course::Assessment::Submission::SubmissionsHelper
   include Course::Assessment::Submission::SubmissionsAutogradedHelper
+  include Course::Assessment::Submission::SubmissionsWorkflowStateHelper
   include Course::Assessment::Answer::ProgrammingHelper
   include Course::Assessment::Answer::ProgrammingTestCaseHelper
 
@@ -60,11 +61,9 @@ module Course::Assessment::Submission::SubmissionsHelper
   # Return the bootstrap panel class based on the status of the submission
   def panel_class
     if @submission.attempting?
-      'panel-info'
-    elsif @submission.submitted?
       'panel-warning'
     elsif @submission.graded?
-      'panel-danger'
+      'panel-info'
     elsif @submission.published?
       'panel-success'
     else

--- a/app/helpers/course/assessment/submission/submissions_workflow_state_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_workflow_state_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 module Course::Assessment::Submission::SubmissionsWorkflowStateHelper
-  # Returns a hash of course_user to submission for searching by course_user
+  # Returns a hash of course_user_id to submission
   #
-  # @return [Hash]
+  # @return [Hash] Hash of submissions by course_user_id
   def submissions_hash
-    @submissions_hash ||= @submissions.map { |s| [s.course_user, s] }.to_h
+    @submissions_hash ||= @submissions.map { |s| [s.course_user_id, s] }.to_h
   end
 
   # Whether there are any confirmed submissions from a group of students
@@ -12,7 +12,8 @@ module Course::Assessment::Submission::SubmissionsWorkflowStateHelper
   # @param [Array<CourseUser>] course_users The course_users to check
   # @return [Boolean] Whether there are any submissions
   def any_confirmed_submissions_by?(course_users)
-    course_users.map { |u| submissions_hash[u] }.any? { |s| s && s.workflow_state != 'attempting' }
+    submissions = course_users.map { |u| submissions_hash[u.id] }
+    submissions.any? { |s| s && s.workflow_state != 'attempting' }
   end
 
   # Returns the list of possible submission states in order
@@ -29,7 +30,7 @@ module Course::Assessment::Submission::SubmissionsWorkflowStateHelper
   # @return [Hash] Hash containing counts for each submission state
   def submission_state_counts(course_users)
     course_users.each_with_object(Hash.new(0)) do |course_user, hash|
-      submission = submissions_hash[course_user]
+      submission = submissions_hash[course_user.id]
       workflow_state = submission ? submission.workflow_state : 'not_started'
       hash[workflow_state] += 1
     end

--- a/app/helpers/course/assessment/submission/submissions_workflow_state_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_workflow_state_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Course::Assessment::Submission::SubmissionsWorkflowStateHelper
+  # Returns a hash of course_user to submission for searching by course_user
+  #
+  # @return [Hash]
+  def submissions_hash
+    @submissions_hash ||= @submissions.map { |s| [s.course_user, s] }.to_h
+  end
+
+  # Whether there are any confirmed submissions from a group of students
+  #
+  # @param [Array<CourseUser>] course_users The course_users to check
+  # @return [Boolean] Whether there are any submissions
+  def any_confirmed_submissions_by?(course_users)
+    course_users.map { |u| submissions_hash[u] }.any? { |s| s && s.workflow_state != 'attempting' }
+  end
+
+  # Returns the list of possible submission states in order
+  # Note: :not_started is not a true workflow state, but the absence of a submission object.
+  #
+  # @return [Array<Symbol>] The possible submission states
+  def submission_state_names
+    Course::Assessment::Submission.workflow_spec.state_names.unshift(:not_started).map(&:to_s)
+  end
+
+  # Returns the count of submissions in each submission state among a group of students.
+  #
+  # @param [Array<CourseUser>] course_users The course_users to count submissions for
+  # @return [Hash] Hash containing counts for each submission state
+  def submission_state_counts(course_users)
+    course_users.each_with_object(Hash.new(0)) do |course_user, hash|
+      submission = submissions_hash[course_user]
+      workflow_state = submission ? submission.workflow_state : 'not_started'
+      hash[workflow_state] += 1
+    end
+  end
+end

--- a/app/views/course/assessment/submission/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submission.html.slim
@@ -1,11 +1,17 @@
+/ @assessment.maximum_grade is a calculated column using a database query
+/ to retrieve the sum of maximum_grade of all questions in the assessment.
+/ This partial uses the controller instance variable @assessment to avoid
+/ recalculating @assessment.maximum_grade for each submission.
+/ In general, accessing instance variables in view partials should be avoided.
+
 = content_tag_for(:tr, submission) do
-  td.col-md-4.col-xs-4 = link_to_course_user(submission.course_user)
+  td.col-md-4.col-xs-4 = link_to_course_user(course_user)
   td.col-md-3.col-xs-3
     = link_to edit_course_assessment_submission_path(current_course, submission.assessment,
                                                      submission) do
       = Course::Assessment::Submission.human_attribute_name(submission.workflow_state)
   td
-    = submission.grade.to_s + ' / ' + submission.assessment.maximum_grade.to_s
+    = submission.grade.to_s + ' / ' + @assessment.maximum_grade.to_s
     - if submission.graded?
       span.text-danger title=t('.graded_not_published_warning')
         =< fa_icon 'exclamation-circle'.freeze

--- a/app/views/course/assessment/submission/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submissions.html.slim
@@ -1,9 +1,20 @@
 h3
   = title
-  - if @assessment.downloadable? && course_users.map { |u| submissions[u] }.any? { |s| s && s.workflow_state != 'attempting' }
+  - if @assessment.downloadable? && any_confirmed_submissions_by?(course_users)
     div.pull-right
       = link_to t('.download'), download_all_course_assessment_submissions_path(current_course, @assessment, students: students),
             class: ['btn', 'btn-primary', 'download']
+
+- if students.nil? && course_users.any?
+  br
+  div.submission-state-histogram
+    - workflow_state_counts = submission_state_counts(course_users)
+    - submission_state_names.each do |state|
+      - count = workflow_state_counts[state]
+      - if count > 0
+        div class="#{state.dasherize}" style="flex: #{count}" title=Course::Assessment::Submission.human_attribute_name(state)
+          = count
+  br
 
 table.table.submissions
   thead
@@ -16,7 +27,7 @@ table.table.submissions
       th
   tbody
     - course_users.each do |course_user|
-      - if submissions[course_user]
-        = render partial: 'submission', object: submissions[course_user]
+      - if submissions_hash[course_user]
+        = render partial: 'submission', object: submissions_hash[course_user]
       - else
         = render partial: 'no_submission', locals: { course_user: course_user }

--- a/app/views/course/assessment/submission/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submission/submissions/_submissions.html.slim
@@ -27,7 +27,7 @@ table.table.submissions
       th
   tbody
     - course_users.each do |course_user|
-      - if submissions_hash[course_user]
-        = render partial: 'submission', object: submissions_hash[course_user]
+      - if submissions_hash[course_user.id]
+        = render partial: 'submission', object: submissions_hash[course_user.id], locals: { course_user: course_user }
       - else
         = render partial: 'no_submission', locals: { course_user: course_user }

--- a/app/views/course/assessment/submission/submissions/index.html.slim
+++ b/app/views/course/assessment/submission/submissions/index.html.slim
@@ -2,21 +2,21 @@
 = page_header format_inline_text(@assessment.title) do
   - can_publish_grades = can?(:publish_all, Course::Assessment::Submission.new(assessment: @assessment))
   - if can_publish_grades && @assessment.delayed_grade_publication?
-    = link_to t('.publish'), publish_all_course_assessment_submissions_path(current_course, @assessment),
-        class: ['btn', 'btn-danger'], method: :patch, data: { confirm: t('.confirm_publish') }
+    = link_to publish_all_course_assessment_submissions_path(current_course, @assessment),
+        class: ['btn', 'btn-success'], method: :patch, data: { confirm: t('.confirm_publish') } do
+      = t('.publish')
 
-- submissions = @submissions.map { |s| [s.course_user, s] }.to_h
 - types = Course::Assessment::Submission::ZipDownloadService::STUDENTS
 
 - if !@my_students.empty?
-  = render partial: 'submissions', object: submissions,
+  = render partial: 'submissions',
       locals: { course_users: @my_students, title: t('.my_student_header'), students: types[:my] }
 
 - students = @course_students.without_phantom_users
-= render partial: 'submissions', object: submissions,
+= render partial: 'submissions',
     locals: { course_users: students, title: t('.student_header'), students: nil }
 
 - other_users = @course_students - students
-= render partial: 'submissions', object: submissions,
+= render partial: 'submissions',
     locals: { course_users: other_users, title: t('.other_header'), students: types[:phantom] }
 end


### PR DESCRIPTION
Resolves #2069

<img width="1185" alt="screen shot 2017-03-28 at 5 56 27 pm" src="https://cloud.githubusercontent.com/assets/4056819/24399620/e97eb1aa-13df-11e7-893f-d5f0dca26f18.png">

The relative size of each section is proportional to the fraction of submissions in each workflow state, with some minimum widths applied. The submission state each section represents appears as a tooltip when hovering over the section.

Submission state panels have had their colours updated to match the color scheme used for the histogram:

| State | Original Color | New Color |
| --- | --- | --- |
| Attempting | Blue | Yellow |
| Submitted | Yellow | Grey |
| Graded | Red | Blue |
| Published | Green | Green |

Also extracted out some of the logic in submission show page and put them into a new helper.
