### PR TITLE
Prevent missing actable for lesson plan items from breaking lesson plan page

### DIFF
--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -2,7 +2,7 @@
 class Course::LessonPlan::Item < ActiveRecord::Base
   include Course::LessonPlan::ItemTodoConcern
 
-  actable
+  actable required: true
   has_many_attachments
 
   after_initialize :set_default_values, if: :new_record?

--- a/app/views/course/lesson_plan/items/index.json.jbuilder
+++ b/app/views/course/lesson_plan/items/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.milestones @milestones, partial: 'course/lesson_plan/milestones/milestone.json.jbuilder', as: :milestone
 
-json.items @items.map(&:specific) do |actable|
+json.items @items.map(&:specific).compact do |actable|
   json.partial! "#{actable.to_partial_path}_lesson_plan_item.json.jbuilder", item: actable
 end
 

--- a/spec/helpers/course/lesson_plan/todos_helper_spec.rb
+++ b/spec/helpers/course/lesson_plan/todos_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::LessonPlan::TodosHelper do
   with_tenant(:instance) do
     describe '#todo_status_class' do
       let(:todo) do
-        item = create(:course_lesson_plan_item, start_at: end_at - 1.day, end_at: end_at)
+        item = create(:course_lesson_plan_event, start_at: end_at - 1.day, end_at: end_at).acting_as
         create(:course_lesson_plan_todo, item: item)
       end
       subject { helper.todo_status_class(todo) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Course, type: :model do
       end
       let!(:lesson_plan_items) do
         [3.days.ago, 2.days.ago, 1.day.from_now, 3.days.from_now].map do |start_at|
-          create(:course_lesson_plan_item, course: course, start_at: start_at)
+          create(:course_lesson_plan_event, course: course, start_at: start_at).acting_as
         end
       end
       subject { course.grouped_lesson_plan_items_with_milestones }


### PR DESCRIPTION
There were a couple of instances where a `LessonPlan::Item`'s `actable_id` became `nil`, resulting in a error when generating the JSON data for the lesson plan page.

Fixes #2501 