### PR TITLE
Fix java parser to account for errors in test case

### DIFF
--- a/lib/autoload/course/assessment/programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/programming_test_case_report.rb
@@ -207,6 +207,7 @@ class Course::Assessment::ProgrammingTestCaseReport
     # @return [Hash]
     def messages
       # prune empty and nil values
+      # error_contents and failure_contents are only being stored and not displayed on the interface
       @messages ||= {
         'error': error_message,
         'error_contents': error_contents,


### PR DESCRIPTION
Thrown errors within the test case are not parsed properly, causing it to be displayed as an autograder error instead of a test-case error.