### PR TITLE
User invitation: Ignore already enrolled/invited users and provide feedback to the user

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -13,9 +13,10 @@ class Course::UserInvitationsController < Course::ComponentController
     current_course.invitations.build
   end
 
-  def create # :nodoc:
-    if invite
-      redirect_to course_user_invitations_path(current_course), success: create_success_message
+  def create
+    result = invite
+    if result
+      redirect_to course_user_invitations_path(current_course), success: create_success_message(*result)
     else
       propagate_errors
       render 'new'
@@ -199,11 +200,15 @@ class Course::UserInvitationsController < Course::ComponentController
   end
 
   # Returns the successful invitation creation message based on file or entry invitation.
-  def create_success_message
+  def create_success_message(new_invitations, existing_invitations, new_course_users, existing_course_users)
     if invite_by_file?
-      t('course.user_invitations.create.file.success')
+      t('.file.success',
+        new_invitations: t('.file.summary.new_invitations', count: new_invitations),
+        already_invited: t('.file.summary.already_invited', count: existing_invitations),
+        new_course_users: t('.file.summary.new_course_users', count: new_course_users),
+        already_enrolled: t('.file.summary.already_enrolled', count: existing_course_users))
     else
-      t('course.user_invitations.create.manual_entry.success')
+      t('.manual_entry.success')
     end
   end
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -86,6 +86,9 @@ ignore_missing:
   - 'errors.messages.*'
   - 'activerecord.errors.messages.*'
 
+# I18n-tasks gives the wrong results for normal (non action) methods in the controller, ignore them here.
+  - 'course.user_invitations.create_success_message.*'
+
 ## Consider these keys used:
 ignore_unused:
 - 'activerecord.attributes.*'
@@ -104,6 +107,9 @@ ignore_unused:
 - 'activemodel.errors.*'
 # Used dynamically by the page_header helper
 - '*.*.header'
+
+# I18n-tasks gives the wrong results for normal (non action) methods in the controller, ignore them here.
+- 'course.user_invitations.create.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -48,7 +48,18 @@ en:
           enable: 'Enable'
       create:
         file:
-          success: 'Successfully invited users from the uploaded file.'
+          success: >
+            Successfully invited users from the uploaded file:
+            %{new_invitations}, %{already_invited}, %{new_course_users}, %{already_enrolled}.
+          summary:
+            new_invitations:
+              one: '1 new invitation sent'
+              other: '%{count} new invitations sent'
+            new_course_users:
+              one: '1 user just enrolled'
+              other: '%{count} users just enrolled'
+            already_enrolled: '%{count} already enrolled'
+            already_invited: '%{count} already invited'
         manual_entry:
           success: 'Successfully invited users with the given details.'
       invitation_fields:


### PR DESCRIPTION
- Already registered users will be ignored and will not raise error
- A summary containing the invitations created, users already invited, users just enrolled and users already enrolled is shown to the user to resolve the confusion.