### PR TITLE
More fixes to user invitation

### DIFF
--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -14,7 +14,7 @@ class User::RegistrationsController < Devise::RegistrationsController
     User.transaction do
       super
       if @invitation && resource.persisted?
-        @invitation.confirm!
+        @invitation.confirm!(confirmer: resource)
       end
     end
   end

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -5,15 +5,20 @@ class User::RegistrationsController < Devise::RegistrationsController
   layout :select_layout
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    if @invitation&.confirmed?
+      message = @invitation.confirmer ? t('.used_with_email', email: @invitation.confirmer.email) : t('.used')
+      redirect_to root_path, danger: message
+    else
+      super
+    end
+  end
 
   # POST /resource
   def create
     User.transaction do
       super
-      if @invitation && resource.persisted?
+      if @invitation && !@invitation.confirmed? && resource.persisted?
         @invitation.confirm!(confirmer: resource)
       end
     end
@@ -86,7 +91,7 @@ class User::RegistrationsController < Devise::RegistrationsController
   def load_invitation
     return unless invitation_param.present?
 
-    @invitation = Course::UserInvitation.unconfirmed.find_by(invitation_key: invitation_param)
+    @invitation = Course::UserInvitation.find_by(invitation_key: invitation_param)
   end
 
   def invitation_param

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -8,6 +8,7 @@ class Course::UserInvitation < ActiveRecord::Base
                     if: :email_changed?
 
   belongs_to :course, inverse_of: :invitations
+  belongs_to :confirmer, class_name: User.name, inverse_of: nil
 
   # Invitations that haven't been confirmed, i.e. pending the user's acceptance.
   scope :unconfirmed, -> { where(confirmed_at: nil) }
@@ -19,8 +20,9 @@ class Course::UserInvitation < ActiveRecord::Base
     find_by(email: user.emails.confirmed.select(:email))
   end
 
-  def confirm!
+  def confirm!(confirmer:)
     self.confirmed_at = Time.zone.now
+    self.confirmer = confirmer
     save!
   end
 

--- a/app/services/course/user_registration_service.rb
+++ b/app/services/course/user_registration_service.rb
@@ -128,7 +128,7 @@ class Course::UserRegistrationService
   # @return [nil] If the code is invalid.
   def accept_invitation(registration, invitation)
     CourseUser.transaction do
-      invitation.confirm!
+      invitation.confirm!(confirmer: registration.user)
       find_or_create_course_user!(registration, invitation.name)
     end
   end

--- a/app/services/course/user_registration_service.rb
+++ b/app/services/course/user_registration_service.rb
@@ -98,10 +98,12 @@ class Course::UserRegistrationService
   #   valid.
   # @return [nil] If the code is invalid.
   def claim_course_invitation_code(registration)
-    invitations = registration.course.invitations.unconfirmed
+    invitations = registration.course.invitations
     invitation = invitations.find_by(invitation_key: registration.code)
     if invitation.nil?
       invalid_code(registration)
+    elsif invitation.confirmed?
+      code_taken(registration, invitation)
     else
       accept_invitation(registration, invitation)
     end
@@ -114,6 +116,17 @@ class Course::UserRegistrationService
   # @return [nil]
   def invalid_code(registration)
     registration.errors.add(:code, I18n.t('course.user_registrations.create.invalid_code'))
+    nil
+  end
+
+  def code_taken(registration, invitation)
+    confirmed_by = invitation.confirmer
+    if confirmed_by
+      registration.errors.
+        add(:code, I18n.t('course.user_registrations.create.code_taken_with_email', email: confirmed_by.email))
+    else
+      registration.errors.add(:code, I18n.t('course.user_registrations.create.code_taken'))
+    end
     nil
   end
 

--- a/app/views/course/mailer/user_added_email.html.slim
+++ b/app/views/course/mailer/user_added_email.html.slim
@@ -1,2 +1,6 @@
-= simple_format(t('.message', course: link_to(@course.title, course_url(@course, host: @course.instance.host)),
-                              coursemology: link_to(t('layout.coursemology'), @course.instance.host)))
+= simple_format(\
+    t('.message', course: link_to(@course.title, course_url(@course, host: @course.instance.host)),
+                  coursemology: link_to(t('layout.coursemology'), @course.instance.host),
+                  email: @recipient.email\
+    )\
+  )

--- a/app/views/course/mailer/user_added_email.text.erb
+++ b/app/views/course/mailer/user_added_email.text.erb
@@ -1,2 +1,3 @@
 <%= t('.message', course: plain_link_to(@course.title, course_url(@course, host: @course.instance.host)),
-                  coursemology: plain_link_to(t('layout.coursemology'), @course.instance.host)) %>
+                  coursemology: plain_link_to(t('layout.coursemology'), @course.instance.host),
+                  email: @recipient.email) %>

--- a/config/locales/en/course/mailer/user_added_email.yml
+++ b/config/locales/en/course/mailer/user_added_email.yml
@@ -5,3 +5,5 @@ en:
         subject: 'Added to Course %{course}'
         message: >
           You have been added to the course %{course} on %{coursemology}.
