### PR TITLE
Replace `try` with safe navigation operator.

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -22,7 +22,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     authorize!(:manage, @assessment)
     @assessment = @assessment.calculated(:maximum_grade)
     @submissions = @submissions.includes(:answers)
-    @my_students = current_course_user.try(:my_students) || []
+    @my_students = current_course_user&.my_students || []
     @course_students = current_course.course_users.students.order_alphabetically
     if params[:published_success]
       flash.now[:success] = t('course.assessment.submission.submissions.publish_all.success')
@@ -58,7 +58,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   # Reload answer to either its latest status or to a fresh answer, depending on parameters.
   def reload_answer
     @answer = @submission.answers.find_by(id: reload_answer_params[:answer_id])
-    @current_question = @answer.try(:question)
+    @current_question = @answer&.question
 
     if @answer.nil?
       head :bad_request

--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -106,7 +106,7 @@ class Course::Forum::ForumsController < Course::Forum::Controller
   end
 
   def add_forum_item_breadcrumb
-    add_breadcrumb @forum.name, course_forum_path(current_course, @forum) if @forum.try(:persisted?)
+    add_breadcrumb @forum.name, course_forum_path(current_course, @forum) if @forum&.persisted?
   end
 
   def skip_load_forum?

--- a/app/controllers/course/forum/topics_controller.rb
+++ b/app/controllers/course/forum/topics_controller.rb
@@ -72,7 +72,7 @@ class Course::Forum::TopicsController < Course::Forum::ComponentController
 
   def add_topic_breadcrumb
     add_breadcrumb @topic.title, course_forum_topic_path(current_course, @forum,
-                                                         @topic) if @topic.try(:persisted?)
+                                                         @topic) if @topic&.persisted?
   end
 
   def mark_posts_read

--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -76,7 +76,7 @@ class Course::UserInvitationsController < Course::ComponentController
   # @return [Tempfile]
   # @return [Hash]
   def invitation_params
-    @invitation_params ||= course_user_invitation_params[:invitations_file].try(:tempfile) ||
+    @invitation_params ||= course_user_invitation_params[:invitations_file]&.tempfile ||
                            course_user_invitation_params[:invitations_attributes]
   end
 

--- a/app/helpers/application_cocoon_helper.rb
+++ b/app/helpers/application_cocoon_helper.rb
@@ -46,7 +46,7 @@ module ApplicationCocoonHelper
   #   @return [String]
   def link_to_add_association(name, form, association = nil, html_options = nil, &block)
     name, form, association, html_options = nil, name, form, association if block_given?
-    html_options = html_options.try(:dup) || {}
+    html_options = html_options&.dup || {}
     replace_cocoon_keys(html_options)
     super(*[name, form, association, html_options].compact, &block)
   end

--- a/app/helpers/application_widgets_helper.rb
+++ b/app/helpers/application_widgets_helper.rb
@@ -25,7 +25,7 @@ module ApplicationWidgetsHelper
     name, options, html_options = [nil, name, options] unless html_options
     options = [:new] + [*options] unless options.is_a?(String)
     block ||= proc { fa_icon 'file'.freeze }
-    resource_button(:new, 'btn-primary'.freeze, name || block, options, html_options.try(:dup))
+    resource_button(:new, 'btn-primary'.freeze, name || block, options, html_options&.dup)
   end
 
   # Create a +edit+ button.
@@ -53,7 +53,7 @@ module ApplicationWidgetsHelper
     name, options, html_options = [nil, name, options] unless html_options
     options = [:edit] + [*options] unless options.is_a?(String)
     block ||= proc { fa_icon 'edit'.freeze }
-    resource_button(:edit, 'btn-default'.freeze, name || block, options, html_options.try(:dup))
+    resource_button(:edit, 'btn-default'.freeze, name || block, options, html_options&.dup)
   end
 
   # Create a +delete+ button.
