### PR TITLE
Add flags to surveys

### DIFF
--- a/app/controllers/course/survey/surveys_controller.rb
+++ b/app/controllers/course/survey/surveys_controller.rb
@@ -73,6 +73,7 @@ class Course::Survey::SurveysController < Course::ComponentController
 
   def survey_params
     params.require(:survey).
-      permit(:title, :description, :base_exp, :start_at, :end_at, :published)
+      permit(:title, :description, :base_exp, :time_bonus_exp, :start_at, :bonus_end_at, :end_at,
+             :published, :anonymous, :allow_response_after_end, :allow_modify_after_submit)
   end
 end

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -5,6 +5,7 @@ class Course::Survey < ActiveRecord::Base
   include Course::ReminderConcern
 
   enum question_type: { text_response: 0, multiple_choice: 1, multiple_response: 2 }
+  validates :end_at, presence: true, if: :allow_response_after_end
 
   # To call Course::Survey::Response.name to force it to load. Otherwise, there might be issues
   # with autoloading of files in production where eager_load is enabled.

--- a/app/views/course/survey/surveys/_survey.json.jbuilder
+++ b/app/views/course/survey/surveys/_survey.json.jbuilder
@@ -1,6 +1,8 @@
 current_user_response = survey.responses.find_by(creator: current_user)
 
-json.(survey, :id, :title, :description, :start_at, :end_at, :base_exp, :published)
+json.(survey, :id, :title, :description, :base_exp, :time_bonus_exp, :published,
+              :start_at, :end_at, :closing_reminded_at,
+              :anonymous, :allow_response_after_end, :allow_modify_after_submit)
 json.isStarted current_user_response.present?
 json.responseId current_user_response && current_user_response.id
 json.submitted_at current_user_response && current_user_response.submitted_at

