### PR TITLE
Handle the new lines in the comments

### DIFF
--- a/app/assets/javascripts/helpers/discussion/edit_post.js
+++ b/app/assets/javascripts/helpers/discussion/edit_post.js
@@ -22,7 +22,7 @@ var EDIT_DISCUSSION_POST = (function($, FORM_HELPERS,
     var courseId = COURSE_HELPERS.courseIdForElement($element);
     var topicId = $topic.data('topicId');
     var postId = $post.data('postId');
-    var postContent = $post.find('.content').html().trim();
+    var postContent = JSON.parse($post.data('content'));
     var postCommenter = $post.find('.user').html();
 
     $post.children().hide();

--- a/app/views/course/discussion/_post.html.slim
+++ b/app/views/course/discussion/_post.html.slim
@@ -1,4 +1,4 @@
-= div_for(post, 'data-post-id' => post.id) do
+= div_for(post, 'data-post-id' => post.id, 'data-content' => post.text.to_json) do
 
   div.header
     div.profile-picture
@@ -23,4 +23,4 @@
             = fa_icon 'trash'.freeze
 
   div.content
-    = format_html(post.text)
+    = format_html(simple_format(post.text))

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -1,5 +1,5 @@
 json.(post, :id, :title, :text)
-
+json.formattedText format_html(simple_format(post.text))
 creator = post.creator
 json.creator do
   json.name creator.name

--- a/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
@@ -99,7 +99,7 @@ export default class CommentCard extends Component {
 
   renderCommentContent() {
     const { editMode } = this.state;
-    const { editValue, post: { text, id } } = this.props;
+    const { editValue, post: { formattedText, id } } = this.props;
 
     if (editMode) {
       return (
@@ -131,7 +131,8 @@ export default class CommentCard extends Component {
         </div>
       );
     }
-    return <div dangerouslySetInnerHTML={{ __html: text }} />;
+
+    return <div dangerouslySetInnerHTML={{ __html: formattedText }} />;
   }
 
   render() {


### PR DESCRIPTION
New lines in the React submission pages are not correctly displayed because the content gets rendered as HTML and the new lines are ignored.

`simple_format` helper is used to help with this case: Two or more consecutive newlines(\n\n) are considered as a paragraph and wrapped in \<p\> tags. One newline (\n) is considered as a linebreak and a \<br /> tag is appended. 

