### PR TITLE
Update yarn scripts for 1.0.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "yarn": "^1.0.0"
   },
   "scripts": {
-    "test": "yarn run jest -- --coverage",
+    "test": "yarn run jest --coverage",
     "build:test": "export NODE_ENV=test && yarn run build:translations && webpack -w",
     "build:production": "export NODE_ENV=production && yarn run build:translations && webpack -p",
     "build:development": "yarn run build:translations && webpack-dev-server",
@@ -16,7 +16,7 @@
     "lint-src": "eslint . --ext .js --ext .jsx --cache --ignore-pattern '**/__test__/**' --ignore-pattern 'coverage/**'",
     "lint-tests": "eslint . --ext .test.js --ext .test.jsx --cache -c .eslintrc.test",
     "lint": "yarn run lint-src && yarn run lint-tests",
-    "lint-fix": "yarn run lint-src -- --fix && yarn run lint-tests -- --fix"
+    "lint-fix": "yarn run lint-src --fix && yarn run lint-tests --fix"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/releases/tag/v1.0.0

> Breaking: Commands run via yarn run are now automatically forwarded trailing options

> warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
