### PR TITLE
Course duplication job

### DIFF
--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -5,10 +5,13 @@ class Course::DuplicationsController < Course::ComponentController
   def show; end
 
   def create
-    if duplicate
-      redirect_to course_duplication_path(current_course), success: t('.duplicating')
-    else
-      redirect_to course_duplication_path(current_course), danger: t('.failed')
+    # when selectable duplication is implemented, pass in additional arrays for all_objects
+    # and selected_objects
+    job = Course::DuplicationJob.perform_later(current_course, current_user,
+                                               create_duplication_params).job
+    respond_to do |format|
+      format.html { redirect_to(job_path(job)) }
+      format.json { render json: { redirect_url: job_path(job) } }
     end
   end
 
@@ -22,15 +25,5 @@ class Course::DuplicationsController < Course::ComponentController
 
   def create_duplication_params # :nodoc
     params.require(:duplication).permit(:new_course_start_date, :new_course_title)
-  end
-
-  # Creates a duplication job for the course
-  #
-  # @return [Boolean] True if the duplication was successful.
-  def duplicate
-    # when selectable duplication is implemented, pass in additional arrays for all_objects
-    # and selected_objects
-    job = Course::DuplicationJob.perform_later(current_course, current_user,
-                                               create_duplication_params).job
   end
 end

--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
 class Course::DuplicationsController < Course::ComponentController
   before_action :authorize_duplication
 
-  def show
-  end
+  def show; end
 
   def create
     if duplicate
@@ -24,23 +24,13 @@ class Course::DuplicationsController < Course::ComponentController
     params.require(:duplication).permit(:new_course_start_date, :new_course_title)
   end
 
-  # Duplicates the course via the service object
+  # Creates a duplication job for the course
   #
   # @return [Boolean] True if the duplication was successful.
   def duplicate
-    duplication_service.duplicate
-  end
-
-  # Create a duplication service object for this object.
-  #
-  # @return [Course::DuplicationService]
-  def duplication_service
     # when selectable duplication is implemented, pass in additional arrays for all_objects
     # and selected_objects
-    @duplication_service ||= Course::DuplicationService.new(
-      current_course,
-      current_user,
-      create_duplication_params
-    )
+    job = Course::DuplicationJob.perform_later(current_course, current_user,
+                                               create_duplication_params).job
   end
 end

--- a/app/jobs/course/duplication_job.rb
+++ b/app/jobs/course/duplication_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class Course::DuplicationJob < ApplicationJob
+  include TrackableJob
+  queue_as :lowest
+
+  protected
+
+  # Performs the duplication job.
+  #
+  # @param [Course] current_course The course to duplicate.
+  # @param [User] current_user The user that initiated the duplication service.
+  # @param [Hash] duplication_params A hash of duplication parameters.
+  # @param [Array] all_objects All the objects in the course.
+  # @param [Array] selected_objects The objects to duplicate.
+  def perform_tracked(current_course, current_user, duplication_params = {},
+                      all_objects = [], selected_objects = [])
+    ActsAsTenant.without_tenant do
+      Course::DuplicationService.duplicate(current_course, current_user, duplication_params,
+                                           all_objects, selected_objects)
+    end
+  end
+end

--- a/app/jobs/course/duplication_job.rb
+++ b/app/jobs/course/duplication_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::DuplicationJob < ApplicationJob
   include TrackableJob
+  include Rails.application.routes.url_helpers
   queue_as :lowest
 
   protected
@@ -15,8 +16,10 @@ class Course::DuplicationJob < ApplicationJob
   def perform_tracked(current_course, current_user, duplication_params = {},
                       all_objects = [], selected_objects = [])
     ActsAsTenant.without_tenant do
-      Course::DuplicationService.duplicate(current_course, current_user, duplication_params,
-                                           all_objects, selected_objects)
+      new_course =
+        Course::DuplicationService.duplicate(current_course, current_user, duplication_params,
+                                             all_objects, selected_objects)
+      redirect_to course_path(new_course) if new_course.valid?
     end
   end
 end

--- a/app/mailers/course/mailer.rb
+++ b/app/mailers/course/mailer.rb
@@ -40,7 +40,8 @@ class Course::Mailer < ApplicationMailer
 
   # Send a notification email to a user informing the completion of his course duplication.
   #
-  # @param [Course] course The course that was duplicated.
+  # @param [Course] original_course The original course that was duplicated.
+  # @param [Course] new_course The resulting course of the duplication.
   # @param [User] user The user who performed the duplication.
   def course_duplicated_email(original_course, new_course, user)
     @original_course = original_course

