### PR TITLE
Allow assessments with no questions to be published.

### DIFF
--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -19,8 +19,6 @@ class Course::Assessment < ActiveRecord::Base
   # the flag to be cleared too early.
   after_commit :clear_duplication_flag
 
-  validate :validate_presence_of_questions, if: :published?
-
   belongs_to :tab, inverse_of: :assessments
 
   # `submissions` association must be put before `questions`, so that all answers will be deleted
@@ -171,10 +169,6 @@ class Course::Assessment < ActiveRecord::Base
   def set_defaults
     self.published = false
     self.autograded ||= false
-  end
-
-  def validate_presence_of_questions
-    errors.add(:published, :no_questions) unless questions.present?
   end
 
   def clear_duplication_flag

--- a/config/locales/en/activerecord/course/assessment.yml
+++ b/config/locales/en/activerecord/course/assessment.yml
@@ -3,7 +3,3 @@ en:
     attributes:
       course/assessment/assessment:
         title: 'Title'
-    errors:
-      models:
-        course/assessment:
-          no_questions: 'Assessment can only be published after adding questions'

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -33,13 +33,12 @@ RSpec.describe Course::Assessment do
     describe 'validations' do
       context 'when it is published' do
         context 'when it has no questions' do
+          # This used to be invalid, but some instructors create assessments to provide
+          # instructions for tasks outside of Coursemology.
+          #
+          # See https://github.com/Coursemology/coursemology2/issues/2387
           subject { build(:assessment, published: true) }
-
-          it 'adds a :no_questions error on :published' do
-            expect(subject.valid?).to be(false)
-            expect(subject.errors[:published]).to include(I18n.t('activerecord.errors.models.' \
-            'course/assessment.no_questions'))
-          end
+          it { is_expected.to be_valid }
         end
 
         context 'when it has questions' do


### PR DESCRIPTION
Supports use case where instructors use assessments to provide
instructions for tasks outside of Coursemology.

References #2387.

Redirect of 'Attempt' error will be implemented in a future PR.