### PR TITLE
Duplicate course by duplicating each top-level object separately

### DIFF
--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -63,6 +63,11 @@ class Course::Achievement < ActiveRecord::Base
       self.conditions = duplicator.duplicate(other.conditions.map(&:actable)).map(&:acting_as)
     elsif duplicator.mode == :object
       self.course = duplicator.options[:target_course]
+
+      duplicate_conditions(duplicator, other)
+      achievement_conditions << other.achievement_conditions.
+                                select { |condition| duplicator.duplicated?(condition.conditional) }.
+                                map { |condition| duplicator.duplicate(condition) }
     end
   end
 end

--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -55,19 +55,10 @@ class Course::Achievement < ActiveRecord::Base
 
   def initialize_duplicate(duplicator, other)
     badge.duplicate_from(other.badge) if other.badge_url
-
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-      self.achievement_conditions = duplicator.duplicate(other.achievement_conditions)
-      # Duplicate actable object directly and let the acting_as gem create the Condition object
-      self.conditions = duplicator.duplicate(other.conditions.map(&:actable)).map(&:acting_as)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-
-      duplicate_conditions(duplicator, other)
-      achievement_conditions << other.achievement_conditions.
-                                select { |condition| duplicator.duplicated?(condition.conditional) }.
-                                map { |condition| duplicator.duplicate(condition) }
-    end
+    self.course = duplicator.options[:target_course]
+    duplicate_conditions(duplicator, other)
+    achievement_conditions << other.achievement_conditions.
+                              select { |condition| duplicator.duplicated?(condition.conditional) }.
+                              map { |condition| duplicator.duplicate(condition) }
   end
 end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -137,30 +137,33 @@ class Course::Assessment < ActiveRecord::Base
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other, duplicator)
+    target_tab = initialize_duplicate_tab(duplicator, other)
     self.folder = duplicator.duplicate(other.folder)
+    folder.parent = target_tab.category.folder
     self.questions = duplicator.duplicate(other.questions.map(&:actable)).compact.map(&:acting_as)
-    if duplicator.mode == :course
-      self.assessment_conditions = duplicator.duplicate(other.assessment_conditions)
-      # Like achievement conditions, duplicate the actable object directly and let the acting_as
-      # gem create the Condition object.
-      self.conditions = duplicator.duplicate(other.conditions.map(&:actable)).map(&:acting_as)
-    elsif duplicator.mode == :object
-      if duplicator.duplicated?(other.tab)
-        target_tab = duplicator.duplicate(other.tab)
-        target_category = target_tab.category
-      else
-        target_category = duplicator.options[:target_course].assessment_categories.first
-        target_tab = target_category.tabs.first
-      end
-      self.tab = target_tab
-      folder.parent = target_category.folder
-
-      duplicate_conditions(duplicator, other)
-      assessment_conditions << other.assessment_conditions.
-                               select { |condition| duplicator.duplicated?(condition.conditional) }.
-                               map { |condition| duplicator.duplicate(condition) }
-    end
+    initialize_duplicate_conditions(duplicator, other)
     @duplicating = true
+  end
+
+  # Parents the assessment under its duplicated parent tab, if it exists.
+  #
+  # @return [Course::Assessment::Tab] The duplicated assessment's tab
+  def initialize_duplicate_tab(duplicator, other)
+    if duplicator.duplicated?(other.tab)
+      target_tab = duplicator.duplicate(other.tab)
+    else
+      target_category = duplicator.options[:target_course].assessment_categories.first
+      target_tab = target_category.tabs.first
+    end
+    self.tab = target_tab
+  end
+
+  # Set up conditions that depend on this assessment and conditions that this assessment depends on.
+  def initialize_duplicate_conditions(duplicator, other)
+    duplicate_conditions(duplicator, other)
+    assessment_conditions << other.assessment_conditions.
+                             select { |condition| duplicator.duplicated?(condition.conditional) }.
+                             map { |condition| duplicator.duplicate(condition) }
   end
 
   private

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -145,11 +145,15 @@ class Course::Assessment < ActiveRecord::Base
       # gem create the Condition object.
       self.conditions = duplicator.duplicate(other.conditions.map(&:actable)).map(&:acting_as)
     elsif duplicator.mode == :object
