### PR TITLE
Email notification settings

### DIFF
--- a/app/controllers/components/course/controller_component_host.rb
+++ b/app/controllers/components/course/controller_component_host.rb
@@ -79,7 +79,8 @@ class Course::ControllerComponentHost
       end
 
       # Returns a model which the current component can use to interface with its persisted
-      # settings.
+      # settings. The class initializer should take an instance of the component as its only
+      # argument.
       #
       # Example:
       # If the component Course::FoobarComponent has settings, define a class
@@ -93,9 +94,12 @@ class Course::ControllerComponentHost
       end
     end
 
-    # Override this method to use a different settings key or settings_on_rails instance.
+    # The settings interface instance for this component.
+    #
+    # @return An instance of the settings interface for the current component.
+    # @return [nil] if the settings interface is not implemented.
     def settings
-      @settings ||= settings_class&.new(current_course.settings(key))
+      @settings ||= settings_class&.new(self)
     end
   end
 

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -34,7 +34,8 @@ class Course::CoursesComponent < SimpleDelegator
     [
       settings_index_item,
       settings_components_item,
-      settings_sidebar_item
+      settings_sidebar_item,
+      settings_notifications
     ]
   end
 
@@ -62,6 +63,15 @@ class Course::CoursesComponent < SimpleDelegator
       type: :settings,
       weight: 3,
       path: course_admin_sidebar_path(current_course)
+    }
+  end
+
+  def settings_notifications
+    {
+      title: t('layouts.course_admin.notifications.title'),
+      type: :settings,
+      weight: 8,
+      path: course_admin_notifications_path(current_course)
     }
   end
 end

--- a/app/controllers/course/admin/notification_settings_controller.rb
+++ b/app/controllers/course/admin/notification_settings_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class Course::Admin::NotificationSettingsController < Course::Admin::Controller
+  before_action :load_settings
+  add_breadcrumb :edit, :course_admin_notifications_path
+
+  def edit
+    @page_data = @settings.email_settings.to_json
+  end
+
+  def update
+    if @settings.update(notification_settings_params) && current_course.save
+      render json: @settings.email_settings
+    else
+      head :bad_request
+    end
+  end
+
+  private
+
+  def notification_settings_params
+    params.require(:notification_settings)
+  end
+
+  def load_settings
+    @settings = Course::Settings::Notifications.new(current_component_host.components)
+  end
+end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -39,7 +39,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
     self.published_at = Time.zone.now
     self.awarder = User.stamper || User.system
     self.awarded_at = Time.zone.now
-    if persisted? && !assessment.autograded?
+    if persisted? && !assessment.autograded? && submission_graded_email_enabled?
       execute_after_commit { Course::Mailer.submission_graded_email(self).deliver_later }
     end
   end
@@ -60,6 +60,10 @@ module Course::Assessment::Submission::WorkflowEventConcern
   end
 
   private
+
+  def submission_graded_email_enabled?
+    Course::Settings::AssessmentsComponent.email_enabled?(assessment.tab.category, :new_grading)
+  end
 
   # Defined outside of the workflow transition as points_awarded and draft_points_awarded are
   # not set during the event transition, hence they are not modifiable within the method itself.

--- a/app/models/concerns/course/settings/email_settings_concern.rb
+++ b/app/models/concerns/course/settings/email_settings_concern.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+#
+# This concern provides common defaults for querying and persisting email notification settings
+# for a course component.
+#
+# The emails settings for the given component is assumed to be stored in the following
+# shape in course.settings:
+#
+#  {
+#    course_component_key: {
+#      emails: {
+#         item_opening: { enabled: true },
+#         item_closing: { enabled: false },
+#         ...
+#      }
+#    }
+#  }
+#
+# To use this concern:
+#   - Include the concern in the settings model for the component.
+#   - Implement `.email_setting_items` and `.component_class`.
+#
+module Course::Settings::EmailSettingsConcern
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Email setting items for the given component.
+    #
+    # @return [Hash] Each key represents an email setting. Each value is a Hash
+    #   representing defaults for the email setting, e.g.
+    #     {
+    #       item_opening: { enabled_by_default: false },
+    #       item_closing: { enabled_by_default: true, days_in_advance: 2 },
+    #     }
+    def email_setting_items
+      raise NotImplementedError, 'Define component email settings in its settings model.'
+    end
+
+    # Returns the class of the component which the setting model is associated with.
+    # This is used for querying settings when a component controller context is not available,
+    # e.g. when emails are sent out asynchronously.
+    #
+    # @return [Class] The component class
+    def component_class
+      raise NotImplementedError, 'Specify component class in settings model.'
+    end
+
+    # Checks whether a type of email notification is enabled for a course.
+    #
+    # @param [Course] course
+    # @param [Symbol] key The email notification type
+    def email_enabled?(course, key)
+      raise ArgumentError, 'Invalid email key' unless valid_email_setting_key?(key)
+
+      user_setting = course.settings(component_class.key, :emails, key).enabled
+      user_setting.nil? ? email_setting_items[key][:enabled_by_default] : user_setting
+    end
+
+    def valid_email_setting_key?(key)
+      email_setting_items.key?(key)
+    end
+  end
+
+  delegate :email_setting_items, to: :class
+  delegate :valid_email_setting_key?, to: :class
+
+  # A list of concrete email settings for the component. This is used by
+  # {Course::Settings::Notifications} for the notifications settings page.
+  # See {Course::Settings::Notifications#email_settings} for details of the hash shape.
+  #
+  # @return [Array<Hash>] Array of setting items
+  def email_settings
+    email_setting_items.map do |setting_key, defaults|
+      user_setting = settings.settings(:emails, setting_key).enabled
+      enabled = user_setting.nil? ? defaults[:enabled_by_default] : user_setting
+      setting = { component: key, key: setting_key, enabled: enabled }
+      respond_to?(:title) && title ? setting.merge(component_title: title) : setting
+    end
+  end
+
+  # Updates an email notification setting.
+  #
+  # @param [Hash] attributes New setting represented by a hash with
+  #  `'key'` and `'enabled'` keys, e.g. { 'key' => 'item_opening', 'enabled' => true }
+  def update_email_setting(attributes)
+    setting_key = attributes['key'].to_sym
+    raise ArgumentError, 'Invalid email key' unless valid_email_setting_key?(setting_key)
+    settings.settings(:emails, setting_key).enabled = attributes['enabled']
+    true
+  end
+end

--- a/app/models/course/settings/announcements_component.rb
+++ b/app/models/course/settings/announcements_component.rb
@@ -1,23 +1,14 @@
 # frozen_string_literal: true
-class Course::Settings::AnnouncementsComponent
-  include ActiveModel::Model
+class Course::Settings::AnnouncementsComponent < Course::Settings::Component
   include ActiveModel::Conversion
-  include ActiveModel::Validations
 
   validates :pagination, numericality: { greater_than: 0 }
-
-  # Initialises the settings adapter
-  #
-  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
-  def initialize(settings)
-    @settings = settings
-  end
 
   # Returns the title of announcements component
   #
   # @return [String] The custom or default title of announcements component
   def title
