### PR TITLE
Add check to send opening reminder emails only in certain situations. 

### DIFF
--- a/spec/jobs/course/assessment/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/opening_reminder_job_spec.rb
@@ -4,13 +4,36 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::OpeningReminderJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let(:assessment) { create(:assessment) }
+    let(:assessment) { create(:assessment, start_at: old_start_at) }
+    let(:time_now) { Time.zone.now }
+    before { assessment.start_at = new_start_at }
+    subject { assessment.save }
 
-    context 'when start_at of the assessment is changed' do
-      it 'creates a opening reminder job' do
-        assessment.start_at = Time.zone.now
+    context 'when old start_at is in the past' do
+      let(:old_start_at) { time_now - 2.days }
 
-        expect { assessment.save }.to have_enqueued_job(Course::Assessment::OpeningReminderJob)
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Assessment::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 3.days }
+        it { expect { subject }.not_to have_enqueued_job(Course::Assessment::OpeningReminderJob) }
+      end
+    end
+
+    context 'when old start_at is in the future' do
+      let(:old_start_at) { time_now + 2.days }
+
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Assessment::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 2.days }
+        it { expect { subject }.to have_enqueued_job(Course::Assessment::OpeningReminderJob) }
       end
     end
   end

--- a/spec/jobs/course/survey/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/survey/opening_reminder_job_spec.rb
@@ -1,16 +1,37 @@
 # frozen_string_literal: true
-require 'rails_helper'
-
 RSpec.describe Course::Survey::OpeningReminderJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let(:survey) { create(:survey) }
+    let(:survey) { create(:survey, start_at: old_start_at) }
+    let(:time_now) { Time.zone.now }
+    before { survey.start_at = new_start_at }
+    subject { survey.save }
 
-    context 'when start_at of the assessment is changed' do
-      it 'creates a opening reminder job' do
-        survey.start_at = Time.zone.now
+    context 'when old start_at is in the past' do
+      let(:old_start_at) { time_now - 2.days }
 
-        expect { survey.save }.to have_enqueued_job(Course::Survey::OpeningReminderJob)
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Survey::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 3.days }
+        it { expect { subject }.not_to have_enqueued_job(Course::Survey::OpeningReminderJob) }
+      end
+    end
+
+    context 'when old start_at is in the future' do
+      let(:old_start_at) { time_now + 2.days }
+
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Survey::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 2.days }
+        it { expect { subject }.to have_enqueued_job(Course::Survey::OpeningReminderJob) }
       end
     end
   end

--- a/spec/jobs/course/video/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/video/opening_reminder_job_spec.rb
@@ -4,13 +4,36 @@ require 'rails_helper'
 RSpec.describe Course::Video::OpeningReminderJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let(:video) { create(:video) }
+    let(:video) { create(:video, start_at: old_start_at) }
+    let(:time_now) { Time.zone.now }
+    before { video.start_at = new_start_at }
+    subject { video.save }
 
-    context 'when start_at is changed' do
-      it 'creates a opening reminder job' do
-        video.start_at = Time.zone.now
+    context 'when old start_at is in the past' do
+      let(:old_start_at) { time_now - 2.days }
 
-        expect { video.save }.to have_enqueued_job(Course::Video::OpeningReminderJob)
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Video::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 3.days }
+        it { expect { subject }.not_to have_enqueued_job(Course::Video::OpeningReminderJob) }
+      end
+    end
+
+    context 'when old start_at is in the future' do
+      let(:old_start_at) { time_now + 2.days }
+
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Video::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 2.days }
+        it { expect { subject }.to have_enqueued_job(Course::Video::OpeningReminderJob) }
       end
     end
   end


### PR DESCRIPTION
This PR modifies the opening reminders not to be sent in certain circumstances.

The logic to be sent is based on the 4 cases: 
 1. Previous start_at and new start_at both before current time - Do not send opening reminder email
 1. Previous start_at before current time, new start_at after current time - To send opening reminder
 1. Previous start_at after current time, new start_at before current time - To send opening reminder
 1. Previous start_at and new start_at after current time - To send opening reminder