### PR TITLE
Send reminder emails for survey opening and closing

### DIFF
--- a/app/controllers/concerns/course/reminder_service_concern.rb
+++ b/app/controllers/concerns/course/reminder_service_concern.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Course::ReminderServiceConcern
+  extend ActiveSupport::Concern
+
+  # Converts a set of course users to a string, with each name on a new line.
+  # Sorts the names alphabetically and prepends an index number to each name.
+  #
+  # @param [Array<CourseUser>] course_users The array of course users to turn into a list.
+  # @return [String] The numbered list of course users.
+  def name_list(course_users)
+    course_users_names = course_users.to_a.map(&:name).sort!
+    course_users_names.each_with_index do |course_user, index|
+      course_users_names[index] = "#{index + 1}. #{course_user}"
+    end.join("\n")
+  end
+end

--- a/app/jobs/course/survey/closing_reminder_job.rb
+++ b/app/jobs/course/survey/closing_reminder_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Course::Survey::ClosingReminderJob < ApplicationJob
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # Prevent the job from retrying due to deleted records
+  end
+
+  protected
+
+  def perform(survey, token)
+    ActsAsTenant.without_tenant do
+      Course::Survey::ReminderService.closing_reminder(survey, token)
+    end
+  end
+end

--- a/app/jobs/course/survey/opening_reminder_job.rb
+++ b/app/jobs/course/survey/opening_reminder_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Course::Survey::OpeningReminderJob < ApplicationJob
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # Prevent the job from retrying due to deleted records
+  end
+
+  protected
+
+  def perform(_, survey, token)
+    ActsAsTenant.without_tenant do
+      Course::Survey::ReminderService.opening_reminder(survey, token)
+    end
+  end
+end

--- a/app/mailers/course/mailer.rb
+++ b/app/mailers/course/mailer.rb
@@ -85,4 +85,52 @@ class Course::Mailer < ApplicationMailer
     mail(to: @recipient.email,
          subject: t('.subject', course: @course.title, assessment: @assessment.title))
   end
+
+  # Send an email to notify a course user that the survey is open.
+  #
+  # @param [User] recipient The course user to notify.
+  # @param [Course::Survey] survey The survey that has opened.
+  def survey_opening_reminder_email(recipient, survey)
+    ActsAsTenant.without_tenant do
+      @course = survey.course
+    end
+    @recipient = recipient
+    @survey = survey
+
+    mail(to: @recipient.email,
+         subject: t('.subject', course: @course.title, survey: @survey.title))
+  end
+
+  # Send a reminder of the survey closing to a single user.
+  #
+  # @param [User] recipient The student who has not completed the survey.
+  # @param [Course::Survey] survey The survey that has opened.
+  def survey_closing_reminder_email(recipient, survey)
+    ActsAsTenant.without_tenant do
+      @course = survey.course
+    end
+    @recipient = recipient
+    @survey = survey
+
+    mail(to: @recipient.email,
+         subject: t('.subject', course: @course.title, survey: @survey.title))
+  end
+
+  # Send an email to a course instructor with the names of users who have not completed
+  # the survey.
+  #
+  # @param [User] recipient The course instructor who will receive this email.
+  # @param [Course::Survey] survey The survey that is closing.
+  # @param [String] student_list The list of students who have not completed the survey.
+  def survey_closing_summary_email(recipient, survey, student_list)
+    ActsAsTenant.without_tenant do
+      @course = survey.course
+    end
+    @recipient = recipient
+    @survey = survey
+    @student_list = student_list
+
+    mail(to: @recipient.email,
+         subject: t('.subject', course: @course.title, survey: @survey.title))
+  end
 end

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -2,6 +2,8 @@
 class Course::Survey < ActiveRecord::Base
   acts_as_lesson_plan_item has_todo: true
 
+  include Course::ReminderConcern
+
   enum question_type: { text_response: 0, multiple_choice: 1, multiple_response: 2 }
 
   # To call Course::Survey::Response.name to force it to load. Otherwise, there might be issues

--- a/app/models/course/survey/response.rb
+++ b/app/models/course/survey/response.rb
@@ -9,6 +9,8 @@ class Course::Survey::Response < ActiveRecord::Base
 
   accepts_nested_attributes_for :answers
 
+  scope :submitted, -> { where.not(submitted_at: nil) }
+
   def submitted?
     submitted_at.present?
   end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -78,6 +78,7 @@ class CourseUser < ActiveRecord::Base
   scope :students, -> { where(role: roles[:student]) }
   scope :phantom, -> { where(phantom: true) }
   scope :without_phantom_users, -> { where(phantom: false) }
+  scope :human, -> { where.not(role: roles[:auto_grader]) }
   scope :with_course_statistics, -> { all.calculated(:experience_points, :achievement_count) }
 
   # Order course_users by experience points for use in the course leaderboard.

