### PR TITLE
Frontend housekeeping

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -21,6 +21,7 @@
     // Use `_` to indicate that the method is private
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-underscore-dangle": 0,
+    "func-names": 0,
   },
   "globals": {
     "window": true,

--- a/client/app/api/Base.js
+++ b/client/app/api/Base.js
@@ -11,8 +11,9 @@ export default class BaseAPI {
     if (this.client) return this.client;
 
     const headers = { Accept: 'application/json', 'X-CSRF-Token': csrfToken };
+    const params = { format: 'json' };
 
-    this.client = axios.create({ headers });
+    this.client = axios.create({ headers, params });
     return this.client;
   }
 }

--- a/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ProgrammingQuestionForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';

--- a/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTemplateView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTemplateView.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';

--- a/client/app/bundles/course/survey/__test__/index.test.js
+++ b/client/app/bundles/course/survey/__test__/index.test.js
@@ -6,8 +6,8 @@ import MockAdapter from 'axios-mock-adapter';
 import ReactTestUtils from 'react-addons-test-utils';
 import ProviderWrapper from 'lib/components/ProviderWrapper';
 import CourseAPI from 'api/course';
-import storeCreator from '../store';
-import routes from '../routes';
+import storeCreator from 'course/survey/store';
+import routes from 'course/survey/routes';
 
 // Mock axios
 const client = CourseAPI.survey.surveys.getClient();

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionForm.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionForm.jsx
@@ -8,10 +8,10 @@ import Toggle from 'lib/components/redux-form/Toggle';
 import DisplayTextField from 'material-ui/TextField';
 import Subheader from 'material-ui/Subheader';
 import formTranslations from 'lib/translations/form';
+import translations from 'course/survey/translations';
+import { questionTypes, formNames } from 'course/survey/constants';
 import QuestionFormOptions from './QuestionFormOptions';
 import QuestionFormDeletedOptions from './QuestionFormDeletedOptions';
