### PR TITLE
Display description for materials and folders

### DIFF
--- a/app/views/course/material/folders/_folder.slim
+++ b/app/views/course/material/folders/_folder.slim
@@ -1,9 +1,11 @@
 = content_tag_for(:tr, folder)
-  th
+  td
     = link_to course_material_folder_path(current_course, folder) do
       => fa_icon 'folder-open'.freeze
       => format_inline_text(folder.name)
       => "(#{format_inline_text(folder.material_count + folder.children_count)})"
+    p.description
+      = format_html(folder.description)
 
   td = format_datetime(folder.updated_at)
   td

--- a/app/views/course/material/folders/_material.slim
+++ b/app/views/course/material/folders/_material.slim
@@ -1,7 +1,9 @@
 = content_tag_for(:tr, material)
-  th
+  td
     => fa_icon 'file-o'.freeze
     = link_to format_inline_text(material.name), [current_course, @folder, material]
+    p.description
+      = format_html(material.description)
 
   td
     = format_datetime(material.updated_at)

--- a/app/views/course/material/folders/edit.html.slim
+++ b/app/views/course/material/folders/edit.html.slim
@@ -3,7 +3,7 @@
 = simple_form_for [current_course, @folder] do |f|
   = f.error_notification
   = f.input :name
-  = f.input :description
+  = f.input :description, input_html: { class: ['no-summernote'] }
   = f.input :can_student_upload
   = f.input :start_at
   = f.input :end_at

--- a/app/views/course/material/materials/edit.html.slim
+++ b/app/views/course/material/materials/edit.html.slim
@@ -4,7 +4,7 @@
 = simple_form_for [current_course, @folder, @material] do |f|
   = f.error_notification
   = f.input :name
-  = f.input :description
+  = f.input :description, input_html: { class: ['no-summernote'] }
   = f.attachment
 
   = f.button :submit


### PR DESCRIPTION
- Display descriptions for materials and folders
- Disabled rich text editor for material/folder description (in case user upload images, etc and mess up the styling), but manually typed tags will still be rendered for backward compatibility and some advance users.  

screenshot:
<img width="1149" alt="screen shot 2017-08-22 at 4 36 39 pm" src="https://user-images.githubusercontent.com/4983239/29556346-26253994-8758-11e7-9019-bed685493e5b.png">

