### PR TITLE
Show student names on survey results page when not anonymous

### DIFF
--- a/app/views/course/survey/surveys/results.json.jbuilder
+++ b/app/views/course/survey/surveys/results.json.jbuilder
@@ -10,7 +10,10 @@ json.sections @sections do |section|
     end
     json.answers student_submitted_answers do |answer|
       json.(answer, :id)
-      json.course_user_name answer.response.course_user.name unless @survey.anonymous?
+      unless @survey.anonymous?
+        json.course_user_name answer.response.course_user.name
+        json.course_user_id answer.response.course_user.id
+      end
       json.phantom answer.response.course_user.phantom?
       if question.text?
         json.(answer, :text_response)

--- a/client/app/api/course/Survey/Surveys.js
+++ b/client/app/api/course/Survey/Surveys.js
@@ -104,7 +104,7 @@ export default class SurveysAPI extends BaseSurveyAPI {
   *       description: string, options: Array, question_type: string, options: Array, ...etc
   *         - Question attributes
   *       answers: Array.<{
-  *         id: number, course_user_name: string, course_user_role: string,
+  *         id: number, course_user_name: string, course_user_id: number, phantom: bool,
   *         text_response: string
   *           - included only if it is a text response question
   *         selected_options: Array.<number>

--- a/client/app/bundles/course/survey/pages/SurveyResults/OptionsQuestionResults.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/OptionsQuestionResults.jsx
@@ -1,0 +1,318 @@
+import React, { PropTypes } from 'react';
+import { CardText } from 'material-ui/Card';
+import Chip from 'material-ui/Chip';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import Toggle from 'material-ui/Toggle';
+import RaisedButton from 'material-ui/RaisedButton';
+import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
+import { cyan500, grey50, grey300 } from 'material-ui/styles/colors';
+import { sorts } from 'course/survey/utils';
+import { questionTypes } from 'course/survey/constants';
+import { optionShape } from 'course/survey/propTypes';
+import Thumbnail from 'course/survey/components/Thumbnail';
+
+const styles = {
+  percentageBarThreshold: 10,
+  expandableThreshold: 10,
+  image: {
+    maxHeight: 80,
+    maxWidth: 80,
+  },
+  imageContainer: {
+    margin: 10,
+    height: 80,
+    width: 80,
+  },
+  bar: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: cyan500,
+    color: grey50,
+    height: 24,
+    borderRadius: 5,
+  },
+  barContainer: {
+    display: 'flex',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    backgroundColor: grey300,
+    width: '100%',
+    height: 24,
+    borderRadius: 5,
+  },
+  percentage: {
+    marginLeft: 5,
+    color: cyan500,
+    fontWeight: 'bold',
+  },
+  percentageHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  sortByPercentage: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  expandToggleStyle: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  wrapText: {
+    whiteSpace: 'normal',
+    wordWrap: 'break-word',
+  },
+  tableWrapper: {
+    overflow: 'inherit',
+  },
+  optionStudentNames: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  nameChip: {
+    margin: 2,
+  },
+};
+
+const translations = defineMessages({
+  serial: {
+    id: 'course.surveys.OptionsQuestionResults.serial',
+    defaultMessage: 'S/N',
+  },
+  respondents: {
+    id: 'course.surveys.OptionsQuestionResults.respondents',
+    defaultMessage: 'Respondents',
+  },
+  count: {
+    id: 'course.surveys.OptionsQuestionResults.count',
+    defaultMessage: 'Count',
+  },
+  percentage: {
+    id: 'course.surveys.OptionsQuestionResults.percentage',
+    defaultMessage: 'Percentage',
+  },
+  sortByPercentage: {
+    id: 'course.surveys.OptionsQuestionResults.sortByPercentage',
+    defaultMessage: 'Sort By Percentage',
+  },
+  sortByCount: {
+    id: 'course.surveys.OptionsQuestionResults.sortByCount',
+    defaultMessage: 'Sort By Count',
+  },
+  multipleChoiceOption: {
+    id: 'course.surveys.OptionsQuestionResults.multipleChoiceOption',
+    defaultMessage: 'Multiple Choice Option',
+  },
+  multipleResponseOption: {
+    id: 'course.surveys.OptionsQuestionResults.multipleResponseOption',
+    defaultMessage: 'Multiple Response Option',
+  },
+  showOptions: {
+    id: 'course.surveys.OptionsQuestionResults.showOptions',
+    defaultMessage: 'Show All {quantity} Options',
+  },
+  hideOptions: {
+    id: 'course.surveys.OptionsQuestionResults.hideOptions',
+    defaultMessage: 'Hide All {quantity} Options',
+  },
+  phantomStudentName: {
+    id: 'course.surveys.OptionsQuestionResults.phantomStudentName',
+    defaultMessage: '{name} (Phantom)',
+  },
+});
+
+class OptionsQuestionResults extends React.Component {
+  static propTypes = {
+    options: PropTypes.arrayOf(optionShape),
+    includePhantoms: PropTypes.bool,
+    anonymous: PropTypes.bool,
+    questionType: PropTypes.string,
+    answers: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      course_user_id: PropTypes.number,
+      course_user_name: PropTypes.string,
+      phantom: PropTypes.bool,
+      selected_options: PropTypes.arrayOf(PropTypes.number),
+    })),
+  }
+
+  static renderPercentageBar(percentage) {
+    return (
+      <div style={styles.barContainer}>
+        <div style={{ ...styles.bar, width: `${percentage}%` }}>
+          {
+            percentage >= styles.percentageBarThreshold ?
+            `${percentage.toFixed(1)}%` : null
+          }
+        </div>
+        {
+          percentage < styles.percentageBarThreshold ?
+            <span style={styles.percentage}>{`${percentage.toFixed(1)}%`}</span> :
+          null
+        }
+      </div>
+    );
+  }
+
+  static renderStudentList(students) {
+    return (
+      <div style={styles.optionStudentNames}>
+        {
+          students.map(student =>
+            <Chip key={student.id} style={styles.nameChip}>
+              {
+                student.phantom ?
+                  <FormattedMessage {...translations.phantomStudentName} values={{ name: student.name }} /> :
+                  student.name
+              }
+            </Chip>
+          )
+        }
+      </div>
+    );
+  }
+
+  static renderOptionRow(breakdown, hasImage, option, index, anonymous) {
+    const percentage = (100 * breakdown[option.id].count) / breakdown.length;
+    const { id, option: optionText, image_url: imageUrl, image_name: imageName } = option;
+
+    return (
+      <TableRow key={id}>
+        <TableRowColumn>{index + 1}</TableRowColumn>
+        {
+          hasImage ?
+            <TableRowColumn>
+              { imageUrl ?
+                <Thumbnail
+                  src={imageUrl}
+                  style={styles.image}
+                  containerStyle={styles.imageContainer}
+                /> : [] }
+            </TableRowColumn> : null
+        }
+        <TableRowColumn colSpan={hasImage ? 3 : 6} style={styles.wrapText}>
+          { optionText || imageName || null }
+        </TableRowColumn>
+        <TableRowColumn>{breakdown[id].count}</TableRowColumn>
+        <TableRowColumn colSpan={6} >
+          {
+            anonymous ?
+            OptionsQuestionResults.renderPercentageBar(percentage) :
+            OptionsQuestionResults.renderStudentList(breakdown[id].students)
+          }
+        </TableRowColumn>
+      </TableRow>
+    );
+  }
+
+  constructor(props) {
+    super(props);
+
+    const expandable = props.options.length > styles.expandableThreshold;
+    this.state = {
+      expandable,
+      expanded: !expandable,
+      sortByPercentage: false,
+    };
+  }
+
+  /**
+   * Computes the list and count of students that selected each option for the current question.
+   */
+  getOptionsBreakdown() {
+    const { includePhantoms, options, answers } = this.props;
+    const breakdown = { length: answers.length };
+    options.forEach((option) => {
+      breakdown[option.id] = { count: 0, students: [] };
+    });
+    answers.forEach((answer) => {
+      answer.selected_options.forEach((selectedOption) => {
+        if (!includePhantoms && answer.phantom) { return; }
+        breakdown[selectedOption].count += 1;
+        breakdown[selectedOption].students.push({
+          id: answer.course_user_id,
+          name: answer.course_user_name,
+          phantom: answer.phantom,
+        });
+      });
+    });
+    return breakdown;
+  }
+
+  renderExpandToggle() {
+    if (!this.state.expandable) { return null; }
+
+    const labelTranslation = this.state.expanded ? 'hideOptions' : 'showOptions';
+    const quantity = this.props.options.length;
+
+    return (
+      <CardText style={styles.expandToggleStyle}>
+        <RaisedButton
+          label={<FormattedMessage {...translations[labelTranslation]} values={{ quantity }} />}
+          onTouchTap={() => this.setState({ expanded: !this.state.expanded })}
+        />
+      </CardText>
+    );
+  }
+
+  renderOptionsResultsTable() {
+    const { anonymous, options, questionType } = this.props;
+    const { MULTIPLE_CHOICE, MULTIPLE_RESPONSE } = questionTypes;
+    const { byWeight } = sorts;
+    const breakdown = this.getOptionsBreakdown();
+    const optionsHeaderTranslation = {
+      [MULTIPLE_CHOICE]: translations.multipleChoiceOption,
+      [MULTIPLE_RESPONSE]: translations.multipleResponseOption,
+    }[questionType];
+    const hasImage = options.some(option => option.image_url);
+    const sortByCount = (a, b) => breakdown[b.id].count - breakdown[a.id].count;
+    const sortMethod = this.state.sortByPercentage ? sortByCount : byWeight;
+
+    return (
+      <Table wrapperStyle={styles.tableWrapper}>
+        <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
+          <TableRow>
+            <TableHeaderColumn>
+              <FormattedMessage {...translations.serial} />
+            </TableHeaderColumn>
+            <TableHeaderColumn colSpan={hasImage ? 4 : 6}>
+              <FormattedMessage {...optionsHeaderTranslation} />
+            </TableHeaderColumn>
+            <TableHeaderColumn>
+              <FormattedMessage {...translations.count} />
+            </TableHeaderColumn>
+            <TableHeaderColumn colSpan={6} >
+              <div style={styles.percentageHeader} >
+                <FormattedMessage {...translations[anonymous ? 'percentage' : 'respondents']} />
+                <div style={styles.sortByPercentage}>
+                  <FormattedMessage {...translations[anonymous ? 'sortByPercentage' : 'sortByCount']} />
+                  <Toggle onToggle={(_, value) => this.setState({ sortByPercentage: value })} />
+                </div>
+              </div>
+            </TableHeaderColumn>
+          </TableRow>
+        </TableHeader>
+        <TableBody displayRowCheckbox={false}>
+          {options.sort(sortMethod).map((option, index) =>
+            OptionsQuestionResults.renderOptionRow(breakdown, hasImage, option, index, anonymous)
+          )}
+        </TableBody>
+      </Table>
+    );
+  }
+
+  render() {
+    const toggle = this.renderExpandToggle();
+    return (
+      <div>
+        { toggle }
+        { this.state.expanded && this.renderOptionsResultsTable() }
+        { this.state.expanded && toggle }
+      </div>
+    );
+  }
+}
+
+export default OptionsQuestionResults;

