### PR TITLE
Implement unmark submission

### DIFF
--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -23,6 +23,12 @@ module Course::Assessment::Submission::WorkflowEventConcern
     publish_answers
   end
 
+  def unmark(_ = nil)
+    answers.each do |answer|
+      answer.unmark! if answer.graded?
+    end
+  end
+
   # Handles the publishing of a submission.
   #
   # This grades all the answers as well.

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -59,14 +59,10 @@ module Course::Assessment::Submission::WorkflowEventConcern
   # not set during the event transition, hence they are not modifiable within the method itself.
   def assign_experience_points
     # publish event (from grade) - Deduce points awarded from draft or updated attribute.
-    if workflow_state_was == 'graded' && workflow_state == 'published'
+    if workflow_state == 'published' &&
+       (workflow_state_was == 'graded' || workflow_state_was == 'submitted')
       self.points_awarded ||= draft_points_awarded
       self.draft_points_awarded = nil
-
-    # grade event - If points are awarded, ignore draft_points, otherwise use draft_points_awarded.
-    elsif workflow_state_was == 'submitted' && workflow_state == 'graded'
-      self.draft_points_awarded = points_awarded
-      self.points_awarded = nil
     end
   end
 

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -24,6 +24,8 @@ class Course::Assessment::Answer < ActiveRecord::Base
     end
     state :graded do
       event :unsubmit, transitions_to: :attempting
+      # Does nothing but revert the state, for the case we want to keep the grading info
+      event :unmark, transitions_to: :evaluated
       event :publish, transitions_to: :graded # To re-grade an answer.
       # Allows answers to be re-evaluated even after being graded. Useful if programming questions
       # get additional test cases.

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -169,7 +169,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
   # Return the points awarded for the submission.
   # If submission is 'graded', return the draft value, otherwise, the return the points awarded.
   def current_points_awarded
-    graded? ? draft_points_awarded : points_awarded
+    published? ? points_awarded : draft_points_awarded
   end
 
   private

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -20,7 +20,8 @@ class Course::Assessment::Submission < ActiveRecord::Base
       event :publish, transitions_to: :published
     end
     state :graded do
-      event :unsubmit, transitions_to: :attempting
+      # Revert to submitted state but keep the grading info.
+      event :unmark, transitions_to: :submitted
       event :publish, transitions_to: :published
     end
     state :published do
@@ -136,6 +137,7 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
   alias_method :finalise=, :finalise!
   alias_method :mark=, :mark!
+  alias_method :unmark=, :unmark!
   alias_method :publish=, :publish!
   alias_method :unsubmit=, :unsubmit!
 

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -51,7 +51,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
       else
         params.require(:submission).permit(
           *workflow_state_params,
-          :points_awarded,
+          :draft_points_awarded,
           answers_attributes: [:id] + update_answers_params
         )
       end

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -68,7 +68,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   def workflow_state_params
     result = []
     result << :finalise if can?(:update, @submission)
-    result.push(:publish, :mark, :unsubmit) if can?(:grade, @submission)
+    result.push(:publish, :mark, :unmark, :unsubmit) if can?(:grade, @submission)
     result
   end
 

--- a/app/views/course/assessment/submission/submissions/_buttons.html.slim
+++ b/app/views/course/assessment/submission/submissions/_buttons.html.slim
@@ -27,6 +27,9 @@ div.submission-buttons
   - if local_assigns[:mark]
     = f.button :submit, t('.mark'), name: 'submission[mark]', class: ['btn-warning']
 
+  - if local_assigns[:unmark]
+    = f.button :submit, t('.unmark'), name: 'submission[unmark]', class: ['btn-warning']
+
   - if local_assigns[:unsubmit]
     = f.button :submit, t('.unsubmit'), name: 'submission[unsubmit]', class: ['btn-danger'],
       data: { confirm: t('.confirm_unsubmit') }

