### PR TITLE
Change sequence of actions when submitting an answer

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -67,7 +67,10 @@ class Course::Assessment::Submission::SubmissionsController < \
     elsif reload_answer_params[:reset_answer]
       @new_answer = @answer.reset_answer
     else
-      @new_answer = @submission.answers.from_question(@current_question.id).last
+      # Return the current_answer referenced from the submission_question when reloading,
+      # instead of using the latest answer.
+      @new_answer = @submission.submission_questions.where(question: @current_question).first.
+                    current_answer
     end
   end
 

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -7,12 +7,14 @@ class Course::Assessment::Submission::SubmissionsController < \
   skip_authorize_resource :submission, only: [:edit, :update, :auto_grade]
   before_action :authorize_submission!, only: [:edit, :update]
   before_action :check_password, only: [:edit, :update]
-  before_action :load_or_create_answers, only: [:edit, :update]
   before_action :check_zombie_jobs, only: [:edit]
   # Questions may be added to assessments with existing submissions.
   # In these cases, new submission_questions must be created when the submission is next
   # edited or updated.
   before_action :load_or_create_submission_questions, only: [:edit, :update]
+  # When the first answer is created, it is assigned to its submission_question.
+  # Thus when a new submission is created, submission_questions must be created first.
+  before_action :load_or_create_answers, only: [:edit, :update]
 
   delegate_to_service(:update)
   delegate_to_service(:load_or_create_answers)

--- a/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
@@ -31,7 +31,8 @@ module Course::Assessment::Submission::SubmissionsAutogradedHelper
     return 'completed' if step <= max_step
   end
 
+  # Get current_answer from the submission question.
   def current_answer
-    @answers.last
+    @current_submission_question.current_answer
   end
 end

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -21,15 +21,15 @@ module Course::Assessment::Submission::SubmissionsHelper
     answer.correct ? 'panel-success' : 'panel-danger'
   end
 
-  # Return the last attempted answer based on the status of current submission.
-  # previous attempt if submission is in attempting state.
-  # current attempt if submission is in submitted, graded or published state.
+  # Return the last graded attempted answer based on the status of current submission,
+  # or the last attempt if there are no evaluated or graded answers.
   #
   # @return [Course::Assessment::Answer]
   def last_attempt(answer)
     submission = answer.submission
     attempts = submission.answers.from_question(answer.question_id)
-    submission.attempting? ? attempts[-2] : attempts[-1]
+    graded_or_evaluated = attempts.select { |x| ['evaluated', 'graded'].include?(x.workflow_state) }
+    graded_or_evaluated.empty? ? attempts.last : graded_or_evaluated.last
   end
 
   # Display button to allow the resetting of an answer.

--- a/app/jobs/course/assessment/answer/auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/auto_grading_job.rb
@@ -18,10 +18,9 @@ class Course::Assessment::Answer::AutoGradingJob < ApplicationJob
   #   finished.
   # @param [Course::Assessment::Answer] answer the answer to be graded.
   # @param [String] redirect_to_path The path to redirect when job finishes.
-  # @param [Boolean] reattempt Whether to create new answer based on current answer after grading.
-  def perform_tracked(answer, redirect_to_path = nil, reattempt = false)
+  def perform_tracked(answer, redirect_to_path = nil)
     ActsAsTenant.without_tenant do
-      Course::Assessment::Answer::AutoGradingService.grade(answer, reattempt)
+      Course::Assessment::Answer::AutoGradingService.grade(answer)
     end
 
     redirect_to redirect_to_path

--- a/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
@@ -23,10 +23,9 @@ class Course::Assessment::Answer::ReducePriorityAutoGradingJob < ApplicationJob
   #   finished.
   # @param [Course::Assessment::Answer] answer the answer to be graded.
   # @param [String] redirect_to_path The path to redirect when job finishes.
-  # @param [Boolean] reattempt Whether to create new answer based on current answer after grading.
-  def perform_tracked(answer, redirect_to_path = nil, reattempt = false)
+  def perform_tracked(answer, redirect_to_path = nil)
     ActsAsTenant.without_tenant do