-    @settings.title
+    settings.title
   end
 
   # Sets the title of announcements component
@@ -25,32 +16,20 @@ class Course::Settings::AnnouncementsComponent
   # @param [String] title The new title
   def title=(title)
     title = nil unless title.present?
-    @settings.title = title
+    settings.title = title
   end
 
   # Returns the announcement pagination count
   #
   # @return [Integer] The pagination count of announcement
   def pagination
-    @settings.pagination || 50
+    settings.pagination || 50
   end
 
   # Sets the announcement pagination number
   #
   # @param [Integer] count The new pagination count
   def pagination=(count)
-    @settings.pagination = count
-  end
-
-  # Update settings with the hash attributes
-  #
-  # @param [Hash] attributes The hash who stores the new settings
-  def update(attributes)
-    attributes.each { |k, v| send("#{k}=", v) }
-    valid?
-  end
-
-  def persisted? #:nodoc:
-    true
+    settings.pagination = count
   end
 end

--- a/app/models/course/settings/announcements_component.rb
+++ b/app/models/course/settings/announcements_component.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 class Course::Settings::AnnouncementsComponent < Course::Settings::Component
   include ActiveModel::Conversion
+  include Course::Settings::EmailSettingsConcern
 
   validates :pagination, numericality: { greater_than: 0 }
+
+  def self.email_setting_items
+    { new_announcement: { enabled_by_default: true } }
+  end
+
+  def self.component_class
+    Course::AnnouncementsComponent
+  end
 
   # Returns the title of announcements component
   #

--- a/app/models/course/settings/assessments_component.rb
+++ b/app/models/course/settings/assessments_component.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+class Course::Settings::AssessmentsComponent < Course::Settings::Component
+  class << self
+    def category_email_setting_items
+      {
+        assessment_opening: { enabled_by_default: true },
+        assessment_closing: { enabled_by_default: true },
+        new_submission: { enabled_by_default: true },
+        new_grading: { enabled_by_default: true }
+      }
+    end
+
+    # Checks whether a type of email notification is enabled for an assessment category.
+    #
+    # @param [Course::Assessment::Category] category
+    # @param [Symbol] key The email notification type
+    def email_enabled?(category, key)
+      raise ArgumentError, 'Invalid email key' unless valid_email_setting_key?(key)
+
+      setting = category.course.
+                settings(Course::AssessmentsComponent.key, category.id.to_s, :emails, key).enabled
+      setting.nil? ? category_email_setting_items[key][:enabled_by_default] : setting
+    end
+
+    def valid_email_setting_key?(key)
+      category_email_setting_items.key?(key)
+    end
+  end
+
+  delegate :category_email_setting_items, to: :class
+  delegate :valid_email_setting_key?, to: :class
+
+  # Generates a list of concrete email settings meant for use on the notifications settings page.
+  # See {Course::Settings::Notifications#email_settings} for details.
+  #
+  # @return [Array<Hash>]
+  def email_settings
+    current_course.assessment_categories.map do |category|
+      category_email_setting_items.map do |setting_key, defaults|
+        email_setting_hash(key, category, setting_key, defaults[:enabled_by_default])
+      end
+    end.flatten
+  end
+
+  # Updates an email notification setting.
+  #
+  # @param [Hash] attributes New setting represented by a hash
+  #   with keys `'key'`, `'enabled'`, `'options'` keys, e.g.
+  #     { 'key' => 'item_opening', 'enabled' => true, 'options' => { 'category_id' => 3 } }
+  def update_email_setting(attributes)
+    category_id = attributes['options']['category_id']
+    setting_key = attributes['key'].to_sym
+    raise ArgumentError, 'Invalid email key' unless valid_email_setting_key?(setting_key)
+    raise ArgumentError, 'Invalid category id' unless valid_category_id?(category_id)
+
+    settings.settings(category_id.to_s, :emails, setting_key).enabled = attributes['enabled']
+    true
+  end
+
+  private
+
+  def valid_category_id?(id)
+    current_course.assessment_categories.exists?(id)
+  end
+
+  # Generates a hash that represents a single email setting.
+  #
+  # @param [Symbol] component_key
+  # @param [Course::Assessment::Category] category
+  # @param [Symbol] setting_key
+  # @param [Boolean] enabled_by_default
+  def email_setting_hash(component_key, category, setting_key, enabled_by_default)
+    setting = settings.settings(category.id.to_s, :emails, setting_key).enabled
+    {
+      key: setting_key,
+      component: component_key,
+      component_title: category.title,
+      options: { category_id: category.id },
+      enabled: setting.nil? ? enabled_by_default : setting
+    }
+  end
+end

--- a/app/models/course/settings/component.rb
+++ b/app/models/course/settings/component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+#
+# This serves as a base class for course settings models that are associated with
+# a course component.
+#
+class Course::Settings::Component < SimpleDelegator
+  include ActiveModel::Validations
+
+  # Update settings with the hash attributes
+  #
+  # @param [Hash] attributes The hash for the new settings
+  def update(attributes)
+    attributes.each { |k, v| send("#{k}=", v) }
+    valid?
+  end
+
+  # TODO: Remove once all setting forms have been ported to React
+  def persisted?
+    true
+  end
+
+  private
+
+  def settings
+    @settings ||= current_course.settings(key)
+  end
+end

--- a/app/models/course/settings/forums_component.rb
+++ b/app/models/course/settings/forums_component.rb
@@ -1,23 +1,14 @@
 # frozen_string_literal: true
-class Course::Settings::ForumsComponent
-  include ActiveModel::Model
+class Course::Settings::ForumsComponent < Course::Settings::Component
   include ActiveModel::Conversion
-  include ActiveModel::Validations
 
   validates :pagination, numericality: { greater_than: 0 }
-
-  # Initialises the settings adapter
-  #
-  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
-  def initialize(settings)
-    @settings = settings
-  end
 
   # Returns the title of forums component
   #
   # @return [String] The custom or default title of forums component
   def title
-    @settings.title
+    settings.title
   end
 
   # Sets the title of forums component
@@ -25,32 +16,20 @@ class Course::Settings::ForumsComponent
   # @param [String] title The new title
   def title=(title)
     title = nil unless title.present?
-    @settings.title = title
+    settings.title = title
   end
 
   # Returns the forum pagination count
   #
   # @return [Integer] The pagination count of forum
   def pagination
-    @settings.pagination || 50
+    settings.pagination || 50
   end
 
   # Sets the forum pagination number
   #
   # @param [Integer] count The new pagination count
   def pagination=(count)
-    @settings.pagination = count
-  end
-
-  # Update settings with the hash attributes
-  #
-  # @param [Hash] attributes The hash who stores the new settings
-  def update(attributes)
-    attributes.each { |k, v| send("#{k}=", v) }
-    valid?
-  end
-
-  def persisted? #:nodoc:
-    true
+    settings.pagination = count
   end
 end

