### PR TITLE
Destroy discussion post on course deletion

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -42,7 +42,8 @@ class Course < ActiveRecord::Base
                                 source: :actable, source_type: Course::LessonPlan::Event.name
   # Achievements must be declared after material_folders or duplication will fail.
   has_many :achievements, dependent: :destroy
-  has_many :discussion_topics, class_name: Course::Discussion::Topic.name, inverse_of: :course
+  has_many :discussion_topics, dependent: :destroy, class_name: Course::Discussion::Topic.name,
+                               inverse_of: :course
   has_many :forums, dependent: :destroy, inverse_of: :course
   has_many :surveys, through: :lesson_plan_items, source: :actable, source_type: Course::Survey.name
   has_many :videos, through: :lesson_plan_items, source: :actable, source_type: Course::Video.name

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Course, type: :model do
     it { is_expected.to have_many(:assessments).through(:assessment_categories) }
     it { is_expected.to have_many(:assessment_skills).dependent(:destroy) }
     it { is_expected.to have_many(:assessment_skill_branches).dependent(:destroy) }
-    it { is_expected.to have_many(:discussion_topics) }
+    it { is_expected.to have_many(:discussion_topics).dependent(:destroy) }
     it { is_expected.to have_many(:forums).dependent(:destroy) }
     it { is_expected.to have_many(:lesson_plan_items).dependent(:destroy) }
     it { is_expected.to have_many(:lesson_plan_milestones).dependent(:destroy) }


### PR DESCRIPTION
Not sure if it was supposed to be the case, but discussion post is not destroy-dependent on course. Courses with discussion posts couldn't be deleted as a result.