-import translations from '../../translations';
-import { questionTypes, formNames } from '../../constants';
 
 const styles = {
   description: {

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormDeletedOptions.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormDeletedOptions.jsx
@@ -4,7 +4,7 @@ import RadioButton from 'material-ui/RadioButton';
 import IconButton from 'material-ui/IconButton';
 import CloseIcon from 'material-ui/svg-icons/navigation/close';
 import { grey600 } from 'material-ui/styles/colors';
-import Thumbnail from '../../components/Thumbnail';
+import Thumbnail from 'course/survey/components/Thumbnail';
 
 const styles = {
   option: {

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormOption.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormOption.jsx
@@ -8,7 +8,7 @@ import CloseIcon from 'material-ui/svg-icons/navigation/close';
 import PhotoIcon from 'material-ui/svg-icons/image/photo';
 import TextField from 'lib/components/redux-form/TextField';
 import { grey700, grey600 } from 'material-ui/styles/colors';
-import Thumbnail from '../../components/Thumbnail';
+import Thumbnail from 'course/survey/components/Thumbnail';
 
 const optionTranslations = defineMessages({
   optionPlaceholder: {

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormOptions.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionFormOptions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import React, { PropTypes } from 'react';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import FlatButton from 'material-ui/FlatButton';

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/index.jsx
@@ -2,9 +2,9 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues, isPristine } from 'redux-form';
-import { formNames } from '../../constants';
-import * as actionCreators from '../../actions/questions';
-import FormDialogue from '../../components/FormDialogue';
+import { formNames } from 'course/survey/constants';
+import * as actionCreators from 'course/survey/actions/questions';
+import FormDialogue from 'course/survey/components/FormDialogue';
 import QuestionForm from './QuestionForm';
 
 function mapStateToProps({ questionForm, ...state }) {

--- a/client/app/bundles/course/survey/containers/SectionFormDialogue/SectionForm.jsx
+++ b/client/app/bundles/course/survey/containers/SectionFormDialogue/SectionForm.jsx
@@ -3,8 +3,8 @@ import { injectIntl, intlShape } from 'react-intl';
 import { reduxForm, Field, Form } from 'redux-form';
 import TextField from 'lib/components/redux-form/TextField';
 import formTranslations from 'lib/translations/form';
-import translations from '../../translations';
-import { formNames } from '../../constants';
+import translations from 'course/survey/translations';
+import { formNames } from 'course/survey/constants';
 
 const styles = {
   title: {

--- a/client/app/bundles/course/survey/containers/SectionFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/SectionFormDialogue/index.jsx
@@ -2,11 +2,11 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { isPristine } from 'redux-form';
-import * as actionCreators from '../../actions/sections';
-import FormDialogue from '../../components/FormDialogue';
-import { formNames } from '../../constants';
+import * as actionCreators from 'course/survey/actions/sections';
+import FormDialogue from 'course/survey/components/FormDialogue';
+import { formNames } from 'course/survey/constants';
+import { sectionShape } from 'course/survey/propTypes';
 import SectionForm from './SectionForm';
-import { sectionShape } from '../../propTypes';
 
 function mapStateToProps({ sectionForm, ...state }) {
   return {

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -4,8 +4,8 @@ import { reduxForm, Field, Form } from 'redux-form';
 import TextField from 'lib/components/redux-form/TextField';
 import DateTimePicker from 'lib/components/redux-form/DateTimePicker';
 import formTranslations from 'lib/translations/form';
-import translations from '../../translations';
-import { formNames } from '../../constants';
+import translations from 'course/survey/translations';
+import { formNames } from 'course/survey/constants';
 
 const styles = {
   title: {

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
@@ -2,10 +2,10 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues, isPristine } from 'redux-form';
-import * as actionCreators from '../../actions/surveys';
-import FormDialogue from '../../components/FormDialogue';
+import * as actionCreators from 'course/survey/actions/surveys';
+import FormDialogue from 'course/survey/components/FormDialogue';
+import { formNames } from 'course/survey/constants';
 import SurveyForm from './SurveyForm';
-import { formNames } from '../../constants';
 
 function mapStateToProps({ surveyForm, ...state }) {
   return {

--- a/client/app/bundles/course/survey/containers/SurveyLayout/DeleteConfirmation.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyLayout/DeleteConfirmation.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
-import { resetDeleteConfirmation } from '../../actions';
+import { resetDeleteConfirmation } from 'course/survey/actions';
 
 const DeleteConfirmation = ({ dispatch, deleteConfirmation }) => (
   <ConfirmationDialog

--- a/client/app/bundles/course/survey/containers/SurveyLayout/index.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyLayout/index.jsx
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import NotificationBar, { notificationShape } from 'lib/components/NotificationBar';
-import SurveyFormDialogue from '../../containers/SurveyFormDialogue';
-import QuestionFormDialogue from '../../containers/QuestionFormDialogue';
-import SectionFormDialogue from '../../containers/SectionFormDialogue';
+import SurveyFormDialogue from 'course/survey/containers/SurveyFormDialogue';
+import QuestionFormDialogue from 'course/survey/containers/QuestionFormDialogue';
+import SectionFormDialogue from 'course/survey/containers/SectionFormDialogue';
 import DeleteConfirmation from './DeleteConfirmation';
 
 const SurveyLayout = ({ notification, children }) => (

--- a/client/app/bundles/course/survey/pages/ResponseShow/ResponseAnswer.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/ResponseAnswer.jsx
@@ -5,8 +5,8 @@ import { Card, CardText } from 'material-ui/Card';
 import { red500 } from 'material-ui/styles/colors';
 import TextField from 'lib/components/redux-form/TextField';
 import Checkbox from 'lib/components/redux-form/Checkbox';
-import { questionTypes } from '../../constants';
-import OptionsListItem from '../../components/OptionsListItem';
+import { questionTypes } from 'course/survey/constants';
+import OptionsListItem from 'course/survey/components/OptionsListItem';
 
 const styles = {
   textResponse: {

--- a/client/app/bundles/course/survey/pages/ResponseShow/ResponseForm.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/ResponseForm.jsx
@@ -3,8 +3,8 @@ import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { reduxForm, FieldArray, Form } from 'redux-form';
 import RaisedButton from 'material-ui/RaisedButton';
 import formTranslations from 'lib/translations/form';
-import { questionTypes, formNames } from '../../constants';
-import { responseShape } from '../../propTypes';
+import { questionTypes, formNames } from 'course/survey/constants';
+import { responseShape } from 'course/survey/propTypes';
 import ResponseSection from './ResponseSection';
 
 const styles = {

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
 import MockAdapter from 'axios-mock-adapter';
-import storeCreator from '../../../store';
+import storeCreator from 'course/survey/store';
 import ResponseShow from '../index';
 
 const client = CourseAPI.survey.responses.getClient();

--- a/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
@@ -8,10 +8,10 @@ import { Card, CardText } from 'material-ui/Card';
 import TitleBar from 'lib/components/TitleBar';
 import Subheader from 'material-ui/Subheader';
 import ArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
-import { questionTypes } from '../../constants';
-import surveyTranslations from '../../translations';
-import { surveyShape, responseShape } from '../../propTypes';
-import { fetchResponse, updateResponse } from '../../actions/responses';
+import { questionTypes } from 'course/survey/constants';
+import surveyTranslations from 'course/survey/translations';
+import { surveyShape, responseShape } from 'course/survey/propTypes';
+import { fetchResponse, updateResponse } from 'course/survey/actions/responses';
 import ResponseForm from './ResponseForm';
 
 const translations = defineMessages({

--- a/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
@@ -2,8 +2,8 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { aWeekStartingTomorrow } from 'lib/date-time-defaults';
-import { showSurveyForm, createSurvey } from '../../actions/surveys';
-import AddButton from '../../components/AddButton';
+import { showSurveyForm, createSurvey } from 'course/survey/actions/surveys';
+import AddButton from 'course/survey/components/AddButton';
 
 const translations = defineMessages({
   newSurvey: {

--- a/client/app/bundles/course/survey/pages/SurveyIndex/SurveysTable.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/SurveysTable.jsx
@@ -6,10 +6,10 @@ import { standardDateFormat } from 'lib/date-time-defaults';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import Toggle from 'material-ui/Toggle';
 import RaisedButton from 'material-ui/RaisedButton';
-import translations from '../../translations';
-import { surveyShape } from '../../propTypes';
-import { updateSurvey } from '../../actions/surveys';
-import RespondButton from '../../containers/RespondButton';
+import translations from 'course/survey/translations';
+import { surveyShape } from 'course/survey/propTypes';
+import { updateSurvey } from 'course/survey/actions/surveys';
+import RespondButton from 'course/survey/containers/RespondButton';
 
 const styles = {
   tableBody: {

--- a/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
@@ -3,9 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount, ReactWrapper } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import storeCreator from '../../../store';
+import storeCreator from 'course/survey/store';
+import SurveyFormDialogue from 'course/survey/containers/SurveyFormDialogue';
 import NewSurveyButton from '../NewSurveyButton';
-import SurveyFormDialogue from '../../../containers/SurveyFormDialogue';
 
 describe('<NewSurveyButton />', () => {
   it('injects handlers that allow surveys to be created', () => {

--- a/client/app/bundles/course/survey/pages/SurveyIndex/__test__/index.test.js
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/__test__/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import storeCreator from '../../../store';
+import storeCreator from 'course/survey/store';
 import SurveyIndex from '../index';
 
 describe('<SurveyIndex />', () => {

--- a/client/app/bundles/course/survey/pages/SurveyIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/index.jsx
@@ -3,11 +3,11 @@ import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import Subheader from 'material-ui/Subheader';
 import TitleBar from 'lib/components/TitleBar';
-import { fetchSurveys } from '../../actions/surveys';
+import { fetchSurveys } from 'course/survey/actions/surveys';
+import surveyTranslations from 'course/survey/translations';
+import { surveyShape } from 'course/survey/propTypes';
 import SurveysTable from './SurveysTable';
 import NewSurveyButton from './NewSurveyButton';
-import surveyTranslations from '../../translations';
-import { surveyShape } from '../../propTypes';
 
 const translations = defineMessages({
   noSurveys: {

--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
@@ -4,10 +4,10 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import Toggle from 'material-ui/Toggle';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import { cyan500, grey50, grey300 } from 'material-ui/styles/colors';
-import { sorts } from '../../utils';
-import { questionTypes } from '../../constants';
-import { optionShape } from '../../propTypes';
-import Thumbnail from '../../components/Thumbnail';
+import { sorts } from 'course/survey/utils';
+import { questionTypes } from 'course/survey/constants';
+import { optionShape } from 'course/survey/propTypes';
+import Thumbnail from 'course/survey/components/Thumbnail';
 
 
 const styles = {

--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsSection.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsSection.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { Card, CardText, CardTitle } from 'material-ui/Card';
-import { sectionShape } from '../../propTypes';
+import { sectionShape } from 'course/survey/propTypes';
 import ResultsQuestion from './ResultsQuestion';
 
 const styles = {

--- a/client/app/bundles/course/survey/pages/SurveyResults/__test__/index.test.js
+++ b/client/app/bundles/course/survey/pages/SurveyResults/__test__/index.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import CourseAPI from 'api/course';
 import MockAdapter from 'axios-mock-adapter';
-import storeCreator from '../../../store';
+import storeCreator from 'course/survey/store';
 import SurveyResults from '../index';
 
 const client = CourseAPI.survey.surveys.getClient();

--- a/client/app/bundles/course/survey/pages/SurveyResults/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/index.jsx
@@ -8,10 +8,10 @@ import Subheader from 'material-ui/Subheader';
 import Toggle from 'material-ui/Toggle';
 import { Card, CardText } from 'material-ui/Card';
 import ArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
-import surveyTranslations from '../../translations';
-import { fetchResults } from '../../actions/surveys';
+import surveyTranslations from 'course/survey/translations';
+import { fetchResults } from 'course/survey/actions/surveys';
+import { surveyShape, sectionShape } from 'course/survey/propTypes';
 import ResultsSection from './ResultsSection';
-import { surveyShape, sectionShape } from '../../propTypes';
 
 const translations = defineMessages({
   includePhantoms: {

--- a/client/app/bundles/course/survey/pages/SurveyShow/NewSectionButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/NewSectionButton.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import RaisedButton from 'material-ui/RaisedButton';
-import { showSectionForm, createSurveySection } from '../../actions/sections';
+import { showSectionForm, createSurveySection } from 'course/survey/actions/sections';
 
 const translations = defineMessages({
   newSection: {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/DeleteSectionButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/DeleteSectionButton.jsx
@@ -2,8 +2,8 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import FlatButton from 'material-ui/FlatButton';
-import { showDeleteConfirmation } from '../../../actions';
-import { deleteSurveySection } from '../../../actions/sections';
+import { showDeleteConfirmation } from 'course/survey/actions';
+import { deleteSurveySection } from 'course/survey/actions/sections';
 
 const translations = defineMessages({
   deleteSection: {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/EditSectionButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/EditSectionButton.jsx
@@ -2,8 +2,8 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import FlatButton from 'material-ui/FlatButton';
-import { showSectionForm, updateSurveySection } from '../../../actions/sections';
-import { sectionShape } from '../../../propTypes';
+import { showSectionForm, updateSurveySection } from 'course/survey/actions/sections';
+import { sectionShape } from 'course/survey/propTypes';
 
 const translations = defineMessages({
   editSection: {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/NewQuestionButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/NewQuestionButton.jsx
@@ -2,9 +2,9 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import FlatButton from 'material-ui/FlatButton';
-import { showQuestionForm, createSurveyQuestion } from '../../../actions/questions';
-import { questionTypes } from '../../../constants';
-import { formatQuestionFormData } from '../../../utils';
+import { showQuestionForm, createSurveyQuestion } from 'course/survey/actions/questions';
+import { questionTypes } from 'course/survey/constants';
+import { formatQuestionFormData } from 'course/survey/utils';
 
 const translations = defineMessages({
   newQuestion: {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/Question.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/Question.jsx
@@ -3,12 +3,12 @@ import React, { PropTypes } from 'react';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { connect } from 'react-redux';
 import { DragSource, DropTarget } from 'react-dnd';
-import { showDeleteConfirmation } from '../../../actions';
-import { formatQuestionFormData } from '../../../utils';
-import { questionShape } from '../../../propTypes';
-import { draggableTypes } from '../../../constants';
+import { showDeleteConfirmation } from 'course/survey/actions';
+import { formatQuestionFormData } from 'course/survey/utils';
+import { questionShape } from 'course/survey/propTypes';
+import { draggableTypes } from 'course/survey/constants';
+import * as questionActions from 'course/survey/actions/questions';
 import QuestionCard from './QuestionCard';
-import * as questionActions from '../../../actions/questions';
 
 const translations = defineMessages({
   editQuestion: {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
@@ -8,10 +8,10 @@ import IconButton from 'material-ui/IconButton';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
-import { questionTypes } from '../../../constants';
-import { questionShape } from '../../../propTypes';
-import translations from '../../../translations';
-import OptionsListItem from '../../../components/OptionsListItem';
+import { questionTypes } from 'course/survey/constants';
+import { questionShape } from 'course/survey/propTypes';
+import translations from 'course/survey/translations';
+import OptionsListItem from 'course/survey/components/OptionsListItem';
 
 const styles = {
   optionWidget: {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/SectionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/SectionCard.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Card, CardText, CardTitle, CardActions } from 'material-ui/Card';
 import Subheader from 'material-ui/Subheader';
-import { surveyShape, sectionShape } from '../../../propTypes';
+import { surveyShape, sectionShape } from 'course/survey/propTypes';
 import Question from './Question';
 import NewQuestionButton from './NewQuestionButton';
 import EditSectionButton from './EditSectionButton';

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/DeleteSectionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/DeleteSectionButton.test.jsx
@@ -3,9 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import storeCreator from '../../../../store';
+import storeCreator from 'course/survey/store';
+import DeleteConfirmation from 'course/survey/containers/SurveyLayout/DeleteConfirmation';
 import DeleteSectionButton from '../DeleteSectionButton';
-import DeleteConfirmation from '../../../../containers/SurveyLayout/DeleteConfirmation';
 
 describe('<DeleteSectionButton />', () => {
   it('injects handlers that allow survey sections to be deleted', () => {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/EditSectionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/EditSectionButton.test.jsx
@@ -3,9 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount, ReactWrapper } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import storeCreator from '../../../../store';
+import storeCreator from 'course/survey/store';
+import SectionFormDialogue from 'course/survey/containers/SectionFormDialogue';
 import EditSectionButton from '../EditSectionButton';
-import SectionFormDialogue from '../../../../containers/SectionFormDialogue';
 
 const section = {
   id: 3,

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/NewQuestionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/__test__/NewQuestionButton.test.jsx
@@ -3,9 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount, ReactWrapper } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import storeCreator from '../../../../store';
+import storeCreator from 'course/survey/store';
+import QuestionFormDialogue from 'course/survey/containers/QuestionFormDialogue';
 import NewQuestionButton from '../NewQuestionButton';
-import QuestionFormDialogue from '../../../../containers/QuestionFormDialogue';
 
 describe('<NewQuestionButton />', () => {
   it('injects handlers that allow survey questions to be created', () => {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/index.jsx
@@ -2,8 +2,8 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { DropTarget } from 'react-dnd';
-import { draggableTypes } from '../../../constants';
-import { changeSection } from '../../../actions/questions';
+import { draggableTypes } from 'course/survey/constants';
+import { changeSection } from 'course/survey/actions/questions';
 import SectionCard from './SectionCard';
 
 class Section extends React.Component {

--- a/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
@@ -13,10 +13,10 @@ import ArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import { formatDateTime } from 'lib/date-time-defaults';
 import TitleBar from 'lib/components/TitleBar';
-import surveyTranslations from '../../translations';
-import { surveyShape } from '../../propTypes';
-import { updateSurvey } from '../../actions/surveys';
-import RespondButton from '../../containers/RespondButton';
+import surveyTranslations from 'course/survey/translations';
+import { surveyShape } from 'course/survey/propTypes';
+import { updateSurvey } from 'course/survey/actions/surveys';
+import RespondButton from 'course/survey/containers/RespondButton';
 import NewSectionButton from './NewSectionButton';
 
 const translations = defineMessages({

--- a/client/app/bundles/course/survey/pages/SurveyShow/__test__/NewSectionButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/__test__/NewSectionButton.test.jsx
@@ -3,9 +3,9 @@ import ReactDOM from 'react-dom';
 import { mount, ReactWrapper } from 'enzyme';
 import ReactTestUtils from 'react-addons-test-utils';
 import CourseAPI from 'api/course';
-import storeCreator from '../../../store';
+import storeCreator from 'course/survey/store';
+import SectionFormDialogue from 'course/survey/containers/SectionFormDialogue';
 import NewSectionButton from '../NewSectionButton';
-import SectionFormDialogue from '../../../containers/SectionFormDialogue';
 
 describe('<NewSectionButton />', () => {
   it('injects handlers that allow survey sections to be created', () => {

--- a/client/app/bundles/course/survey/pages/SurveyShow/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/__test__/index.test.jsx
@@ -5,7 +5,7 @@ import CourseAPI from 'api/course';
 import MockAdapter from 'axios-mock-adapter';
 import TestBackend from 'react-dnd-test-backend';
 import { DragDropContext } from 'react-dnd';
-import storeCreator from '../../../store';
+import storeCreator from 'course/survey/store';
 import { ConnectedSurveyShow } from '../index';
 
 // Mock axios

--- a/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
@@ -5,9 +5,9 @@ import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import Subheader from 'material-ui/Subheader';
-import { showDeleteConfirmation } from '../../actions';
-import surveyTranslations from '../../translations';
-import * as surveyActions from '../../actions/surveys';
+import { showDeleteConfirmation } from 'course/survey/actions';
+import surveyTranslations from 'course/survey/translations';
+import * as surveyActions from 'course/survey/actions/surveys';
 import SurveyDetails from './SurveyDetails';
 import Section from './Section';
 

--- a/client/app/lib/axios.js
+++ b/client/app/lib/axios.js
@@ -2,6 +2,7 @@ import originAxios from 'axios';
 import { csrfToken } from 'lib/helpers/server-context';
 
 const headers = { Accept: 'application/json', 'X-CSRF-Token': csrfToken };
+const params = { format: 'json' };
 
-const axios = originAxios.create({ headers });
+const axios = originAxios.create({ headers, params });
 export default axios;

--- a/client/app/lib/components/redux-form/Toggle.jsx
+++ b/client/app/lib/components/redux-form/Toggle.jsx
@@ -9,17 +9,15 @@ const errorStyle = {
 };
 
 // Toggle implementation with an error displayed at the bottom.
-const Toggle = function ({ errorText, ...props }) {
-  return (
-    <div>
-      <MaterialToggle {...props} />
-      {
+const Toggle = ({ errorText, ...props }) => (
+  <div>
+    <MaterialToggle {...props} />
+    {
         errorText &&
         <div style={errorStyle}>{errorText}</div>
       }
-    </div>
-  );
-};
+  </div>
+);
 
 Toggle.propTypes = {
   errorText: PropTypes.string,

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,8 @@
     "moduleNameMapper": {
       "^api(.*)$": "<rootDir>/app/api$1",
       "^lib(.*)$": "<rootDir>/app/lib$1",
-      "^utils(.*)$": "<rootDir>/app/__test__/utils$1"
+      "^utils(.*)$": "<rootDir>/app/__test__/utils$1",
+      "^course(.*)$": "<rootDir>/app/bundles/course$1"
     },
     "coveragePathIgnorePatterns": ["/node_modules/", "/__test__/"]
   },

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -61,6 +61,7 @@ const config = {
     alias: {
       lib: path.resolve('./app/lib'),
       api: path.resolve('./app/api'),
+      course: path.resolve('./app/bundles/course'),
     },
   },
 


### PR DESCRIPTION
- Reduce noise when linting.
- Avoid long `../../../` chains when doing imports for survey mini-app. Survey nesting is getting a little deep.
- Append `?format=json` to URL for json requests so that hitting the back button to go to front end pages do not result in raw JSON data being shown.