--- a/app/mailers/course/mailer.rb
+++ b/app/mailers/course/mailer.rb
@@ -38,6 +38,18 @@ class Course::Mailer < ApplicationMailer
          subject: t('.subject', course: @course.title))
   end
 
+  # Send a notification email to a user informing the completion of his course duplication.
+  #
+  # @param [Course] course The course that was duplicated.
+  # @param [User] user The user who performed the duplication.
+  def course_duplicated_email(original_course, new_course, user)
+    @original_course = original_course
+    @new_course = new_course
+    @recipient = user
+
+    mail(to: @recipient.email, subject: t('.subject', new_course: @new_course.title))
+  end
+
   # Send a reminder of the assessment closing to a single user
   #
   # @param [Course::Assessment] assessment The assessment that is closing.

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -172,6 +172,7 @@ class Course < ActiveRecord::Base
     self.start_at ||= Time.zone.now
     self.end_at ||= 1.month.from_now
 
-    course_users.build(user: creator, role: :owner) if creator && course_users.empty?
+    return unless creator && course_users.empty?
+    course_users.build(user: creator, role: :owner, creator: creator, updater: updater)
   end
 end

--- a/app/services/course/duplication_service.rb
+++ b/app/services/course/duplication_service.rb
@@ -2,13 +2,21 @@
 
 # Provides a service object for duplicating courses
 class Course::DuplicationService
-  # Constructor for the duplication service object.
-  #
-  # @param [Course] current_course The current course.
-  # @param [User] current_user The user that initiated the duplication service.
-  # @param [Hash] duplication_params A hash of duplication parameters.
-  # @param [Array] all_objects All the objects in the course.
-  # @param [Array] selected_objects The objects to duplicate.
+  class << self
+    # Constructor for the duplication service object.
+    #
+    # @param [Course] current_course The course to duplicate.
+    # @param [User] current_user The user that initiated the duplication service.
+    # @param [Hash] duplication_params A hash of duplication parameters.
+    # @param [Array] all_objects All the objects in the course.
+    # @param [Array] selected_objects The objects to duplicate.
+    def duplicate(current_course, current_user, duplication_params = {},
+                  all_objects = [], selected_objects = [])
+      service = new(current_course, current_user, duplication_params, all_objects, selected_objects)
+      service.duplicate
+    end
+  end
+
   def initialize(current_course, current_user,
                  duplication_params = {}, all_objects = [], selected_objects = [])
     @current_course = current_course
@@ -38,8 +46,10 @@ class Course::DuplicationService
   #
   # @return [Duplicator]
   def duplicator
+    # TODO: Include survey objects after survey duplication is implemented
+    excluded_objects = @all_objects - @selected_objects | @current_course.surveys
     @duplicator ||=
-      Duplicator.new(@all_objects - @selected_objects, time_shift, new_course_title, @current_user)
+      Duplicator.new(excluded_objects, time_shift, new_course_title, @current_user)
   end
 
   # Calculate the amount of time the objects in the new course have to be shifted by

--- a/app/services/course/duplication_service.rb
+++ b/app/services/course/duplication_service.rb
@@ -35,7 +35,12 @@ class Course::DuplicationService
   # @return [Boolean] Whether the duplication succeeded.
   def duplicate
     @new_course = duplicator.duplicate(@current_course)
-    @new_course.save
+    result = @new_course.save
+    if result
+      Course::Mailer.course_duplicated_email(@current_course, @new_course,
+                                             @current_user).deliver_now
+    end
+    result
   end
 
   private

--- a/app/services/course/duplication_service.rb
+++ b/app/services/course/duplication_service.rb
@@ -32,15 +32,14 @@ class Course::DuplicationService
   # Duplicate the course with the duplicator.
   # Do not just pass in @selected_objects or object parents could be set incorrectly.
   #
-  # @return [Boolean] Whether the duplication succeeded.
+  # @return [Course] The duplicate course
   def duplicate
     @new_course = duplicator.duplicate(@current_course)
-    result = @new_course.save
-    if result
+    if @new_course.save
       Course::Mailer.course_duplicated_email(@current_course, @new_course,
                                              @current_user).deliver_now
     end
-    result
+    @new_course
   end
 
   private

