### PR TITLE
Complete email settings

### DIFF
--- a/app/mailers/course/mailer.rb
+++ b/app/mailers/course/mailer.rb
@@ -31,6 +31,9 @@ class Course::Mailer < ApplicationMailer
     ActsAsTenant.without_tenant do
       @course = enrol_request.course
     end
+
+    return unless Course::Settings::UsersComponent.email_enabled?(@course, :new_enrol_request)
+
     @enrol_request = enrol_request
     @recipient = OpenStruct.new(name: t('course.mailer.user_registered_email.recipients'))
 

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -62,7 +62,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
   private
 
   def submission_graded_email_enabled?
-    Course::Settings::AssessmentsComponent.email_enabled?(assessment.tab.category, :new_grading)
+    Course::Settings::AssessmentsComponent.email_enabled?(assessment.tab.category, :grades_released)
   end
 
   # Defined outside of the workflow transition as points_awarded and draft_points_awarded are

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -219,9 +219,15 @@ class Course::Assessment::Submission < ActiveRecord::Base
   end
 
   def send_submit_notification
-    return unless course_user.real_student? && workflow_state_was == 'attempting'
+    return unless workflow_state_was == 'attempting'
     return if assessment.autograded?
+    return if !course_user.real_student? && !phantom_submission_email_enabled?
 
     Course::AssessmentNotifier.assessment_submitted(creator, course_user, self)
+  end
+
+  def phantom_submission_email_enabled?
+    Course::Settings::AssessmentsComponent.
+      email_enabled?(assessment.tab.category, :new_phantom_submission)
   end
 end

--- a/app/models/course/settings/assessments_component.rb
+++ b/app/models/course/settings/assessments_component.rb
@@ -7,7 +7,7 @@ class Course::Settings::AssessmentsComponent < Course::Settings::Component
         assessment_closing: { enabled_by_default: true },
         new_submission: { enabled_by_default: true },
         new_phantom_submission: { enabled_by_default: true },
-        new_grading: { enabled_by_default: true }
+        grades_released: { enabled_by_default: true }
       }
     end
 

--- a/app/models/course/settings/assessments_component.rb
+++ b/app/models/course/settings/assessments_component.rb
@@ -6,6 +6,7 @@ class Course::Settings::AssessmentsComponent < Course::Settings::Component
         assessment_opening: { enabled_by_default: true },
         assessment_closing: { enabled_by_default: true },
         new_submission: { enabled_by_default: true },
+        new_phantom_submission: { enabled_by_default: true },
         new_grading: { enabled_by_default: true }
       }
     end

--- a/app/models/course/settings/assessments_component.rb
+++ b/app/models/course/settings/assessments_component.rb
@@ -7,6 +7,7 @@ class Course::Settings::AssessmentsComponent < Course::Settings::Component
         assessment_closing: { enabled_by_default: true },
         new_submission: { enabled_by_default: true },
         new_phantom_submission: { enabled_by_default: true },
+        new_comment: { enabled_by_default: true },
         grades_released: { enabled_by_default: true }
       }
     end

--- a/app/models/course/settings/users_component.rb
+++ b/app/models/course/settings/users_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Course::Settings::UsersComponent < Course::Settings::Component
+  include Course::Settings::EmailSettingsConcern
+
+  def self.email_setting_items
+    {
+      new_enrol_request: { enabled_by_default: true }
+    }
+  end
+
+  def self.component_class
+    Course::UsersComponent
+  end
+end

--- a/app/notifiers/course/assessment/answer/comment_notifier.rb
+++ b/app/notifiers/course/assessment/answer/comment_notifier.rb
@@ -1,10 +1,19 @@
 class Course::Assessment::Answer::CommentNotifier < Notifier::Base
   # To be called when user adds a post to a programming annotation.
   def annotation_replied(user, post)
+    return unless email_enabled?(post)
+
     activity = create_activity(actor: user, object: post, event: :annotated)
     post.topic.subscriptions.includes(:user).each do |subscription|
       activity.notify(subscription.user, :email) unless subscription.user == user
     end
     activity.save!
+  end
+
+  private
+
+  def email_enabled?(post)
+    category = post.topic.actable.file.answer.submission.assessment.tab.category
+    Course::Settings::AssessmentsComponent.email_enabled?(category, :new_comment)
   end
 end

--- a/app/notifiers/course/assessment/submission_question/comment_notifier.rb
+++ b/app/notifiers/course/assessment/submission_question/comment_notifier.rb
@@ -1,10 +1,19 @@
 class Course::Assessment::SubmissionQuestion::CommentNotifier < Notifier::Base
   # To be called when user comments on an submission_question.
   def post_replied(user, post)
+    return unless email_enabled?(post)
+
     activity = create_activity(actor: user, object: post, event: :replied)
     post.topic.subscriptions.includes(:user).each do |subscription|
       activity.notify(subscription.user, :email) unless subscription.user == user
     end
     activity.save!
