### PR TITLE
Tweak CPP online editor output

### DIFF
--- a/app/services/course/assessment/question/programming/cpp/cpp_autograde_pre.cc
+++ b/app/services/course/assessment/question/programming/cpp/cpp_autograde_pre.cc
@@ -105,26 +105,15 @@ void RecordProperties(T1 a, T2 b) {
 
 // Generates the properties for the `output` and `expected` fields
 // in the Primitive_visitor() for floating point numbers.
-// If the float is integral, display it with a '.0' to make it clear
-// to students that it's a float or double type.
+// Use to_string() for number conversions as it matches what students see when they use printf.
 //
-// https://stackoverflow.com/questions/15313808/how-to-check-if-float-is-a-whole-number
+// http://en.cppreference.com/w/cpp/string/basic_string/to_string
 template<typename T1, typename T2>
 void RecordFloatProperties(T1 a, T2 b) {
 	std::ostringstream output;
 	std::ostringstream expected;
-	if (a == floor(a)) {
-		output << std::fixed << std::setprecision(1) << a;
-	}
-	else {
-		output << a;
-	}
-	if (b == floor(b)) {
-		expected << std::fixed << std::setprecision(1) << b;
-	}
-	else {
-		expected << b;
-	}
+	output << std::to_string(a);
+	expected << std::to_string(b);
 	::testing::Test::RecordProperty("output", output.str());
 	::testing::Test::RecordProperty("expected", expected.str());
 }

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Cpp/OnlineEditorCppView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Cpp/OnlineEditorCppView.jsx
@@ -298,16 +298,16 @@ class OnlineEditorCppView extends React.Component {
             id="course.assessment.question.programming.onlineEditorCppView.testCasesDescription"
             defaultMessage={
               '{note}: The expression in the {expression} column will be compared with the ' +
-              'expression in the {expected} column using the equality operator. The return value ' +
-              'of {print} is {none} and the printed output should not be confused with the ' +
-              'return value.'
+              'expression in the {expected} column using {expect_star} assertions from the ' +
+              '{googletest}. Floating point numbers are formatted with {tostring}.'
             }
             values={{
               note: <b>{intl.formatMessage(translations.testCaseDescriptionNote)}</b>,
               expression: <b>{intl.formatMessage(translations.expressionHeader)}</b>,
               expected: <b>{intl.formatMessage(translations.expectedHeader)}</b>,
-              print: <code>{intl.formatMessage(translations.testCaseDescriptionPrint)}</code>,
-              none: <code>{intl.formatMessage(translations.testCaseDescriptionNone)}</code>,
+              expect_star: <code>EXPECT_*</code>,
+              googletest: <a href="https://github.com/google/googletest">{intl.formatMessage(translations.testCaseDescriptionGoogleTest)}</a>,
+              tostring: <code><a href="http://en.cppreference.com/w/cpp/string/basic_string/to_string">std::to_string</a></code>,
             }}
           />
         </div>

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorView.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/OnlineEditorView.intl.js
@@ -86,6 +86,11 @@ export default defineMessages({
     defaultMessage: 'None',
     description: 'Value of the none key that is passed into the test case description.',
   },
+  testCaseDescriptionGoogleTest: {
+    id: 'course.assessment.question.programming.onlineEditorView.testCaseDescriptionGoogleTest',
+    defaultMessage: 'Google Test Framework',
+    description: "Name of Google's C++ test framework",
+  },
   addNewTestButton: {
     id: 'course.assessment.question.programming.onlineEditorView.addNewTestButton',
     defaultMessage: 'Add new test',


### PR DESCRIPTION
1. Consistently display floating point numbers with `std::to_string` instead of truncating trailing zeroes.
2. Update test case note to provide CPP specific details.

Fixes #2461.

### Test Case Display on Submission Edit Page
![screen shot 2017-08-25 at 11 17 09 am](https://user-images.githubusercontent.com/1902527/29701487-967f2400-899e-11e7-8ce1-81bdc7e57922.png)

### Note on Question Edit Page
![screen shot 2017-08-25 at 2 06 34 pm](https://user-images.githubusercontent.com/1902527/29701504-b74cbb70-899e-11e7-9426-d76dca80836c.png)

