### PR TITLE
Run ProgrammingEvaluation in service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 dist: trusty
-sudo: false
+sudo: true
 language: ruby
 branches:
   except:
     - /^bundle-update-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}+$/
 rvm:
   - 2.3.1
+services:
+  - docker
 addons:
   apt:
     packages:
@@ -33,9 +35,11 @@ env:
     - GROUP="misc"
 
 before_install:
+  - nvm install 6
   - node --version
   - npm list -g yarn --depth=0 || npm install -g yarn
   - yarn --version
+  - docker --version
   - gem update bundler
   # from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
   # and also from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-200965782

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,8 @@ gem 'ejs'
 gem 'high_voltage'
 # Paginator for Rails
 gem 'kaminari'
+# Work with Docker
+gem 'docker-api'
 
 group :development do
   # Spring speeds up development by keeping your application running in the background.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,9 @@ GEM
       railties (>= 3.0)
     diff-lcs (1.3)
     docile (1.1.5)
+    docker-api (1.33.2)
+      excon (>= 0.38.0)
+      json
     easy_translate (0.5.0)
       json
       thread
@@ -166,6 +169,7 @@ GEM
       launchy (~> 2.1)
       mail (~> 2.6)
     erubis (2.7.0)
+    excon (0.55.0)
     execjs (2.7.0)
     exifr (1.2.5)
     factory_girl (4.8.0)
@@ -576,6 +580,7 @@ DEPENDENCIES
   devise!
   devise-multi_email (~> 1.0.5)
   devise_masquerade
+  docker-api
   edge
   ejs
   email_spec
@@ -642,7 +647,6 @@ DEPENDENCIES
   webpack-rails
   workflow
   yard
-
 
 BUNDLED WITH
    1.14.6