--- a/app/models/course/settings/leaderboard_component.rb
+++ b/app/models/course/settings/leaderboard_component.rb
@@ -1,24 +1,14 @@
 # frozen_string_literal: true
-class Course::Settings::LeaderboardComponent
-  include ActiveModel::Model
+class Course::Settings::LeaderboardComponent < Course::Settings::Component
   include ActiveModel::Conversion
-  include ActiveModel::Validations
 
   validates :display_user_count, numericality: { greater_than_or_equal_to: 0 }
-
-  # Initialises the settings adapter
-  #
-  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
-  def initialize(settings)
-    @settings = settings
-    @group_leaderboard_settings = settings.settings(:group_leaderboard)
-  end
 
   # Returns the title of leaderboard component
   #
   # @return [String] The custom or default title of leaderboard component
   def title
-    @settings.title
+    settings.title
   end
 
   # Sets the title of leaderboard component
@@ -26,28 +16,28 @@ class Course::Settings::LeaderboardComponent
   # @param [String] title The new title
   def title=(title)
     title = nil unless title.present?
-    @settings.title = title
+    settings.title = title
   end
 
   # Returns the number of users to be displayed on the leaderboard
   #
   # @return [Integer] The number of users to be displayed
   def display_user_count
-    @settings.display_user_count || 30
+    settings.display_user_count || 30
   end
 
   # Set the number of users to be displayed on the leaderboard
   #
   # @param [Integer] count The number of users to be displayed
   def display_user_count=(count)
-    @settings.display_user_count = count
+    settings.display_user_count = count
   end
 
   # Returns whether group leaderboard is enabled (disabled by default).
   #
   # @return [Boolean] Setting on whether group leaderboard is enabled.
   def enable_group_leaderboard
-    @group_leaderboard_settings.enabled == true
+    group_leaderboard_settings.enabled == true
   end
 
   # Enable or disable the option to display group leaderboard
@@ -57,14 +47,14 @@ class Course::Settings::LeaderboardComponent
   #   This method will handle this conversion to Boolean.
   def enable_group_leaderboard=(option)
     option = ActiveRecord::Type::Boolean.new.type_cast_from_user(option)
-    @group_leaderboard_settings.enabled = option
+    group_leaderboard_settings.enabled = option
   end
 
   # Returns the title of group leaderboard
   #
   # @return [String] The custom or default title of group leaderboard component
   def group_leaderboard_title
-    @group_leaderboard_settings.title
+    group_leaderboard_settings.title
   end
 
   # Sets the title of group leaderboard
@@ -72,18 +62,12 @@ class Course::Settings::LeaderboardComponent
   # @param [String] title The new title
   def group_leaderboard_title=(group_leaderboard_title)
     group_leaderboard_title = nil unless group_leaderboard_title.present?
-    @group_leaderboard_settings.title = group_leaderboard_title
+    group_leaderboard_settings.title = group_leaderboard_title
   end
 
-  # Update settings with the hash attributes
-  #
-  # @param [Hash] attributes The hash who stores the new settings
-  def update(attributes)
-    attributes.each { |k, v| send("#{k}=", v) }
-    valid?
-  end
+  private
 
-  def persisted? #:nodoc:
-    true
+  def group_leaderboard_settings
+    @group_leaderboard_settings ||= settings.settings(:group_leaderboard)
   end
 end

--- a/app/models/course/settings/materials_component.rb
+++ b/app/models/course/settings/materials_component.rb
@@ -1,21 +1,12 @@
 # frozen_string_literal: true
-class Course::Settings::MaterialsComponent
-  include ActiveModel::Model
+class Course::Settings::MaterialsComponent < Course::Settings::Component
   include ActiveModel::Conversion
-  include ActiveModel::Validations
-
-  # Initialises the settings adapter
-  #
-  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
-  def initialize(settings)
-    @settings = settings
-  end
 
   # Returns the title of materials component
   #
   # @return [String] The custom or default title of announcements component
   def title
-    @settings.title
+    settings.title
   end
 
   # Sets the title of materials component
@@ -23,18 +14,6 @@ class Course::Settings::MaterialsComponent
   # @param [String] title The new title
   def title=(title)
     title = nil if title.blank?
-    @settings.title = title
-  end
-
-  # Update settings with the hash attributes
-  #
-  # @param [Hash] attributes The hash who stores the new settings
-  def update(attributes)
-    attributes.each { |k, v| send("#{k}=", v) }
-    valid?
-  end
-
-  def persisted? #:nodoc:
-    true
+    settings.title = title
   end
 end

--- a/app/models/course/settings/notifications.rb
+++ b/app/models/course/settings/notifications.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+#
+# This model facilitates displaying and setting of notification settings.
+#
+# To add email notification settings to a course component, ensure that these two methods
+# are defined on the component's setting model
+# (see {Course::ControllerComponentHost::Settings::ClassMethods#settings_class}):
+#
+# - `#email_settings` - see {#email_settings} for details
+# - `#update_email_setting` - see {#update} for details
+#
+class Course::Settings::Notifications
+  def initialize(components)
+    @components = components
+  end
+
+  # Consolidates email settings from each course component.
+  # Each setting item should be a hash in the format similar to the this example:
+  #
+  # ```
+  # {
+  #   component: :course_assessments_component, # Component key
+  #   key: :new_assignment,         # Email setting key
+  #   enabled: true,                # The user's setting, otherwise, the default setting
+  #   component_title: 'Quests',    # [Optional] Title to be displayed as the (sub)component's name
+  #   options: { category_id: 5 },  # [Optional] Other info for the setting
+  # }
+  # ```
+  #
+  # @return [Array<Hash>] Array of setting items
+  def email_settings
+    all_settings = settings_interfaces_hash.values.map do |settings|
+      settings.respond_to?(:email_settings) ? settings.email_settings : nil
+    end
+    all_settings.compact.flatten.sort_by { |item| item[:component] }
+  end
+
+  # Updates a single email setting. It delegates the updating to the appropriate settings model.
+  # The attributes hash is expected to have the following shape:
+  #
+  # ```
+  # {
+  #   'component' => 'course_assessments_component', # Component key
+  #   'key' => 'new_assignment',           # Email setting key
+  #   'enabled' => false,                  # The new setting
+  #   'options' => { 'category_id' => 5 }, # [Optional] Other info for the setting
+  # }
+  # ```
+  #
+  # @param [Hash] attributes
+  # @return [Boolean] true if updating succeeds, false otherwise
+  def update(attributes)
+    settings_interface = settings_interfaces_hash[attributes['component']]
+    return false unless settings_interface
+    settings_interface.update_email_setting(attributes)
+  end
+
+  private
+
+  # Maps component keys to component setting model instances.
+  #
+  # @return [Hash{String => Object}]
+  def settings_interfaces_hash
+    @settings_interfaces_hash ||= @components.map do |component|
+      settings = component.settings
+      settings && [component.key.to_s, settings]
+    end.compact.to_h
+  end
+end

