### PR TITLE
Do not show wrong answer for evaluation test case failures

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/Checkbox.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/Checkbox.jsx
@@ -5,6 +5,7 @@ export default class Checkbox extends Component {
   static propTypes = {
     style: PropTypes.object,        // eslint-disable-line react/forbid-prop-types
     checked: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool.isRequired,
     indeterminate: PropTypes.bool,
     onChange: PropTypes.func,
   };
@@ -16,7 +17,7 @@ export default class Checkbox extends Component {
   };
 
   render() {
-    const { style, checked, indeterminate, onChange } = this.props;
+    const { disabled, style, checked, indeterminate, onChange } = this.props;
     return (
       <input
         type="checkbox"
@@ -28,6 +29,7 @@ export default class Checkbox extends Component {
           }
         }}
         onChange={onChange}
+        disabled={disabled}
       />
     );
   }

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
@@ -95,7 +95,7 @@ export default class ReadOnlyEditor extends Component {
         return false;
       }
     }
-    return true;
+    return annotations.length > 0;
   }
 
   isIndeterminateState() {
@@ -140,6 +140,7 @@ export default class ReadOnlyEditor extends Component {
             }
           }}
           checked={this.isAllExpanded()}
+          disabled={this.props.annotations.length === 0}
           indeterminate={this.isIndeterminateState()}
         />
         Expand all comments

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -57,10 +57,10 @@ class SubmissionEditForm extends Component {
   }
 
   componentDidMount() {
-    const { questionIds } = this.props;
+    const { questionIds, tabbedView } = this.props;
     let initialStep = this.props.step;
 
-    if (initialStep !== null) {
+    if (initialStep !== null && !tabbedView) {
       initialStep = initialStep < 0 ? 0 : initialStep;
       initialStep = initialStep >= questionIds.length - 1 ? questionIds.length - 1 : initialStep;
       scroller.scrollTo(`step${initialStep}`, { offset: -60 });

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -10,8 +10,7 @@ import { Card, CardHeader, CardText } from 'material-ui/Card';
 import CircularProgress from 'material-ui/CircularProgress';
 import RaisedButton from 'material-ui/RaisedButton';
 import Paper from 'material-ui/Paper';
-import { red100, red200, red900, yellow900, grey100, blue500,
-         green200, green900, white } from 'material-ui/styles/colors';
+import { red100, red200, red900, yellow900, grey100, blue500, white } from 'material-ui/styles/colors';
 
 /* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
 import Dialog from 'material-ui/Dialog';
@@ -130,7 +129,7 @@ class SubmissionEditForm extends Component {
       } else if (explanation.failureType === 'private_test') {
         title = intl.formatMessage(translations.privateTestCaseFailure);
       } else {
-        title = intl.formatMessage(translations.wrong);
+        return null;
       }
 
       return (
@@ -138,10 +137,10 @@ class SubmissionEditForm extends Component {
           <CardHeader
             style={{
               ...styles.explanationHeader,
-              backgroundColor: explanation.correct ? green200 : red200,
+              backgroundColor: red200,
             }}
             title={title}
-            titleColor={explanation.correct ? green900 : red900}
+            titleColor={red900}
           />
           <CardText>
             {explanation.explanations.map(exp => <div dangerouslySetInnerHTML={{ __html: exp }} />)}


### PR DESCRIPTION
The following bugs on the submission page are fixed in this PR:

- Explanation panel with title "Wrong!" shown for evaluation test case failures for manually graded assessment
- react-scroll trying to scroll to non-existing element when step param is present on tabbed assessments
- "Expand all" programming annotations checkbox checked and not disabled when there are no annotations