### PR TITLE
Do not allow rich text in comments center

### DIFF
--- a/app/assets/javascripts/helpers/discussion/edit_post.js
+++ b/app/assets/javascripts/helpers/discussion/edit_post.js
@@ -22,7 +22,7 @@ var EDIT_DISCUSSION_POST = (function($, FORM_HELPERS,
     var courseId = COURSE_HELPERS.courseIdForElement($element);
     var topicId = $topic.data('topicId');
     var postId = $post.data('postId');
-    var postContent = $post.find('.content').html();
+    var postContent = $post.find('.content').html().trim();
     var postCommenter = $post.find('.user').html();
 
     $post.children().hide();

--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -63,7 +63,7 @@
         }
       };
 
-    $('textarea.text').not('.summernote-initialised').each(function() {
+    $('textarea.text').not('.summernote-initialised').not('.no-summernote').each(function() {
       var $summernote = $(this);
       function onImageCompressed(dataUrl) {
         var img = document.createElement('img');

--- a/app/assets/javascripts/templates/course/discussion/post.jst.ejs
+++ b/app/assets/javascripts/templates/course/discussion/post.jst.ejs
@@ -3,7 +3,7 @@
   <%= postCommenter %>
   <div class="form-group text">
     <textarea name="discussion_post[text]"
-              class="form-control text airmode"
+              class="form-control text no-summernote"
               aria-label="<%= I18n.t('javascript.course.discussion.post.text.label') %>"
       ><%= postContent %></textarea>
   </div>

--- a/app/assets/stylesheets/course/discussion/comments_center.scss
+++ b/app/assets/stylesheets/course/discussion/comments_center.scss
@@ -7,7 +7,7 @@
 
   .post-form {
     .btn {
-      margin-top: -15px;
+      margin-top: -10px;
     }
   }
 }

--- a/app/views/course/discussion/posts/_form.html.slim
+++ b/app/views/course/discussion/posts/_form.html.slim
@@ -2,5 +2,5 @@
 div.post-form style='display: none'
   = simple_form_for Course::Discussion::Post.new, url: course_topic_posts_path(current_course, topic) do |f|
     = f.hidden_field :parent_id
-    = f.input :text, label: false, input_html: { class: ['airmode'] }
+    = f.input :text, label: false, input_html: { class: ['no-summernote'] }
     = f.button :submit, t('.comment')


### PR DESCRIPTION
After the react submission page, the texts displayed at the comments center are not consistent with the submissions page. 