### PR TITLE
Generate lesson plan item type key upon item update only if necessary

### DIFF
--- a/client/app/bundles/course/lesson-plan/reducers/lessonPlan.js
+++ b/client/app/bundles/course/lesson-plan/reducers/lessonPlan.js
@@ -37,7 +37,8 @@ export default function (state = initialState, action) {
       };
     }
     case actionTypes.ITEM_UPDATE_SUCCESS: {
-      const items = updateOrAppend(state.items, generateTypeKey(action.item));
+      const item = action.item.lesson_plan_item_type ? generateTypeKey(action.item) : action.item;
+      const items = updateOrAppend(state.items, item);
       return {
         ...state,
         items,


### PR DESCRIPTION
Do not generate key when the item type is absent (i.e. has not changed). This fixes a bug where the UI is not updated after the 'published' status of a lesson plan item is toggled.