### PR TITLE
Admin stats

### DIFF
--- a/app/assets/stylesheets/system/admin.scss
+++ b/app/assets/stylesheets/system/admin.scss
@@ -1,0 +1,12 @@
+.system-admin-courses,
+.system-admin-instance-courses {
+  &.index {
+    td.active-level {
+      text-align: center;
+    }
+
+    .progress {
+      margin-bottom: 3px;
+    }
+  }
+}

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Controller < ApplicationController
   load_and_authorize_resource :course
+  before_action :set_last_active_at
   helper name
 
   before_action :add_course_breadcrumb
@@ -73,5 +74,14 @@ class Course::Controller < ApplicationController
   def add_course_breadcrumb
     add_breadcrumb(current_course.title, course_path(current_course)) if
       current_course.present? && current_course.id.present?
+  end
+
+  def set_last_active_at
+    return if current_course.nil? || current_course_user.nil?
+
+    # Only update the timestamp every hour
+    return if current_course_user.last_active_at && current_course_user.last_active_at > 1.hour.ago
+
+    current_course_user.update_column(:last_active_at, Time.zone.now)
   end
 end

--- a/app/controllers/system/admin/courses_controller.rb
+++ b/app/controllers/system/admin/courses_controller.rb
@@ -5,7 +5,7 @@ class System::Admin::CoursesController < System::Admin::Controller
 
   def index
     @courses = Course.ordered_by_title.page(page_param).includes(:instance).
-               search(search_param).with_owners
+               search(search_param).calculated(:active_user_count, :user_count).with_owners
   end
 
   def destroy

--- a/app/controllers/system/admin/instance/courses_controller.rb
+++ b/app/controllers/system/admin/instance/courses_controller.rb
@@ -6,7 +6,7 @@ class System::Admin::Instance::CoursesController < System::Admin::Instance::Cont
 
   def index
     @courses = @instance.courses.ordered_by_title.page(page_param).
-               search(search_param).with_owners
+               search(search_param).calculated(:active_user_count, :user_count).with_owners
   end
 
   def destroy

--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -4,7 +4,8 @@ class System::Admin::InstancesController < System::Admin::Controller
   add_breadcrumb :index, :admin_instances_path
 
   def index #:nodoc:
-    @instances = Instance.order_for_display.page(page_param).calculated(:course_count, :user_count)
+    @instances = Instance.order_for_display.page(page_param).
+                 calculated(:active_course_count, :course_count, :active_user_count, :user_count)
   end
 
   def new #:nodoc:

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -48,6 +48,16 @@ class Course < ActiveRecord::Base
 
   accepts_nested_attributes_for :invitations, :assessment_categories
 
+  calculated :user_count, (lambda do
+    CourseUser.select("count('*')").
+      where('course_users.course_id = courses.id')
+  end)
+
+  calculated :active_user_count, (lambda do
+    CourseUser.select("count('*')").
+      where('course_users.course_id = courses.id').merge(CourseUser.active_in_past_7_days)
+  end)
+
   scope :ordered_by_title, -> { order(:title) }
   scope :ordered_by_start_at, ->(direction = :desc) { order(start_at: direction) }
   scope :ordered_by_end_at, ->(direction = :desc) { order(end_at: direction) }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -70,6 +70,8 @@ class Course < ActiveRecord::Base
     end
   end)
 
+  scope :active_in_past_7_days, -> { joins(:course_users).merge(CourseUser.active_in_past_7_days) }
+
   delegate :staff, to: :course_users
   delegate :instructors, to: :course_users
   delegate :managers, to: :course_users

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -92,6 +92,7 @@ class CourseUser < ActiveRecord::Base
   end)
 
   scope :order_alphabetically, ->(direction = :asc) { order(name: direction) }
+  scope :active_in_past_7_days, -> { where('last_active_at > ?', 7.days.ago) }
 
   # Test whether the current scope includes the current user.
   #

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -65,6 +65,12 @@ class Instance < ActiveRecord::Base
     order("CASE \"id\" WHEN #{DEFAULT_INSTANCE_ID} THEN 0 ELSE 1 END").order_by_name
   end)
 