--- a/app/models/course/settings/survey_component.rb
+++ b/app/models/course/settings/survey_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class Course::Settings::SurveyComponent < Course::Settings::Component
+  include Course::Settings::EmailSettingsConcern
+
+  def self.email_setting_items
+    {
+      survey_opening: { enabled_by_default: true },
+      survey_closing: { enabled_by_default: true }
+    }
+  end
+
+  def self.component_class
+    Course::SurveyComponent
+  end
+end

--- a/app/models/course/settings/topics_component.rb
+++ b/app/models/course/settings/topics_component.rb
@@ -1,39 +1,23 @@
 # frozen_string_literal: true
-class Course::Settings::TopicsComponent
-  include ActiveModel::Model
+class Course::Settings::TopicsComponent < Course::Settings::Component
   include ActiveModel::Conversion
-  include ActiveModel::Validations
 
   validates :pagination, numericality: { greater_than: 0, less_than_or_equal_to: 50 }
 
-  def initialize(settings)
-    @settings = settings
-  end
-
   def title
-    @settings.title
+    settings.title
   end
 
   def title=(title)
     title = nil unless title.present?
-    @settings.title = title
+    settings.title = title
   end
 
   def pagination
-    @settings.pagination || 10
+    settings.pagination || 10
   end
 
   def pagination=(count)
-    @settings.pagination = count
-  end
-
-  def update(attributes)
-    attributes.each { |k, v| send("#{k}=", v) }
-    valid?
-  end
-
-  def persisted?
-    # For simple_form to generate correct button text ( Update instead of Create ).
-    true
+    settings.pagination = count
   end
 end

--- a/app/models/course/settings/videos_component.rb
+++ b/app/models/course/settings/videos_component.rb
@@ -1,21 +1,12 @@
 # frozen_string_literal: true
-class Course::Settings::VideosComponent
-  include ActiveModel::Model
+class Course::Settings::VideosComponent < Course::Settings::Component
   include ActiveModel::Conversion
-  include ActiveModel::Validations
-
-  # Initialises the settings adapter
-  #
-  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
-  def initialize(settings)
-    @settings = settings
-  end
 
   # Returns the title of video component
   #
   # @return [String] The custom or default title of video component
   def title
-    @settings.title
+    settings.title
   end
 
   # Sets the title of video component
@@ -23,18 +14,6 @@ class Course::Settings::VideosComponent
   # @param [String] title The new title
   def title=(title)
     title = nil unless title.present?
-    @settings.title = title
-  end
-
-  # Update settings with the hash attributes
-  #
-  # @param [Hash] attributes The hash who stores the new settings
-  def update(attributes)
-    attributes.each { |k, v| send("#{k}=", v) }
-    valid?
-  end
-
-  def persisted? #:nodoc:
-    true
+    settings.title = title
   end
 end

--- a/app/models/course/settings/virtual_classrooms_component.rb
+++ b/app/models/course/settings/virtual_classrooms_component.rb
@@ -1,65 +1,56 @@
 # frozen_string_literal: true
-class Course::Settings::VirtualClassroomsComponent
-  include ActiveModel::Model
+class Course::Settings::VirtualClassroomsComponent < Course::Settings::Component
   include ActiveModel::Conversion
-  include ActiveModel::Validations
 
   validates :pagination, numericality: { greater_than: 0 }
-
-  # Initialises the settings adapter
-  #
-  # @param [#settings] settings The settings object provided by the settings_on_rails gem.
-  def initialize(settings)
-    @settings = settings
-  end
 
   # Returns BrainCert Whiteboard API key of virtual classrooms component
   #
   # @return [String] The custom or default API key for virtual classrooms component
   def braincert_whiteboard_api_key
-    @settings.braincert_whiteboard_api_key
+    settings.braincert_whiteboard_api_key
   end
 
   # Returns BrainCert timezone of Virtual Classrooms component
   #
   # @return [Integer] The custom or default timezone for virtual classrooms component
   def braincert_whiteboard_timezone
-    @settings.braincert_whiteboard_timezone || 28 # 28 is GMT
+    settings.braincert_whiteboard_timezone || 28 # 28 is GMT
   end
 
   # Sets BrainCert Whiteboard timezone
   #
   # @return [Integer] The custom or default timezone for virtual classrooms component
   def braincert_whiteboard_timezone=(value)
-    @settings.braincert_whiteboard_timezone = value
+    settings.braincert_whiteboard_timezone = value
   end
 
   # Sets BrainCert Whiteboard API key of virtual classrooms component
   #
   # @param [String] value The new API key
   def braincert_whiteboard_api_key=(value)
-    @settings.braincert_whiteboard_api_key = value
+    settings.braincert_whiteboard_api_key = value
   end
 
   # Returns BrainCert Virtual Classroom server region
   #
   # @return [String] The custom or default title of virtual classrooms component
   def braincert_server_region
-    @settings.braincert_server_region || 7 # 7 is code for Singapore
+    settings.braincert_server_region || 7 # 7 is code for Singapore
   end
 
   # Sets BrainCert Virtual Classroom server region
   #
   # @param [String] value The new API key
   def braincert_server_region=(value)
-    @settings.braincert_server_region = value
+    settings.braincert_server_region = value
   end
 
   # Returns the title of virtual classrooms component
   #
   # @return [String] The custom or default title of virtual classrooms component
   def title
-    @settings.title
+    settings.title
   end
 
   # Sets the title of virtual classrooms component
@@ -67,14 +58,14 @@ class Course::Settings::VirtualClassroomsComponent
   # @param [String] title The new title
   def title=(title)
     title = nil unless title.present?
-    @settings.title = title
+    settings.title = title
   end
 
   # Returns the max duration of virtual classrooms component
   #
   # @return [String] The custom or default max_duration of virtual classrooms component
   def max_duration
-    @settings.max_duration || 60
+    settings.max_duration || 60
   end
 
   # Sets the max duration of virtual classrooms component
@@ -82,32 +73,20 @@ class Course::Settings::VirtualClassroomsComponent
   # @param [String] max_duration The new max duration
   def max_duration=(max_duration)
     max_duration = nil unless max_duration.present?
-    @settings.max_duration = max_duration
+    settings.max_duration = max_duration
   end
 
   # Returns the virtual classroom pagination count
   #
   # @return [Integer] The pagination count of virtual classroom
   def pagination
-    @settings.pagination || 50
+    settings.pagination || 50
   end
 
   # Sets the virtual classroom pagination number
   #
   # @param [Integer] count The new pagination count
   def pagination=(count)
-    @settings.pagination = count
-  end
-
-  # Update settings with the hash attributes
-  #
-  # @param [Hash] attributes The hash who stores the new settings
-  def update(attributes)
-    attributes.each { |k, v| send("#{k}=", v) }
-    valid?
-  end
-
-  def persisted? #:nodoc:
-    true
+    settings.pagination = count
   end
 end

--- a/app/notifiers/course/announcement_notifier.rb
+++ b/app/notifiers/course/announcement_notifier.rb
@@ -1,8 +1,11 @@
 class Course::AnnouncementNotifier < Notifier::Base
   # To be called when an announcement is made.
   def new_announcement(user, announcement)
