### PR TITLE
Random fixes to CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ branches:
 rvm:
   - 2.3.1
 addons:
+  apt:
+    packages:
+      - ghostscript
   postgresql: "9.4"
   hosts:
     - coursemology.lvh.me

--- a/app/services/course/assessment/question/scribing_import_service.rb
+++ b/app/services/course/assessment/question/scribing_import_service.rb
@@ -39,19 +39,20 @@ class Course::Assessment::Question::ScribingImportService
 
     MiniMagick::Image.new(file.tempfile.path).pages.each_with_index.map do |page, index|
       temp_name = "#{filename}[#{index + 1}].png"
-      process_pdf(page.path, temp_name)
+      temp_file = Tempfile.new([temp_name, '.png'])
+      process_pdf(page.path, temp_file.path)
 
       # Leave filename sanitization to attachment reference
       ActionDispatch::Http::UploadedFile.
-        new(tempfile: Tempfile.new(temp_name), filename: temp_name.dup, type: 'image/png')
+        new(tempfile: temp_file, filename: temp_name.dup, type: 'image/png')
     end
   end
 
   # Process the PDF given the image path, with the new_name as the new file name.
   #
   # @param [String] image_path
-  # @param [String] new_name File name of newly processed file
-  def process_pdf(image_path, new_name)
+  # @param [String] new_image_path File path of newly processed file
+  def process_pdf(image_path, new_image_path)
     MiniMagick::Tool::Convert.new do |convert|
       convert.render
       convert.density(300)
@@ -59,7 +60,7 @@ class Course::Assessment::Question::ScribingImportService
       convert.background('white')
       convert.flatten
       convert << image_path
-      convert << new_name
+      convert << new_image_path
     end
   end
 

--- a/app/services/course/assessment/question/scribing_import_service.rb
+++ b/app/services/course/assessment/question/scribing_import_service.rb
@@ -73,7 +73,8 @@ class Course::Assessment::Question::ScribingImportService
     next_weight = max_weight ? max_weight + 1 : 0
     files.map.with_index(next_weight) do |file, weight|
       build_scribing_question(weight).tap do |question|
-        question.file = file
+        question.build_attachment(attachment: Attachment.find_or_create_by(file: file),
+                                  name: file.original_filename)
       end
     end
   end

--- a/config/locales/en/course/assessment/question/scribing.yml
+++ b/config/locales/en/course/assessment/question/scribing.yml
@@ -4,7 +4,7 @@ en:
       question:
         scribing:
           create:
-            success: 'The scribin question was created.'
+            success: 'The scribing question was created.'
             failure: 'Could not create scribing question.'
           update:
             failure: 'Could not update scribing question.'

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -12,10 +12,11 @@ RSpec.describe Course::Assessment do
       create(:assessment, :with_all_question_types, course: course, published: false)
     end
     let(:published_started_assessment) do
-      create(:assessment, :published_with_mcq_question, course: course)
+      create(:assessment, :published_with_all_question_types, course: course)
     end
     let(:published_not_started_assessment) do
-      create(:assessment, :published_with_mcq_question, start_at: 1.day.from_now, course: course)
+      create(:assessment, :published_with_all_question_types,
+             start_at: 1.day.from_now, course: course)
     end
     let(:published_assessment_with_attemping_submission) do
       create(:assessment, :published_with_all_question_types, course: course)


### PR DESCRIPTION
- Failing assessment ability: From #2333 
- Fixed bug 1 in the scribing question import - Build and create attachments first before saving attachment_reference, otherwise duplicated attachments would result in a failed save on the scribing question. 
- Fixed bug 2 in the scribing question import - specify the temp file name clearly so that imagemagick can pick up the correct file to process.
- Added ghostscript to travis CI as it is a dependency for scribing import service.