+  # The number of active courses (in the past 7 days) in the instance.
+  calculated :active_course_count, (lambda do
+    Course.unscoped.active_in_past_7_days.where('courses.instance_id = instances.id').
+      select("count('*')")
+  end)
+
   # @!attribute [r] course_count
   #   The number of courses in the instance.
   calculated :course_count, (lambda do
@@ -75,6 +81,13 @@ class Instance < ActiveRecord::Base
   #   The number of users in the instance.
   calculated :user_count, (lambda do
     InstanceUser.unscoped.where('instance_users.instance_id = instances.id').select("count('*')")
+  end)
+
+  # The number of active users (in the past 7 days) in the instance.
+  calculated :active_user_count, (lambda do
+    InstanceUser.unscoped.joins(:user).merge(User.active_in_past_7_days).
+      where('instance_users.instance_id = instances.id').
+      select("count('*')")
   end)
 
   def self.use_relative_model_naming?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,7 @@ class User < ActiveRecord::Base
 
   scope :ordered_by_name, -> { order(:name) }
   scope :human_users, -> { where.not(id: [User::SYSTEM_USER_ID, User::DELETED_USER_ID]) }
+  scope :active_in_past_7_days, -> { where('current_sign_in_at > ?', 7.days.ago) }
 
   # Gets whether the current user is one of the the built in users.
   #

--- a/app/views/layouts/system_admin.html.slim
+++ b/app/views/layouts/system_admin.html.slim
@@ -5,9 +5,9 @@
       = sidebar do
         ul.nav.nav-pills.nav-stacked
           li
-            = link_to(t('system.admin.navbar.users'), admin_users_path)
-          li
             = link_to(t('system.admin.navbar.system_announcements'), admin_announcements_path)
+          li
+            = link_to(t('system.admin.navbar.users'), admin_users_path)
           li
             = link_to(t('system.admin.navbar.instances'), admin_instances_path)
           li

--- a/app/views/layouts/system_admin_instance.html.slim
+++ b/app/views/layouts/system_admin_instance.html.slim
@@ -5,11 +5,11 @@
       = sidebar do
         ul.nav.nav-pills.nav-stacked
           li
+            = link_to(t('system.admin.instance.navbar.announcements'), admin_instance_announcements_path)
+          li
             = link_to(t('system.admin.instance.navbar.users'), admin_instance_users_path)
           li
             = link_to(t('system.admin.instance.navbar.courses'), admin_instance_courses_path)
-          li
-            = link_to(t('system.admin.instance.navbar.announcements'), admin_instance_announcements_path)
           li
             = link_to(t('system.admin.instance.navbar.components'), admin_instance_components_path)
       div.col-lg-10.col.md-9.col-sm-8 class=page_class

--- a/app/views/system/admin/courses/_course.html.slim
+++ b/app/views/system/admin/courses/_course.html.slim
@@ -1,9 +1,14 @@
+- active_level = course.user_count == 0 ? 0 : course.active_user_count * 100 / course.user_count.to_f
+
 = content_tag_for(:tr, course)
   td = (current_page - 1) * per_page + course_counter + 1
   th
     = link_to format_inline_text(course.title),
               course_url(course, host: course.instance.host, port: nil)
-  td = format_datetime(course.created_at)
+  td = format_datetime(course.created_at, :date_only_long)
+  td.active-level
+    = display_progress_bar(active_level, 'progress-bar-success')
+    = "#{course.active_user_count} / #{course.user_count}"
   td
     = link_to format_inline_text(course.instance.name),
               root_url(host: course.instance.host, port: nil)

--- a/app/views/system/admin/courses/index.html.slim
+++ b/app/views/system/admin/courses/index.html.slim
@@ -17,6 +17,7 @@ table.table.table-middle-align.table-hover
       th = t('.serial_number')
       th = t('.title')
       th = t('.created_at')
+      th = t('.users')
       th = t('.instance')
       th = t('.owners')
       th

--- a/app/views/system/admin/courses/index.html.slim
+++ b/app/views/system/admin/courses/index.html.slim
@@ -1,8 +1,11 @@
-/ Show total number of courses when search field is blank (nil or empty string)
-- if params['search'].blank?
-  = page_header t('.header_with_count', count: Course.unscoped.all.count)
-- else
-  = page_header
+= page_header
+
+- if params[:search].blank?
+  .panel.panel-default
+    .panel-heading = t('common.summary')
+    .panel-body
+      div = t('.total_courses_html', count: Course.unscoped.count)
+      div = t('.active_courses_html', count: Course.unscoped.active_in_past_7_days.count)
 
 = render partial: 'layouts/search_form', locals: { url: admin_courses_path, placeholder: t('.search_placeholder') }
 

--- a/app/views/system/admin/instance/courses/_course.html.slim
+++ b/app/views/system/admin/instance/courses/_course.html.slim
@@ -1,8 +1,13 @@
+- active_level = course.user_count == 0 ? 0 : course.active_user_count * 100 / course.user_count.to_f
+
 = content_tag_for(:tr, course)
   td = (current_page - 1) * per_page + course_counter + 1
   th
     = link_to format_inline_text(course.title), course_path(course)
   td = format_datetime(course.created_at)
+  td.active-level
+    = display_progress_bar(active_level, 'progress-bar-success')
+    = "#{course.active_user_count} / #{course.user_count}"
   td
     ul.list-unstyled
       - course.course_users.each do |course_owner|

--- a/app/views/system/admin/instance/courses/index.html.slim
+++ b/app/views/system/admin/instance/courses/index.html.slim
@@ -17,6 +17,7 @@ table.table.table-middle-align.table-hover
       th = t('.serial_number')
       th = t('.title')
       th = t('.created_at')
+      th = t('.users')
       th = t('.owners')
       th
   tbody

--- a/app/views/system/admin/instance/courses/index.html.slim
+++ b/app/views/system/admin/instance/courses/index.html.slim
@@ -1,8 +1,11 @@
-/ Show  number of courses in instance when search field is blank (nil or empty string)
+= page_header
+
 - if params['search'].blank?
-  = page_header t('.header_with_count', count: @courses.total_count)
-- else
-  = page_header
+  .panel.panel-default
+    .panel-heading = t('common.summary')
+    .panel-body
+      div = t('.total_courses_html', count: Course.count)
+      div = t('.active_courses_html', count: Course.active_in_past_7_days.count)
 
 = render partial: 'layouts/search_form', locals: { url: admin_instance_courses_path, placeholder: t('.search_placeholder') }
 

--- a/app/views/system/admin/instance/users/index.html.slim
+++ b/app/views/system/admin/instance/users/index.html.slim
@@ -1,5 +1,12 @@
 = page_header
 
+- if params[:search].blank?
+  .panel.panel-default
+    .panel-heading = t('common.summary')
+    .panel-body
+      div = t('.total_users_html', count: current_tenant.users.count)
+      div = t('.active_users_html', count: current_tenant.users.active_in_past_7_days.count )
+
 = render partial: 'layouts/search_form', locals: { url: admin_instance_users_path, placeholder: t('.search_placeholder') }
 
 table.table.table-middle-align.table-hover

--- a/app/views/system/admin/instances/_instance.html.slim
+++ b/app/views/system/admin/instances/_instance.html.slim
@@ -7,9 +7,15 @@
 
   td = instance.host
 
-  td = link_to instance.user_count, admin_instance_users_url(host: instance.host)
+  td
+    = instance.active_user_count
+    = ' / '
+    = link_to instance.user_count, admin_instance_users_url(host: instance.host)
 
-  td = link_to instance.course_count, admin_instance_courses_url(host: instance.host)
+  td
+    = instance.active_course_count
+    = ' / '
+    = link_to instance.course_count, admin_instance_courses_url(host: instance.host)
 
   td
     = edit_button([:admin, instance]) if can?(:edit, instance)

--- a/app/views/system/admin/instances/index.html.slim
+++ b/app/views/system/admin/instances/index.html.slim
@@ -9,8 +9,12 @@ table.table.table-middle-align.table-hover
       th= t('.serial_number')
       th= t('.name')
       th= t('.host_name')
-      th= t('.users')
-      th= t('.courses')
+      th
+        div data-toggle="tooltip" title="#{t('.users_hint')}"
+          = t('.users')
+      th
+        div data-toggle="tooltip" title="#{t('.courses_hint')}"
+          = t('.courses')
 
   tbody
     = render partial: 'instance', collection: @instances,

--- a/app/views/system/admin/users/index.html.slim
+++ b/app/views/system/admin/users/index.html.slim
@@ -1,5 +1,12 @@
 = page_header
 
+- if params[:search].blank?
+  .panel.panel-default
+    .panel-heading = t('common.summary')
+    .panel-body
+      div = t('.total_users_html', count: User.count)
+      div = t('.active_users_html', count: User.active_in_past_7_days.count)
+
 = render partial: 'layouts/search_form', locals: { url: admin_users_path, placeholder: t('.search_placeholder') }
 
 table.table.table-middle-align.table-hover

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -12,6 +12,7 @@ en:
     submit: 'Submit'
     show_more: 'See all'
     show_less: 'See less'
+    summary: 'Summary'
     click_here: 'Click here'
   helpers:
     submit:

--- a/config/locales/en/system/admin/courses.yml
+++ b/config/locales/en/system/admin/courses.yml
@@ -4,7 +4,8 @@ en:
       courses:
         index:
           header: 'Courses'
-          header_with_count: 'Courses (%{count})'
+          total_courses_html: 'Total Courses: <strong>%{count}</strong>'
+          active_courses_html: 'Active Courses (in the past 7 days): <strong>%{count}</strong>'
           serial_number: 'S/N'
           title: 'Title'
           created_at: 'Created At'

--- a/config/locales/en/system/admin/courses.yml
+++ b/config/locales/en/system/admin/courses.yml
@@ -9,6 +9,7 @@ en:
           serial_number: 'S/N'
           title: 'Title'
           created_at: 'Created At'
+          users: 'Active / Total Users'
           instance: 'Instance'
           owners: 'Owners'
           search_placeholder: 'Search course title, description or related users'

--- a/config/locales/en/system/admin/instance/courses.yml
+++ b/config/locales/en/system/admin/instance/courses.yml
@@ -10,6 +10,7 @@ en:
             serial_number: 'S/N'
             title: 'Title'
             created_at: 'Created At'
+            users: 'Active / Total Users'
             owners: 'Owners'
             search_placeholder: 'Search course title, description or related users'
           destroy:

--- a/config/locales/en/system/admin/instance/courses.yml
+++ b/config/locales/en/system/admin/instance/courses.yml
@@ -5,7 +5,8 @@ en:
         courses:
           index:
             header: 'Courses'
-            header_with_count: 'Courses (%{count})'
+            total_courses_html: 'Total Courses: <strong>%{count}</strong>'
+            active_courses_html: 'Active Courses (in the past 7 days): <strong>%{count}</strong>'
             serial_number: 'S/N'
             title: 'Title'
             created_at: 'Created At'

--- a/config/locales/en/system/admin/instance/users.yml
+++ b/config/locales/en/system/admin/instance/users.yml
@@ -7,6 +7,8 @@ en:
             header: 'Users'
             related_courses: 'Related Courses'
             search_placeholder: 'Search user name or emails'
+            total_users_html: 'Total Users: <strong>%{count}</strong>'
+            active_users_html: 'Active Users (in the past 7 days): <strong>%{count}</strong>'
           update:
             success: '%{user} was updated.'
           destroy:

--- a/config/locales/en/system/admin/instances.yml
+++ b/config/locales/en/system/admin/instances.yml
@@ -3,12 +3,14 @@ en:
     admin:
       instances:
         index:
-          header: 'Instance Management'
+          header: 'Instances'
           serial_number: 'S/N'
           name: 'Name'
           host_name: 'Host Name'
-          users: 'Total Users'
-          courses: 'Total Courses'
+          users: 'Active / Total Users'
+          users_hint: 'Number of active users in the past 7 days'
+          courses: 'Active / Total Courses'
+          courses_hint: 'Number of active courses in the past 7 days'
         new:
           header: 'New Instance'
         create:

--- a/config/locales/en/system/admin/users.yml
+++ b/config/locales/en/system/admin/users.yml
@@ -6,6 +6,8 @@ en:
           header: 'Users'
           related_instances: 'Related Instances'
           search_placeholder: 'Search user name or emails'
+          total_users_html: 'Total Users: <strong>%{count}</strong>'
+          active_users_html: 'Active Users (in the past 7 days): <strong>%{count}</strong>'
         update:
           success: '%{user} was updated.'
         destroy:

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -89,7 +89,15 @@ RSpec.feature 'Course: Homepage' do
     end
 
     context 'As a user registered for the course' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
+
+      scenario 'I can visit the course homepage' do
+        visit course_path(course)
+
+        expect(course_user.reload.last_active_at).to be_within(1.hour).of(Time.zone.now)
+      end
+
       scenario 'I am able to see announcements in course homepage' do
         valid_announcement = create(:course_announcement, course: course)
         visit course_path(course)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -242,5 +242,25 @@ RSpec.describe Course, type: :model do
         expect(new_count).to eq(old_count + 1)
       end
     end
+
+    describe 'calculated attributes' do
+      let(:course) { create(:course) }
+      let!(:course_users) { create_list(:course_user, 2, course: course) }
+
+      describe '.active_user_count' do
+        before { course_users.sample.update_column(:last_active_at, Time.zone.now) }
+        subject do
+          Course.where(id: course.id).calculated(:active_user_count).first.active_user_count
+        end
+
+        it { is_expected.to eq(1) }
+      end
+
+      describe '.user_count' do
+        subject { Course.where(id: course.id).calculated(:user_count).first.user_count }
+
+        it { is_expected.to eq(course.course_users.count) }
+      end
+    end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -229,5 +229,18 @@ RSpec.describe Course, type: :model do
         it { is_expected.to be_truthy }
       end
     end
+
+    describe '.active_in_past_7_days' do
+      let!(:courses) { create_list(:course, 3) }
+
+      it 'returns the active courses' do
+        old_count = instance.courses.active_in_past_7_days.count
+
+        create(:course_user, course: courses.sample, last_active_at: Time.zone.now)
+
+        new_count = instance.courses.active_in_past_7_days.count
+        expect(new_count).to eq(old_count + 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Provide more stats in system and instance admin pages:

- Users and Active users count
- Courses and Active courses count
- Active Course users tracking, timestamps are updated when users visit courses.


screenshots:
![screen shot 2017-07-18 at 4 41 40 pm](https://user-images.githubusercontent.com/4983239/28308161-018fd38c-6bd8-11e7-9f24-0d9874fa7d88.png)

![screen shot 2017-07-18 at 4 48 07 pm](https://user-images.githubusercontent.com/4983239/28308495-f37423c4-6bd8-11e7-9c26-38989d20072d.png)
