### PR TITLE
Coursemology2#1843 add role to invite

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -68,7 +68,7 @@ class Course::UserInvitationsController < Course::ComponentController
       params[:course] = { invitations_attributes: {} } unless params.key?(:course)
 
       params.require(:course).permit(:invitations_file, :registration_key,
-                                     invitations_attributes: [:name, :email])
+                                     invitations_attributes: [:name, :email, :role])
     end
   end
 

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -152,5 +152,6 @@ class CourseUser < ActiveRecord::Base
 
   def set_defaults # :nodoc:
     self.name ||= user.name if user
+    self.role ||= CourseUser.roles[:student]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,7 +101,7 @@ class User < ActiveRecord::Base
     self.name = invitation.name
     self.email = invitation.email
     skip_confirmation!
-    course_users.build(course: invitation.course, name: invitation.name,
+    course_users.build(course: invitation.course, name: invitation.name, role: invitation.role,
                        creator: self, updater: self)
   end
 

--- a/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
@@ -102,15 +102,15 @@ module Course::UserInvitationService::EmailInvitationConcern
   # @return [void]
   def invite_from_form(users)
     invite_users(users.map do |(_, value)|
-      { name: value[:name], email: value[:email] }
+      { name: value[:name], email: value[:email], role: value[:role] }
     end)
   end
 
   # Invites the given users into the course.
   #
   # @param [Array<Hash{Symbol=>String}>] users A mutable array of users to add. Each hash must have
-  #   two attributes: the +:name+ and the +:email+ of the user to add. The provided +emails+
-  #   are NOT case sensitive.
+  #   three attributes: the +:name+, the +:email+ of the user to add, as well as his intended +:role+ in the course.
+  #   The provided +emails+ are NOT case sensitive.
   # @return
   #   [Array<(Array<Course::UserInvitation>, Array<Course::UserInvitation>, Array<CourseUser>, Array<CourseUser>)>]
   #   A tuple containing the users newly invited, already invited, newly registered and already registered respectively.
@@ -161,7 +161,7 @@ module Course::UserInvitationService::EmailInvitationConcern
       if course_user
         existing_course_users << course_user
       else
-        new_course_users << @current_course.course_users.build(user: user[:user], name: user[:name],
+        new_course_users << @current_course.course_users.build(user: user[:user], name: user[:name], role: user[:role],
                                                                creator: @current_user, updater: @current_user)
       end
     end
@@ -183,7 +183,7 @@ module Course::UserInvitationService::EmailInvitationConcern
       if invitation
         existing_invitations << invitation
       else
-        new_invitations << @current_course.invitations.build(name: user[:name], email: user[:email])
+        new_invitations << @current_course.invitations.build(name: user[:name], email: user[:email], role: user[:role])
       end
     end
 

--- a/app/views/course/user_invitations/_invitation_fields.html.slim
+++ b/app/views/course/user_invitations/_invitation_fields.html.slim
@@ -1,4 +1,11 @@
 = content_tag_for(:tr, f.object, class: 'nested-fields') do
   td = f.input :name, label: false, input_html: { class: 'invitation_name' }
   td = f.input :email, label: false, input_html: { class: 'invitation_email' }
+  td = f.input :role,
+               as: :select,
+               collection: Course::UserInvitation.roles.keys,
+               label: false,
+               label_method: lambda { |role_key| t("course.users.role.#{role_key}") },
+               include_blank: false,
+               input_html: { class: 'invitation_role' }
   td = link_to_remove_association  t('.remove'), f

--- a/app/views/course/user_invitations/new.html.slim
+++ b/app/views/course/user_invitations/new.html.slim
@@ -38,6 +38,7 @@ div.methods role='tabpanel'
             tr
               th = t('common.name')
               th = t('common.email')
+              th = t('common.role')
               th
                 div.pull-right
                   = link_to_add_association t('.individual.add_user'), f, :invitations,

--- a/db/migrate/20170819040619_add_role_to_course_user_invitation.rb
+++ b/db/migrate/20170819040619_add_role_to_course_user_invitation.rb
@@ -1,0 +1,5 @@
+class AddRoleToCourseUserInvitation < ActiveRecord::Migration
+  def change
+    add_column :course_user_invitations, :role, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170816073714) do
+ActiveRecord::Schema.define(version: 20170819040619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -696,6 +696,7 @@ ActiveRecord::Schema.define(version: 20170816073714) do
     t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_user_invitations_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_user_invitations_course_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.string   "name",           :limit=>255, :null=>false
     t.string   "email",          :limit=>255, :null=>false, :index=>{:name=>"index_course_user_invitations_on_email", :case_sensitive=>false}
+    t.integer  "role",           :default=>0, :null=>false
     t.string   "invitation_key", :limit=>32, :null=>false, :index=>{:name=>"index_course_user_invitations_on_invitation_key", :unique=>true}
     t.datetime "sent_at"
     t.datetime "confirmed_at"


### PR DESCRIPTION
Allow invitation to have roles specified. Roles are immediately assigned on registration.