### PR TITLE
Update Ruby version to 2.4.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   except:
     - /^bundle-update-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}+$/
 rvm:
-  - 2.3.1
+  - 2.4.1
 services:
   - docker
 addons:


### PR DESCRIPTION
DO NOT MERGE yet. Environments need to be upgraded before we run all future tests on 2.4.1 only.