### PR TITLE
Remove squeel queries from codebase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,8 @@ gem 'activerecord-userstamp', '>= 3.0.2'
 gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
 gem 'calculated_attributes', '>= 0.1.3'
-# Squeel as an SQL-like DSL
-gem 'squeel'
+# Baby Squeel as an SQL-like DSL
+gem 'baby_squeel'
 # For multiple table inheritance
 #   TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
 gem 'active_record-acts_as', github: 'Coursemology/active_record-acts_as'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     autoprefixer-rails (7.0.1)
       execjs
     awesome_print (1.7.0)
+    baby_squeel (0.3.1)
+      activerecord (>= 4.0.0)
     bcrypt (3.1.11)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -555,6 +557,7 @@ DEPENDENCIES
   acts_as_tenant
   after_commit_action
   autoprefixer-rails
+  baby_squeel
   bootstrap-sass
   bootstrap-sass-extras (>= 0.0.7)
   bootstrap-select-rails
@@ -630,7 +633,6 @@ DEPENDENCIES
   simplecov
   slim-rails
   spring
-  squeel
   summernote-rails
   themes_on_rails (>= 0.3.1)!
   traceroute
@@ -643,7 +645,6 @@ DEPENDENCIES
   webpack-rails
   workflow
   yard
-
 
 BUNDLED WITH
    1.14.6

--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -13,8 +13,8 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
       Course::CourseUserPreloadService.new(updater_ids, current_course)
 
     @experience_points_records =
-      @experience_points_records.active.includes { actable }.
-      includes(:updater).order(updated_at: :desc).page(page_param)
+      @experience_points_records.active.
+      includes(:actable, :updater).order(updated_at: :desc).page(page_param)
   end
 
   def update

--- a/app/controllers/course/lesson_plan/items_controller.rb
+++ b/app/controllers/course/lesson_plan/items_controller.rb
@@ -49,7 +49,7 @@ class Course::LessonPlan::ItemsController < Course::LessonPlan::Controller
   # @return [Hash{Integer => Array<String>]
   def assessment_tabs_titles_hash
     @assessment_tabs_titles_hash ||=
-      current_course.assessment_categories.includes { tabs }.map(&:tabs).flatten.
+      current_course.assessment_categories.includes(:tabs).map(&:tabs).flatten.
       map do |tab|
         [tab.id, tab_title_array(tab)]
       end.to_h

--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -104,7 +104,11 @@ class Course::UserInvitationsController < Course::ComponentController
     @invitations ||= begin
       ids = resend_invitation_params
       ids ||= current_course.invitations.unconfirmed.select(:id)
-      ids.blank? ? [] : current_course.invitations.unconfirmed.where { id >> ids }
+      if ids.blank?
+        []
+      else
+        current_course.invitations.unconfirmed.where('course_user_invitations.id IN (?)', ids)
+      end
     end
   end
 

--- a/app/models/concerns/course/forum_participation_concern.rb
+++ b/app/models/concerns/course/forum_participation_concern.rb
@@ -4,11 +4,11 @@ module Course::ForumParticipationConcern
 
   module ClassMethods
     def forum_posts
-      joins { topic }.where { topic.actable_type == Course::Forum::Topic }
+      joins(:topic).where('course_discussion_topics.actable_type = ?', Course::Forum::Topic.name)
     end
 
     def from_course(course)
-      joins { topic }.where { topic.course_id == course.id }
+      joins(:topic).where('course_discussion_topics.course_id = ?', course.id)
     end
   end
 end

--- a/app/models/concerns/course/search_concern.rb
+++ b/app/models/concerns/course/search_concern.rb
@@ -11,9 +11,9 @@ module Course::SearchConcern
       return all if keyword.blank?
 
       condition = "%#{keyword}%"
-      joins { users.outer }.
-        where { (title =~ condition) | (description =~ condition) | (users.name =~ condition) }.
-        group { courses.id }
+      joining { users.outer }.
+        where.has { (title =~ condition) | (description =~ condition) | (users.name =~ condition) }.
+        group('courses.id')
     end
   end
 end

--- a/app/models/concerns/course_user/achievements_concern.rb
+++ b/app/models/concerns/course_user/achievements_concern.rb
@@ -2,6 +2,6 @@
 module CourseUser::AchievementsConcern
   # Order achievements based on when each course_user obtained the achievement.
   def ordered_by_date_obtained
