### PR TITLE
Swap around expected and expression in custom_evaluation

### DIFF
--- a/app/services/course/assessment/question/programming/cpp/cpp_autograde_pre.cc
+++ b/app/services/course/assessment/question/programming/cpp/cpp_autograde_pre.cc
@@ -95,10 +95,10 @@ void expect_equals(const char * a, const char * b) {
 // in the Primitive_visitor() regardless of their types.
 template<typename T1, typename T2>
 void RecordProperties(T1 a, T2 b) {
-	std::ostringstream output;
 	std::ostringstream expected;
-	output << a;
-	expected << b;
+	std::ostringstream output;
+	expected << a;
+	output << b;
 	::testing::Test::RecordProperty("output", output.str());
 	::testing::Test::RecordProperty("expected", expected.str());
 }
@@ -110,13 +110,13 @@ void RecordProperties(T1 a, T2 b) {
 // http://en.cppreference.com/w/cpp/string/basic_string/to_string
 template<typename T1, typename T2>
 void RecordFloatProperties(T1 a, T2 b) {
-	std::ostringstream output;
 	std::ostringstream expected;
-	output << std::to_string(a);
-	expected << std::to_string(b);
+	std::ostringstream output;
+	expected << std::to_string(a);
+	output << std::to_string(b);
 	::testing::Test::RecordProperty("output", output.str());
 	::testing::Test::RecordProperty("expected", expected.str());
 }
 
 template<typename T1, typename T2>
-void custom_evaluation(T1 expression, T2 expected);
+void custom_evaluation(T1 expected, T2 expression);

--- a/app/services/course/assessment/question/programming/cpp/cpp_package_service.rb
+++ b/app/services/course/assessment/question/programming/cpp/cpp_package_service.rb
@@ -177,7 +177,7 @@ class Course::Assessment::Question::Programming::Cpp::CppPackageService < \
       test_fn = <<-CPlusPlus
         TEST(Autograder, test_#{test_type}_#{format('%02i', index)}) {
           RecordProperty("expression", #{test[:expression].inspect});
-          custom_evaluation(#{test[:expression]}, #{test[:expected]});
+          custom_evaluation(#{test[:expected]}, #{test[:expression]});
           #{hint};
         }
       CPlusPlus

--- a/client/app/bundles/course/assessment/question/programming/constants/onlineEditorDefaultTemplates.js
+++ b/client/app/bundles/course/assessment/question/programming/constants/onlineEditorDefaultTemplates.js
@@ -13,7 +13,7 @@ public:
 
 // This function will be called on the expected and expression-output entered in the test case.
 template<typename T1, typename T2>
-void custom_evaluation(T1 expression, T2 expected) {
+void custom_evaluation(T1 expected, T2 expression) {
     // void expect_equals(a, b) is overloaded to generate the appropriate test assertions
     // for the respective type-pairs,
     // It also records the 'expected' and 'output' properties for you
@@ -24,7 +24,7 @@ void custom_evaluation(T1 expression, T2 expected) {
     // You will also have to use ::testing::Test::RecordProperty()
     // to record the 'expected' and 'output' properties
 
-    expect_equals(expression, expected);
+    expect_equals(expected, expression);
 }
 `;
 


### PR DESCRIPTION
Fixes a bug where templates left empty can still show up as correct.

See: https://coursemology.org/courses/1168/assessments/16936/submissions/489270/edit?step=5

Bug (example): 
In the evaluation of two values:
`custom_evaluation(add(1,1), answer_add(1,1));`
in this case, if `add` does not return anything (an empty template), it seems to get its return value from the second function `answer_add`, which causes both to evaluate to the same value. This only seems to happen if the second argument is a function itself.

Fix:
Swap around the `expression` and `expected` arguments in `custom_evaluation`