### PR TITLE
Revert virtual_classroom lesson plan event type

### DIFF
--- a/app/models/course/lesson_plan/event.rb
+++ b/app/models/course/lesson_plan/event.rb
@@ -2,7 +2,7 @@
 class Course::LessonPlan::Event < ActiveRecord::Base
   acts_as_lesson_plan_item
 
-  enum event_type: { other: 0, virtual_classroom: 1, recitation: 2, tutorial: 3 }
+  enum event_type: { other: 0, lecture: 1, recitation: 2, tutorial: 3 }
   def initialize_duplicate(duplicator, other)
     self.course = duplicator.duplicate(other.course)
     copy_attributes(other, duplicator.time_shift)

--- a/spec/factories/course_lesson_plan_events.rb
+++ b/spec/factories/course_lesson_plan_events.rb
@@ -16,9 +16,9 @@ FactoryGirl.define do
       sequence(:title) { |n| "Example Tutorial #{n}" }
     end
 
-    factory :virtual_classroom do
-      event_type :virtual_classroom
-      sequence(:title) { |n| "Example VirtualClassroom #{n}" }
+    factory :lecture do
+      event_type :lecture
+      sequence(:title) { |n| "Example Lecture #{n}" }
     end
   end
 end

--- a/spec/services/course/duplication_service_spec.rb
+++ b/spec/services/course/duplication_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Course::DuplicationService, type: :service do
           create(:course_lesson_plan_event, course: course)
           create(:recitation, course: course)
           create(:tutorial, course: course)
-          create(:virtual_classroom, course: course)
+          create(:lecture, course: course)
         end
 
         it 'duplicates a course with the new title' do


### PR DESCRIPTION
The `lecture` type was replaced in https://github.com/Coursemology/coursemology2/commit/228006eecc141a62a41a55c23a8b991c3043b73b#diff-01e16c90acc5417a9143b663a1631147L5, and I think it was unintentional.

cc @xyc0562 

