### PR TITLE
Only mark the announcements as read after the action

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -10,6 +10,7 @@ $white: #ffffff !default;
 $grey-light: #cccccc !default;
 
 //## Variables for colors used in Coursemology.
+$unread-highlight: #f8e3e3 !default;
 $course-achievement-granted-bg: $state-success-bg !default;
 $course-achievement-locked-bg: $gray-lighter !default;
 $course-assessment-not-started-bg: $gray-lighter !default;
@@ -26,7 +27,7 @@ $course-discussion-post-border-radius: $border-radius-base !default;
 $course-discussion-post-shadow-color: $gray-lighter !default;
 $course-discussion-post-annotation-trigger-bg-color: $body-bg !default;
 $course-discussion-post-annotation-trigger-color: $brand-primary !default;
-$course-forum-unread-highlight: #f8e3e3 !default;
+$course-forum-unread-highlight: $unread-highlight !default;
 $course-video-not-started-bg: $gray-lighter !default;
 $course-video-submission-not-started: $red !default;
 

--- a/app/assets/stylesheets/course/_announcement.scss
+++ b/app/assets/stylesheets/course/_announcement.scss
@@ -11,6 +11,12 @@
 
   @include timestamp;
 
+  &.unread {
+    background-color: $unread-highlight;
+    border-radius: 4px;
+    padding: 4px;
+  }
+
   .content {
     font-size: 13px;
     line-height: 18px;

--- a/spec/features/course/announcement_pagination_spec.rb
+++ b/spec/features/course/announcement_pagination_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe 'Course: Announcements', type: :feature do
     let!(:instance) { Instance.default }
 
     with_tenant(:instance) do
+      let(:announcement_count) { 30 }
       let(:course) { create(:course) }
-      let(:user) { create(:course_manager, course: course).user }
+      let!(:user) { create(:course_manager, course: course).user }
       let!(:announcements) do
-        create_list(:course_announcement, 30, course: course)
+        create_list(:course_announcement, announcement_count, course: course)
       end
 
       before do
@@ -22,10 +23,21 @@ RSpec.describe 'Course: Announcements', type: :feature do
         visit course_announcements_path(course)
 
         expect(page).to have_selector('nav.pagination')
-        course.announcements.sorted_by_sticky.sorted_by_date.page(1).each do |announcement|
-          expect(page).to have_selector('div', text: announcement.title)
-          expect(page).to have_selector('div', text: announcement.content)
+        announcements = course.announcements.sorted_by_sticky.sorted_by_date.page(1)
+        announcements.each do |announcement|
+          expect(page).to have_selector('div.unread', text: announcement.title)
+          expect(page).to have_selector('div.unread', text: announcement.content)
         end
+
+        # In total there are two pages, the test is to ensure that only the announcements in the
+        # current page get marked as unread.
+        expect(course.announcements.unread_by(user).count).
+          to eq(announcement_count - announcements.size)
+
+        # Visit the page again should not reduce the unread count.
+        visit course_announcements_path(course)
+        expect(course.announcements.unread_by(user).count).
+          to eq(announcement_count - announcements.size)
       end
 
       context 'after clicked second page' do


### PR DESCRIPTION
* Use a different background color for unread announcements
* Fixed a bug that the announcements in the next page get marked as unread