### PR TITLE
Show private/evaluation tests to all types of assessments

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -71,9 +71,9 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
 
   def assessment_params
     base_params = [:title, :description, :base_exp, :time_bonus_exp, :start_at, :end_at,
-                   :bonus_end_at, :published, :autograded]
+                   :bonus_end_at, :published, :autograded, :show_private, :show_evaluation]
     if autograded?
-      base_params += [:skippable, :show_private, :show_evaluation]
+      base_params += [:skippable]
     else
       base_params += [:password, :tabbed_view, :delayed_grade_publication]
     end

--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -18,16 +18,16 @@ h3 = t('.test_cases')
               type_heading: t('.public'), is_grader: is_grader }
 
 / Display the private tests to students, only if the `show_private` option is enabled and
-/ the student get the answer correct.
-- if is_grader || answer.correct? && assessment.show_private?
+/ the submission is published.
+- if is_grader || submission.published? && assessment.show_private?
   - if test_cases_and_results['private_test'].present?
     = render partial: 'course/assessment/answer/programming/test_cases_of_type',
       locals: { test_cases_and_results: test_cases_and_results['private_test'],
                 type_heading: t('.private'), is_grader: is_grader }
 
 / Display the evaluation tests to students, only if the `show_evaluation` option is enabled and
-/ the student get the answer correct.
-- if is_grader || answer.correct? && assessment.show_evaluation?
+/ the submission is published.
+- if is_grader || submission.published? && assessment.show_evaluation?
   - if test_cases_and_results['evaluation_test'].present?
     = render partial: 'course/assessment/answer/programming/test_cases_of_type',
       locals: { test_cases_and_results: test_cases_and_results['evaluation_test'],

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -142,28 +142,6 @@ class AssessmentForm extends React.Component {
             style={styles.toggle}
             disabled={submitting}
           />
-          <Field
-            name="show_private"
-            component={Toggle}
-            label={<FormattedMessage {...translations.showPrivate} />}
-            labelPosition="right"
-            style={styles.toggle}
-            disabled={submitting}
-          />
-          <div style={styles.hint}>
-            <FormattedMessage {...translations.showPrivateHint} />
-          </div>
-          <Field
-            name="show_evaluation"
-            component={Toggle}
-            label={<FormattedMessage {...translations.showEvaluation} />}
-            labelPosition="right"
-            style={styles.toggle}
-            disabled={submitting}
-          />
-          <div style={styles.hint}>
-            <FormattedMessage {...translations.showEvaluationHint} />
-          </div>
         </div>
       );
     }
@@ -327,6 +305,29 @@ class AssessmentForm extends React.Component {
         }
 
         {this.renderExtraOptions()}
+
+        <Field
+          name="show_private"
+          component={Toggle}
+          label={<FormattedMessage {...translations.showPrivate} />}
+          labelPosition="right"
+          style={styles.toggle}
+          disabled={submitting}
+        />
+        <div style={styles.hint}>
+          <FormattedMessage {...translations.showPrivateHint} />
+        </div>
+        <Field
+          name="show_evaluation"
+          component={Toggle}
+          label={<FormattedMessage {...translations.showEvaluation} />}
+          labelPosition="right"
+          style={styles.toggle}
+          disabled={submitting}
+        />
+        <div style={styles.hint}>
+          <FormattedMessage {...translations.showEvaluationHint} />
+        </div>
 
         {
           folderAttributes &&

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
@@ -39,7 +39,7 @@ const translations = defineMessages({
   },
   showPrivateHint: {
     id: 'course.assessment.form.showPrivateHint',
-    defaultMessage: 'Show private tests after students answer the question correctly (For programming questions)',
+    defaultMessage: 'Show private tests to students after the submission is graded and published (For programming questions)',
   },
   showEvaluation: {
     id: 'course.assessment.form.showEvaluation',
@@ -47,7 +47,7 @@ const translations = defineMessages({
   },
   showEvaluationHint: {
     id: 'course.assessment.form.showEvaluationHint',
-    defaultMessage: 'Show evaluation tests after students answer the question correctly (For programming questions)',
+    defaultMessage: 'Show evaluation tests to students after the submission is graded and published (For programming questions)',
   },
   published: {
     id: 'course.assessment.form.published',


### PR DESCRIPTION
Further cleared the requirements and now the behavior changes to: 

* `Show private/evaluation` options are available for all types of assessments
* Test cases are shown only after the submission is published