--- a/lib/autoload/coursemology_docker_container.rb
+++ b/lib/autoload/coursemology_docker_container.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+class CoursemologyDockerContainer < Docker::Container
+  # The path to the Coursemology user home directory.
+  HOME_PATH = '/home/coursemology'.freeze
+
+  # The path to where the package will be extracted.
+  PACKAGE_PATH = File.join(HOME_PATH, 'package')
+
+  # The path to where the test report will be at.
+  REPORT_PATH = File.join(PACKAGE_PATH, 'report.xml')
+
+  class << self
+    def create(image, argv: nil)
+      pull_image(image) unless Docker::Image.exist?(image)
+
+      ActiveSupport::Notifications.instrument('create.docker.evaluator.coursemology',
+                                              image: image) do |payload|
+        options = { 'Image' => image }
+        options['Cmd'] = argv if argv.present?
+
+        payload[:container] = super(options)
+      end
+    end
+
+    private
+
+    # Pulls the given image from Docker Hub.
+    #
+    # @param [String] image The image to pull.
+    def pull_image(image)
+      ActiveSupport::Notifications.instrument('pull.docker.evaluator.coursemology',
+                                              image: image) do
+        Docker::Image.create('fromImage' => image)
+      end
+    end
+  end
+
+  # Waits for the container to exit the Running state.
+  #
+  # This will time out for long running operations, so keep retrying until we return.
+  #
+  # @param [Fixnum|nil] time The amount of time to wait.
+  # @return [Fixnum] The exit code of the container.
+  def wait(time = nil)
+    container_state = info
+    while container_state.fetch('State', {}).fetch('Running', true)
+      super
+      refresh!
+      container_state = info
+    end
+
+    container_state['State']['ExitCode']
+  rescue Docker::Error::TimeoutError
+    retry
+  end
+
+  # Gets the exit code of the container.
+  #
+  # @return [Fixnum] The exit code of the container, if +wait+ was called before.
+  # @return [nil] If the container is still running, or +wait+ was not called.
+  def exit_code
+    info.fetch('State', {})['ExitCode']
+  end
+
+  def delete
+    ActiveSupport::Notifications.instrument('destroy.docker.evaluator.coursemology',
+                                            container: id) do
+      super
+    end
+  end
+
+  # Copies the contents of the package to the container.
+  #
+  # @param [String] package The path to the package.
+  def copy_package(package)
+    tar = tar_package(package)
+    archive_in_stream(HOME_PATH) do
+      tar.read(Excon.defaults[:chunk_size]).to_s
+    end
+  end
+
+  def execute_package
+    start!
+    wait
+  end
+
+  # Gets the output that Coursemology is interested in.
+  #
+  # @return [Array<(String, String, String, Integer)>] The stdout, stderr, test report and exit
+  #   code.
+  def evaluation_result
+    _, stdout, stderr = container_streams
+
+    [stdout, stderr, extract_test_report, exit_code]
+  end
+
+  private
+
+  # Converts the zip package into a tar package for the container.
+  #
+  # This also adds an additional +package+ directory to the start of the path, following tar
+  # convention.
+  #
+  # @param [String] package The path to the package to convert to a tar.
+  # @return [IO] A stream containing the tar.
+  def tar_package(package)
+    tar_file_stream = StringIO.new
+    tar_file = Gem::Package::TarWriter.new(tar_file_stream)
+    Zip::File.open(package) do |zip_file|
+      copy_archive(zip_file, tar_file, File.basename(PACKAGE_PATH))
+      tar_file.close
+    end
+
+    tar_file_stream.seek(0)
+    tar_file_stream
+  end
+
+  # Copies every entry from the zip archive to the tar archive, adding the optional prefix to the
+  # start of each file name.
+  #
+  # @param [Zip::File] zip_file The zip file to read from.
+  # @param [Gem::Package::TarWriter] tar_file The tar file to write to.
+  # @param [String] prefix The prefix to add to every file name in the tar.
+  def copy_archive(zip_file, tar_file, prefix = nil)
+    zip_file.each do |entry|
+      next unless entry.file?
+
+      zip_entry_stream = entry.get_input_stream
+      new_entry_name = prefix ? File.join(prefix, entry.name) : entry.name
+      tar_file.add_file(new_entry_name, 0o664) do |tar_entry_stream|
+        IO.copy_stream(zip_entry_stream, tar_entry_stream)
+      end
+
+      zip_entry_stream.close
+    end
+  end
+
+  # Gets the logs and parses them
+  #
+  # @return [Array<(String, String, String)>] The stdin, stdout, and stderr output.
+  def container_streams
+    log_stream = logs(stdout: true, stderr: true)
+    parse_docker_stream(log_stream)
+  end
+
+  def extract_test_report
+    stream = extract_test_report_archive
+
+    tar_file = Gem::Package::TarReader.new(stream)
+    tar_file.each do |file|
+      test_report = file.read
+      return test_report.force_encoding(Encoding::UTF_8) if test_report
+    end
+  rescue Docker::Error::NotFoundError
+    return nil
+  end
+
+  # Extracts the test report from the container.
+  #
+  # @return [StringIO] The stream containing the archive, the pointer is reset to the start of the
+  #   stream.
+  def extract_test_report_archive
+    stream = StringIO.new
+    archive_out(REPORT_PATH) do |bytes|
+      stream.write(bytes)
+    end
+
+    stream.seek(0)
+    stream
+  end
+
+  # Represents one block of the Docker Attach protocol.
+  DockerAttachBlock = Struct.new(:stream, :length, :bytes)
+
+  # Parses a Docker +attach+ protocol stream into its constituent protocols.
+  #
+  # See https://docs.docker.com/engine/reference/api/docker_remote_api_v1.19/#attach-to-a-container.
+  #
+  # This drops all blocks belonging to streams other than STDIN, STDOUT, or STDERR.
+  #
+  # @param [String] string The input stream to parse.
+  # @return [Array<(String, String, String)>] The stdin, stdout, and stderr output.
+  def parse_docker_stream(string)
+    result = [''.dup, ''.dup, ''.dup]
+    stream = StringIO.new(string)
+
+    while (block = parse_docker_stream_read_block(stream))
+      next if block.stream >= result.length
+      result[block.stream] << block.bytes
+    end
+
+    stream.close
+    result
+  end
+
+  # Reads a block from the given stream, and parses it according to the Docker +attach+ protocol.
+  #
+  # @param [IO] stream The stream to read.
+  # @raise [IOError] If the stream is corrupt.
+  # @return [DockerAttachBlock] If there is data in the stream.
+  # @return [nil] If there is no data left in the stream.
+  def parse_docker_stream_read_block(stream)
+    header = stream.read(8)
+    return nil if header.blank?
+    fail IOError unless header.length == 8
+
+    console_stream, _, _, _, length = header.unpack('C4N')
+    DockerAttachBlock.new(console_stream, length, stream.read(length))
+  end
+end