+
+          To view the course, please log in with %{email}.

--- a/config/locales/en/course/user_registrations.yml
+++ b/config/locales/en/course/user_registrations.yml
@@ -11,5 +11,11 @@ en:
         new_enrol_request_button: 'Request to enrol'
       create:
         invalid_code: 'You have entered an invalid invitation code.'
+        code_taken: >
+          The provided invitation code has been claimed by another account,
+          please use that account the to access the course instead.
+        code_taken_with_email: >
+          The provided invitation code has been claimed by %{email},
+          please use that account to access the course instead.
         requested: 'You have submitted registration request to the course.'
         registered: 'You have been registered as a %{role}.'

--- a/config/locales/en/user/registrations.yml
+++ b/config/locales/en/user/registrations.yml
@@ -7,6 +7,10 @@ en:
           Already registered? If you have an existing Coursemology account, you can %{sign_in}.
         password_hint: "#{length} characters minimum"
         sign_up: :'user.registrations.new.header'
+        used: >
+          The provided invitation code has been claimed by another account, please use that account to log in instead.
+        used_with_email: >
+          The provided invitation code has been claimed by %{email}, please use that account to log in instead.
       edit:
         header: 'Account Settings'
         new_password_hint: "Leave blank if you don't want to change it"

--- a/db/migrate/20170816073714_add_confirmer_id_to_course_user_invitations.rb
+++ b/db/migrate/20170816073714_add_confirmer_id_to_course_user_invitations.rb
@@ -1,0 +1,5 @@
+class AddConfirmerIdToCourseUserInvitations < ActiveRecord::Migration
+  def change
+    add_column :course_user_invitations, :confirmer_id, :integer, foreign_key: { references: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721061506) do
+ActiveRecord::Schema.define(version: 20170816073714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -699,6 +699,7 @@ ActiveRecord::Schema.define(version: 20170721061506) do
     t.string   "invitation_key", :limit=>32, :null=>false, :index=>{:name=>"index_course_user_invitations_on_invitation_key", :unique=>true}
     t.datetime "sent_at"
     t.datetime "confirmed_at"
+    t.integer  "confirmer_id",   :index=>{:name=>"fk__course_user_invitations_confirmer_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_confirmer_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at",     :null=>false

--- a/spec/controllers/course/user_invitations_controller_spec.rb
+++ b/spec/controllers/course/user_invitations_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Course::UserInvitationsController, type: :controller do
       end
 
       context 'if the provided invitation has already been confirmed' do
-        before { invitation.confirm! }
+        before { invitation.confirm!(confirmer: user) }
         it 'will not load the invitation' do
           subject
           expect(controller.instance_variable_get(:@invitations)).to be_empty

--- a/spec/factories/course_user_invitations.rb
+++ b/spec/factories/course_user_invitations.rb
@@ -4,5 +4,10 @@ FactoryGirl.define do
     course
     sequence(:name) { |n| "course user #{n}" }
     email { generate(:email) }
+
+    trait :confirmed do
+      confirmed_at 1.day.ago
+      confirmer { build(:user) }
+    end
   end
 end

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'Courses: Invitations', js: true do
 
         old_time = 1.day.ago
         invitations = create_list(:course_user_invitation, 3, course: course, sent_at: old_time)
-        invitations.first.confirm!
+        invitations.first.confirm!(confirmer: user)
         invitation_to_delete = invitations.second
         invitation_to_resend = invitations.last
         visit course_user_invitations_path(course)

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Users: Sign Up' do
 
     context 'As a user invited by course staffs' do
       let(:course) { create(:course) }
-      let!(:invitation) { create(:course_user_invitation, course: course) }
+      let(:invitation) { create(:course_user_invitation, course: course) }
       let(:invited_email) { invitation.email }
 
       scenario 'I can register for an account' do
@@ -48,6 +48,17 @@ RSpec.feature 'Users: Sign Up' do
         expect(email).to be_confirmed
         expect(invitation.reload).to be_confirmed
         expect(invitation.confirmer).to eq(email.user)
+      end
+
+      context 'when the invitation code is confirmed' do
+        let(:invitation) { create(:course_user_invitation, :confirmed, course: course) }
+
+        scenario 'I am redirected with an error' do
+          visit new_user_registration_path(invitation: invitation.invitation_key)
+
+          expect(current_path).to eq(root_path)
+          expect(page).to have_selector('div.alert', text: I18n.t('user.registrations.new.used_with_email'))
+        end
       end
     end
   end

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -47,6 +47,7 @@ RSpec.feature 'Users: Sign Up' do
         expect(email).to be_primary
         expect(email).to be_confirmed
         expect(invitation.reload).to be_confirmed
+        expect(invitation.confirmer).to eq(email.user)
       end
     end
   end


### PR DESCRIPTION
- Track who confirmed the invitation
- When the invitation code is used, let user know which email used it
- Further mention user's email when they are added to the course