### PR TITLE
Preserve annotations across programming answer attempts

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -63,10 +63,10 @@ class Course::Assessment::Submission::SubmissionsController < \
     render json: { redirect_url: job_path(job.job) }
   end
 
-  # Reload answer to either its latest status or to a fresh answer, depending on parameters.
+  # Reload the current answer or reset it, depending on parameters.
+  # current_answer has the most recent copy of the answer.
   def reload_answer
     @answer = @submission.answers.find_by(id: reload_answer_params[:answer_id])
-    @current_question = @answer&.question
 
     if @answer.nil?
       head :bad_request
@@ -74,7 +74,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     elsif reload_answer_params[:reset_answer]
       @new_answer = @answer.reset_answer
     else
-      @new_answer = @submission.answers.from_question(@current_question.id).last
+      @new_answer = @answer
     end
 
     respond_to do |format|
@@ -184,8 +184,7 @@ class Course::Assessment::Submission::SubmissionsController < \
 
     dead_answers.each do |a|
       old_job = a.auto_grading.job
-      job = a.auto_grade!(redirect_to_path: old_job.redirect_to,
-                          reattempt: true, reduce_priority: true)
+      job = a.auto_grade!(redirect_to_path: old_job.redirect_to, reduce_priority: true)
 
       logger.debug(message: 'Restart Answer Grading', answer_id: a.id, job_id: job.job.id,
                    old_job_id: old_job.id)

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -172,7 +172,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   def check_zombie_jobs # rubocop:disable MethodLength, Metrics/AbcSize
     return unless @submission.attempting?
 
-    submitted_answers = @submission.latest_answers.select(&:submitted?)
+    submitted_answers = @submission.answers.latest_answers.select(&:submitted?)
     return if submitted_answers.empty?
 
     dead_answers = submitted_answers.select do |a|

--- a/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
@@ -31,7 +31,8 @@ module Course::Assessment::Submission::SubmissionsAutogradedHelper
     return 'completed' if step <= max_step
   end
 
+  # Fallback to the last answer if current_answer flag is not set on any answer.
   def current_answer
-    @answers.last
+    @answers.find { |ans| ans.current_answer == true } || @answers.last
   end
 end

--- a/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
@@ -30,9 +30,4 @@ module Course::Assessment::Submission::SubmissionsAutogradedHelper
     return 'disabled' if step > max_step
     return 'completed' if step <= max_step
   end
-
-  # Fallback to the last answer if current_answer flag is not set on any answer.
-  def current_answer
-    @answers.find { |ans| ans.current_answer == true } || @answers.last
-  end
 end

--- a/app/helpers/course/assessment/submission/submissions_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_helper.rb
@@ -13,14 +13,24 @@ module Course::Assessment::Submission::SubmissionsHelper
     "course_assessment_submission_question_#{submission_question.id}_comments"
   end
 
-  # Return the last attempted answer based on the status of current submission.
-  # previous attempt if submission is in attempting state.
-  # current attempt if submission is in submitted, graded or published state.
+  # Return the last non-current attempt if the submission is being attempted,
+  # or the current_answer if it's in other states.
+  # If there are no non-current attempts, just return the current attempt.
+  #
+  # The last non-current attempt contains the most recent autograding result if the submission is
+  # being attempted.
+  # When the submission is finalised, current_answer contains the autograding result.
   #
   # @return [Course::Assessment::Answer]
   def last_attempt(answer)
     submission = answer.submission
+
     attempts = submission.answers.from_question(answer.question_id)
-    submission.attempting? ? attempts[-2] : attempts[-1]
+    last_non_current_answer = attempts.reject(&:current_answer?).last
+    current_answer = attempts.find(&:current_answer?)
+    # Fallback to last attempt if none of the attempts have been autograded.
+    latest_attempt = last_non_current_answer || attempts.last
+
+    submission.attempting? ? latest_attempt : current_answer
   end
 end

--- a/app/jobs/course/assessment/answer/auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/auto_grading_job.rb
@@ -18,10 +18,9 @@ class Course::Assessment::Answer::AutoGradingJob < ApplicationJob
   #   finished.
   # @param [Course::Assessment::Answer] answer the answer to be graded.
   # @param [String] redirect_to_path The path to redirect when job finishes.
-  # @param [Boolean] reattempt Whether to create new answer based on current answer after grading.
-  def perform_tracked(answer, redirect_to_path = nil, reattempt = false)
+  def perform_tracked(answer, redirect_to_path = nil)
     ActsAsTenant.without_tenant do
