### PR TITLE
Set awarded_at for manually_awarded experience_points_records

### DIFF
--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -3,6 +3,7 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
   actable
 
   before_save :send_notification, if: :reached_new_level?
+  before_create :set_awarded_at, if: :manually_awarded?
 
   validates :reason, presence: true, if: :manually_awarded?
 
@@ -53,5 +54,9 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
     exp_changed = points_awarded - (points_awarded_was || 0)
     current_exp = course_user.experience_points
     course_user.course.level_for(current_exp + exp_changed)
+  end
+
+  def set_awarded_at
+    self.awarded_at ||= Time.zone.now
   end
 end

--- a/spec/factories/course_experience_points_records.rb
+++ b/spec/factories/course_experience_points_records.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     end
     points_awarded { rand(1..20) * 100 }
     draft_points_awarded nil
-    awarded_at { 1.day.ago }
+    awarded_at nil
     awarder { creator }
     reason { 'Reason for manually-awarded experience points' if manually_awarded? }
 

--- a/spec/models/course/experience_points_record_spec.rb
+++ b/spec/models/course/experience_points_record_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe Course::ExperiencePointsRecord do
     let(:course) { create(:course) }
     let(:course_user) { create(:course_user, course: course) }
 
+    describe 'callbacks' do
+      context 'when record is manually awarded' do
+        subject { create(:course_experience_points_record) }
+        it 'sets awarded_at' do
+          expect(subject.reload.awarded_at).not_to be_nil
+        end
+      end
+
+      context 'when record is no manually awarded' do
+        subject { create(:course_assessment_submission).acting_as }
+        it 'does not set awarded_at' do
+          expect(subject.reload.awarded_at).to be_nil
+        end
+      end
+    end
+
     describe '.active' do
       it 'only returns active records' do
         active = create_list(:course_experience_points_record, 2, course_user: course_user)


### PR DESCRIPTION
Realised that this wasn't set. 

Will also have to run a manual script to do the updates in production for the existing records.