### PR TITLE
Stop hound from complaining about empty lines after magic comments.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,3 +58,6 @@ Style/RegexpLiteral:
 
 Style/NumericPredicate:
   EnforcedStyle: comparison
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false


### PR DESCRIPTION
Existing files do not follow this rule.

[ci skip]