@@ -81,7 +81,7 @@ module ApplicationWidgetsHelper
     name, options, html_options = [nil, name, options] unless html_options
     block ||= proc { fa_icon 'trash'.freeze }
 
-    html_options = html_options.try(:dup) || {}
+    html_options = html_options&.dup || {}
     html_options.reverse_merge!(method: :delete,
                                 data: { confirm: t('helpers.buttons.delete_confirm_message') })
     resource_button(:delete, 'btn-danger'.freeze, name || block, options, html_options)

--- a/app/helpers/course/assessment/answer/programming_test_case_helper.rb
+++ b/app/helpers/course/assessment/answer/programming_test_case_helper.rb
@@ -53,7 +53,7 @@ module Course::Assessment::Answer::ProgrammingTestCaseHelper
     results_hash = auto_grading ? auto_grading.test_results.group_by(&:test_case) : {}
     test_cases_by_type.each do |type, test_cases|
       test_cases_by_type[type] =
-        test_cases.map { |test_case| [test_case, results_hash[test_case].try(&:first)] }.
+        test_cases.map { |test_case| [test_case, results_hash[test_case]&.first] }.
         sort_by { |test_case, _| test_case.identifier }.to_h
     end
   end

--- a/app/models/concerns/user_omniauth_facebook_concern.rb
+++ b/app/models/concerns/user_omniauth_facebook_concern.rb
@@ -7,7 +7,7 @@ module UserOmniauthFacebookConcern
     # This is a override of `Devise::Models::Registerable::ClassMethods#new_with_session`
     def new_with_session(params, session)
       super.tap do |user|
-        facebook_data = session['devise.facebook_data'].try(:deep_symbolize_keys)
+        facebook_data = session['devise.facebook_data']&.deep_symbolize_keys
         if facebook_data && (info = facebook_data[:info])
           user.name ||= info[:name] if info[:name]
           user.email ||= info[:email] if info[:email]

--- a/app/services/course/assessment/question/programming/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming/python/python_package_service.rb
@@ -91,7 +91,7 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
     if @old_meta.present?
       package.unzip_file @tmp_dir
 
-      @old_meta['data_files'].try(:each) do |file|
+      @old_meta['data_files']&.each do |file|
         next if data_files_to_delete.try(:include?, (file['filename']))
         # new files overrides old ones
         next if new_data_filenames.include?(file['filename'])
@@ -161,7 +161,7 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
     end
 
     Zip::File.open(tmp.path) do |zip|
-      @test_params[:data_files].try(:each) do |file|
+      @test_params[:data_files]&.each do |file|
         next if file.nil?
         zip.add(file.original_filename, file.tempfile.path)
       end

--- a/app/views/course/assessment/answer/_autograded.html.slim
+++ b/app/views/course/assessment/answer/_autograded.html.slim
@@ -5,7 +5,7 @@
         = link_to_reset_answer(answer)
       = base_answer_form.button :button, t('common.submit'), value: answer.id,
           name: 'answer_id', class: ['btn-danger', 'submit-answer']
-  - elsif answer.submitted? && job = answer.try(:auto_grading).try(:job)
+  - elsif answer.submitted? && job = answer&.auto_grading&.job
     - if job.errored?
       p.bg-danger = t('.error')
       = base_answer_form.button :button, t('common.submit'), value: answer.id,

--- a/app/views/course/assessment/answer/_manually_graded.html.slim
+++ b/app/views/course/assessment/answer/_manually_graded.html.slim
@@ -27,7 +27,7 @@
                                              class: ['submit-answer', 'btn-danger'],
                                              title: t('.run_code_evaluation_warning'),
                                              disabled: !enable_submit_button?(programming_answer)
-  - elsif answer.submitted? && job = answer.try(:auto_grading).try(:job)
+  - elsif answer.submitted? && job = answer&.auto_grading&.job
     - if job.errored?
       p.bg-danger = t('.error')
       = base_answer_form.button :button, button_text, value: answer.id, name: 'answer_id', class: ['submit-answer', 'btn-danger']

