### PR TITLE
Fix forum post layout and buttons

### DIFF
--- a/app/models/concerns/course/discussion/topic/posts_concern.rb
+++ b/app/models/concerns/course/discussion/topic/posts_concern.rb
@@ -2,15 +2,6 @@ module Course::Discussion::Topic::PostsConcern
   extend ActiveSupport::Concern
   include Course::Discussion::Post::OrderingConcern
 
-  # Builds a new post in this topic.
-  #
-  # This defaults to set the new post to be a child of the latest post, ordered topologically.
-  def build(attributes = {}, &block)
-    attributes[:parent] ||= ordered_topologically.last unless attributes.key?(:parent_id)
-
-    super
-  end
-
   # Reloads the association.
   def reload
     remove_instance_variable(:@ordered_topologically) if defined?(@ordered_topologically)

--- a/app/views/course/forum/forums/_controls.html.slim
+++ b/app/views/course/forum/forums/_controls.html.slim
@@ -7,6 +7,12 @@ span.pull-right
   .btn-group
     - if can?(:subscribe, @forum)
       = render partial: 'subscribe_button', locals: { user: current_user, forum: @forum }
-    = new_button([current_course, @forum, :topic]) if can?(:create, Course::Forum::Topic.new(forum: @forum))
+    - if can?(:create, Course::Forum::Topic.new(forum: @forum))
+      = new_button([current_course, @forum, :topic], title: '') do
+        => fa_icon 'file'
+        = t('.new_topic')
+
+  .btn-group
     = edit_button([current_course, @forum]) if can?(:edit, @forum)
     = delete_button([current_course, @forum]) if can?(:destroy, @forum)
+

--- a/app/views/course/forum/forums/index.html.slim
+++ b/app/views/course/forum/forums/index.html.slim
@@ -5,7 +5,10 @@
       = link_to t('.mark_all_as_read'), mark_all_as_read_course_forums_path(current_course),
                                         title: t('.mark_all_description'),
                                         class: ['btn', 'btn-default'], method: :patch
-    = new_button([current_course, :forum]) if can?(:create, Course::Forum.new(course: current_course))
+    - if can?(:create, Course::Forum.new(course: current_course))
+      = new_button([current_course, :forum], title: '') do
+        => fa_icon 'file'
+        = t('.new_forum')
 
 table.table.forum-list.table-hover
   thead

--- a/config/locales/en/course/forum/forums.yml
+++ b/config/locales/en/course/forum/forums.yml
@@ -14,6 +14,7 @@ en:
           posts: 'Posts'
           views: 'Views'
           no_forum: 'No Forum'
+          new_forum: 'New Forum'
           mark_all_as_read: 'Mark all as read'
           mark_all_description: 'Mark all forum topics as read'
         show:
@@ -65,5 +66,6 @@ en:
         mark_as_read:
           success: 'All topics in the forum have been marked as read'
         controls:
+          new_topic: 'New topic'
           mark_as_read: 'Mark as read'
           mark_forum_description: 'Mark all topics in current forum as read'

--- a/config/locales/en/course/forum/topics.yml
+++ b/config/locales/en/course/forum/topics.yml
@@ -9,7 +9,7 @@ en:
         edit_topic:
           header: 'Edit Topic'
         show:
-          post_reply: 'Post a reply'
+          post_reply: 'Add a post'
           locked_topic: 'You are unable to reply as this topic is locked by the teaching staff.'
         new:
           header: 'New Topic'

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -119,7 +119,6 @@ RSpec.feature 'Course: Forum: Post: Management' do
 
         new_post = topic.posts.reload.last
         expect(new_post.text).to eq(post_content)
-        expect(new_post.parent).to eq(parent_post)
         expect(page).to have_content_tag_for(new_post)
       end
 
@@ -213,7 +212,6 @@ RSpec.feature 'Course: Forum: Post: Management' do
 
         new_post = topic.posts.reload.last
         expect(new_post.text).to eq(post_content)
-        expect(new_post.parent).to eq(parent_post)
         expect(page).to have_content_tag_for(new_post)
       end
 


### PR DESCRIPTION
Fix #2444

The posts created through the reply box at the bottom won't have the parent set (previously it was set to the last post).

Also reorganized and the buttons and their texts.

**before**:
<img width="467" alt="screen shot 2017-08-22 at 4 03 14 pm" src="https://user-images.githubusercontent.com/4983239/29554911-786fed98-8753-11e7-8f5e-0b32c29018d6.png">


**now**:
<img width="557" alt="screen shot 2017-08-22 at 4 02 50 pm" src="https://user-images.githubusercontent.com/4983239/29554909-77252fde-8753-11e7-88e9-363392f773ad.png">