### PR TITLE
Remove default evaluation memory limit.

### DIFF
--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -10,7 +10,9 @@ class Course::Assessment::Question::Programming < ActiveRecord::Base
 
   # Maximum memory (in MB) the programming question can allow.
   # Do NOT change this to num.megabytes as the ProgramingEvaluationService expects it in MB.
-  MEMORY_LIMIT = 128
+  # Currently set to nil as Java evaluations do not work with a `ulimit` below 3 GB.
+  # Docker container memory limits will keep the evaluation in check.
+  MEMORY_LIMIT = nil
 
   acts_as :question, class_name: Course::Assessment::Question.name
 

--- a/spec/services/course/assessment/programming_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_evaluation_service_spec.rb
@@ -114,10 +114,9 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
 
       it 'prefixes the image with coursemology/evaluator-image' do
         # 30 seconds is the default time limit when unspecified.
-        # 128 MB is the default memory limit when unspecified. Value here is in kilobytes.
         expect(CoursemologyDockerContainer).to \
           receive(:create).with("coursemology/evaluator-image-#{image}",
-                                hash_including(argv: ['-c30', '-m131072']))
+                                hash_including(argv: ['-c30']))
 
         container
       end


### PR DESCRIPTION
Setting ulimit causes Java evaluations to fail unless the limit is so
high (3 GB) it becomes meaningless.