### PR TITLE
Limit template file size

### DIFF
--- a/config/locales/en/activerecord/course/assessment/answer/programming_file.yml
+++ b/config/locales/en/activerecord/course/assessment/answer/programming_file.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/answer/programming_file:
+          attributes:
+            content:
+              exceed_size_limit: 'The file should be smaller than 50KB or 1000 lines'

--- a/spec/models/course/assessment/answer/programming_file_spec.rb
+++ b/spec/models/course/assessment/answer/programming_file_spec.rb
@@ -60,5 +60,26 @@ RSpec.describe Course::Assessment::Answer::ProgrammingFile do
         it { is_expected.to eq('1') }
       end
     end
+
+    describe 'validations' do
+      context 'when the content exceeds the size or lines limit' do
+        let(:invalid_content) do
+          too_many_lines = "new line\n" * 1500
+          size_too_big = 'Im 10bytes' * 6 * 1024 # 60KB
+
+          [too_many_lines, size_too_big].sample
+        end
+        let(:file) do
+          create(:course_assessment_answer_programming_file)
+        end
+
+        it 'is not valid' do
+          expect(file).to be_valid
+
+          file.content = invalid_content
+          expect(file).not_to be_valid
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This is to avoid the case that staff cannot view the student submission when the file is too big.