### PR TITLE
Add clearfix to course user achievements display

### DIFF
--- a/app/assets/stylesheets/course/users.scss
+++ b/app/assets/stylesheets/course/users.scss
@@ -14,6 +14,8 @@
   }
 
   &.show {
+    @include automatically-clear;
+
     .achievement {
       text-align: center;
 

--- a/app/views/course/users/_achievement.html.slim
+++ b/app/views/course/users/_achievement.html.slim
@@ -1,4 +1,4 @@
-= div_for(achievement, class: ['col-xs-4', 'col-sm-3', 'col-md-2']) do
+= div_for(achievement, class: ['col-xs-4', 'col-sm-3', 'col-md-2', 'col-lg-2']) do
   = link_to course_achievement_path(current_course, achievement) do
     = display_achievement_badge(achievement)
     h6 = format_inline_text(achievement.title)

--- a/app/views/course/users/show.html.slim
+++ b/app/views/course/users/show.html.slim
@@ -21,6 +21,6 @@ div.row
 
 - unless current_component_host[:course_achievements_component].nil?
   - if @course_user.student? && @course_user.achievements.present?
-    div.row
-      h2 = Course::Achievement.model_name.human.pluralize
+    h2 = Course::Achievement.model_name.human.pluralize
+    div.row.automatically-clear
       = render partial: 'achievement', collection: @course_user.achievements


### PR DESCRIPTION
Fix #2335 

I discovered that the page showing the users who have earned a particular achievement uses a mixin to solve the same problem as #2335.

https://github.com/Coursemology/coursemology2/blob/master/app/assets/stylesheets/mixins/_automatically_clear.scss