### PR TITLE
Added braincert_server_region setting to virtual classrooms

### DIFF
--- a/app/controllers/course/admin/virtual_classroom_settings_controller.rb
+++ b/app/controllers/course/admin/virtual_classroom_settings_controller.rb
@@ -17,7 +17,7 @@ class Course::Admin::VirtualClassroomSettingsController < Course::Admin::Control
 
   def virtual_classroom_settings_params #:nodoc:
     params.require(:virtual_classroom_settings).permit(
-      :title, :pagination, :braincert_whiteboard_api_key, :max_duration
+      :title, :pagination, :braincert_whiteboard_api_key, :max_duration, :braincert_server_region
     )
   end
 

--- a/app/models/course/virtual_classroom_settings.rb
+++ b/app/models/course/virtual_classroom_settings.rb
@@ -27,6 +27,20 @@ class Course::VirtualClassroomSettings
     @settings.braincert_whiteboard_api_key = value
   end
 
+  # Returns BrainCert Virtual Classroom server region
+  #
+  # @return [String] The custom or default title of virtual classrooms component
+  def braincert_server_region
+    @settings.braincert_server_region || 7 # 7 is code for Singapore
+  end
+
+  # Sets BrainCert Virtual Classroom server region
+  #
+  # @param [String] value The new API key
+  def braincert_server_region=(value)
+    @settings.braincert_server_region = value
+  end
+
   # Returns the title of virtual classrooms component
   #
   # @return [String] The custom or default title of virtual classrooms component

--- a/app/services/course/virtual_classroom/braincert_api_service.rb
+++ b/app/services/course/virtual_classroom/braincert_api_service.rb
@@ -118,7 +118,8 @@ class Course::VirtualClassroom::BraincertApiService
       start_time: @virtual_classroom.start_at.in_time_zone(0).strftime(TIME_BRAINCERT),
       end_time: @virtual_classroom.end_at.in_time_zone(0).strftime(TIME_BRAINCERT),
       date: @virtual_classroom.start_at.in_time_zone(0).to_date.strftime(DATE_ISO),
-      ispaid: 0, is_recurring: 0, seat_attendees: 25, record: 1, isRegion: 2
+      ispaid: 0, is_recurring: 0, seat_attendees: 25, record: 1,
+      isRegion: @settings.braincert_server_region
     }
   end
 end

--- a/app/views/course/admin/virtual_classroom_settings/edit.html.slim
+++ b/app/views/course/admin/virtual_classroom_settings/edit.html.slim
@@ -2,6 +2,7 @@
   = f.error_notification
   = f.input :title, as: :string, placeholder: t('.title_placeholder')
   = f.input :braincert_whiteboard_api_key, placeholder: t('.braincert_whiteboard_api_key_hint')
+  = f.input :braincert_server_region, placeholder: t('.braincert_server_region_hint')
   = f.input :max_duration, placeholder: t('.max_duration_hint')
   = f.input :pagination, as: :integer
   = f.button :submit

--- a/config/locales/en/course/admin/virtual_classroom_settings.yml
+++ b/config/locales/en/course/admin/virtual_classroom_settings.yml
@@ -6,6 +6,8 @@ en:
           title_placeholder: 'Leave blank to use default title'
           braincert_whiteboard_api_key_hint: >
             Braincert Virtual Classroom API Key for the Virtual Classroom Component
+          braincert_server_region_hint: >
+            Braincert Virtual Classroom Server Region
           max_duration_hint: >
             Max allowed duration of virtual classes
         update:


### PR DESCRIPTION
Added a braincert_server_region option to virtual classrooms component settings, with default set to Singapore.