--- a/app/views/course/assessment/answer/programming/_test_cases.html.slim
+++ b/app/views/course/assessment/answer/programming/_test_cases.html.slim
@@ -7,7 +7,7 @@
 / Test case results table
 h3 = t('.test_cases')
 
-- if !submission.attempting? && auto_grading.try(:job).try(:submitted?)
+- if !submission.attempting? && auto_grading&.job&.submitted?
   div.alert.alert-warning
     => fa_icon 'exclamation'
     = t('.evaluation_warning')

--- a/app/views/course/assessment/submission/submissions/_statistics.html.slim
+++ b/app/views/course/assessment/submission/submissions/_statistics.html.slim
@@ -85,7 +85,7 @@ div.panel.panel-default
           - answer_by_question = \
               @submission.answers.latest_answers.includes(:grader).group_by(&:question)
           - @submission.assessment.questions.each do |question|
-            - answer = answer_by_question[question].try(:first)
+            - answer = answer_by_question[question]&.first
             tr
               th = format_inline_text(question.display_title)
               - if show_graders

--- a/app/views/course/video/videos/_video_lesson_plan_item.json.jbuilder
+++ b/app/views/course/video/videos/_video_lesson_plan_item.json.jbuilder
@@ -4,5 +4,5 @@ json.item_path course_videos_path(current_course)
 json.description item.description
 json.edit_path edit_course_video_path(current_course, item) if can?(:update, item)
 json.delete_path course_video_path(current_course, item) if can?(:destroy, item)
-type = current_component_host[:course_videos_component].try(:title) || t('components.video.name')
+type = current_component_host[:course_videos_component]&.title || t('components.video.name')
 json.lesson_plan_item_type [type]

--- a/lib/autoload/course/assessment/programming_package.rb
+++ b/lib/autoload/course/assessment/programming_package.rb
@@ -186,7 +186,7 @@ class Course::Assessment::ProgrammingPackage
     if @path
       @file = Zip::File.open(@path.to_s)
     elsif @stream
-      @file = Zip::File.new(@stream.try(:path), true, true)
+      @file = Zip::File.new(@stream&.path, true, true)
       @file.read_from_stream(@stream)
       @file.instance_variable_set(:@stored_entries, @file.instance_variable_get(:@entry_set).dup)
     end

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
 
     tab do
       category = course.assessment_categories.first
-      category.try(:tabs).try(:first) || build(:course_assessment_tab, course: course)
+      category&.tabs&.first || build(:course_assessment_tab, course: course)
     end
     title { generate(:course_assessment_assessment_name) }
     description { generate(:course_assessment_assessment_description) }

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
     describe '#invite' do
       def verify_existing_user(user)
         created_course_user = course.course_users.find do |course_user|
-          course_user.try(:user).try(:email) == user.email
+          course_user&.user&.email == user.email
         end
         expect(created_course_user).not_to be_nil
         expect(created_course_user.name).to eq(user.name)

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -2,7 +2,7 @@
 # Test group helpers for setting the tenant for tests.
 module ActsAsTenant::TestGroupHelpers
   def self.build_host(instance)
-    port = Capybara.current_session.try(:server).try(:port)
+    port = Capybara.current_session&.server&.port
     if port
       "http://#{instance.host}:#{port}"
     else


### PR DESCRIPTION
Not all use if `try` can be replaced with the safe navigation operator.

In particular:

1. Where it's a symbol rather than a method.
In `app/helpers/application_widgets_helper.rb`, do not try to replace `resource_name = resource.try(:model_name).try(:human) || object_name.humanize`
2. Where the functions need to take in parameters.
In `app/services/course/assessment/question/programming/python/python_package_service.rb`. Do not try to "fix" `next if data_files_to_delete.try(:include?, (file['filename']))`.