### PR TITLE
Display images in announcement emails

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -3,6 +3,8 @@
 #
 # @api private
 class ActivityMailer < ApplicationMailer
+  helper ApplicationHTMLFormattersHelper
+
   # Emails a recipient, informing him of an activity.
   #
   # @param [User] recipient The recipient of the email.

--- a/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
+++ b/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
@@ -4,7 +4,7 @@
 
 - message.subject = t('.subject', course: course.title, announcement: announcement.title)
 
-= simple_format(t('.message', course: link_to(course.title, course_url(course, host: host)),
+= format_html(t('.message', course: link_to(course.title, course_url(course, host: host)),
                               announcement: link_to(:announcement,
                                                     course_announcements_url(course, host: host)),
                               content: announcement.content))

--- a/config/locales/en/notifiers/course/announcement_notifier/new/course_notifications/email.yml
+++ b/config/locales/en/notifiers/course/announcement_notifier/new/course_notifications/email.yml
@@ -8,6 +8,5 @@ en:
               subject: >
                 %{course} New Announcement: %{announcement}
               message: >
-                New %{announcement} from course: %{course}
-
+                <p>New %{announcement} from course: %{course}</p>
                 %{content}


### PR DESCRIPTION
Resolves #2238 

This change essentially applies the same whitelist when displaying them inside Coursemology to displaying them them in emails.