+    email_enabled = Course::Settings::AnnouncementsComponent.
+                    email_enabled?(announcement.course, :new_announcement)
+
     create_activity(actor: user, object: announcement, event: :new).
       notify(announcement.course, :email).
-      save
+      save if email_enabled
   end
 end

--- a/app/services/course/assessment/reminder_service.rb
+++ b/app/services/course/assessment/reminder_service.rb
@@ -15,6 +15,7 @@ class Course::Assessment::ReminderService
 
   def closing_reminder(assessment, token)
     return unless assessment.closing_reminder_token == token && assessment.published?
+    return unless email_enabled?(assessment, :assessment_closing)
 
     # Send reminder emails to each student who hasn't submitted.
     recipients = uncompleted_students(assessment)
@@ -34,6 +35,10 @@ class Course::Assessment::ReminderService
   end
 
   private
+
+  def email_enabled?(assessment, key)
+    Course::Settings::AssessmentsComponent.email_enabled?(assessment.tab.category, key)
+  end
 
   # Returns a Set of students who have not completed the given assessment.
   #

--- a/app/services/course/survey/reminder_service.rb
+++ b/app/services/course/survey/reminder_service.rb
@@ -11,11 +11,13 @@ class Course::Survey::ReminderService
 
   def opening_reminder(survey, token)
     return unless survey.opening_reminder_token == token && survey.published?
+    return unless email_enabled?(survey, :survey_opening)
     send_opening_reminder(survey)
   end
 
   def closing_reminder(survey, token)
     return unless survey.closing_reminder_token == token && survey.published?
+    return unless email_enabled?(survey, :survey_closing)
     send_closing_reminder(survey)
   end
 
@@ -34,6 +36,10 @@ class Course::Survey::ReminderService
   end
 
   private
+
+  def email_enabled?(survey, key)
+    Course::Settings::SurveyComponent.email_enabled?(survey.course, key)
+  end
 
   # Send reminder emails to each student who hasn't submitted.
   #

--- a/app/views/course/admin/notification_settings/edit.html.slim
+++ b/app/views/course/admin/notification_settings/edit.html.slim
@@ -1,0 +1,1 @@
+#notification-settings data=@page_data

--- a/client/app/api/course/Admin/Base.js
+++ b/client/app/api/course/Admin/Base.js
@@ -1,0 +1,7 @@
+import BaseCourseAPI from '../Base';
+
+export default class BaseAdminAPI extends BaseCourseAPI {
+  _getUrlPrefix() {
+    return `/courses/${this.getCourseId()}/admin`;
+  }
+}

--- a/client/app/api/course/Admin/Notifications.js
+++ b/client/app/api/course/Admin/Notifications.js
@@ -1,0 +1,16 @@
+import BaseAdminAPI from './Base';
+
+export default class NotificationsAPI extends BaseAdminAPI {
+  /**
+   * Update a notification setting.
+   *
+   * @param {object} params
+   *   - params in the format of { notification_settings: { :component, :key, :enabled, :options } }
+   * @return {Promise}
+   * success response: {}
+   * error response: {}
+   */
+  update(params) {
+    return this.getClient().patch(`${this._getUrlPrefix()}/notifications`, params);
+  }
+}

--- a/client/app/api/course/Admin/index.js
+++ b/client/app/api/course/Admin/index.js
@@ -1,0 +1,9 @@
+import NotificationsAPI from './Notifications';
+
+const AdminAPI = {
+  notifications: new NotificationsAPI(),
+};
+
+Object.freeze(AdminAPI);
+
+export default AdminAPI;

--- a/client/app/api/course/index.js
+++ b/client/app/api/course/index.js
@@ -5,6 +5,7 @@ import MaterialsAPI from './Materials';
 import MaterialFoldersAPI from './MaterialFolders';
 import LessonPlanAPI from './LessonPlan';
 import SurveyAPI from './Survey';
