### PR TITLE
Display autograding failure message only when the job has an error

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -32,10 +32,9 @@ class JobsController < ApplicationController
   end
 
   def show_errored_job
-    if @job.redirect_to.present?
-      redirect_to @job.redirect_to
-    else
-      response.status = :internal_server_error
+    respond_to do |format|
+      format.html { redirect_to(@job.redirect_to) if @job.redirect_to.present? }
+      format.json {}
     end
   end
 

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -17,6 +17,10 @@ export function setNotification(message, errors) {
 }
 
 function buildErrorMessage(error) {
+  if (!error || !error.response || !error.data) {
+    return '';
+  }
+
   if (typeof error.response.data.error === 'string') {
     return error.response.data.error;
   }
@@ -36,7 +40,7 @@ function pollJob(url, onSuccess, onFailure) {
           onSuccess();
         } else if (data.status === 'errored') {
           clearInterval(poller);
-          onFailure();
+          onFailure(data);
         }
       })
       .catch(() => {
@@ -57,7 +61,10 @@ function getEvaluationResult(submissionId, answerId, questionId) {
           questionId,
         });
       })
-      .catch(() => dispatch({ type: actionTypes.AUTOGRADE_FAILURE, questionId }));
+      .catch(() => {
+        dispatch(setNotification(translations.requestFailure));
+        dispatch({ type: actionTypes.AUTOGRADE_FAILURE, questionId });
+      });
   };
 }
 
