### PR TITLE
Prevent view partials from being rendered on bad requests

### DIFF
--- a/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
@@ -10,7 +10,7 @@ class Course::Assessment::Submission::Answer::Programming::AnnotationsController
       if super && @annotation.save
         send_created_notification(@post)
       else
-        render status: :bad_request
+        head :bad_request
       end
     end
   end

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -61,7 +61,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     @current_question = @answer.try(:question)
 
     if @answer.nil?
-      render status: :bad_request
+      head :bad_request
     elsif reload_answer_params[:reset_answer]
       @new_answer = @answer.reset_answer
     else

--- a/app/controllers/course/assessment/submission_question/comments_controller.rb
+++ b/app/controllers/course/assessment/submission_question/comments_controller.rb
@@ -17,7 +17,7 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
       if super && @submission_question.save
         send_created_notification(@post)
       else
-        render status: :bad_request
+        head :bad_request
       end
     end
   end

--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -15,16 +15,16 @@ class Course::Discussion::PostsController < Course::ComponentController
     if super
       send_created_notification(@post)
     else
-      render status: :bad_request
+      head :bad_request
     end
   end
 
   def update
-    render status: :bad_request unless super
+    head :bad_request unless super
   end
 
   def destroy
-    render status: :bad_request unless super
+    head :bad_request unless super
   end
 
   protected

--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -32,7 +32,7 @@ class Course::Discussion::TopicsController < Course::ComponentController
                 @topic.unmark_as_pending
               end
 
-    render status: :bad_request unless success
+    head :bad_request unless success
   end
 
   private


### PR DESCRIPTION
This solves part of #2190. 

Just some background on #2190: the error was from rendering a post partial as the `@post` had a `nil` value for `created_at`. I did some digging, and realise that if you submitted an invalid post, the post is not persisted, but rails tries to re-render the entire programming file annotation. This is because of the usage of `render status: :bad_request`. For some reason, this line is ignored, and a `Status 500 (Internal Server Error)` is returned instead. 

This PR removes the usage of `render status: :bad_request`, and instead uses `head :bad_request`. 

---

The other trigger for #2190 is front-end sending invalid data to the backend. To date, I found 1 cause, but I suspect there could be many others:

When you open up the comment box, quickly type a few characters and click on Submit (almost instantaneously), I've observed that a blank string is sent to the server. I suspect this is because of Summernote having some lag or is still executing some callbacks, but I need to investigate more to figure this out. 

I understand @jeremyyap and @jchiam are working on a react page for Programming assessment questions, so I will not fix this for now. We might need to relook at this for the summernote for react. 