### PR TITLE
Add specs to ensure that only submission creator can destroy their own attachment in submissions

### DIFF
--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -53,5 +53,11 @@ FactoryGirl.define do
         submission.points_awarded = rand(1..10) * 100
       end
     end
+
+    # Ensure that creator of submission is the same as creator of experience_points_record
+    after(:build) do |submission, evaluator|
+      user = evaluator.creator ? evaluator.creator : submission.creator
+      submission.experience_points_record.creator = user
+    end
   end
 end

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe Course::Assessment do
              assessment: published_started_assessment, creator: coursemate.user)
     end
 
+    def get_text_response_answer_for(submission)
+      submission.latest_answers.select do |ans|
+        ans.specific.class == Course::Assessment::Answer::TextResponse
+      end.first.specific
+    end
+
     context 'when the user is a Course Student' do
       let(:user) { course_user.user }
 
@@ -54,6 +60,20 @@ RSpec.describe Course::Assessment do
       it { is_expected.to be_able_to(:read, submitted_submission) }
       it { is_expected.not_to be_able_to(:update, coursemate_attempting_submission) }
       it { is_expected.not_to be_able_to(:read, coursemate_submitted_submission) }
+
+      it do
+        is_expected.to be_able_to(:destroy_attachment,
+                                  get_text_response_answer_for(attempting_submission))
+      end
+      it do
+        is_expected.not_to be_able_to(:destroy_attachment,
+                                      get_text_response_answer_for(submitted_submission))
+      end
+      it do
+        is_expected.
+          not_to be_able_to(:destroy_attachment,
+                            get_text_response_answer_for(coursemate_attempting_submission))
+      end
 
       context 'when the course is self directed' do
         let(:course) { create(:course, advance_start_at_duration_days: 3) }
@@ -73,6 +93,10 @@ RSpec.describe Course::Assessment do
       let(:user) { create(:course_teaching_assistant, course: course).user }
       it { is_expected.to be_able_to(:manage, published_started_assessment) }
       it { is_expected.not_to be_able_to(:publish_grades, published_started_assessment) }
+      it do
+        is_expected.not_to be_able_to(:destroy_attachment,
+                                      get_text_response_answer_for(attempting_submission))
+      end
     end
 
     context 'when the user is a Course Staff' do


### PR DESCRIPTION
Follow up from #2329.