### PR TITLE
Center text align in table columns: submission status, total grade, EXP

### DIFF
--- a/app/assets/stylesheets/course/assessment/submissions.scss
+++ b/app/assets/stylesheets/course/assessment/submissions.scss
@@ -6,5 +6,14 @@
       margin: 5px;
       padding: 10px;
     }
+
+    .submissions-list {
+      .table-workflow-state,
+      .table-grade,
+      .table-current-points-awarded,
+      .table-buttons {
+        @extend .text-center;
+      }
+    }
   }
 }

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -4,7 +4,8 @@
   td = link_to(format_inline_text(assessment.title),
                course_assessment_path(current_course, assessment))
   td = format_datetime(submission.submitted_at) if submission.submitted_at
-  td = Course::Assessment::Submission.human_attribute_name(submission.workflow_state)
+  td.table-workflow-state
+    = Course::Assessment::Submission.human_attribute_name(submission.workflow_state)
   - if pending
     td
       - @service.group_managers_of(submission.course_user).each do |manager|
@@ -15,19 +16,19 @@
   - can_see_grades = \
       submission.published? || (submission.graded? && can?(:grade, submission.assessment))
   - if can_see_grades
-    td
+    td.table-grade
       = submission.grade.to_s + ' / ' + assessment.maximum_grade.to_s
       - if submission.graded?
         span.text-danger title=t('.graded_not_published_warning')
           =< fa_icon 'exclamation-circle'.freeze
     - if current_course.gamified?
-      td = submission.current_points_awarded
+      td.table-current-points-awarded = submission.current_points_awarded
   - else
-    td = '-- / ' + assessment.maximum_grade.to_s
+    td.table-grade = '-- / ' + assessment.maximum_grade.to_s
     - if current_course.gamified?
       td
 
-  td
+  td.table-buttons
     - button_class = ['btn', 'btn-block']
     - link_path = edit_course_assessment_submission_path(current_course, assessment, submission)
     - if current_course_user && current_course_user.staff? && submission.submitted?

--- a/app/views/course/assessment/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submissions/_submissions.html.slim
@@ -1,15 +1,15 @@
-table.table.table-middle-align.table-hover
+table.table.table-middle-align.submissions-list.table-hover
   thead
     tr
       th = CourseUser.human_attribute_name(:name)
       th = Course::Assessment.human_attribute_name(:title)
       th = Course::Assessment::Submission.human_attribute_name(:submitted_at)
-      th = Course::Assessment::Submission.human_attribute_name(:status)
+      th.table-workflow-state = Course::Assessment::Submission.human_attribute_name(:status)
       - if pending
         th = Course::GroupUser.human_attribute_name(:manager)
-      th = Course::Assessment::Submission.human_attribute_name(:grade)
+      th.table-grade = Course::Assessment::Submission.human_attribute_name(:grade)
       - if current_course.gamified?
-        th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
+        th.table-current-points-awarded = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
       th
       th
   tbody

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTable.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTable.jsx
@@ -28,6 +28,10 @@ const styles = {
     whiteSpace: 'normal',
     wordBreak: 'break-word',
   },