--- a/app/views/course/duplications/show.html.slim
+++ b/app/views/course/duplications/show.html.slim
@@ -13,4 +13,8 @@ div.panel.panel-default
       input_html: { value: 1.day.from_now }
   = f.input :new_course_title,
       input_html: { value: t('.new_course_title', current_course_title: current_course.title) }
-  = f.button :submit, t('.duplicate')
+  = f.button :submit, t('.duplicate'), class: 'duplicate'
+br
+div
+  p = t('.close_window')
+  p = t('.email_notify')

--- a/app/views/course/mailer/course_duplicated_email.html.slim
+++ b/app/views/course/mailer/course_duplicated_email.html.slim
@@ -1,0 +1,3 @@
+= simple_format(t('.message', original_course: @original_course.title,
+                              new_course: @new_course.title,
+                              click_here: plain_link_to(t('.click_here'), course_url(@new_course, host: @new_course.instance.host))))

--- a/app/views/course/mailer/course_duplicated_email.text.erb
+++ b/app/views/course/mailer/course_duplicated_email.text.erb
@@ -1,0 +1,3 @@
+<%= t('.message', original_course: @original_course.title,
+                  new_course: @new_course.title,
+                  click_here: plain_link_to(t('.click_here'), course_url(@new_course, host: @new_course.instance.host))) %>

--- a/config/locales/en/course/duplications.yml
+++ b/config/locales/en/course/duplications.yml
@@ -6,6 +6,5 @@ en:
         duplicate: :'course.duplications.show.header'
         course_start_date: 'Current Course Start Date'
         new_course_title: 'Copy of %{current_course_title}'
-      create:
-        duplicating: 'Your course has been duplicated. Check the courses tab to find it.'
-        failed: 'Uhoh, your course failed to duplicate.'
+        close_window: 'Duplication usually takes some time to complete. You may close the window while duplication is in progress.'
+        email_notify: 'You will receive an email with a link to the new course when it becomes available.'

--- a/config/locales/en/course/mailer/course_duplicated_email.yml
+++ b/config/locales/en/course/mailer/course_duplicated_email.yml
@@ -1,0 +1,10 @@
+en:
+  course:
+    mailer:
+      course_duplicated_email:
+        subject: 'Course Duplication Completed: %{new_course}'
+        click_here: 'Click here'
+        message: >
+          Duplication of %{original_course} to %{new_course} has completed.
+
+          %{click_here} to view the duplicated course.

--- a/lib/autoload/duplicator.rb
+++ b/lib/autoload/duplicator.rb
@@ -36,7 +36,8 @@ class Duplicator
     duplicated_stuff = []
     stuff = [*stuff] unless stuff_is_enumerable
     stuff.each do |obj|
-      duplicated_stuff << duplicate_object(obj)
+      duplicated_object = duplicate_object(obj)
+      duplicated_stuff << duplicated_object unless duplicated_object.nil?
     end
     stuff_is_enumerable ? duplicated_stuff : duplicated_stuff[0]
   end

--- a/spec/features/course/duplication_spec.rb
+++ b/spec/features/course/duplication_spec.rb
@@ -26,10 +26,15 @@ RSpec.feature 'Course: Duplication' do
         expect(page).to have_field('New course start date')
         expect(page).to have_field('New course title')
 
-        expect { click_button I18n.t('course.duplications.show.duplicate') }.
-          to change { instance.courses.count }.by(1)
-        # After duplicating, go back to the duplication page
-        expect(current_path).to eq(course_duplication_path(course))
+        expect do
+          click_button I18n.t('course.duplications.show.duplicate')
+          wait_for_job
+        end.to change { instance.courses.count }.by(1)
+
+        new_course = instance.courses.last
+
+        # After duplicating, redirect to the new course
+        expect(current_path).to eq(course_path(new_course))
       end
     end
 

--- a/spec/jobs/course/duplication_job_spec.rb
+++ b/spec/jobs/course/duplication_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::DuplicationJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:user) { create(:course_manager, course: course).user }
+    subject { Course::DuplicationJob }
+
+    it 'can be queued' do
+      expect { subject.perform_later(course, user) }.
+        to have_enqueued_job(subject).exactly(:once)
+    end
+
+    it 'duplicates the course' do
+      expect { subject.perform_now(course, user) }.
+        to change { instance.courses.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2198 

This PR will do the following:

- [x] Exclude survey objects from course duplication for now
- [x] Move course duplication into a job
- [x] Send email to notify user of job completion
- [x] Update course duplication UI to redirect to job path
- [x] Update and add course duplication specs