--- a/app/views/course/assessment/submission/submissions/_manually_graded.html.slim
+++ b/app/views/course/assessment/submission/submissions/_manually_graded.html.slim
@@ -17,6 +17,7 @@
         finalise: @submission.attempting? && can?(:update, @submission),
         auto_grade: @submission.submitted? && can_grade,
         mark: @submission.submitted? && @assessment.delayed_grade_publication? && can_grade,
+        unmark: @submission.graded? && can_grade,
         publish: @submission.submitted? && !@assessment.delayed_grade_publication? && can_grade,
-        unsubmit: !@submission.attempting? && can_grade\
+        unsubmit: !@submission.attempting? && !@submission.graded? && can_grade\
       }

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -37,7 +37,8 @@ div.panel.panel-default
               - if can?(:grade, @submission)
                 / TODO: Factor in time-based experience points
                 td
-                  = f.input :points_awarded, label: false,
+                  - exp_field = @submission.published? ? :points_awarded : :draft_points_awarded
+                  = f.input exp_field, label: false,
                             input_html: { class: 'submission-points-awarded',
                                           'data-base-points' => @submission.assessment.base_exp,
                                           value: @submission.current_points_awarded },

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -39,6 +39,7 @@ en:
             auto_grade: 'Auto Grade Submission'
             evaluate_answers: 'Evaluate Answers'
             unsubmit: 'Unsubmit Submission'
+            unmark: 'Revert to Submitted'
             confirm_finalise: |+
               THIS ACTION IS IRREVERSIBLE
 

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
       creator
     end
     assessment { build(:assessment, course: course) }
+    points_awarded nil
 
     trait :attempting do
       after(:build) do |submission|
@@ -38,8 +39,7 @@ FactoryGirl.define do
 
         # Revert publisher and published at if given.
         submission.mark!
-        submission.draft_points_awarded = submission.points_awarded
-        submission.points_awarded = nil
+        submission.draft_points_awarded = rand(1..10) * 100
       end
     end
 
@@ -50,6 +50,7 @@ FactoryGirl.define do
         submission.publish!
         submission.publisher = evaluator.publisher if evaluator.publisher
         submission.published_at = evaluator.published_at if evaluator.published_at
+        submission.points_awarded = rand(1..10) * 100
       end
     end
   end

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         # This field should be filled when page loads
         correct_exp = (assessment.base_exp * submission.grade /
           assessment.questions.map(&:maximum_grade).sum).to_i
-        expect(find_field('submission_points_awarded').value).to eq(correct_exp.to_s)
+        expect(find_field('submission_draft_points_awarded').value).to eq(correct_exp.to_s)
 
         submission_maximum_grade = 0
         submission.answers.each do |answer|
@@ -240,7 +240,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         end
 
         # This field should be automatically filled
-        expect(find_field('submission_points_awarded').value).to eq(assessment.base_exp.to_s)
+        expect(find_field('submission_draft_points_awarded').value).to eq(assessment.base_exp.to_s)
 
         # Test EXP multiplier
         multiplier = 0.5
@@ -248,7 +248,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
           find('input').set multiplier
         end
         new_exp = (assessment.base_exp * multiplier).to_i
