### PR TITLE
Fix random failing spec

### DIFF
--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -142,10 +142,10 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
             end
           end
         end
-        click_button I18n.t('helpers.buttons.update')
+        find(:button, I18n.t('helpers.buttons.update')).trigger('click')
 
-        expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(page).to have_selector('div.alert.alert-success')
+        expect(current_path).to eq(course_assessment_path(course, assessment))
         expect(mrq.reload.options.count).to eq(options.count)
 
         # Delete all MRQ options

--- a/spec/features/course/assessment_condition_management_spec.rb
+++ b/spec/features/course/assessment_condition_management_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature 'Course: Assessments' do
         expect do
           find_link(nil, href: condition_delete_path).click
           accept_confirm_dialog
+          expect(page).to have_selector('div.alert-success')
         end.to change { assessment.conditions.count }.by(-1)
       end
     end

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -124,6 +124,9 @@ RSpec.feature 'Courses: Invitations', js: true do
                   href: course_user_invitation_path(course, invitation_to_delete)).click
         expect(page).to have_selector('.confirm-btn')
         accept_confirm_dialog
+
+        expect(page).to have_selector('div.alert-success',
+                                      text: I18n.t('course.user_invitations.destroy.success'))
         expect(current_path).to eq(course_user_invitations_path(course))
         expect(page).not_to have_content_tag_for(invitation_to_delete)
       end

--- a/spec/features/course/lesson_plan_event_management_spec.rb
+++ b/spec/features/course/lesson_plan_event_management_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature 'Course: Events' do
           expect(page).not_to have_link(nil, href: deletion_path)
           expect(page).to have_selector('.confirm-btn')
           accept_confirm_dialog
+          expect(page).to have_selector('div.alert-success')
         end.to change(course.lesson_plan_events, :count).by(-1)
 
         # Go to edit event page


### PR DESCRIPTION
Reference #2161

There's this spec always fails on travis:
```
 1) Course: Assessments: Questions: Multiple Response Management with tenant :instance As a Course Manager I can edit a question and delete an option
     Failure/Error: click_button I18n.t('helpers.buttons.update')
     
     Capybara::Poltergeist::MouseEventFailed:
       Firing a click at co-ordinates [59, 46] failed. Poltergeist detected another element with CSS selector 'html.wf-roboto-n4-active.wf-varelaround-n4-active.wf-active body nav.navbar.navbar-inverse.navbar-fixed-top div.container-fluid div.navbar-header a.navbar-brand' at this position. It may be overlapping the element you are trying to interact with. If you don't care about overlapping elements, try using node.trigger('click').
```