### PR TITLE
Redirect to assessment show page when attempting with no questions.

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -30,7 +30,14 @@ class Course::Assessment::Submission::SubmissionsController < \
   end
 
   def create
-    raise IllegalStateError if @assessment.questions.empty?
+    # Show the assessment description if there are no questions.
+    # https://github.com/Coursemology/coursemology2/issues/2387
+    if @assessment.questions.empty?
+      redirect_to course_assessment_path(current_course, @assessment),
+                  danger: t('.no_questions')
+      return
+    end
+
     @submission.session_id = authentication_service.generate_authentication_token!
     if @submission.save
       log_service.log_submission_access(request) if @assessment.password_protected?

--- a/config/locales/en/course/assessment/submission/submissions.yml
+++ b/config/locales/en/course/assessment/submission/submissions.yml
@@ -21,6 +21,7 @@ en:
               Are you sure you want to publish?
           create:
             failure: 'Could not create submission: %{error}'
+            no_questions: 'This assessment has no questions. Check the description for your tasks.'
           edit:
             attempt: :'course.assessment.assessments.assessment.attempt'
             files: :'course.assessment.assessments.show.files'

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:empty_assessment) { create(:assessment, course: course, published: false) }
+    let(:published_empty_assessment) { create(:assessment, course: course, published: true) }
     let(:not_started_assessment) do
       create(:assessment, :published_with_all_question_types, :not_started, course: course)
     end
@@ -47,6 +48,18 @@ RSpec.describe 'Course: Assessments: Attempt' do
         visit course_assessments_path(course)
 
         expect(page).not_to have_content_tag_for(empty_assessment)
+      end
+
+      scenario 'Attempting empty assessments shows the assessment description' do
+        published_empty_assessment
+        visit course_assessments_path(course)
+
+        within find(content_tag_selector(published_empty_assessment)) do
+          find_link(I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
+                    href: course_assessment_submissions_path(course, published_empty_assessment)).
+            click
+        end
+        expect(current_path).to eq(course_assessment_path(course, published_empty_assessment))
       end
 
       scenario 'I cannot attempt unsatisfied assessments' do


### PR DESCRIPTION
If there are no questions in the assessment, go to the assessment show
page which has the description instead of raising IllegalStateError.

Add flash message to explain to the user why he's there.
Add translation.

Add spec to test the redirection.

Fixes #2387.