### PR TITLE
Add a drag-and-drop zone to upload achievement badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ node_modules
 
 # Ignore build for client
 /client/build
+
+# Ignore all yarn errors
+yarn-error.log

--- a/app/views/course/achievement/achievements/_form.html.slim
+++ b/app/views/course/achievement/achievements/_form.html.slim
@@ -6,8 +6,11 @@
   = f.input :description
 
   = f.label t('.badge')
-  div.achievement-form = display_achievement_badge(@achievement)
-  = f.file_field :badge
+  - badge_url = \
+      @achievement.new_record? ? image_url('achievement_blank.png') : @achievement.badge.medium.url
+  div.achievement-form#achievement-badge data-badge-url=badge_url
+    = display_achievement_badge(@achievement)
+    = f.file_field :badge
 
   = f.input :published
 

--- a/client/app/bundles/course/achievement/achievements.jsx
+++ b/client/app/bundles/course/achievement/achievements.jsx
@@ -1,10 +1,15 @@
+import React from 'react';
 import axios from 'lib/axios';
+import { render } from 'react-dom';
 import { defineMessages } from 'react-intl';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
 import renderNotificationBar from 'lib/helpers/renderNotificationBar';
+import BadgeUploader from './badge-uploader';
 
 require('jquery-ui/ui/widgets/sortable');
 
 const ACHIEVEMENTS_SELECTOR = '#sortable ';
+const BADGE_UPLOADER_SELECTOR = 'achievement-badge';
 const BUTTON_SELECTOR = '#reorder ';
 const REORDER_ICON_SELECTOR = '.fa-reorder ';
 
@@ -75,6 +80,22 @@ function initializeReorderingButton() {
   });
 }
 
+// Function to render the drag-and-drop badge uploader.
+function renderBadgeUploader() {
+  const mountNode = document.getElementById(BADGE_UPLOADER_SELECTOR);
+  const fileUrl = mountNode.getAttribute('data-badge-url');
+  render(
+    <ProviderWrapper>
+      <BadgeUploader
+        currentFileUrl={fileUrl}
+      />
+    </ProviderWrapper>
+    , mountNode
+  );
+}
+
+
 $(document).ready(() => {
   initializeReorderingButton();
+  renderBadgeUploader();
 });

--- a/client/app/bundles/course/achievement/badge-uploader.jsx
+++ b/client/app/bundles/course/achievement/badge-uploader.jsx
@@ -1,0 +1,110 @@
+import React, { PropTypes } from 'react';
+import { injectIntl, defineMessages, intlShape } from 'react-intl';
+import Avatar from 'material-ui/Avatar';
+import Badge from 'material-ui/Badge';
+import Dropzone from 'react-dropzone';
+import IconButton from 'material-ui/IconButton';
+import CloseIcon from 'material-ui/svg-icons/navigation/close';
+
+const styles = {
+  badge: {
+    height: '120px',
+    marginRight: '1em',
+    width: '120px',
+  },
+  badgeIconActive: {
+    backgroundColor: 'rgb(200,200,200)',
+  },
+  badgeIconInactive: {
+    backgroundColor: 'rgb(225,225,225)',
+  },
+  dropzone: {
+    backgroundColor: 'rgb(225,225,225)',
+    borderRadius: '5px',
+    height: '200px',
+    paddingTop: '30px',
+    textAlign: 'center',
+    width: '100%',
+  },
+};
+
+const translations = defineMessages({
+  badgeUploaderTitle: {
+    id: 'course.achievement.badgeUploaderTitle',
+    defaultMessage: 'Click to select a new file, or drag and drop it into the zone.',
+  },
+});
+
+const propTypes = {
+  currentFileUrl: PropTypes.string,
+  intl: intlShape.isRequired,
+};
+
+class BadgeUploader extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { files: [] };
+  }
+
+  onDrop = (files) => {
+    this.setState({ files });
+  }
+
+  badgeContent = () => {
+    if (this.state.files.length === 0) { return ''; }
+    return (
+      <IconButton
+        tooltip="Remove Picture"
+        onTouchTap={() => { this.setState({ files: [] }); }}
+      >
+        <CloseIcon />
+      </IconButton>
+    );
+  }
+
+  renderBadge = () => {
+    const { currentFileUrl } = this.props;
+    return (
+      <Badge
+        badgeContent={this.badgeContent()}
+        badgeStyle={this.state.files.length > 0 ? styles.badgeIconActive : styles.badgeIconInactive}
+        style={styles.badge}
+      >
+        <Avatar
+          size={100}
+          src={this.state.files.length > 0 ? this.state.files[0].preview : currentFileUrl}
+        />
+      </Badge>
+    );
+  }
+
+  renderFile = () => {
+    const { intl } = this.props;
+    return (
+      <div>
+        {this.renderBadge()}
+        {intl.formatMessage(translations.badgeUploaderTitle)}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Dropzone
+        inputProps={{
+          id: 'badge',
+          name: 'achievement[badge]',
+        }}
+        style={styles.dropzone}
+        multiple={false}
+        onDrop={this.onDrop}
+      >
+        {this.renderFile}
+      </Dropzone>
+    );
+  }
+}
+
+BadgeUploader.propTypes = propTypes;
+
+export default injectIntl(BadgeUploader);

--- a/client/package.json
+++ b/client/package.json
@@ -82,6 +82,7 @@
     "react-dnd": "^2.3.0",
     "react-dnd-html5-backend": "^2.3.0",
     "react-dom": "^0.14.8 || ^15.0.0",
+    "react-dropzone": "^3.13.1",
     "react-intl": "jeremyyap/react-intl#build",
     "react-redux": "^5.0.3",
     "react-router-dom": "^4.1.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -245,6 +245,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+attr-accept@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.0.tgz#b5cd35227f163935a8f1de10ed3eba16941f6be6"
+
 autoprefixer@^6.3.1:
   version "6.7.5"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.5.tgz#50848f39dc08730091d9495023487e7cc21f518d"
@@ -4744,7 +4748,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4:
+prop-types@^15.5.4, prop-types@^15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -4902,6 +4906,13 @@ react-dnd@^2.3.0:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+
+react-dropzone@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-3.13.1.tgz#5380d47585b44ad2877c0b5a9b92abe7bd2a12e5"
+  dependencies:
+    attr-accept "^1.0.3"
+    prop-types "^15.5.7"
 
 react-event-listener@^0.4.0:
   version "0.4.1"


### PR DESCRIPTION
This is partly to learn a little more about react and some of the conventions we use, and also to make it a little easier for everyone to upload badges for Achievements. 

#### Uploading a badge for a new achievement
![ocd](https://cloud.githubusercontent.com/assets/4353853/26103982/88a6dc62-3a6e-11e7-89e1-1df7c489ea1c.gif)

#### Replacing a badge for an existing achievement
![ocd2](https://cloud.githubusercontent.com/assets/4353853/26103983/88cf3a04-3a6e-11e7-8446-29136e358171.gif)

Currently this is very primitive and does not support async uploading yet, as I think it will be a little hard to manage unless the entire page is on react (so that we can properly undo badge changes). 