-      Course::Assessment::Answer::AutoGradingService.grade(answer, reattempt)
+      Course::Assessment::Answer::AutoGradingService.grade(answer)
     end
 
     redirect_to redirect_to_path

--- a/app/models/course/assessment/submission_question.rb
+++ b/app/models/course/assessment/submission_question.rb
@@ -7,6 +7,8 @@ class Course::Assessment::SubmissionQuestion < ActiveRecord::Base
                           inverse_of: :submission_questions
   belongs_to :question, class_name: Course::Assessment::Question.name,
                         inverse_of: :submission_questions
+  belongs_to :current_answer, class_name: Course::Assessment::Answer.name,
+                              inverse_of: false
 
   after_initialize :set_course, if: :new_record?
   before_validation :set_course, if: :new_record?

--- a/app/services/course/assessment/submission/autograded_assessment_update_service.rb
+++ b/app/services/course/assessment/submission/autograded_assessment_update_service.rb
@@ -8,6 +8,13 @@ class Course::Assessment::Submission::AutogradedAssessmentUpdateService <
     @answers = @submission.answers.where(question: current_question)
   end
 
+  def load_or_create_submission_questions
+    super if @submission.attempting?
+
+    @current_submission_question = @submission.submission_questions.
+                                   where(question: current_question).first
+  end
+
   private
 
   def step_param

--- a/app/views/course/assessment/submission/submissions/_manually_graded_answers.html.slim
+++ b/app/views/course/assessment/submission/submissions/_manually_graded_answers.html.slim
@@ -1,12 +1,12 @@
 / TODO: Implement flag to display all answers, or only latest answers.
 
-- answers_by_question = f.object.latest_answers.group_by(&:question)
 - submission_questions_by_question = f.object.submission_questions.group_by(&:question)
 - f.object.assessment.questions.each do |question|
   div.answer-content
     = render partial: question, suffix: 'question'
-    - if answers = answers_by_question[question]
-      = render partial: 'course/assessment/answer/answer', object: answers.last
+    - if submission_question = submission_questions_by_question[question].first
+      = render partial: 'course/assessment/answer/answer',
+               object: submission_question.current_answer
     - else
       div.alert.alert-warning
         = t('course.assessment.submission.submissions.no_answer')

--- a/app/views/course/assessment/submission/submissions/_manually_graded_answers_tabbed.html.slim
+++ b/app/views/course/assessment/submission/submissions/_manually_graded_answers_tabbed.html.slim
@@ -1,5 +1,4 @@
 / TODO: Implement flag to display all answers, or only latest answers.
-- answers_by_question = f.object.latest_answers.group_by(&:question)
 - submission_questions_by_question = f.object.submission_questions.group_by(&:question)
 
 ul.nav.nav-tabs.tab-header role="tab-list"
@@ -12,8 +11,9 @@ div.tab-content
   - f.object.assessment.questions.each do |question|
     div.tab-pane.fade role="tabpanel" id="#{question.id}"
       = render partial: question, suffix: 'question'
-      - if answers = answers_by_question[question]
-        = render partial: 'course/assessment/answer/answer', object: answers.last
+      - if submission_question = submission_questions_by_question[question].first
+        = render partial: 'course/assessment/answer/answer',
+                 object: submission_question.current_answer
       - else
         div.alert.alert-warning
           = t('course.assessment.submission.submissions.no_answer')

