### PR TITLE
Implement forum questions and latest_post column

### DIFF
--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -8,29 +8,6 @@ module Course::Discussion::PostsConcern
                                        class: Course::Discussion::Post.name, parent: false
   end
 
-  def create
-    Course::Discussion::Post.transaction do
-      return true if @post.save && create_topic_subscription && update_topic_pending_status
-      raise ActiveRecord::Rollback
-    end
-  end
-
-  def edit
-  end
-
-  def update
-    @post.update_attributes(post_params)
-  end
-
-  def destroy
-    @post.destroy
-  end
-
-  # Render a new post in a separate page
-  def reply
-    @reply_post = @post.children.build
-  end
-
   protected
 
   # Update pending status of the topic:

--- a/app/controllers/concerns/course/forum/topic_controller_hiding_concern.rb
+++ b/app/controllers/concerns/course/forum/topic_controller_hiding_concern.rb
@@ -25,9 +25,9 @@ module Course::Forum::TopicControllerHidingConcern
     when [true, false]
       t('course.forum.topics.hidden.failure')
     when [false, true]
-      t('course.forum.topics.shown.success')
+      t('course.forum.topics.unhidden.success')
     when [false, false]
-      t('course.forum.topics.shown.failure')
+      t('course.forum.topics.unhidden.failure')
     end
   end
 end

--- a/app/controllers/concerns/course/forum/topic_controller_resolving_concern.rb
+++ b/app/controllers/concerns/course/forum/topic_controller_resolving_concern.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Course::Forum::TopicControllerResolvingConcern
+  extend ActiveSupport::Concern
+
+  def set_resolved
+    authorize!(:resolve, @topic)
+    if @topic.update_attributes(resolved_params)
+      redirect_to course_forum_topic_path(current_course, @forum, @topic),
+                  success: resolved_state_text(true)
+    else
+      redirect_to course_forum_topic_path(current_course, @forum, @topic),
+                  danger: resolved_state_text(false)
+    end
+  end
+
+  private
+
+  def resolved_params
+    params.permit(:resolved)
+  end
+
+  def resolved_state_text(successful)
+    case [@topic.resolved, successful]
+    when [true, true]
+      t('course.forum.topics.resolved.success')
+    when [true, false]
+      t('course.forum.topics.resolved.failure')
+    when [false, true]
+      t('course.forum.topics.unresolved.success')
+    when [false, false]
+      t('course.forum.topics.unresolved.failure')
+    end
+  end
+end

--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -8,7 +8,7 @@ class Course::Forum::ForumsController < Course::Forum::Controller
   end
 
   def show
-    @topics = @forum.topics.accessible_by(current_ability).order_by_date.with_topic_statistics.
+    @topics = @forum.topics.accessible_by(current_ability).order_by_latest_post.with_topic_statistics.
               page(page_param).with_read_marks_for(current_user).includes(:creator).with_latest_post
   end
 

--- a/app/controllers/course/forum/posts_controller.rb
+++ b/app/controllers/course/forum/posts_controller.rb
@@ -9,8 +9,7 @@ class Course::Forum::PostsController < Course::Forum::ComponentController
 
   def create
     if super
-      # Update parent topic updated_at to invalidate all read marks
-      @topic.touch
+      @topic.update_column(:latest_post_at, @post.created_at)
       send_created_notification(@post)
       redirect_to course_forum_topic_path(current_course, @forum, @topic),
                   success: t('course.discussion.posts.create.success')
@@ -38,6 +37,7 @@ class Course::Forum::PostsController < Course::Forum::ComponentController
 
   def destroy
     if super
+      @topic.update_column(:latest_post_at, @topic.posts.last&.created_at || @topic.created_at)
       redirect_to course_forum_topic_path(current_course, @forum, @topic),
                   success: t('course.discussion.posts.destroy.success')
     else

