### PR TITLE
Allow rich text for descriptions in surveys

### DIFF
--- a/app/views/course/survey/questions/_question.json.jbuilder
+++ b/app/views/course/survey/questions/_question.json.jbuilder
@@ -1,5 +1,6 @@
-json.(question, :id, :description, :required, :question_type, :max_options, :min_options, :weight,
+json.(question, :id, :required, :question_type, :max_options, :min_options, :weight,
       :grid_view, :section_id)
+json.description format_html(question.description)
 json.canUpdate can?(:update, question)
 json.canDelete can?(:destroy, question)
 options = @question_options || question.options

--- a/app/views/course/survey/responses/_answer.json.jbuilder
+++ b/app/views/course/survey/responses/_answer.json.jbuilder
@@ -1,8 +1,9 @@
 answer = @answers_hash[question.id]
 
 json.question do
-  json.(question, :id, :description, :required, :question_type, :max_options, :min_options,
+  json.(question, :id, :required, :question_type, :max_options, :min_options,
         :weight, :grid_view)
+  json.description format_html(question.description)
   json.options question.options.includes(attachment_references: :attachment),
                partial: 'course/survey/questions/option', as: :option
 end

--- a/app/views/course/survey/responses/_response.json.jbuilder
+++ b/app/views/course/survey/responses/_response.json.jbuilder
@@ -1,14 +1,16 @@
 @answers_hash = response.answers.map { |answer| [answer.question_id, answer] }.to_h
 
 json.survey do
-  json.(survey, :id, :title, :description, :start_at, :end_at, :base_exp, :published)
+  json.(survey, :id, :title, :start_at, :end_at, :base_exp, :published)
+  json.description format_html(survey.description)
 end
 
 json.response do
   json.(response, :id, :submitted_at)
   json.creator_name response.creator.name
   json.sections survey.sections do |section|
-    json.(section, :id, :title, :description, :weight)
+    json.(section, :id, :title, :weight)
+    json.description format_html(section.description)
     json.answers section.questions, partial: 'answer', as: :question
   end
 end

--- a/app/views/course/survey/sections/_section.json.jbuilder
+++ b/app/views/course/survey/sections/_section.json.jbuilder
@@ -1,4 +1,5 @@
-json.(section, :id, :title, :description, :weight)
+json.(section, :id, :title, :weight)
+json.description format_html(section.description)
 questions = @questions || section.questions
 json.questions questions, partial: 'course/survey/questions/question', as: :question
 json.canCreateQuestion can?(:create, Course::Survey::Question.new(section: section))

--- a/app/views/course/survey/surveys/_survey.json.jbuilder
+++ b/app/views/course/survey/surveys/_survey.json.jbuilder
@@ -1,6 +1,7 @@
-json.(survey, :id, :title, :description, :base_exp, :time_bonus_exp, :published,
+json.(survey, :id, :title, :base_exp, :time_bonus_exp, :published,
               :start_at, :end_at, :closing_reminded_at,
               :anonymous, :allow_response_after_end, :allow_modify_after_submit)
+json.description format_html(survey.description)
 
 canUpdate = can?(:update, survey)
 json.canUpdate canUpdate

--- a/app/views/course/survey/surveys/results.json.jbuilder
+++ b/app/views/course/survey/surveys/results.json.jbuilder
@@ -1,8 +1,11 @@
 json.sections @sections do |section|
-  json.(section, :id, :title, :description, :weight)
+  json.(section, :id, :title, :weight)
+  json.description format_html(section.description)
+
   json.questions section.questions do |question|
-    json.(question, :id, :description, :required, :question_type, :max_options, :min_options, :weight,
+    json.(question, :id, :required, :question_type, :max_options, :min_options, :weight,
           :grid_view)
+    json.description format_html(question.description)
     json.options question.options, partial: 'course/survey/questions/option', as: :option
 
     student_submitted_answers = question.answers.select do |answer|

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -8,6 +8,7 @@
     // See https://github.com/yannickcr/eslint-plugin-react/issues/847
     "react/no-unused-prop-types": ["warn", { "skipShapeProps": true }],
     "react/require-default-props": "off",
+    "react/no-danger": "off",
     "react/no-array-index-key": "warn",
     "import/no-extraneous-dependencies": ["warn", { "devDependencies": true }],
     "max-len": ["warn", 120],

--- a/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTemplateView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTemplateView.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import Immutable from 'immutable';
 
 import React, { PropTypes } from 'react';

--- a/client/app/bundles/course/lesson-plan/components/LessonPlanItem.jsx
+++ b/client/app/bundles/course/lesson-plan/components/LessonPlanItem.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';

--- a/client/app/bundles/course/lesson-plan/components/LessonPlanItemEdit.jsx
+++ b/client/app/bundles/course/lesson-plan/components/LessonPlanItemEdit.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
 import moment from 'lib/moment';

--- a/client/app/bundles/course/lesson-plan/components/LessonPlanMilestone.jsx
+++ b/client/app/bundles/course/lesson-plan/components/LessonPlanMilestone.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
 import { FormattedDate, injectIntl, defineMessages, intlShape } from 'react-intl';

--- a/client/app/bundles/course/survey/containers/ResponseForm/ResponseAnswer.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/ResponseAnswer.jsx
@@ -176,7 +176,7 @@ class ResponseAnswer extends React.Component {
     return (
       <Card style={styles.answerCard}>
         <CardText>
-          <p>{`${index + 1}. ${question.description}`}</p>
+          <p dangerouslySetInnerHTML={{ __html: `${index + 1}. ${question.description}` }} />
           {
             answer.present ?
               <div>

--- a/client/app/bundles/course/survey/containers/ResponseForm/ResponseSection.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/ResponseSection.jsx
@@ -50,7 +50,7 @@ class ResponseSection extends React.Component {
       <Card style={styles.card}>
         <CardTitle
           title={section.title}
-          subtitle={section.description}
+          subtitle={<div dangerouslySetInnerHTML={{ __html: section.description }} />}
         />
         <FieldArray
           name={`${member}.answers`}

--- a/client/app/bundles/course/survey/pages/ResponseEdit/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseEdit/index.jsx
@@ -103,7 +103,11 @@ class ResponseEdit extends React.Component {
     const { survey } = this.props;
     return (
       <div>
-        { survey.description ? <Card><CardText>{survey.description}</CardText></Card> : null }
+        {
+          survey.description ?
+            <Card><CardText dangerouslySetInnerHTML={{ __html: survey.description }} /></Card> :
+          null
+        }
         { this.renderBody() }
       </div>
     );

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/__snapshots__/index.test.jsx.snap
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/__snapshots__/index.test.jsx.snap
@@ -7,9 +7,13 @@ exports[`<ResponseShow /> shows form and admin buttons if user has permissions a
     expanded={null}
     initiallyExpanded={false}
   >
-    <CardText>
-      Description
-    </CardText>
+    <CardText
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Description",
+        }
+      }
+    />
   </Card>
   <div>
     <Table

--- a/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
@@ -119,7 +119,11 @@ class ResponseShow extends React.Component {
 
     return (
       <div>
-        { survey.description ? <Card><CardText>{survey.description}</CardText></Card> : null }
+        {
+          survey.description ?
+            <Card><CardText dangerouslySetInnerHTML={{ __html: survey.description }} /></Card> :
+          null
+        }
         { this.renderBody() }
         { this.renderRespondButton() }
         { this.renderUnsubmitButton() }

--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsQuestion.jsx
@@ -69,7 +69,7 @@ class ResultsQuestion extends React.Component {
     return (
       <Card style={styles.card}>
         <CardText>
-          <p>{ `${index + 1}. ${question.description}` }</p>
+          <p dangerouslySetInnerHTML={{ __html: `${index + 1}. ${question.description}` }} />
           { question.required ?
             <p style={styles.required}><FormattedMessage {...formTranslations.starRequired} /></p> : null }
         </CardText>

--- a/client/app/bundles/course/survey/pages/SurveyResults/ResultsSection.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyResults/ResultsSection.jsx
@@ -13,7 +13,7 @@ const ResultsSection = ({ section, includePhantoms, anonymous }) => (
   <Card style={styles.card}>
     <CardTitle
       title={section.title}
-      subtitle={section.description}
+      subtitle={<div dangerouslySetInnerHTML={{ __html: section.description }} />}
     />
     <CardText>
       {

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
@@ -159,7 +159,7 @@ class QuestionCard extends React.Component {
       >
         <CardText style={styles.cardText}>
           { this.renderAdminMenu() }
-          <p>{ question.description }</p>
+          <p dangerouslySetInnerHTML={{ __html: question.description }} />
           { question.required ?
             <p style={styles.required}><FormattedMessage {...formTranslations.starRequired} /></p> : null }
         </CardText>

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/SectionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/SectionCard.jsx
@@ -66,7 +66,7 @@ class SectionCard extends React.Component {
       >
         <CardTitle
           title={section.title}
-          subtitle={section.description}
+          subtitle={<div dangerouslySetInnerHTML={{ __html: section.description }} />}
           subtitleStyle={styles.subtitle}
           showExpandableButton={section.questions.length > 0}
         />

--- a/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
@@ -54,7 +54,7 @@ class SurveyDetails extends React.Component {
         <h4>
           <FormattedMessage {...surveyTranslations.description} />
         </h4>
-        <p>{survey.description}</p>
+        <p dangerouslySetInnerHTML={{ __html: survey.description }} />
       </CardText>
     );
   }


### PR DESCRIPTION
Survey, section and questions descriptions in v1 are input using a rich text editor. After they are migrated to v2, the descriptions are escaped and not rendered correctly. This PR allows the rich text to be displayed. Staff will be able to type HTML in the description boxes for description fields.