### PR TITLE
Modify file upload question and allow attachments to be viewed and deleted

### DIFF
--- a/app/assets/stylesheets/attachments.scss
+++ b/app/assets/stylesheets/attachments.scss
@@ -1,4 +1,7 @@
 .attachment {
+  margin-bottom: 0.5em;
+
+  .delete-attachment,
   .uploaded-by {
     padding-left: 1em;
   }

--- a/app/assets/stylesheets/attachments.scss
+++ b/app/assets/stylesheets/attachments.scss
@@ -1,0 +1,5 @@
+.attachment {
+  .uploaded-by {
+    padding-left: 1em;
+  }
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -72,10 +72,6 @@ table.codehilite {
   margin-bottom: 1em;
 }
 
-.uploaded-by {
-  padding-left: 1em;
-}
-
 .btn > .fa-spinner {
   margin-left: 0.2em;
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -75,3 +75,7 @@ table.codehilite {
 .btn > .fa-spinner {
   margin-left: 0.2em;
 }
+
+.attachment-uploader {
+  margin-bottom: 1em;
+}

--- a/app/controllers/attachment_references_controller.rb
+++ b/app/controllers/attachment_references_controller.rb
@@ -5,4 +5,14 @@ class AttachmentReferencesController < ApplicationController
   def show
     redirect_to @attachment_reference.url(filename: @attachment_reference.name)
   end
+
+  def destroy
+    authorize!(:destroy_attachment, @attachment_reference.attachable)
+    if @attachment_reference.destroy
+      flash.now[:success] = t('.success')
+    else
+      flash.now[:danger] = t('.failure',
+                             error: @attachment_reference.errors.full_messsages.to_sentence)
+    end
+  end
 end

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -18,6 +18,7 @@ module Course::Assessment::AssessmentAbility
     allow_students_manage_annotations_for_own_assessment_submissions
     allow_students_read_own_assessment_answers
     allow_students_read_submission_question
+    allow_student_to_destroy_own_attachments_text_response_question
   end
 
   def define_staff_assessment_permissions
@@ -170,5 +171,12 @@ module Course::Assessment::AssessmentAbility
 
   def allow_staff_read_submission_questions
     can :read, Course::Assessment::SubmissionQuestion, discussion_topic: course_staff_hash
+  end
+
+  # Prevent everyone from destroying their own attachment, unless they are attempting the question.
+  def allow_student_to_destroy_own_attachments_text_response_question
+    cannot :destroy_attachment, Course::Assessment::Answer::TextResponse
+    can :destroy_attachment, Course::Assessment::Answer::TextResponse,
+        submission: assessment_submission_attempting_hash(user)
   end
 end

--- a/app/views/attachment_references/destroy.js.erb
+++ b/app/views/attachment_references/destroy.js.erb
@@ -1,0 +1,8 @@
+<%- if @attachment_reference.destroyed? %>
+  $('#<%= dom_id(@attachment_reference) %>').remove();
+<% end %>
+
+// Remove older flash messages, and show users the new flash message
+$('.course-layout').parents('.container-fluid:first').find('.alert').remove();
+$('.course-layout').parents('.container-fluid:first').prepend('<%= j(flash_messages) %>');
+window.scrollTo(0, 0);

--- a/app/views/attachments/_attachment.html.slim
+++ b/app/views/attachments/_attachment.html.slim
@@ -1,0 +1,4 @@
+= content_tag_for(:div, attachment, class: ['attachment'])
+  span = link_to format_inline_text(attachment.name), attachment_reference_path(attachment),
+                 target: "_blank"
+  span.uploaded-by = t('.uploaded_by', name: attachment.creator.name)

--- a/app/views/attachments/_attachment.html.slim
+++ b/app/views/attachments/_attachment.html.slim
@@ -1,4 +1,9 @@
+- delete = local_assigns[:delete] ? local_assigns[:delete] : false
 = content_tag_for(:div, attachment, class: ['attachment'])
   span = link_to format_inline_text(attachment.name), attachment_reference_path(attachment),
                  target: "_blank"
   span.uploaded-by = t('.uploaded_by', name: attachment.creator.name)
+  - if delete
+    span.delete-attachment
+      = link_to t('.delete_attachment'), attachment_reference_path(attachment),
+                data: { confirm: t('.confirm_delete_attachment') }, method: :delete, remote: true

--- a/app/views/course/assessment/answer/text_responses/_text_response.html.slim
+++ b/app/views/course/assessment/answer/text_responses/_text_response.html.slim
@@ -1,9 +1,17 @@
 - question = text_response.question.specific
+- submission = text_response.submission
+
 - unless question.hide_text?
   - readonly = cannot?(:update, text_response.answer)
   = f.input :answer_text, label: false, readonly: readonly
+
 - if question.allow_attachment?
-  = f.attachment
+  - if submission.attempting?
+    = f.attachment allow_delete: can?(:destroy_attachment, text_response)
+  - else
+    strong => t('.uploaded_files')
+    - text_response.attachments.each do |attachment|
+      = render partial: 'attachments/attachment', locals: { attachment: attachment }
 
 - if last_attempt && last_attempt.auto_grading && last_attempt.auto_grading.result
   = render partial: 'course/assessment/answer/explanation',
@@ -11,4 +19,4 @@
 
 - if question.auto_gradable? && can?(:grade, text_response.answer)
   = render partial: 'course/assessment/answer/text_responses/solution',
-    locals: { question: question }
+           locals: { question: question }

--- a/app/views/layouts/_attachment_uploader.html.slim
+++ b/app/views/layouts/_attachment_uploader.html.slim
@@ -2,19 +2,14 @@
   - unless f.object.attachments.empty?
     strong = t('.uploaded_files')
     - f.object.attachments.each do |attachment|
-      div
-        span = link_to format_inline_text(attachment.name), '#'
-        span.uploaded-by = t('.uploaded_by', name: attachment.creator.name)
+      = render partial: 'attachments/attachment', locals: { attachment: attachment }
   div
     strong = t('.new_files')
     = f.file_field :files, multiple: true
 - else
   - if f.object.attachment.present? && f.object.attachment.persisted?
     strong => t('.uploaded_file')
-    div
-      span = link_to format_inline_text(f.object.attachment.name),
-                               attachment_reference_path(f.object.attachment), target: "_blank"
-      span.uploaded-by = t('.uploaded_by', name: f.object.attachment.creator.name)
+    = render partial: 'attachments/attachment', locals: { attachment: f.object.attachment }
 
   div
     = f.file_field :file

--- a/app/views/layouts/_attachment_uploader.html.slim
+++ b/app/views/layouts/_attachment_uploader.html.slim
@@ -1,15 +1,17 @@
-- if multiple
-  - unless f.object.attachments.empty?
-    strong = t('.uploaded_files')
-    - f.object.attachments.each do |attachment|
-      = render partial: 'attachments/attachment', locals: { attachment: attachment }
-  div
-    strong = t('.new_files')
-    = f.file_field :files, multiple: true
-- else
-  - if f.object.attachment.present? && f.object.attachment.persisted?
-    strong => t('.uploaded_file')
-    = render partial: 'attachments/attachment', locals: { attachment: f.object.attachment }
-
-  div
-    = f.file_field :file
+div.attachment-uploader
+  - if multiple
+    - unless f.object.attachments.empty?
+      strong => t('.uploaded_files')
+      - f.object.attachments.each do |attachment|
+        = render partial: 'attachments/attachment',
+                 locals: { attachment: attachment, delete: allow_delete }
+    div
+      strong = t('.new_files')
+      = f.file_field :files, multiple: true
+  - else
+    - if f.object.attachment.present? && f.object.attachment.persisted?
+      strong => t('.uploaded_file')
+      = render partial: 'attachments/attachment',
+               locals: { attachment: f.object.attachment, delete: allow_delete }
+    div
+      = f.file_field :file

--- a/config/locales/en/attachment_references.yml
+++ b/config/locales/en/attachment_references.yml
@@ -1,0 +1,5 @@
+en:
+  attachment_references:
+    destroy:
+      success: 'Attachment has been deleted'
+      failure: 'Failed to delete attachment: %{error}'

--- a/config/locales/en/attachments.yml
+++ b/config/locales/en/attachments.yml
@@ -2,3 +2,5 @@ en:
   attachments:
     attachment:
       uploaded_by: :'layouts.materials_uploader.uploaded_by'
+      delete_attachment: 'Delete'
+      confirm_delete_attachment: 'Are you sure you want to delete this attachment?'

--- a/config/locales/en/attachments.yml
+++ b/config/locales/en/attachments.yml
@@ -1,0 +1,4 @@
+en:
+  attachments:
+    attachment:
+      uploaded_by: :'layouts.materials_uploader.uploaded_by'

--- a/config/locales/en/course/assessment/answer/text_responses.yml
+++ b/config/locales/en/course/assessment/answer/text_responses.yml
@@ -3,6 +3,8 @@ en:
     assessment:
       answer:
         text_responses:
+          text_response:
+            uploaded_files: 'Uploaded Files'
           solution:
             solutions: 'Solutions'
             solution_type: :'course.assessment.question.text_responses.form.solution_type'

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -36,7 +36,6 @@ en:
       uploaded_files: 'Uploaded Files:'
       uploaded_file: 'Uploaded File:'
       new_files: 'Upload New Files'
-      uploaded_by: :'layouts.materials_uploader.uploaded_by'
     materials_uploader:
       uploaded_by: 'Uploaded By: %{name}'
     mailer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,6 +339,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :attachment_references, path: 'attachments', only: [:show]
+  resources :attachment_references, path: 'attachments', only: [:show, :destroy]
   resources :attachments, only: [:create]
 end

--- a/lib/extensions/attachable/action_view/helpers/form_builder.rb
+++ b/lib/extensions/attachable/action_view/helpers/form_builder.rb
@@ -2,9 +2,12 @@
 module Extensions::Attachable::ActionView::Helpers::FormBuilder
   # Method from ActsAsAttachable framework.
   # Hepler to support f.attachments in form
-  def attachments
+  #
+  # @param [Boolean] allow_delete Specify if attachments can be deleted.
+  def attachments(allow_delete: true)
     multiple = !object.respond_to?(:attachment)
-    @template.render 'layouts/attachment_uploader', f: self, multiple: multiple
+    @template.render 'layouts/attachment_uploader',
+                     f: self, multiple: multiple, allow_delete: allow_delete
   end
   alias_method :attachment, :attachments
 end

--- a/lib/extensions/attachable/active_record/base.rb
+++ b/lib/extensions/attachable/active_record/base.rb
@@ -12,8 +12,12 @@ module Extensions::Attachable::ActiveRecord::Base
     # @example Has many attachments on a column
     #   has_many_attachments on: :description #=> description is associated with the attachments
     #   of the model, updating description will result in attachments changing.
+    #
     #   You can further implement `description_attachment_references_removed` reader in this case to
     #   override the default method. The attachment_references ids returned by it will be removed.
+    #
+    #   For deletion of attachments, it is necessary for the model to implement the
+    #   +:destroy_attachment+ CanCanCan permission on the +attachable+ object.
     def has_many_attachments(options = {}) # rubocop:disable Style/PredicateName
       include HasManyAttachments
 


### PR DESCRIPTION
This is to support file upload question and editing of materials. In essence, this allows:
 - Viewing of uploaded attachments
 - Deletion of uploaded attachments
 - Only the student to delete uploaded file attachments, when the submission is in attempting state. 
 - Staff cannot destroy attachments for file upload questions unless they are on their own submission.

See below for more details:
#### Uploading and deleting attachment in file upload question
![delete-attachment](https://user-images.githubusercontent.com/4353853/27248821-811de450-533b-11e7-8f43-fae2dddee857.gif)
#### View of submitted file upload answer
<img width="1339" alt="screen shot 2017-06-17 at 9 07 07 am" src="https://user-images.githubusercontent.com/4353853/27248886-7b2a5c80-533c-11e7-84f3-402f6c9504c5.png">