--- a/app/services/course/survey/reminder_service.rb
+++ b/app/services/course/survey/reminder_service.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+class Course::Survey::ReminderService
+  include Course::ReminderServiceConcern
+
+  class << self
+    delegate :opening_reminder, to: :new
+    delegate :closing_reminder, to: :new
+    delegate :send_opening_reminder, to: :new
+    delegate :send_closing_reminder, to: :new
+  end
+
+  def opening_reminder(survey, token)
+    return unless survey.opening_reminder_token == token && survey.published?
+    send_opening_reminder(survey)
+  end
+
+  def closing_reminder(survey, token)
+    return unless survey.closing_reminder_token == token && survey.published?
+    send_closing_reminder(survey)
+  end
+
+  def send_opening_reminder(survey)
+    # Send notification email to all course users that do not have auto_grader role
+    recipients = survey.course.course_users.human.includes(:user)
+    recipients.each do |recipient|
+      Course::Mailer.survey_opening_reminder_email(recipient.user, survey).deliver_later
+    end
+  end
+
+  def send_closing_reminder(survey)
+    students = uncompleted_students(survey)
+    closing_reminder_students(survey, students)
+    closing_reminder_staff(survey, students)
+  end
+
+  private
+
+  # Send reminder emails to each student who hasn't submitted.
+  #
+  # @param [Course::Survey] survey The survey to query.
+  def closing_reminder_students(survey, recipients)
+    recipients.each do |recipient|
+      Course::Mailer.survey_closing_reminder_email(recipient.user, survey).deliver_later
+    end
+  end
+
+  # Send an email to each instructor with a list of students who haven't submitted.
+  #
+  # @param [Course::Survey] survey The survey to query.
+  def closing_reminder_staff(survey, students)
+    course_instructors = survey.course.instructors.includes(:user).map(&:user)
+    student_list = name_list(students)
+    course_instructors.each do |instructor|
+      Course::Mailer.survey_closing_summary_email(instructor, survey, student_list).deliver_later
+    end
+  end
+
+  # Returns a Set of students who have not completed the given survey.
+  #
+  # @param [Course::Survey] survey The survey to query.
+  # @return [Set<CourseUser>] Set of CourseUsers who have not finished the survey.
+  def uncompleted_students(survey)
+    course_users = survey.course.course_users
+    # Eager load :user as it's needed for the recipient email.
+    students = course_users.student.includes(:user)
+    submitted =
+      survey.responses.submitted.includes(experience_points_record: { course_user: :user }).
+      map(&:course_user)
+    Set.new(students) - Set.new(submitted)
+  end
+end

--- a/app/views/course/mailer/survey_closing_reminder_email.html.slim
+++ b/app/views/course/mailer/survey_closing_reminder_email.html.slim
@@ -1,0 +1,5 @@
+- host = @course.instance.host
+- time = Time.use_zone(@recipient.time_zone) { @survey.end_at.to_formatted_s(:long) }
+
+= simple_format(t('.message', survey: link_to(@survey.title, course_survey_url(@course, @survey, host: host)),
+                              time: time))

--- a/app/views/course/mailer/survey_closing_reminder_email.text.erb
+++ b/app/views/course/mailer/survey_closing_reminder_email.text.erb
@@ -1,0 +1,4 @@
+<% host = @course.instance.host %>
+<% time = Time.use_zone(@recipient.time_zone) { @survey.end_at.to_formatted_s(:long) } %>
+<%= t('.message', survey: plain_link_to(@survey.title, course_survey_url(@course, @survey, host: host)),
+                  time: time) %>

--- a/app/views/course/mailer/survey_closing_summary_email.html.slim
+++ b/app/views/course/mailer/survey_closing_summary_email.html.slim
@@ -1,0 +1,5 @@
+- host = @course.instance.host
+- time = Time.use_zone(@recipient.time_zone) { @survey.end_at.to_formatted_s(:long) }
+
+= simple_format(t('.message', survey: link_to(@survey.title, course_survey_url(@course, @survey, host: host)),
+                              time: time, student_list: @student_list))

--- a/app/views/course/mailer/survey_closing_summary_email.text.erb
+++ b/app/views/course/mailer/survey_closing_summary_email.text.erb
@@ -1,0 +1,4 @@
+<% host = @course.instance.host %>
+<% time = Time.use_zone(@recipient.time_zone) { @survey.end_at.to_formatted_s(:long) } %>
+<%= t('.message', survey: plain_link_to(@survey.title, course_survey_url(@course, @survey, host: host)),
+                  time: time, student_list: @student_list) %>

--- a/app/views/course/mailer/survey_opening_reminder_email.html.slim
+++ b/app/views/course/mailer/survey_opening_reminder_email.html.slim
@@ -1,0 +1,2 @@
+- host = @course.instance.host
+= simple_format(t('.message', survey: link_to(@survey.title, course_survey_url(@course, @survey, host: host))))

