### PR TITLE
Zhengwei/java autograder interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,7 +201,7 @@ gem 'rubyzip', require: 'zip'
 gem 'nokogiri', '>= 1.6.8'
 
 # Polyglot support
-gem 'coursemology-polyglot', '>= 0.1.0'
+gem 'coursemology-polyglot', '>= 0.2.9'
 
 # To assist with bulk inserts into database
 gem 'activerecord-import', '>= 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       url
     concurrent-ruby (1.0.5)
     consistency_fail (0.3.5)
-    coursemology-polyglot (0.2.7)
+    coursemology-polyglot (0.2.9)
       activesupport (~> 4.2.0, >= 4.2.2)
     crass (1.0.2)
     devise-multi_email (1.0.5)
@@ -580,7 +580,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   codecov
   consistency_fail
-  coursemology-polyglot (>= 0.1.0)
+  coursemology-polyglot (>= 0.2.9)
   devise!
   devise-multi_email (~> 1.0.5)
   devise_masquerade
@@ -652,6 +652,5 @@ DEPENDENCIES
   workflow
   yard
 
-
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/services/course/assessment/answer/programming_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_auto_grading_service.rb
@@ -109,7 +109,7 @@ class Course::Assessment::Answer::ProgrammingAutoGradingService < \
   # @return [Array<Course::Assessment::Question::ProgrammingTestCase>]
   def build_test_case_records_from_report(question, auto_grading, test_report)
     test_cases = question.test_cases.map { |test_case| [test_case.identifier, test_case] }.to_h
-    test_results = parse_test_report(test_report)
+    test_results = parse_test_report(question.language, test_report)
 
     test_results.map do |test_result|
       test_case = find_test_case(test_cases, test_result)
@@ -169,9 +169,15 @@ class Course::Assessment::Answer::ProgrammingAutoGradingService < \
 
   # Parses the test report for test cases and statuses.
   #
+  # @param [Coursemology::Polyglot::Language] lanugage The language of which the
+  #   test_report will be parsed based on
   # @param [String] test_report The test case report from evaluating the package.
   # @return [Array<>]
-  def parse_test_report(test_report)
-    Course::Assessment::ProgrammingTestCaseReport.new(test_report).test_cases
+  def parse_test_report(language, test_report)
+    if language.is_a?(Coursemology::Polyglot::Language::Java)
+      Course::Assessment::Java::JavaProgrammingTestCaseReport.new(test_report).test_cases
+    else
+      Course::Assessment::ProgrammingTestCaseReport.new(test_report).test_cases
+    end
   end
 end

--- a/app/services/course/assessment/question/programming/java/RunTests.java
+++ b/app/services/course/assessment/question/programming/java/RunTests.java
@@ -1,0 +1,33 @@
+import org.testng.TestNG;
+import org.testng.reporters.XMLReporter;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlTest;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RunTests {
+	public static void main(String[] args){
+		XMLReporter reporter = new XMLReporter();
+		reporter.getConfig().setGenerateTestResultAttributes(true);
+		reporter.getConfig().setOutputDirectory(".");
+
+		XmlSuite suite = new XmlSuite();
+		suite.setName("AllTests");
+
+		List<XmlClass> classes = new ArrayList<XmlClass>();
+		classes.add(new XmlClass("Autograder"));
+
+		XmlTest test = new XmlTest(suite);
+		test.setName("tests");
+		test.setXmlClasses(classes);
+
+		List<XmlSuite> suites = new ArrayList<XmlSuite>();
+		suites.add(suite);
+
+		TestNG testNG = new TestNG();
+		testNG.setXmlSuites(suites);
+		testNG.addListener(reporter);
+		testNG.run();
+	}
+}

