### PR TITLE
Make the course count uniq

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -80,7 +80,7 @@ class Course < ActiveRecord::Base
     end
   end)
 
-  scope :active_in_past_7_days, -> { joins(:course_users).merge(CourseUser.active_in_past_7_days) }
+  scope :active_in_past_7_days, -> { joins(:course_users).merge(CourseUser.active_in_past_7_days).uniq }
 
   delegate :staff, to: :course_users
   delegate :instructors, to: :course_users

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -68,7 +68,7 @@ class Instance < ActiveRecord::Base
   # The number of active courses (in the past 7 days) in the instance.
   calculated :active_course_count, (lambda do
     Course.unscoped.active_in_past_7_days.where('courses.instance_id = instances.id').
-      select("count('*')")
+      select('count(distinct courses.id)')
   end)
 
   # @!attribute [r] course_count

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -101,8 +101,13 @@ RSpec.describe Instance do
   with_tenant(:instance) do
     describe '.active_course_count' do
       let!(:courses) { create_list(:course, 2, instance: instance) }
+      let(:active_course) { courses.sample }
       # Make one of the courses active
-      before { courses.first.course_users.first.update_column(:last_active_at, Time.zone.now) }
+      before do
+        # Create another course user to ensure the result is correct after after joins
+        create(:course_student, course: active_course)
+        active_course.course_users.update_all(last_active_at: Time.zone.now)
+      end
 
       subject { Instance.where(id: instance.id).calculated(:active_course_count).first }
 


### PR DESCRIPTION
A distinct count is required because there could be multiple rows after course joins course_users