### PR TITLE
Add indicator that forum topic is locked

### DIFF
--- a/app/views/course/forum/topics/_topic.html.slim
+++ b/app/views/course/forum/topics/_topic.html.slim
@@ -3,6 +3,8 @@
 = content_tag_for(:tr, topic, class: topic_class) do
   td = fa_icon 'envelope' if topic.unread?(current_user)
   th
+    - if topic.locked?
+      span => fa_icon 'lock'.freeze, title: t('.locked')
     = link_to(format_inline_text(topic.title),
               course_forum_topic_path(current_course, @forum, topic))
     div.started-by

--- a/config/locales/en/course/forum/topics.yml
+++ b/config/locales/en/course/forum/topics.yml
@@ -3,6 +3,7 @@ en:
     forum:
       topics:
         topic:
+          locked: 'This topic is locked.'
           started_by_html: 'Started by %{user}'
         new_topic:
           header: 'New Topic'


### PR DESCRIPTION
Forgot to add this. Now students can tell whether a topic is locked from looking at the forum topics. 
 
<img width="567" alt="screen shot 2017-08-22 at 5 07 35 pm" src="https://user-images.githubusercontent.com/4353853/29557695-7e14f44c-875c-11e7-9af0-63fa55a8f8b9.png">