--- a/app/services/course/assessment/question/programming/java/java_autograde_pre.java
+++ b/app/services/course/assessment/question/programming/java/java_autograde_pre.java
@@ -1,0 +1,213 @@
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeSuite;
+import org.testng.Reporter;
+import org.testng.ITestResult;
+import java.util.Arrays;
+
+public class Autograder {
+	// For standard byte, short, int, long comparisons - .equals() directly uses == to compare the values
+	// For float, double comparisons - .equals() returns true if a == b,
+	//									returns true for NaN values,
+	//									returns false for +0.0 and -0.0
+	void expectEquals(byte expression, byte expected) {
+		Assert.assertEquals((Byte) expression, (Byte) expected);
+	}
+
+	void expectEquals(byte expression, short expected) {
+		Assert.assertEquals((Short)(short) expression, (Short) expected);
+	}
+
+	void expectEquals(byte expression, int expected) {
+		Assert.assertEquals((Integer)(int) expression, (Integer) expected);
+	}
+
+	void expectEquals(byte expression, long expected) {
+		Assert.assertEquals((Long)(long) expression, (Long) expected);
+	}
+	
+	void expectEquals(byte expression, double expected) {
+		Assert.assertEquals((Double)(double) expression, (Double) expected);
+	}
+
+	void expectEquals(byte expression, float expected) {
+		Assert.assertEquals((Float)(float) expression, (Float) expected);
+	}
+
+	void expectEquals(short expression, byte expected) {
+		Assert.assertEquals((Short) expression, (Short)(short) expected);
+	}
+
+	void expectEquals(short expression, short expected) {
+		System.out.println("short, short");
+		Assert.assertEquals((Short) expression, (Short) expected);
+	}
+
+	void expectEquals(short expression, int expected) {
+		Assert.assertEquals((Integer)(int) expression, (Integer) expected);
+	}
+
+	void expectEquals(short expression, long expected) {
+		Assert.assertEquals((Long)(long) expression, (Long) expected);
+	}
+	
+	void expectEquals(short expression, double expected) {
+		Assert.assertEquals((Double)(double) expression, (Double) expected);
+	}
+
+	void expectEquals(short expression, float expected) {
+		Assert.assertEquals((Float)(float) expression, (Float) expected);
+	}
+
+	void expectEquals(int expression, byte expected) {
+		Assert.assertEquals((Integer) expression, (Integer)(int) expected);
+	}
+
+	void expectEquals(int expression, short expected) {
+		Assert.assertEquals((Integer) expression, (Integer)(int) expected);
+	}
+
+	void expectEquals(int expression, int expected) {
+		Assert.assertEquals((Integer) expression, (Integer) expected);
+	}
+
+	void expectEquals(int expression, long expected) {
+		Assert.assertEquals((Long)(long) expression, (Long) expected);
+	}
+	
+	void expectEquals(int expression, double expected) {
+		Assert.assertEquals((Double)(double) expression, (Double) expected);
+	}
+
+	void expectEquals(int expression, float expected) {
+		Assert.assertEquals((Float)(float) expression, (Float) expected);
+	}
+
+	void expectEquals(long expression, byte expected) {
+		Assert.assertEquals((Long) expression, (Long)(long) expected);
+	}
+
+	void expectEquals(long expression, short expected) {
+		Assert.assertEquals((Long) expression, (Long)(long) expected);
+	}
+
+	void expectEquals(long expression, int expected) {
+		Assert.assertEquals((Long) expression, (Long)(long) expected);
+	}
+
+	void expectEquals(long expression, long expected) {
+		Assert.assertEquals((Long) expression, (Long) expected);
+	}
+	
+	void expectEquals(long expression, double expected) {
+		Assert.assertEquals((Double)(double) expression, (Double) expected);
+	}
+
+	void expectEquals(long expression, float expected) {
+		Assert.assertEquals((Double)(double) expression, (Double)(double) expected);
+	}
+
+	void expectEquals(double expression, byte expected) {
+		Assert.assertEquals((Double) expression, (Double)(double) expected);
+	}
+
+	void expectEquals(double expression, short expected) {
+		Assert.assertEquals((Double) expression, (Double)(double) expected);
+	}
+
+	void expectEquals(double expression, int expected) {
+		Assert.assertEquals((Double) expression, (Double)(double) expected);
+	}
+
+	void expectEquals(double expression, long expected) {
+		Assert.assertEquals((Double) expression, (Double)(double) expected);
+	}
+	
+	void expectEquals(double expression, double expected) {
+		Assert.assertEquals((Double) expression, (Double) expected);
+	}
+
+	void expectEquals(double expression, float expected) {
+		Assert.assertEquals((Double) expression, (Double)(double) expected);
+	}
+
+	void expectEquals(float expression, byte expected) {
+		Assert.assertEquals((Float) expression, (Float)(float) expected);
+	}
+
+	void expectEquals(float expression, short expected) {
+		Assert.assertEquals((Float) expression, (Float)(float) expected);
+	}
+
+	void expectEquals(float expression, int expected) {
+		Assert.assertEquals((Float) expression, (Float)(float) expected);
+	}
+
+	void expectEquals(float expression, long expected) {
+		Assert.assertEquals((Double)(double) expression, (Double)(double) expected);
+	}
+	
+	void expectEquals(float expression, double expected) {
+		Assert.assertEquals((Double)(double) expression, (Double) expected);
+	}
+
+	void expectEquals(float expression, float expected) {
+		Assert.assertEquals((Float) expression, (Float) expected);
+	}
+
+	void expectEquals(char expression, char expected) {
+		Assert.assertEquals((Character) expression, (Character) expected);
+	}
+
+	void expectEquals(boolean expression, boolean expected) {
+		Assert.assertEquals((Boolean) expression, (Boolean) expected);
+	}
+
+	void expectEquals(Object expression, Object expected) {
+		Assert.assertEquals(expression, expected);
+	}
+
+	String printValue(Object val) {
+		return String.valueOf(val);
+	}
+
+	String printValue(byte [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(short [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(int [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(long [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(double [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(float [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(char [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(boolean [] val) {
+		return Arrays.toString(val);
+	}
+
+	String printValue(Object [] val) {
+		return Arrays.toString(val);
+	}
+
+	void setAttribute(String field, String message) {
+		ITestResult res = Reporter.getCurrentTestResult();
+		res.setAttribute(field, message);
+	}

--- a/app/services/course/assessment/question/programming/java/java_build.xml
+++ b/app/services/course/assessment/question/programming/java/java_build.xml
@@ -1,0 +1,69 @@
+<project name="testng">
+	<property name="build" value="./build"></property>
+	<property name="test" value="./tests"></property>
+	<property name="src" value="./submission"></property>
+	<property name="soln" value="./solution"></property>
+	<property name="aux" value="."></property>
+	<property name="lib" value="./../lib"></property>
+
+	<path id="classpath">
+		<pathelement location="${build}"/>
+		<fileset dir="${lib}">
+			<include name="jcommander-1.72.jar"/>
+			<include name="testng-6.11.jar" />
+		</fileset>
+	</path>
+
+	<target name="aux-compile">
+		<mkdir dir="${aux}"/>
+		<mkdir dir="${build}"/>
+		<javac srcdir="${aux}" destdir="${build}" includes="*.java" includeantruntime="false"/>
+	</target>
+
+	<!-- To compile the submission files -->
+	<target name="src-compile" depends="aux-compile">
+		<mkdir dir="${build}"/>
+		<javac srcdir="${src}" destdir="${build}" includeantruntime="false">
+			<classpath refid="classpath"></classpath>
+		</javac>
+	</target>
+
+	<target name="test-compile" depends="src-compile">
+		<mkdir dir="${build}"/>
+		<javac srcdir="${test}" destdir="${build}" includeantruntime="false">
+		    <classpath refid="classpath"></classpath>
+		</javac>
+	</target>
+
+	<taskdef name="testng" classname="org.testng.TestNGAntTask" classpathref="classpath"></taskdef>
+
+	<target name="testng" depends="test-compile">
+		<java classname="RunTests">
+			<classpath refid="classpath"></classpath>
+		</java>
+	</target>
+
+
+	<!-- To compile the solution files -->
+	<target name="sol-compile" depends="aux-compile">
+		<mkdir dir="${build}"/>
+		<javac srcdir="${soln}" destdir="${build}" includeantruntime="false">
+		    <classpath refid="classpath"></classpath>
+		</javac>
+	</target>
+
+	<target name="testsol-compile" depends="sol-compile">
+		<mkdir dir="${build}"/>
+		<javac srcdir="${test}" destdir="${build}" includeantruntime="false">
+		    <classpath refid="classpath"></classpath>
+		</javac>
+	</target>
+
+	<taskdef name="testng-sol" classname="org.testng.TestNGAntTask" classpathref="classpath"></taskdef>
+
+	<target name="testng-sol" depends="testsol-compile">
+		<java classname="RunTests">
+			<classpath refid="classpath"></classpath>
+		</java>
+	</target>
+</project>

--- a/app/services/course/assessment/question/programming/java/java_package_service.rb
+++ b/app/services/course/assessment/question/programming/java/java_package_service.rb
@@ -1,0 +1,350 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::Programming::Java::JavaPackageService < \
+  Course::Assessment::Question::Programming::LanguagePackageService
+
+  def initialize(params)
+    @test_params = test_params params if params.present?
+  end
+
+  def submission_templates
+    if submit_as_file?
+      templates = []
+      @test_params[:submission_files].map do |file|
+        template_file = { filename: file.original_filename, content: File.read(file.tempfile.path) }
+        templates.push(template_file)
+      end
+
+      templates
+    else
+      [
+        filename: 'template',
+        content: @test_params[:submission] || ''
+      ]
+    end
+  end
+
+  def generate_package(old_attachment)
+    return nil if @test_params.blank?
+    @tmp_dir = Dir.mktmpdir
+    @old_meta = old_attachment.present? ? extract_meta(old_attachment, nil) : nil
+    data_files_to_keep = old_attachment.present? ? find_files_to_keep('data_files', old_attachment) : []
+    submission_files_to_keep = old_attachment.present? ? find_files_to_keep('submission_files', old_attachment) : []
+    solution_files_to_keep = old_attachment.present? ? find_files_to_keep('solution_files', old_attachment) : []
+    @meta = generate_meta(data_files_to_keep, submission_files_to_keep, solution_files_to_keep)
+
+    return nil if @meta == @old_meta
+
+    @attachment = generate_zip_file(data_files_to_keep, submission_files_to_keep, solution_files_to_keep)
+    FileUtils.remove_entry @tmp_dir if @tmp_dir.present?
+    @attachment
+  end
+
+  def extract_meta(attachment, template_files)
+    return @meta if @meta.present? && attachment == @attachment
+
+    # attachment will be nil if the question is not autograded, in that case the meta data will be
+    # generated from the template files in the database.
+    return generate_non_autograded_meta(template_files) if attachment.nil?
+
+    extract_autograded_meta(attachment)
+  end
+
+  private
+
+  def extract_autograded_meta(attachment)
+    attachment.open(binmode: true) do |temporary_file|
+      begin
+        package = Course::Assessment::ProgrammingPackage.new(temporary_file)
+        meta = package.meta_file
+        @old_meta = meta.present? ? JSON.parse(meta) : nil
+      ensure
+        next unless package
+        temporary_file.close
+      end
+    end
+  end
+
+  def generate_non_autograded_meta(template_files)
+    meta = default_meta
+
+    return meta if template_files.blank?
+
+    meta[:submission] = template_files
+
+    meta.as_json
+  end
+
+  def extract_from_package(package, file_type, new_filenames, files_to_delete)
+    files_to_keep = []
+
+    if @old_meta.present?
+      package.unzip_file @tmp_dir
+      @old_meta[file_type].try(:each) do |file|
+        next if files_to_delete.try(:include?, (file['filename']))
+        # new files overrides old ones
+        next if new_filenames.include?(file['filename'])
+        files_to_keep.append(File.new(File.join(resolve_folder_path(@tmp_dir, file_type), file['filename'])))
+      end
+    end
+
+    files_to_keep
+  end
+
+  def resolve_folder_path(tmp_dir, file_type)
+    if file_type == 'submission_files'
+      tmp_dir + '/submission'
+    elsif file_type == 'solution_files'
+      tmp_dir + '/solution'
+    # Data files do not need resolution
+    else
+      tmp_dir
+    end
+  end
+
+  def find_files_to_keep(file_type, attachment)
+    new_filenames = (@test_params[file_type] || []).reject(&:nil?).map(&:original_filename)
+
+    attachment.open(binmode: true) do |temporary_file|
+      begin
+        package = Course::Assessment::ProgrammingPackage.new(temporary_file)
+        files_to_delete = file_type + '_to_delete'
+        return extract_from_package(package, file_type, new_filenames, @test_params[files_to_delete])
+      ensure
+        next unless package
+        temporary_file.close
+      end
+    end
+  end
+
+  def generate_zip_file(data_files_to_keep, submission_files_to_keep, solution_files_to_keep)
+    tmp = Tempfile.new(['package', '.zip'])
+    autograde_build_path = File.join(File.expand_path(File.dirname(__FILE__)),
+                'java_build.xml').freeze
+    autograde_pre_path = File.join(File.expand_path(File.dirname(__FILE__)),
+                'java_autograde_pre.java').freeze
+    autograde_run_path = File.join(File.expand_path(File.dirname(__FILE__)),
+                'RunTests.java').freeze
+    makefile_path = File.join(File.expand_path(File.dirname(__FILE__)),
+                'java_simple_makefile').freeze
+    standard_makefile_path = File.join(File.expand_path(File.dirname(__FILE__)),
+                'java_standard_makefile').freeze
+
+    Zip::OutputStream.open(tmp.path) do |zip|
+      if submit_as_file?
+        # Creates Makefile for standard java files (submitted as whole file)
+        zip.put_next_entry 'Makefile'
+        zip.print File.read(standard_makefile_path)
+      else
+        generate_simple_submission_solution_files(zip)
+
+        # Creates Makefile for simple java files (submitted as template)
+        zip.put_next_entry 'Makefile'
+        zip.print File.read(makefile_path)
+      end
+
+      # Create JavaTest class file which is used to run the tests files
+      zip.put_next_entry 'tests/'
+      zip.put_next_entry 'tests/RunTests.java'
+      zip.print File.read(autograde_run_path)
+
+      # Create Autograder test file containing all the test functions
+      zip.put_next_entry 'tests/prepend'
+      zip.print @test_params[:prepend]
+      zip.print "\n"
+      zip.print File.read(autograde_pre_path)
+      zip.print "\n"
+
+      zip.put_next_entry 'tests/append'
+      zip.print @test_params[:append]
+      zip.print "\n"
+
+      zip.put_next_entry 'tests/autograde'
+      [:public, :private, :evaluation].each do |test_type|
+        zip_test_files(test_type, zip)
+      end
+      # To close up the Autograder class
+      zip.print '}'
+
+      # Creates ant build file
+      zip.put_next_entry 'build.xml'
+      zip.print File.read(autograde_build_path)
+
+      zip.put_next_entry '.meta'
+      zip.print @meta.to_json
+    end
+
+    Zip::File.open(tmp.path) do |zip|
+      # @test_params should have the [:submission_files] key if submitted as a file
+      if submit_as_file?
+        generate_standard_submission_solution_files(zip, submission_files_to_keep, solution_files_to_keep)
+      end
+
+      @test_params[:data_files].try(:each) do |file|
+        next if file.nil?
+        zip.add(file.original_filename, file.tempfile.path)
+      end
+
+      data_files_to_keep.each do |file|
+        zip.add(File.basename(file.path), file.path)
+      end
+    end
+
+    tmp
+  end
+
+  # Used to generate submission and solution template files for simple java implementation
+  # (Submitted as template files)
+  def generate_simple_submission_solution_files(zip)
+    # Create solution directory and create solution files
+    zip.put_next_entry 'solution/'
+    zip.put_next_entry 'solution/template'
+    zip.print @test_params[:solution]
+
+    # # Create submission directory with template file
+    zip.put_next_entry 'submission/'
+    zip.put_next_entry 'submission/template'
+    zip.print @test_params[:submission]
+    zip.print "\n"
+  end
+
+  # Used to generate submission and solution files for the regular java implementation
+  # (Submitted as whole files)
+  def generate_standard_submission_solution_files(zip, submission_files_to_keep, solution_files_to_keep)
+    zip.mkdir('submission')
+    @test_params[:submission_files].try(:each) do |file|
+      next if file.nil?
+      zip.add('submission/' + file.original_filename, file.tempfile.path)
+    end
+
+    submission_files_to_keep.each do |file|
+      zip.add('submission/' + File.basename(file.path), file.path)
+    end
+
+    zip.mkdir('solution')
+    @test_params[:solution_files].try(:each) do |file|
+      next if file.nil?
+      zip.add('solution/' + file.original_filename, file.tempfile.path)
+    end
+
+    solution_files_to_keep.each do |file|
+      zip.add('solution/' + File.basename(file.path), file.path)
+    end
+  end
+
+  def zip_test_files(test_type, zip) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    tests = @test_params[:test_cases]
+    tests[test_type]&.each&.with_index(1) do |test, index|
+      # String types should be displayed with quotes, other types will be converted to string
+      # with the str method.
+      expected = string?(test[:expected]) ? test[:expected].inspect : "#{test[:expected]}"
+      hint = test[:hint].blank? ? String(nil) : "result.setAttribute(\"hint\", #{test[:hint].inspect});"
+
+      test_fn = <<-Java
+        @Test
+        public void test_#{test_type}_#{format('%02i', index)}() {
+          ITestResult result = Reporter.getCurrentTestResult();
+          result.setAttribute("expression", #{test[:expression].inspect});
+          #{test[:inline_code]}
+          result.setAttribute("expected", printValue(#{test[:expected]}));
+          result.setAttribute("output", printValue(#{test[:expression]}));
+          #{hint}
+          expectEquals(#{test[:expression]}, #{test[:expected]});
+        }
+      Java
+
+      zip.print test_fn
+    end
+  end
+
+  def get_files_meta(files_to_keep, new_files)
+    files = []
+
+    new_files.each do |file|
+      sha256 = Digest::SHA256.file(file.tempfile).hexdigest
+      files.append(filename: file.original_filename, size: file.tempfile.size, hash: sha256)
+    end
+
+    files_to_keep.each do |file|
+      sha256 = Digest::SHA256.file(file).hexdigest
+      files.append(filename: File.basename(file.path), size: file.size, hash: sha256)
+    end
+
+    files.sort_by { |file| file[:filename].downcase }
+  end
+
+  def generate_meta(data_files_to_keep, submission_files_to_keep, solution_files_to_keep)
+    meta = default_meta
+
+    [:submission, :solution, :prepend, :append].each { |field| meta[field] = @test_params[field] }
+
+    new_data_files = (@test_params[:data_files] || []).reject(&:nil?)
+    meta[:data_files] = get_files_meta(data_files_to_keep, new_data_files)
+
+    meta[:submit_as_file] = submit_as_file?
+
+    new_submission_files = (@test_params[:submission_files] || []).reject(&:nil?)
+    meta[:submission_files] = get_files_meta(submission_files_to_keep, new_submission_files)
+
+    new_solution_files = (@test_params[:solution_files] || []).reject(&:nil?)
+    meta[:solution_files] = get_files_meta(solution_files_to_keep, new_solution_files)
+
+    [:public, :private, :evaluation].each do |test_type|
+      meta[:test_cases][test_type] = @test_params[:test_cases][test_type] || []
+    end
+
+    meta.as_json
+  end
+
+  # Defines the default meta to be used by the online editor for rendering.
+  #
+  # @return [Hash]
+  def default_meta
+    {
+      submission: '',
+      solution: '',
+      submit_as_file: false,
+      submission_files: [],
+      solution_files: [],
+      prepend: '',
+      append: '',
+      data_files: [],
+      test_cases: {
+        public: [],
+        private: [],
+        evaluation: []
+      }
+    }
+  end
+
+  # Permits the fields that are used to generate a the package for the language.
+  #
+  # @param [ActionController::Parameters] params The parameters containing the data for package
+  #   generation.
+  def test_params(params)
+    test_params = params.require(:question_programming).permit(
+      :prepend, :append, :autograded, :solution, :submission, :submit_as_file,
+      submission_files: [],
+      solution_files: [],
+      data_files: [],
+      test_cases: {
+        public: [:expression, :expected, :hint, :inline_code],
+        private: [:expression, :expected, :hint, :inline_code],
+        evaluation: [:expression, :expected, :hint, :inline_code]
+      }
+    )
+
+    whitelist(params, test_params)
+  end
+
+  def whitelist(params, test_params)
+    test_params.tap do |whitelisted|
+      whitelisted[:data_files_to_delete] = params['question_programming']['data_files_to_delete']
+      whitelisted[:submission_files_to_delete] = params['question_programming']['submission_files_to_delete']
+      whitelisted[:solution_files_to_delete] = params['question_programming']['solution_files_to_delete']
+    end
+  end
+
+  def submit_as_file?
+    @test_params[:submit_as_file] == 'true'
+  end
+end

--- a/app/services/course/assessment/question/programming/java/java_simple_makefile
+++ b/app/services/course/assessment/question/programming/java/java_simple_makefile
@@ -1,0 +1,21 @@
+prepare:
+
+compile:
+
+Autograder.java:
+	cat tests/prepend tests/append submission/template tests/autograde >> tests/Autograder.java
+
+test: Autograder.java
+	ant testng
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+solution:
+	ant testng-sol
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+clean:
+	rm -rf report.xml test-output build tests/Autograder.java
+
+.PHONY: prepare compile test solution clean

--- a/app/services/course/assessment/question/programming/java/java_standard_makefile
+++ b/app/services/course/assessment/question/programming/java/java_standard_makefile
@@ -1,0 +1,21 @@
+prepare:
+
+compile:
+
+Autograder.java:
+	cat tests/prepend tests/append tests/autograde >> tests/Autograder.java
+
+test: Autograder.java
+	ant testng
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+solution:
+	ant testng-sol
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+clean:
+	rm -rf report.xml test-output build tests/Autograder.java
+
+.PHONY: prepare compile test solution clean

--- a/app/services/course/assessment/question/programming/programming_package_service.rb
+++ b/app/services/course/assessment/question/programming/programming_package_service.rb
@@ -45,6 +45,8 @@ class Course::Assessment::Question::Programming::ProgrammingPackageService
         Course::Assessment::Question::Programming::Python::PythonPackageService.new params
       elsif @language.is_a?(Coursemology::Polyglot::Language::CPlusPlus)
         Course::Assessment::Question::Programming::Cpp::CppPackageService.new params
+      elsif @language.is_a?(Coursemology::Polyglot::Language::Java)
+        Course::Assessment::Question::Programming::Java::JavaPackageService.new params
       else
         raise NotImplementedError
       end

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -113,7 +113,7 @@ class Course::Assessment::Question::ProgrammingImportService
       :public_test
     elsif test_case_name =~ /evaluation/i
       :evaluation_test
-    else
+    elsif test_case_name =~ /private/i
       :private_test
     end
   end
@@ -123,6 +123,10 @@ class Course::Assessment::Question::ProgrammingImportService
   # @param [String] test_report The test case report from evaluating the package.
   # @return [Array<>]
   def parse_test_report(test_report)
-    Course::Assessment::ProgrammingTestCaseReport.new(test_report).test_cases
+    if @question.language.is_a?(Coursemology::Polyglot::Language::Java)
+      Course::Assessment::Java::JavaProgrammingTestCaseReport.new(test_report).test_cases
+    else
+      Course::Assessment::ProgrammingTestCaseReport.new(test_report).test_cases
+    end
   end
 end

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -1,7 +1,7 @@
 json.question do
   json.(@programming_question, :id, :title, :description, :staff_only_comments, :maximum_grade,
                                :weight, :language_id, :memory_limit, :time_limit)
-  json.languages Coursemology::Polyglot::Language.all do |lang|
+  json.languages Coursemology::Polyglot::Language.all.order(:name) do |lang|
     json.(lang, :id, :name)
     json.editor_mode lang.ace_mode
   end
@@ -10,10 +10,11 @@ json.question do
     json.(skill, :id, :title)
   end
 
+  has_submissions = @programming_question.answers.without_attempting_state.count
   json.autograded @programming_question.persisted? ?
     @programming_question.attachment.present? : @assessment.autograded?
-  json.has_auto_gradings @programming_question.auto_gradable? &&
-    @programming_question.answers.without_attempting_state.count > 0
+  json.has_auto_gradings @programming_question.auto_gradable? && has_submissions
+  json.has_submissions has_submissions
   json.display_autograded_toggle display_autograded_toggle?
   json.autograded_assessment @assessment.autograded?
   json.published_assessment @assessment.published?

--- a/client/app/bundles/course/assessment/question/programming/actions/onlineEditorActionCreators.jsx
+++ b/client/app/bundles/course/assessment/question/programming/actions/onlineEditorActionCreators.jsx
@@ -1,5 +1,12 @@
 import actionTypes from '../constants/onlineEditorConstants';
 
+export function toggleSubmitAsFile(newValue) {
+  return {
+    type: actionTypes.TOGGLE_SUBMIT_AS_FILE,
+    newValue,
+  };
+}
+
 export function updateCodeBlock(field, newValue) {
   return {
     type: actionTypes.CODE_BLOCK_UPDATE,
@@ -33,24 +40,27 @@ export function deleteTestCase(testType, index) {
   };
 }
 
-export function updateNewDataFile(filename, index) {
+export function updateNewPackageFile(fileType, filename, index) {
   return {
-    type: actionTypes.NEW_DATA_FILE_UPDATE,
+    type: actionTypes.NEW_PACKAGE_FILE_UPDATE,
+    fileType,
     index,
     filename,
   };
 }
 
-export function deleteNewDataFile(index) {
+export function deleteNewPackageFile(fileType, index) {
   return {
-    type: actionTypes.NEW_DATA_FILE_DELETE,
+    type: actionTypes.NEW_PACKAGE_FILE_DELETE,
+    fileType,
     index,
   };
 }
 
-export function deleteExistingDataFile(filename, toDelete) {
+export function deleteExistingPackageFile(fileType, filename, toDelete) {
   return {
-    type: actionTypes.EXISTING_DATA_FILE_DELETE,
+    type: actionTypes.EXISTING_PACKAGE_FILE_DELETE,
+    fileType,
     filename,
     toDelete,
   };

--- a/client/app/bundles/course/assessment/question/programming/components/ExistingPackageFile.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/ExistingPackageFile.jsx
@@ -9,8 +9,8 @@ import { grey100, grey300, white } from 'material-ui/styles/colors';
 import styles from './../containers/OnlineEditor/OnlineEditorView.scss';
 import { formatBytes } from './../reducers/utils';
 
-function ExistingDataFile(props) {
-  const { filename, filesize, toDelete, deleteExistingDataFile, isLoading, isLast } = props;
+function ExistingPackageFile(props) {
+  const { filename, fileType, filesize, toDelete, deleteExistingPackageFile, isLoading, isLast } = props;
   const buttonClass = toDelete ? 'fa fa-undo' : 'fa fa-trash';
   const buttonColor = toDelete ? white : grey300;
   const rowStyle = toDelete ?
@@ -26,13 +26,13 @@ function ExistingDataFile(props) {
           backgroundColor={buttonColor}
           icon={<i className={buttonClass} />}
           disabled={isLoading}
-          onClick={() => { deleteExistingDataFile(filename, !toDelete); }}
+          onClick={() => { deleteExistingPackageFile(props.fileType, filename, !toDelete); }}
           style={{ minWidth: '40px', width: '40px' }}
         />
         <input
           type="checkbox"
           hidden
-          name={`question_programming[data_files_to_delete][${filename}]`}
+          name={`question_programming[${`${fileType}_to_delete`}][${filename}]`}
           checked={toDelete}
         />
       </TableHeaderColumn>
@@ -42,13 +42,14 @@ function ExistingDataFile(props) {
   );
 }
 
-ExistingDataFile.propTypes = {
+ExistingPackageFile.propTypes = {
   filename: PropTypes.string.isRequired,
+  fileType: PropTypes.string.isRequired,
   filesize: PropTypes.number.isRequired,
   toDelete: PropTypes.bool.isRequired,
-  deleteExistingDataFile: PropTypes.func.isRequired,
+  deleteExistingPackageFile: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
   isLast: PropTypes.bool.isRequired,
 };
 
-export default injectIntl(ExistingDataFile);
+export default injectIntl(ExistingPackageFile);

--- a/client/app/bundles/course/assessment/question/programming/components/NewPackageFile.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/NewPackageFile.jsx
@@ -4,34 +4,36 @@ import {
   TableHeaderColumn, TableRow, TableRowColumn,
 } from 'material-ui/Table';
 import RaisedButton from 'material-ui/RaisedButton';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { grey300 } from 'material-ui/styles/colors';
 import styles from './../containers/OnlineEditor/OnlineEditorView.scss';
-import translations from './../containers/OnlineEditor/OnlineEditorView.intl';
 
-class NewDataFile extends React.Component {
+class NewPackageFile extends React.Component {
   static propTypes = {
     index: PropTypes.number.isRequired,
+    fileType: PropTypes.string.isRequired,
     filename: PropTypes.string,
     showDeleteButton: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
-    intl: intlShape.isRequired,
-    updateNewDataFile: PropTypes.func.isRequired,
-    deleteNewDataFile: PropTypes.func.isRequired,
+    updateNewPackageFile: PropTypes.func.isRequired,
+    deleteNewPackageFile: PropTypes.func.isRequired,
+    buttonLabel: PropTypes.string.isRequired,
   }
 
-  newDataFileChangeHandler(index) {
+  static getPackageFileName(fileType) {
+    return `question_programming[${fileType}][]`;
+  }
+
+  newPackageFileChangeHandler(index) {
     return (e) => {
       const files = e.target.files;
       const filename = files.length === 0 ? null : files[0].name;
-      this.props.updateNewDataFile(filename, index);
+      this.props.updateNewPackageFile(this.props.fileType, filename, index);
     };
   }
 
   render() {
-    const {
-      index, filename, showDeleteButton, isLoading, intl,
-    } = this.props;
+    const { index, filename, showDeleteButton, isLoading } = this.props;
     let deleteButton = null;
     const addFileButtonStyle = {};
     let rowStyle = { borderBottom: 'none' };
@@ -42,7 +44,7 @@ class NewDataFile extends React.Component {
           backgroundColor={grey300}
           icon={<i className="fa fa-trash" />}
           disabled={isLoading}
-          onClick={() => { this.props.deleteNewDataFile(index); }}
+          onClick={() => { this.props.deleteNewPackageFile(this.props.fileType, index); }}
           style={{ minWidth: '40px', width: '40px' }}
         />
       );
@@ -58,7 +60,7 @@ class NewDataFile extends React.Component {
         <TableRowColumn>
           <RaisedButton
             className={styles.fileInputButton}
-            label={intl.formatMessage(translations.addDataFileButton)}
+            label={this.props.buttonLabel}
             labelPosition="before"
             containerElement="label"
             primary
@@ -67,10 +69,10 @@ class NewDataFile extends React.Component {
           >
             <input
               type="file"
-              name="question_programming[data_files][]"
+              name={NewPackageFile.getPackageFileName(this.props.fileType)}
               className={styles.uploadInput}
               disabled={isLoading}
-              onChange={this.newDataFileChangeHandler(index)}
+              onChange={this.newPackageFileChangeHandler(index)}
             />
           </RaisedButton>
           <div style={{ display: 'inline-block' }}>{filename}</div>
@@ -80,4 +82,4 @@ class NewDataFile extends React.Component {
   }
 }
 
-export default injectIntl(NewDataFile);
+export default injectIntl(NewPackageFile);

--- a/client/app/bundles/course/assessment/question/programming/components/TestCase.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/TestCase.jsx
@@ -1,14 +1,13 @@
 import Immutable from 'immutable';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl } from 'react-intl';
-import {
-  TableHeaderColumn, TableRow, TableRowColumn,
-} from 'material-ui/Table';
+import { injectIntl, intlShape } from 'react-intl';
+import { TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 import { grey300 } from 'material-ui/styles/colors';
 import styles from './../containers/OnlineEditor/OnlineEditorView.scss';
+import translations from './../containers/OnlineEditor/OnlineEditorView.intl';
 
 class TestCase extends React.Component {
   static propTypes = {
@@ -21,6 +20,9 @@ class TestCase extends React.Component {
     expression: PropTypes.string.isRequired,
     expected: PropTypes.string.isRequired,
     hint: PropTypes.string.isRequired,
+    enableInlineCodeEditor: PropTypes.bool.isRequired,
+    showCodeEditor: PropTypes.bool.isRequired,
+    intl: intlShape.isRequired,
   }
 
   static getTestInputName(type, field) {
@@ -33,6 +35,15 @@ class TestCase extends React.Component {
 
       if (!this.props.isLoading) {
         this.props.deleteTestCase(this.props.type, index);
+      }
+    };
+  }
+
+  inlineCodeEditorHandler(type, index, newValue) {
+    return (e) => {
+      e.preventDefault();
+      if (!this.props.isLoading) {
+        this.props.updateTestCase(type, index, 'show_code_editor', newValue);
       }
     };
   }
@@ -55,31 +66,66 @@ class TestCase extends React.Component {
     );
   }
 
+  renderCodeEditorButton(type, index, showCodeEditor) {
+    return (
+      <TableRowColumn style={{ paddingLeft: 10, paddingRight: 10 }}>
+        {
+          showCodeEditor ?
+            <RaisedButton
+              className={styles.codeEditorButtonCell}
+              label={this.props.intl.formatMessage(translations.hideTestCaseCodeEditorButton)}
+              labelPosition="before"
+              containerElement="label"
+              primary
+              disabled={this.props.isLoading}
+              onClick={this.inlineCodeEditorHandler(type, index, !showCodeEditor)}
+              style={{ marginRight: 0, width: 30 }}
+            />
+            :
+            <RaisedButton
+              className={styles.codeEditorButtonCell}
+              label={this.props.intl.formatMessage(translations.showTestCaseCodeEditorButton)}
+              labelPosition="before"
+              containerElement="label"
+              primary
+              disabled={this.props.isLoading}
+              onClick={this.inlineCodeEditorHandler(type, index, !showCodeEditor)}
+              style={{ marginRight: 0, width: 30 }}
+            />
+        }
+      </TableRowColumn>
+    );
+  }
+
   render() {
     const displayedIndex = (`0${this.props.index + 1}`).slice(-2);
+    const { type, index, isLoading, test, expression, expected, hint,
+      enableInlineCodeEditor, showCodeEditor } = this.props;
     return (
       <TableRow>
         <TableHeaderColumn className={styles.deleteButtonCell}>
           <RaisedButton
+            name={TestCase.getTestInputName(type, 'inlineCode')}
             backgroundColor={grey300}
             icon={<i className="fa fa-trash" />}
-            disabled={this.props.isLoading}
-            onClick={this.testCaseDeleteHandler(this.props.type, this.props.index)}
+            disabled={isLoading}
+            onClick={this.testCaseDeleteHandler(type, index)}
             style={{ minWidth: '40px', width: '40px' }}
           />
         </TableHeaderColumn>
         <TableRowColumn className={styles.testCell}>
-          test_{this.props.type}_{displayedIndex}
+            test_{type}_{displayedIndex}
         </TableRowColumn>
         <TableRowColumn className={styles.testCell}>
-          { this.renderInput(this.props.test, 'expression', this.props.expression, this.props.index) }
+          { this.renderInput(test, 'expression', expression, index) }
         </TableRowColumn>
         <TableRowColumn className={styles.testCell}>
-          { this.renderInput(this.props.test, 'expected', this.props.expected, this.props.index) }
+          { this.renderInput(test, 'expected', expected, index) }
         </TableRowColumn>
         <TableRowColumn className={styles.testCell}>
-          { this.renderInput(this.props.test, 'hint', this.props.hint, this.props.index) }
+          { this.renderInput(test, 'hint', hint, index) }
         </TableRowColumn>
+        { enableInlineCodeEditor ? this.renderCodeEditorButton(type, index, showCodeEditor) : null }
       </TableRow>
     );
   }

--- a/client/app/bundles/course/assessment/question/programming/constants/onlineEditorConstants.jsx
+++ b/client/app/bundles/course/assessment/question/programming/constants/onlineEditorConstants.jsx
@@ -3,13 +3,14 @@
 import mirrorCreator from 'mirror-creator';
 
 const editorActionTypes = mirrorCreator([
+  'TOGGLE_SUBMIT_AS_FILE',
   'CODE_BLOCK_UPDATE',
   'TEST_CASE_CREATE',
   'TEST_CASE_UPDATE',
   'TEST_CASE_DELETE',
-  'NEW_DATA_FILE_UPDATE',
-  'NEW_DATA_FILE_DELETE',
-  'EXISTING_DATA_FILE_DELETE',
+  'NEW_PACKAGE_FILE_UPDATE',
+  'NEW_PACKAGE_FILE_DELETE',
+  'EXISTING_PACKAGE_FILE_DELETE',
 ]);
 
 export default editorActionTypes;

--- a/client/app/bundles/course/assessment/question/programming/constants/onlineEditorDefaultTemplates.js
+++ b/client/app/bundles/course/assessment/question/programming/constants/onlineEditorDefaultTemplates.js
@@ -1,4 +1,4 @@
-const cppAppend = `// This is a global environment that is setup before the tests are run.
+export const cppAppend = `// This is a global environment that is setup before the tests are run.
 // Since googletest does not allow function calls in the global scope
 class GlobalEnv : public testing::Environment {
 public:
@@ -11,21 +11,30 @@ public:
     }
 };
 
-// This is called on the expression and expected values for each test case.
+// This function will be called on the expected and expression-output entered in the test case.
 template<typename T1, typename T2>
 void custom_evaluation(T1 expression, T2 expected) {
     // void expect_equals(a, b) is overloaded to generate the appropriate test assertions
-    // for the respective type-pairs, 
+    // for the respective type-pairs,
     // It also records the 'expected' and 'output' properties for you
-    // and currently supports comparisons between:
+    // and supports comparisons between:
     //    int, double, float, bool, char, char*, const char*
     // For any other types (arrays, structs... etc) - you can choose to overload expect_equals() or
     // just write your test here.
-    // You will also have to use ::testing::Test::RecordProperty() 
+    // You will also have to use ::testing::Test::RecordProperty()
     // to record the 'expected' and 'output' properties
 
     expect_equals(expression, expected);
 }
 `;
 
-module.exports = { data: cppAppend };
+export const javaAppend = `// NOTE:
+// void expectEquals(Object expression, Object expected) { Assert.assertEquals(expression, expected) }
+// will be called on the expression and expected values that you input into each test case
+// It has been overloaded to handle all java primitive types as well
+// If you wish to make comparisons between other types/classes, you may overload this function
+
+// String printValue(Object val) { ... } will be called on the expected and expression values by default.
+// It has been overloaded to handle java primitives and their arrays.
+// You can also choose to overload this function to declare how to print different types of values.
+`;

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Cpp/OnlineEditorCppView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Cpp/OnlineEditorCppView.intl.js
@@ -1,0 +1,9 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  appendSubtitle: {
+    id: 'course.assessment.question.programming.onlineEditorCppView.appendSubtitle',
+    defaultMessage: 'For any function/variable declarations',
+    description: 'Subtitle for append code block.',
+  },
+});

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Cpp/OnlineEditorCppView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Cpp/OnlineEditorCppView.jsx
@@ -14,7 +14,8 @@ import 'brace/theme/monokai';
 
 import styles from './../OnlineEditorView.scss';
 import translations from './../OnlineEditorView.intl';
-import { ExistingDataFile, NewDataFile, TestCase, EditorCard } from './../OnlineEditorBase';
+import cppTranslations from './OnlineEditorCppView.intl';
+import { ExistingPackageFile, NewPackageFile, TestCase, EditorCard } from './../OnlineEditorBase';
 
 const MAX_TEST_CASES = 99;
 
@@ -26,9 +27,9 @@ const propTypes = {
     createTestCase: PropTypes.func.isRequired,
     updateTestCase: PropTypes.func.isRequired,
     deleteTestCase: PropTypes.func.isRequired,
-    updateNewDataFile: PropTypes.func.isRequired,
-    deleteNewDataFile: PropTypes.func.isRequired,
-    deleteExistingDataFile: PropTypes.func.isRequired,
+    updateNewPackageFile: PropTypes.func.isRequired,
+    deleteNewPackageFile: PropTypes.func.isRequired,
+    deleteExistingPackageFile: PropTypes.func.isRequired,
   }),
   isLoading: PropTypes.bool.isRequired,
   autograded: PropTypes.bool.isRequired,
@@ -51,8 +52,8 @@ class OnlineEditorCppView extends React.Component {
     };
   }
 
-  renderExistingDataFiles = () => {
-    const numFiles = this.props.data.get('data_files').size;
+  renderExistingPackageFiles(fileType, header) {
+    const numFiles = this.props.data.get(fileType).size;
     if (numFiles === 0) {
       return null;
     }
@@ -62,13 +63,14 @@ class OnlineEditorCppView extends React.Component {
       const filename = fileData.get('filename');
 
       return (
-        <ExistingDataFile
+        <ExistingPackageFile
           key={hash}
           {...{
             filename,
+            fileType,
             filesize: fileData.get('size'),
             toDelete: this.props.dataFiles.get('to_delete').has(filename),
-            deleteExistingDataFile: this.props.actions.deleteExistingDataFile,
+            deleteExistingPackageFile: this.props.actions.deleteExistingPackageFile,
             isLoading: this.props.isLoading,
             isLast: numFiles === index + 1,
           }}
@@ -79,7 +81,7 @@ class OnlineEditorCppView extends React.Component {
     return (
       <Card initiallyExpanded>
         <CardHeader
-          title={this.props.intl.formatMessage(translations.currentDataFilesHeader)}
+          title={header}
           textStyle={{ fontWeight: 'bold' }}
           actAsExpander
           showExpandableButton
@@ -106,30 +108,31 @@ class OnlineEditorCppView extends React.Component {
     );
   }
 
-  renderNewDataFiles() {
+  renderNewPackageFiles(fileType, header, buttonLabel) {
     const renderNewFile = (fileData, index) => {
       const key = fileData.get('key');
       return (
-        <NewDataFile
+        <NewPackageFile
           key={key}
           {...{
             index,
+            fileType,
             filename: fileData.get('filename'),
             showDeleteButton: this.props.dataFiles.get('key') !== key,
             isLoading: this.props.isLoading,
-            intl: this.props.intl,
-            updateNewDataFile: this.props.actions.updateNewDataFile,
-            deleteNewDataFile: this.props.actions.deleteNewDataFile,
+            updateNewPackageFile: this.props.actions.updateNewPackageFile,
+            deleteNewPackageFile: this.props.actions.deleteNewPackageFile,
+            buttonLabel,
           }}
         />
       );
     };
-    const newDataFilesRows = this.props.dataFiles.get('new').map(renderNewFile);
+    const newPackageFilesRows = this.props.dataFiles.get('new').map(renderNewFile);
 
     return (
       <Card initiallyExpanded>
         <CardHeader
-          title={this.props.intl.formatMessage(translations.newDataFilesHeader)}
+          title={header}
           textStyle={{ fontWeight: 'bold' }}
           actAsExpander
           showExpandableButton
@@ -137,7 +140,7 @@ class OnlineEditorCppView extends React.Component {
         <CardText expandable style={{ padding: 0 }}>
           <Table selectable={false}>
             <TableBody displayRowCheckbox={false}>
-              { newDataFilesRows }
+              { newPackageFilesRows }
             </TableBody>
           </Table>
         </CardText>
@@ -168,6 +171,9 @@ class OnlineEditorCppView extends React.Component {
           expression,
           expected,
           hint,
+          enableInlineCodeEditor: false,
+          showCodeEditor: test.get('showCodeEditor') || false,
+          intl: this.props.intl,
         }}
       />
       ));
@@ -267,14 +273,25 @@ class OnlineEditorCppView extends React.Component {
           {
             this.renderEditorCard(
               intl.formatMessage(translations.appendTitle),
-              intl.formatMessage(translations.cppAppendSubtitle),
+              intl.formatMessage(cppTranslations.appendSubtitle),
               'append'
             )
           }
         </div>
         <h3>{ intl.formatMessage(translations.dataFilesHeader) }</h3>
-        { this.renderExistingDataFiles() }
-        { this.renderNewDataFiles() }
+        {
+          this.renderExistingPackageFiles(
+            'data_files',
+            this.props.intl.formatMessage(translations.currentDataFilesHeader)
+          )
+        }
+        {
+          this.renderNewPackageFiles(
+            'data_files',
+            this.props.intl.formatMessage(translations.newDataFilesHeader),
+            intl.formatMessage(translations.addDataFileButton)
+          )
+        }
         <h3>{ intl.formatMessage(translations.testCasesHeader) }</h3>
         <div style={{ marginBottom: '0.5em' }}>
           <FormattedMessage

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Java/OnlineEditorJavaView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Java/OnlineEditorJavaView.intl.js
@@ -1,0 +1,80 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  prependSubtitle: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.prependSubtitle',
+    defaultMessage: 'For any library imports (optional, hidden, inserted before student\'s code)',
+    description: 'Subtitle for prepend code block.',
+  },
+  appendSubtitle: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.appendSubtitle',
+    defaultMessage: 'Within the scope for the test class: Declare any methods or instance variables here',
+    description: 'Subtitle for append code block.',
+  },
+  submitAsFileToggle: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.submitAsFileToggle',
+    defaultMessage: 'File Submission',
+  },
+  submitAsFileToggleDisabled: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.submitAsFileToggleDisabled',
+    defaultMessage: 'File Submission (This option cannot be switched as some answers have already been submitted)',
+  },
+  addSubmissionFileButton: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.addSubmissionFileButton',
+    defaultMessage: 'Add Submission File',
+  },
+  addSolutionFileButton: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.addSolutionFileButton',
+    defaultMessage: 'Add Solution File',
+  },
+  submissionFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.submissionFilesHeader',
+    defaultMessage: 'Submission Files (Required)',
+    description: 'Header for the submission files of the online editor.',
+  },
+  solutionFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.solutionFilesHeader',
+    defaultMessage: 'Solution Files (Required)',
+    description: 'Header for the solution files of the online editor.',
+  },
+  newSubmissionFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.newSubmissionFilesHeader',
+    defaultMessage: 'New Submission Files',
+    description: 'Header for the new submission files panel.',
+  },
+  newSolutionFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.newSolutionFilesHeader',
+    defaultMessage: 'New Solution Files',
+    description: 'Header for the new solution files panel.',
+  },
+  currentSubmissionFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.currentSubmissionFilesHeader',
+    defaultMessage: 'Current Submission Files',
+    description: 'Header for the current submission files panel.',
+  },
+  currentSolutionFilesHeader: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.currentSolutionFilesHeader',
+    defaultMessage: 'Current Solution Files',
+    description: 'Header for the current solution files panel.',
+  },
+  testCaseDescriptionCode: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.testCaseDescriptionCode',
+    defaultMessage: 'CODE',
+    description: 'Value of the code key that is passed into the test case description.',
+  },
+  testCaseDescriptionEditor: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.testCaseDescriptionEditor',
+    defaultMessage: 'CODE EDITOR',
+    description: 'Value of the code key that is passed into the test case description.',
+  },
+  expectEquals: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.expectEquals',
+    defaultMessage: 'void expectEquals(expression, expected)',
+    description: 'Function template for expectEquals',
+  },
+  fileSubmissionDescriptionNote: {
+    id: 'course.assessment.question.programming.onlineEditorJavaView.fileSubmissionDescriptionNote',
+    defaultMessage: 'File Submission',
+    description: 'Value of the key that is passed into the description of the file submission toggle.',
+  },
+});

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Java/OnlineEditorJavaView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Java/OnlineEditorJavaView.jsx
@@ -1,0 +1,501 @@
+import Immutable from 'immutable';
+
+import React, { PropTypes } from 'react';
+import AceEditor from 'react-ace';
+import { injectIntl, FormattedMessage, intlShape } from 'react-intl';
+import { Card, CardHeader, CardText } from 'material-ui/Card';
+import FlatButton from 'material-ui/FlatButton';
+import Toggle from 'material-ui/Toggle';
+import {
+  Table, TableBody, TableFooter, TableHeader, TableHeaderColumn, TableRow, TableRowColumn,
+} from 'material-ui/Table';
+import transitions from 'material-ui/styles/transitions';
+
+import 'brace/mode/java';
+import 'brace/theme/monokai';
+
+import styles from './../OnlineEditorView.scss';
+import translations from './../OnlineEditorView.intl';
+import javaTranslations from './OnlineEditorJavaView.intl';
+import { ExistingPackageFile, NewPackageFile, TestCase, EditorCard } from './../OnlineEditorBase';
+
+const MAX_TEST_CASES = 99;
+
+const propTypes = {
+  data: PropTypes.instanceOf(Immutable.Map).isRequired,
+  testData: PropTypes.instanceOf(Immutable.Map).isRequired,
+  actions: React.PropTypes.shape({
+    toggleSubmitAsFile: PropTypes.func.isRequired,
+    updateCodeBlock: PropTypes.func.isRequired,
+    createTestCase: PropTypes.func.isRequired,
+    updateTestCase: PropTypes.func.isRequired,
+    deleteTestCase: PropTypes.func.isRequired,
+    updateNewPackageFile: PropTypes.func.isRequired,
+    deleteNewPackageFile: PropTypes.func.isRequired,
+    deleteExistingPackageFile: PropTypes.func.isRequired,
+  }),
+  isLoading: PropTypes.bool.isRequired,
+  autograded: PropTypes.bool.isRequired,
+  hasSubmissions: PropTypes.bool.isRequired,
+  intl: intlShape.isRequired,
+};
+
+const contextTypes = {
+  muiTheme: React.PropTypes.object.isRequired,
+};
+
+class OnlineEditorJavaView extends React.Component {
+
+  static getTestInputName(type, field) {
+    return `question_programming[test_cases][${type}][][${field}]`;
+  }
+
+  testCaseCreateHandler(type) {
+    return (e) => {
+      e.preventDefault();
+
+      if (!this.props.isLoading) {
+        this.props.actions.createTestCase(type);
+      }
+    };
+  }
+
+  renderExistingPackageFiles(fileType, header) {
+    const numFiles = this.props.data.get(fileType).size;
+    if (numFiles === 0) {
+      return null;
+    }
+
+    const renderDataFile = (fileData, index) => {
+      const hash = fileData.get('hash');
+      const filename = fileData.get('filename');
+
+      return (
+        <ExistingPackageFile
+          key={hash}
+          {...{
+            filename,
+            fileType,
+            filesize: fileData.get('size'),
+            toDelete: this.props.testData.getIn([fileType, 'to_delete']).has(filename),
+            deleteExistingPackageFile: this.props.actions.deleteExistingPackageFile,
+            isLoading: this.props.isLoading,
+            isLast: numFiles === index + 1,
+          }}
+        />
+      );
+    };
+
+    return (
+      <Card initiallyExpanded>
+        <CardHeader
+          title={header}
+          textStyle={{ fontWeight: 'bold' }}
+          actAsExpander
+          showExpandableButton
+        />
+        <CardText expandable style={{ padding: 0 }}>
+          <Table selectable={false}>
+            <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
+              <TableRow>
+                <TableHeaderColumn className={styles.deleteButtonCell} />
+                <TableHeaderColumn>
+                  {this.props.intl.formatMessage(translations.fileNameHeader)}
+                </TableHeaderColumn>
+                <TableHeaderColumn>
+                  {this.props.intl.formatMessage(translations.fileSizeHeader)}
+                </TableHeaderColumn>
+              </TableRow>
+            </TableHeader>
+            <TableBody displayRowCheckbox={false}>
+              {this.props.data.get(fileType).map(renderDataFile)}
+            </TableBody>
+          </Table>
+        </CardText>
+      </Card>
+    );
+  }
+
+  renderNewPackageFiles(fileType, header, buttonLabel) {
+    const renderNewFile = (fileData, index) => {
+      const key = fileData.get('key');
+      return (
+        <NewPackageFile
+          key={key}
+          {...{
+            index,
+            fileType,
+            filename: fileData.get('filename'),
+            showDeleteButton: this.props.testData.getIn([fileType, 'key']) !== key,
+            isLoading: this.props.isLoading,
+            updateNewPackageFile: this.props.actions.updateNewPackageFile,
+            deleteNewPackageFile: this.props.actions.deleteNewPackageFile,
+            buttonLabel,
+          }}
+        />
+      );
+    };
+    const newPackageFilesRows = this.props.testData.getIn([fileType, 'new']).map(renderNewFile);
+
+    return (
+      <Card initiallyExpanded>
+        <CardHeader
+          title={header}
+          textStyle={{ fontWeight: 'bold' }}
+          actAsExpander
+          showExpandableButton
+        />
+        <CardText expandable style={{ padding: 0 }}>
+          <Table selectable={false}>
+            <TableBody displayRowCheckbox={false}>
+              { newPackageFilesRows }
+            </TableBody>
+          </Table>
+        </CardText>
+      </Card>
+    );
+  }
+
+  renderTestCases(header, testCases, type) {
+    const allTestCases = this.props.data.get('test_cases');
+    const numAllTestCases = allTestCases.get('public').size + allTestCases.get('private').size
+      + allTestCases.get('evaluation').size;
+
+    const identifier = this.props.intl.formatMessage(translations.identifierHeader);
+    const expression = this.props.intl.formatMessage(translations.expressionHeader);
+    const expected = this.props.intl.formatMessage(translations.expectedHeader);
+    const hint = this.props.intl.formatMessage(translations.hintHeader);
+
+    const rows = [...testCases.get(type).entries()].map(([index, test]) => (
+      <TestCase
+        key={index}
+        {...{
+          updateTestCase: this.props.actions.updateTestCase,
+          deleteTestCase: this.props.actions.deleteTestCase,
+          isLoading: this.props.isLoading,
+          type,
+          index,
+          test,
+          expression,
+          expected,
+          hint,
+          enableInlineCodeEditor: true,
+          showCodeEditor: test.get('show_code_editor') || false,
+          intl: this.props.intl,
+        }}
+      />
+      ));
+
+    const editors = [...testCases.get(type).entries()].map(([index, test]) => {
+      const showCodeEditor = test.get('show_code_editor') || false;
+      const inlineCode = test.get('inline_code') || '';
+      let editorStyle = { display: 'none' };
+      if (showCodeEditor) {
+        editorStyle = {};
+      }
+      return (
+        <TableRow id={index} style={editorStyle}>
+          <TableRowColumn colSpan="6" style={{ textAlign: 'center', paddingLeft: 0, paddingRight: 0 }}>
+            <textarea
+              name={OnlineEditorJavaView.getTestInputName(type, 'inline_code')}
+              value={test.get('inline_code')}
+              style={{ display: 'none' }}
+              readOnly="true"
+            />
+            <AceEditor
+              mode="java"
+              theme="monokai"
+              width="100%"
+              minLines={4}
+              maxLines={Math.max(20, inlineCode.split(/\r\n|\r|\n/).length)}
+              name={OnlineEditorJavaView.getTestInputName(type, 'inline_code')}
+              value={test.get('inline_code')}
+              onChange={e => this.props.actions.updateTestCase(type, index, 'inline_code', e)}
+              editorProps={{ $blockScrolling: true }}
+              setOptions={{ useSoftTabs: true, readOnly: this.props.isLoading }}
+            />
+          </TableRowColumn>
+        </TableRow>
+      );
+    });
+
+    // To interweave the two arrays
+    const testCaseRows = [];
+    rows.forEach((val, index) => {
+      testCaseRows.push(val);
+      testCaseRows.push(editors[index]);
+    });
+
+    return (
+      <Card initiallyExpanded>
+        <CardHeader
+          title={header}
+          textStyle={{ fontWeight: 'bold' }}
+          actAsExpander
+          showExpandableButton
+        />
+        <CardText expandable style={{ padding: 0 }}>
+          <Table selectable={false}>
+            <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
+              <TableRow>
+                <TableHeaderColumn className={styles.deleteButtonCell} />
+                <TableHeaderColumn>{identifier}</TableHeaderColumn>
+                <TableHeaderColumn>{expression}</TableHeaderColumn>
+                <TableHeaderColumn>{expected}</TableHeaderColumn>
+                <TableHeaderColumn>{hint}</TableHeaderColumn>
+                <TableHeaderColumn />
+              </TableRow>
+            </TableHeader>
+            <TableBody displayRowCheckbox={false}>
+              {testCaseRows}
+            </TableBody>
+            <TableFooter adjustForCheckbox={false}>
+              <TableRow>
+                <TableRowColumn colSpan="6" style={{ textAlign: 'center' }}>
+                  <FlatButton
+                    label={this.props.intl.formatMessage(translations.addNewTestButton)}
+                    icon={<i className="fa fa-plus" />}
+                    disabled={this.props.isLoading || numAllTestCases >= MAX_TEST_CASES}
+                    onClick={this.testCaseCreateHandler(type)}
+                  />
+                </TableRowColumn>
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </CardText>
+      </Card>
+    );
+  }
+
+  renderEditorCard(header, subtitle, field) {
+    const value = this.props.data.get(field) || '';
+    return (
+      <EditorCard
+        {...{
+          updateCodeBlock: this.props.actions.updateCodeBlock,
+          mode: 'java',
+          field,
+          value,
+          header,
+          subtitle,
+          isLoading: this.props.isLoading,
+        }}
+      />
+    );
+  }
+
+  renderAutogradedFields() {
+    const { intl, data } = this.props;
+    const submitAsFile = this.props.data.get('submit_as_file');
+    const testCases = data.get('test_cases');
+    const testCaseError = data.getIn(['test_cases', 'error']);
+    const errorTextElement = testCaseError && (
+    <div
+      style={{
+        fontSize: 12,
+        lineHeight: '12px',
+        color: this.context.muiTheme.textField.errorColor,
+        transition: transitions.easeOut(),
+        marginBottom: '1em',
+      }}
+    >
+      {testCaseError}
+    </div>
+      );
+
+    return (
+      <div>
+        <div style={{ marginBottom: '1em' }}>
+          {
+            submitAsFile ?
+              <div style={{ marginBottom: '20px' }}>
+                <h3>{this.props.intl.formatMessage(javaTranslations.solutionFilesHeader)}</h3>
+                {
+                  this.renderExistingPackageFiles(
+                    'solution_files',
+                    this.props.intl.formatMessage(javaTranslations.currentSolutionFilesHeader)
+                    )
+                }
+                {
+                  this.renderNewPackageFiles('solution_files',
+                    this.props.intl.formatMessage(javaTranslations.newSolutionFilesHeader),
+                    intl.formatMessage(javaTranslations.addSolutionFileButton)
+                  )
+                }
+              </div>
+              :
+              this.renderEditorCard(
+                intl.formatMessage(translations.solutionTitle),
+                intl.formatMessage(translations.solutionSubtitle),
+                'solution'
+              )
+          }
+          {
+            this.renderEditorCard(
+              intl.formatMessage(translations.prependTitle),
+              intl.formatMessage(javaTranslations.prependSubtitle),
+              'prepend'
+            )
+          }
+          {
+            this.renderEditorCard(
+              intl.formatMessage(translations.appendTitle),
+              intl.formatMessage(javaTranslations.appendSubtitle),
+              'append'
+            )
+          }
+        </div>
+        <h3>{ intl.formatMessage(translations.dataFilesHeader) }</h3>
+        {
+          this.renderExistingPackageFiles(
+            'data_files',
+            this.props.intl.formatMessage(translations.currentDataFilesHeader)
+            )
+        }
+        {
+          this.renderNewPackageFiles('data_files',
+            this.props.intl.formatMessage(translations.newDataFilesHeader),
+            intl.formatMessage(translations.addDataFileButton)
+            )
+        }
+        <h3>{ intl.formatMessage(translations.testCasesHeader) }</h3>
+        <div style={{ marginBottom: '0.5em' }}>
+          <FormattedMessage
+            id="course.assessment.question.programming.onlineEditorJavaView.testCasesDescription"
+            defaultMessage={
+              '{note}: The expression in the {expression} column will be compared with the ' +
+              'expression in the {expected} column using the {expectEquals} method as described ' +
+              'in the append.'
+            }
+            values={{
+              note: <b>{intl.formatMessage(translations.testCaseDescriptionNote)}</b>,
+              expression: <b>{intl.formatMessage(translations.expressionHeader)}</b>,
+              expected: <b>{intl.formatMessage(translations.expectedHeader)}</b>,
+              expectEquals: <code>{intl.formatMessage(javaTranslations.expectEquals)}</code>,
+            }}
+          />
+        </div>
+        <div style={{ marginBottom: '0.5em' }}>
+          <FormattedMessage
+            id="course.assessment.question.programming.onlineEditorJavaView.testCasesCodeDescription"
+            defaultMessage={
+              '{editor}: Clicking {code} will toggle a code editor for you to write code into each ' +
+              'test case. This allows you to initialize variables and call functions for each test. ' +
+              'For example: {codeExample}' +
+              '{codeExampleExpression} and {codeExampleExpected} can then be input into {expression} and ' +
+              '{expected} respectively.'
+            }
+            values={{
+              expression: <b>{intl.formatMessage(translations.expressionHeader)}</b>,
+              expected: <b>{intl.formatMessage(translations.expectedHeader)}</b>,
+              code: <b>{intl.formatMessage(javaTranslations.testCaseDescriptionCode)}</b>,
+              editor: <b>{intl.formatMessage(javaTranslations.testCaseDescriptionEditor)}</b>,
+              /* eslint-disable react/jsx-indent */
+              codeExample:
+                <pre style={{ marginTop: '0.5em', paddingTop: '3px', paddingBottom: '3px' }}>
+                  <p style={{ marginBottom: 0 }}>
+                    {'int array [] = {0,0,0}; // Initialize variables'}
+                  </p>
+                  <p style={{ marginBottom: 0 }}>{'addOneToArray(array); // Make function calls'}</p>
+                  <p style={{ marginBottom: 0 }}>{'int expected [] = {1,1,1}; // Make function calls'}</p>
+                  <p style={{ marginBottom: 0 }}>
+                    {'setAttribute("expression", "addOneToArray([0,0,0])");'}
+                    {' // Override the default expression displayed'}
+                  </p>
+                </pre>,
+              /* eslint-enable react/jsx-indent */
+              codeExampleExpected: <code>{'expected'}</code>,
+              codeExampleExpression: <code>{'array'}</code>,
+            }}
+          />
+        </div>
+        { errorTextElement }
+        {
+          this.renderTestCases(intl.formatMessage(translations.publicTestCases),
+          testCases, 'public')
+        }
+        {
+          this.renderTestCases(intl.formatMessage(translations.privateTestCases),
+          testCases, 'private')
+        }
+        {
+          this.renderTestCases(intl.formatMessage(translations.evaluationTestCases),
+          testCases, 'evaluation')
+        }
+      </div>
+    );
+  }
+
+  render() {
+    const { intl, autograded, isLoading, hasSubmissions } = this.props;
+    const submitAsFile = this.props.data.get('submit_as_file');
+    let toggleLabel = intl.formatMessage(javaTranslations.submitAsFileToggle);
+    if (hasSubmissions) {
+      toggleLabel = intl.formatMessage(javaTranslations.submitAsFileToggleDisabled);
+    }
+    return (
+      <div id="java-online-editor">
+        {
+          <div className={styles.submitAsFileToggle}>
+            <Toggle
+              label={toggleLabel}
+              labelPosition="right"
+              toggled={submitAsFile}
+              onToggle={(e) => {
+                if (hasSubmissions) return;
+                this.props.actions.toggleSubmitAsFile(e.target.checked);
+              }}
+              readOnly={hasSubmissions}
+              disabled={isLoading}
+              style={{ margin: '1em 0', paddingTop: 10 }}
+            />
+            <input hidden name="question_programming[submit_as_file]" value={submitAsFile} />
+            <FormattedMessage
+              id="course.assessment.question.programming.onlineEditorJavaView.fileSubmissionDescription"
+              defaultMessage={
+                '{file_submission}: Toggling this option on will allow you to upload java class files to be ' +
+                'compiled individually, and allows you to test (individual/multiple) java classes. ' +
+                'Toggled off, you will input code as templates, which will be used for you to test ' +
+                'java functions'
+              }
+              values={{
+                file_submission: <b>{intl.formatMessage(javaTranslations.fileSubmissionDescriptionNote)}</b>,
+              }}
+            />
+          </div>
+        }
+        {
+          submitAsFile ?
+            <div>
+              <h3>{this.props.intl.formatMessage(javaTranslations.submissionFilesHeader)}</h3>
+              {
+                this.renderExistingPackageFiles(
+                  'submission_files',
+                  this.props.intl.formatMessage(javaTranslations.currentSubmissionFilesHeader)
+                )
+              }
+              {
+                this.renderNewPackageFiles(
+                  'submission_files',
+                  this.props.intl.formatMessage(javaTranslations.newSubmissionFilesHeader),
+                  intl.formatMessage(javaTranslations.addSubmissionFileButton)
+                )
+              }
+            </div>
+            :
+            this.renderEditorCard(
+              intl.formatMessage(translations.submissionTitle),
+              null,
+              'submission'
+            )
+        }
+        { autograded ? this.renderAutogradedFields() : null }
+      </div>
+    );
+  }
+}
+
+OnlineEditorJavaView.propTypes = propTypes;
+OnlineEditorJavaView.contextTypes = contextTypes;
+
+export default injectIntl(OnlineEditorJavaView);

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditor.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditor.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import OnlineEditorPythonView from './Python/OnlineEditorPythonView';
 import OnlineEditorCppView from './Cpp/OnlineEditorCppView';
+import OnlineEditorJavaView from './Java/OnlineEditorJavaView';
 import { validation as editorValidation } from './OnlineEditorBase';
 
 const translations = defineMessages({
@@ -27,6 +28,7 @@ const propTypes = {
   autograded: PropTypes.bool.isRequired,
   autogradedAssessment: PropTypes.bool.isRequired,
   intl: intlShape.isRequired,
+  hasSubmissions: PropTypes.bool.isRequired,
 };
 
 export function validation(data, pathOfKeysToData, intl) {
@@ -36,6 +38,7 @@ export function validation(data, pathOfKeysToData, intl) {
   switch (mode) {
     case 'python':
     case 'c_cpp':
+    case 'java':
       return errors.concat(
         editorValidation(data, pathOfKeysToData.concat([mode]), intl)
       );
@@ -45,9 +48,8 @@ export function validation(data, pathOfKeysToData, intl) {
 }
 
 const OnlineEditor = (props) => {
-  const { data, actions, intl, isLoading, autograded, autogradedAssessment } = props;
+  const { data, actions, intl, isLoading, autograded, autogradedAssessment, hasSubmissions } = props;
   const mode = data.get('mode');
-
   switch (mode) {
     case 'python':
       return (<OnlineEditorPythonView
@@ -70,6 +72,19 @@ const OnlineEditor = (props) => {
           isLoading,
           autograded,
           autogradedAssessment,
+        }}
+      />);
+
+    case 'java':
+      return (<OnlineEditorJavaView
+        {...{
+          actions,
+          data: data.get('java'),
+          testData: data,
+          isLoading,
+          autograded,
+          autogradedAssessment,
+          hasSubmissions,
         }}
       />);
 

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorBase.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorBase.jsx
@@ -1,6 +1,6 @@
 import translations from './OnlineEditorView.intl';
-import ExistingDataFile from './../../components/ExistingDataFile';
-import NewDataFile from './../../components/NewDataFile';
+import ExistingPackageFile from './../../components/ExistingPackageFile';
+import NewPackageFile from './../../components/NewPackageFile';
 import TestCase from './../../components/TestCase';
 import EditorCard from './../../components/EditorCard';
 
@@ -50,8 +50,8 @@ export function validation(data, pathOfKeysToData, intl) {
 }
 
 export {
-  ExistingDataFile,
-  NewDataFile,
+  ExistingPackageFile,
+  NewPackageFile,
   TestCase,
   EditorCard,
 };

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorView.intl.js
@@ -21,11 +21,6 @@ export default defineMessages({
     defaultMessage: '(optional, hidden, appended after student\'s code)',
     description: 'Subtitle for append code block.',
   },
-  cppAppendSubtitle: {
-    id: 'course.assessment.question.programming.onlineEditorView.cppAppendSubtitle',
-    defaultMessage: 'For any function/variable declarations (optional, hidden, appended after student\'s code)',
-    description: 'Subtitle for append code block.',
-  },
   solutionTitle: {
     id: 'course.assessment.question.programming.onlineEditorView.solutionTitle',
     defaultMessage: 'Solution Template',
@@ -95,6 +90,16 @@ export default defineMessages({
     id: 'course.assessment.question.programming.onlineEditorView.addNewTestButton',
     defaultMessage: 'Add new test',
     description: 'Button for adding new test case.',
+  },
+  showTestCaseCodeEditorButton: {
+    id: 'course.assessment.question.programming.onlineEditorView.showTestCaseCodeEditorButton',
+    defaultMessage: 'Code',
+    description: 'Button for showing the test case inline code editor.',
+  },
+  hideTestCaseCodeEditorButton: {
+    id: 'course.assessment.question.programming.onlineEditorView.hideTestCaseCodeEditorButton',
+    defaultMessage: 'Hide',
+    description: 'Button for hiding the test case inline code editor.',
   },
   publicTestCases: {
     id: 'course.assessment.question.programming.onlineEditorView.publicTestCases',

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorView.scss
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorView.scss
@@ -1,4 +1,10 @@
 // scss-lint:disable ImportantRule
+.codeEditorButtonCell {
+  text-align: center;
+  vertical-align: middle !important;
+  width: 50px;
+}
+
 .deleteButtonCell {
   padding-left: 12px !important;
   text-align: center;
@@ -25,5 +31,10 @@
   position: absolute;
   right: 0;
   top: 0;
+}
+
+.submitAsFileToggle {
+  flex: 1 100%;
+  padding-bottom: 10px;
 }
 // scss-lint:enable ImportantRule

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Python/OnlineEditorPythonView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Python/OnlineEditorPythonView.jsx
@@ -14,7 +14,7 @@ import 'brace/theme/monokai';
 
 import styles from './../OnlineEditorView.scss';
 import translations from './../OnlineEditorView.intl';
-import { ExistingDataFile, NewDataFile, TestCase, EditorCard } from './../OnlineEditorBase';
+import { ExistingPackageFile, NewPackageFile, TestCase, EditorCard } from './../OnlineEditorBase';
 
 const MAX_TEST_CASES = 99;
 
@@ -26,9 +26,9 @@ const propTypes = {
     createTestCase: PropTypes.func.isRequired,
     updateTestCase: PropTypes.func.isRequired,
     deleteTestCase: PropTypes.func.isRequired,
-    updateNewDataFile: PropTypes.func.isRequired,
-    deleteNewDataFile: PropTypes.func.isRequired,
-    deleteExistingDataFile: PropTypes.func.isRequired,
+    updateNewPackageFile: PropTypes.func.isRequired,
+    deleteNewPackageFile: PropTypes.func.isRequired,
+    deleteExistingPackageFile: PropTypes.func.isRequired,
   }),
   isLoading: PropTypes.bool.isRequired,
   autograded: PropTypes.bool.isRequired,
@@ -51,8 +51,8 @@ class OnlineEditorPythonView extends React.Component {
     };
   }
 
-  renderExistingDataFiles = () => {
-    const numFiles = this.props.data.get('data_files').size;
+  renderExistingPackageFiles(fileType, header) {
+    const numFiles = this.props.data.get(fileType).size;
     if (numFiles === 0) {
       return null;
     }
@@ -62,13 +62,14 @@ class OnlineEditorPythonView extends React.Component {
       const filename = fileData.get('filename');
 
       return (
-        <ExistingDataFile
+        <ExistingPackageFile
           key={hash}
           {...{
             filename,
+            fileType,
             filesize: fileData.get('size'),
             toDelete: this.props.dataFiles.get('to_delete').has(filename),
-            deleteExistingDataFile: this.props.actions.deleteExistingDataFile,
+            deleteExistingPackageFile: this.props.actions.deleteExistingPackageFile,
             isLoading: this.props.isLoading,
             isLast: numFiles === index + 1,
           }}
@@ -79,7 +80,7 @@ class OnlineEditorPythonView extends React.Component {
     return (
       <Card initiallyExpanded>
         <CardHeader
-          title={this.props.intl.formatMessage(translations.currentDataFilesHeader)}
+          title={header}
           textStyle={{ fontWeight: 'bold' }}
           actAsExpander
           showExpandableButton
@@ -106,30 +107,31 @@ class OnlineEditorPythonView extends React.Component {
     );
   }
 
-  renderNewDataFiles() {
+  renderNewPackageFiles(fileType, header, buttonLabel) {
     const renderNewFile = (fileData, index) => {
       const key = fileData.get('key');
       return (
-        <NewDataFile
+        <NewPackageFile
           key={key}
           {...{
             index,
+            fileType,
             filename: fileData.get('filename'),
             showDeleteButton: this.props.dataFiles.get('key') !== key,
             isLoading: this.props.isLoading,
-            intl: this.props.intl,
-            updateNewDataFile: this.props.actions.updateNewDataFile,
-            deleteNewDataFile: this.props.actions.deleteNewDataFile,
+            updateNewPackageFile: this.props.actions.updateNewPackageFile,
+            deleteNewPackageFile: this.props.actions.deleteNewPackageFile,
+            buttonLabel,
           }}
         />
       );
     };
-    const newDataFilesRows = this.props.dataFiles.get('new').map(renderNewFile);
+    const newPackageFilesRows = this.props.dataFiles.get('new').map(renderNewFile);
 
     return (
       <Card initiallyExpanded>
         <CardHeader
-          title={this.props.intl.formatMessage(translations.newDataFilesHeader)}
+          title={header}
           textStyle={{ fontWeight: 'bold' }}
           actAsExpander
           showExpandableButton
@@ -137,7 +139,7 @@ class OnlineEditorPythonView extends React.Component {
         <CardText expandable style={{ padding: 0 }}>
           <Table selectable={false}>
             <TableBody displayRowCheckbox={false}>
-              { newDataFilesRows }
+              { newPackageFilesRows }
             </TableBody>
           </Table>
         </CardText>
@@ -168,6 +170,9 @@ class OnlineEditorPythonView extends React.Component {
           expression,
           expected,
           hint,
+          enableInlineCodeEditor: false,
+          showCodeEditor: test.get('showCodeEditor') || false,
+          intl: this.props.intl,
         }}
       />
       ));
@@ -273,12 +278,22 @@ class OnlineEditorPythonView extends React.Component {
           }
         </div>
         <h3>{ intl.formatMessage(translations.dataFilesHeader) }</h3>
-        { this.renderExistingDataFiles() }
-        { this.renderNewDataFiles() }
+        {
+          this.renderExistingPackageFiles(
+            'data_files',
+            this.props.intl.formatMessage(translations.currentDataFilesHeader)
+          )
+        }
+        {
+          this.renderNewPackageFiles('data_files',
+            this.props.intl.formatMessage(translations.newDataFilesHeader),
+            intl.formatMessage(translations.addDataFileButton)
+          )
+        }
         <h3>{ intl.formatMessage(translations.testCasesHeader) }</h3>
         <div style={{ marginBottom: '0.5em' }}>
           <FormattedMessage
-            id="course.assessment.question.programming.onlineEditorPythonView.testCasesDescription"
+            id="course.assessment.question.programming.OnlineEditorViewitorPythonView.testCasesDescription"
             defaultMessage={
               '{note}: The expression in the {expression} column will be compared with the ' +
               'expression in the {expected} column using the equality operator. The return value ' +

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -428,6 +428,7 @@ class ProgrammingQuestionForm extends React.Component {
             isLoading: this.props.data.get('is_loading'),
             autograded: this.props.data.getIn(['question', 'autograded']),
             autogradedAssessment: this.props.data.getIn(['question', 'autograded_assessment']),
+            hasSubmissions: this.props.data.getIn(['question', 'has_submissions']),
           }}
         />
       );

--- a/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+# Represents a Java Programming Question test report.
+#
+# Due to JUnit lacking the features to append meta data onto testcases,
+# Java evaluation uses TestNG go get around this.
+# This is used to parse TestNG's xml report.
+class Course::Assessment::Java::JavaProgrammingTestCaseReport <
+  Course::Assessment::ProgrammingTestCaseReport
+  class TestSuite
+    # Creates a new test suite. This represents a \<testsuite> element.
+    #
+    # @param [Nokogiri::XML::Element] suite
+    def initialize(suite)
+      @suite = suite
+    end
+
+    # The name of the test suite.
+    #
+    # @return [String]
+    def name
+      @suite['name']
+    end
+
+    # The identifier for the test suite.
+    #
+    # @return [String]
+    def identifier
+      name
+    end
+
+    # The duration for running the test suite.
+    #
+    # @return [Float|nil] The duration for the test suite, nil if the duration was not recorded.
+    def duration
+      @duration ||= begin
+        duration = @suite['duration-ms']
+        duration ? duration.to_f / 1000 : nil
+      end
+    end
+
+    # Gets the test cases found in this test suite.
+    #
+    # @return [Enumerable<Course::Assessment::JavaProgrammingTestCaseReport::TestCase>]
+    def test_cases
+      @suite.search('./test/class/test-method').map do |test_case|
+        TestCase.new(self, test_case)
+      end
+    end
+  end
+
+  class TestCase
+    attr_reader :test_suite
+
+    # Creates a new test case. This represents a \<testcase> element.
+    #
+    # @param [Course::Assessment::JavaProgrammingTestCaseReport::TestSuite] test_suite The suite this
+    #   test case belongs to.
+    # @param [Nokogiri::XML::Element] test_case
+    def initialize(test_suite, test_case)
+      @test_suite = test_suite
+      @test_case = test_case
+    end
+
+    # The name of the class.
+    #
+    # @return [String]
+    def class_name
+      @test_case['classname']
+    end
+
+    # The name of the test case.
+    #
+    # @return [String]
+    def name
+      @test_case['name']
+    end
+
+    # The duration for running the test case.
+    #
+    # @return [Float|nil] The duration for the test case, nil if not recorded.
+    def duration
+      @duration ||= begin
+        duration = @test_case['duration-ms']
+        duration ? duration.to_f / 1000 : nil
+      end
+    end
+
+    # The identifier for this test case. This attempts to be unique, but it might not be.
+    #
+    # @return [String]
+    def identifier
+      class_name = self.class_name ? self.class_name + '/' : ''
+      "#{@test_suite.identifier}/#{class_name}#{name.underscore}"
+    end
+
+    # The test expression
+    #
+    # @return [String]
+    def expression
+      @expression ||= get_test_case_metadata('expression')
+    end
+
+    # The expected value from running the test expression
+    #
+    # @return [String]
+    def expected
+      @expected ||= get_test_case_metadata('expected')
+    end
+
+    # A hint to help the student pass the test case
+    #
+    # @return [String]
+    def hint
+      @hint ||= get_test_case_metadata('hint')
+    end
+
+    # The output from the function under test.
+    # Needs to be initialized by the test code.
+    #
+    # @return [String]
+    def output
+      @output ||= get_test_case_metadata('output')
+    end
+
+    # If there's a failure, return the failure type and failure message.
+    #
+    # @return [String|nil] A combined string with the failure type and failure message,
+    # nil if no failure.
+    def failure_message
+      return nil unless failed?
+      failure_body = @test_case.search('exception/message').children[1].text
+      "#{failure_type}: #{failure_body}"
+    end
+
+    # If there's a failure, return the contents of the failure tag.
+    # This contains the full traceback.
+    #
+    # @return [String|nil] Full traceback of failure, nil if there's no failure.
+    def failure_contents
+      return nil unless failed?
+      @test_case.search('exception/full-stacktrace').children[1].text
+    end
+
+    # If there's a failure, return the failure type attribute.
+    #
+    # @return [String|nil] The type attribute, nil if there's no failure.
+    def failure_type
+      return nil unless failed?
+      @test_case.search('exception')[0]['class']
+    end
+
+    # Checks if the test case was skipped.
+    #
+    # @return [Boolean]
+    def skipped?
+      status == 'SKIP'
+    end
+
+    # Checks if the test case has failed.
+    #
+    # @return [Boolean]
+    def failed?
+      status == 'FAIL'
+    end
+
+    # Checks if the test case has passed.
+    #
+    # @return [Boolean]
+    def passed?
+      status == 'PASS'
+    end
+
+    # Checks the status of the test case
+    # Can either be 'PASS','FAIL' or 'SKIP'
+    #
+    # @return [String]
+    def status
+      @test_case['status']
+    end
+
+    # Combines the different strings above into a hash
+    #
+    # @return [Hash]
+    def messages
+      # prune empty and nil values
+      @messages ||= {
+        'error': nil,
+        'error_contents': nil,
+        'hint': hint,
+        'failure': failure_message,
+        'failure_contents': failure_contents,
+        'output': output
+      }.reject! { |_, v| v.blank? }
+    end
+
+    private
+
+    # Looks for the metadata attribute value in the test case XML.
+    # This can be stored either as attributes of the test case XML tag
+    # or as attributes of a child meta tag.
+    #
+    # @param [String] attribute_name The name of the attribute to retrieve.
+    # @return [String]
+    def get_test_case_metadata(attribute_name)
+      attribute = @test_case.search("./attributes/attribute[@name=#{attribute_name.inspect}]")
+      if attribute.present?
+        attribute.children[1].text
+      else
+        ''
+      end
+    end
+  end
+
+  # Parses a test case report.
+  #
+  # @param [String] report The report XML to parse.
+  def initialize(report)
+    @report = Nokogiri::XML::Document.parse(report)
+  end
+
+  # Gets the set of test suites found in this report.
+  #
+  # @return [Enumerable<Course::Assessment::JavaProgrammingTestCaseReport::TestSuite>]
+  def test_suites
+    @report.search('./testng-results/suite').map do |suite|
+      TestSuite.new(suite)
+    end
+  end
+
+  # Gets the set of test cases in this report.
+  #
+  # @return [Enumerable<Course::Assessment::JavaProgrammingTestCaseReport::TestCase>]
+  def test_cases
+    test_suites.map(&:test_cases).tap(&:flatten!).select { |test_case| valid_test_method(test_case) }
+  end
+
+  private
+
+  # Checks if a test-method has a public, evaluation or private in its name
+  #
+  # @return [Boolean]
+  def valid_test_method(test_case)
+    test_case.name =~ /public/i || test_case.name =~ /evaluation/i || test_case.name =~ /private/i
+  end
+end

--- a/spec/fixtures/course/programming_multiple_test_suite_report.xml
+++ b/spec/fixtures/course/programming_multiple_test_suite_report.xml
@@ -7,12 +7,12 @@
             <property name="compiler.debug" value="on" />
             <property name="project.jdk.classpath" value="jdk.classpath.1.6" />
         </properties>
-        <testcase classname="JUnitXmlReporter.constructor" name="should default path to an empty string" time="0.006">
+        <testcase classname="JUnitXmlReporter.constructor" name="test_public_1" time="0.006">
             <failure message="test failure">Assertion failed</failure>
         </testcase>
-        <testcase classname="JUnitXmlReporter.constructor" name="should default consolidate to true" time="0">
+        <testcase classname="JUnitXmlReporter.constructor" name="test_private_2" time="0">
             <skipped />
         </testcase>
-        <testcase classname="JUnitXmlReporter.constructor" name="should default useDotNotation to true" time="0" />
+        <testcase classname="JUnitXmlReporter.constructor" name="test_evaluation_3" time="0" />
     </testsuite>
 </testsuites>

--- a/spec/fixtures/course/programming_single_test_suite_report.xml
+++ b/spec/fixtures/course/programming_single_test_suite_report.xml
@@ -5,7 +5,7 @@
         <property name="compiler.debug" value="on" />
         <property name="project.jdk.classpath" value="jdk.classpath.1.6" />
     </properties>
-    <testcase classname="JUnitXmlReporter.constructor" name="should default path to an empty string" time="0.006">
+    <testcase classname="JUnitXmlReporter.constructor" name="test_public_1" time="0.006">
         <error message="mosaic() takes 1 positional argument but 4 were given" type="TypeError">
             <![CDATA[Traceback (most recent call last):
   File "tests/test_autograde_runes.py", line 53, in test_mosaic
@@ -13,8 +13,8 @@
 TypeError: mosaic() takes 1 positional argument but 4 were given
 ]]>		</error>
     </testcase>
-    <testcase classname="JUnitXmlReporter.constructor" name="should default consolidate to true" time="0">
+    <testcase classname="JUnitXmlReporter.constructor" name="test_private_2" time="0">
         <skipped />
     </testcase>
-    <testcase classname="JUnitXmlReporter.constructor" name="should default useDotNotation to true" time="0" />
+    <testcase classname="JUnitXmlReporter.constructor" name="test_evaluation_3" time="0" />
 </testsuite>

--- a/spec/fixtures/course/programming_single_test_suite_report_meta.xml
+++ b/spec/fixtures/course/programming_single_test_suite_report_meta.xml
@@ -10,7 +10,7 @@
 TypeError: mosaic() takes 1 positional argument but 4 were given
 ]]>			</error>
 		</testcase>
-		<testcase classname="Mission01" name="test_simple_fractal" time="0.000">
+		<testcase classname="Mission01" name="test_private_simple_fractal" time="0.000">
 			<error message="module 'mission01-template' has no attribute 'simple_fractal'" type="AttributeError">
 <![CDATA[Traceback (most recent call last):
   File "tests/test_autograde_runes.py", line 69, in test_simple_fractal

--- a/spec/fixtures/course/programming_single_test_suite_report_pass.xml
+++ b/spec/fixtures/course/programming_single_test_suite_report_pass.xml
@@ -5,7 +5,7 @@
         <property name="compiler.debug" value="on" />
         <property name="project.jdk.classpath" value="jdk.classpath.1.6" />
     </properties>
-    <testcase classname="JUnitXmlReporter.constructor" name="should default path to an empty string" time="0.006" />
-    <testcase classname="JUnitXmlReporter.constructor" name="should default consolidate to true" time="0" />
-    <testcase classname="JUnitXmlReporter.constructor" name="should default useDotNotation to true" time="0" />
+    <testcase classname="JUnitXmlReporter.constructor" name="test_public_1" time="0.006" />
+    <testcase classname="JUnitXmlReporter.constructor" name="test_private_2" time="0" />
+    <testcase classname="JUnitXmlReporter.constructor" name="test_evaluation_3" time="0" />
 </testsuite>

--- a/spec/fixtures/course/programming_single_test_suite_report_test_case_meta.xml
+++ b/spec/fixtures/course/programming_single_test_suite_report_test_case_meta.xml
@@ -9,7 +9,7 @@
 TypeError: mosaic() takes 1 positional argument but 4 were given
 ]]>			</error>
 		</testcase>
-		<testcase classname="Mission01" name="test_simple_fractal" time="0.000">
+		<testcase classname="Mission01" name="test_private_simple_fractal" time="0.000">
 			<error message="module 'mission01-template' has no attribute 'simple_fractal'" type="AttributeError">
 <![CDATA[Traceback (most recent call last):
   File "tests/test_autograde_runes.py", line 69, in test_simple_fractal

--- a/spec/libraries/course/assessment/programming_test_case_report_spec.rb
+++ b/spec/libraries/course/assessment/programming_test_case_report_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
 
       describe '#name' do
         it 'returns the name attribute' do
-          expect(subject.name).to eq('should default path to an empty string')
+          expect(subject.name).to eq('test_public_1')
         end
       end
 

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
       end
 
       it 'infers that the test case is private' do
-        expect(subject.send(:infer_test_case_type, 'test_fractal')).to eq(:private_test)
+        expect(subject.send(:infer_test_case_type, 'test_private_fractal')).to eq(:private_test)
       end
 
       it 'infers that the test case is an evaluation test' do


### PR DESCRIPTION
Java autograder's implementation for its interface.

Has two modes (apart from autograded):
1. Submit as a regular template file (similar to that of the python/cpp implementation)
2. Submit as a file (in the form of file uploads for submission and solution files)

Uses a custom parser to read TestNG xml reports which is used to run the tests in the docker container