### PR TITLE
Tweak survey UI/UX

### DIFF
--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
@@ -5,6 +5,7 @@ import Toggle from 'material-ui/Toggle';
 import RaisedButton from 'material-ui/RaisedButton';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import { cyan500, grey50, grey300 } from 'material-ui/styles/colors';
+import formTranslations from 'lib/translations/form';
 import { sorts } from 'course/survey/utils';
 import { questionTypes } from 'course/survey/constants';
 import { optionShape } from 'course/survey/propTypes';
@@ -68,6 +69,9 @@ const styles = {
   },
   tableWrapper: {
     overflow: 'inherit',
+  },
+  required: {
+    fontStyle: 'italic',
   },
 };
 
@@ -355,7 +359,9 @@ class ResultsQuestion extends React.Component {
     return (
       <Card style={styles.card}>
         <CardText>
-          {`${index + 1}. ${question.description}`}
+          <p>{ `${index + 1}. ${question.description}` }</p>
+          { question.required ?
+            <p style={styles.required}><FormattedMessage {...formTranslations.starRequired} /></p> : null }
         </CardText>
         {this.renderSpecificResults()}
       </Card>

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
@@ -8,6 +8,7 @@ import IconButton from 'material-ui/IconButton';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
+import formTranslations from 'lib/translations/form';
 import { questionTypes } from 'course/survey/constants';
 import { questionShape } from 'course/survey/propTypes';
 import translations from 'course/survey/translations';
@@ -46,6 +47,9 @@ const styles = {
   },
   fields: {
     marginTop: 0,
+  },
+  required: {
+    fontStyle: 'italic',
   },
 };
 
@@ -155,7 +159,9 @@ class QuestionCard extends React.Component {
       >
         <CardText style={styles.cardText}>
           { this.renderAdminMenu() }
-          <p>{question.description}</p>
+          <p>{ question.description }</p>
+          { question.required ?
+            <p style={styles.required}><FormattedMessage {...formTranslations.starRequired} /></p> : null }
         </CardText>
         <CardText expandable style={styles.fields}>
           { QuestionCard.renderSpecificFields(question) }

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/SectionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/SectionCard.jsx
@@ -43,8 +43,21 @@ class SectionCard extends React.Component {
     this.state = { expanded: true };
   }
 
+  renderActions() {
+    const { section, first, last, disabled, index: sectionIndex } = this.props;
+    return (
+      <CardActions>
+        { section.canCreateQuestion ? <NewQuestionButton sectionId={section.id} {...{ disabled }} /> : null }
+        { section.canUpdate ? <EditSectionButton {...{ section, disabled }} /> : null }
+        { section.canDelete ? <DeleteSectionButton sectionId={section.id} {...{ disabled }} /> : null }
+        { section.canUpdate && !first ? <MoveUpButton {...{ sectionIndex, disabled }} /> : null }
+        { section.canUpdate && !last ? <MoveDownButton {...{ sectionIndex, disabled }} /> : null }
+      </CardActions>
+    );
+  }
+
   render() {
-    const { section, first, last, disabled, index: sectionIndex, survey: { draggedQuestion } } = this.props;
+    const { section, index: sectionIndex, survey: { draggedQuestion } } = this.props;
     return (
       <Card
         style={styles.card}
@@ -57,6 +70,7 @@ class SectionCard extends React.Component {
           subtitleStyle={styles.subtitle}
           showExpandableButton={section.questions.length > 0}
         />
+        { section.questions.length > 1 ? this.renderActions() : null }
         <CardText>
           {
             section.questions.length < 1 ?
@@ -72,13 +86,7 @@ class SectionCard extends React.Component {
             )
           }
         </CardText>
-        <CardActions>
-          { section.canCreateQuestion ? <NewQuestionButton sectionId={section.id} {...{ disabled }} /> : null }
-          { section.canUpdate ? <EditSectionButton {...{ section, disabled }} /> : null }
-          { section.canDelete ? <DeleteSectionButton sectionId={section.id} {...{ disabled }} /> : null }
-          { section.canUpdate && !first ? <MoveUpButton {...{ sectionIndex, disabled }} /> : null }
-          { section.canUpdate && !last ? <MoveDownButton {...{ sectionIndex, disabled }} /> : null }
-        </CardActions>
+        { this.renderActions() }
       </Card>
     );
   }

--- a/client/app/lib/translations/form.jsx
+++ b/client/app/lib/translations/form.jsx
@@ -45,6 +45,10 @@ const translations = defineMessages({
     id: 'lib.form.validation.required',
     defaultMessage: 'Required',
   },
+  starRequired: {
+    id: 'lib.form.validation.starRequired',
+    defaultMessage: '* Required',
+  },
   invalid: {
     id: 'lib.form.validation.invalid',
     defaultMessage: 'Invalid',


### PR DESCRIPTION
- Add indicator for required survey questions on Survey show and results pages.
- Add action buttons to top of section card for SurveyShow.
    - When users want to edit the title/description of the section, they have to scroll all the way to the bottom to look for the edit button. This PR co-locates the edit button with the fields it edits.
    - Likewise, for the moving of sections, user is likely to be looking at the section header when s/he is thinking of doing this.

Thanks @Teo-ShaoWei for the feedback.