### PR TITLE
Upgrade yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - 'if [ "$GROUP" = "misc" ]; then bundle exec rake factory_girl:lint; fi'
   - 'if [ "$GROUP" = "misc" ]; then bundle exec rake assets:precompile; fi'
   - 'if [ "$GROUP" = "misc" ]; then cd client && yarn; fi'
-  - 'if [ "$GROUP" = "misc" ]; then yarn lint --prefix; fi'
+  - 'if [ "$GROUP" = "misc" ]; then yarn lint; fi'
   - 'if [ "$GROUP" = "misc" ]; then yarn test; fi'
   - 'if [ "$GROUP" = "misc" ]; then cd ..; fi'
   - 'if [ "$GROUP" != "misc" ]; then export CODECOV_FLAG=backend; fi'

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "Coursemology Frontend",
   "engines": {
     "node": ">=5.10.0",
-    "yarn": "^0.24.4"
+    "yarn": "^1.0.0"
   },
   "scripts": {
     "test": "yarn run jest -- --coverage",


### PR DESCRIPTION
Recent release of yarn causes travis to install v1.0.

As `package.json` specified and older version, yarn could not install packages and all the builds errored out.

Fix this by upgrading the required version of yarn.