-        expect(find_field('submission_points_awarded').value).to eq(new_exp.to_s)
+        expect(find_field('submission_draft_points_awarded').value).to eq(new_exp.to_s)
 
         click_button I18n.t('course.assessment.submission.submissions.buttons.publish')
         expect(current_path).to eq(

--- a/spec/features/course/assessment/submission/password_protected_and_deplayed_publishing_spec.rb
+++ b/spec/features/course/assessment/submission/password_protected_and_deplayed_publishing_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
         expect(page).to have_button(I18n.t('course.assessment.submission.submissions.buttons.mark'))
 
         fill_in find('input.form-control.grade')[:name], with: 0
-        fill_in 'submission[points_awarded]', with: 50
+        fill_in 'submission[draft_points_awarded]', with: 50
 
         click_button I18n.t('course.assessment.submission.submissions.buttons.mark')
         expect(page).to have_button(I18n.t('course.assessment.submission.submissions.buttons.save'))

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
           within all(content_tag_selector(submission)).last do
             expect(page).
               to have_text(submission.class.human_attribute_name(submission.workflow_state))
-            expect(page).to have_text(submission.points_awarded)
+            expect(page).to have_text(submission.current_points_awarded)
           end
         end
 

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -7,7 +7,9 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:course_student) { create(:course_student, course: course) }
-    let(:submission) { create(:submission, course: course, creator: course_student.user) }
+    let(:submission) do
+      create(:submission, :published, course: course, creator: course_student.user)
+    end
     let(:record) { submission.acting_as }
     let(:manual_record) do
       # Set the updater to a user not in the course to make sure the page still works in this case.

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -384,22 +384,6 @@ RSpec.describe Course::Assessment::Submission do
         submission.mark!
         expect(submission.answers.all?(&:graded?)).to be(true)
       end
-
-      context 'when assessment enables delayed_grade_publication' do
-        let(:assessment_traits) { [:with_all_question_types, :delay_grade_publication] }
-        let(:points_awarded) { 50 }
-        before do
-          submission1.points_awarded = points_awarded
-          submission1.mark!
-          submission1.save!
-        end
-        subject { submission1 }
-
-        it 'sets the draft_points_awarded to points_awarded, and points_awarded to nil' do
-          expect(subject.points_awarded).to be_nil
-          expect(subject.draft_points_awarded).to eq(points_awarded)
-        end
-      end
     end
 
     describe '#publish!' do

--- a/spec/services/course/assessment/question/answers_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/question/answers_evaluation_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Assessment::Question::AnswersEvaluationService do
     let(:question) { create(:course_assessment_question_multiple_response) }
     let(:student) { create(:course_student, course: question.assessment.course).user }
     let!(:submission) do
-      create(:submission, :graded, assessment: question.assessment, creator: student)
+      create(:submission, :submitted, assessment: question.assessment, creator: student)
     end
     let!(:answers) { submission.answers }
     subject { Course::Assessment::Question::AnswersEvaluationService.new(question) }
@@ -17,7 +17,9 @@ RSpec.describe Course::Assessment::Question::AnswersEvaluationService do
       before { subject.call }
 
       it 'auto grades the associated answers' do
-        expect(answers.all?(&:graded?)).to be_truthy
+        wait_for_job
+        answers.each(&:reload)
+        expect(answers.all?(&:evaluated?)).to be_truthy
       end
     end
   end

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -75,23 +75,13 @@ module TrackableJob::SpecHelpers
   end
 end
 
-module TrackableJob::ModelSpecHelpers
-  def wait_for_job
-    if ActiveJob::Base.queue_adapter == ActiveJob::QueueAdapters::BackgroundThreadAdapter
-      ActiveJob::QueueAdapters::BackgroundThreadAdapter.wait_for_jobs
-    end
-  end
-end
-
 RSpec.configure do |config|
   config.extend ActiveJob::TestGroupHelpers
   config.around(:each, type: :job,
                 &ActiveJob::TestGroupHelpers.with_active_job_queue_adapter_method)
   config.around(:each,
                 &ActiveJob::TestGroupHelpers.method(:ensure_jobs_completion))
-  config.include TrackableJob::SpecHelpers, type: :controller
-  config.include TrackableJob::SpecHelpers, type: :feature
-  config.include TrackableJob::ModelSpecHelpers, type: :model
+  config.include TrackableJob::SpecHelpers
 
   config.backtrace_exclusion_patterns << /\/spec\/support\/active_job\.rb/
 end


### PR DESCRIPTION
Implements #2234, this will fix #2235 as well. 

Draft points will only be moved to published points when the submission is published. The view will directly access and set draft points all other times. 