--- a/app/views/course/mailer/survey_opening_reminder_email.text.erb
+++ b/app/views/course/mailer/survey_opening_reminder_email.text.erb
@@ -1,0 +1,3 @@
+<% host = @course.instance.host %>
+<%= t('.message',
+      survey: plain_link_to(@survey.title, course_survey_url(@course, @survey, host: host))) %>

--- a/config/locales/en/course/mailer/survey_closing_reminder_email.yml
+++ b/config/locales/en/course/mailer/survey_closing_reminder_email.yml
@@ -1,0 +1,7 @@
+en:
+  course:
+    mailer:
+      survey_closing_reminder_email:
+        subject: '%{course}: Reminder about %{survey}'
+        message: >
+          Please be reminded that %{survey} will expire on %{time}.

--- a/config/locales/en/course/mailer/survey_closing_summary_reminder.yml
+++ b/config/locales/en/course/mailer/survey_closing_summary_reminder.yml
@@ -1,0 +1,9 @@
+en:
+  course:
+    mailer:
+      survey_closing_summary_email:
+        subject: '%{course}: Reminder about %{survey}'
+        message: >
+          Emails were sent to the following students to remind them that %{survey} will expire on %{time}:
+
+          %{student_list}

--- a/config/locales/en/course/mailer/survey_opening_reminder_email.yml
+++ b/config/locales/en/course/mailer/survey_opening_reminder_email.yml
@@ -1,0 +1,7 @@
+en:
+  course:
+    mailer:
+      survey_opening_reminder_email:
+        subject: '%{course}: %{survey} has opened.'
+        message: >
+          You may respond to the survey %{survey}.

--- a/spec/jobs/course/survey/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/survey/closing_reminder_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::ClosingReminderJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:survey) { create(:survey) }
+
+    context 'when end_at of the survey is changed' do
+      it 'creates a closing reminder job' do
+        survey.end_at = 1.day.from_now
+
+        expect { survey.save }.to have_enqueued_job(Course::Survey::ClosingReminderJob)
+      end
+
+      context 'when end_at is a past time' do
+        it 'does not do anything' do
+          survey.end_at = 1.day.ago
+
+          expect { survey.save }.
+            not_to have_enqueued_job(Course::Survey::ClosingReminderJob)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/course/survey/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/survey/opening_reminder_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::OpeningReminderJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:survey) { create(:survey) }
+
+    context 'when start_at of the assessment is changed' do
+      it 'creates a opening reminder job' do
+        survey.start_at = Time.zone.now
+
+        expect { survey.save }.to have_enqueued_job(Course::Survey::OpeningReminderJob)
+      end
+    end
+  end
+end

--- a/spec/services/course/survey/reminder_service_spec.rb
+++ b/spec/services/course/survey/reminder_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::ReminderService do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:survey) do
+      create(:survey, course: course, published: true, end_at: Time.zone.now + 1.day,
+                      creator: course.creator, updater: course.creator)
+    end
+    let!(:unresponded_student) { create(:course_student, course: course) }
+    let!(:responded_student) { create(:course_student, course: course) }
+    let!(:response) do
+      create(:response, survey: survey, course_user: responded_student,
+                        submitted_at: Time.zone.now,
+                        creator: responded_student.user, updater: responded_student.user)
+    end
+    let(:course_creator_email) { course.creator.email }
+    let(:unresponded_student_email) { unresponded_student.user.email }
+    let(:responded_student_email) { responded_student.user.email }
+
+    describe '#opening_reminder' do
+      subject do
+        Course::Survey::ReminderService.opening_reminder(survey, survey.opening_reminder_token)
+      end
+
+      it 'notifies all course users' do
+        subject
+        emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
+        expect(emails).to include(course_creator_email)
+        expect(emails).to include(unresponded_student_email)
+        expect(emails).to include(responded_student_email)
+
+        email_body = ActionMailer::Base.deliveries.find do |mail|
+          mail.to.last == responded_student_email
+        end.body.parts.first.body
+        expect(email_body).to include('course.mailer.survey_opening_reminder_email.message')
+      end
+    end
+
+    describe '#closing_reminder' do
+      subject do
+        Course::Survey::ReminderService.closing_reminder(survey, survey.closing_reminder_token)
+      end
+
+      it 'notifies students who have not completed the survey and sends a summary to staff' do
+        subject
+        emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
+        expect(emails).not_to include(responded_student_email)
+
+        find_email_body = lambda do |email|
+          ActionMailer::Base.deliveries.find { |mail| mail.to.last == email }.body.parts.first.body
+        end
+        student_email_body = find_email_body.call(unresponded_student_email)
+        staff_email_body = find_email_body.call(course_creator_email)
+
+        expect(student_email_body).to include('course.mailer.survey_closing_reminder_email.message')
+        expect(staff_email_body).to include('course.mailer.survey_closing_summary_email.message')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the next PR, will put a button on the ResponseIndex page to manually trigger the sending of closing reminder.