### PR TITLE
Allow surveys to be anonymous

### DIFF
--- a/app/controllers/course/survey/responses_controller.rb
+++ b/app/controllers/course/survey/responses_controller.rb
@@ -24,6 +24,7 @@ class Course::Survey::ResponsesController < Course::Survey::SurveysController
   end
 
   def show
+    authorize!(:read_answers, @response)
     respond_to do |format|
       format.html { render 'course/survey/surveys/index' }
       format.json { render_response_json }

--- a/app/controllers/course/survey/surveys_controller.rb
+++ b/app/controllers/course/survey/surveys_controller.rb
@@ -7,7 +7,9 @@ class Course::Survey::SurveysController < Course::ComponentController
   def index
     respond_to do |format|
       format.html
-      format.json
+      format.json do
+        @surveys = @surveys.includes(responses: { experience_points_record: :course_user })
+      end
     end
   end
 
@@ -72,8 +74,11 @@ class Course::Survey::SurveysController < Course::ComponentController
   end
 
   def survey_params
-    params.require(:survey).
-      permit(:title, :description, :base_exp, :time_bonus_exp, :start_at, :bonus_end_at, :end_at,
-             :published, :anonymous, :allow_response_after_end, :allow_modify_after_submit)
+    fields = [
+      :title, :description, :base_exp, :time_bonus_exp, :start_at, :bonus_end_at, :end_at,
+      :published, :allow_response_after_end, :allow_modify_after_submit
+    ]
+    fields << :anonymous if !@survey.anonymous || !@survey.has_student_response?
+    params.require(:survey).permit(*fields)
   end
 end

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -14,6 +14,12 @@ class Course::Survey < ActiveRecord::Base
   has_many :questions, through: :sections
   has_many :sections, inverse_of: :survey, dependent: :destroy
 
+  def has_student_response?
+    responses.find do |response|
+      response.experience_points_record.course_user.student?
+    end.present?
+  end
+
   def initialize_duplicate(duplicator, other)
     copy_attributes(other, duplicator.time_shift)
     self.sections = duplicator.duplicate(other.sections)

--- a/app/views/course/survey/responses/_response_experience_points_reason.html.slim
+++ b/app/views/course/survey/responses/_response_experience_points_reason.html.slim
@@ -1,4 +1,7 @@
 - response = response_experience_points_reason
 - survey = response.survey
-= link_to(format_inline_text(survey.title),
-          course_survey_response_path(current_course, survey, response))
+- title = format_inline_text(survey.title)
+- if can?(:read_answers, response)
+  = link_to(title, course_survey_response_path(current_course, survey, response))
+- else
+  = link_to(title, course_survey_responses_path(current_course, survey))

--- a/app/views/course/survey/responses/index.json.jbuilder
+++ b/app/views/course/survey/responses/index.json.jbuilder
@@ -1,15 +1,19 @@
 responses = @responses.map { |r| [r.course_user_id, r] }.to_h
 json.responses @course_students do |student|
+  response = responses[student.id]
+  canReadAnswers = response.present? && can?(:read_answers, response)
+
   json.course_user do
     json.(student, :id, :name)
     json.phantom student.phantom?
     json.path course_user_path(current_course, student)
   end
-  response = responses[student.id]
-  json.started !!response
+
+  json.present !!response
   if response
-    json.(response, :submitted_at)
-    json.path course_survey_response_path(current_course, @survey, response)
+    json.(response, :id, :submitted_at)
+    json.canUnsubmit can?(:unsubmit, response)
+    json.path course_survey_response_path(current_course, @survey, response) if canReadAnswers
   end
 end
 json.survey do

--- a/app/views/course/survey/surveys/_survey.json.jbuilder
+++ b/app/views/course/survey/surveys/_survey.json.jbuilder
@@ -1,14 +1,16 @@
-current_user_response = survey.responses.find_by(creator: current_user)
-
 json.(survey, :id, :title, :description, :base_exp, :time_bonus_exp, :published,
               :start_at, :end_at, :closing_reminded_at,
               :anonymous, :allow_response_after_end, :allow_modify_after_submit)