--- a/db/migrate/20170713082612_add_current_answer_to_submission_question.rb
+++ b/db/migrate/20170713082612_add_current_answer_to_submission_question.rb
@@ -1,0 +1,6 @@
+class AddCurrentAnswerToSubmissionQuestion < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_submission_questions, :current_answer_id, :integer,
+               foreign_key: { references: :course_assessment_answers }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170706030838) do
+ActiveRecord::Schema.define(version: 20170713082612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -356,10 +356,11 @@ ActiveRecord::Schema.define(version: 20170706030838) do
   end
 
   create_table "course_assessment_submission_questions", force: :cascade do |t|
-    t.integer  "submission_id", :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_submission_questions_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_submission_questions_question_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",    :null=>false
-    t.datetime "updated_at",    :null=>false
+    t.integer  "submission_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_submission_questions_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "question_id",       :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_submission_questions_question_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "current_answer_id", :index=>{:name=>"fk__course_assessment_submission_questions_current_answer_id"}, :foreign_key=>{:references=>"course_assessment_answers", :name=>"fk_course_assessment_submission_questions_current_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",        :null=>false
+    t.datetime "updated_at",        :null=>false
   end
   add_index "course_assessment_submission_questions", ["submission_id", "question_id"], :name=>"idx_course_assessment_submission_questions_on_sub_and_qn", :unique=>true
 

--- a/lib/tasks/db/update_current_answers.rake
+++ b/lib/tasks/db/update_current_answers.rake
@@ -1,0 +1,22 @@
+namespace :db do
+  task update_current_answers: :environment do
+    # Set the newly added current_answer ID in the course_assessment_submission_questions table.
+    #
+    # SQL statement adapted from
+    # https://stackoverflow.com/questions/7019831/bulk-batch-update-upsert-in-postgresql
+    ActsAsTenant.without_tenant do
+      connection = ActiveRecord::Base.connection
+
+      # Set current_answer column to the last answer (assumed to be the largest ID)
+      # for each submission_question.
+      connection.exec_query(<<-SQL)
+				UPDATE course_assessment_submission_questions SET current_answer_id = tmp_table.max_id
+        FROM (SELECT MAX(id) AS max_id, submission_id, question_id
+              FROM course_assessment_answers
+              GROUP BY submission_id, question_id) AS tmp_table
+        WHERE course_assessment_submission_questions.submission_id = tmp_table.submission_id
+              AND course_assessment_submission_questions.question_id = tmp_table.question_id
+      SQL
+    end
+  end
+end

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -54,7 +54,25 @@ FactoryGirl.define do
       end
     end
 
+    # Build submission questions, assign current_answer if available.
+    # Declare this trait after the ones above so answers will be created.
+    trait :with_submission_questions do
+      after(:build) do |submission|
+        assessment = submission.assessment
+        assessment.questions.each do |qn|
+          sub_qn = build(:course_assessment_submission_question, course: assessment.course,
+                                                                 assessment: assessment,
+                                                                 submission: submission,
+                                                                 question: qn)
+          answer = submission.answers.find { |ans| ans.question == sub_qn.question }
+          sub_qn.current_answer = answer if answer
+          submission.submission_questions << sub_qn
+        end
+      end
+    end
+
     # Ensure that creator of submission is the same as creator of experience_points_record
+    # Build submission questions.
     after(:build) do |submission, evaluator|
       user = evaluator.creator ? evaluator.creator : submission.creator
       submission.experience_points_record.creator = user

--- a/spec/features/course/assessment/answer/text_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/text_response_answer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Course: Assessments: Submissions: Text Response Answers' do
 
     context 'As Course Staff' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
-      let(:submission_traits) { :submitted }
+      let(:submission_traits) { [:submitted, :with_submission_questions] }
 
       scenario 'I can view the grading scheme' do
         visit edit_course_assessment_submission_path(course, assessment, submission)


### PR DESCRIPTION
## Current implementation

Currently, an answer would be marked as submitted, evaluated by the auto grader, then a new one will be created for the student to work on.

This had the side effect of making programming annotations "disappear" as annotations were attached to an answer, and only the latest answer was shown. The last graded result was also shown by finding the 2nd last answer.

## New implementation

This PR introduces the concept of a "current_answer", referenced from 
`course_assessment_submission_question`, which will always be the shown to the student as the answer he works on.

When the student submits, a copy is created, the copy is submitted, then evaluated by the auto grader.

In this scheme, the answer shown to the student is always the "current_answer" referenced from the submission_question, and the last graded result is displayed by finding the last graded answer.

Fixes #2346.

DO NOT MERGE YET, additional testing is required, and further thought on the state transitions of answers and submissions.