### PR TITLE
Add tests for survey controller and model

### DIFF
--- a/app/models/course/survey/response.rb
+++ b/app/models/course/survey/response.rb
@@ -18,11 +18,15 @@ class Course::Survey::Response < ActiveRecord::Base
   def submit
     self.submitted_at = Time.zone.now
     self.points_awarded = survey.base_exp
+    self.awarded_at = Time.zone.now
+    self.awarder = creator
   end
 
   def unsubmit
     self.submitted_at = nil
     self.points_awarded = 0
+    self.awarded_at = nil
+    self.awarder = nil
   end
 
   def build_missing_answers_and_options

--- a/spec/controllers/course/survey/responses_controller_spec.rb
+++ b/spec/controllers/course/survey/responses_controller_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Survey::ResponsesController do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:admin) { create(:administrator) }
+    let!(:course) { create(:course, creator: admin) }
+    let!(:student) { create(:course_student, course: course) }
+    let!(:survey) { create(:survey, course: course) }
+    let!(:survey_question) do
+      section = create(:course_survey_section, survey: survey)
+      create(:course_survey_question, question_type: :text, section: section)
+    end
+    let(:response) { create(:response, *response_traits, survey: survey, creator: student.user) }
+    let(:response_traits) { nil }
+
+    before { sign_in(user) }
+
+    describe '#update' do
+      context 'when params include unsubmitting of the survey response' do
+        let(:user) { admin }
+        let(:response_traits) { :submitted }
+        let!(:response_answer) do
+          create(:course_survey_answer, question: survey_question, response: response)
+        end
+        let(:new_response_text) { response_answer.text_response + 'New Stuff' }
+        let(:response_params) do
+          { unsubmit: true,
+            answer_attributes: { id: response_answer.id, text_response: new_response_text } }
+        end
+        subject do
+          patch :update, format: :json, course_id: course.id, survey_id: survey.id, id: response.id,
+                         response: response_params
+        end
+
+        it 'unsubmits the survey response' do
+          subject
+          expect(response.reload.submitted?).to be_falsey
+        end
+
+        it 'does not update the answer attributes' do
+          subject
+          expect(response.reload.answers.first.text_response).not_to eq(new_response_text)
+        end
+
+        context 'when user is a student' do
+          let(:user) { student.user }
+
+          it 'raises an error' do
+            expect { subject }.to raise_exception(CanCan::AccessDenied)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/course_survey_answers.rb
+++ b/spec/factories/course_survey_answers.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 FactoryGirl.define do
+  sequence(:course_survey_answer_text) { |n| "Response to survey question #{n}" }
   factory :course_survey_answer, class: Course::Survey::Answer.name do
     response
     association :question, factory: :course_survey_question
+    text_response do
+      generate(:course_survey_answer_text) if question.text?
+    end
   end
 end

--- a/spec/factories/course_survey_responses.rb
+++ b/spec/factories/course_survey_responses.rb
@@ -8,7 +8,13 @@ FactoryGirl.define do
     survey { build(:survey, course: course) }
 
     trait :submitted do
-      submitted_at { 1.day.ago }
+      transient do
+        submitted_time { 1.day.ago }
+      end
+
+      submitted_at { submitted_time }
+      awarded_at { submitted_time }
+      awarder { creator }
     end
   end
 end

--- a/spec/models/course/survey/response_spec.rb
+++ b/spec/models/course/survey/response_spec.rb
@@ -30,6 +30,29 @@ RSpec.describe Course::Survey::Response do
       end
     end
 
+    describe '#submit' do
+      subject { response.tap(&:submit) }
+
+      it 'sets the correct attributes' do
+        expect(subject.submitted_at).not_to be_nil
+        expect(subject.points_awarded).to eq(survey.base_exp)
+        expect(subject.awarded_at).not_to be_nil
+        expect(subject.awarder).to eq(subject.creator)
+      end
+    end
+
+    describe '#unsubmit' do
+      let(:response_traits) { :submitted }
+      subject { response.tap(&:unsubmit) }
+
+      it 'sets the correct attributes' do
+        expect(subject.submitted_at).to be_nil
+        expect(subject.points_awarded).to eq(0)
+        expect(subject.awarded_at).to be_nil
+        expect(subject.awarder).to be_nil
+      end
+    end
+
     describe 'callbacks from Course::Survey::Response::TodoConcern' do
       subject do
         Course::LessonPlan::Todo.find_by(item_id: survey.lesson_plan_item.id, user_id: student.id)


### PR DESCRIPTION
Follow up from #2202. Wrote some tests for the `#unsubmit` model method and controller tests. 

cc: @jchiam 