--- a/spec/components/course/controller_component_host_spec.rb
+++ b/spec/components/course/controller_component_host_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
       end
 
       context 'with preferences' do
-        let(:sample_component) { default_enabled_components.first }
+        let(:sample_component) { default_enabled_components.select(&:can_be_disabled?).first }
         context 'disable a component in course' do
           before { course.settings(sample_component.key).enabled = false }
 

--- a/spec/libraries/coursemology_docker_container_spec.rb
+++ b/spec/libraries/coursemology_docker_container_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CoursemologyDockerContainer do
+  let(:image) { 'coursemology/evaluator-image-python:2.7' }
+  let(:package) do
+    Rails.root.join('spec', 'fixtures', 'course', 'programming_question_template.zip')
+  end
+  subject { CoursemologyDockerContainer.create(image) }
+
+  describe '#wait' do
+    it 'retries until the container finishes' do
+      subject.start!
+
+      called = 0
+      expect(subject.connection).to receive(:post).and_wrap_original do |block, *args|
+        excon_params = args.third
+        excon_params[:read_timeout] = called == 0 ? 0 : nil
+        called += 1
+
+        block.call(*args)
+      end.at_least(:twice)
+
+      expect(subject.wait(0.01)).not_to be_nil
+    end
+
+    it 'returns the exit code of the container' do
+      expect(subject.wait).to eq(subject.exit_code)
+    end
+  end
+
+  describe '#exit_code' do
+    context 'when the container has been waited upon' do
+      it 'returns the exit code of the container' do
+        subject.wait
+        expect(subject.exit_code).not_to be_nil
+      end
+    end
+
+    context 'when the container is still running' do
+      it 'returns nil' do
+        expect(subject.exit_code).to be_nil
+      end
+    end
+  end
+
+  describe '#copy_package' do
+    it 'copies to the home directory' do
+      expect(subject).to receive(:archive_in_stream).with(subject.class::HOME_PATH)
+      subject.send(:copy_package, package)
+    end
+  end
+
+  describe '#tar_package' do
+    let(:tar_stream) { subject.send(:tar_package, package) }
+    it 'resets the stream to the start' do
+      expect(tar_stream.tell).to eq(0)
+    end
+
+    it 'copies all files, prefixed with the package directory name' do
+      tar = Gem::Package::TarReader.new(tar_stream)
+      entries = []
+      tar.each do |entry|
+        entries << entry.full_name
+      end
+
+      expect(entries).to contain_exactly('package/Makefile', 'package/submission/__init__.py')
+    end
+  end
+
+  describe '#execute_package' do
+    after { subject.send(:delete) }
+
+    def evaluate_result
+      expect(subject).to receive(:start!).and_call_original
+      subject.send(:execute_package)
+    end
+
+    it 'evaluates the result' do
+      evaluate_result
+    end
+
+    it 'returns only when the container has stopped running' do
+      evaluate_result
+      subject.refresh!
+      expect(subject.info['State']['Running']).to be(false)
+    end
+  end
+
+  describe '#evaluation_result' do
+    before { subject.send(:execute_package) }
+    after { subject.send(:delete) }
+
+    it 'does not expose raw Docker Attach Protocol in the output' do
+      stdout, stderr = subject.send(:evaluation_result)
+      expect(stdout).not_to include("\u0000")
+      expect(stderr).not_to include("\u0000")
+    end
+
+    it 'sets the return code of the container' do
+      _, _, _, exit_code = subject.send(:evaluation_result)
+      expect(exit_code).to eq(2)
+    end
+  end
+
+  describe '#extract_test_report' do
+    let(:report_path) do
+      Rails.root.join('spec', 'fixtures', 'course', 'programming_single_test_suite_report.xml')
+    end
+    let(:report_contents) { File.read(report_path) }
+
+    def copy_report(contents)
+      subject.start!
+      subject.wait
+      tar = StringIO.new(Docker::Util.create_tar('report.xml' => contents))
+      subject.archive_in_stream(CoursemologyDockerContainer::PACKAGE_PATH) { tar.read }
+    end
+
+    after { subject.send(:delete) }
+
+    it 'returns the test report' do
+      copy_report(report_contents)
+      test_report = subject.send(:extract_test_report)
+      expect(test_report).to eq(report_contents)
+      expect(test_report.encoding).to eq Encoding::UTF_8
+    end
+
+    it 'does not crash when report is nil' do
+      copy_report(nil)
+      test_report = subject.send(:extract_test_report)
+      expect(test_report).to be_nil
+    end
+
+    context 'when running the tests fails' do
+      it 'returns nil' do
+        expect(subject.send(:extract_test_report)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/course/assessment/programming_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_evaluation_service_spec.rb
@@ -92,31 +92,12 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
     context 'when the evaluation times out' do
       it 'raises a Timeout::Error' do
         expect do
+          # Pass in a non-zero timeout as Ruby's Timeout treats 0 as infinite.
           subject.execute(course, Coursemology::Polyglot::Language::Python::Python2Point7.instance,
                           64, 5.seconds, File.join(Rails.root, 'spec', 'fixtures', 'course',
-                                                   'programming_question_template.zip'), 0.seconds)
+                                                   'programming_question_template.zip'),
+                          0.1.seconds)
         end.to raise_error(Timeout::Error)
