### PR TITLE
Fixes to user invitation service

### DIFF
--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -2,6 +2,7 @@
 class Course::UserInvitation < ActiveRecord::Base
   after_initialize :generate_invitation_key, if: :new_record?
 
+  schema_validations auto_create: false
   validates :email, uniqueness: { scope: :course_id },
                     format: { with: Devise.email_regexp },
                     if: :email_changed?

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -3,7 +3,7 @@ en:
     user_invitations:
       errors:
         duplicate_user: '%{user} appears more than once in the submission.'
-        invalid_email: '%{email} is an invalid email address.'
+        invalid_email: "%{email} is invalid: %{message}."
       index:
         header: 'Invitations'
         progress: '%{accepted} accepted / %{total} invited'

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         it 'sets the proper errors' do
           invite
           errors = course.invitations.map(&:errors).tap(&:compact!).reject(&:empty?)
-          expect(errors.length).to eq(2)
+          expect(errors.length).to eq(1)
           expect(errors.first[:email].all? { |error| error =~ /been taken/ }).to be_truthy
         end
       end


### PR DESCRIPTION
Due to a bug in rails (same with the one in duplication), the valid records get saved without rollback when there are invalid records.  Fixed by saving the records individually and rollback when there're errors.
