### PR TITLE
Remove simple_format monkey patch

### DIFF
--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -11,7 +11,7 @@ module ApplicationFormattersHelper
   # @param [String] text The text to display.
   # @return [String]
   def format_block_text(text)
-    format_html(simple_format(text, {}, sanitize: false))
+    simple_format(html_escape(text), {}, sanitize: false)
   end
 
   # Formats the given user-input string. The string is assumed not to contain HTML markup.
@@ -19,7 +19,7 @@ module ApplicationFormattersHelper
   # @param [String] text The text to display.
   # @return [String]
   def format_inline_text(text)
-    format_html(html_escape(text))
+    html_escape(text)
   end
 
   # Formats the given User as a user-visible string.

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -98,15 +98,6 @@ module ApplicationHTMLFormattersHelper
     format_with_pipeline(HTMLSanitizerPipeline, text)
   end
 
-  # Replaces the Rails simple_format to escape HTML.
-  #
-  # @return [String]
-  def simple_format(text, *args)
-    text = html_escape(text) unless text.html_safe?
-    args.unshift(text)
-    super(*args)
-  end
-
   # Sanitises and formats the given user-input string. The string is assumed to contain HTML markup.
   #
   # @param [String] text The text to display

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -3,7 +3,7 @@
 #
 # @api private
 class ActivityMailer < ApplicationMailer
-  helper ApplicationHTMLFormattersHelper
+  helper ApplicationFormattersHelper
 
   # Emails a recipient, informing him of an activity.
   #

--- a/app/views/course/assessment/answer/programming/_test_cases_of_type.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases_of_type.html.slim
@@ -23,13 +23,13 @@ div.panel.panel-default
       - test_cases_and_results.each do |test_case, test_case_result|
         = content_tag_for(:tr, test_case, class: test_result_class(test_case_result)) do
           - if is_grader
-            th = format_html(test_case.identifier)
-          td = format_html(test_case.expression)
+            th = format_inline_text(test_case.identifier)
+          td = format_inline_text(test_case.expression)
           td
-            div.expected = format_html(test_case.expected)
+            div.expected = format_inline_text(test_case.expected)
           - if is_grader
             td
-              div.output = simple_format(get_output(test_case_result))
+              div.output = format_inline_text(get_output(test_case_result))
           - if @submission.attempting?
             td
               - unless test_case_result && test_case_result.passed?

--- a/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
+++ b/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
@@ -4,7 +4,9 @@
 
 - message.subject = t('.subject', course: course.title, announcement: announcement.title)
 
-= format_html(t('.message', course: link_to(course.title, course_url(course, host: host)),
-                              announcement: link_to(:announcement,
-                                                    course_announcements_url(course, host: host)),
-                              content: announcement.content))
+- course_link = link_to(format_inline_text(course.title), course_url(course, host: host))
+- announcement_link = link_to(:announcement, course_announcements_url(course, host: host))
+
+= format_html(t('.message', course: course_link,
+                            announcement: announcement_link,
+                            content: announcement.content))

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -5,13 +5,17 @@
 - unsubscribe_url = subscribe_course_forum_topic_url(course, topic.forum, topic, subscribe: false,
                                                      host: host)
 
-- message.subject = t('.subject', course: course.title, topic: topic.title)
+- course_title = format_inline_text(course_title)
+- topic_title = format_inline_text(topic_title)
+- post_author = format_inline_text(post.creator.name)
 
-= simple_format(t('.message',
-                topic: link_to(topic.title,
+- message.subject = t('.subject', course: course_title, topic: topic_title)
+
+= format_html(t('.message',
+                topic: link_to(topic_title,
                                course_forum_topic_url(course, topic.forum, topic, host: host)),
                 post: post.text,
-                post_author: post.creator.name))
+                post_author: post_author))
 
 = simple_format(t('.unsubscribe.message',
                 unsubscribe_link: link_to(t('.unsubscribe.tag'), unsubscribe_url)))

--- a/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/topic_notifier/created/user_notifications/email.html.slim
@@ -6,9 +6,12 @@
 - unsubscribe_url = unsubscribe_course_forum_url(course, topic.forum, host: host)
 - topic_url = course_forum_topic_url(course, topic.forum, topic, host: host)
 
-- message.subject = t('.subject', course: course.title, forum: topic.forum.name)
+- course_title = format_inline_text(course.title)
+- forum_name = format_inline_text(topic.forum.name)
 
-= simple_format(t('.message', topic: topic_url, post: post.text))
+- message.subject = t('.subject', course: course_title, forum: forum_name)
+
+= format_html(t('.message', topic: topic_url, post: post.text))
 
 = simple_format(t('.unsubscribe.message',
                 unsubscribe_link: link_to(t('.unsubscribe.tag'), unsubscribe_url)))

--- a/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/forum/post_notifier/replied/user_notifications/email.yml
@@ -8,11 +8,9 @@ en:
               email:
                 subject: '%{course} New reply for forum topic: %{topic}'
                 message: >
-                  %{post_author} replied,
+                  <p>%{post_author} replied,</p>
                   %{post}
-
-                  You can respond here: %{topic}
-
+                  <p>You can respond here: %{topic}</p>
                 unsubscribe:
                   tag: 'Unsubscribe'
                   message: '%{unsubscribe_link} from email notifications for this topic'

--- a/config/locales/en/notifiers/course/forum/topic_notifier/created/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/forum/topic_notifier/created/user_notifications/email.yml
@@ -8,8 +8,7 @@ en:
               email:
                 subject: '%{course} New topic created in forum: %{forum}'
                 message: >
-                  A new topic has been created in the forum: %{topic}
-
+                  <p>A new topic has been created in the forum: %{topic}</p>
                   %{post}
 
                 unsubscribe:

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -166,9 +166,9 @@ RSpec.describe ApplicationFormattersHelper do
       end
     end
 
-    describe '#simple_format' do
+    describe '#format_block_text' do
       it 'escapes HTML' do
-        expect(helper.simple_format('<')).to have_tag('p') do
+        expect(helper.format_block_text('<')).to have_tag('p') do
           with_text('<')
         end
       end


### PR DESCRIPTION
- Moved HTML escaping to previously unused function `format_block_text`
- HTML escape programming question test case expression and expected values
- Do not escape HTML for new topic and post reply notification emails
- Remove unnecessary `format_html` call from `format_inline_text`

**Programming question test cases**

Before:

![before](https://cloud.githubusercontent.com/assets/4056819/25323690/bc352fd4-28f3-11e7-8ed6-a102d5b389cf.png)

After:

![after](https://cloud.githubusercontent.com/assets/4056819/25323693/bf6d198c-28f3-11e7-9e0a-e76c47459603.png)