+  end
+
+  private
+
+  def email_enabled?(post)
+    category = post.topic.actable.submission.assessment.tab.category
+    Course::Settings::AssessmentsComponent.email_enabled?(category, :new_comment)
   end
 end

--- a/client/app/bundles/course/admin/pages/NotificationSettings/index.jsx
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/index.jsx
@@ -10,6 +10,13 @@ import { updateNotificationSetting } from 'course/admin/actions/notifications';
 import adminTranslations, { defaultComponentTitles } from 'course/admin/translations.intl';
 import translations, { settingTitles, settingDescriptions } from './translations.intl';
 
+const styles = {
+  wrapText: {
+    whiteSpace: 'normal',
+    wordWrap: 'break-word',
+  },
+};
+
 class NotificationSettings extends React.Component {
   static propTypes = {
     notification: notificationShape,
@@ -46,13 +53,13 @@ class NotificationSettings extends React.Component {
 
     return (
       <TableRow key={setting.component + setting.component_title + setting.key}>
-        <TableRowColumn>
+        <TableRowColumn colSpan={2}>
           { componentTitle }
         </TableRowColumn>
-        <TableRowColumn>
+        <TableRowColumn colSpan={3}>
           { settingTitle }
         </TableRowColumn>
-        <TableRowColumn colSpan={2}>
+        <TableRowColumn colSpan={7} style={styles.wrapText}>
           { settingDescription }
         </TableRowColumn>
         <TableRowColumn>
@@ -79,13 +86,13 @@ class NotificationSettings extends React.Component {
           displaySelectAll={false}
         >
           <TableRow>
-            <TableHeaderColumn>
+            <TableHeaderColumn colSpan={2}>
               <FormattedMessage {...adminTranslations.component} />
             </TableHeaderColumn>
-            <TableHeaderColumn>
+            <TableHeaderColumn colSpan={3}>
               <FormattedMessage {...translations.setting} />
             </TableHeaderColumn>
-            <TableHeaderColumn colSpan={2}>
+            <TableHeaderColumn colSpan={7}>
               <FormattedMessage {...translations.description} />
             </TableHeaderColumn>
             <TableHeaderColumn>

--- a/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
@@ -62,8 +62,8 @@ export const settingDescriptions = defineMessages({
     defaultMessage: "Sends 'New Submission' email for phantom students also. If 'New Submission' email\
       notification is disabled, no emails will be sent even though this setting is enabled.",
   },
-  new_grading: {
-    id: 'course.admin.NotificationSettings.settingDescriptions.new_grading',
+  grades_released: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.grades_released',
     defaultMessage: 'Notify a student when grades for a submission have been released.',
   },
 });
@@ -97,9 +97,9 @@ export const settingTitles = defineMessages({
     id: 'course.admin.NotificationSettings.settingTitles.new_phantom_submission',
     defaultMessage: 'New Phantom Submission',
   },
-  new_grading: {
-    id: 'course.admin.NotificationSettings.settingTitles.new_grading',
-    defaultMessage: 'New Grading',
+  grades_released: {
+    id: 'course.admin.NotificationSettings.settingTitles.grades_released',
+    defaultMessage: 'Grades Released',
   },
 });
 

--- a/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
@@ -54,7 +54,13 @@ export const settingDescriptions = defineMessages({
   },
   new_submission: {
     id: 'course.admin.NotificationSettings.settingDescriptions.new_submission',
-    defaultMessage: "Notify a student's group managers when the student makes a submission.",
+    defaultMessage: "Notify student's group managers when the student makes a submission. Select whether to\
+      send this notification for phantom students via the 'New Phantom Submission' setting.",
+  },
+  new_phantom_submission: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.new_phantom_submission',
+    defaultMessage: "Sends 'New Submission' email for phantom students also. If 'New Submission' email\
+      notification is disabled, no emails will be sent even though this setting is enabled.",
   },
   new_grading: {
     id: 'course.admin.NotificationSettings.settingDescriptions.new_grading',
@@ -86,6 +92,10 @@ export const settingTitles = defineMessages({
   new_submission: {
     id: 'course.admin.NotificationSettings.settingTitles.new_submission',
     defaultMessage: 'New Submission',
+  },
+  new_phantom_submission: {
+    id: 'course.admin.NotificationSettings.settingTitles.new_phantom_submission',
+    defaultMessage: 'New Phantom Submission',
   },
   new_grading: {
     id: 'course.admin.NotificationSettings.settingTitles.new_grading',

--- a/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
@@ -70,6 +70,10 @@ export const settingDescriptions = defineMessages({
     id: 'course.admin.NotificationSettings.settingDescriptions.new_comment',
     defaultMessage: 'Notify users when comments or programming question annotations are made.',
   },
+  new_enrol_request: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.new_enrol_request',
+    defaultMessage: 'Notify staff when users request to enrol in the course.',
+  },
 });
 
 export const settingTitles = defineMessages({
@@ -108,6 +112,10 @@ export const settingTitles = defineMessages({
   new_comment: {
     id: 'course.admin.NotificationSettings.settingTitles.new_comment',
     defaultMessage: 'New Comment',
+  },
+  new_enrol_request: {
+    id: 'course.admin.NotificationSettings.settingTitles.new_enrol_request',
+    defaultMessage: 'New Enrol Request',
   },
 });
 

--- a/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
@@ -66,6 +66,10 @@ export const settingDescriptions = defineMessages({
     id: 'course.admin.NotificationSettings.settingDescriptions.grades_released',
     defaultMessage: 'Notify a student when grades for a submission have been released.',
   },
+  new_comment: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.new_comment',
+    defaultMessage: 'Notify users when comments or programming question annotations are made.',
+  },
 });
 
 export const settingTitles = defineMessages({
@@ -100,6 +104,10 @@ export const settingTitles = defineMessages({
   grades_released: {
     id: 'course.admin.NotificationSettings.settingTitles.grades_released',
     defaultMessage: 'Grades Released',
+  },
+  new_comment: {
+    id: 'course.admin.NotificationSettings.settingTitles.new_comment',
+    defaultMessage: 'New Comment',
   },
 });
 

--- a/client/app/bundles/course/admin/translations.intl.js
+++ b/client/app/bundles/course/admin/translations.intl.js
@@ -16,6 +16,10 @@ export const defaultComponentTitles = defineMessages({
     id: 'course.admin.componentTitles.course_survey_component',
     defaultMessage: 'Surveys',
   },
+  course_users_component: {
+    id: 'course.admin.componentTitles.course_users_component',
+    defaultMessage: 'Users',
+  },
 });
 
 export default translations;

--- a/db/migrate/20170720071725_rename_assessment_opened_email_settings_key.rb
+++ b/db/migrate/20170720071725_rename_assessment_opened_email_settings_key.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class RenameAssessmentOpenedEmailSettingsKey < ActiveRecord::Migration
+  def change_assessment_email_key(old_key, new_key)
+    ActsAsTenant.without_tenant do
+      Course.all.each do |course|
+        course.settings.course_assessments_component&.each do |category_id, value|
+          next unless value['emails'] && !value['emails'][old_key].nil?
+          settings = course.settings(:course_assessments_component, category_id, :emails)
+          settings.public_send("#{new_key}=", value['emails'][old_key])
+          settings.public_send("#{old_key}=", nil)
+          course.save!
+        end
+      end
+    end
+  end
+
+  def up
+    change_assessment_email_key('assessment_opened', 'assessment_opening')
+  end
+
+  def down
+    change_assessment_email_key('assessment_opening', 'assessment_opened')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170706030838) do
+ActiveRecord::Schema.define(version: 20170720071725) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/mailers/course/mailer_spec.rb
+++ b/spec/mailers/course/mailer_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe Course::Mailer, type: :mailer do
       it 'sets the correct subject' do
         expect(subject.subject).to eq(I18n.t('course.mailer.user_registered_email.subject'))
       end
+
+      context 'when email notification for new enrol request is disabled' do
+        before do
+          context = OpenStruct.new(key: Course::UsersComponent.key, current_course: course)
+          Course::Settings::UsersComponent.new(context).
+            update_email_setting('key' => 'new_enrol_request', 'enabled' => false)
+          course.save!
+        end
+
+        it 'does not send an email notification' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
     end
   end
 end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -418,7 +418,7 @@ RSpec.describe Course::Assessment::Submission do
         before do
           context = OpenStruct.new(key: Course::AssessmentsComponent.key, current_course: course)
           setting = {
-            'key' => 'new_grading', 'enabled' => false,
+            'key' => 'grades_released', 'enabled' => false,
             'options' => { 'category_id' => assessment.tab.category.id }
           }
           Course::Settings::AssessmentsComponent.new(context).update_email_setting(setting)

--- a/spec/models/course/settings/assessments_component_spec.rb
+++ b/spec/models/course/settings/assessments_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Course::Settings::AssessmentsComponent do
       subject { settings.update_email_setting(payload) && course.save! }
 
       context 'when all arguments are valid' do
-        let(:key) { :new_grading }
+        let(:key) { :grades_released }
         before { subject }
 
         it 'persists the setting' do


### PR DESCRIPTION
Fixes #1688. Fixes #2366.

- The "New Phantom Submission" emails setting depends on the "New Submission" setting. It is possible to disable the "New Phantom Submission" toggle when "New Submission" is disabled, but I don't think the benefit of doing that justifies the cost. Instead, I put the caveat in the setting description.
- Decided not to implement v1's "New Student" email setting (Notify students when their enrolment request is approved). Is there a use case for disabling this notification?
- It is possible to have separate settings for assessment comments and annotations, but I think it makes more sense to keep them combined. Also, each assessment category has quite a few settings already and the list of settings is rather long if there is more than one category.
- After this PR, all settings for courses imported from v1 should have all their settings (except "New Student") exposed via the notification settings page.
- The reason why I used the key `assessment_opened` instead of `assessment_opening` for the migration was that assessment opening happens after the assessment has opened (hence the past tense), but assessment closing notification happens a day before it actually closes. Have renamed this to follow the current convention to avoid confusion.