### PR TITLE
Allow course managers to duplicate their course

### DIFF
--- a/app/controllers/components/course/duplication_component.rb
+++ b/app/controllers/components/course/duplication_component.rb
@@ -6,7 +6,7 @@ class Course::DuplicationComponent < SimpleDelegator
   end
 
   def sidebar_items
-    return [] unless current_user.administrator?
+    return [] unless can?(:duplicate, current_course)
     [
       {
         key: :duplication,

--- a/app/models/instance_user.rb
+++ b/app/models/instance_user.rb
@@ -3,7 +3,7 @@ class InstanceUser < ActiveRecord::Base
   include InstanceUserSearchConcern
   acts_as_tenant :instance, inverse_of: :instance_users
 
-  enum role: { normal: 0, instructor: 1, administrator: 2, auto_grader: 3 }
+  enum role: { normal: 0, instructor: 1, administrator: 2 }
   belongs_to :user, inverse_of: :instance_users
 
   scope :ordered_by_username, -> { joins(:user).merge(User.order(name: :asc)) }

--- a/spec/features/course/duplication_spec.rb
+++ b/spec/features/course/duplication_spec.rb
@@ -41,10 +41,10 @@ RSpec.feature 'Course: Duplication' do
     context 'As a Course Administrator' do
       let(:user) { create(:course_manager, course: course).user }
 
-      scenario 'I cannot view the Duplication Sidebar item but can duplicate a course' do
+      scenario 'I can view the Duplication Sidebar item and can duplicate a course' do
         visit course_path(course)
 
-        expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+        expect(page).to have_selector('li', text: 'layouts.duplication.title')
 
         visit course_duplication_path(course)
 

--- a/spec/models/duplication_ability_spec.rb
+++ b/spec/models/duplication_ability_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course, type: :model do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    subject { Ability.new(user) }
+    let!(:course) { create(:course, :enrollable) }
+
+    context 'when the user is a Normal User' do
+      let(:user) { create(:user) }
+
+      it { is_expected.not_to be_able_to(:duplicate, course) }
+    end
+
+    context 'when the user is a Course Student' do
+      let(:user) { create(:course_student, course: course).user }
+
+      it { is_expected.not_to be_able_to(:duplicate, course) }
+    end
+
+    context 'when the user is a Course Teaching Assistant' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
+
+      it { is_expected.not_to be_able_to(:duplicate, course) }
+    end
+
+    context 'when the user is a Course Manager' do
+      let(:user) { create(:course_manager, course: course).user }
+
+      it { is_expected.to be_able_to(:duplicate, course) }
+    end
+  end
+end


### PR DESCRIPTION
Show the "Duplicate Course" sidebar component to course managers, instead of just Coursemology administrators.