### PR TITLE
Implement memory limits for programming evaluations

### DIFF
--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -8,6 +8,10 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
   # Maximum CPU time a programming question can allow before the evaluation gets killed.
   CPU_TIMEOUT = 30.seconds
 
+  # Maximum memory (in MB) the programming question can allow.
+  # Do NOT change this to num.megabytes as the ProgramingEvaluationService expects it in MB.
+  MEMORY_LIMIT = 128
+
   acts_as :question, class_name: Course::Assessment::Question.name
 
   before_save :process_package, unless: :skip_process_package?

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -4,6 +4,7 @@ class Course::Assessment::ProgrammingEvaluationService
   # The default timeout for the job to finish.
   DEFAULT_TIMEOUT = 5.minutes
   CPU_TIMEOUT = Course::Assessment::Question::Programming::CPU_TIMEOUT
+  MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
   # The ratio to multiply the memory limits from our evaluation to the container by.
   MEMORY_LIMIT_RATIO = 1.megabyte / 1.kilobyte
@@ -87,7 +88,7 @@ class Course::Assessment::ProgrammingEvaluationService
                  time_limit, package, timeout)
     @course = course
     @language = language
-    @memory_limit = memory_limit
+    @memory_limit = memory_limit || MEMORY_LIMIT
     @time_limit = time_limit || CPU_TIMEOUT
     @package = package
     @timeout = timeout || DEFAULT_TIMEOUT

--- a/lib/autoload/coursemology_docker_container.rb
+++ b/lib/autoload/coursemology_docker_container.rb
@@ -10,6 +10,11 @@ class CoursemologyDockerContainer < Docker::Container
   # The path to where the test report will be at.
   REPORT_PATH = File.join(PACKAGE_PATH, 'report.xml')
 
+  # Maximum amount of memory the docker container can use.
+  # Enforced by Docker.
+  # https://docs.docker.com/engine/admin/resource_constraints/
+  CONTAINER_MEMORY_LIMIT = 128.megabytes
+
   class << self
     def create(image, argv: nil)
       pull_image(image) unless Docker::Image.exist?(image)
@@ -18,6 +23,7 @@ class CoursemologyDockerContainer < Docker::Container
                                               image: image) do |payload|
         options = { 'Image' => image }
         options['Cmd'] = argv if argv.present?
+        options['HostConfig'] = { 'memory' => CONTAINER_MEMORY_LIMIT }
 
         payload[:container] = super(options)
       end

--- a/spec/services/course/assessment/programming_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_evaluation_service_spec.rb
@@ -114,9 +114,10 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
 
       it 'prefixes the image with coursemology/evaluator-image' do
         # 30 seconds is the default time limit when unspecified.
+        # 128 MB is the default memory limit when unspecified. Value here is in kilobytes.
         expect(CoursemologyDockerContainer).to \
           receive(:create).with("coursemology/evaluator-image-#{image}",
-                                hash_including(argv: ['-c30']))
+                                hash_including(argv: ['-c30', '-m131072']))
 
         container
       end


### PR DESCRIPTION
There are 2 memory limits in this PR.

1. Evaluation memory limit. This is enforced by `ulimit` in the evaluation bash script and only applies to the `make test` step. Previously unlimited by default, this prevents student code from maliciously or accidentally eating up all the memory on the worker.

2. Container memory limit. Enforced by Docker (https://docs.docker.com/engine/admin/resource_constraints/#limit-a-containers-access-to-memory). This limits the amount of memory used by the container and applies to all steps in the evaluation process.
C compilation can take up to nearly 200 MB of memory, causing the host out-of-memory killer to kick in if there are a handful of concurrent C autograding jobs.

Limiting the amount of memory the container has access to slows down compilation but does not prevent it.

The evaluation memory limit is naturally constrained by the container memory limit. It's currently not assigned a maximum as the container memory limit might be changed if we have more resources to spare or find a way to allocate them better.