-      end
-    end
-
-    describe '#create_evaluation' do
-      subject do
-        Course::Assessment::ProgrammingEvaluationService.
-          new(course, Coursemology::Polyglot::Language::Python::Python2Point7.instance, 64,
-              5.seconds, File.join(Rails.root, 'spec', 'fixtures', 'course',
-                                   'programming_question_template.zip'), 5.seconds)
-      end
-
-      it 'creates the package for the evaluator to download' do
-        evaluation = subject.send(:create_evaluation)
-
-        # Remove the leading / because Pathname treats it as an absolute path.
-        expect(Rails.public_path + evaluation.package_path[1..-1]).to exist
-      end
-
-      it 'successfully creates the evaluation' do
-        evaluation = subject.send(:create_evaluation)
-        expect(evaluation).to be_persisted
       end
     end
   end

--- a/spec/support/stubs/course/assessment/stubbed_programming_evaluation_service.rb
+++ b/spec/support/stubs/course/assessment/stubbed_programming_evaluation_service.rb
@@ -2,32 +2,13 @@
 module Course::Assessment::StubbedProgrammingEvaluationService
   private
 
-  def wait_for_evaluation(evaluation)
-    thread = Thread.new do
-      ActiveRecord::Base.connection_pool.with_connection do
-        ActsAsTenant.without_tenant do
-          populate_mock_result(evaluation)
-        end
-      end
-    end
-    thread.abort_on_exception = true
+  def evaluate_in_container
+    attributes = FactoryGirl.attributes_for(:course_assessment_programming_evaluation, :completed).
+                   slice(:stdout, :stderr, :test_report, :exit_code)
+    # For timeout testing
+    sleep(0.2)
 
-    super
-  end
-
-  # Populates the evaluation with fake results.
-  #
-  # @param [Course::Assessment::ProgrammingEvaluation] evaluation The evaluation to populate
-  #   mock results for.
-  def populate_mock_result(evaluation)
-    evaluation = Course::Assessment::ProgrammingEvaluation.find(evaluation.id)
-    attributes = FactoryGirl.
-                 attributes_for(:course_assessment_programming_evaluation, :completed).
-                 slice(:stdout, :stderr, :test_report, :exit_code)
-    evaluation.assign!(User.system)
-    evaluation.assign_attributes(attributes)
-    evaluation.complete!
-    evaluation.save!
+    [attributes[:stdout], attributes[:stderr], attributes[:test_report], attributes[:exit_code]]
   end
 end
 


### PR DESCRIPTION
Evaluate packages directly in ProgrammingEvaluationService instead of waiting for an external evaluator.

This will save the polling time, but worker servers will need to have Docker installed.

DO NOT MERGE YET.
For initial feedback, some refactoring and additional tests will be necessary.