-      target_category = duplicator.options[:target_course].assessment_categories.first
-      target_tab = target_category.tabs.first
+      if duplicator.duplicated?(other.tab)
+        target_tab = duplicator.duplicate(other.tab)
+        target_category = target_tab.category
+      else
+        target_category = duplicator.options[:target_course].assessment_categories.first
+        target_tab = target_category.tabs.first
+      end
       self.tab = target_tab
-      self.folder.parent = target_category.folder
-      self.folder.owner = self
+      folder.parent = target_category.folder
     end
     @duplicating = true
   end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -154,6 +154,11 @@ class Course::Assessment < ActiveRecord::Base
       end
       self.tab = target_tab
       folder.parent = target_category.folder
+
+      duplicate_conditions(duplicator, other)
+      assessment_conditions << other.assessment_conditions.
+                               select { |condition| duplicator.duplicated?(condition.conditional) }.
+                               map { |condition| duplicator.duplicate(condition) }
     end
     @duplicating = true
   end

--- a/app/models/course/assessment/category.rb
+++ b/app/models/course/assessment/category.rb
@@ -35,18 +35,11 @@ class Course::Assessment::Category < ActiveRecord::Base
   end
 
   def initialize_duplicate(duplicator, other)
-    # duplicate the folder (single object)
     self.folder = duplicator.duplicate(other.folder)
-
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-      self.tabs = duplicator.duplicate(other.tabs).compact
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-      tabs << other.tabs.select { |tab| duplicator.duplicated?(tab) }.map do |tab|
-        duplicator.duplicate(tab).tap do |duplicate_tab|
-          duplicate_tab.assessments.each { |assessment| assessment.folder.parent = folder }
-        end
+    self.course = duplicator.options[:target_course]
+    tabs << other.tabs.select { |tab| duplicator.duplicated?(tab) }.map do |tab|
+      duplicator.duplicate(tab).tap do |duplicate_tab|
+        duplicate_tab.assessments.each { |assessment| assessment.folder.parent = folder }
       end
     end
   end

--- a/app/models/course/assessment/category.rb
+++ b/app/models/course/assessment/category.rb
@@ -43,6 +43,11 @@ class Course::Assessment::Category < ActiveRecord::Base
       self.tabs = duplicator.duplicate(other.tabs).compact
     elsif duplicator.mode == :object
       self.course = duplicator.options[:target_course]
+      tabs << other.tabs.select { |tab| duplicator.duplicated?(tab) }.map do |tab|
+        duplicator.duplicate(tab).tap do |duplicate_tab|
+          duplicate_tab.assessments.each { |assessment| assessment.folder.parent = folder }
+        end
+      end
     end
   end
 

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -95,6 +95,13 @@ class Course::Assessment::Question < ActiveRecord::Base
     self.weight = other.weight
   end
 
+  # Associates duplicated skills with the current question
+  def associate_duplicated_skills(duplicator, other)
+    skills << other.skills.
+              select { |skill| duplicator.duplicated?(skill) }.
+              map { |skill| duplicator.duplicate(skill) }
+  end
+
   private
 
   def set_defaults

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -40,6 +40,8 @@ class Course::Assessment::Question::MultipleResponse < ActiveRecord::Base
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
+    associate_duplicated_skills(duplicator, other)
+
     self.options = duplicator.duplicate(other.options)
   end
 

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -89,6 +89,7 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
+    associate_duplicated_skills(duplicator, other)
 
     # TODO: check if there are any side effects from this
     self.import_job_id = nil

