### PR TITLE
Re-evaluate the package when time/memory limit or language changes

### DIFF
--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -51,8 +51,7 @@ FactoryGirl.define do
       after(:build) do |assessment, evaluator|
         evaluator.question_count.downto(1).each do
           question = build(:course_assessment_question_programming, :auto_gradable,
-                           template_package: true, template_package_deferred: false,
-                           assessment: assessment)
+                           template_package: true, assessment: assessment)
           assessment.questions << question.acting_as
         end
       end

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
         within find(content_tag_selector(submission.answers.first)) do
-          assessment.questions.first.actable.test_cases.each do |solution|
-            expect(page).to have_content_tag_for(solution)
+          assessment.questions.first.actable.test_cases.each do |test_case|
+            expect(page).to have_content_tag_for(test_case)
           end
         end
 

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments' do
       #   3. Non auto_gradable programming question (no test-cases)
       assessment = create(:assessment, :published_with_programming_question, course: course)
       create(:course_assessment_question_programming,
-             template_package: true, template_package_deferred: false, assessment: assessment,
+             template_package: true, assessment: assessment,
              evaluation_test_case_count: 1)
       create(:course_assessment_question_programming,
-             template_package: true, template_package_deferred: false, assessment: assessment)
+             template_package: true, assessment: assessment)
       assessment.reload
     end
     let(:multiple_programming_submission) do

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
       let(:question_traits) do
         [{
           template_package: true,
-          template_package_deferred: false,
           test_cases: question_test_cases,
           maximum_grade: 3
         }]


### PR DESCRIPTION
Fix #1204 

Found this bug when doing the migration.

Basically, if the import job fails due to time/memory limit, increase the limit won't make it evaluate again.

This PR fixes the code to evaluate again if any of those fields changed. and does some minor refactoring in programming question spec.