### PR TITLE
Update survey abilities

### DIFF
--- a/app/models/components/course/surveys_ability_component.rb
+++ b/app/models/components/course/surveys_ability_component.rb
@@ -13,19 +13,16 @@ module Course::SurveysAbilityComponent
 
   private
 
-  def surveys_published_all_course_users_hash
-    { lesson_plan_item: course_all_course_users_hash.merge(published: true) }
-  end
-
-  def surveys_open_published_all_course_users_hash
-    surveys_published_all_course_users_hash.deep_merge(lesson_plan_item: already_started_hash)
-  end
-
   def define_staff_survey_permissions
     allow_staff_manage_surveys
     allow_staff_manage_sections
     allow_staff_manage_questions
     allow_staff_manage_responses
+    allow_staff_test_survey
+  end
+
+  def survey_all_staff_hash
+    { survey: { lesson_plan_item: course_staff_hash } }
   end
 
   def allow_staff_manage_surveys
@@ -33,39 +30,116 @@ module Course::SurveysAbilityComponent
   end
 
   def allow_staff_manage_sections
-    can :manage, Course::Survey::Section, survey: { lesson_plan_item: course_staff_hash }
+    can :manage, Course::Survey::Section, survey_all_staff_hash
   end
 
   def allow_staff_manage_questions
-    can :manage, Course::Survey::Question,
-        section: { survey: { lesson_plan_item: course_staff_hash } }
+    can :manage, Course::Survey::Question, section: survey_all_staff_hash
   end
 
   def allow_staff_manage_responses
-    can :manage, Course::Survey::Response, survey: { lesson_plan_item: course_staff_hash }
+    can :read, Course::Survey::Response, survey_all_staff_hash
+    can :unsubmit, Course::Survey::Response,
+        survey_all_staff_hash.merge(submitted_at: (Time.min..Time.max))
+    can :read_answers, Course::Survey::Response,
+        survey_all_staff_hash.merge(survey: { anonymous: false })
+  end
+
+  def allow_staff_test_survey
+    can :create, Course::Survey::Response, survey_all_staff_hash
+    can [:read_answers, :modify], Course::Survey::Response,
+        survey_all_staff_hash.merge(creator_id: user.id)
+    can :submit, Course::Survey::Response,
+        survey_all_staff_hash.merge(creator_id: user.id, submitted_at: nil)
   end
 
   def define_student_survey_permissions
     allow_students_show_published_surveys
     allow_students_show_open_survey_sections
-    allow_students_read_update_own_response
+    allow_students_read_own_response
+    allow_students_update_own_response
     allow_students_create_response
+    allow_students_submit_own_response
+    allow_students_modify_own_response_to_active_survey
+    allow_students_modify_own_response_to_modifiable_submitted_survey
+    allow_students_modify_own_response_to_respondable_expired_survey
+  end
+
+  def survey_published_all_course_users_hash
+    { lesson_plan_item: course_all_course_users_hash.merge(published: true) }
+  end
+
+  def survey_open_all_course_users_hash
+    survey_published_all_course_users_hash.deep_merge(lesson_plan_item: already_started_hash)
+  end
+
+  def survey_active_all_course_users_hashes
+    currently_valid_hashes.map do |currently_valid_hash|
+      survey_published_all_course_users_hash.deep_merge(lesson_plan_item: currently_valid_hash)
+    end
+  end
+
+  def survey_expired_but_respondable
+    survey_published_all_course_users_hash.deep_merge(
+      lesson_plan_item: { end_at: (Time.min..Time.zone.now) },
+      allow_response_after_end: true
+    )
   end
 
   def allow_students_show_published_surveys
-    can :read, Course::Survey, surveys_published_all_course_users_hash
+    can :read, Course::Survey, survey_published_all_course_users_hash
   end
 
   def allow_students_show_open_survey_sections
-    can :read, Course::Survey::Section, survey: surveys_open_published_all_course_users_hash
+    can :read, Course::Survey::Section, survey: survey_open_all_course_users_hash
   end
 
-  def allow_students_read_update_own_response
-    can [:read, :update], Course::Survey::Response,
-        survey: surveys_open_published_all_course_users_hash, creator_id: user.id
+  def allow_students_read_own_response
+    can [:read, :read_answers], Course::Survey::Response,
+        survey: survey_open_all_course_users_hash, creator_id: user.id
   end
 
   def allow_students_create_response