--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
@@ -1,151 +1,20 @@
 import React, { PropTypes } from 'react';
 import { Card, CardText } from 'material-ui/Card';
-import Chip from 'material-ui/Chip';
-import { defineMessages, FormattedMessage } from 'react-intl';
-import Toggle from 'material-ui/Toggle';
-import RaisedButton from 'material-ui/RaisedButton';
-import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
-import { cyan500, grey50, grey300 } from 'material-ui/styles/colors';
+import { FormattedMessage } from 'react-intl';
 import formTranslations from 'lib/translations/form';
-import { sorts } from 'course/survey/utils';
 import { questionTypes } from 'course/survey/constants';
 import { optionShape } from 'course/survey/propTypes';
-import Thumbnail from 'course/survey/components/Thumbnail';
+import TextResponseResults from './TextResponseResults';
+import OptionsQuestionResults from './OptionsQuestionResults';
 
 const styles = {
-  percentageBarThreshold: 10,
-  optionThresholdQuantity: 10,
   card: {
     marginBottom: 15,
-  },
-  image: {
-    maxHeight: 80,
-    maxWidth: 80,
-  },
-  imageContainer: {
-    margin: 10,
-    height: 80,
-    width: 80,
-  },
-  bar: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: cyan500,
-    color: grey50,
-    height: 24,
-    borderRadius: 5,
-  },
-  barContainer: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-    backgroundColor: grey300,
-    width: '100%',
-    height: 24,
-    borderRadius: 5,
-  },
-  percentage: {
-    marginLeft: 5,
-    color: cyan500,
-    fontWeight: 'bold',
-  },
-  percentageHeader: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  sortByPercentage: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  expandToggleStyle: {
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  wrapText: {
-    whiteSpace: 'normal',
-    wordWrap: 'break-word',
-  },
-  tableWrapper: {
-    overflow: 'inherit',
   },
   required: {
     fontStyle: 'italic',
   },
-  optionStudentNames: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
-  nameChip: {
-    margin: 2,
-  },
 };