+import AdminAPI from './Admin';
 
 const CourseAPI = {
   achievements: new AchievementsAPI(),
@@ -14,6 +15,7 @@ const CourseAPI = {
   materialFolders: new MaterialFoldersAPI(),
   lessonPlan: new LessonPlanAPI(),
   survey: SurveyAPI,
+  admin: AdminAPI,
 };
 
 Object.freeze(CourseAPI);

--- a/client/app/bundles/course/admin/actions/index.js
+++ b/client/app/bundles/course/admin/actions/index.js
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+import actionTypes from '../constants';
+
+export function setNotification(message) {
+  return (dispatch) => {
+    dispatch({
+      type: actionTypes.SET_ADMIN_NOTIFICATION,
+      message,
+    });
+  };
+}

--- a/client/app/bundles/course/admin/actions/notifications.js
+++ b/client/app/bundles/course/admin/actions/notifications.js
@@ -1,0 +1,23 @@
+/* eslint-disable import/prefer-default-export */
+import CourseAPI from 'api/course';
+import actionTypes from '../constants';
+import { setNotification } from './index';
+
+export function updateNotificationSetting(value, successMessage, failureMessage) {
+  const payload = { notification_settings: value };
+  return (dispatch) => {
+    dispatch({ type: actionTypes.NOTIFICATION_SETTING_UPDATE_REQUEST });
+    return CourseAPI.admin.notifications.update(payload)
+      .then((response) => {
+        dispatch({
+          type: actionTypes.NOTIFICATION_SETTING_UPDATE_SUCCESS,
+          updatedSettings: response.data,
+        });
+        setNotification(successMessage)(dispatch);
+      })
+      .catch(() => {
+        dispatch({ type: actionTypes.NOTIFICATION_SETTING_UPDATE_FAILURE });
+        setNotification(failureMessage)(dispatch);
+      });
+  };
+}

--- a/client/app/bundles/course/admin/constants.js
+++ b/client/app/bundles/course/admin/constants.js
@@ -1,0 +1,10 @@
+import mirrorCreator from 'mirror-creator';
+
+const actionTypes = mirrorCreator([
+  'SET_ADMIN_NOTIFICATION',
+  'NOTIFICATION_SETTING_UPDATE_REQUEST',
+  'NOTIFICATION_SETTING_UPDATE_SUCCESS',
+  'NOTIFICATION_SETTING_UPDATE_FAILURE',
+]);
+
+export default actionTypes;

--- a/client/app/bundles/course/admin/notification-settings.jsx
+++ b/client/app/bundles/course/admin/notification-settings.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
+import NotificationSettings from 'course/admin/pages/NotificationSettings';
+import storeCreator from './store';
+
+$(document).ready(() => {
+  const mountNode = document.getElementById('notification-settings');
+
+  if (mountNode) {
+    const data = mountNode.getAttribute('data');
+    const attributes = JSON.parse(data);
+    const initialData = { admin: { notificationSettings: attributes } };
+    const store = storeCreator(initialData);
+
+    const Page = () => (
+      <ProviderWrapper store={store}>
+        <NotificationSettings />
+      </ProviderWrapper>
+    );
+
+    render(
+      <Page />,
+      mountNode
+    );
+  }
+});

--- a/client/app/bundles/course/admin/pages/NotificationSettings/__test__/index.test.jsx
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/__test__/index.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import CourseAPI from 'api/course';
+import storeCreator from 'course/admin/store';
+import NotificationSettings from '../index';
+
+const emailSettings = [
+  {
+    component: 'sample_component',
+    component_title: 'Component Name',
+    key: 'email_for_some_event',
+    enabled: false,
+    options: { subcomponentId: 9 },
+  },
+];
+
+describe('<NotificationSettings />', () => {
+  it('allow emails notification settings to be set', () => {
+    const spy = jest.spyOn(CourseAPI.admin.notifications, 'update');
+    const store = storeCreator({ admin: { notificationSettings: emailSettings } });
+
+    const notificationSettings = mount(
+      <NotificationSettings />,
+      buildContextOptions(store)
+    );
+
+    const toggles = notificationSettings.find('Toggle');
+    expect(toggles.length).toBe(1);
+
+    const toggle = toggles.first();
+    toggle.props().onToggle(null, true);
+    const expectedPayload = {
+      notification_settings: {
+        component: 'sample_component',
+        key: 'email_for_some_event',
+        enabled: true,
+        options: { subcomponentId: 9 },
+      },
+    };
+    expect(spy).toHaveBeenCalledWith(expectedPayload);
+  });
+});

--- a/client/app/bundles/course/admin/pages/NotificationSettings/index.jsx
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/index.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+import Subheader from 'material-ui/Subheader';
+import Toggle from 'material-ui/Toggle';
+import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
+import NotificationBar, { notificationShape } from 'lib/components/NotificationBar';
+import { updateNotificationSetting } from 'course/admin/actions/notifications';
+import adminTranslations, { defaultComponentTitles } from 'course/admin/translations.intl';
+import translations, { settingTitles, settingDescriptions } from './translations.intl';
+
+class NotificationSettings extends React.Component {
+  static propTypes = {
+    notification: notificationShape,
+    emailSettings: PropTypes.arrayOf(PropTypes.shape({
+      component: PropTypes.string,
+      component_title: PropTypes.string,
+      key: PropTypes.string,
+      enabled: PropTypes.bool,
+      options: PropTypes.shape(),
+    })),
+    dispatch: PropTypes.func.isRequired,
+  };
+
+  handleComponentNotificationSettingUpdate = (setting, settingTitle) => {
+    const { dispatch } = this.props;
+    const { component, key, options } = setting;
+    return (_, enabled) => {
+      const payload = { component, key, enabled, options };
+      const successMessage = <FormattedMessage {...translations.updateSuccess} values={{ setting: settingTitle }} />;
+      const failureMessage = <FormattedMessage {...translations.updateFailure} values={{ setting: settingTitle }} />;
+      dispatch(updateNotificationSetting(payload, successMessage, failureMessage));
+    };
+  }
+
+  renderRow(setting) {
+    const componentTitle = setting.component_title ||
+      (defaultComponentTitles[setting.component] &&
+        <FormattedMessage {...defaultComponentTitles[setting.component]} />) ||
+      setting.component;
+    const settingTitle = (settingTitles[setting.key] &&
+      <FormattedMessage {...settingTitles[setting.key]} />) || setting.key;
+    const settingDescription = (settingDescriptions[setting.key] &&
+      <FormattedMessage {...settingDescriptions[setting.key]} />) || '';
+
+    return (
+      <TableRow key={setting.component + setting.component_title + setting.key}>
+        <TableRowColumn>
+          { componentTitle }
+        </TableRowColumn>
+        <TableRowColumn>
+          { settingTitle }
+        </TableRowColumn>
+        <TableRowColumn colSpan={2}>
+          { settingDescription }
+        </TableRowColumn>
+        <TableRowColumn>
+          <Toggle
+            toggled={setting.enabled}
+            onToggle={this.handleComponentNotificationSettingUpdate(setting, settingTitle)}
+          />
+        </TableRowColumn>
+      </TableRow>
+    );
+  }
+
+  renderEmailSettingsTable() {
+    const { emailSettings } = this.props;
+
+    if (emailSettings.length < 1) {
+      return <Subheader><FormattedMessage {...translations.noEmailSettings} /></Subheader>;
+    }
+
+    return (
+      <Table>
+        <TableHeader
+          adjustForCheckbox={false}
+          displaySelectAll={false}
+        >
+          <TableRow>
+            <TableHeaderColumn>
+              <FormattedMessage {...adminTranslations.component} />
+            </TableHeaderColumn>
+            <TableHeaderColumn>
+              <FormattedMessage {...translations.setting} />
+            </TableHeaderColumn>
+            <TableHeaderColumn colSpan={2}>
+              <FormattedMessage {...translations.description} />
+            </TableHeaderColumn>
+            <TableHeaderColumn>
+              <FormattedMessage {...translations.enabled} />
+            </TableHeaderColumn>
+          </TableRow>
+        </TableHeader>
+        <TableBody
+          displayRowCheckbox={false}
+        >
+          { emailSettings.map(item => this.renderRow(item)) }
+        </TableBody>
+      </Table>
+    );
+  }
+
+  render() {
+    const { notification } = this.props;
+
+    return (
+      <div>
+        <h2><FormattedMessage {...translations.emailSettings} /></h2>
+        {this.renderEmailSettingsTable()}
+
+        <NotificationBar notification={notification} />
+      </div>
+    );
+  }
+}
+
+export default connect(state => ({
+  notification: state.notification,
+  emailSettings: state.notificationSettings,
+}))(NotificationSettings);

--- a/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
@@ -1,0 +1,96 @@
+import { defineMessages } from 'react-intl';
+
+const translations = defineMessages({
+  setting: {
+    id: 'course.admin.NotificationSettings.setting',
+    defaultMessage: 'Setting',
+  },
+  description: {
+    id: 'course.admin.NotificationSettings.description',
+    defaultMessage: 'Description',
+  },
+  enabled: {
+    id: 'course.admin.NotificationSettings.enabled',
+    defaultMessage: 'Enabled?',
+  },
+  emailSettings: {
+    id: 'course.admin.NotificationSettings.emailSettings',
+    defaultMessage: 'Email Settings',
+  },
+  updateSuccess: {
+    id: 'course.admin.NotificationSettings.updateSuccess',
+    defaultMessage: 'Setting for "{setting}" updated.',
+  },
+  updateFailure: {
+    id: 'course.admin.NotificationSettings.updateFailure',
+    defaultMessage: 'Failed to update setting "{setting}".',
+  },
+  noEmailSettings: {
+    id: 'course.admin.NotificationSettings.noEmailSettings',
+    defaultMessage: 'None of the enabled components have email settings.',
+  },
+});
+
+export const settingDescriptions = defineMessages({
+  new_announcement: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.new_announcement',
+    defaultMessage: 'Notify all users whenever a new announcement is made.',
+  },
+  survey_opening: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.survey_opening',
+    defaultMessage: 'Notify students when a new survey is available.',
+  },
+  survey_closing: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.survey_closing',
+    defaultMessage: 'Notify students when a survey is about to expire.',
+  },
+  assessment_opening: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.assessment_opening',
+    defaultMessage: 'Notify students when a new assessment is available.',
+  },
+  assessment_closing: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.assessment_closing',
+    defaultMessage: 'Notify students when an assessment is about to be due.',
+  },
+  new_submission: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.new_submission',
+    defaultMessage: "Notify a student's group managers when the student makes a submission.",
+  },
+  new_grading: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.new_grading',
+    defaultMessage: 'Notify a student when grades for a submission have been released.',
+  },
+});
+
+export const settingTitles = defineMessages({
+  new_announcement: {
+    id: 'course.admin.NotificationSettings.settingTitles.new_announcement',
+    defaultMessage: 'New Announcement',
+  },
+  survey_opening: {
+    id: 'course.admin.NotificationSettings.settingTitles.survey_opening',
+    defaultMessage: 'Survey Opening',
+  },
+  survey_closing: {
+    id: 'course.admin.NotificationSettings.settingTitles.survey_closing',
+    defaultMessage: 'Survey Closing',
+  },
+  assessment_opening: {
+    id: 'course.admin.NotificationSettings.settingTitles.assessment_opening',
+    defaultMessage: 'Assessment Opening',
+  },
+  assessment_closing: {
+    id: 'course.admin.NotificationSettings.settingTitles.assessment_closing',
+    defaultMessage: 'Assessment Closing',
+  },
+  new_submission: {
+    id: 'course.admin.NotificationSettings.settingTitles.new_submission',
+    defaultMessage: 'New Submission',
+  },
+  new_grading: {
+    id: 'course.admin.NotificationSettings.settingTitles.new_grading',
+    defaultMessage: 'New Grading',
+  },
+});
+
+export default translations;