-    can :create, Course::Survey::Response, survey: surveys_open_published_all_course_users_hash
+    survey_active_all_course_users_hashes.each do |ability_hash|
+      can :create, Course::Survey::Response, survey: ability_hash
+    end
+    can :create, Course::Survey::Response, survey: survey_expired_but_respondable
+  end
+
+  def allow_students_update_own_response
+    can :update, Course::Survey::Response, creator_id: user.id
+  end
+
+  def allow_students_submit_own_response
+    survey_active_all_course_users_hashes.each do |ability_hash|
+      can :submit, Course::Survey::Response,
+          creator_id: user.id, submitted_at: nil, survey: ability_hash
+    end
+    can :submit, Course::Survey::Response, creator_id: user.id, submitted_at: nil,
+                                           survey: survey_expired_but_respondable
+  end
+
+  # To both modify (i.e. update/save changes) and submit a response, user will go to the same
+  # response edit page. When the `edit` controller action is hit, cancancan will check if user
+  # can `:edit` or `:update` (they are aliases) it. If the user can modify OR submit a
+  # response, the user should be able to `:edit`/`:update` it. Thus, we need a separate
+  # `:modify` ability to disambiguate it from the less strict `:edit`/`:update` ability.
+
+  def allow_students_modify_own_response_to_active_survey
+    survey_active_all_course_users_hashes.each do |ability_hash|
+      can :modify, Course::Survey::Response,
+          creator_id: user.id, submitted_at: nil, survey: ability_hash
+    end
+  end
+
+  def allow_students_modify_own_response_to_modifiable_submitted_survey
+    can :modify, Course::Survey::Response,
+        creator_id: user.id, submitted_at: (Time.min..Time.max),
+        survey: survey_open_all_course_users_hash.deep_merge(allow_modify_after_submit: true)
+  end
+
+  def allow_students_modify_own_response_to_respondable_expired_survey
+    can :modify, Course::Survey::Response, creator_id: user.id, submitted_at: nil,
+                                           survey: survey_expired_but_respondable
   end
 end

--- a/app/views/course/survey/responses/_response.json.jbuilder
+++ b/app/views/course/survey/responses/_response.json.jbuilder
@@ -13,5 +13,9 @@ json.response do
   end
 end
 
-json.canUnsubmit can?(:manage, @survey)
-json.isResponseCreator current_user.id == @response.creator_id
+json.flags do
+  json.canModify can?(:modify, @response)
+  json.canSubmit can?(:submit, @response)
+  json.canUnsubmit can?(:unsubmit, @response)
+  json.isResponseCreator current_user.id == @response.creator_id
+end

--- a/client/app/api/course/Survey/Responses.js
+++ b/client/app/api/course/Survey/Responses.js
@@ -28,7 +28,11 @@ export default class ResponsesAPI extends BaseSurveyAPI {
   *             }>,
   *           }>
   *       }>
-  *   }
+  *   },
+  *   flags: {
+  *     canModify: bool, canSubmit: bool, canUnsubmit: bool, isResponseCreator: bool,
+  *       - Flags that define actions user can perform
+  *   },
   * }
   */
 