--- a/app/controllers/course/forum/topics_controller.rb
+++ b/app/controllers/course/forum/topics_controller.rb
@@ -2,11 +2,12 @@
 class Course::Forum::TopicsController < Course::Forum::ComponentController
   include Course::Forum::TopicControllerHidingConcern
   include Course::Forum::TopicControllerLockingConcern
+  include Course::Forum::TopicControllerResolvingConcern
   include Course::Forum::TopicControllerSubscriptionConcern
 
   before_action :load_topic, except: [:new, :create]
   load_resource :topic, class: Course::Forum::Topic.name, through: :forum, only: [:new, :create]
-  authorize_resource :topic, class: Course::Forum::Topic.name
+  authorize_resource :topic, class: Course::Forum::Topic.name, except: [:set_resolved]
   before_action :add_topic_breadcrumb
   after_action :mark_posts_read, only: [:show]
 

--- a/app/helpers/course/forum/controller_helper.rb
+++ b/app/helpers/course/forum/controller_helper.rb
@@ -6,4 +6,20 @@ module Course::Forum::ControllerHelper
             title: t('course.forum.forums.next_unread.description'),
             class: ['btn', 'btn-default']
   end
+
+  def topic_type_icon(topic)
+    case topic.topic_type
+    when 'question'
+      if topic.resolved?
+        fa_icon 'question-circle', title: t('course.forum.topics.topic.question.resolved')
+      else
+        fa_icon 'question-circle', title: t('course.forum.topics.topic.question.unresolved'),
+                                   style: 'color: red'
+      end
+    when 'sticky'
+      fa_icon 'thumb-tack', title: t('course.forum.topics.topic.sticky')
+    when 'announcement'
+      fa_icon 'bullhorn', title: t('course.forum.topics.topic.announcement')
+    end
+  end
 end

--- a/app/helpers/course/forum/controller_helper.rb
+++ b/app/helpers/course/forum/controller_helper.rb
@@ -11,10 +11,11 @@ module Course::Forum::ControllerHelper
     case topic.topic_type
     when 'question'
       if topic.resolved?
-        fa_icon 'question-circle', title: t('course.forum.topics.topic.question.resolved')
+        fa_icon 'check-circle', title: t('course.forum.topics.topic.question.resolved'),
+                                class: 'text-info'
       else
         fa_icon 'question-circle', title: t('course.forum.topics.topic.question.unresolved'),
-                                   style: 'color: red'
+                                   class: 'text-warning'
       end
     when 'sticky'
       fa_icon 'thumb-tack', title: t('course.forum.topics.topic.sticky')

--- a/app/models/components/course/forums_ability_component.rb
+++ b/app/models/components/course/forums_ability_component.rb
@@ -9,6 +9,7 @@ module Course::ForumsAbilityComponent
       allow_students_create_topics
       allow_students_update_topics
       allow_student_reply_unlocked_topics
+      allow_student_resolve_own_topics
       allow_staff_manage_forums
       allow_staff_manage_topics
     end
@@ -48,6 +49,10 @@ module Course::ForumsAbilityComponent
   def allow_student_reply_unlocked_topics
     can :reply, Course::Forum::Topic, topic_all_course_users_hash.reverse_merge(locked: false)
     cannot :reply, Course::Forum::Topic, topic_all_course_users_hash.reverse_merge(locked: true)
+  end
+
+  def allow_student_resolve_own_topics
+    can :resolve, Course::Forum::Topic, creator_id: user.id
   end
 
   def allow_staff_manage_forums

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -6,6 +6,7 @@ class Course::Forum::Topic < ActiveRecord::Base
   acts_as_readable on: :updated_at
   acts_as_discussion_topic
 
+  after_initialize :set_defaults, if: :new_record?
   after_initialize :generate_initial_post, unless: :persisted?
   after_create :mark_as_read_for_creator
   after_update :mark_as_read_for_updater
