### PR TITLE
Duplicate assessment emails settings

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -154,6 +154,7 @@ class Course < ActiveRecord::Base
     logo.duplicate_from(other.logo) if other.logo_url
 
     # This also duplicates assessments.
+    self.assessment_categories = duplicator.duplicate(other.assessment_categories)
     self.lesson_plan_items = duplicator.duplicate(other.lesson_plan_items.map(&:actable)).
                              map(&:acting_as)
     self.lesson_plan_milestones = duplicator.duplicate(other.lesson_plan_milestones)

--- a/spec/services/course/duplication/course_duplication_service_spec.rb
+++ b/spec/services/course/duplication/course_duplication_service_spec.rb
@@ -451,6 +451,30 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
           expect(new_attachment).to eq attachment
         end
       end
+
+      context 'when assessment categories have settings' do
+        let!(:categories) { create_list(:course_assessment_category, 2, course: course) }
+
+        before do
+          context = OpenStruct.new(key: Course::AssessmentsComponent.key, current_course: course)
+          settings_interface = Course::Settings::AssessmentsComponent.new(context)
+          course.assessment_categories.each do |category|
+            setting = {
+              'key' => 'new_comment', 'enabled' => false, 'options' => { 'category_id' => category.id }
+            }
+            settings_interface.update_email_setting(setting)
+          end
+          course.save!
+        end
+
+        it 'duplicates the settings' do
+          all_new_comment_emails_disabled = new_course.assessment_categories.none? do |category|
+            Course::Settings::AssessmentsComponent.email_enabled?(category, :new_comment)
+          end
+
+          expect(all_new_comment_emails_disabled).to be(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The id's of each category are used as keys in the settings and need to be updated after the course has been persisted.