+  tableCenterCell: {
+    ...this.tableCell,
+    textAlign: 'center',
+  },
 };
 
 export default class SubmissionsTable extends React.Component {
@@ -107,19 +111,19 @@ export default class SubmissionsTable extends React.Component {
             {submission.courseStudent.name}
           </a>
         </TableRowColumn>
-        <TableRowColumn style={styles.tableCell}>
+        <TableRowColumn style={styles.tableCenterCell}>
           {this.renderSubmissionWorkflowState(submission)}
         </TableRowColumn>
-        <TableRowColumn style={styles.tableCell}>
+        <TableRowColumn style={styles.tableCenterCell}>
           {submission.grade !== undefined ? `${submission.grade} / ${assessment.maximumGrade}` : null}
         </TableRowColumn>
-        {assessment.gamified ? <TableRowColumn style={styles.tableCell}>
+        {assessment.gamified ? <TableRowColumn style={styles.tableCenterCell}>
           {submission.pointsAwarded !== undefined ? submission.pointsAwarded : null}
         </TableRowColumn> : null}
-        <TableRowColumn style={styles.tableCell}>
+        <TableRowColumn style={styles.tableCenterCell}>
           {SubmissionsTable.formatDate(submission.dateSubmitted)}
         </TableRowColumn>
-        <TableRowColumn style={styles.tableCell}>
+        <TableRowColumn style={styles.tableCenterCell}>
           {SubmissionsTable.formatDate(submission.dateGraded)}
         </TableRowColumn>
         <TableRowColumn style={{ width: 48, padding: 12 }}>
@@ -162,16 +166,22 @@ export default class SubmissionsTable extends React.Component {
       </TableHeaderColumn>
     );
 
+    const tableHeaderCenterColumnFor = field => (
+      <TableHeaderColumn style={styles.tableCenterCell}>
+        <FormattedMessage {...submissionsTranslations[field]} />
+      </TableHeaderColumn>
+    );
+
     return (
       <Table selectable={false}>
         <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
           <TableRow>
             {tableHeaderColumnFor('studentName')}
-            {tableHeaderColumnFor('submissionStatus')}
-            {tableHeaderColumnFor('grade')}
-            {assessment.gamified ? tableHeaderColumnFor('experiencePoints') : null}
-            {tableHeaderColumnFor('dateSubmitted')}
-            {tableHeaderColumnFor('dateGraded')}
+            {tableHeaderCenterColumnFor('submissionStatus')}
+            {tableHeaderCenterColumnFor('grade')}
+            {assessment.gamified ? tableHeaderCenterColumnFor('experiencePoints') : null}
+            {tableHeaderCenterColumnFor('dateSubmitted')}
+            {tableHeaderCenterColumnFor('dateGraded')}
             <TableHeaderColumn style={{ width: 48, padding: 0 }}>
               {this.renderDownloadButton()}
             </TableHeaderColumn>

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/translations.js
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/translations.js
@@ -8,7 +8,7 @@ const translations = defineMessages({
   },
   studentName: {
     id: 'course.assessment.submission.submissions.studentName',
-    defaultMessage: 'Student Name',
+    defaultMessage: 'Name',
   },
   submissionStatus: {
     id: 'course.assessment.submission.submissions.submissionStatus',
@@ -16,19 +16,19 @@ const translations = defineMessages({
   },
   grade: {
     id: 'course.assessment.submission.submissions.grade',
-    defaultMessage: 'Grade',
+    defaultMessage: 'Total Grade',
   },
   experiencePoints: {
     id: 'course.assessment.submission.submissions.experiencePoints',
-    defaultMessage: 'Experience Points',
+    defaultMessage: 'Experience Points Awarded',
   },
   dateSubmitted: {
     id: 'course.assessment.submission.submissions.dateSubmitted',
-    defaultMessage: 'Date Submitted',
+    defaultMessage: 'Submitted At',
   },
   dateGraded: {
     id: 'course.assessment.submission.submissions.dateGraded',
-    defaultMessage: 'Date Graded',
+    defaultMessage: 'Graded At',
   },
   download: {
     id: 'course.assessment.submission.submissions.download',

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -79,11 +79,11 @@ const translations = defineMessages({
   },
   student: {
     id: 'course.assessment.submission.student',
-    defaultMessage: 'Student',
+    defaultMessage: 'Name',
   },
   status: {
     id: 'course.assessment.submission.status',
-    defaultMessage: 'Status',
+    defaultMessage: 'Submission Status',
   },
   totalGrade: {
     id: 'course.assessment.submission.totalGrade',

--- a/config/locales/en/activerecord/course_user.yml
+++ b/config/locales/en/activerecord/course_user.yml
@@ -5,4 +5,4 @@ en:
         name: 'Name'
       course_user:
         level_number: 'Level'
-        created_at: 'Enrolled at'
+        created_at: 'Enrolled At'

--- a/config/locales/en/course/achievement/course_users.yml
+++ b/config/locales/en/course/achievement/course_users.yml
@@ -4,7 +4,7 @@ en:
       course_users:
         course_users_form:
           header: 'Award Achievement'
-          name: 'Student Name'
+          name: 'Name'
           enabled: 'Obtained Achievement'
           button: 'Update Users'
           phantom_user_header: 'Phantom Users'

--- a/config/locales/en/course/video/submissions.yml
+++ b/config/locales/en/course/video/submissions.yml
@@ -17,6 +17,6 @@ en:
             watched: 'Watched'
             not_watched: 'Has Not Started'
           submissions:
-            student_name: 'Student Name'
+            student_name: 'Name'
             status: 'Status'
             start_at: 'Watched At'


### PR DESCRIPTION
Center text alignment for the following table columns, as requested by @benleong:
1. Submission Status
1. Total Grade
1. Experience Points Awarded

Also, standardised the following table headers across different submission summary pages:
1. "Name"
1. "Total Grade"
1. "Experience Points Awarded"