### PR TITLE
Migration prepration 

### DIFF
--- a/app/models/concerns/course/assessment/submission/todo_concern.rb
+++ b/app/models/concerns/course/assessment/submission/todo_concern.rb
@@ -17,6 +17,8 @@ module Course::Assessment::Submission::TodoConcern
   end
 
   def update_todo
+    return unless todo
+
     if attempting?
       todo.update_attribute(:workflow_state, 'in_progress') unless todo.in_progress?
     elsif submitted? || graded? || published?
@@ -28,7 +30,8 @@ module Course::Assessment::Submission::TodoConcern
 
   # Skip callback if assessment is deleted as todo will be deleted.
   def restart_todo
-    return if assessment.destroying?
+    return if assessment.destroying? || todo.nil?
+
     todo.update_attribute(:workflow_state, 'not_started') unless todo.not_started?
   rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message

--- a/app/models/concerns/course/survey/response/todo_concern.rb
+++ b/app/models/concerns/course/survey/response/todo_concern.rb
@@ -17,6 +17,8 @@ module Course::Survey::Response::TodoConcern
   end
 
   def update_todo
+    return unless todo
+
     if submitted?
       todo.update_attribute(:workflow_state, 'completed') unless todo.completed?
     else
@@ -28,7 +30,7 @@ module Course::Survey::Response::TodoConcern
 
   # Skip callback if survey is deleted as todo will be deleted.
   def restart_todo
-    return if survey.destroying?
+    return if survey.destroying? || todo.nil?
     todo.update_attribute(:workflow_state, 'not_started') unless todo.not_started?
   rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message

--- a/app/models/concerns/course/video/submission/todo_concern.rb
+++ b/app/models/concerns/course/video/submission/todo_concern.rb
@@ -17,6 +17,8 @@ module Course::Video::Submission::TodoConcern
   end
 
   def complete_todo
+    return unless todo
+
     todo.update_attribute(:workflow_state, 'completed') unless todo.completed?
   rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message
@@ -24,7 +26,8 @@ module Course::Video::Submission::TodoConcern
 
   # Skip callback if video is deleted as todo will be deleted.
   def restart_todo
-    return if video.destroying?
+    return if video.destroying? || todo.nil?
+
     todo.update_attribute(:workflow_state, 'not_started') unless todo.not_started?
   rescue ActiveRecord::ActiveRecordError => error
     raise ActiveRecord::Rollback, error.message

--- a/app/views/user/registrations/edit.html.slim
+++ b/app/views/user/registrations/edit.html.slim
@@ -11,11 +11,3 @@
 
   div.form-actions
     = f.button :submit
-
-h3
-  = t('.cancel_account')
-
-p
-  = t('.unhappy')
-  = link_to t('.cancel_account'), registration_path(resource_name),
-      data: { confirm: t('.confirm_deletion') }, method: :delete

--- a/config/locales/en/user/registrations.yml
+++ b/config/locales/en/user/registrations.yml
@@ -11,6 +11,3 @@ en:
         header: 'Account Settings'
         new_password_hint: "Leave blank if you don't want to change it"
         current_password_required_hint: 'We need your current password to confirm your changes'
-        cancel_account: 'Cancel my account'
-        confirm_deletion: 'Are you sure?'
-        unhappy: 'Unhappy?'


### PR DESCRIPTION
* 	Don't allow user to cancel their accounts
       * Actually this feature is already broken for those users who enrolled in a course, we probably won't support user deletion since the user stamp is everywhere.
* 	Check the presence of TODO before updating it