### PR TITLE
Minor fixes for surveys

### DIFF
--- a/app/views/course/survey/questions/_option.json.jbuilder
+++ b/app/views/course/survey/questions/_option.json.jbuilder
@@ -1,4 +1,5 @@
-json.(option, :id, :option, :weight)
+json.(option, :id, :weight)
+json.option format_html(option.option)
 unless option.attachment.nil?
   json.image_url option.attachment.url
   json.image_name option.attachment.name

--- a/app/views/course/surveys/_todo_survey_button.html.slim
+++ b/app/views/course/surveys/_todo_survey_button.html.slim
@@ -1,7 +1,7 @@
 - survey = todo_survey_button
 - response = survey.responses.find_by(creator: current_user)
 - if response
-  = link_to t('.respond'), course_survey_response_path(current_course, survey, response),
+  = link_to t('.respond'), edit_course_survey_response_path(current_course, survey, response),
             class: ['btn', 'btn-info']
 - else
   = link_to t('.respond'), course_survey_path(current_course, survey),

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -10,6 +10,7 @@
     react/prefer-stateless-function: "off",
     react/require-default-props: "off",
     react/no-array-index-key: "warn",
+    react/no-danger: "off",
     import/no-extraneous-dependencies: ["warn", { devDependencies: true }],
     import/prefer-default-export: "warn",
     jsx-a11y/label-has-for: "off",

--- a/client/app/bundles/course/survey/components/OptionsListItem.jsx
+++ b/client/app/bundles/course/survey/components/OptionsListItem.jsx
@@ -84,7 +84,7 @@ class OptionsListItem extends React.PureComponent {
               style={styles.image}
               containerStyle={styles.imageContainer}
             /> : [] }
-          { optionText || null }
+          <p dangerouslySetInnerHTML={{ __html: optionText || null }} />
         </div>
       </div>
     );

--- a/client/app/bundles/course/survey/containers/ResponseForm/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/__test__/index.test.jsx
@@ -88,7 +88,7 @@ const responseData = {
 };
 
 describe('<ResponseForm />', () => {
-  it('validates answers', () => {
+  it('validates answers when submitting but not when saving', () => {
     const { flags, response, survey } = responseData;
     const mockEndpoint = jest.fn();
     const onSubmit = data => mockEndpoint(buildResponsePayload(data));
@@ -122,6 +122,28 @@ describe('<ResponseForm />', () => {
       multipleResponseAnswer.find('renderMultipleResponseOptions').find('p').first().text();
     expect(multipleResponseAnswerError).toEqual('Please select at most 2 option(s).');
 
+    const saveButton = responseForm.find('button').first();
+    ReactTestUtils.Simulate.touchTap(ReactDOM.findDOMNode(saveButton.node));
+    const saveExpectedPayload = {
+      response: {
+        answers_attributes: [{
+          id: 3,
+          question_option_ids: [],
+          text_response: null,
+        }, {
+          id: 4,
+          question_option_ids: [],
+          text_response: undefined,
+        }, {
+          id: 5,
+          question_option_ids: [3, 4, 5],
+          text_response: undefined,
+        }],
+        submit: false,
+      },
+    };
+    expect(mockEndpoint).toHaveBeenCalledWith(saveExpectedPayload);
+
     const textResponse = textResponseAnswer.find('textarea').last();
     const newAnswer = 'New Answer';
     textResponse.simulate('change', { target: { value: newAnswer } });
@@ -130,7 +152,7 @@ describe('<ResponseForm />', () => {
     lastMRQOptionCheckbox.props().onCheck(null, false);
 
     ReactTestUtils.Simulate.touchTap(ReactDOM.findDOMNode(submitButton.node));
-    const expectedPayload = {
+    const submitExpectedPayload = {
       response: {
         answers_attributes: [{
           id: 3,
@@ -148,6 +170,6 @@ describe('<ResponseForm />', () => {
         submit: true,
       },
     };
-    expect(mockEndpoint).toHaveBeenCalledWith(expectedPayload);
+    expect(mockEndpoint).toHaveBeenCalledWith(submitExpectedPayload);
   });
 });

--- a/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable camelcase */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { reduxForm, FieldArray, Form } from 'redux-form';
+import { reduxForm, FieldArray, Form, getFormValues } from 'redux-form';
 import RaisedButton from 'material-ui/RaisedButton';
 import formTranslations from 'lib/translations/form';
 import { formNames } from 'course/survey/constants';
@@ -68,6 +69,7 @@ class ResponseForm extends React.Component {
     response: responseShape.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool.isRequired,
+    formValues: PropTypes.shape(),
 
     handleSubmit: PropTypes.func.isRequired,
   };
@@ -99,7 +101,7 @@ class ResponseForm extends React.Component {
   }
 
   renderSaveButton() {
-    const { pristine, flags: { canModify, isSubmitting } } = this.props;
+    const { pristine, onSubmit, formValues, flags: { canModify, isSubmitting } } = this.props;
     if (!canModify) { return null; }
 
     return (
@@ -108,6 +110,7 @@ class ResponseForm extends React.Component {
         type="submit"
         primary
         label={<FormattedMessage {...formTranslations.save} />}
+        onTouchTap={() => onSubmit({ ...formValues, submit: false })}
         disabled={isSubmitting || pristine}
       />
     );
@@ -159,4 +162,6 @@ class ResponseForm extends React.Component {
 export default reduxForm({
   form: formNames.SURVEY_RESPONSE,
   enableReinitialize: true,
-})(ResponseForm);
+})(connect(state => ({
+  formValues: getFormValues(formNames.SURVEY_RESPONSE)(state),
+}))(ResponseForm));


### PR DESCRIPTION
The todo button needed to be fixed as a result of #2237, where the page to edit the response was shifted from `.../response/:response_id` to `.../response/:response_id/edit`.

For survey options, I don't think it is necessary to clutter the interface with a full rich text-editor. V1 did not have it either.