--- a/app/models/course/assessment/question/scribing.rb
+++ b/app/models/course/assessment/question/scribing.rb
@@ -7,6 +7,13 @@ class Course::Assessment::Question::Scribing < ActiveRecord::Base
     'course/assessment/question/scribing/scribing'
   end
 
+  def initialize_duplicate(duplicator, other)
+    copy_attributes(other)
+    associate_duplicated_skills(duplicator, other)
+
+    self.attachment = duplicator.duplicate(other.attachment)
+  end
+
   # Scribing is not autogradable, don't need last attempt
   def attempt(submission, _last_attempt = nil)
     answer = Course::Assessment::Answer::Scribing.new(submission: submission, question: question)

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -49,6 +49,8 @@ class Course::Assessment::Question::TextResponse < ActiveRecord::Base
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
+    associate_duplicated_skills(duplicator, other)
+
     self.solutions = duplicator.duplicate(other.solutions)
   end
 

--- a/app/models/course/assessment/skill.rb
+++ b/app/models/course/assessment/skill.rb
@@ -11,17 +11,11 @@ class Course::Assessment::Skill < ActiveRecord::Base
   scope :order_by_title, ->(direction = :asc) { order(title: direction) }
 
   def initialize_duplicate(duplicator, other)
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-      self.skill_branch = duplicator.duplicate(other.skill_branch)
-      self.questions = duplicator.duplicate(other.questions.map(&:actable)).compact.map(&:acting_as)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-      self.skill_branch = duplicator.duplicated?(other.skill_branch) ? duplicator.duplicate(other.skill_branch) : nil
-      questions << other.questions.map(&:actable).
-                   select { |question| duplicator.duplicated?(question) }.
-                   map { |question| duplicator.duplicate(question).acting_as }
-    end
+    self.course = duplicator.options[:target_course]
+    self.skill_branch = duplicator.duplicated?(other.skill_branch) ? duplicator.duplicate(other.skill_branch) : nil
+    questions << other.questions.map(&:actable).
+                 select { |question| duplicator.duplicated?(question) }.
+                 map { |question| duplicator.duplicate(question).acting_as }
   end
 
   private

--- a/app/models/course/assessment/skill.rb
+++ b/app/models/course/assessment/skill.rb
@@ -18,6 +18,9 @@ class Course::Assessment::Skill < ActiveRecord::Base
     elsif duplicator.mode == :object
       self.course = duplicator.options[:target_course]
       self.skill_branch = duplicator.duplicated?(other.skill_branch) ? duplicator.duplicate(other.skill_branch) : nil
+      questions << other.questions.map(&:actable).
+                   select { |question| duplicator.duplicated?(question) }.
+                   map { |question| duplicator.duplicate(question).acting_as }
     end
   end
 

--- a/app/models/course/assessment/skill_branch.rb
+++ b/app/models/course/assessment/skill_branch.rb
@@ -5,14 +5,9 @@ class Course::Assessment::SkillBranch < ActiveRecord::Base
   scope :ordered_by_title, -> { order(:title) }
 
   def initialize_duplicate(duplicator, other)
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-      self.skills = duplicator.duplicate(other.skills)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-      self.skills << other.skills.
-                     select { |skill| duplicator.duplicated?(skill) }.
-                     map { |skill| duplicator.duplicate(skill) }
-    end
+    self.course = duplicator.options[:target_course]
+    skills << other.skills.
+              select { |skill| duplicator.duplicated?(skill) }.
+              map { |skill| duplicator.duplicate(skill) }
   end
 end

--- a/app/models/course/assessment/tab.rb
+++ b/app/models/course/assessment/tab.rb
@@ -19,22 +19,17 @@ class Course::Assessment::Tab < ActiveRecord::Base
   end
 
   def initialize_duplicate(duplicator, other)