-    order { course_user_achievements.obtained_at.desc }
+    order('course_user_achievements.obtained_at DESC')
   end
 end

--- a/app/models/concerns/course_user/staff_concern.rb
+++ b/app/models/concerns/course_user/staff_concern.rb
@@ -28,11 +28,11 @@ module CourseUser::StaffConcern
   def published_submissions # rubocop:disable Metrics/AbcSize
     @published_submissions ||=
       Course::Assessment::Submission.
-      joins { experience_points_record.course_user }.
-      where { experience_points_record.course_user.role == CourseUser.roles[:student] }.
-      where { experience_points_record.course_user.phantom == false  }.
-      where { experience_points_record.course_user.course_id == my { course_id } }.
-      where { publisher_id == my { user_id } }
+      joins(experience_points_record: :course_user).
+      where('course_users.role = ?', CourseUser.roles[:student]).
+      where('course_users.phantom = ?', false).
+      where('course_assessment_submissions.publisher_id = ?', user_id).
+      where('course_users.course_id = ?', course_id)
   end
 
   # Returns the average marking time of the staff.

--- a/app/models/concerns/instance_user_search_concern.rb
+++ b/app/models/concerns/instance_user_search_concern.rb
@@ -12,9 +12,9 @@ module InstanceUserSearchConcern
       return all if keyword.blank?
 
       condition = "%#{keyword}%"
-      joins { user.emails.outer }.
-        where { (user.name =~ condition) | (user.emails.email =~ condition) }.
-        group { instance_users.id }
+      joining { user.emails.outer }.
+        where.has { (sql('users.name') =~ condition) | (sql('user_emails.email') =~ condition) }.
+        group('instance_users.id')
     end
   end
 end

--- a/app/models/concerns/user_search_concern.rb
+++ b/app/models/concerns/user_search_concern.rb
@@ -12,9 +12,9 @@ module UserSearchConcern
       return all if keyword.blank?
 
       condition = "%#{keyword}%"
-      joins { emails.outer }.
-        where { (name =~ condition) | (emails.email =~ condition) }.
-        group { users.id }
+      joining { emails.outer }.
+        where.has { (name =~ condition) | (emails.email =~ condition) }.
+        group('users.id')
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -59,8 +59,7 @@ class Course < ActiveRecord::Base
   # @!method containing_user
   #   Selects all the courses with user as one of its members
   scope :containing_user, (lambda do |user|
-    joins { course_users }.
-    where { course_users.user_id == user.id }
+    joins(:course_users).where('course_users.user_id = ?', user.id)
   end)
 
   # @!method with_owners

--- a/app/models/course/assessment/answer/programming_file_annotation.rb
+++ b/app/models/course/assessment/answer/programming_file_annotation.rb
@@ -10,9 +10,9 @@ class Course::Assessment::Answer::ProgrammingFileAnnotation < ActiveRecord::Base
   # Specific implementation of Course::Discussion::Topic#from_user, this is not supposed to be
   # called directly.
   scope :from_user, (lambda do |user_id|
-    joins { file.answer.answer.submission }.
-      where { file.answer.answer.submission.creator_id >> user_id }.
-      joins { discussion_topic }.select { discussion_topic.id }
+    joining { file.answer.answer.submission }.
+      where.has { file.answer.answer.submission.creator_id.in(user_id) }.
+      joining { discussion_topic }.selecting { discussion_topic.id }
   end)
 
   def notify(post)

