### PR TITLE
Assign regrading answers to a lower priority queue

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -163,7 +163,8 @@ class Course::Assessment::Submission::SubmissionsController < \
 
     dead_answers.each do |a|
       old_job = a.auto_grading.job
-      job = a.auto_grade!(old_job.redirect_to, true)
+      job = a.auto_grade!(redirect_to_path: old_job.redirect_to,
+                          reattempt: true, reduce_priority: true)
 
       logger.debug(message: 'Restart Answer Grading', answer_id: a.id, job_id: job.job.id,
                    old_job_id: old_job.id)

--- a/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Course::Assessment::Answer::ReducePriorityAutoGradingJob < ApplicationJob
+  include TrackableJob
+
+  # The Answer Auto Grading Job needs to be at a higher priority than submission auto grading jobs,
+  # because it is fired off by submission auto grading jobs. If this is at an equal or lower
+  # priority than the submission auto grading job, then it is possible that the answer auto grading
+  # jobs might never get to run, and then the submission auto grading jobs will never return.
+  #
+  # Lowering this *will* eventually cause a deadlock.
+  #
+  # Answers are regraded when their question is updated. This causes a large spike in the number
+  # of answer auto grading jobs. To prevent active users from getting timely feedback on their
+  # answers, queue these regrading jobs at a lower priority than answer grading jobs.
+  queue_as :medium_high
+
+  protected
+
+  # Performs the auto grading.
+  #
+  # @param [String|nil] redirect_to_path The path to be redirected after auto grading job was
+  #   finished.
+  # @param [Course::Assessment::Answer] answer the answer to be graded.
+  # @param [String] redirect_to_path The path to redirect when job finishes.
+  # @param [Boolean] reattempt Whether to create new answer based on current answer after grading.
+  def perform_tracked(answer, redirect_to_path = nil, reattempt = false)
+    ActsAsTenant.without_tenant do
+      Course::Assessment::Answer::AutoGradingService.grade(answer, reattempt)
+    end
+
+    redirect_to redirect_to_path
+  end
+end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -57,10 +57,12 @@ class Course::Assessment::Answer < ActiveRecord::Base
   # @param [String|nil] redirect_to_path The path to be redirected after auto grading job was
   #   finished.
   # @param [Boolean] reattempt Whether to create new answer based on current answer after grading.
+  # @param [Boolean] reduce_priority Whether this answer should be queued at a lower priority.
+  #   Used for regrading answers when question is changed, and for submission answers.
   # @return [Course::Assessment::Answer::AutoGradingJob|nil] The autograding job instance will be
   #   returned if the answer is graded using a job, nil will be returned if answer is graded inline.
   # @raise [IllegalStateError] When the answer has not been submitted.
-  def auto_grade!(redirect_to_path = nil, reattempt = false)
+  def auto_grade!(redirect_to_path: nil, reattempt: false, reduce_priority: false)
     raise IllegalStateError if attempting?
 
     ensure_auto_grading!
@@ -68,10 +70,10 @@ class Course::Assessment::Answer < ActiveRecord::Base
       Course::Assessment::Answer::AutoGradingService.grade(self, reattempt)
       nil
     else
-      Course::Assessment::Answer::AutoGradingJob.
+      auto_grading_job_class(reduce_priority).
         perform_later(self, redirect_to_path, reattempt).tap do |job|
-        auto_grading.update_column(:job_id, job.job_id)
-      end
+          auto_grading.update_column(:job_id, job.job_id)
+        end
     end
   end
 
@@ -151,5 +153,13 @@ class Course::Assessment::Answer < ActiveRecord::Base
     self.graded_at = nil
     self.submitted_at = nil
     auto_grading.mark_for_destruction if auto_grading
+  end
+
+  def auto_grading_job_class(reduce_priority)
+    if reduce_priority
+      Course::Assessment::Answer::ReducePriorityAutoGradingJob
+    else
+      Course::Assessment::Answer::AutoGradingJob
+    end
   end
 end

--- a/app/services/course/assessment/question/answers_evaluation_service.rb
+++ b/app/services/course/assessment/question/answers_evaluation_service.rb
@@ -9,6 +9,8 @@ class Course::Assessment::Question::AnswersEvaluationService
   end
 
   def call
-    @question.answers.without_attempting_state.each(&:auto_grade!)
+    @question.answers.without_attempting_state.find_each do |a|
+      a.auto_grade!(reduce_priority: true)
+    end
   end
 end

--- a/app/services/course/assessment/submission/auto_grading_service.rb
+++ b/app/services/course/assessment/submission/auto_grading_service.rb
@@ -54,14 +54,14 @@ class Course::Assessment::Submission::AutoGradingService
   # @return [Course::Assessment::Answer::AutoGradingJob] The job created to grade.
   def grade_answer(answer)
     raise ArgumentError if answer.changed?
-    answer.auto_grade!
+    answer.auto_grade!(reduce_priority: true)
     # Catch errors if answer is in attempting state, caused by a race condition where
     # a new attempting answer is created while the submission is finalised, but before the
     # autograding job is executed.
   rescue IllegalStateError
     answer.finalise!
     answer.save!
-    answer.auto_grade!
+    answer.auto_grade!(reduce_priority: true)
   end
 
   # Waits for the given list of +TrackableJob::Job+s to enter the finished state.

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -159,7 +159,8 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
       answer.finalise! if answer.attempting?
       # Only save if answer is graded in another server
       answer.save! unless answer.grade_inline?
-      answer.auto_grade!(edit_submission_path, true)
+      answer.auto_grade!(redirect_to_path: edit_submission_path,
+                         reattempt: true, reduce_priority: false)
     end
   end
 

--- a/spec/jobs/course/assessment/answer/reduce_priority_auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/reduce_priority_auto_grading_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Answer::ReducePriorityAutoGradingJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    subject { Course::Assessment::Answer::ReducePriorityAutoGradingJob }
+    let(:course) { create(:course) }
+    let(:student_user) { create(:course_student, course: course).user }
+    let(:assessment) do
+      create(:assessment, :published_with_mrq_question, course: course)
+    end
+    let(:question) { assessment.questions.first }
+    let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+    let(:answer) do
+      create(:course_assessment_answer_multiple_response, :submitted,
+             assessment: assessment, submission: submission, question: question).answer
+    end
+    let!(:auto_grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
+
+    it 'can be queued' do
+      expect { subject.perform_later(answer) }.to \
+        have_enqueued_job(subject).exactly(:once).on_queue('medium_high')
+    end
+
+    it 'evaluates answers' do
+      subject.perform_now(answer)
+      expect(answer).to be_evaluated
+    end
+  end
+end


### PR DESCRIPTION
Changes in questions triggers a regrading of all answers.
Queue these regrading jobs at a lower priority to prevent user triggered
answer grading jobs from being delayed for too long.

Sidekiq queue configuration needs to be modified to include the `regrading_answers` queue just below the `highest` queue.