-    if duplicator.mode == :course
-      self.assessments = duplicator.duplicate(other.assessments).compact
-    elsif duplicator.mode == :object
-      self.category = if duplicator.duplicated?(other.category)
-                        duplicator.duplicate(other.category)
-                      else
-                        duplicator.options[:target_course].assessment_categories.first
-                      end
-
-      assessments <<
-        other.assessments.select { |assessment| duplicator.duplicated?(assessment) }.map do |assessment|
-          duplicator.duplicate(assessment).tap do |duplicate_assessment|
-            duplicate_assessment.folder.parent = category.folder
-          end
+    self.category = if duplicator.duplicated?(other.category)
+                      duplicator.duplicate(other.category)
+                    else
+                      duplicator.options[:target_course].assessment_categories.first
+                    end
+    assessments <<
+      other.assessments.select { |assessment| duplicator.duplicated?(assessment) }.map do |assessment|
+        duplicator.duplicate(assessment).tap do |duplicate_assessment|
+          duplicate_assessment.folder.parent = category.folder
         end
-    end
+      end
   end
 
   private

--- a/app/models/course/condition/assessment.rb
+++ b/app/models/course/condition/assessment.rb
@@ -60,6 +60,7 @@ class Course::Condition::Assessment < ActiveRecord::Base
   end
 
   def initialize_duplicate(duplicator, other)
+    self.assessment = duplicator.duplicate(other.assessment)
     self.conditional_type = other.conditional_type
     self.conditional = duplicator.duplicate(other.conditional)
 

--- a/app/models/course/condition/level.rb
+++ b/app/models/course/condition/level.rb
@@ -27,14 +27,8 @@ class Course::Condition::Level < ActiveRecord::Base
   end
 
   def initialize_duplicate(duplicator, other)
-    self.conditional_type = other.conditional_type
     self.conditional = duplicator.duplicate(other.conditional)
-
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-    end
+    self.course = duplicator.options[:target_course]
   end
 
   # Class that the condition depends on.

--- a/app/models/course/forum.rb
+++ b/app/models/course/forum.rb
@@ -67,12 +67,8 @@ class Course::Forum < ActiveRecord::Base
     'forums/forum'
   end
 
-  def initialize_duplicate(duplicator, other)
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-    end
+  def initialize_duplicate(duplicator, _other)
+    self.course = duplicator.options[:target_course]
   end
 
   private

--- a/app/models/course/lesson_plan/event.rb
+++ b/app/models/course/lesson_plan/event.rb
@@ -4,11 +4,6 @@ class Course::LessonPlan::Event < ActiveRecord::Base
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other, duplicator)
-
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-    end
+    self.course = duplicator.options[:target_course]
   end
 end

--- a/app/models/course/lesson_plan/milestone.rb
+++ b/app/models/course/lesson_plan/milestone.rb
@@ -2,13 +2,8 @@
 class Course::LessonPlan::Milestone < ActiveRecord::Base
   belongs_to :course, inverse_of: :lesson_plan_milestones
 
-  def initialize_duplicate(duplicator, other)
+  def initialize_duplicate(duplicator, _other)
     self.start_at = duplicator.time_shift(start_at)
-
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-    end
+    self.course = duplicator.options[:target_course]
   end
 end

--- a/app/models/course/level.rb
+++ b/app/models/course/level.rb
@@ -60,11 +60,7 @@ class Course::Level < ActiveRecord::Base
     self.next ? self.next.experience_points_threshold : experience_points_threshold
   end
 
-  def initialize_duplicate(duplicator, other)
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-    end
+  def initialize_duplicate(duplicator, _other)
+    self.course = duplicator.options[:target_course]
   end
 end

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -83,22 +83,27 @@ class Course::Material::Folder < ActiveRecord::Base
     self.created_at = other.created_at
     self.materials = duplicator.duplicate(other.materials).compact
     self.owner = duplicator.duplicate(other.owner)
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-      self.parent = duplicator.duplicate(other.parent)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-      self.parent = duplicator.options[:target_course].root_folder
-      self.parent = if duplicator.duplicated?(other.parent)
-                      duplicator.duplicate(other.parent)
-                    else
-                      duplicator.options[:target_course].root_folder
-                    end
-      children << other.children.
-                  select { |folder| duplicator.duplicated?(folder) }.
-                  map { |folder| duplicator.duplicate(folder) }
-    end
+    self.course = duplicator.options[:target_course]
+    initialize_duplicate_parent(duplicator, other)
+    initialize_duplicate_children(duplicator, other)
     @duplicating = true