-json.canUpdate can?(:update, survey)
+
+canUpdate = can?(:update, survey)
+json.canUpdate canUpdate
 json.canDelete can?(:destroy, survey)
 json.canCreateSection can?(:create, Course::Survey::Section.new(survey: survey))
 json.canViewResults can?(:manage, survey)
-json.canRespond can?(:create, survey.responses.new)
+json.canRespond can?(:create, Course::Survey::Response.new(survey: survey))
+json.hasStudentResponse survey.has_student_response? if canUpdate
 
+current_user_response = survey.responses.find_by(creator: current_user)
 if current_user_response
   json.response do
     json.(current_user_response, :id, :submitted_at)

--- a/app/views/course/survey/surveys/results.json.jbuilder
+++ b/app/views/course/survey/surveys/results.json.jbuilder
@@ -10,7 +10,7 @@ json.sections @sections do |section|
     end
     json.answers student_submitted_answers do |answer|
       json.(answer, :id)
-      json.course_user_name answer.response.course_user.name
+      json.course_user_name answer.response.course_user.name unless @survey.anonymous?
       json.phantom answer.response.course_user.phantom?
       if question.text?
         json.(answer, :text_response)

--- a/client/app/api/course/Survey/Surveys.js
+++ b/client/app/api/course/Survey/Surveys.js
@@ -15,6 +15,8 @@ export default class SurveysAPI extends BaseSurveyAPI {
   *      - true if user can respond to a survey after it expires
   *   allow_modify_after_submit: bool,
   *      - true if user can update survey after it has been submitted
+  *   hasStudentResponse: bool,
+  *      - true if there is at least one student response for the survey
   *   response: Array.<{ id: number, submitted_at: string, canModify: bool, canSubmit: bool }>
   *      - Response details if it exists. Otherwise, null.
   *   sections:

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -53,6 +53,10 @@ const surveyFormTranslations = defineMessages({
       results but not individual responses. You may not toggle this setting once there is one \
       or more student submissions.',
   },
+  hasStudentResponse: {
+    id: 'course.surveys.SurveyForm.hasStudentResponse',
+    defaultMessage: 'At least one student has responded to this survey. You may not remove anonymity.',
+  },
 });
 
 const validate = (values) => {
@@ -85,10 +89,13 @@ const propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
+  disableAnonymousToggle: PropTypes.bool,
   disabled: PropTypes.bool,
 };
 
