### PR TITLE
Do not allow rich text request reasons

### DIFF
--- a/app/views/instance_user_role_requests/_form.html.slim
+++ b/app/views/instance_user_role_requests/_form.html.slim
@@ -5,6 +5,6 @@ p = t('.hint')
                    label: t('.role_label')
   = f.input :organization
   = f.input :designation
-  = f.input :reason
+  = f.input :reason, as: :string
 
   = f.button :submit, f.object.persisted? ? t('.edit_button') : t('.create_button')


### PR DESCRIPTION
Set the reason to normal string and disabled rich text editor.