@@ -160,6 +167,7 @@ export function unsubmit(submissionId) {
       .then((data) => {
         dispatch({ type: actionTypes.UNSUBMIT_SUCCESS, payload: data });
         dispatch(setNotification(translations.updateSuccess));
+        dispatch(reset(formNames.SUBMISSION));
       })
       .catch((error) => {
         dispatch({ type: actionTypes.UNSUBMIT_FAILURE });
@@ -183,7 +191,10 @@ export function submitAnswer(submissionId, answer) {
         } else if (data.redirect_url) {
           pollJob(data.redirect_url,
             () => dispatch(getEvaluationResult(submissionId, answer.id, questionId)),
-            () => dispatch({ type: actionTypes.AUTOGRADE_FAILURE, questionId })
+            (errorData) => {
+              dispatch({ type: actionTypes.AUTOGRADE_FAILURE, questionId, payload: errorData });
+              dispatch(setNotification(translations.requestFailure));
+            }
           );
         } else {
           dispatch({
@@ -193,9 +204,9 @@ export function submitAnswer(submissionId, answer) {
           });
         }
       })
-      .catch((error) => {
+      .catch(() => {
         dispatch({ type: actionTypes.AUTOGRADE_FAILURE, questionId });
-        dispatch(setNotification(translations.updateFailure, buildErrorMessage(error)));
+        dispatch(setNotification(translations.requestFailure));
       });
   };
 }

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -80,7 +80,7 @@ class SubmissionEditForm extends Component {
             handleSubmitAnswer, isSaving } = this.props;
     const question = questions[id];
     const { answerId, attemptsLeft, attemptLimit, autogradable } = question;
-    const { hasError, isAutograding, isResetting } = questionsFlags[id] || {};
+    const { jobError, isAutograding, isResetting } = questionsFlags[id] || {};
 
     if (!attempting) {
       return null;
@@ -93,7 +93,7 @@ class SubmissionEditForm extends Component {
 
       return (
         <div>
-          {hasError ? <Paper style={{ padding: 10, backgroundColor: red100, marginBottom: 20 }}>
+          {jobError ? <Paper style={{ padding: 10, backgroundColor: red100, marginBottom: 20 }}>
             {intl.formatMessage(translations.autogradeFailure)}
           </Paper> : null}
           <RaisedButton

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -178,7 +178,7 @@ class SubmissionEditStepForm extends Component {
 
   renderAutogradingErrorPanel(id) {
     const { intl, questionsFlags, questions } = this.props;
-    const { hasError } = questionsFlags[id] || {};
+    const { jobError } = questionsFlags[id] || {};
     const { type } = questions[id];
 
     if (type === questionTypes.Programming && jobError) {

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -181,7 +181,7 @@ class SubmissionEditStepForm extends Component {
     const { hasError } = questionsFlags[id] || {};
     const { type } = questions[id];
 
-    if (type === questionTypes.Programming && hasError) {
+    if (type === questionTypes.Programming && jobError) {
       return (
         <Paper style={{ padding: 10, backgroundColor: red100, marginBottom: 20 }}>
           {intl.formatMessage(translations.autogradeFailure)}

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -121,7 +121,7 @@ export const annotationShape = PropTypes.shape({
 });
 
 export const questionFlagsShape = PropTypes.shape({
-  hasError: PropTypes.bool.isRequired,
+  jobError: PropTypes.bool.isRequired,
   isAutograding: PropTypes.bool.isRequired,
   isResetting: PropTypes.bool.isRequired,
 });

--- a/client/app/bundles/course/assessment/submission/reducers/questionsFlags.js
+++ b/client/app/bundles/course/assessment/submission/reducers/questionsFlags.js
@@ -9,7 +9,7 @@ export default function (state = {}, action) {
         [answer.questionId]: {
           isResetting: false,
           isAutograding: !!answer.autograding && answer.autograding.status === 'submitted',
-          hasError: !!answer.autograding && answer.autograding.status === 'errored',
+          jobError: !!answer.autograding && answer.autograding.status === 'errored',
         },
       }), {});
     case actions.AUTOGRADE_REQUEST: {
@@ -29,18 +29,19 @@ export default function (state = {}, action) {
         [questionId]: {
           ...state[questionId],
           isAutograding: false,
-          hasError: false,
+          jobError: false,
         },
       };
     }
     case actions.AUTOGRADE_FAILURE: {
-      const { questionId } = action;
+      const { questionId, payload } = action;
+      const jobError = payload && payload.status === 'errored';
       return {
         ...state,
         [questionId]: {
           ...state[questionId],
           isAutograding: false,
-          hasError: true,
+          jobError: !!jobError,
         },
       };
     }

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -173,6 +173,10 @@ const translations = defineMessages({
     id: 'course.assessment.submission.updateFailure',
     defaultMessage: 'Submission update failed: {errors}',
   },
+  requestFailure: {
+    id: 'course.assessment.submission.requestFailure',
+    defaultMessage: 'An error occurred while processing your request.',
+  },
   autogradeFailure: {
     id: 'course.assessment.submission.autogradeFailure',
     defaultMessage: '(T_T) Sorry, the autograder is having mood swings and quit on us. \

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe JobsController do
   let(:job) { create(:trackable_job, *job_traits) }
   let(:job_traits) { nil }
+  let(:format) { :html }
   before do
     controller.instance_variable_set(:@job, job)
   end
@@ -18,7 +19,7 @@ RSpec.describe JobsController do
       it { is_expected.to redirect_to(redirect_path) }
     end
 
-    before { get 'show', id: job.id }
+    before { get 'show', id: job.id, format: format }
 
     context 'when the job is in progress' do
       it { is_expected.to respond_with(:accepted) }
@@ -37,8 +38,19 @@ RSpec.describe JobsController do
         expect_to_redirect_to_job_redirect_to
       end
 
-      context 'when the job does not have a redirec_to path' do
-        it { is_expected.to respond_with(:internal_server_error) }
+      context 'when the job does not have a redirect_to path' do
+        it { is_expected.to respond_with(:ok) }
+      end
+
+      context 'when the requested format is json' do
+        render_views
+        let(:format) { :json }
+        let(:json_response) { JSON.parse(response.body) }
+
+        it 'responses with an errored job status' do
+          expect(response.status).to be(200)
+          expect(json_response['status']).to eq('errored')
+        end
       end
     end
   end


### PR DESCRIPTION
- Display "autograder mood swing..." message only when the job has an error (it was displayed for all kinds of errors before)

See commit messages for more details.