### PR TITLE
Show forum voting activity on activity feed

### DIFF
--- a/app/views/course/forum/posts/_post.html.slim
+++ b/app/views/course/forum/posts/_post.html.slim
@@ -1,6 +1,8 @@
 - post_class = ['post']
 - post_class.concat(unread_class(post))
 = div_for(post, class: post_class) do
+  a name=dom_id(post)
+
   = div_for(post.creator) do
     = display_user_image(post.creator)
     span.name = link_to_user(post.creator)

--- a/app/views/notifiers/course/forum/post_notifier/voted/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/voted/course_notifications/_feed.html.slim
@@ -7,5 +7,5 @@
   // TODO: Display user image here.
   - user_link = link_to_user(activity.actor)
   - topic_link = link_to topic.title, topic_path
-  => t('.replied_to_topic_html', user: user_link, topic: topic_link)
+  => t('.voted_on_topic_html', user: user_link, topic: topic_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -27,6 +27,10 @@ en:
             course_notifications:
               feed:
                 replied_to_topic_html: '%{user} replied to %{topic}'
+          voted:
+            course_notifications:
+              feed:
+                voted_on_topic_html: '%{user} voted on %{topic}'
       video_notifier:
         attempted:
           course_notifications:


### PR DESCRIPTION
This allow voting activity to be seen on activity feed for migrated courses. Implementation of voting notifications is deferred to a later PR.