-const SurveyForm = ({ handleSubmit, intl, onSubmit, disabled, shiftEndDate, formValues }) => (
+const SurveyForm = ({
+  handleSubmit, intl, onSubmit, disabled, disableAnonymousToggle, shiftEndDate, formValues,
+}) => (
   <Form onSubmit={handleSubmit(onSubmit)}>
     <Field
       name="title"
@@ -153,7 +160,7 @@ const SurveyForm = ({ handleSubmit, intl, onSubmit, disabled, shiftEndDate, form
       label={intl.formatMessage(translations.allowResponseAfterEnd)}
       labelPosition="right"
       style={styles.toggle}
-      disabled={false}
+      disabled={disabled}
     />
     <div style={styles.hint}>
       { intl.formatMessage(surveyFormTranslations.allowResponseAfterEndHint) }
@@ -164,7 +171,7 @@ const SurveyForm = ({ handleSubmit, intl, onSubmit, disabled, shiftEndDate, form
       label={intl.formatMessage(translations.allowModifyAfterSubmit)}
       labelPosition="right"
       style={styles.toggle}
-      disabled={false}
+      disabled={disabled}
     />
     <div style={styles.hint}>
       { intl.formatMessage(surveyFormTranslations.allowModifyAfterSubmitHint) }
@@ -175,10 +182,14 @@ const SurveyForm = ({ handleSubmit, intl, onSubmit, disabled, shiftEndDate, form
       label={intl.formatMessage(translations.anonymous)}
       labelPosition="right"
       style={styles.toggle}
-      disabled={false}
+      disabled={disableAnonymousToggle || disabled}
     />
     <div style={styles.hint}>
-      { intl.formatMessage(surveyFormTranslations.anonymousHint) }
+      {
+        disableAnonymousToggle ?
+        intl.formatMessage(surveyFormTranslations.hasStudentResponse) :
+        intl.formatMessage(surveyFormTranslations.anonymousHint)
+      }
     </div>
   </Form>
 );

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
@@ -19,6 +19,7 @@ function mapStateToProps({ surveyForm, ...state }) {
 const propTypes = {
   dispatch: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
+  hasStudentResponse: PropTypes.bool.isRequired,
   disabled: PropTypes.bool.isRequired,
   pristine: PropTypes.bool.isRequired,
   formTitle: PropTypes.string,
@@ -40,6 +41,7 @@ const SurveyFormDialogue = ({
   pristine,
   formValues,
   formTitle,
+  hasStudentResponse,
   initialValues,
   onSubmit,
 }) => {
@@ -48,6 +50,15 @@ const SurveyFormDialogue = ({
     submitSurveyForm,
     shiftEndDate,
   } = bindActionCreators(actionCreators, dispatch);
+
+  const surveyFormProps = {
+    shiftEndDate,
+    formValues,
+    initialValues,
+    onSubmit,
+    disabled,
+    disableAnonymousToggle: initialValues && initialValues.anonymous && hasStudentResponse,
+  };
 
   return (
     <FormDialogue
@@ -58,7 +69,7 @@ const SurveyFormDialogue = ({
       disabled={disabled}
       open={visible}
     >
-      <SurveyForm {...{ shiftEndDate, formValues, initialValues, onSubmit, disabled }} />
+      <SurveyForm {...surveyFormProps} />
     </FormDialogue>
   );
 };

--- a/client/app/bundles/course/survey/pages/ResponseIndex/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/__test__/index.test.jsx
@@ -19,7 +19,7 @@ const responsesData = {
       phantom: true,
       path: '/courses/1/users/1',
     },
-    started: true,
+    present: true,
     submitted_at: '2017-03-01T09:10:01.180+08:00',
     path: '/courses/1/surveys/2/responses/5',
   }, {
@@ -29,7 +29,7 @@ const responsesData = {
       phantom: false,
       path: '/courses/1/users/2',
     },
-    started: false,
+    present: false,
   }, {
     course_user: {
       id: 3,
@@ -37,13 +37,24 @@ const responsesData = {
       phantom: false,
       path: '/courses/1/users/3',
     },
-    started: true,
+    present: true,
     submitted_at: null,
     path: '/courses/1/surveys/2/responses/6',
+  }, {
+    course_user: {
+      id: 4,
+      name: 'Student D',
+      phantom: true,
+      path: '/courses/1/users/4',
+    },
+    present: true,
+    submitted_at: '2017-03-03T09:10:01.180+08:00',
+    path: '/courses/1/surveys/2/responses/7',
   }],
   survey: {
     id: 2,
     title: 'Test Responses Page',
+    end_at: '2017-03-02T09:10:01.180+08:00',
   },
 };
 
@@ -76,7 +87,7 @@ describe('<ResponseIndex />', () => {
     const tableBodies = responseIndex.find('TableBody');
     const phantomStudentRows = tableBodies.at(2).find('TableRow');
     const realStudentRows = tableBodies.at(1).find('TableRow');
-    const getStatus = row => row.find('td').last().text();
+    const getStatus = row => row.find('td').at(1).text();
     expect(getStatus(phantomStudentRows.first())).toBe('Submitted');
     expect(getStatus(realStudentRows.first())).toBe('Not Started');
     expect(getStatus(realStudentRows.last())).toBe('Responding');

--- a/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
@@ -51,14 +51,29 @@ class SurveyShow extends React.Component {
   showEditSurveyForm = (survey) => {
     const { dispatch, intl } = this.props;
     const { showSurveyForm } = surveyActions;
+    const {
+      title, description, base_exp, time_bonus_exp, start_at, end_at, hasStudentResponse,
+      allow_response_after_end, allow_modify_after_submit, anonymous,
+    } = survey;
+
+    const initialValues = {
+      title,
+      description,
+      base_exp,
+      time_bonus_exp,
+      allow_response_after_end,
+      allow_modify_after_submit,
+      anonymous,
+    };
 
     return () => dispatch(showSurveyForm({
       onSubmit: this.updateSurveyHandler,
       formTitle: intl.formatMessage(translations.editSurvey),
+      hasStudentResponse,
       initialValues: {
-        ...survey,
-        start_at: new Date(survey.start_at),
-        end_at: new Date(survey.end_at),
+        ...initialValues,
+        start_at: new Date(start_at),
+        end_at: new Date(end_at),
       },
     }));
   }

--- a/client/app/bundles/course/survey/reducers/responses.js
+++ b/client/app/bundles/course/survey/reducers/responses.js
@@ -1,4 +1,5 @@
 import actionTypes from '../constants';
+import { updateOrAppend } from './utils';
 
 const initialState = {
   isLoading: false,
@@ -19,6 +20,12 @@ export default function (state = initialState, action) {
     }
     case actionTypes.LOAD_RESPONSES_FAILURE: {
       return { ...state, isLoading: false };
+    }
+    case actionTypes.UNSUBMIT_RESPONSE_SUCCESS: {
+      const { canUnsubmit } = action.flags;
+      const response = { ...action.response, canUnsubmit };
+      const responses = updateOrAppend(state.responses, response);
+      return { ...state, responses };
     }
     default:
       return state;

--- a/client/app/bundles/course/survey/reducers/surveyForm.js
+++ b/client/app/bundles/course/survey/reducers/surveyForm.js
@@ -5,6 +5,7 @@ const initialState = {
   disabled: false,
   onSubmit: () => {},
   formTitle: '',
+  hasStudentResponse: false,
   initialValues: {},
 };
 

--- a/spec/controllers/course/survey/responses_controller_spec.rb
+++ b/spec/controllers/course/survey/responses_controller_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe Course::Survey::ResponsesController do
           expect(response_answer_count).not_to eq(survey.questions.count)
         end
       end
+
+      context 'when the survey is anonymous' do
+        let(:survey_traits) { [:published, :currently_active, :anonymous] }
+
+        context "when staff views a student's response" do
+          let(:user) { manager.user }
+
+          it 'denies access' do
+            expect { subject }.to raise_exception(CanCan::AccessDenied)
+          end
+        end
+
+        context 'when user views his own response' do
+          let(:user) { student.user }
+
+          it { is_expected.to render_template('course/survey/responses/_response') }
+        end
+      end
     end
 
     describe '#edit' do
@@ -102,6 +120,14 @@ RSpec.describe Course::Survey::ResponsesController do
         it 'creates answers for all new question' do
           response_answer_count = survey.responses.find(survey_response.id).answers.count
           expect(response_answer_count).to eq(survey.questions.count)
+        end
+      end
+
+      context 'when user is not response creator' do
+        let(:user) { manager.user }
+
+        it 'denies access' do
+          expect { subject }.to raise_exception(CanCan::AccessDenied)
         end
       end
     end


### PR DESCRIPTION
Grant pseudo-anonymity to students so that they will be more forthcoming with answers. Although difficult, it is still possible for staff to deduce who made which response.

- If anonymous, prevent staff from accessing response show page
- Staff can see who has not submitted so that they can chase students to submit.
- When anonymous, staff cannot access response show page to unsubmit responses - allow unsubmission from response index page.
- Once a student has responded to an anonymous survey, prevent staff from turning off anonymity.