@@ -41,11 +42,10 @@ class Course::Forum::Topic < ActiveRecord::Base
     Course::Forum::Topic::View.where('topic_id = course_forum_topics.id').select("count('*')")
   end)
 
-  # @!method self.order_by_date
-  #   Orders the topics by their date. This uses the modification date, so topics with new posts
-  #   will float to the top.
-  scope :order_by_date, (lambda do
-    order(updated_at: :desc)
+  # @!method self.order_by_latest_post
+  #   Orders the topics by their latest post
+  scope :order_by_latest_post, (lambda do
+    order(latest_post_at: :desc)
   end)
 
   # @!method self.with_latest_post
@@ -110,5 +110,9 @@ class Course::Forum::Topic < ActiveRecord::Base
   # Set the course as the same course of the forum.
   def set_course
     self.course ||= forum.course if forum
+  end
+
+  def set_defaults
+    self.latest_post_at ||= Time.zone.now
   end
 end

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -3,7 +3,7 @@ class Course::Forum::Topic < ActiveRecord::Base
   extend FriendlyId
   friendly_id :slug_candidates, use: :scoped, scope: :forum
 
-  acts_as_readable on: :updated_at
+  acts_as_readable on: :latest_post_at
   acts_as_discussion_topic
 
   after_initialize :set_defaults, if: :new_record?

--- a/app/views/course/forum/forums/show.html.slim
+++ b/app/views/course/forum/forums/show.html.slim
@@ -7,9 +7,9 @@
       tr
         th
         th = t('.topics')
-        th = t('.votes')
-        th = t('.posts')
-        th = t('.views')
+        th.hidden-xs = t('.votes')
+        th.hidden-xs = t('.posts')
+        th.hidden-xs = t('.views')
         th = t('.latest_post')
     tbody
       - if @topics.empty?

--- a/app/views/course/forum/topics/_controls.html.slim
+++ b/app/views/course/forum/topics/_controls.html.slim
@@ -16,7 +16,7 @@
   - if can?(:set_hidden, @topic)
     - if @topic.hidden
       = link_to hidden_course_forum_topic_path(current_course, @forum, @topic, hidden: false),
-                title: t('course.forum.topics.shown.tag'), class: ['btn', 'btn-info'],
+                title: t('course.forum.topics.unhidden.tag'), class: ['btn', 'btn-info'],
                 method: :put do
         = fa_icon 'eye'.freeze
     - else

--- a/app/views/course/forum/topics/_topic.html.slim
+++ b/app/views/course/forum/topics/_topic.html.slim
@@ -5,6 +5,8 @@
   th
     - if topic.locked?
       span => fa_icon 'lock'.freeze, title: t('.locked')
+    span => topic_type_icon(topic)
+
     = link_to(format_inline_text(topic.title),
               course_forum_topic_path(current_course, @forum, topic))
 

--- a/app/views/course/forum/topics/_topic.html.slim
+++ b/app/views/course/forum/topics/_topic.html.slim
@@ -7,14 +7,15 @@
       span => fa_icon 'lock'.freeze, title: t('.locked')
     = link_to(format_inline_text(topic.title),
               course_forum_topic_path(current_course, @forum, topic))
+
     div.started-by
       = t('.started_by_html', user: link_to_user(topic.creator))
-  td = topic.vote_count
-  td = topic.post_count
-  td = topic.view_count
+  td.hidden-xs = topic.vote_count
+  td.hidden-xs = topic.post_count
+  td.hidden-xs = topic.view_count
   td.latest-post
     - last_post = topic.posts.last
     - if last_post
       = link_to_user(last_post.creator)
-      | , 
-      = format_datetime(last_post.created_at, :short)
+      | ,
+      =< format_datetime(last_post.created_at, :short)

--- a/app/views/course/forum/topics/show.html.slim
+++ b/app/views/course/forum/topics/show.html.slim
@@ -1,6 +1,19 @@
 = page_header format_inline_text(@topic.title) do
   = render 'controls'
 
+- if @topic.topic_type == 'question'
+  - if @topic.resolved?
+    div.alert.alert-info
+      = t('course.forum.topics.resolved.message')
+      - if can?(:resolve, @topic)
+        - link = link_to t('course.forum.topics.unresolved.tag'), resolved_course_forum_topic_path(current_course, @forum, @topic, resolved: false), class: 'alert-link', method: :put
+        =< t('course.forum.topics.unresolved.tag_html', unresolve_link: link)
+  - else
+    div.alert.alert-warning
+      = t('course.forum.topics.unresolved.message')
+      - if can?(:resolve, @topic)
+        - link = link_to t('course.forum.topics.resolved.tag'), resolved_course_forum_topic_path(current_course, @forum, @topic, resolved: true), class: 'alert-link', method: :put
+        =< t('course.forum.topics.resolved.tag_html', resolve_link: link)
 = display_topic @topic.acting_as, post_partial: 'course/forum/posts/post',
                                   post_locals: { show_buttons: false },
                                   read_marks: true,

--- a/config/locales/en/course/forum/topics.yml
+++ b/config/locales/en/course/forum/topics.yml
@@ -48,7 +48,19 @@ en:
           tag: 'Hide'
           success: "The topic was successfully hidden."
           failure: "The topic could not be hidden."
-        shown:
-          tag: 'Show'
-          success: "The topic was successfully shown."
-          failure: "The topic could not be shown."
+        unhidden:
+          tag: 'Unhide'
+          success: "The topic was successfully unhidden."
+          failure: "The topic could not be unhidden."
+        resolved:
+          message: 'This question topic has been resolved.'
+          tag: 'Mark as resolved'
+          tag_html: '%{resolve_link} once you have found the answer.'
+          success: "The topic was successfully marked as resolved."
+          failure: "The topic could not be marked as resolved."
+        unresolved:
+          message: 'This question topic is unresolved.'
+          tag: 'Mark as unresolved'
+          tag_html: '%{unresolve_link}.'
+          success: "The topic was successfully marked as unresolved."
+          failure: "The topic could not be marked as unresolved."

--- a/config/locales/en/course/forum/topics.yml
+++ b/config/locales/en/course/forum/topics.yml
@@ -4,6 +4,11 @@ en:
       topics:
         topic:
           locked: 'This topic is locked.'
+          question:
+            resolved: 'Question'
+            unresolved: 'Question (unresolved)'
+          sticky: 'Sticky'
+          announcement: 'Announcement'
           started_by_html: 'Started by %{user}'
         new_topic:
           header: 'New Topic'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -255,6 +255,7 @@ Rails.application.routes.draw do
             delete 'subscribe', on: :member
             put 'locked' => 'topics#set_locked', on: :member
             put 'hidden' => 'topics#set_hidden', on: :member
+            put 'resolved' => 'topics#set_resolved', on: :member
           end
 
           get 'unsubscribe', on: :member

--- a/db/migrate/20170904093138_add_resolved_to_course_forum_topic.rb
+++ b/db/migrate/20170904093138_add_resolved_to_course_forum_topic.rb
@@ -1,0 +1,7 @@
+class AddResolvedToCourseForumTopic < ActiveRecord::Migration
+  def change
+    add_column :course_forum_topics, :resolved, :boolean, default: false, null: false
+    # Set all previous forum questions to resolved
+    Course::Forum::Topic.where(topic_type: 1).update_all(resolved: true)
+  end
+end

--- a/db/migrate/20170905095543_add_latest_post_at_to_course_forum_topic.rb
+++ b/db/migrate/20170905095543_add_latest_post_at_to_course_forum_topic.rb
@@ -1,0 +1,30 @@
+class AddLatestPostAtToCourseForumTopic < ActiveRecord::Migration
+  def change
+    add_column :course_forum_topics, :latest_post_at, :datetime
+
+    exec_query(<<-SQL)
+      UPDATE course_forum_topics
+      SET latest_post_at = created_at
+    SQL
+
+    exec_query(<<-SQL)
+      UPDATE course_forum_topics AS cft
+      SET latest_post_at = t2.latest_post_at
+      FROM (
+        SELECT cdt.actable_id AS id, t1.latest_post_at AS latest_post_at FROM (
+          (
+            SELECT topic_id, MAX(created_at) AS latest_post_at
+            FROM course_discussion_posts
+            GROUP BY topic_id
+          ) AS t1
+          JOIN course_discussion_topics AS cdt
+          ON cdt.id = t1.topic_id
+          AND cdt.actable_type = 'Course::Forum::Topic'
+        )
+      ) AS t2
+      WHERE cft.id = t2.id
+    SQL
+
+    change_column_null :course_forum_topics, :latest_post_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170904093138) do
+ActiveRecord::Schema.define(version: 20170905095543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -480,17 +480,18 @@ ActiveRecord::Schema.define(version: 20170904093138) do
   add_index "course_forum_subscriptions", ["forum_id", "user_id"], :name=>"index_course_forum_subscriptions_on_forum_id_and_user_id", :unique=>true
 
   create_table "course_forum_topics", force: :cascade do |t|
-    t.integer  "forum_id",   :null=>false, :index=>{:name=>"fk__course_forum_topics_forum_id"}, :foreign_key=>{:references=>"course_forums", :name=>"fk_course_forum_topics_forum_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",      :limit=>255, :null=>false
-    t.string   "slug",       :limit=>255
-    t.boolean  "locked",     :default=>false
-    t.boolean  "hidden",     :default=>false
-    t.integer  "topic_type", :default=>0
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_forum_topics_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_forum_topics_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-    t.boolean  "resolved",   :default=>false, :null=>false
+    t.integer  "forum_id",       :null=>false, :index=>{:name=>"fk__course_forum_topics_forum_id"}, :foreign_key=>{:references=>"course_forums", :name=>"fk_course_forum_topics_forum_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "title",          :limit=>255, :null=>false
+    t.string   "slug",           :limit=>255
+    t.boolean  "locked",         :default=>false
+    t.boolean  "hidden",         :default=>false
+    t.integer  "topic_type",     :default=>0
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_forum_topics_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_forum_topics_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
+    t.boolean  "resolved",       :default=>false, :null=>false
+    t.datetime "latest_post_at", :null=>false
   end
   add_index "course_forum_topics", ["forum_id", "slug"], :name=>"index_course_forum_topics_on_forum_id_and_slug", :unique=>true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170819040619) do
+ActiveRecord::Schema.define(version: 20170904093138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -490,6 +490,7 @@ ActiveRecord::Schema.define(version: 20170819040619) do
     t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_forum_topics_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at", :null=>false
     t.datetime "updated_at", :null=>false
+    t.boolean  "resolved",   :default=>false, :null=>false
   end
   add_index "course_forum_topics", ["forum_id", "slug"], :name=>"index_course_forum_topics_on_forum_id_and_slug", :unique=>true
 

--- a/spec/controllers/course/forum/topics_controller_spec.rb
+++ b/spec/controllers/course/forum/topics_controller_spec.rb
@@ -126,14 +126,43 @@ RSpec.describe Course::Forum::TopicsController, type: :controller do
         end
       end
 
-      context 'when set shown fails' do
+      context 'when set unhidden fails' do
         subject do
           put :set_hidden, course_id: course, forum_id: forum, id: topic_stub, hidden: false
         end
 
         it { is_expected.to redirect_to(course_forum_topic_path(course, forum, topic_stub)) }
         it 'sets an error flash message' do
-          expect(flash[:danger]).to eq(I18n.t('course.forum.topics.shown.failure'))
+          expect(flash[:danger]).to eq(I18n.t('course.forum.topics.unhidden.failure'))
+        end
+      end
+    end
+
+    describe '#resolved' do
+      before do
+        controller.instance_variable_set(:@topic, topic_stub)
+        subject
+      end
+
+      context 'when set resolved fails' do
+        subject do
+          put :set_resolved, course_id: course, forum_id: forum, id: topic_stub, resolved: true
+        end
+
+        it { is_expected.to redirect_to(course_forum_topic_path(course, forum, topic_stub)) }
+        it 'sets an error flash message' do
+          expect(flash[:danger]).to eq(I18n.t('course.forum.topics.resolved.failure'))
+        end
+      end
+
+      context 'when set unresolved fails' do
+        subject do
+          put :set_resolved, course_id: course, forum_id: forum, id: topic_stub, resolved: false
+        end
+
+        it { is_expected.to redirect_to(course_forum_topic_path(course, forum, topic_stub)) }
+        it 'sets an error flash message' do
+          expect(flash[:danger]).to eq(I18n.t('course.forum.topics.unresolved.failure'))
         end
       end
     end

--- a/spec/features/course/forum/topic_management_spec.rb
+++ b/spec/features/course/forum/topic_management_spec.rb
@@ -164,19 +164,41 @@ RSpec.feature 'Course: Forum: Topic: Management' do
                   href: hidden_course_forum_topic_path(course, forum, topic, hidden: true)).click
 
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
-        expect(page).to have_link(I18n.t('course.forum.topics.shown.tag'),
+        expect(page).to have_link(I18n.t('course.forum.topics.unhidden.tag'),
                                   href: hidden_course_forum_topic_path(course, forum, topic,
                                                                        hidden: false))
         expect(topic.reload.hidden).to eq(true)
 
         # Set shown
-        find_link(I18n.t('course.forum.topics.shown.tag'),
+        find_link(I18n.t('course.forum.topics.unhidden.tag'),
                   href: hidden_course_forum_topic_path(course, forum, topic, hidden: false)).click
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
         expect(page).to have_link(I18n.t('course.forum.topics.hidden.tag'),
                                   href: hidden_course_forum_topic_path(course, forum, topic,
                                                                        hidden: true))
         expect(topic.reload.hidden).to eq(false)
+      end
+
+      scenario 'I can set resolved state of a question topic' do
+        topic = create(:forum_topic, forum: forum, topic_type: :question)
+        visit course_forum_topic_path(course, forum, topic)
+        find_link(I18n.t('course.forum.topics.resolved.tag'),
+                  href: resolved_course_forum_topic_path(course, forum, topic,
+                                                         resolved: true)).click
+
+        expect(topic.reload.resolved).to eq(true)
+
+        expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
+        find_link(I18n.t('course.forum.topics.unresolved.tag'),
+                  href: resolved_course_forum_topic_path(course, forum, topic,
+                                                         resolved: false)).click
+
+        expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
+        expect(page).to have_link(I18n.t('course.forum.topics.resolved.tag'),
+                                  href: resolved_course_forum_topic_path(course, forum, topic,
+                                                                         resolved: true))
+
+        expect(topic.reload.resolved).to eq(false)
       end
     end
 
@@ -303,6 +325,34 @@ RSpec.feature 'Course: Forum: Topic: Management' do
                                   href: subscribe_course_forum_topic_path(course, forum, topic,
                                                                           subscribe: true))
         expect(topic.subscriptions.where(user: user).empty?).to eq(true)
+      end
+
+      scenario 'I can set resolved state of my own question topic' do
+        topic = create(:forum_topic, forum: forum, topic_type: :question, creator: user)
+        visit course_forum_topic_path(course, forum, topic)
+        find_link(I18n.t('course.forum.topics.resolved.tag'),
+                  href: resolved_course_forum_topic_path(course, forum, topic,
+                                                         resolved: true)).click
+
+        expect(topic.reload.resolved).to eq(true)
+
+        expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
+        find_link(I18n.t('course.forum.topics.unresolved.tag'),
+                  href: resolved_course_forum_topic_path(course, forum, topic,
+                                                         resolved: false)).click
+
+        expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
+        expect(page).to have_link(I18n.t('course.forum.topics.resolved.tag'),
+                                  href: resolved_course_forum_topic_path(course, forum, topic,
+                                                                         resolved: true))
+
+        expect(topic.reload.resolved).to eq(false)
+      end
+
+      scenario 'I can see resolved state of a question topic' do
+        topic = create(:forum_topic, forum: forum, topic_type: :question)
+        visit course_forum_topic_path(course, forum, topic)
+        expect(page).to have_text(I18n.t('course.forum.topics.unresolved.message'))
       end
     end
   end

--- a/spec/models/course/forum/topic_ability_spec.rb
+++ b/spec/models/course/forum/topic_ability_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Course::Forum::Topic, type: :model do
     let(:shown_topic) { build_stubbed(:forum_topic, forum: forum) }
     let(:hidden_topic) { build_stubbed(:forum_topic, :hidden, forum: forum) }
     let(:locked_topic) { build_stubbed(:forum_topic, :locked, forum: forum) }
+    let(:question_topic) { build_stubbed(:forum_topic, topic_type: :question, forum: forum) }
 
     context 'when the user is a Course Student' do
       let(:user) { create(:course_student, course: course).user }
@@ -18,6 +19,9 @@ RSpec.describe Course::Forum::Topic, type: :model do
       end
       let(:my_hidden_topic) do
         build_stubbed(:forum_topic, forum: forum, hidden: true, creator: user)
+      end
+      let(:my_question_topic) do
+        build_stubbed(:forum_topic, forum: forum, topic_type: :question, creator: user)
       end
 
       it { is_expected.to be_able_to(:show, shown_topic) }
@@ -29,6 +33,8 @@ RSpec.describe Course::Forum::Topic, type: :model do
       it { is_expected.not_to be_able_to(:update, hidden_topic) }
       it { is_expected.to be_able_to(:reply, shown_topic) }
       it { is_expected.not_to be_able_to(:reply, locked_topic) }
+      it { is_expected.to be_able_to(:resolve, my_question_topic) }
+      it { is_expected.not_to be_able_to(:resolve, question_topic) }
     end
 
     context 'when the user is a Course Staff' do

--- a/spec/models/course/forum/topic_spec.rb
+++ b/spec/models/course/forum/topic_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Course::Forum::Topic, type: :model do
 
       it 'sorts by updated date' do
         expect(topics).not_to be_empty
-        consecutive = topics.each_cons(2)
-        expect(consecutive.all? { |first, second| first.updated_at <= second.updated_at })
+        consecutive = forum.topics.order_by_latest_post.each_cons(2)
+        expect(consecutive.all? { |first, second| first.latest_post_at <= second.latest_post_at })
       end
     end
 

--- a/spec/models/course/forum/topic_spec.rb
+++ b/spec/models/course/forum/topic_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Course::Forum::Topic, type: :model do
       end
     end
 
-    describe '.order_by_date' do
+    describe '.order_by_latest_post' do
       let!(:topics) { create_list(:forum_topic, topic_count, forum: forum) }
       let(:topic_count) { 3 }
 


### PR DESCRIPTION
Implements #869

- For question type topics, allow the topic creator and course staff to mark the question as resolved or unresolved. The status of the topic is visible at the top of the topic as well as at the forum topics listing.

- Add a new column `latest_post_at` to forum topics. Although forum topic's `updated_at` is updated each time a new post is created under the topic, the column can't be used to sort topics by latest posts as it is also updated upon any topic action (lock/unlock, hide/unhide, mark as resolved/unresolved).

- Previously, forum topics would revert back to unread on any topic action as well. This is because the read/unread status is determined by comparing against the `updated_at` timestamp. Switching `acts_as_readable_on` to the new column `latest_post_at` fixes this issue.