--- a/client/app/bundles/course/admin/reducers/index.js
+++ b/client/app/bundles/course/admin/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import notification from './notification';
+import notificationSettings from './notificationSettings';
+
+export default combineReducers({
+  notification,
+  notificationSettings,
+});

--- a/client/app/bundles/course/admin/reducers/notification.js
+++ b/client/app/bundles/course/admin/reducers/notification.js
@@ -1,0 +1,15 @@
+import actionTypes from '../constants';
+
+const initialState = {};
+
+export default function (state = initialState, action) {
+  const { type } = action;
+
+  switch (type) {
+    case actionTypes.SET_ADMIN_NOTIFICATION: {
+      return { message: action.message };
+    }
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/admin/reducers/notificationSettings.js
+++ b/client/app/bundles/course/admin/reducers/notificationSettings.js
@@ -1,0 +1,14 @@
+import actionTypes from '../constants';
+
+const initialState = [];
+
+export default function (state = initialState, action) {
+  const { type } = action;
+
+  switch (type) {
+    case actionTypes.NOTIFICATION_SETTING_UPDATE_SUCCESS:
+      return action.updatedSettings;
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/admin/store.js
+++ b/client/app/bundles/course/admin/store.js
@@ -1,0 +1,13 @@
+import { compose, createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import rootReducer from './reducers';
+
+export default ({ admin }) => {
+  const initialStates = admin;
+  const storeCreator = (process.env.NODE_ENV === 'development') ?
+    // eslint-disable-next-line global-require
+    compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :
+    compose(applyMiddleware(thunkMiddleware))(createStore);
+
+  return storeCreator(rootReducer, initialStates);
+};

--- a/client/app/bundles/course/admin/translations.intl.js
+++ b/client/app/bundles/course/admin/translations.intl.js
@@ -1,0 +1,21 @@
+import { defineMessages } from 'react-intl';
+
+const translations = defineMessages({
+  component: {
+    id: 'course.admin.component',
+    defaultMessage: 'Component',
+  },
+});
+
+export const defaultComponentTitles = defineMessages({
+  course_announcements_component: {
+    id: 'course.admin.componentTitles.course_announcements_component',
+    defaultMessage: 'Announcements',
+  },
+  course_survey_component: {
+    id: 'course.admin.componentTitles.course_survey_component',
+    defaultMessage: 'Surveys',
+  },
+});
+
+export default translations;

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -41,6 +41,8 @@ en:
             edit: :'course.discussion.topics.index.header'
         video_settings:
           edit: :'course.video.videos.index.header'
+        notification_settings:
+          edit: :'layouts.course_admin.notifications.title'
       users:
         index: 'Users'
         students: :'course.users.students.header'

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -28,6 +28,8 @@ en:
         title: :'course.admin.component_settings.index.header'
       sidebar_settings:
         title: 'Sidebar'
+      notifications:
+        title: 'Notifications'
     course_users:
       title: 'Manage Users'
     duplication:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,9 @@ Rails.application.routes.draw do
         get 'sidebar' => 'sidebar_settings#edit'
         patch 'sidebar' => 'sidebar_settings#update'
 
+        get 'notifications' => 'notification_settings#edit'
+        patch 'notifications' => 'notification_settings#update'
+
         get 'announcements' => 'announcement_settings#edit'
         patch 'announcements' => 'announcement_settings#update'
 

--- a/spec/controllers/course/admin/notification_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/notification_settings_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Admin::NotificationSettingsController, type: :controller do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let(:course) { create(:course, creator: user) }
+    let(:json_response) { JSON.parse(response.body) }
+    before { sign_in(user) }
+
+    describe '#edit' do
+      subject { get :edit, course_id: course }
+      it { is_expected.to render_template(:edit) }
+    end
+
+    describe '#update' do
+      subject { patch :update, course_id: course, notification_settings: payload }
+
+      context 'when valid parameters are received' do
+        render_views
+        let(:payload) do
+          {
+            'component' => 'course_announcements_component',
+            'key' => 'new_announcement',
+            'enabled' => false
+          }
+        end
+        before { subject }
+
+        it 'responds with the necessary fields' do
+          new_announcement_setting =
+            json_response.find { |setting| setting['key'] == 'new_announcement' }
+          expect(new_announcement_setting['enabled']).to eq(false)
+        end
+      end
+
+      context 'when invalid parameters are received' do
+        let(:payload) { { 'component' => 'invalid_component' } }
+        it { is_expected.to have_http_status(:bad_request) }
+      end
+    end
+  end
+end

--- a/spec/features/course/leaderboard_viewing_spec.rb
+++ b/spec/features/course/leaderboard_viewing_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe 'Course: Leaderboard: View' do
         end
 
         before do
-          settings = Course::Settings::LeaderboardComponent.
-                     new(course.settings(:course_leaderboard_component))
+          context = OpenStruct.new(current_course: course, key: Course::LeaderboardComponent.key)
+          settings = Course::Settings::LeaderboardComponent.new(context)
           settings.enable_group_leaderboard = true
           course.save
         end

--- a/spec/models/course/settings/assessments_component_spec.rb
+++ b/spec/models/course/settings/assessments_component_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Settings::AssessmentsComponent do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:category) { course.assessment_categories.first }
+    let(:settings) do
+      context = OpenStruct.new(current_course: course, key: Course::AssessmentsComponent.key)
+      Course::Settings::AssessmentsComponent.new(context)
+    end
+
+    describe '.email_enabled?' do
+      subject { Course::Settings::AssessmentsComponent.email_enabled?(category, key) }
+
+      context 'when email setting key is valid' do
+        let(:key) { :assessment_opening }
+
+        context 'when there is no custom setting' do
+          it 'returns the default setting' do
+            default_setting = Course::Settings::AssessmentsComponent.
+                              category_email_setting_items[:assessment_opening][:enabled_by_default]
+            expect(subject).to eq(default_setting)
+          end
+        end
+      end
+
+      context 'when email setting key is invalid' do
+        let(:key) { :unknown_key }
+
+        it { expect { subject }.to raise_exception(ArgumentError) }
+      end
+    end
+
+    describe '#update_email_setting' do
+      let(:payload) do
+        { 'key' => key, 'enabled' => false, 'options' => { 'category_id' => category.id } }
+      end
+      subject { settings.update_email_setting(payload) && course.save! }
+
+      context 'when all arguments are valid' do
+        let(:key) { :new_grading }
+        before { subject }
+
+        it 'persists the setting' do
+          setting = Course::Settings::AssessmentsComponent.email_enabled?(category, key)
+          expect(setting).to eq(payload['enabled'])
+        end
+      end
+
+      context 'when an argument is invalid' do
+        let(:key) { :unknown_key }
+
+        it { expect { subject }.to raise_exception(ArgumentError) }
+      end
+    end
+
+    describe '#email_settings' do
+      subject { settings.email_settings }
+
+      it 'returns setting items in the required shape' do
+        expect(subject.length).
+          to eq(Course::Settings::AssessmentsComponent.category_email_setting_items.length)
+        expect(subject.last.keys).
+          to contain_exactly(:component, :component_title, :enabled, :key, :options)
+      end
+    end
+  end
+end

--- a/spec/notifiers/course/announcement_notifier_spec.rb
+++ b/spec/notifiers/course/announcement_notifier_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe Course::AnnouncementNotifier, type: :notifier do
       it 'sends an email notification' do
         expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(2)
       end
+
+      context 'when email notification for new announcement is disabled' do
+        before do
+          context = OpenStruct.new(key: Course::AnnouncementsComponent.key, current_course: course)
+          Course::Settings::AnnouncementsComponent.new(context).
+            update_email_setting('key' => 'new_announcement', 'enabled' => false)
+          course.save!
+        end
+
+        it 'does not send a course notification' do
+          expect { subject }.to change(course.notifications, :count).by(0)
+        end
+
+        it 'does not send an email notification' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
     end
   end
 end

--- a/spec/notifiers/course/assessment_notifier_spec.rb
+++ b/spec/notifiers/course/assessment_notifier_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Course::AssessmentNotifier, type: :notifier do
   let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
+    let(:settings_context) do
+      OpenStruct.new(key: Course::AssessmentsComponent.key, current_course: course)
+    end
+
     describe '#assessment_attempted' do
       let(:course) { create(:course) }
       let(:assessment) { create(:assessment, course: course) }
@@ -23,9 +27,24 @@ RSpec.describe Course::AssessmentNotifier, type: :notifier do
       let(:user) { course_user.user }
       let(:submission) { create(:submission, course: course, creator: user) }
 
-      context 'when user do not belongs to any group' do
-        subject { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }
+      subject { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }
 
+      context 'when "new submission" emails are disabled' do
+        before do
+          setting = {
+            'key' => 'new_submission', 'enabled' => false,
+            'options' => { 'category_id' => submission.assessment.tab.category.id }
+          }
+          Course::Settings::AssessmentsComponent.new(settings_context).update_email_setting(setting)
+          course.save!
+        end
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
+
+      context 'when user does not belong to any group' do
         it 'sends an email notification' do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
         end
@@ -38,8 +57,6 @@ RSpec.describe Course::AssessmentNotifier, type: :notifier do
           create(:course_group_manager, group: group, course_user: teaching_assistant)
         end
         let!(:group_user) { create(:course_group_user, group: group, course_user: course_user) }
-
-        subject { Course::AssessmentNotifier.assessment_submitted(user, course_user, submission) }
 
         it 'sends an email notification' do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(2)
@@ -60,6 +77,21 @@ RSpec.describe Course::AssessmentNotifier, type: :notifier do
 
       it 'sends an email notification' do
         expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(2)
+      end
+
+      context 'when "assessment opening" emails are disabled' do
+        before do
+          setting = {
+            'key' => 'assessment_opening', 'enabled' => false,
+            'options' => { 'category_id' => assessment.tab.category.id }
+          }
+          Course::Settings::AssessmentsComponent.new(settings_context).update_email_setting(setting)
+          course.save!
+        end
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
       end
     end
   end

--- a/spec/services/course/survey/reminder_service_spec.rb
+++ b/spec/services/course/survey/reminder_service_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe Course::Survey::ReminderService do
         end.body.parts.first.body
         expect(email_body).to include('course.mailer.survey_opening_reminder_email.message')
       end
+
+      context 'when "survey opening" emails are disabled' do
+        before do
+          context = OpenStruct.new(key: Course::SurveyComponent.key, current_course: course)
+          Course::Settings::SurveyComponent.new(context).
+            update_email_setting('key' => 'survey_opening', 'enabled' => false)
+          course.save!
+        end
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
     end
 
     describe '#closing_reminder' do
@@ -57,6 +70,19 @@ RSpec.describe Course::Survey::ReminderService do
 
         expect(student_email_body).to include('course.mailer.survey_closing_reminder_email.message')
         expect(staff_email_body).to include('course.mailer.survey_closing_summary_email.message')
+      end
+
+      context 'when "survey opening" emails are disabled' do
+        before do
+          context = OpenStruct.new(key: Course::SurveyComponent.key, current_course: course)
+          Course::Settings::SurveyComponent.new(context).
+            update_email_setting('key' => 'survey_closing', 'enabled' => false)
+          course.save!
+        end
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
       end
     end
   end


### PR DESCRIPTION
Implements email settings for announcements, assessments and survey components. Settings for other components will be implemented in a subsequent PR. For #1688. 

- The first commit gives the settings model for each component access to the full context of the component, rather than just the appropriate sub-tree of the course settings. This is useful for the assessment settings model since it needs to query assessment categories.
- Since certain components might need to handle settings differently (e.g. assessments stores a set of settings for each category), the logic for handling notification settings resides in each individual component's setting model instead of `Course::Settings::Notifications`. Components that store a flat list of email settings under the `emails` key its settings can simply `Course::Settings::EmailSettingsConcern`.
- If the need arises, it should not be too difficult to add switches for other kinds of notifications (e.g. activity feed) or to allow setting of the email notification lead time (currently hard coded at 1 day). 