### PR TITLE
Fix random failure in lesson plan milestone deletion spec

### DIFF
--- a/spec/features/course/lesson_plan_milestone_management_spec.rb
+++ b/spec/features/course/lesson_plan_milestone_management_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature 'Course: Lesson Plan Milestones' do
           expect(page).not_to have_link(nil, href: deletion_path)
           expect(page).to have_selector('.confirm-btn')
           accept_confirm_dialog
+          expect(page).to have_selector('div.alert-success')
         end.to change(course.lesson_plan_milestones, :count).by(-1)
 
         # Go to edit milestone page


### PR DESCRIPTION
Reference #2161
Follow up #2253, did a search and this should be the last place...

```
1) Course: Lesson Plan Milestones with tenant :instance As a Course Manager I can delete a course milestone and visit the edit milestone page
     Failure/Error:
       expect do
         find_link(nil, href: deletion_path).click
         expect(page).not_to have_link(nil, href: deletion_path)
         expect(page).to have_selector('.confirm-btn')
         accept_confirm_dialog
       end.to change(course.lesson_plan_milestones, :count).by(-1)
     
       expected #count to have changed by -1, but was changed by 0
     # ./spec/features/course/lesson_plan_milestone_management_spec.rb:49:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in <top (required)>'
```