### PR TITLE
Fix behavior of watching videos

### DIFF
--- a/app/views/course/video/videos/_video_attempt_button.html.slim
+++ b/app/views/course/video/videos/_video_attempt_button.html.slim
@@ -1,4 +1,4 @@
-- if can?(:attempt, video)
+- if can?(:attempt, video) && current_course_user
   - submission = video.submissions.select { |s| s.creator == current_user }.first
   - if submission
     = link_to t('.rewatch'),

--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -15,7 +15,7 @@ en:
       models:
         course/assessment/submission:
           experience_points_record:
-            inconsistent_user: 'the creator of the submission must be the same as the course user'
+            inconsistent_user: 'creator must be the same as the course user record'
             absent_award_attributes: >
               there is no award attributes for your submission, please try again
               or contact the Coursemology team

--- a/config/locales/en/activerecord/course/video/submission.yml
+++ b/config/locales/en/activerecord/course/video/submission.yml
@@ -3,6 +3,7 @@ en:
     errors:
       models:
         course/video/submission:
-          experience_points_record:
-            inconsistent_user: 'the creator of the submission must be the same as the course user'
+          attributes:
+            experience_points_record:
+              inconsistent_user: 'creator must be the same as the course user record'
           submission_already_exists: "Looks like you have already created a submission. Try again?"


### PR DESCRIPTION
Currently, global administrators can see the 'Watch' button for videos in courses they don't belong to, but click it results in some non-readable error. This PR: 
 - Disables the 'Watch' button for Admins (since they don't have a course_user). To remove this when #2386 is fixed.
 - Fix the error message (for both video and assessment submissions).