### PR TITLE
BrainCert changed GMT timezone code from 28 to 30

### DIFF
--- a/app/services/course/virtual_classroom/braincert_api_service.rb
+++ b/app/services/course/virtual_classroom/braincert_api_service.rb
@@ -114,7 +114,7 @@ class Course::VirtualClassroom::BraincertApiService
   def create_classroom_params
     {
       title: @virtual_classroom.title,
-      timezone: 28, # 28 means time zone 0
+      timezone: 30, # GMT Time
       start_time: @virtual_classroom.start_at.in_time_zone(0).strftime(TIME_BRAINCERT),
       end_time: @virtual_classroom.end_at.in_time_zone(0).strftime(TIME_BRAINCERT),
       date: @virtual_classroom.start_at.in_time_zone(0).to_date.strftime(DATE_ISO),


### PR DESCRIPTION
BrainCert has changed their GMT timezone settings code. Thus braincert_api_service needs to reflect this change.