### PR TITLE
Invite all users regardless of whether CSV file has a header.

### DIFF
--- a/spec/fixtures/course/no_header_invitation.csv
+++ b/spec/fixtures/course/no_header_invitation.csv
@@ -1,0 +1,2 @@
+Foo,bar@foo.com
+Blank Email,blank@name.com

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -243,6 +243,24 @@ RSpec.describe Course::UserInvitationService, type: :service do
           expect(subject.flatten.count).to eq(1)
         end
       end
+
+      context 'when the provided csv file has no header' do
+        subject do
+          stubbed_user_invitation_service.
+            send(:invite_from_file,
+                 File.open(File.join(__dir__,
+                                     '../../fixtures/course/no_header_invitation.csv')))
+        end
+
+        it 'does not raise an exception' do
+          expect { subject }.not_to raise_exception
+        end
+
+        it 'invites all users including the first row' do
+          # No header CSV has 2 entries
+          expect(subject.flatten.count).to eq(2)
+        end
+      end
     end
 
     describe '#invite_from_form' do


### PR DESCRIPTION
Ignore rows without email addresses in the CSV file. This will ignore the first row if it's a header row, but will invite the user if there's an email address.

Prevents first student from being silently excluded if the instructor does not follow the given file format on the user invitation page.

Fixes #1943.