--- a/client/app/bundles/course/survey/actions/responses.js
+++ b/client/app/bundles/course/survey/actions/responses.js
@@ -43,10 +43,9 @@ export function fetchResponse(responseId) {
       .then((data) => {
         dispatch({
           type: actionTypes.LOAD_RESPONSE_SUCCESS,
-          canUnsubmit: data.canUnsubmit,
-          isResponseCreator: data.isResponseCreator,
           survey: data.survey,
           response: data.response,
+          flags: data.flags,
         });
       })
       .catch(() => {
@@ -69,10 +68,9 @@ export function updateResponse(
       .then((data) => {
         dispatch({
           type: actionTypes.UPDATE_RESPONSE_SUCCESS,
-          canUnsubmit: data.canUnsubmit,
-          isResponseCreator: data.isResponseCreator,
           survey: data.survey,
           response: data.response,
+          flags: data.flags,
         });
 
         if (payload.response.submit) {
@@ -106,7 +104,9 @@ export function unsubmitResponse(
       .then((data) => {
         dispatch({
           type: actionTypes.UNSUBMIT_RESPONSE_SUCCESS,
+          survey: data.survey,
           response: data.response,
+          flags: data.flags,
         });
         setNotification(successMessage)(dispatch);
       })
@@ -130,7 +130,7 @@ export function fetchResponses() {
         });
       })
       .catch(() => {
-        dispatch({ type: actionTypes.LOAD_RESPONSE_FAILURE });
+        dispatch({ type: actionTypes.LOAD_RESPONSES_FAILURE });
       });
   };
 }

--- a/client/app/bundles/course/survey/pages/ResponseShow/ResponseAnswer.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/ResponseAnswer.jsx
@@ -53,21 +53,23 @@ class ResponseAnswer extends React.Component {
     fields: PropTypes.shape({
       get: PropTypes.func.isRequired,
     }).isRequired,
+    disabled: PropTypes.bool.isRequired,
   };
 
-  static renderTextResponseField(question, member) {
+  static renderTextResponseField(question, member, disabled) {
     return (
       <Field
         name={`${member}[text_response]`}
         component={TextField}
         style={styles.textResponse}
+        disabled={disabled}
         multiLine
       />
     );
   }
 
   static renderMultipleResponseOptions(props) {
-    const { fields, question, meta: { dirty, error } } = props;
+    const { fields, question, disabled, meta: { dirty, error } } = props;
     const { grid_view: grid, options } = question;
 
     return (
@@ -86,6 +88,7 @@ class ResponseAnswer extends React.Component {
                   component={Checkbox}
                   style={grid ? styles.gridOptionWidget : styles.listOptionWidget}
                   iconStyle={grid ? styles.gridOptionWidgetIcon : {}}
+                  disabled={disabled}
                 />
               );
               const { option: optionText, image_url: imageUrl } = option;
@@ -102,17 +105,17 @@ class ResponseAnswer extends React.Component {
     );
   }
 
-  static renderMultipleResponseField(question, member) {
+  static renderMultipleResponseField(question, member, disabled) {
     return (
       <FieldArray
         name={`${member}[options]`}
         component={ResponseAnswer.renderMultipleResponseOptions}
-        {...{ question }}
+        {...{ question, disabled }}
       />
     );
   }
 
-  static renderMultipleChoiceOptions({ question, ...props }) {
+  static renderMultipleChoiceOptions({ question, disabled, ...props }) {
     const { input: { onChange, value }, meta: { dirty, error } } = props;
     const { grid_view: grid, options } = question;
 
@@ -130,6 +133,7 @@ class ResponseAnswer extends React.Component {
                 iconStyle={grid ? styles.gridOptionWidgetIcon : {}}
                 onCheck={(event, buttonValue) => onChange(buttonValue)}
                 checked={id === value}
+                disabled={disabled}
               />
             );
             return (
@@ -144,19 +148,19 @@ class ResponseAnswer extends React.Component {
     );
   }
 
-  static renderMultipleChoiceField(question, member) {
+  static renderMultipleChoiceField(question, member, disabled) {
     return (
       <Field
         name={`${member}[selected_option]`}
         component={ResponseAnswer.renderMultipleChoiceOptions}
-        {...{ question }}
+        {...{ question, disabled }}
       />
     );
   }
 
   render() {
     const { TEXT, MULTIPLE_CHOICE, MULTIPLE_RESPONSE } = questionTypes;
-    const { member, index, fields } = this.props;
+    const { member, index, fields, disabled } = this.props;
     const answer = fields.get(index);
     const question = answer.question;
 
@@ -177,7 +181,7 @@ class ResponseAnswer extends React.Component {
             answer.present ?
               <div>
                 <Field name={`${member}[${index}][id]`} component="hidden" />
-                { renderer(question, member) }
+                { renderer(question, member, disabled) }
               </div> :
               <div style={styles.errorText}>
                 <FormattedMessage {...translations.noAnswer} />

--- a/client/app/bundles/course/survey/pages/ResponseShow/ResponseForm.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/ResponseForm.jsx
@@ -115,7 +115,7 @@ class ResponseForm extends React.Component {
             const section = fields.get(index);
             return (
               <ResponseSection
-                disabled={response.submitted_at}
+                disabled={!!response.submitted_at}
                 key={section.id}
                 {...{ member, index, fields }}
               />

--- a/client/app/bundles/course/survey/pages/ResponseShow/ResponseSection.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/ResponseSection.jsx
@@ -16,10 +16,11 @@ class ResponseSection extends React.Component {
     fields: PropTypes.shape({
       get: PropTypes.func.isRequired,
     }).isRequired,
+    disabled: PropTypes.bool.isRequired,
   }
 
   static renderAnswers(props) {
-    const { fields } = props;
+    const { fields, disabled } = props;
     return (
       <CardText>
         {
@@ -28,7 +29,7 @@ class ResponseSection extends React.Component {
             return (
               <ResponseAnswer
                 key={answer.id || `q${answer.question.id}`}
-                {...{ member, index, fields }}
+                {...{ member, index, fields, disabled }}
               />
             );
           })
@@ -38,7 +39,7 @@ class ResponseSection extends React.Component {
   }
 
   render() {
-    const { member, index, fields } = this.props;
+    const { member, index, fields, disabled } = this.props;
     const section = fields.get(index);
 
     if (section.answers.length < 1) {
@@ -54,6 +55,7 @@ class ResponseSection extends React.Component {
         <FieldArray
           name={`${member}.answers`}
           component={ResponseSection.renderAnswers}
+          disabled={disabled}
         />
       </Card>
     );

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
@@ -40,8 +40,12 @@ const responseData = {
     title: 'Test Response',
     description: 'Form working?',
   },
-  canUnsubmit: false,
-  isResponseCreator: true,
+  flags: {
+    canModify: true,
+    canSubmit: true,
+    canUnsubmit: false,
+    isResponseCreator: true,
+  },
 };
 
 beforeEach(() => {

--- a/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
@@ -59,10 +59,10 @@ class ResponseShow extends React.Component {
   static propTypes = {
     surveys: PropTypes.arrayOf(surveyShape),
     response: responseShape,
-    canUnsubmit: PropTypes.bool.isRequired,
-    isResponseCreator: PropTypes.bool.isRequired,
-    isUnsubmitting: PropTypes.bool.isRequired,
-    isLoading: PropTypes.bool.isRequired,
+    flags: PropTypes.shape({
+      isResponseCreator: PropTypes.bool.isRequired,
+      isLoading: PropTypes.bool.isRequired,
+    }),
     params: PropTypes.shape({
       courseId: PropTypes.string.isRequired,
     }).isRequired,
@@ -163,21 +163,18 @@ class ResponseShow extends React.Component {
   }
 
   renderBody() {
-    const { canUnsubmit, isResponseCreator, response, isLoading, isUnsubmitting } = this.props;
-    if (isLoading) { return <LoadingIndicator />; }
+    const { response, flags } = this.props;
+    if (flags.isLoading) { return <LoadingIndicator />; }
 
     return (
       <div>
-        { !isResponseCreator ? this.renderSubmissionInfo() : null }
+        { !flags.isResponseCreator ? this.renderSubmissionInfo() : null }
         <Subheader><FormattedMessage {...surveyTranslations.questions} /></Subheader>
         <ResponseForm
-          canUnsubmit={canUnsubmit}
-          isUnsubmitting={isUnsubmitting}
-          isResponseCreator={isResponseCreator}
           initialValues={ResponseShow.buildInitialValues(response)}
           onSubmit={this.handleUpdateResponse}
           onUnsubmit={this.handleUnsubmitResponse}
-          {...{ response }}
+          {...{ response, flags }}
         />
       </div>
     );

--- a/client/app/bundles/course/survey/reducers/responseForm.js
+++ b/client/app/bundles/course/survey/reducers/responseForm.js
@@ -2,11 +2,15 @@ import actionTypes from '../constants';
 import { sortResponseElements } from '../utils';
 
 const initialState = {
-  isLoading: false,
-  isUnsubmitting: false,
-  canUnsubmit: false,
-  isResponseCreator: false,
   response: {},
+  flags: {
+    isLoading: false,
+    isUnsubmitting: false,
+    canModify: false,
+    canSubmit: false,
+    canUnsubmit: false,
+    isResponseCreator: false,
+  },
 };
 
 export default function (state = initialState, action) {
@@ -14,7 +18,7 @@ export default function (state = initialState, action) {
   switch (type) {
     case actionTypes.CREATE_RESPONSE_REQUEST:
     case actionTypes.LOAD_RESPONSE_REQUEST: {
-      return { ...state, isLoading: true };
+      return { ...state, flags: { ...state.flags, isLoading: true } };
     }
     case actionTypes.UPDATE_RESPONSE_SUCCESS:
     case actionTypes.CREATE_RESPONSE_SUCCESS:
@@ -22,27 +26,25 @@ export default function (state = initialState, action) {
       return {
         ...state,
         response: sortResponseElements(action.response),
-        canUnsubmit: action.canUnsubmit,
-        isResponseCreator: action.isResponseCreator,
-        isLoading: false,
+        flags: { ...state.flags, ...action.flags, isLoading: false },
       };
     }
     case actionTypes.CREATE_RESPONSE_FAILURE:
     case actionTypes.LOAD_RESPONSE_FAILURE: {
-      return { ...state, isLoading: false };
+      return { ...state, flags: { ...state.flags, isLoading: false } };
     }
     case actionTypes.UNSUBMIT_RESPONSE_REQUEST: {
-      return { ...state, isUnsubmitting: true };
+      return { ...state, flags: { ...state.flags, isUnsubmitting: true } };
     }
     case actionTypes.UNSUBMIT_RESPONSE_SUCCESS: {
       return {
         ...state,
         response: sortResponseElements(action.response),
-        isUnsubmitting: false,
+        flags: { ...state.flags, ...action.flags, isUnsubmitting: false },
       };
     }
     case actionTypes.UNSUBMIT_RESPONSE_FAILURE: {
-      return { ...state, isUnsubmitting: false };
+      return { ...state, flags: { ...state.flags, isUnsubmitting: false } };
     }
     default:
       return state;

--- a/spec/factories/course_surveys.rb
+++ b/spec/factories/course_surveys.rb
@@ -4,5 +4,43 @@ FactoryGirl.define do
   factory :course_survey, class: Course::Survey.name,
                           aliases: [:survey], parent: :course_lesson_plan_item do
     title { generate(:course_survey_name) }
+    anonymous false
+    allow_response_after_end false
+    allow_modify_after_submit false
+  end
+
+  trait :published do
+    published true
+  end
+
+  trait :unpublished do
+    published false
+  end
+
+  trait :anonymous do
+    anonymous true
+  end
+
+  trait :allow_response_after_end do
+    allow_response_after_end true
+  end
+
+  trait :allow_modify_after_submit do
+    allow_modify_after_submit true
+  end
+
+  trait :not_started do
+    start_at { 1.day.from_now }
+    end_at { 3.days.from_now }
+  end
+
+  trait :expired do
+    start_at { 3.days.ago }
+    end_at { 1.day.ago }
+  end
+
+  trait :currently_active do
+    start_at { 2.days.ago }
+    end_at { 2.days.from_now }
   end
 end

--- a/spec/models/course/survey/survey_ability_spec.rb
+++ b/spec/models/course/survey/survey_ability_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Course::LessonPlan::Event do
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }
-    let(:survey) { create(:survey, course: course, published: true) }
+    let(:student) { create(:course_student, course: course) }
+    let(:survey) { create(:survey, *survey_traits, course: course) }
+    let(:survey_traits) { [] }
 
     context 'when the user is a Course Staff' do
       let(:user) { create(:course_manager, course: course).user }
@@ -18,17 +20,127 @@ RSpec.describe Course::LessonPlan::Event do
         expect(course.surveys.accessible_by(subject)).
           to contain_exactly(survey)
       end
+
+      context 'when the survey is being prepared' do
+        let(:survey_traits) { [:unpublished, :not_started] }
+        let(:response) { build(:response, survey: survey, creator: user) }
+        let(:submitted_response) do
+          build(:response, survey: survey, creator: user, submitted_at: Time.zone.now)
+        end
+
+        it 'allows the user to try out the survey before publishing it' do
+          expect(subject).to be_able_to(:create, response)
+          expect(subject).to be_able_to(:submit, response)
+          expect(subject).to be_able_to(:modify, response)
+          expect(subject).to be_able_to(:read_answers, response)
+          expect(subject).not_to be_able_to(:submit, submitted_response)
+        end
+      end
+
+      context 'when the survey is anonymous' do
+        let(:survey_traits) { [:anonymous] }
+        let(:response) { build(:response, survey: survey, creator: student.user) }
+
+        it 'allows user to view response meta-data but not answers' do
+          expect(subject).to be_able_to(:read, response)
+          expect(subject).not_to be_able_to(:read_answers, response)
+        end
+      end
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:user) { student.user }
 
-      it { is_expected.to be_able_to(:show, survey) }
-      it { is_expected.not_to be_able_to(:manage, survey) }
+      context 'when the survey is published' do
+        let(:survey_traits) { [:published] }
 
-      it 'allows the user to see all surveys' do
-        expect(course.surveys.accessible_by(subject)).
-          to contain_exactly(survey)
+        it { is_expected.to be_able_to(:show, survey) }
+
+        it 'allows the user to see all published surveys' do
+          expect(course.surveys.accessible_by(subject)).
+            to contain_exactly(survey)
+        end
+      end
+
+      context 'when the survey is not published' do
+        let(:survey_traits) { [:unpublished] }
+
+        it { is_expected.not_to be_able_to(:show, survey) }
+      end
+
+      context 'when the survey is published and has opened' do
+        let(:survey_traits) { [:published, :currently_active] }
+        let(:response) { build(:response, survey: survey, creator: user) }
+
+        it { is_expected.to be_able_to(:create, response) }
+        it { is_expected.to be_able_to(:modify, response) }
+        it { is_expected.to be_able_to(:submit, response) }
+        it { is_expected.to be_able_to(:read_answers, response) }
+        it { is_expected.not_to be_able_to(:unsubmit, response) }
+      end
+
+      context 'when published survey is expired' do
+        let(:response) { build(:response, survey: survey, creator: user) }
+
+        context 'when responses are not allowed after survey expiry' do
+          let(:survey_traits) { [:published, :expired] }
+
+          it 'does not allow user to create a response' do
+            expect(subject).not_to be_able_to(:create, response)
+          end
+
+          it 'does not allow user to submit a response' do
+            expect(subject).not_to be_able_to(:submit, response)
+          end
+
+          context 'when responses has not been submitted' do
+            it 'does not allow user to modify a response' do
+              expect(subject).not_to be_able_to(:modify, response)
+            end
+          end
+        end
+
+        context 'when responses are allowed after survey expiry' do
+          let(:survey_traits) { [:published, :expired, :allow_response_after_end] }
+
+          it 'allows user to create a response' do
+            expect(subject).to be_able_to(:create, response)
+          end
+
+          it 'allows user to submit a response' do
+            expect(subject).to be_able_to(:submit, response)
+          end
+
+          context 'when responses has not been submitted' do
+            it 'allows user to modify a response' do
+              expect(subject).to be_able_to(:modify, response)
+            end
+          end
+        end
+      end
+
+      context 'when survey response has been submitted' do
+        let(:response) { build(:response, :submitted, survey: survey, creator: user) }
+
+        it 'does not allow re-submission' do
+          expect(subject).not_to be_able_to(:submit, response)
+        end
+
+        context 'when modifications are not allowed after survey response submission' do
+          let(:survey_traits) { [:published, :currently_active] }
+
+          it 'does not allow user to modify his response' do
+            expect(subject).not_to be_able_to(:modify, response)
+          end
+        end
+
+        context 'when modifications are allowed after survey response submission' do
+          let(:survey_traits) { [:published, :currently_active, :allow_modify_after_submit] }
+
+          it 'allows user to modify his response' do
+            expect(subject).to be_able_to(:modify, response)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR updates the abilities for survey to depend on the newly added booleans. The different cases for the abilities are enumerated [here](https://docs.google.com/spreadsheets/d/1rLt9O3K3VI90hrYRgEPeFDudxYGW0_SrLE0gv2N7F1U/edit#gid=0).

This only hides/disables unavailable actions in the frontend. The backend checks will come in the next PR.

