### PR TITLE
For Python, put quote marks around output if it's a string.

### DIFF
--- a/app/services/course/assessment/question/programming/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming/python/python_package_service.rb
@@ -174,7 +174,7 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
         self.meta['expected'] = #{expected}
         #{hint}
         _out = #{test[:expression]}
-        self.meta['output'] = _out
+        self.meta['output'] = "'" + _out + "'" if isinstance(_out, str) else _out
         self.assertEqual(_out, #{test[:expected]})
       PYTHON
 


### PR DESCRIPTION
Only for the test case UI. Manually uploaded packages will need to
handle this themselves.

Fixes #2175.

<img width="840" alt="screen shot 2017-08-03 at 10 31 07 pm" src="https://user-images.githubusercontent.com/1902527/28926978-eff80952-789b-11e7-9cec-af080eb25fb1.png">