+  end
+
+  def initialize_duplicate_parent(duplicator, other)
+    duplicating_course_root_folder = duplicator.mode == :course && other.parent.nil?
+    self.parent = if duplicating_course_root_folder
+                    nil
+                  elsif duplicator.duplicated?(other.parent)
+                    duplicator.duplicate(other.parent)
+                  else
+                    duplicator.options[:target_course].root_folder
+                  end
+  end
+
+  def initialize_duplicate_children(duplicator, other)
+    children << other.children.
+                select { |folder| duplicator.duplicated?(folder) }.
+                map { |folder| duplicator.duplicate(folder) }
   end
 
   private

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -89,6 +89,14 @@ class Course::Material::Folder < ActiveRecord::Base
     elsif duplicator.mode == :object
       self.course = duplicator.options[:target_course]
       self.parent = duplicator.options[:target_course].root_folder
+      self.parent = if duplicator.duplicated?(other.parent)
+                      duplicator.duplicate(other.parent)
+                    else
+                      duplicator.options[:target_course].root_folder
+                    end
+      children << other.children.
+                  select { |folder| duplicator.duplicated?(folder) }.
+                  map { |folder| duplicator.duplicate(folder) }
     end
     @duplicating = true
   end

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -31,11 +31,6 @@ class Course::Survey < ActiveRecord::Base
   def initialize_duplicate(duplicator, other)
     copy_attributes(other, duplicator)
     self.sections = duplicator.duplicate(other.sections)
-
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-    end
+    self.course = duplicator.options[:target_course]
   end
 end

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -40,11 +40,6 @@ class Course::Video < ActiveRecord::Base
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other, duplicator)
-
-    if duplicator.mode == :course
-      self.course = duplicator.duplicate(other.course)
-    elsif duplicator.mode == :object
-      self.course = duplicator.options[:target_course]
-    end
+    self.course = duplicator.options[:target_course]
   end
 end

--- a/lib/autoload/duplicator.rb
+++ b/lib/autoload/duplicator.rb
@@ -52,6 +52,10 @@ class Duplicator
     @duplicated_objects.key?(source_object)
   end
 
+  def set_option(key, value)
+    @options[key] = value
+  end
+
   private
 
   # Maps a block onto a single item or a collection of items. An array is returned if a collection received.

--- a/lib/autoload/duplicator.rb
+++ b/lib/autoload/duplicator.rb
@@ -27,18 +27,7 @@ class Duplicator
   # @return duplicated_stuff A reference to a single duplicated object or an Array of duplicated
   #   objects
   def duplicate(stuff)
-    # Track if an enumerable or single object was passed in. Needed to handle single element
-    # collections.
-    # Note that ActiveRecord CollectionProxy is not an Enumerable, so check for to_a instead.
-    return nil unless stuff
-    stuff_is_enumerable = stuff.respond_to?(:to_a)
-    duplicated_stuff = []
-    stuff = [*stuff] unless stuff_is_enumerable
-    stuff.each do |obj|
-      duplicated_object = duplicate_object(obj)
-      duplicated_stuff << duplicated_object unless duplicated_object.nil?
-    end
-    stuff_is_enumerable ? duplicated_stuff : duplicated_stuff[0]
+    map_item_or_collection(stuff) { |item| duplicate_object(item) }
   end
 
   # Time shifts the datetime passed to this function.
@@ -65,12 +54,19 @@ class Duplicator
 
   private
 