--- a/app/models/course/assessment/programming_evaluation.rb
+++ b/app/models/course/assessment/programming_evaluation.rb
@@ -55,7 +55,7 @@ class Course::Assessment::ProgrammingEvaluation < ActiveRecord::Base
   #   Gets the programming evaluation jobs which are in the submitted state, and pending
   #   allocation to an evaluator.
   scope :pending, (lambda do
-    where do
+    where.has do
       (status == 'submitted') | (
         (status == 'assigned') & (assigned_at < Time.zone.now - TIMEOUT))
     end
@@ -64,7 +64,7 @@ class Course::Assessment::ProgrammingEvaluation < ActiveRecord::Base
   # @!method self.finished
   #   Gets the programming evaluation jobs which have finished, which are those which are
   #   completed or errored.
-  scope :finished, -> { where { (status == 'completed') | (status == 'errored') } }
+  scope :finished, -> { where(status: ['completed', 'errored']) }
 
   # Checks if the given task is still pending assignment to an evaluator.
   #

--- a/app/models/course/assessment/submission_question.rb
+++ b/app/models/course/assessment/submission_question.rb
@@ -14,9 +14,9 @@ class Course::Assessment::SubmissionQuestion < ActiveRecord::Base
   # Specific implementation of Course::Discussion::Topic#from_user, this is not supposed to be
   # called directly.
   scope :from_user, (lambda do |user_id|
-    joins { submission }.
-      where { submission.creator_id >> user_id }.
-      joins { discussion_topic }.select { discussion_topic.id }
+    joining { submission }.
+      where.has { submission.creator_id.in(user_id) }.
+      joining { discussion_topic }.selecting { discussion_topic.id }
   end)
 
   def notify(post)

--- a/app/models/course/condition/achievement.rb
+++ b/app/models/course/condition/achievement.rb
@@ -62,7 +62,7 @@ class Course::Condition::Achievement < ActiveRecord::Base
   def required_achievements_for(conditional)
     # Course::Condition::Achievement.
     #   joins { condition.conditional(Course::Achievement) }.
-    #   where { condition.conditional.id == achievement.id }.
+    #   where.has { condition.conditional.id == achievement.id }.
     #   map(&:achievement)
 
     # Workaround, pending the squeel bugfix (activerecord-hackery/squeel#390) that will allow

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -75,9 +75,9 @@ class Course::Condition::Assessment < ActiveRecord::Base
 
   def published_submissions_with_minimum_grade(user, minimum_grade)
     assessment.submissions.by_user(user).with_published_state.
-      joins { answers }.
-      group { course_assessment_submissions.id }.
-      having { coalesce(sum(answers.grade), 0) >= minimum_grade }
+      joins(:answers).
+      group('course_assessment_submissions.id').
+      when_having { coalesce(sum(answers.grade), 0) >= minimum_grade }
   end
 
   def validate_assessment_condition

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -27,7 +27,8 @@ class Course::Discussion::Post < ActiveRecord::Base
   scope :with_user_votes, (lambda do |user|
     post_ids = pluck('course_discussion_posts.id')
     votes = Course::Discussion::Post::Vote.
-      where { post_id.in(post_ids) & (creator_id == user.id) }
+      where('course_discussion_post_votes.post_id IN (?)', post_ids).
+      where('course_discussion_post_votes.creator_id = ?', user.id)
 
     all.tap do |result|
       preloader = ActiveRecord::Associations::Preloader::ManualPreloader.new
@@ -39,16 +40,16 @@ class Course::Discussion::Post < ActiveRecord::Base
   #   The number of upvotes for the given post.
   calculated :upvotes, (lambda do
     Vote.upvotes.
-      select { count(id) }.
-      where { post_id == course_discussion_posts.id }
+      select('count(id)').
+      where('post_id = course_discussion_posts.id')
   end)
 
   # @!attribute [r] downvotes
   #   The number of downvotes for the given post.
   calculated :downvotes, (lambda do
     Vote.downvotes.
-      select { count(id) }.
-      where { post_id == course_discussion_posts.id }
+      select('count(id)').
+      where('post_id = course_discussion_posts.id')
   end)
 
   # Calculates the total number of votes given to this post.

--- a/app/models/course/experience_points/disbursement.rb
+++ b/app/models/course/experience_points/disbursement.rb
@@ -87,9 +87,7 @@ class Course::ExperiencePoints::Disbursement
   # @param [Integer] group_id The id of the group
   # @return [Array<CourseUser>] The students in the group
   def students_from_group(group_id)
-    course.course_users.
-      joins { group_users }.
-      merge(Course::GroupUser.normal).
-      where { group_users.group_id == group_id }
+    course.course_users.joins(:group_users).where('course_group_users.group_id = ?', group_id).
+      merge(Course::GroupUser.normal)
   end
 end

--- a/app/models/course/experience_points/forum_disbursement.rb
+++ b/app/models/course/experience_points/forum_disbursement.rb
@@ -144,10 +144,12 @@ class Course::ExperiencePoints::ForumDisbursement < Course::ExperiencePoints::Di
   # @return [Array<Course::Discussion::Post>]
   def discussion_posts
     return [] if end_time_preceeds_start_time?
-    @discussion_posts ||=
+    @discussion_posts ||= begin
+      user_ids = forum_participants.map(&:user_id)
       Course::Discussion::Post.forum_posts.from_course(course).calculated(:upvotes, :downvotes).
-      where(created_at: start_time..end_time).
-      where { creator_id >> my { forum_participants.map(&:user_id) } }
+        where(created_at: start_time..end_time).
+        where(creator_id: user_ids)
+    end
   end
 
   # Check if end time preceeds start time and sets an error if necessary.

--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -11,7 +11,7 @@ class Course::ExperiencePointsRecord < ActiveRecord::Base
   # TODO: Add an optional: true when moving to Rails 5.
   belongs_to :awarder, class_name: User.name, inverse_of: nil
 
-  scope :active, -> { where { points_awarded != nil } } # rubocop:disable Style/NonNilCheck
+  scope :active, -> { where.not(points_awarded: nil) }
 
   # Checks if the current record is active, i.e. it has been granted by a course staff.
   #

--- a/app/models/course/forum.rb
+++ b/app/models/course/forum.rb
@@ -10,30 +10,31 @@ class Course::Forum < ActiveRecord::Base
   # @!attribute [r] topic_count
   #   The number of topics in this forum.
   calculated :topic_count, (lambda do
-    Course::Forum::Topic.where { course_forum_topics.forum_id == course_forums.id }.
-      select { count('*') }
+    Course::Forum::Topic.where('course_forum_topics.forum_id = course_forums.id').
+      select("count('*')")
   end)
 
   # @!attribute [r] topic_post_count
   #   The number of posts in this forum.
   calculated :topic_post_count, (lambda do
-    Course::Forum::Topic.joins { discussion_topic.outer.posts.outer }.
-      where { course_forum_topics.forum_id == course_forums.id }.
-      select { count('*') }
+    Course::Forum::Topic.
+      joining { discussion_topic.outer.posts.outer }.
+      where('course_forum_topics.forum_id = course_forums.id').
+      select("count('*')")
   end)
 
   # @!attribute [r] topic_view_count
   #   The number of views in this forum.
   calculated :topic_view_count, (lambda do
-    Course::Forum::Topic.joins { views }.
-      where { course_forum_topics.forum_id == course_forums.id }.
-      select { count('*') }
+    Course::Forum::Topic.joins(:views).
+      where('course_forum_topics.forum_id = course_forums.id').
+      select("count('*')")
   end)
 
   calculated :topic_unread_count, (lambda do |user|
-    Course::Forum::Topic.where { course_forum_topics.forum_id == course_forums.id }.
+    Course::Forum::Topic.where('course_forum_topics.forum_id = course_forums.id').
       unread_by(user).
-      select { count('*') }
+      select("count('*')")
   end)
 
   # @!method self.with_forum_statistics

--- a/app/models/course/forum/search.rb
+++ b/app/models/course/forum/search.rb
@@ -32,7 +32,7 @@ class Course::Forum::Search
 
     @posts ||=
       Course::Discussion::Post.forum_posts.from_course(@course).
-      includes { topic.actable.forum }.
+      includes(topic: { actable: :forum }).
       calculated(:upvotes, :downvotes).
       where(created_at: start_time..end_time).
       where(creator_id: @user)

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -14,7 +14,7 @@ class Course::LessonPlan::Item < ActiveRecord::Base
   # @!method self.ordered_by_date
   #   Orders the lesson plan items by the starting date.
   scope :ordered_by_date, (lambda do
-    order { start_at }
+    order(:start_at)
   end)
 
   scope :ordered_by_date_and_title, (lambda do

--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -40,7 +40,7 @@ class Course::Material < ActiveRecord::Base
   def validate_name_is_unique_among_folders
     return if folder.nil?
 
-    conflicts = folder.children.where { name =~ my { name } }
+    conflicts = folder.children.where.has { |parent| name =~ parent.name }
     errors.add(:name, :taken) unless conflicts.empty?
   end
 

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -20,16 +20,16 @@ class Course::Material::Folder < ActiveRecord::Base
   # @!attribute [r] material_count
   #   Returns the number of files in current folder.
   calculated :material_count, (lambda do
-    Course::Material.select { count('*') }.
-      where { course_materials.folder_id == course_material_folders.id }
+    Course::Material.select("count('*')").
+      where('course_materials.folder_id = course_material_folders.id')
   end)
 
   # @!attribute [r] children_count
   #   Returns the number of subfolders in current folder.
   calculated :children_count, (lambda do
-    select { count('*') }.
+    select("count('*')").
       from('course_material_folders children').
-      where { children.parent_id == course_material_folders.id }
+      where('children.parent_id = course_material_folders.id')
   end)
 
   scope :with_content_statistics, ->() { all.calculated(:material_count, :children_count) }
@@ -104,7 +104,7 @@ class Course::Material::Folder < ActiveRecord::Base
   def validate_name_is_unique_among_materials
     return if parent.nil?
 
-    conflicts = parent.materials.where { name =~ my { name } }
+    conflicts = parent.materials.where.has { |parent| name =~ parent.name }
     errors.add(:name, :taken) unless conflicts.empty?
   end
 

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -12,9 +12,8 @@ class Course::Video < ActiveRecord::Base
   # @!method self.ordered_by_date_and_title
   #   Orders the videos by the starting date and title.
   scope :ordered_by_date_and_title, (lambda do
-    select('course_videos.*').
-      select('course_lesson_plan_items.start_at, course_lesson_plan_items.title').
-      joins { lesson_plan_item }.
+    select('course_videos.*, course_lesson_plan_items.start_at, course_lesson_plan_items.title').
+      joins(:lesson_plan_item).
       merge(Course::LessonPlan::Item.ordered_by_date_and_title)
   end)
 

--- a/app/models/instance_user.rb
+++ b/app/models/instance_user.rb
@@ -9,6 +9,6 @@ class InstanceUser < ActiveRecord::Base
   scope :ordered_by_username, -> { joins(:user).merge(User.order(name: :asc)) }
 
   def self.search_and_ordered_by_username(keyword)
-    keyword.blank? ? ordered_by_username : search(keyword).group { user.name }.ordered_by_username
+    keyword.blank? ? ordered_by_username : search(keyword).group('users.name').ordered_by_username
   end
 end

--- a/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
@@ -125,8 +125,9 @@ module Course::UserInvitationService::EmailInvitationConcern
   # @param [Array<String>] email_addresses An array of email addresses to query.
   # @return [Hash{String=>User}] The mapping from email address to users.
   def find_existing_users(email_addresses)
-    found_users = @current_instance.users.includes(:emails).references(emails: :email).
-                  where { emails.email.in(email_addresses) }
+    # TODO: Move this search query into the +User+ model.
+    found_users = @current_instance.users.includes(:emails).joins(:emails).
+                  where('user_emails.email IN (?)', email_addresses)
 
     found_users.each.flat_map do |user|
       user.emails.map { |user_email| [user_email.email, user] }
@@ -181,7 +182,7 @@ module Course::UserInvitationService::EmailInvitationConcern
       Course::Mailer.user_invitation_email(@current_course, invitation).deliver_later
     end
     ids = invitations.select(&:id)
-    Course::UserInvitation.where { id >> ids }.update_all(sent_at: Time.zone.now)
+    Course::UserInvitation.where(id: ids).update_all(sent_at: Time.zone.now)
     true
   end
 

--- a/app/services/course/material/preload_service.rb
+++ b/app/services/course/material/preload_service.rb
@@ -22,6 +22,7 @@ class Course::Material::PreloadService
 
   def assessments_folders
     @assessments_folders ||=
-      @course.material_folders.where { owner_type == Course::Assessment.name }.includes(:materials)
+      @course.material_folders.includes(:materials).
+      where('course_material_folders.owner_type = ?', Course::Assessment.name)
   end
 end

--- a/client/app/lib/helpers/initializeComponent.jsx
+++ b/client/app/lib/helpers/initializeComponent.jsx
@@ -16,7 +16,7 @@ const initializeComponent = (Component, nodeId, storeCreator) => {
 
   const params = { format: 'json' };
   axios.get('', { params }).then((response) => {
-    $(document).ready(renderComponent(response.data));
+    $(document).ready(() => { renderComponent(response.data); });
   });
 };
 

--- a/lib/extensions/polyglot_with_database/coursemology/polyglot/language.rb
+++ b/lib/extensions/polyglot_with_database/coursemology/polyglot/language.rb
@@ -26,7 +26,7 @@ module Extensions::PolyglotWithDatabase::Coursemology::Polyglot::Language
       if !languages || languages.empty?
         all
       else
-        where { name.in(languages) }
+        where(name: languages)
       end
     end)
   end

--- a/lib/extensions/time_bounded_record/active_record/base.rb
+++ b/lib/extensions/time_bounded_record/active_record/base.rb
@@ -8,11 +8,11 @@ module Extensions::TimeBoundedRecord::ActiveRecord::Base
     private
 
     def started
-      where { (start_at == nil) | (start_at <= Time.zone.now) }
+      where.has { (start_at == nil) | (start_at <= Time.zone.now) }
     end
 
     def ended
-      where { (end_at == nil) | (end_at >= Time.zone.now) }
+      where.has { (end_at == nil) | (end_at >= Time.zone.now) }
     end
   end
 

--- a/spec/features/course/lesson_plan_milestone_management_spec.rb
+++ b/spec/features/course/lesson_plan_milestone_management_spec.rb
@@ -6,7 +6,11 @@ RSpec.feature 'Course: Lesson Plan Milestones' do
 
   with_tenant(:instance) do
     let!(:course) { create(:course) }
-    let(:milestones) { create_list(:course_lesson_plan_milestone, 2, course: course) }
+    let(:milestones) do
+      [2.days.ago, 2.days.from_now].map do |start_at|
+        create(:course_lesson_plan_milestone, course: course, start_at: start_at)
+      end
+    end
 
     before do
       login_as(user, scope: :user)

--- a/spec/features/course/lesson_plan_spec.rb
+++ b/spec/features/course/lesson_plan_spec.rb
@@ -2,7 +2,6 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Lesson Plan' do
-  subject { page }
   let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
@@ -32,10 +31,6 @@ RSpec.feature 'Course: Lesson Plan' do
       end
     end
 
-    let!(:assessments) do
-      create_list(:course_assessment_assessment, 1, course: course)
-    end
-
     before do
       login_as(user, scope: :user)
     end
@@ -45,13 +40,11 @@ RSpec.feature 'Course: Lesson Plan' do
 
       scenario 'I can view all lesson plan items and milestones', js: true do
         visit course_lesson_plan_path(course)
-        milestones.each do |m|
-          expect(subject).to have_text(m.title)
-        end
+        expect(page).to have_link(nil, href: new_course_lesson_plan_event_path(course))
+        expect(page).to have_link(nil, href: new_course_lesson_plan_milestone_path(course))
 
-        events.each do |item|
-          expect(subject).to have_text(item.title)
-        end
+        milestones.each { |milestone| expect(page).to have_text(milestone.title) }
+        events.each { |event| expect(page).to have_text(event.title) }
       end
     end
 
@@ -69,13 +62,8 @@ RSpec.feature 'Course: Lesson Plan' do
         expect(page).not_to have_link(nil, href: new_course_lesson_plan_event_path(course))
         expect(page).not_to have_link(nil, href: new_course_lesson_plan_milestone_path(course))
 
-        milestones.each do |m|
-          expect(subject).to have_text(m.title)
-        end
-
-        events.each do |item|
-          expect(subject).to have_text(item.title)
-        end
+        milestones.each { |milestone| expect(page).to have_text(milestone.title) }
+        events.each { |event| expect(page).to have_text(event.title) }
       end
     end
   end

--- a/spec/libraries/date_time_helpers.rb
+++ b/spec/libraries/date_time_helpers.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 RSpec.describe Extensions::DateTimeHelpers do
   describe '.min' do
     it 'is a valid time in database' do
-      expect { User.where { created_at > Time.min } }.not_to raise_error
+      expect { User.where.has { created_at > Time.min } }.not_to raise_error
     end
   end
 
   describe '.max' do
     it 'is a valid time in database' do
-      expect { User.where { created_at < Time.max } }.not_to raise_error
+      expect { User.where.has { created_at < Time.max } }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Starts #2271. Squeel is not being maintained now, hence removing all dependencies on it would be useful. 

This PR removes all Squeel queries from Coursemology, and replaces them with vanilla ActiveRecord and baby_squeel (aimed at replacing Squeel, without monkey-patching ActiveRecord). For most parts, I've opted to stick to normal Activerecord to ensure easier upgrade paths in the future. 

Note that however, `cancancan-squeel`, which has a dependency on squeel, is still installed. This is because the `cancancan-squeel` adapter does fix certain issues with self-joins and calculated attributes which is still necessary for Coursemology to function. The next step is to work on an alternative for that adapter. 