### PR TITLE
Do not reset forms after unsubmit

### DIFF
--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -164,7 +164,6 @@ export function unsubmit(submissionId) {
       .then((data) => {
         dispatch({ type: actionTypes.UNSUBMIT_SUCCESS, payload: data });
         dispatch(setNotification(translations.updateSuccess));
-        dispatch(reset(formNames.SUBMISSION));
       })
       .catch((error) => {
         dispatch({ type: actionTypes.UNSUBMIT_FAILURE });


### PR DESCRIPTION
Introduced in #2457, but after #2458 it's not necessary