### PR TITLE
Survey housekeeping

### DIFF
--- a/app/controllers/course/survey/surveys_controller.rb
+++ b/app/controllers/course/survey/surveys_controller.rb
@@ -84,8 +84,7 @@ class Course::Survey::SurveysController < Course::ComponentController
       :title, :description, :base_exp, :time_bonus_exp, :start_at, :bonus_end_at, :end_at,
       :published, :allow_response_after_end, :allow_modify_after_submit
     ]
-    fields << :anonymous if action_name == 'create' || !@survey.anonymous ||
-                            !@survey.has_student_response?
+    fields << :anonymous if action_name == 'create' || @survey.can_toggle_anonymity?
     params.require(:survey).permit(*fields)
   end
 end

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -20,6 +20,10 @@ class Course::Survey < ActiveRecord::Base
     end.present?
   end
 
+  def can_toggle_anonymity?
+    !anonymous || !has_student_response?
+  end
+
   def initialize_duplicate(duplicator, other)
     copy_attributes(other, duplicator.time_shift)
     self.sections = duplicator.duplicate(other.sections)

--- a/app/views/course/survey/responses/_response.json.jbuilder
+++ b/app/views/course/survey/responses/_response.json.jbuilder
@@ -16,8 +16,8 @@ json.response do
 end
 
 json.flags do
-  json.canModify can?(:modify, @response)
-  json.canSubmit can?(:submit, @response)
-  json.canUnsubmit can?(:unsubmit, @response)
-  json.isResponseCreator current_user.id == @response.creator_id
+  json.canModify can?(:modify, response)
+  json.canSubmit can?(:submit, response)
+  json.canUnsubmit can?(:unsubmit, response)
+  json.isResponseCreator current_user.id == response.creator_id
 end

--- a/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
@@ -93,6 +93,7 @@ class ResponseForm extends React.Component {
       canSubmit: PropTypes.bool.isRequired,
       canUnsubmit: PropTypes.bool.isRequired,
       isResponseCreator: PropTypes.bool.isRequired,
+      isSubmitting: PropTypes.bool.isRequired,
     }),
     response: responseShape.isRequired,
     onSubmit: PropTypes.func.isRequired,
@@ -127,7 +128,7 @@ class ResponseForm extends React.Component {
   }
 
   renderSaveButton() {
-    const { pristine, flags: { canModify } } = this.props;
+    const { pristine, flags: { canModify, isSubmitting } } = this.props;
     if (!canModify) { return null; }
 
     return (
@@ -137,14 +138,14 @@ class ResponseForm extends React.Component {
         primary
         label={<FormattedMessage {...formTranslations.save} />}
         buttonStyle={styles.saveButton}
-        disabled={pristine}
+        disabled={isSubmitting || pristine}
       />
     );
   }
 
   renderSubmitButton() {
     const {
-      handleSubmit, onSubmit, response, flags: { canSubmit, isResponseCreator },
+      handleSubmit, onSubmit, response, flags: { canSubmit, isResponseCreator, isSubmitting },
     } = this.props;
 
     if (!isResponseCreator) { return null; }
@@ -160,14 +161,14 @@ class ResponseForm extends React.Component {
         primary
         label={<FormattedMessage {...submitButtonTranslation} />}
         onTouchTap={handleSubmit(data => onSubmit({ ...data, submit: true }))}
-        disabled={!!response.submitted_at}
+        disabled={isSubmitting || !!response.submitted_at}
       />
     );
   }
 
   render() {
     const {
-      handleSubmit, onSubmit, response, flags: { canSubmit, canModify }, readOnly,
+      handleSubmit, onSubmit, response, flags: { canSubmit, canModify, isSubmitting }, readOnly,
     } = this.props;
 
     return (
@@ -175,7 +176,7 @@ class ResponseForm extends React.Component {
         <FieldArray
           name="sections"
           component={ResponseForm.renderSections}
-          disabled={readOnly || !(canModify || canSubmit)}
+          disabled={isSubmitting || readOnly || !(canModify || canSubmit)}
           {...{ response }}
         />
         <br />

--- a/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
@@ -110,7 +110,7 @@ class ResponseShow extends React.Component {
 
   renderUnsubmitButton() {
     const { response, flags: { canUnsubmit, isLoading } } = this.props;
-    if (!canUnsubmit || isLoading) { return null; }
+    if (!canUnsubmit || isLoading || !response.submitted_at) { return null; }
     return <UnsubmitButton responseId={response.id} />;
   }
 

--- a/client/app/bundles/course/survey/reducers/responseForm.js
+++ b/client/app/bundles/course/survey/reducers/responseForm.js
@@ -5,6 +5,7 @@ const initialState = {
   response: {},
   flags: {
     isLoading: false,
+    isSubmitting: false,
     canModify: false,
     canSubmit: false,
     canUnsubmit: false,
@@ -20,6 +21,9 @@ export default function (state = initialState, action) {
     case actionTypes.LOAD_RESPONSE_REQUEST: {
       return { ...state, flags: { ...state.flags, isLoading: true } };
     }
+    case actionTypes.UPDATE_RESPONSE_REQUEST: {
+      return { ...state, flags: { ...state.flags, isSubmitting: true } };
+    }
     case actionTypes.UPDATE_RESPONSE_SUCCESS:
     case actionTypes.CREATE_RESPONSE_SUCCESS:
     case actionTypes.LOAD_RESPONSE_EDIT_SUCCESS:
@@ -27,13 +31,16 @@ export default function (state = initialState, action) {
       return {
         ...state,
         response: sortResponseElements(action.response),
-        flags: { ...state.flags, ...action.flags, isLoading: false },
+        flags: { ...state.flags, ...action.flags, isLoading: false, isSubmitting: false },
       };
     }
     case actionTypes.CREATE_RESPONSE_FAILURE:
     case actionTypes.LOAD_RESPONSE_EDIT_FAILURE:
     case actionTypes.LOAD_RESPONSE_FAILURE: {
       return { ...state, flags: { ...state.flags, isLoading: false } };
+    }
+    case actionTypes.UPDATE_RESPONSE_FAILURE: {
+      return { ...state, flags: { ...state.flags, isSubmitting: false } };
     }
     case actionTypes.UNSUBMIT_RESPONSE_SUCCESS: {
       return {


### PR DESCRIPTION
- Disable survey response form when it is being submitted to prevent user from submitting twice in quick succession 
- For normal staff, the unsubmit button will be hidden after unsubmission is made, but this does not happen for administrator. This PRs fixes that.
- Fix abstraction breech in `_response.json.jbuilder`
- To address @weiqingtoh's [suggestion](https://github.com/Coursemology/coursemology2/pull/2260#discussion_r114067646), move `can_toggle_anonymity?` logic to controller.