+  # Maps a block onto a single item or a collection of items. An array is returned if a collection received.
+  # Otherwise, the result of the block is returned.
+  def map_item_or_collection(item_or_collection, &block)
+    item_or_collection.respond_to?(:to_ary) ? item_or_collection.map(&block) : yield(item_or_collection)
+  end
+
   # Deep copy +source_object+ and its children. +source_object+ must provide a
   # +initialize_duplicate+ method which duplicates its children.
   #
   # @param [#initialize_duplicate] source_object The object to be duplicated.
   # @return duplicated_object A reference to the duplicated object.
   def duplicate_object(source_object)
+    return nil unless source_object
     @duplicated_objects.fetch(source_object) do |key|
       if !@exclusion_set.include?(key)
         source_object.dup.tap do |duplicate|

--- a/lib/extensions/conditional/active_record/base.rb
+++ b/lib/extensions/conditional/active_record/base.rb
@@ -52,6 +52,14 @@ module Extensions::Conditional::ActiveRecord::Base
     def satisfiable?
       raise NotImplementedError, 'Subclasses must implement a #satisfiable? method.'
     end
+
+    # Duplicate conditions if dependent objects have been duplicated
+    def duplicate_conditions(duplicator, other)
+      conditions_to_duplicate = other.conditions.to_a.select do |condition|
+        duplicator.duplicated?(condition.actable.dependent_object)
+      end.map(&:actable)
+      conditions << duplicator.duplicate(conditions_to_duplicate).map(&:acting_as)
+    end
   end
 
   module ConditionInstanceMethods

--- a/lib/extensions/conditional/active_record/base.rb
+++ b/lib/extensions/conditional/active_record/base.rb
@@ -56,7 +56,9 @@ module Extensions::Conditional::ActiveRecord::Base
     # Duplicate conditions if dependent objects have been duplicated
     def duplicate_conditions(duplicator, other)
       conditions_to_duplicate = other.conditions.to_a.select do |condition|
-        duplicator.duplicated?(condition.actable.dependent_object)
+        dependent_object = condition.actable.dependent_object
+        duplicated = duplicator.duplicated?(condition.actable.dependent_object)
+        duplicator.mode == :course ? (dependent_object.nil? || duplicated) : duplicated
       end.map(&:actable)
       conditions << duplicator.duplicate(conditions_to_duplicate).map(&:acting_as)
     end

--- a/spec/services/course/duplication/course_duplication_service_spec.rb
+++ b/spec/services/course/duplication/course_duplication_service_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
     let!(:survey) { create(:survey, course: course) }
 
     describe '#duplicate_course' do
+      context 'when saving fails' do
+        let!(:invalid_event) do
+          create(:course_lesson_plan_event, course: course).tap do |event|
+            event.acting_as.update_columns(time_bonus_exp: 1, bonus_end_at: nil)
+          end
+        end
+
+        it 'rolls back the whole transaction' do
+          expect { new_course }.to change { Course.count }.by(0)
+          expect(new_course).to be_nil
+        end
+      end
+
       context 'when children are simple' do
         let!(:forum) { create(:forum, course: course) }
         let!(:milestones) { create_list(:course_lesson_plan_milestone, 3, course: course) }

--- a/spec/services/course/duplication/course_duplication_service_spec.rb
+++ b/spec/services/course/duplication/course_duplication_service_spec.rb
@@ -92,18 +92,20 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
 
         it 'duplicates lesson plan milestones' do
           # Check that new milestones are assigned to the new course
-          new_course.lesson_plan_milestones.each do |new_milestone|
+          old_milestones = course.lesson_plan_milestones.sort_by(&:title)
+          new_milestones = new_course.lesson_plan_milestones.sort_by(&:title)
+          new_milestones.each do |new_milestone|
             expect(new_milestone.course).to eq new_course
           end
 
           # Check attributes of duplicated milestones
-          course.lesson_plan_milestones.each_index do |i|
+          new_milestones.each_index do |i|
             expect(new_course.lesson_plan_milestones[i].title).
-              to eq course.lesson_plan_milestones[i].title
+              to eq old_milestones[i].title
             expect(new_course.lesson_plan_milestones[i].description).
