### PR TITLE
For cpp, display integral floats with trailing '.0'.

### DIFF
--- a/app/services/course/assessment/question/programming/cpp/cpp_autograde_pre.cc
+++ b/app/services/course/assessment/question/programming/cpp/cpp_autograde_pre.cc
@@ -1,6 +1,9 @@
 template<typename T1, typename T2>
 void RecordProperties(T1 a, T2 b);
 
+template<typename T1, typename T2>
+void RecordFloatProperties(T1 a, T2 b);
+
 // Catches all type mismatches
 // Any type-matches or allowed type-mismatches are explicitly defined
 template <typename T1, typename T2>
@@ -19,42 +22,42 @@ void expect_equals(const int &a, const int &b) {
 
 void expect_equals(const int &a, const double &b) {
 	EXPECT_DOUBLE_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const int &a, const float &b) {
 	EXPECT_FLOAT_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const double &a, const int &b) {
 	EXPECT_DOUBLE_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const double &a, const double &b) {
 	EXPECT_DOUBLE_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const double &a, const float &b) {
 	EXPECT_FLOAT_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const float &a, const int &b) {
 	EXPECT_FLOAT_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const float &a, const double &b) {
 	EXPECT_FLOAT_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const float &a, const float &b) {
 	EXPECT_FLOAT_EQ(a, b);
-	RecordProperties(a, b);
+	RecordFloatProperties(a, b);
 }
 
 void expect_equals(const bool &a, const bool &b) {
@@ -96,6 +99,32 @@ void RecordProperties(T1 a, T2 b) {
 	std::ostringstream expected;
 	output << a;
 	expected << b;
+	::testing::Test::RecordProperty("output", output.str());
+	::testing::Test::RecordProperty("expected", expected.str());
+}
+
+// Generates the properties for the `output` and `expected` fields
+// in the Primitive_visitor() for floating point numbers.
+// If the float is integral, display it with a '.0' to make it clear
+// to students that it's a float or double type.
+//
+// https://stackoverflow.com/questions/15313808/how-to-check-if-float-is-a-whole-number
+template<typename T1, typename T2>
+void RecordFloatProperties(T1 a, T2 b) {
+	std::ostringstream output;
+	std::ostringstream expected;
+	if (a == floor(a)) {
+		output << std::fixed << std::setprecision(1) << a;
+	}
+	else {
+		output << a;
+	}
+	if (b == floor(b)) {
+		expected << std::fixed << std::setprecision(1) << b;
+	}
+	else {
+		expected << b;
+	}
 	::testing::Test::RecordProperty("output", output.str());
 	::testing::Test::RecordProperty("expected", expected.str());
 }


### PR DESCRIPTION
Make it more obvious to students that the expected return type is a float.
Trailing zeroes in the 'expected' field will still get dropped.

See screenshots for an example:

### Question Edit page (instructor view)
![question_edit](https://user-images.githubusercontent.com/1902527/29511107-a25d2508-8690-11e7-8b28-52af2a80e61c.png)

### Submission edit page (student/instructor view)
![submission_edit](https://user-images.githubusercontent.com/1902527/29511121-b62f8abc-8690-11e7-8428-6240ee56b7b6.png)

@zhengwei143 let us know if you have a better suggestion on how to do this