-
-const translations = defineMessages({
-  serial: {
-    id: 'course.surveys.ResultsQuestion.serial',
-    defaultMessage: 'S/N',
-  },
-  respondent: {
-    id: 'course.surveys.ResultsQuestion.respondent',
-    defaultMessage: 'Respondent',
-  },
-  respondents: {
-    id: 'course.surveys.ResultsQuestion.respondents',
-    defaultMessage: 'Respondents',
-  },
-  count: {
-    id: 'course.surveys.ResultsQuestion.count',
-    defaultMessage: 'Count',
-  },
-  percentage: {
-    id: 'course.surveys.ResultsQuestion.percentage',
-    defaultMessage: 'Percentage',
-  },
-  sortByPercentage: {
-    id: 'course.surveys.ResultsQuestion.sortByPercentage',
-    defaultMessage: 'Sort By Percentage',
-  },
-  sortByCount: {
-    id: 'course.surveys.ResultsQuestion.sortByCount',
-    defaultMessage: 'Sort By Count',
-  },
-  responses: {
-    id: 'course.surveys.ResultsQuestion.responses',
-    defaultMessage: 'Responses',
-  },
-  multipleChoiceOption: {
-    id: 'course.surveys.ResultsQuestion.multipleChoiceOption',
-    defaultMessage: 'Multiple Choice Option',
-  },
-  multipleResponseOption: {
-    id: 'course.surveys.ResultsQuestion.multipleResponseOption',
-    defaultMessage: 'Multiple Response Option',
-  },
-  showResponses: {
-    id: 'course.surveys.ResultsQuestion.showResponses',
-    defaultMessage: 'Show Responses ({quantity}/{total} responded{phantoms, plural, \
-      =0 {} one {, {phantoms} Phantom} other {, {phantoms} Phantoms}})',
-  },
-  hideResponses: {
-    id: 'course.surveys.ResultsQuestion.hideResponses',
-    defaultMessage: 'Hide Responses',
-  },
-  showOptions: {
-    id: 'course.surveys.ResultsQuestion.showOptions',
-    defaultMessage: 'Show All {quantity} Options',
-  },
-  hideOptions: {
-    id: 'course.surveys.ResultsQuestion.hideOptions',
-    defaultMessage: 'Hide All {quantity} Options',
-  },
-  phantomStudentName: {
-    id: 'course.surveys.ResultsQuestion.phantomStudentName',
-    defaultMessage: '{name} (Phantom)',
-  },
-});
 
 class ResultsQuestion extends React.Component {
   static propTypes = {
@@ -163,6 +32,7 @@ class ResultsQuestion extends React.Component {
       options: PropTypes.arrayOf(optionShape),
       answers: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.number,
+        course_user_id: PropTypes.number,
         course_user_name: PropTypes.string,
         phantom: PropTypes.bool,
         selected_options: PropTypes.arrayOf(PropTypes.number),
@@ -170,249 +40,14 @@ class ResultsQuestion extends React.Component {
     }).isRequired,
   }
 
-  static renderPercentageBar(percentage) {
-    return (
-      <div style={styles.barContainer}>
-        <div style={{ ...styles.bar, width: `${percentage}%` }}>
-          {
-            percentage >= styles.percentageBarThreshold ?
-            `${percentage.toFixed(1)}%` : null
-          }
-        </div>
-        {
-          percentage < styles.percentageBarThreshold ?
-            <span style={styles.percentage}>{`${percentage.toFixed(1)}%`}</span> :
-          null
-        }
-      </div>
-    );
-  }
-
-  static renderOptionRow(breakdown, hasImage, option, index, anonymous) {
-    const percentage = (100 * breakdown[option.id].count) / breakdown.length;
-    const { id, option: optionText, image_url: imageUrl, image_name: imageName } = option;
-
-    return (
-      <TableRow key={id}>
-        <TableRowColumn>{index + 1}</TableRowColumn>
-        {
-          hasImage ?
-            <TableRowColumn>
-              { imageUrl ?
-                <Thumbnail
-                  src={imageUrl}
-                  style={styles.image}
-                  containerStyle={styles.imageContainer}
-                /> : [] }
-            </TableRowColumn> : null
-        }
-        <TableRowColumn colSpan={hasImage ? 3 : 6} style={styles.wrapText}>
-          { optionText || imageName || null }
-        </TableRowColumn>
-        <TableRowColumn>{breakdown[id].count}</TableRowColumn>
-        <TableRowColumn colSpan={6} >
-          <div style={styles.optionStudentNames}>
-            {
-              anonymous ?
-              ResultsQuestion.renderPercentageBar(percentage) :
-              breakdown[id].students.map(student =>
-                <Chip key={student.id} style={styles.nameChip}>
-                  {
-                    student.phantom ?
-                      <FormattedMessage {...translations.phantomStudentName} values={{ name: student.name }} /> :
-                    student.name
-                  }
-                </Chip>
-              )
-            }
-          </div>
-        </TableRowColumn>
-      </TableRow>
-    );
-  }
-
-  static renderTextResultsTable(answers, anonymous) {
-    return (
-      <Table>
-        <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
-          <TableRow>
-            <TableHeaderColumn colSpan={2}>
-              <FormattedMessage {...translations.serial} />
-            </TableHeaderColumn>
-            {
-              anonymous ||
-              <TableHeaderColumn colSpan={5}>
-                <FormattedMessage {...translations.respondent} />
-              </TableHeaderColumn>
-            }
-            <TableHeaderColumn colSpan={15}>
-              <FormattedMessage {...translations.responses} />
-            </TableHeaderColumn>
-          </TableRow>
-        </TableHeader>
-        <TableBody displayRowCheckbox={false}>
-          {answers.map((answer, index) => (
-            <TableRow key={answer.id}>
-              <TableRowColumn colSpan={2}>
-                { index + 1 }
-              </TableRowColumn>
-              {
-                anonymous ||
-                <TableRowColumn colSpan={5} style={styles.wrapText}>
-                  {
-                    answer.phantom ?
-                      <FormattedMessage
-                        {...translations.phantomStudentName}
-                        values={{ name: answer.course_user_name }}
-                      /> :
-                    answer.course_user_name
-                  }
-                </TableRowColumn>
-              }
-              <TableRowColumn colSpan={15} style={styles.wrapText}>
-                { answer.text_response }
-              </TableRowColumn>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    );
-  }
-
-  constructor(props) {
-    super(props);
-    const { question: { question_type: questionType, answers, options } } = props;
-    const maxRows = questionType === questionTypes.TEXT ? answers.length : options.length;
-    const expandable = maxRows > styles.optionThresholdQuantity;
-    this.state = {
-      expandable,
-      expanded: !expandable,
-      sortByPercentage: false,
-    };
-  }
-
-  /**
-   * Computes the list and count of students that selected each option for the current question.
-   */
-  getOptionsBreakdown() {
-    const { includePhantoms, question: { options, answers } } = this.props;
-    const breakdown = { length: answers.length };
-    options.forEach((option) => {
-      breakdown[option.id] = { count: 0, students: [] };
-    });
-    answers.forEach((answer) => {
-      answer.selected_options.forEach((selectedOption) => {
-        if (!includePhantoms && answer.phantom) { return; }
-        breakdown[selectedOption].count += 1;
-        breakdown[selectedOption].students.push({
-          id: answer.course_user_id,
-          name: answer.course_user_name,
-          phantom: answer.phantom,
-        });
-      });
-    });
-    return breakdown;
-  }
-
-  renderExpandToggle(values) {
-    if (!this.state.expandable) { return null; }
-
-    const { question } = this.props;
-    let labelTranslation;
-    if (question.question_type === questionTypes.TEXT) {
-      labelTranslation = this.state.expanded ? 'hideResponses' : 'showResponses';
-    } else {
-      labelTranslation = this.state.expanded ? 'hideOptions' : 'showOptions';
-    }
-
-    return (
-      <CardText style={styles.expandToggleStyle}>
-        <RaisedButton
-          label={<FormattedMessage {...translations[labelTranslation]} values={values} />}
-          onTouchTap={() => this.setState({ expanded: !this.state.expanded })}
-        />
-      </CardText>
-    );
-  }
-
-  renderOptionsResultsTable() {
-    const { question: { options, question_type: questionType }, anonymous } = this.props;
-    const { MULTIPLE_CHOICE, MULTIPLE_RESPONSE } = questionTypes;
-    const { byWeight } = sorts;
-    const breakdown = this.getOptionsBreakdown();
-    const optionsHeaderTranslation = {
-      [MULTIPLE_CHOICE]: translations.multipleChoiceOption,
-      [MULTIPLE_RESPONSE]: translations.multipleResponseOption,
-    }[questionType];
-    const hasImage = options.some(option => option.image_url);
-    const sortByCount = (a, b) => breakdown[b.id].count - breakdown[a.id].count;
-    const sortMethod = this.state.sortByPercentage ? sortByCount : byWeight;
-
-    return (
-      <Table wrapperStyle={styles.tableWrapper}>
-        <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
-          <TableRow>
-            <TableHeaderColumn>
-              <FormattedMessage {...translations.serial} />
-            </TableHeaderColumn>
-            <TableHeaderColumn colSpan={hasImage ? 4 : 6}>
-              <FormattedMessage {...optionsHeaderTranslation} />
-            </TableHeaderColumn>
-            <TableHeaderColumn>
-              <FormattedMessage {...translations.count} />
-            </TableHeaderColumn>
-            <TableHeaderColumn colSpan={6} >
-              <div style={styles.percentageHeader} >
-                <FormattedMessage {...translations[anonymous ? 'percentage' : 'respondents']} />
-                <div style={styles.sortByPercentage}>
-                  <FormattedMessage {...translations[anonymous ? 'sortByPercentage' : 'sortByCount']} />
-                  <Toggle onToggle={(_, value) => this.setState({ sortByPercentage: value })} />
-                </div>
-              </div>
-            </TableHeaderColumn>
-          </TableRow>
-        </TableHeader>
-        <TableBody displayRowCheckbox={false}>
-          {options.sort(sortMethod).map((option, index) =>
-            ResultsQuestion.renderOptionRow(breakdown, hasImage, option, index, anonymous)
-          )}
-        </TableBody>
-      </Table>
-    );
-  }
-
   renderTextResults() {
     const { includePhantoms, question: { answers }, anonymous } = this.props;
-    const filteredAnswers = includePhantoms ? answers : answers.filter(answer => !answer.phantom);
-    const nonEmptyAnswers = filteredAnswers.filter(answer => (
-      answer.text_response && answer.text_response.trim().length > 0
-    ));
-    const validPhantomResponses = includePhantoms ? nonEmptyAnswers.filter(answer => answer.phantom) : [];
-    const toggle = this.renderExpandToggle({
-      total: filteredAnswers.length,
-      quantity: nonEmptyAnswers.length,
-      phantoms: validPhantomResponses.length,
-    });
-
-    return (
-      <div>
-        { toggle }
-        { this.state.expanded ? ResultsQuestion.renderTextResultsTable(nonEmptyAnswers, anonymous) : null }
-        { this.state.expanded ? toggle : null}
-      </div>
-    );
+    return <TextResponseResults {...{ includePhantoms, answers, anonymous }} />;
   }
 
   renderOptionsResults() {
-    const optionsCount = this.props.question.options.length;
-    const toggle = this.renderExpandToggle({ quantity: optionsCount });
-    return (
-      <div>
-        { toggle }
-        { this.state.expanded ? this.renderOptionsResultsTable() : null }
-        { this.state.expanded ? toggle : null }
-      </div>
-    );
+    const { question: { options, answers, question_type: questionType }, anonymous, includePhantoms } = this.props;
+    return <OptionsQuestionResults {...{ options, answers, questionType, anonymous, includePhantoms }} />;
   }
 
   renderSpecificResults() {

--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
@@ -106,11 +106,12 @@ const translations = defineMessages({
   },
   showResponses: {
     id: 'course.surveys.ResultsQuestion.showResponses',
-    defaultMessage: 'Show All {quantity} Responses',
+    defaultMessage: 'Show Responses ({quantity}/{total} responded{phantoms, plural, \
+      =0 {} one {, {phantoms} Phantom} other {, {phantoms} Phantoms}})',
   },
   hideResponses: {
     id: 'course.surveys.ResultsQuestion.hideResponses',
-    defaultMessage: 'Hide All {quantity} Responses',
+    defaultMessage: 'Hide Responses',
   },
   showOptions: {
     id: 'course.surveys.ResultsQuestion.showOptions',
@@ -249,8 +250,9 @@ class ResultsQuestion extends React.Component {
     return breakdown;
   }
 
-  renderExpandToggle(quantity) {
+  renderExpandToggle(values) {
     if (!this.state.expandable) { return null; }
+
     const { question } = this.props;
     let labelTranslation;
     if (question.question_type === questionTypes.TEXT) {
@@ -258,10 +260,11 @@ class ResultsQuestion extends React.Component {
     } else {
       labelTranslation = this.state.expanded ? 'hideOptions' : 'showOptions';
     }
+
     return (
       <CardText style={styles.expandToggleStyle}>
         <RaisedButton
-          label={<FormattedMessage {...translations[labelTranslation]} values={{ quantity }} />}
+          label={<FormattedMessage {...translations[labelTranslation]} values={values} />}
           onTouchTap={() => this.setState({ expanded: !this.state.expanded })}
         />
       </CardText>
@@ -320,22 +323,30 @@ class ResultsQuestion extends React.Component {
     const nonEmptyAnswers = filteredAnswers.filter(answer => (
       answer.text_response && answer.text_response.trim().length > 0
     ));
+    const validPhantomResponses = includePhantoms ? nonEmptyAnswers.filter(answer => answer.phantom) : [];
+    const toggle = this.renderExpandToggle({
+      total: filteredAnswers.length,
+      quantity: nonEmptyAnswers.length,
+      phantoms: validPhantomResponses.length,
+    });
+
     return (
       <div>
-        { this.renderExpandToggle(nonEmptyAnswers.length) }
+        { toggle }
         { this.state.expanded ? ResultsQuestion.renderTextResultsTable(nonEmptyAnswers) : null }
-        { this.state.expanded ? this.renderExpandToggle(nonEmptyAnswers.length) : null}
+        { this.state.expanded ? toggle : null}
       </div>
     );
   }
 
   renderOptionsResults() {
     const optionsCount = this.props.question.options.length;
+    const toggle = this.renderExpandToggle({ quantity: optionsCount });
     return (
       <div>
-        { this.renderExpandToggle(optionsCount) }
+        { toggle }
         { this.state.expanded ? this.renderOptionsResultsTable() : null }
-        { this.state.expanded ? this.renderExpandToggle(optionsCount) : null }
+        { this.state.expanded ? toggle : null }
       </div>
     );
   }

--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsSection.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsSection.jsx
@@ -9,7 +9,7 @@ const styles = {
   },
 };
 
-const ResultsSection = ({ section, includePhantoms }) => (
+const ResultsSection = ({ section, includePhantoms, anonymous }) => (
   <Card style={styles.card}>
     <CardTitle
       title={section.title}
@@ -20,7 +20,7 @@ const ResultsSection = ({ section, includePhantoms }) => (
           section.questions.map((question, index) =>
             <ResultsQuestion
               key={question.id}
-              {...{ question, index, includePhantoms }}
+              {...{ question, index, includePhantoms, anonymous }}
             />
           )
         }
@@ -31,6 +31,7 @@ const ResultsSection = ({ section, includePhantoms }) => (
 ResultsSection.propTypes = {
   section: sectionShape.isRequired,
   includePhantoms: PropTypes.bool.isRequired,
+  anonymous: PropTypes.bool.isRequired,
 };
 
 export default ResultsSection;

--- a/client/app/bundles/course/survey/pages/SurveyResults/TextResponseResults.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/TextResponseResults.jsx
@@ -1,0 +1,154 @@
+import React, { PropTypes } from 'react';
+import { CardText } from 'material-ui/Card';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import RaisedButton from 'material-ui/RaisedButton';
+import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
+
+const styles = {
+  expandableThreshold: 10,
+  expandToggleStyle: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  wrapText: {
+    whiteSpace: 'normal',
+    wordWrap: 'break-word',
+  },
+};
+
+const translations = defineMessages({
+  serial: {
+    id: 'course.surveys.TextResponseResults.serial',
+    defaultMessage: 'S/N',
+  },
+  respondent: {
+    id: 'course.surveys.TextResponseResults.respondent',
+    defaultMessage: 'Respondent',
+  },
+  responses: {
+    id: 'course.surveys.TextResponseResults.responses',
+    defaultMessage: 'Responses',
+  },
+  showResponses: {
+    id: 'course.surveys.TextResponseResults.showResponses',
+    defaultMessage: 'Show Responses ({quantity}/{total} responded{phantoms, plural, \
+      =0 {} one {, {phantoms} Phantom} other {, {phantoms} Phantoms}})',
+  },
+  hideResponses: {
+    id: 'course.surveys.TextResponseResults.hideResponses',
+    defaultMessage: 'Hide Responses',
+  },
+  phantomStudentName: {
+    id: 'course.surveys.TextResponseResults.phantomStudentName',
+    defaultMessage: '{name} (Phantom)',
+  },
+});
+
+class TextResponseResults extends React.Component {
+  static propTypes = {
+    includePhantoms: PropTypes.bool.isRequired,
+    anonymous: PropTypes.bool.isRequired,
+    answers: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      course_user_id: PropTypes.number,
+      course_user_name: PropTypes.string,
+      phantom: PropTypes.bool,
+      selected_options: PropTypes.arrayOf(PropTypes.number),
+    })),
+  }
+
+  static renderTextResultsTable(answers, anonymous) {
+    return (
+      <Table>
+        <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
+          <TableRow>
+            <TableHeaderColumn colSpan={2}>
+              <FormattedMessage {...translations.serial} />
+            </TableHeaderColumn>
+            {
+              anonymous ? null :
+              <TableHeaderColumn colSpan={5}>
+                <FormattedMessage {...translations.respondent} />
+              </TableHeaderColumn>
+            }
+            <TableHeaderColumn colSpan={15}>
+              <FormattedMessage {...translations.responses} />
+            </TableHeaderColumn>
+          </TableRow>
+        </TableHeader>
+        <TableBody displayRowCheckbox={false}>
+          {answers.map((answer, index) => (
+            <TableRow key={answer.id}>
+              <TableRowColumn colSpan={2}>
+                { index + 1 }
+              </TableRowColumn>
+              {
+                anonymous ? null :
+                <TableRowColumn colSpan={5} style={styles.wrapText}>
+                  {
+                    answer.phantom ?
+                      <FormattedMessage
+                        {...translations.phantomStudentName}
+                        values={{ name: answer.course_user_name }}
+                      /> :
+                      answer.course_user_name
+                  }
+                </TableRowColumn>
+              }
+              <TableRowColumn colSpan={15} style={styles.wrapText}>
+                { answer.text_response }
+              </TableRowColumn>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  }
+
+  constructor(props) {
+    super(props);
+
+    const expandable = props.answers.length > styles.expandableThreshold;
+    this.state = {
+      expandable,
+      expanded: !expandable,
+    };
+  }
+
+  renderExpandToggle(values) {
+    if (!this.state.expandable) { return null; }
+    const labelTranslation = this.state.expanded ? 'hideResponses' : 'showResponses';
+    return (
+      <CardText style={styles.expandToggleStyle}>
+        <RaisedButton
+          label={<FormattedMessage {...translations[labelTranslation]} values={values} />}
+          onTouchTap={() => this.setState({ expanded: !this.state.expanded })}
+        />
+      </CardText>
+    );
+  }
+
+  render() {
+    const { includePhantoms, answers, anonymous } = this.props;
+    const filteredAnswers = includePhantoms ? answers : answers.filter(answer => !answer.phantom);
+    const nonEmptyAnswers = filteredAnswers.filter(answer => (
+      answer.text_response && answer.text_response.trim().length > 0
+    ));
+    const validPhantomResponses = includePhantoms ? nonEmptyAnswers.filter(answer => answer.phantom) : [];
+    const toggle = this.renderExpandToggle({
+      total: filteredAnswers.length,
+      quantity: nonEmptyAnswers.length,
+      phantoms: validPhantomResponses.length,
+    });
+
+    return (
+      <div>
+        { toggle }
+        { this.state.expanded && TextResponseResults.renderTextResultsTable(nonEmptyAnswers, anonymous) }
+        { this.state.expanded && toggle }
+      </div>
+    );
+  }
+}
+
+export default TextResponseResults;

--- a/client/app/bundles/course/survey/pages/SurveyResults/__test__/ResultsQuestion.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/__test__/ResultsQuestion.test.jsx
@@ -40,6 +40,7 @@ const getMultipleChoiceData = (optionCount) => {
     options,
     answers: [{
       id: 22,
+      course_user_id: 122,
       course_user_name: 'Lee',
       phantom: false,
       selected_options: [optionCount > 0 ? optionCount - 1 : 0],

--- a/client/app/bundles/course/survey/pages/SurveyResults/__test__/ResultsQuestion.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/__test__/ResultsQuestion.test.jsx
@@ -54,7 +54,7 @@ const contextOptions = {
 
 const testExpandLongQuestion = (question) => {
   const resultsQuestion = mount(
-    <ResultsQuestion {...{ question }} includePhantoms index={1} />,
+    <ResultsQuestion {...{ question }} includePhantoms anonymous={false} index={1} />,
     contextOptions
   );
   expect(resultsQuestion.find('Table')).toHaveLength(0);
@@ -77,7 +77,7 @@ describe('<ResultsQuestion />', () => {
   it('allows sorting by percentage', () => {
     const question = getMultipleChoiceData(2);
     const resultsQuestion = mount(
-      <ResultsQuestion {...{ question }} includePhantoms={false} index={1} />,
+      <ResultsQuestion {...{ question }} includePhantoms={false} anonymous={false} index={1} />,
       contextOptions
     );
     const lastOptionCountCell = () => resultsQuestion.find('TableRow').last().find('td').at(3);

--- a/client/app/bundles/course/survey/pages/SurveyResults/__test__/index.test.js
+++ b/client/app/bundles/course/survey/pages/SurveyResults/__test__/index.test.js
@@ -35,6 +35,7 @@ const resultsData = {
   survey: {
     id: 6,
     title: 'Test Response',
+    anonymous: false,
   },
 };
 

--- a/client/app/bundles/course/survey/pages/SurveyResults/__test__/index.test.js
+++ b/client/app/bundles/course/survey/pages/SurveyResults/__test__/index.test.js
@@ -43,7 +43,7 @@ beforeEach(() => {
 });
 
 describe('<SurveyResults />', () => {
-  it('allows phantom students to be included in the results', async () => {
+  it('allows phantom students to be excluded from the results', async () => {
     const surveyId = resultsData.survey.id;
     const resultsUrl = `/courses/${courseId}/surveys/${surveyId}/results`;
     mock.onGet(resultsUrl).reply(200, resultsData);
@@ -65,8 +65,8 @@ describe('<SurveyResults />', () => {
     // Toggling 'include phantoms' should result in one more entry
     const rowsPriorToToggle = surveyResults.find('TableRow').length;
     const includePhantomToggle = surveyResults.find('Toggle').first();
-    includePhantomToggle.props().onToggle(null, true);
+    includePhantomToggle.props().onToggle(null, false);
     const rowsAfterToggle = surveyResults.find('TableRow').length;
-    expect(rowsAfterToggle).toBe(rowsPriorToToggle + 1);
+    expect(rowsAfterToggle).toBe(rowsPriorToToggle - 1);
   });
 });

--- a/client/app/bundles/course/survey/pages/SurveyResults/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/index.jsx
@@ -27,6 +27,10 @@ const translations = defineMessages({
     id: 'course.surveys.SurveyResults.noSections',
     defaultMessage: 'This survey does not have any questions yet.',
   },
+  noPhantoms: {
+    id: 'course.surveys.SurveyResults.noPhantoms',
+    defaultMessage: 'No phantom student responses.',
+  },
 });
 
 class SurveyResults extends React.Component {
@@ -43,7 +47,7 @@ class SurveyResults extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { includePhantoms: false };
+    this.state = { includePhantoms: true };
   }
 
   componentDidMount() {
@@ -70,20 +74,6 @@ class SurveyResults extends React.Component {
     return { totalStudents, realStudents };
   }
 
-  renderIncludePhantomToggle() {
-    return (
-      <Card>
-        <CardText>
-          <Toggle
-            label={<FormattedMessage {...translations.includePhantoms} />}
-            labelPosition="right"
-            onToggle={(_, value) => this.setState({ includePhantoms: value })}
-          />
-        </CardText>
-      </Card>
-    );
-  }
-
   renderBody() {
     const { sections, isLoading } = this.props;
     const noSections = sections && sections.length < 1;
@@ -105,12 +95,14 @@ class SurveyResults extends React.Component {
               />
             </h4>
             {
-              totalStudents === realStudents ? null :
-              <Toggle
-                label={<FormattedMessage {...translations.includePhantoms} />}
-                labelPosition="right"
-                onToggle={(_, value) => this.setState({ includePhantoms: value })}
-              />
+              totalStudents === realStudents ?
+                <p><FormattedMessage {...translations.noPhantoms} /></p> :
+                <Toggle
+                  label={<FormattedMessage {...translations.includePhantoms} />}
+                  labelPosition="right"
+                  toggled={this.state.includePhantoms}
+                  onToggle={(_, value) => this.setState({ includePhantoms: value })}
+                />
             }
           </CardText>
         </Card>

--- a/client/app/bundles/course/survey/pages/SurveyResults/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/index.jsx
@@ -74,7 +74,7 @@ class SurveyResults extends React.Component {
     return { totalStudents, realStudents };
   }
 
-  renderBody() {
+  renderBody(anonymous) {
     const { sections, isLoading } = this.props;
     const noSections = sections && sections.length < 1;
     if (isLoading) { return <LoadingIndicator />; }
@@ -112,7 +112,7 @@ class SurveyResults extends React.Component {
             <ResultsSection
               key={section.id}
               includePhantoms={this.state.includePhantoms}
-              {...{ section, index }}
+              {...{ section, index, anonymous }}
             />
           )
         }
@@ -131,7 +131,7 @@ class SurveyResults extends React.Component {
           iconElementLeft={<IconButton><ArrowBack /></IconButton>}
           onLeftIconButtonTouchTap={() => browserHistory.push(`/courses/${courseId}/surveys`)}
         />
-        { this.renderBody() }
+        { this.renderBody(survey && survey.anonymous) }
       </div>
     );
   }

--- a/client/app/bundles/course/survey/reducers/results.js
+++ b/client/app/bundles/course/survey/reducers/results.js
@@ -12,10 +12,11 @@ export default function (state = initialState, action) {
       return { ...state, isLoading: true };
     }
     case actionTypes.LOAD_SURVEY_RESULTS_SUCCESS: {
+      const anonymous = action.survey.anonymous;
       return {
         isLoading: false,
         sections: action.sections ?
-          action.sections.map(sortResultsSectionElements).sort(sorts.byWeight) : [],
+          action.sections.map(sortResultsSectionElements(anonymous)).sort(sorts.byWeight) : [],
       };
     }
     case actionTypes.LOAD_SURVEY_RESULTS_FAILURE: {

--- a/client/app/bundles/course/survey/utils/index.js
+++ b/client/app/bundles/course/survey/utils/index.js
@@ -4,7 +4,7 @@ export const sorts = {
 
 /**
  * Sorts an array attribute of an object and returns the updated item.
- * By default, the attribute is sorted by weight. Each member of the  array attribute may
+ * By default, the attribute is sorted by weight. Each member of the array attribute may
  * be further sorted by specifying an appropriate mapMethod.
  *
  * @param {Object} item
@@ -16,7 +16,7 @@ export const sorts = {
 export const sortAttributeArray = (
   item,
   attribute,
-  mapMethod = option => option,
+  mapMethod = attr => attr,
   sortMethod = sorts.byWeight
 ) => {
   const attributeArray = item[attribute];
@@ -57,13 +57,23 @@ export const sortResponseElements = response => (
   sortAttributeArray(response, 'sections', sortResponseSectionElements)
 );
 
+const sortResultsQuestionElements = (question) => {
+  const sortAnswersByStudentName = (a, b) => a.course_user_name.localeCompare(b.course_user_name);
+  return sortAttributeArray(question, 'answers', attr => attr, sortAnswersByStudentName);
+};
+
 /**
  * Returns the given survey results section with it's descendent elements sorted appropriately.
+ * Sort answers by respondent's name unless the survey is anonymous and names are not given.
  *
+ * @param {Object} anonymous
  * @param {Object} section
  * @return {Object} The updated section
  */
-export const sortResultsSectionElements = section => sortAttributeArray(section, 'questions');
+export const sortResultsSectionElements = anonymous => section => (
+  anonymous ? sortAttributeArray(section, 'questions') :
+  sortAttributeArray(section, 'questions', sortResultsQuestionElements)
+);
 
 export const sortSurveysByDate = surveys => surveys.sort((a, b) => {
   const dateOrder = new Date(a.start_at) - new Date(b.start_at);

--- a/spec/controllers/course/survey/surveys_controller_spec.rb
+++ b/spec/controllers/course/survey/surveys_controller_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Course::Survey::SurveysController do
           )
 
           expect(multiple_choice_question['answers'][0].keys).to contain_exactly(
-            'id', 'course_user_name', 'phantom', 'selected_options'
+            'id', 'course_user_name', 'course_user_id', 'phantom', 'selected_options'
           )
 
           expect(multiple_choice_question['options'][0].keys).to contain_exactly(


### PR DESCRIPTION
- Add student names to both text and options questions when survey is not anonymous.
- Show more detailed breakdown on number of respondents and how many phantoms on expand/collapse button. Details are put in the button text for prominence.
- Split ResultsQuestions into small components because it is getting large in size. 