-              to eq course.lesson_plan_milestones[i].description
+              to eq old_milestones[i].description
             expect(new_course.lesson_plan_milestones[i].start_at).
-              to be_within(1.second).of course.lesson_plan_milestones[i].start_at + time_shift
+              to be_within(1.second).of old_milestones[i].start_at + time_shift
           end
         end
 

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -330,14 +330,50 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
         end
       end
 
-      context 'when a material folder is selected' do
-        let(:folder) { create(:course_material_folder, course: source_course) }
+      context 'when a material folder are present' do
+        let(:grandparent_folder) { create(:course_material_folder, course: source_course) }
+        let(:parent_folder) do
+          create(:course_material_folder, course: source_course, parent: grandparent_folder)
+        end
+        let(:folder) do
+          create(:course_material_folder, course: source_course, parent: parent_folder)
+        end
         let!(:content) { create(:course_material, folder: folder) }
-        let(:source_objects) { [folder] }
 
-        it 'duplicates the folder and its contents' do
-          expect { duplicate_objects }.to change { destination_course.material_folders.count }.by(1)
-          expect(folder.reload.materials.first.name).to eq(content.name)
+        context 'when folders are duplicated but not their parents' do
+          let(:source_objects) { [grandparent_folder, folder] }
+
+          it 'sets the root folders as their parents' do
+            expect { duplicate_objects }.to change { destination_course.material_folders.count }.by(2)
+            duplicate_grandparent_folder, duplicate_folder = duplicate_objects
+            expect(duplicate_folder.materials.first.name).to eq(content.name)
+            expect(duplicate_grandparent_folder.parent.id).to be(destination_course.root_folder.id)
+            expect(duplicate_folder.parent.id).to be(destination_course.root_folder.id)
+          end
+        end
+
+        context 'when children are duplicated before their parents' do
+          let(:source_objects) { [folder, parent_folder, grandparent_folder] }
+
+          it 'associates them' do
+            expect { duplicate_objects }.to change { destination_course.material_folders.count }.by(3)
+            duplicate_folder, duplicate_parent_folder, duplicate_grandparent_folder = duplicate_objects
+            expect(duplicate_grandparent_folder.parent.id).to be(destination_course.root_folder.id)
+            expect(duplicate_parent_folder.parent).to be(duplicate_grandparent_folder)
+            expect(duplicate_folder.parent).to be(duplicate_parent_folder)
+          end
+        end
+
+        context 'when children are duplicated after their parents' do
+          let(:source_objects) { [grandparent_folder, parent_folder, folder] }
+
+          it 'associates them' do
+            expect { duplicate_objects }.to change { destination_course.material_folders.count }.by(3)
+            duplicate_grandparent_folder, duplicate_parent_folder, duplicate_folder = duplicate_objects
+            expect(duplicate_grandparent_folder.parent.id).to be(destination_course.root_folder.id)
+            expect(duplicate_parent_folder.parent).to be(duplicate_grandparent_folder)
+            expect(duplicate_folder.parent).to be(duplicate_parent_folder)
+          end
         end
       end
 


### PR DESCRIPTION
Next step in #2007.

- Added more automatic linkages when associated top-level objects are both duplicated. 'Top-level' refers to objects that users can select whether to duplicate or not. These linkages will be made explicit to the user in the frontend (#2168), e.g. Users will be notified that a assessment question skill will be dropped unless they explicitly select the skill to be duplicated.
- Have changed the course duplication implementation to duplicate and save one top-level object at a time, instead of saving the course and all its children at one go. Two reasons for this:
    - They serve as break-points for progress reporting, which will be implemented later.
    - Helps ensure that object duplication is correct, since course duplication specs need to pass.
- I chose not to duplicate level conditions if user cherry-picks its conditional object for duplication because there is no guarantee that the levels in the destination course is the same as the source course. Frontend will inform user of this dropped condition.

