### PR TITLE
Display current course start time on duplication page

### DIFF
--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -23,7 +23,7 @@ class Course::DuplicationsController < Course::ComponentController
   private
 
   def create_duplication_params # :nodoc
-    params.require(:duplication).permit(:new_start_date, :new_title)
+    params.require(:duplication).permit(:new_start_at, :new_title)
   end
 
   # Construct the options to be sent to the duplication job.

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -169,8 +169,8 @@ class Course < ActiveRecord::Base
 
   # Set default values
   def set_defaults
-    self.start_at ||= Time.zone.now
-    self.end_at ||= 1.month.from_now
+    self.start_at ||= Time.zone.now.beginning_of_hour
+    self.end_at ||= self.start_at + 1.month
 
     return unless creator && course_users.empty?
     course_users.build(user: creator, role: :owner, creator: creator, updater: updater)

--- a/app/services/course/duplication/course_duplication_service.rb
+++ b/app/services/course/duplication/course_duplication_service.rb
@@ -9,7 +9,7 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
     # @param [Hash] options The options to be sent to the Duplicator object.
     # @option options [User] :current_user (+User.system+) The user triggering the duplication.
     # @option options [String] :new_title ('Duplicated') The title for the duplicated course.
-    # @option options [DateTime] :new_start_date Start date for the duplicated course.
+    # @option options [DateTime] :new_start_at Start date and time for the duplicated course.
     # @param [Array] all_objects All the objects in the course.
     # @param [Array] selected_objects The objects to duplicate.
     # @return [Course] The duplicated course
@@ -18,8 +18,8 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
       options[:excluded_objects] = excluded_objects
       options[:current_course] = current_course
       options[:time_shift] =
-        if options[:new_start_date]
-          Time.zone.parse(options[:new_start_date]) - current_course.start_at
+        if options[:new_start_at]
+          Time.zone.parse(options[:new_start_at]) - current_course.start_at
         else
           0
         end

--- a/app/views/course/duplications/show.html.slim
+++ b/app/views/course/duplications/show.html.slim
@@ -1,15 +1,18 @@
 - add_breadcrumb :show
 = page_header t('.header')
 
+- t = Date.tomorrow
+- new_start_at = current_course.start_at.change(year: t.year, month: t.month, day: t.day)
+
 div.panel.panel-default
   div.panel-heading
-    h4.panel-title = t('.course_start_date')
-  div.panel-body = format_datetime(current_course.start_at, :date_only_long)
+    h4.panel-title = t('.course_start_time')
+  div.panel-body = format_datetime(current_course.start_at, :rfc822)
 
 = simple_form_for :duplication,
   url: course_duplication_path(current_course),
   method: :post do |f|
-  = f.input :new_start_date, as: :bootstrap_date_time, input_html: { value: 1.day.from_now }
+  = f.input :new_start_at, as: :bootstrap_date_time, input_html: { value: new_start_at }
   = f.input :new_title,
       input_html: { value: t('.new_course_title', current_course_title: current_course.title) }
   = f.button :submit, t('.duplicate'), class: 'duplicate'

--- a/config/locales/en/course/duplications.yml
+++ b/config/locales/en/course/duplications.yml
@@ -4,7 +4,7 @@ en:
       show:
         header: 'Duplicate Course'
         duplicate: :'course.duplications.show.header'
-        course_start_date: 'Current Course Start Date'
+        course_start_time: 'Current Course Start Time'
         new_course_title: 'Copy of %{current_course_title}'
         close_window: 'Duplication usually takes some time to complete. You may close the window while duplication is in progress.'
         email_notify: 'You will receive an email with a link to the new course when it becomes available.'

--- a/spec/features/course/duplication_spec.rb
+++ b/spec/features/course/duplication_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Course: Duplication' do
       scenario 'I can duplicate a course' do
         visit course_duplication_path(course)
 
-        expect(page).to have_field('New start date')
+        expect(page).to have_field('New start at')
         expect(page).to have_field('New title')
 
         expect do
@@ -50,7 +50,7 @@ RSpec.feature 'Course: Duplication' do
 
         # Just test that the Duplicate form can be seen since the actual duplication is already
         # tested under the System Administrator context.
-        expect(page).to have_field('New start date')
+        expect(page).to have_field('New start at')
         expect(page).to have_field('New title')
       end
     end

--- a/spec/services/course/duplication/course_duplication_service_spec.rb
+++ b/spec/services/course/duplication/course_duplication_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
     let(:new_course) do
       options = {
         current_user: admin,
-        new_start_date: (course.start_at + 1.day).iso8601,
+        new_start_at: (course.start_at + 1.day).iso8601,
         new_title: I18n.t('course.duplications.show.new_course_title_prefix')
       }
       Course::Duplication::CourseDuplicationService.duplicate_course(course, options)


### PR DESCRIPTION
The current course start time is displayed and the default duplicated
course start time is set to the same time as that of the current course.
This is important because duplicated course will have start and end date
of all items shifted by the difference between the start times of the two
courses. Default start and end times of a newly created course is rounded
to the nearest hour to make it cleaner.

<img width="328" alt="screen shot 2017-04-24 at 9 22 43 pm" src="https://cloud.githubusercontent.com/assets/4056819/25340211/9e3e3dce-2937-11e7-8360-79710a9e8492.png">
