### PR TITLE
Allow skill descriptions to be blank

### DIFF
--- a/db/migrate/20170426024809_remove_constraint_in_skills.rb
+++ b/db/migrate/20170426024809_remove_constraint_in_skills.rb
@@ -1,0 +1,6 @@
+class RemoveConstraintInSkills < ActiveRecord::Migration
+  def change
+    change_column :course_assessment_skill_branches, :description, :text, null: true
+    change_column :course_assessment_skills, :description, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170420063829) do
+ActiveRecord::Schema.define(version: 20170426024809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -327,7 +327,7 @@ ActiveRecord::Schema.define(version: 20170420063829) do
   create_table "course_assessment_skill_branches", force: :cascade do |t|
     t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_skill_branches_course_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.string   "title",       :limit=>255, :null=>false
-    t.text     "description", :null=>false
+    t.text     "description"
     t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skill_branches_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skill_branches_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at",  :null=>false
@@ -338,7 +338,7 @@ ActiveRecord::Schema.define(version: 20170420063829) do
     t.integer  "course_id",       :null=>false, :index=>{:name=>"fk__course_assessment_skills_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_skills_course_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "skill_branch_id", :index=>{:name=>"fk__course_assessment_skills_skill_branch_id"}, :foreign_key=>{:references=>"course_assessment_skill_branches", :name=>"fk_course_assessment_skills_skill_branch_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.string   "title",           :limit=>255, :null=>false
-    t.text     "description",     :null=>false
+    t.text     "description"
     t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skills_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skills_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at",      :null=>false


### PR DESCRIPTION
Don't think we should enforce the user to input the description and also in migration most of the records from v1 don't have the description.