### PR TITLE
Fix forum indentation for the first post

### DIFF
--- a/app/views/course/discussion/_posts.html.slim
+++ b/app/views/course/discussion/_posts.html.slim
@@ -1,7 +1,7 @@
 - post_locals ||= {}
 - posts.each do |post|
   = render partial: post_partial, object: post.first, locals: post_locals
-  - nest_replies = max_depth > 1 && (posts.length > 1 || post.second.length > 1)
+  - nest_replies = max_depth > 1
   - replies_class = nest_replies ? 'nested' : nil
   - replies_max_depth = nest_replies ? max_depth - 1 : max_depth
   div.replies class=replies_class


### PR DESCRIPTION
The child posts are not indented if all children are replies to the first post. 

This PR undoes such behavior to keep consistent with other posts. 