-      Course::Assessment::Answer::AutoGradingService.grade(answer, reattempt)
+      Course::Assessment::Answer::AutoGradingService.grade(answer)
     end
 
     redirect_to redirect_to_path

--- a/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
@@ -23,10 +23,9 @@ class Course::Assessment::Answer::ReducePriorityAutoGradingJob < ApplicationJob
   #   finished.
   # @param [Course::Assessment::Answer] answer the answer to be graded.
   # @param [String] redirect_to_path The path to redirect when job finishes.
-  # @param [Boolean] reattempt Whether to create new answer based on current answer after grading.
-  def perform_tracked(answer, redirect_to_path = nil, reattempt = false)
+  def perform_tracked(answer, redirect_to_path = nil)
     ActsAsTenant.without_tenant do
-      Course::Assessment::Answer::AutoGradingService.grade(answer, reattempt)
+      Course::Assessment::Answer::AutoGradingService.grade(answer)
     end
 
     redirect_to redirect_to_path

--- a/app/models/concerns/course/assessment/questions_concern.rb
+++ b/app/models/concerns/course/assessment/questions_concern.rb
@@ -2,9 +2,9 @@
 module Course::Assessment::QuestionsConcern
   extend ActiveSupport::Concern
 
-  # Attempts the given set of questions.
+  # Attempts the questions in the given submission without a current_answer.
   #
-  # This will create answers for questions without any answers which are not being attempted, and
+  # This will create answers for questions without any current_answer, and
   # return them in the same order as specified.
   #
   # @param [Course::Assessment::Submission] submission The submission which will contain the
@@ -12,13 +12,10 @@ module Course::Assessment::QuestionsConcern
   # @return [Array<Course::Assessment::Answer>] The answers for the questions, in the same order
   #   specified. Newly initialized answers will not be persisted.
   def attempt(submission)
-    attempting_answers = submission.answers.latest_answers.
-                         merge(submission.answers.with_attempting_state).
-                         where(question: self).
-                         map { |answer| [answer.question, answer] }.to_h
+    current_answers = submission.current_answers.map { |answer| [answer.question, answer] }.to_h
 
     map do |question|
-      attempting_answers.fetch(question) { question.attempt(submission) }
+      current_answers.fetch(question) { question.attempt(submission) }
     end
   end
 

--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -7,12 +7,12 @@ module Course::Assessment::Submission::AnswersConcern
     unscope(:order).select('DISTINCT ON (question_id) *').order(:question_id, created_at: :desc)
   end
 
-  # Load the answers of specific question.
+  # Load the answers belonging to a specific question.
+  #
+  # Keep this as a scope so the freshest data will be fetched from the database even if the
+  # CollectionProxy does not have the freshest data.
+  # Do not "optimise" by using `select` on the existing CollectionProxy or MCQ results will break.
   def from_question(question_id)
-    if loaded?
-      select { |a| a.question_id == question_id }
-    else
-      where(question_id: question_id)
-    end
+    where(question_id: question_id)
   end
 end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -10,10 +10,10 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
   # Handles the finalisation of a submission.
   #
-  # This finalises all latest answers as well.
+  # This finalises all current answers as well.
   def finalise(_ = nil)
     self.submitted_at = Time.zone.now
-    latest_answers.select(&:attempting?).each(&:finalise!)
+    current_answers.select(&:attempting?).each(&:finalise!)
   end
 
   # Handles the marking of a submission.
@@ -49,7 +49,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
     # Skip the state validation in answers.
     @unsubmitting = true
 
-    unsubmit_latest_answers
+    unsubmit_current_answers
     self.points_awarded = nil
     self.draft_points_awarded = nil
     self.awarded_at = nil
@@ -82,8 +82,8 @@ module Course::Assessment::Submission::WorkflowEventConcern
     end
   end
 
-  def unsubmit_latest_answers
-    latest_answers.each do |answer|
+  def unsubmit_current_answers
+    current_answers.each do |answer|
       answer.unsubmit! unless answer.attempting?
     end
   end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -166,12 +166,21 @@ class Course::Assessment::Submission < ActiveRecord::Base
 
   # The total grade of the submission
   def grade
-    latest_answers.map { |a| a.grade || 0 }.sum
+    current_answers.map { |a| a.grade || 0 }.sum
   end
 
-  # The latest answer is last answer of the question, ordered by created_at.
+  # The latest answer is the last answer of the question, ordered by created_at.
   def latest_answers
     answers.group_by(&:question_id).map { |pair| pair[1].last }
