### PR TITLE
Set awarder for newly created manually awarded exp records

### DIFF
--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -3,7 +3,7 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
   actable
 
   before_save :send_notification, if: :reached_new_level?
-  before_create :set_awarded_at, if: :manually_awarded?
+  before_create :set_awarded_attributes, if: :manually_awarded?
 
   validates :reason, presence: true, if: :manually_awarded?
 
@@ -56,7 +56,8 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
     course_user.course.level_for(current_exp + exp_changed)
   end
 
-  def set_awarded_at
+  def set_awarded_attributes
     self.awarded_at ||= Time.zone.now
+    self.awarder ||= User.stamper
   end
 end

--- a/spec/factories/course_experience_points_records.rb
+++ b/spec/factories/course_experience_points_records.rb
@@ -15,7 +15,8 @@ FactoryGirl.define do
     points_awarded { rand(1..20) * 100 }
     draft_points_awarded nil
     awarded_at nil
-    awarder { creator }
+    # Set factory behavior to be consistent with model
+    awarder { manually_awarded? ? creator : nil }
     reason { 'Reason for manually-awarded experience points' if manually_awarded? }
 
     trait :inactive do

--- a/spec/models/course/experience_points_record_spec.rb
+++ b/spec/models/course/experience_points_record_spec.rb
@@ -10,18 +10,23 @@ RSpec.describe Course::ExperiencePointsRecord do
     let(:course) { create(:course) }
     let(:course_user) { create(:course_user, course: course) }
 
-    describe 'callbacks' do
+    describe 'after_create callbacks' do
       context 'when record is manually awarded' do
-        subject { create(:course_experience_points_record) }
-        it 'sets awarded_at' do
+        # Build a record with nil attributes and test if the callback sets the attributes correctly.
+        subject do
+          build(:course_experience_points_record, awarder: nil, awarded_at: nil).tap(&:save)
+        end
+        it 'sets the awarded attributes' do
           expect(subject.reload.awarded_at).not_to be_nil
+          expect(subject.reload.awarder).not_to be_nil
         end
       end
 
-      context 'when record is no manually awarded' do
+      context 'when record is not manually awarded' do
         subject { create(:course_assessment_submission).acting_as }
-        it 'does not set awarded_at' do
+        it 'does not set awarded attributes' do
           expect(subject.reload.awarded_at).to be_nil
+          expect(subject.reload.awarder).to be_nil
         end
       end
     end


### PR DESCRIPTION
Realised I forgot to set this while solving #2207 using #2210.

This should fix it!