### PR TITLE
Fix All Courses page layout and styling

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -21,6 +21,7 @@ $course-assessment-submission-answer-correct-border-radius: $border-radius-base 
 $course-assessment-submission-answer-correct-bg: $state-success-bg !default;
 $course-assessment-submission-answer-correct-border-text: $state-success-text !default;
 $course-assessment-submission-not-started-text: $red !default;
+$course-course-hover-bg: #87cefa !default;
 $course-discussion-post-border: 1px solid $panel-default-border !default;
 $course-discussion-post-border-color: $panel-default-border !default;
 $course-discussion-post-border-radius: $border-radius-base !default;
@@ -77,3 +78,4 @@ $user-profile-picture: $picture-large !default;
 $course-assessment-question-card-shadow: rgba(0, 0, 0, 0.12) !default;
 $course-assessment-question-card-hover-shadow: rgba(0, 0, 0, 0.25) !default;
 $course-assessment-submission-shadow: rgba(0, 0, 0, 0.2) !default;
+$course-course-hover-shadow: rgba(0, 0, 0, 0.1) !default;

--- a/app/assets/stylesheets/course/courses.scss
+++ b/app/assets/stylesheets/course/courses.scss
@@ -9,8 +9,8 @@
     .message-holder {
       border: 1px solid $gray-lighter;
       border-radius: 4px;
-      padding: 10px;
       margin-bottom: 10px;
+      padding: 10px;
 
       .announcement {
         @include announcement;
@@ -38,6 +38,26 @@
   }
 
   &.index {
+    .box {
+      transition: background-color 0.2s, box-shadow 0.2s;
+
+      &:hover {
+        background-color: $course-course-hover-bg;
+        box-shadow: 2px 2px 2px $course-course-hover-shadow;
+      }
+
+      > a {
+        display: block;
+        height: 100%;
+        margin: -4px;
+        padding: 4px;
+
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+
     .caption {
       margin: 5px 0;
 

--- a/app/assets/stylesheets/mixins/_bootstrap_grid_equal_height.scss
+++ b/app/assets/stylesheets/mixins/_bootstrap_grid_equal_height.scss
@@ -11,11 +11,18 @@
     display: flex;
     flex-direction: column;
   }
+
+  &::before,
+  &::after {
+    display: none;
+  }
 }
 
 .is-flex {
   .box {
     background: none;
+    flex-grow: 1;
+    height: 100%;
     position: static;
   }
 

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -6,7 +6,7 @@ class Course::CoursesController < Course::Controller
   before_action :load_todos, only: [:show]
 
   def index # :nodoc:
-    @courses = Course.publicly_accessible.ordered_by_start_at.page(page_param)
+    @courses = Course.publicly_accessible.ordered_by_start_at.page(page_param).per(24)
   end
 
   def show # :nodoc:


### PR DESCRIPTION
- Fix empty space on first row, last position when using Safari
- Make height of tiles in the same row equal
- Change pagination from 25 per page to 24 per page. This makes a nice grid on all screen sizes because 24 is divisible by 2, 3 and 4.
- Add custom hover animation instead of underlining all the text in the course title

Before:
<img width="309" alt="screen shot 2017-08-30 at 10 32 12 pm" src="https://user-images.githubusercontent.com/4056819/29877878-7584f552-8dd3-11e7-8181-c4983b510856.png">

After:
<img width="314" alt="screen shot 2017-08-30 at 10 31 47 pm" src="https://user-images.githubusercontent.com/4056819/29877884-7cf194a8-8dd3-11e7-850b-05934f573a6a.png">