+  end
+
+  # The answers with current_answer flag set to true.
+  #
+  # If there are multiple current_answers for a particular question, return the first one.
+  # This guards against a race condition creating multiple current_answers for a given
+  # question in load_or_create_answers.
+  def current_answers
+    answers.select(&:current_answer?).group_by(&:question_id).map { |pair| pair[1].first }
   end
 
   # Returns all graded answers of the question in current submission.

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -169,11 +169,6 @@ class Course::Assessment::Submission < ActiveRecord::Base
     current_answers.map { |a| a.grade || 0 }.sum
   end
 
-  # The latest answer is the last answer of the question, ordered by created_at.
-  def latest_answers
-    answers.group_by(&:question_id).map { |pair| pair[1].last }
-  end
-
   # The answers with current_answer flag set to true.
   #
   # If there are multiple current_answers for a particular question, return the first one.

--- a/app/services/course/assessment/submission/auto_grading_service.rb
+++ b/app/services/course/assessment/submission/auto_grading_service.rb
@@ -88,9 +88,10 @@ class Course::Assessment::Submission::AutoGradingService
     submission.publish!
   end
 
-  # Gets the ungraded answers for the given submission
+  # Gets the ungraded answers for the given submission.
+  # When the submission is being graded, the `current_answers` are the ones to grade.
   def ungraded_answers(submission)
-    submission.reload.latest_answers.select { |a| a.attempting? || a.submitted? }
+    submission.reload.current_answers.select { |a| a.attempting? || a.submitted? }
   end
 
   # Calculating scheme:

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -161,9 +161,8 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
     if job
       render json: { redirect_url: job_path(job.job) }
     else
-      current_question = answer&.question
-      new_answer = @submission.answers.from_question(current_question.id).last
-      render new_answer
+      # Render the current_answer.
+      render answer
     end
   end
 

--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -13,14 +13,14 @@ json.fields do
   end
 end
 
-if answer.submitted? && job = answer&.auto_grading&.job
+if last_attempt.submitted? && job = last_attempt&.auto_grading&.job
   json.autograding do
     json.path job_path(job) if job.submitted?
     json.status job.status
   end
 end
 
-if answer.submitted? && !answer.auto_grading
+if last_attempt.submitted? && !last_attempt.auto_grading
   json.autograding do
     json.status :submitted
   end

--- a/app/views/course/assessment/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/edit.json.jbuilder
@@ -20,7 +20,7 @@ json.assessment do
   json.categoryId @assessment.tab.category_id
 end
 
-answers = @submission.latest_answers
+answers = @submission.current_answers
 
 json.partial! 'questions', assessment: @assessment, submission: @submission, can_grade: can_grade,
                            answers: answers

--- a/client/app/bundles/course/assessment/submission/reducers/explanations.js
+++ b/client/app/bundles/course/assessment/submission/reducers/explanations.js
@@ -26,6 +26,15 @@ export default function (state = {}, action) {
         return obj;
       }, { [questionId]: action.payload.explanation });
     }
+    case actions.AUTOGRADE_FAILURE: {
+      const { questionId } = action;
+      return {
+        ...state,
+        [questionId]: { correct: null,
+          explanations: [],
+        },
+      };
+    }
     default:
       return state;
   }

--- a/client/app/bundles/course/assessment/submission/reducers/testCases.js
+++ b/client/app/bundles/course/assessment/submission/reducers/testCases.js
@@ -26,6 +26,30 @@ export default function (state = {}, action) {
         return obj;
       }, { [questionId]: action.payload.testCases });
     }
+    case actions.AUTOGRADE_FAILURE: {
+      // Clear the previous test results in the test case results display.
+      const { questionId } = action;
+
+      const questionState = {};
+      // For each test case in each test type, add back the data without the output
+      // and passed values.
+      Object.keys(state[questionId]).forEach((testType) => {
+        if (testType !== 'stdout' && testType !== 'stderr') {
+          questionState[testType] = state[questionId][testType].map(testCase =>
+            ({
+              identifier: testCase.identifier,
+              expression: testCase.expression,
+              expected: testCase.expected,
+            })
+          );
+        }
+      });
+
+      return {
+        ...state,
+        [questionId]: questionState,
+      };
+    }
     default:
       return state;
   }

