### PR TITLE
Update rb-fsevent, as 0.10.0 and 0.10.1 got yanked off rubygems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
-    rb-fsevent (0.10.1)
+    rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rb-kqueue (0.2.5)
@@ -647,7 +647,6 @@ DEPENDENCIES
   webpack-rails
   workflow
   yard
-
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
- See https://github.com/thibaudgg/rb-fsevent/issues/77#issuecomment-312436406

This is preventing us from during `bundle install` now >_<