--- a/client/app/api/course/Survey/Surveys.js
+++ b/client/app/api/course/Survey/Surveys.js
@@ -11,6 +11,10 @@ export default class SurveysAPI extends BaseSurveyAPI {
   *      - true if user can view results for this survey
   *   canUpdate: bool, canDelete: bool,
   *      - true if user can update and delete this survey respectively
+  *   allow_response_after_end: bool,
+  *      - true if user can respond to a survey after it expires
+  *   allow_modify_after_submit: bool,
+  *      - true if user can update survey after it has been submitted
   *   sections:
   *     Array.<{
   *       id: number, title: string, weight: number, ...etc

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -3,6 +3,7 @@ import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { reduxForm, Field, Form } from 'redux-form';
 import TextField from 'lib/components/redux-form/TextField';
 import DateTimePicker from 'lib/components/redux-form/DateTimePicker';
+import Toggle from 'lib/components/redux-form/Toggle';
 import formTranslations from 'lib/translations/form';
 import translations from 'course/survey/translations';
 import { formNames } from 'course/survey/constants';
@@ -14,11 +15,18 @@ const styles = {
   description: {
     width: '100%',
   },
-  dateTimeDiv: {
+  columns: {
     display: 'flex',
   },
-  dateTimeInput: {
+  oneColumn: {
     flex: 1,
+  },
+  toggle: {
+    marginTop: 16,
+  },
+  hint: {
+    fontSize: 14,
+    marginBottom: 12,
   },
 };
 
@@ -26,6 +34,24 @@ const surveyFormTranslations = defineMessages({
   startEndValidationError: {
     id: 'course.surveys.SurveyForm.startEndValidationError',
     defaultMessage: "Must be after 'Opens At'",
+  },
+  allowResponseAfterEndHint: {
+    id: 'course.surveys.SurveyForm.allowResponseAfterEndHint',
+    defaultMessage: 'Allow students to submit responses after the survey has expired. \
+      If this is enabled, students who submit before the deadline will get both the base and bonus \
+      points, whereas students who submit after the deadline will only be awarded the base points.',
+  },
+  allowModifyAfterSubmitHint: {
+    id: 'course.surveys.SurveyForm.allowModifyAfterSubmitHint',
+    defaultMessage: 'Allow students to modify their responses after they have submitted it. If \
+      this is disabled, you will have to manually unsubmit their responses to allow them to \
+      edit it.',
+  },
+  anonymousHint: {
+    id: 'course.surveys.SurveyForm.anonymousHint',
+    defaultMessage: 'If you make the survey anonymous, you will be able to see aggregate survey \
+      results but not individual responses. You may not toggle this setting once there is one \
+      or more student submissions.',
   },
 });
 
@@ -41,6 +67,10 @@ const validate = (values) => {
 
   if (values.end_at && new Date(values.start_at) >= new Date(values.end_at)) {
     errors.end_at = surveyFormTranslations.startEndValidationError;
+  }
+
+  if (values.allow_response_after_end && !values.end_at) {
+    errors.end_at = formTranslations.required;
   }
 
   return errors;
@@ -77,30 +107,79 @@ const SurveyForm = ({ handleSubmit, intl, onSubmit, disabled, shiftEndDate, form
       rows={2}
       {...{ disabled }}
     />
-    <div style={styles.dateTimeDiv}>
+    <div style={styles.columns}>
       <Field
         name="start_at"
         floatingLabelText={intl.formatMessage(translations.opensAt)}
         component={DateTimePicker}
         afterChange={(_, newStartAt) => shiftEndDate(formNames.SURVEY, newStartAt, formValues)}
-        style={styles.dateTimeInput}
+        style={styles.oneColumn}
         {...{ disabled }}
       />
       <Field
         name="end_at"
         floatingLabelText={intl.formatMessage(translations.expiresAt)}
         component={DateTimePicker}
-        style={styles.dateTimeInput}
+        style={styles.oneColumn}
         {...{ disabled }}
       />
     </div>
+    <div style={styles.columns}>
+      <div style={styles.oneColumn}>
+        <Field
+          name="base_exp"
+          floatingLabelText={intl.formatMessage(translations.basePoints)}
+          component={TextField}
+          type="number"
+          {...{ disabled }}
+        />
+      </div>
+      {
+        formValues && formValues.allow_response_after_end &&
+        <div style={styles.oneColumn}>
+          <Field
+            name="time_bonus_exp"
+            floatingLabelText={intl.formatMessage(translations.bonusPoints)}
+            component={TextField}
+            type="number"
+            {...{ disabled }}
+          />
+        </div>
+      }
+    </div>
     <Field
-      name="base_exp"
-      floatingLabelText={intl.formatMessage(translations.points)}
-      component={TextField}
-      type="number"
-      {...{ disabled }}
+      name="allow_response_after_end"
+      component={Toggle}
+      label={intl.formatMessage(translations.allowResponseAfterEnd)}
+      labelPosition="right"
+      style={styles.toggle}
+      disabled={false}
     />
+    <div style={styles.hint}>
+      { intl.formatMessage(surveyFormTranslations.allowResponseAfterEndHint) }
+    </div>
+    <Field
+      name="allow_modify_after_submit"
+      component={Toggle}
+      label={intl.formatMessage(translations.allowModifyAfterSubmit)}
+      labelPosition="right"
+      style={styles.toggle}
+      disabled={false}
+    />
+    <div style={styles.hint}>
+      { intl.formatMessage(surveyFormTranslations.allowModifyAfterSubmitHint) }
+    </div>
+    <Field
+      name="anonymous"
+      component={Toggle}
+      label={intl.formatMessage(translations.anonymous)}
+      labelPosition="right"
+      style={styles.toggle}
+      disabled={false}
+    />
+    <div style={styles.hint}>
+      { intl.formatMessage(surveyFormTranslations.anonymousHint) }
+    </div>
   </Form>
 );
 

--- a/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import { aWeekStartingTomorrow } from 'lib/date-time-defaults';
 import { showSurveyForm, createSurvey } from 'course/survey/actions/surveys';
+import { formatSurveyFormData } from 'course/survey/utils';
 import AddButton from 'course/survey/components/AddButton';
 
 const translations = defineMessages({
@@ -30,7 +31,7 @@ class NewSurveyButton extends React.Component {
   createSurveyHandler = (data) => {
     const { dispatch, intl } = this.props;
 
-    const payload = { survey: data };
+    const payload = formatSurveyFormData(data);
     const successMessage = intl.formatMessage(translations.success, data);
     const failureMessage = intl.formatMessage(translations.failure);
     return dispatch(createSurvey(payload, successMessage, failureMessage));

--- a/client/app/bundles/course/survey/pages/SurveyIndex/SurveysTable.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/SurveysTable.jsx
@@ -22,6 +22,10 @@ const styles = {
   button: {
     marginRight: 15,
   },
+  wrap: {
+    whiteSpace: 'normal',
+    wordWrap: 'break-word',
+  },
 };
 
 class SurveysTable extends React.Component {
@@ -67,24 +71,29 @@ class SurveysTable extends React.Component {
           adjustForCheckbox={false}
         >
           <TableRow>
-            <TableHeaderColumn colSpan={4}>
+            <TableHeaderColumn colSpan={6}>
               {intl.formatMessage(translations.title)}
             </TableHeaderColumn>
-            <TableHeaderColumn>{intl.formatMessage(translations.points)}</TableHeaderColumn>
-            <TableHeaderColumn colSpan={2}>
+            <TableHeaderColumn colSpan={3} style={styles.wrap}>
+              {intl.formatMessage(translations.basePoints)}
+            </TableHeaderColumn>
+            <TableHeaderColumn colSpan={3} style={styles.wrap}>
+              {intl.formatMessage(translations.bonusPoints)}
+            </TableHeaderColumn>
+            <TableHeaderColumn colSpan={5}>
               {intl.formatMessage(translations.opensAt)}
             </TableHeaderColumn>
-            <TableHeaderColumn colSpan={2}>
+            <TableHeaderColumn colSpan={5}>
               {intl.formatMessage(translations.expiresAt)}
             </TableHeaderColumn>
             {
               canCreate ?
-                <TableHeaderColumn>
+                <TableHeaderColumn colSpan={2}>
                   {intl.formatMessage(translations.published)}
                 </TableHeaderColumn> :
                 null
             }
-            <TableHeaderColumn colSpan={canCreate ? 4 : 2} />
+            <TableHeaderColumn colSpan={canCreate ? 14 : 4} />
           </TableRow>
         </TableHeader>
         <TableBody
@@ -94,28 +103,31 @@ class SurveysTable extends React.Component {
           {
             surveys.map(survey => (
               <TableRow key={survey.id}>
-                <TableRowColumn colSpan={4}>
+                <TableRowColumn colSpan={6}>
                   <Link to={`/courses/${courseId}/surveys/${survey.id}`}>
                     { survey.title }
                   </Link>
                 </TableRowColumn>
-                <TableRowColumn>
+                <TableRowColumn colSpan={3}>
                   { survey.base_exp }
                 </TableRowColumn>
-                <TableRowColumn colSpan={2}>
+                <TableRowColumn colSpan={3}>
+                  { survey.allow_response_after_end ? survey.time_bonus_exp : '-' }
+                </TableRowColumn>
+                <TableRowColumn colSpan={5}>
                   { intl.formatDate(survey.start_at, standardDateFormat) }
                 </TableRowColumn>
-                <TableRowColumn colSpan={2}>
+                <TableRowColumn colSpan={5}>
                   { survey.end_at ? intl.formatDate(survey.end_at, standardDateFormat) : [] }
                 </TableRowColumn>
                 {
                   canCreate ?
-                    <TableHeaderColumn>
+                    <TableHeaderColumn colSpan={2}>
                       { this.renderPublishToggle(survey) }
                     </TableHeaderColumn> :
                     null
                 }
-                <TableHeaderColumn colSpan={canCreate ? 4 : 2}>
+                <TableHeaderColumn colSpan={canCreate ? 14 : 4}>
                   <div style={styles.buttonsColumn}>
                     {
                       survey.canViewResults ?

--- a/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
@@ -27,10 +27,13 @@ describe('<NewSurveyButton />', () => {
     // Fill survey form
     const survey = {
       base_exp: 0,
+      time_bonus_exp: 0,
       start_at: new Date('2016-12-31T16:00:00.000Z'),
       end_at: new Date('2017-01-07T15:59:00.000Z'),
+      bonus_end_at: null,
       title: 'Funky survey title',
     };
+
     const startAt = '01-01-2017';
     const dialogInline = surveyFormDialogue.find('RenderToLayer').first().node.layerElement;
     const surveyForm = new ReactWrapper(dialogInline, true).find('form');

--- a/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
@@ -13,6 +13,7 @@ import ArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import { formatDateTime } from 'lib/date-time-defaults';
 import TitleBar from 'lib/components/TitleBar';
+import libTranslations from 'lib/translations';
 import surveyTranslations from 'course/survey/translations';
 import { surveyShape } from 'course/survey/propTypes';
 import { updateSurvey } from 'course/survey/actions/surveys';
@@ -129,10 +130,46 @@ class SurveyDetails extends React.Component {
               </TableRow>
               <TableRow>
                 <TableRowColumn>
-                  <FormattedMessage {...surveyTranslations.points} />
+                  <FormattedMessage {...surveyTranslations.basePoints} />
                 </TableRowColumn>
                 <TableRowColumn>
                   {survey.base_exp}
+                </TableRowColumn>
+              </TableRow>
+              <TableRow>
+                <TableRowColumn>
+                  <FormattedMessage {...surveyTranslations.bonusPoints} />
+                </TableRowColumn>
+                <TableRowColumn>
+                  {survey.allow_response_after_end ? survey.time_bonus_exp : '-'}
+                </TableRowColumn>
+              </TableRow>
+              <TableRow>
+                <TableRowColumn>
+                  <FormattedMessage {...surveyTranslations.anonymous} />
+                </TableRowColumn>
+                <TableRowColumn>
+                  <FormattedMessage {...libTranslations[survey.anonymous ? 'yes' : 'no']} />
+                </TableRowColumn>
+              </TableRow>
+              <TableRow>
+                <TableRowColumn>
+                  <FormattedMessage {...surveyTranslations.allowResponseAfterEnd} />
+                </TableRowColumn>
+                <TableRowColumn>
+                  <FormattedMessage
+                    {...libTranslations[survey.allow_response_after_end ? 'yes' : 'no']}
+                  />
+                </TableRowColumn>
+              </TableRow>
+              <TableRow>
+                <TableRowColumn>
+                  <FormattedMessage {...surveyTranslations.allowModifyAfterSubmit} />
+                </TableRowColumn>
+                <TableRowColumn>
+                  <FormattedMessage
+                    {...libTranslations[survey.allow_modify_after_submit ? 'yes' : 'no']}
+                  />
                 </TableRowColumn>
               </TableRow>
             </TableBody>

--- a/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
@@ -7,6 +7,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import Subheader from 'material-ui/Subheader';
 import { showDeleteConfirmation } from 'course/survey/actions';
 import surveyTranslations from 'course/survey/translations';
+import { formatSurveyFormData } from 'course/survey/utils';
 import * as surveyActions from 'course/survey/actions/surveys';
 import LoadingIndicator from 'course/survey/components/LoadingIndicator';
 import SurveyDetails from './SurveyDetails';
@@ -41,7 +42,7 @@ class SurveyShow extends React.Component {
     const { dispatch, intl, params: { surveyId } } = this.props;
     const { updateSurvey } = surveyActions;
 
-    const payload = { survey: data };
+    const payload = formatSurveyFormData(data);
     const successMessage = intl.formatMessage(surveyTranslations.updateSuccess, data);
     const failureMessage = intl.formatMessage(surveyTranslations.updateFailure);
     return dispatch(updateSurvey(surveyId, payload, successMessage, failureMessage));
@@ -50,17 +51,14 @@ class SurveyShow extends React.Component {
   showEditSurveyForm = (survey) => {
     const { dispatch, intl } = this.props;
     const { showSurveyForm } = surveyActions;
-    const { start_at, end_at, title, description, base_exp } = survey;
 
     return () => dispatch(showSurveyForm({
       onSubmit: this.updateSurveyHandler,
       formTitle: intl.formatMessage(translations.editSurvey),
       initialValues: {
-        start_at: new Date(start_at),
-        end_at: new Date(end_at),
-        title,
-        description,
-        base_exp,
+        ...survey,
+        start_at: new Date(survey.start_at),
+        end_at: new Date(survey.end_at),
       },
     }));
   }

--- a/client/app/bundles/course/survey/translations.js
+++ b/client/app/bundles/course/survey/translations.js
@@ -21,6 +21,26 @@ const translations = defineMessages({
     id: 'course.surveys.fields.expiresAt',
     defaultMessage: 'Expires At',
   },
+  anonymous: {
+    id: 'course.surveys.fields.anonymous',
+    defaultMessage: 'Anonymous',
+  },
+  allowResponseAfterEnd: {
+    id: 'course.surveys.fields.allowResponseAfterEnd',
+    defaultMessage: 'Allow Responses After Survey Expires',
+  },
+  allowModifyAfterSubmit: {
+    id: 'course.surveys.fields.allowModifyAfterSubmit',
+    defaultMessage: 'Allow Submitted Responses To Be Modified',
+  },
+  basePoints: {
+    id: 'course.surveys.fields.basePoints',
+    defaultMessage: 'Base Points Awarded',
+  },
+  bonusPoints: {
+    id: 'course.surveys.fields.bonusPoints',
+    defaultMessage: 'Bonus Points Awarded',
+  },
   points: {
     id: 'course.surveys.fields.points',
     defaultMessage: 'Points Awarded',

--- a/client/app/bundles/course/survey/translations.js
+++ b/client/app/bundles/course/survey/translations.js
@@ -35,15 +35,11 @@ const translations = defineMessages({
   },
   basePoints: {
     id: 'course.surveys.fields.basePoints',
-    defaultMessage: 'Base Points Awarded',
+    defaultMessage: 'Base Points',
   },
   bonusPoints: {
     id: 'course.surveys.fields.bonusPoints',
-    defaultMessage: 'Bonus Points Awarded',
-  },
-  points: {
-    id: 'course.surveys.fields.points',
-    defaultMessage: 'Points Awarded',
+    defaultMessage: 'Bonus Points',
   },
   published: {
     id: 'course.surveys.fields.published',

--- a/client/app/bundles/course/survey/utils/index.js
+++ b/client/app/bundles/course/survey/utils/index.js
@@ -105,3 +105,17 @@ export const formatQuestionFormData = (data) => {
 
   return payload;
 };
+
+export const formatSurveyFormData = (data) => {
+  const payload = { ...data };
+  if (data.allow_response_after_end) {
+    payload.bonus_end_at = data.end_at;
+  } else {
+    payload.bonus_end_at = null;
+    payload.time_bonus_exp = 0;
+  }
+
+  return (
+    { survey: payload }
+  );
+};

--- a/client/app/lib/translations/index.js
+++ b/client/app/lib/translations/index.js
@@ -1,0 +1,14 @@
+import { defineMessages } from 'react-intl';
+
+const translations = defineMessages({
+  yes: {
+    id: 'lib.yes',
+    defaultMessage: 'Yes',
+  },
+  no: {
+    id: 'lib.no',
+    defaultMessage: 'No',
+  },
+});
+
+export default translations;

--- a/db/migrate/20170407083553_add_reminded_at_and_allow_responsee_to_surveys.rb
+++ b/db/migrate/20170407083553_add_reminded_at_and_allow_responsee_to_surveys.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class AddRemindedAtAndAllowResponseeToSurveys < ActiveRecord::Migration
+  def change
+    add_column :course_surveys, :closing_reminded_at, :datetime
+    rename_column :course_surveys, :allow_modify, :allow_modify_after_submit
+    add_column :course_surveys, :allow_response_after_end, :bool, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170309094211) do
+ActiveRecord::Schema.define(version: 20170407083553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -615,12 +615,14 @@ ActiveRecord::Schema.define(version: 20170309094211) do
   end
 
   create_table "course_surveys", force: :cascade do |t|
-    t.boolean  "anonymous",    :default=>false, :null=>false
-    t.boolean  "allow_modify", :default=>false, :null=>false
-    t.integer  "creator_id",   :null=>false, :index=>{:name=>"fk__course_surveys_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_surveys_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",   :null=>false, :index=>{:name=>"fk__course_surveys_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_surveys_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",   :null=>false
-    t.datetime "updated_at",   :null=>false
+    t.boolean  "anonymous",                 :default=>false, :null=>false
+    t.boolean  "allow_modify_after_submit", :default=>false, :null=>false
+    t.boolean  "allow_response_after_end",  :default=>false, :null=>false
+    t.datetime "closing_reminded_at"
+    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_surveys_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_surveys_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_surveys_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_surveys_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",                :null=>false
+    t.datetime "updated_at",                :null=>false
   end
 
   create_table "course_survey_sections", force: :cascade do |t|


### PR DESCRIPTION
Advances #1020.

- Added the flags `allow_response_after_end` and `allow_modification_after_submit` to the surveys table.
- Allows the flags to be set via the front end.