--- a/db/migrate/20170720080032_add_current_answer_to_course_assessment_answers.rb
+++ b/db/migrate/20170720080032_add_current_answer_to_course_assessment_answers.rb
@@ -1,0 +1,28 @@
+class AddCurrentAnswerToCourseAssessmentAnswers < ActiveRecord::Migration
+  def change
+    add_column :course_assessment_answers, :current_answer, :boolean, null: false, default: false
+
+    reversible do |dir|
+      dir.up { set_current_answers }
+      dir.down {}
+    end
+  end
+
+  # Take the latest created_at answer as the current_answer.
+  def set_current_answers
+    execute <<-SQL
+      WITH current_answers AS (
+        WITH max_created_table AS (
+          SELECT MAX(created_at) AS max_created_at, submission_id, question_id FROM course_assessment_answers
+          GROUP BY submission_id, question_id
+        )
+        SELECT id FROM course_assessment_answers, max_created_table
+          WHERE course_assessment_answers.created_at = max_created_table.max_created_at
+          AND course_assessment_answers.submission_id = max_created_table.submission_id
+          AND course_assessment_answers.question_id = max_created_table.question_id
+      )
+      UPDATE course_assessment_answers SET current_answer = true
+        FROM current_answers WHERE course_assessment_answers.id = current_answers.id
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -183,6 +183,7 @@ ActiveRecord::Schema.define(version: 20170915083041) do
     t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_assessment_answers_actable", :with=>["actable_id"], :unique=>true}
     t.integer  "submission_id",  :null=>false, :index=>{:name=>"fk__course_assessment_answers_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_answers_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "question_id",    :null=>false, :index=>{:name=>"fk__course_assessment_answers_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_answers_question_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.boolean  "current_answer", :default=>false, :null=>false
     t.string   "workflow_state", :limit=>255, :null=>false
     t.datetime "submitted_at"
     t.decimal  "grade",          :precision=>4, :scale=>1

--- a/spec/factories/course_assessment_answers.rb
+++ b/spec/factories/course_assessment_answers.rb
@@ -9,6 +9,8 @@ FactoryGirl.define do
       submission_traits []
     end
 
+    current_answer { false }
+
     submission do
       traits = *submission_traits
       options = traits.extract_options!

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -14,6 +14,11 @@ FactoryGirl.define do
     trait :attempting do
       after(:build) do |submission|
         submission.answers = submission.assessment.questions.attempt(submission)
+        # These are the first answers, so set their `current_answer` flag.
+        submission.answers.map do |answer|
+          answer.current_answer = true
+          answer.save!
+        end
       end
     end
 

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Course::Assessment do
     end
 
     def get_text_response_answer_for(submission)
-      submission.latest_answers.select do |ans|
+      submission.answers.latest_answers.select do |ans|
         ans.specific.class == Course::Assessment::Answer::TextResponse
       end.first.specific
     end

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -150,7 +150,11 @@ RSpec.describe Course::Assessment do
         context 'when some questions are being attempted' do
           before do
             assessment.questions.limit(1).attempt(submission).tap do |answers|
+              # In actual use, load_or_create_answers in the Submission update service sets
+              # current_answer to true.
+              answers.map { |ans| ans.current_answer = true }
               answers.each(&:save)
+              submission.answers << answers
             end
           end
 
@@ -163,7 +167,11 @@ RSpec.describe Course::Assessment do
         context 'when all questions are being attempted' do
           before do
             assessment.questions.attempt(submission).tap do |answers|
+              # In actual use, load_or_create_answers in the Submission update service sets
+              # current_answer to true.
+              answers.map { |ans| ans.current_answer = true }
               answers.each(&:save)
+              submission.answers << answers
             end
           end
 

--- a/spec/services/course/assessment/answer/auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/auto_grading_service_spec.rb
@@ -64,18 +64,6 @@ RSpec.describe Course::Assessment::Answer::AutoGradingService do
           expect(answer).to be_graded
         end
       end
-
-      context 'when reattempt is true' do
-        subject { Course::Assessment::Answer::AutoGradingService.grade(answer, true) }
-
-        context 'when submission state is submitted' do
-          let(:submission_traits) { :submitted }
-          it 'does not create a new attempting answer' do
-            subject
-            expect(submission.reload.latest_answers).to include(answer)
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Use a flag to determine if an answer is current_answer.
When student makes a new attempt, copy the current answer and grade that one instead.
Add in some logic to handle cases where the autograding job fails.
Submit/unsubmit only the current_answer when the submission is submitted/unsubmitted.

This cannot be decoupled from the frontend. The backend **MUST** provide consistent data to the frontend or there will be a huge mixup between `current_answer` and `latest_answer`. Students will wonder why they don't see their latest code and it'll be impossible to untangle the mess.

Fixes #2346.