### PR TITLE
Implement cherry-picking duplication for assessments

### DIFF
--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+class Course::ObjectDuplicationsController < Course::ComponentController
+  before_action :authorize_duplication
+
+  def new
+    load_target_courses_data
+    load_assessments_component_data
+  end
+
+  def create
+    job = Course::ObjectDuplicationJob.perform_later(
+      current_course, authorized_target_course, objects_to_duplicate, current_user: current_user
+    ).job
+    render json: { redirect_url: job_path(job) }
+  end
+
+  protected
+
+  def authorize_duplication
+    authorize!(:duplicate, current_course)
+  end
+
+  private
+
+  def load_target_courses_data
+    @target_courses = ActsAsTenant.without_tenant do
+      Course.accessible_by(current_ability, :duplicate_to).includes(:instance)
+    end
+  end
+
+  def load_assessments_component_data
+    @categories = current_course.assessment_categories.includes(tabs: :assessments)
+  end
+
+  def create_duplication_params
+    @create_duplication_params ||= begin
+      items_params = course_item_finders.keys.map { |key| { key => [] } }
+      params.require(:object_duplication).permit(:target_course_id, items: items_params)
+    end
+  end
+
+  def authorized_target_course
+    ActsAsTenant.without_tenant do
+      Course.find(create_duplication_params[:target_course_id]).tap do |target_course|
+        authorize!(:duplicate_to, target_course)
+      end
+    end
+  end
+
+  # @return [Hash] Hash mapping each item type to finders that search for items of that type within
+  #   the current course
+  def course_item_finders
+    @course_item_finders ||= {
+      'CATEGORY' => ->(ids) { current_course.assessment_categories.find(ids) },
+      'TAB' => ->(ids) { current_course.assessment_tabs.find(ids) },
+      'ASSESSMENT' => ->(ids) { current_course.assessments.find(ids) }
+    }
+  end
+
+  def objects_to_duplicate
+    create_duplication_params[:items].map do |item_type, ids|
+      course_item_finders[item_type].call(ids)
+    end.flatten
+  end
+end

--- a/app/jobs/course/object_duplication_job.rb
+++ b/app/jobs/course/object_duplication_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class Course::ObjectDuplicationJob < ApplicationJob
+  include TrackableJob
+  include Rails.application.routes.url_helpers
+  queue_as :duplication
+
+  protected
+
+  # Performs the object duplication job.
+  #
+  # @param [Course] current_course Course to duplicate from.
+  # @param [Course] target_course Course to duplicate to.
+  # @param [Object|Array] objects The object(s) to duplicate.
+  # @param [Hash] options The options to be sent to the Duplicator object.
+  def perform_tracked(current_course, target_course, objects, options = {})
+    ActsAsTenant.without_tenant do
+      Course::Duplication::ObjectDuplicationService.duplicate_objects(current_course, target_course, objects, options)
+      redirect_to course_url(options[:target_course], host: target_course.instance.host)
+    end
+  end
+end

--- a/app/models/components/course/duplication_ability_component.rb
+++ b/app/models/components/course/duplication_ability_component.rb
@@ -3,17 +3,28 @@ module Course::DuplicationAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_owner_duplicate_course if user
+    if user
+      disallow_superusers_duplicate_via_frontend
+      allow_managers_duplicate_to_course
+      allow_managers_duplicate_from_course
+    end
 
     super
   end
 
   private
 
-  def allow_owner_duplicate_course
-    # Actually unnecessary because course managers can :manage courses.
-    # This is for consistency if more fine grained permissions need to be defined when
-    # duplication cherry picking is supported.
+  # Include in the list of target courses only courses which superusers can duplicate to.
+  # Without this, the list will consist of all courses in the instance.
+  def disallow_superusers_duplicate_via_frontend
+    cannot :duplicate_to, Course
+  end
+
+  def allow_managers_duplicate_to_course
+    can :duplicate_to, Course, course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
+  end
+
+  def allow_managers_duplicate_from_course
     can :duplicate, Course, course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
   end
 end

--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -56,6 +56,7 @@ class Course::Achievement < ActiveRecord::Base
   def initialize_duplicate(duplicator, other)
     badge.duplicate_from(other.badge) if other.badge_url
     self.course = duplicator.options[:target_course]
+    self.published = false if duplicator.options[:unpublish_all]
     duplicate_conditions(duplicator, other)
     achievement_conditions << other.achievement_conditions.
                               select { |condition| duplicator.duplicated?(condition.conditional) }.

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -145,6 +145,8 @@ class Course::Assessment < ActiveRecord::Base
     @duplicating = true
   end
 
+  private
+
   # Parents the assessment under its duplicated parent tab, if it exists.
   #
   # @return [Course::Assessment::Tab] The duplicated assessment's tab
@@ -165,8 +167,6 @@ class Course::Assessment < ActiveRecord::Base
                              select { |condition| duplicator.duplicated?(condition.conditional) }.
                              map { |condition| duplicator.duplicate(condition) }
   end
-
-  private
 
   # Sets the course of the lesson plan item to be the same as the one for the assessment.
   def propagate_course

--- a/app/models/course/assessment/category.rb
+++ b/app/models/course/assessment/category.rb
@@ -44,6 +44,13 @@ class Course::Assessment::Category < ActiveRecord::Base
     end
   end
 
+  # @return [Boolean] true if post-duplication processing is successful.
+  def after_duplicate_save(duplicator)
+    User.with_stamper(duplicator.options[:current_user]) do
+      build_initial_tab ? save : true
+    end
+  end
+
   private
 
   def build_initial_tab

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -32,7 +32,7 @@ class Course::LessonPlan::Item < ActiveRecord::Base
   def copy_attributes(other, duplicator)
     self.title = other.title
     self.description = other.description
-    self.published = other.published
+    self.published = duplicator.options[:unpublish_all] ? false : other.published
     self.base_exp = other.base_exp
     self.time_bonus_exp = other.time_bonus_exp
     self.start_at = duplicator.time_shift(other.start_at)

--- a/app/services/course/duplication/object_duplication_service.rb
+++ b/app/services/course/duplication/object_duplication_service.rb
@@ -5,14 +5,16 @@ class Course::Duplication::ObjectDuplicationService < Course::Duplication::BaseS
   class << self
     # Constructor for the object duplication service.
     #
-    # @param [Array] objects The objects to duplicate.
+    # @param [Course] current_course Course to duplicate from.
+    # @param [Course] target_course Course to duplicate to.
+    # @param [Object|Array] objects The object(s) to duplicate.
     # @param [Hash] options The options to be sent to the Duplicator object.
     # @option options [User] :current_user (+User.system+) The user triggering the duplication.
-    # @option options [Course] :current_course
-    # @option options [DateTime] :target_course
-    # @return [Array] The duplicated objects
-    def duplicate_objects(objects, options = {})
-      options[:time_shift] = time_shift(options[:current_course], options[:target_course])
+    # @return [Object|Array] The duplicated object(s).
+    def duplicate_objects(current_course, target_course, objects, options = {})
+      options[:time_shift] = time_shift(current_course, target_course)
+      options[:current_course] = current_course
+      options[:target_course] = target_course
       options.reverse_merge!(DEFAULT_OBJECT_DUPLICATION_OPTIONS)
       service = new(options)
       service.duplicate_objects(objects)
@@ -34,7 +36,9 @@ class Course::Duplication::ObjectDuplicationService < Course::Duplication::BaseS
 
   # Duplicate the objects with the duplicator.
   #
-  # @return [Course] The duplicated objects
+  # @param [Object|Array] objects An object or an array of objects to duplicate.
+  # @return [Object] The duplicated object, if `objects` is a single object.
+  # @return [Array] Array of duplicated objects, if `objects` is an array.
   def duplicate_objects(objects)
     # TODO: Inform the user when the duplication is complete.
     Course.transaction do

--- a/app/services/course/duplication/object_duplication_service.rb
+++ b/app/services/course/duplication/object_duplication_service.rb
@@ -32,7 +32,7 @@ class Course::Duplication::ObjectDuplicationService < Course::Duplication::BaseS
   end
 
   DEFAULT_OBJECT_DUPLICATION_OPTIONS =
-    { mode: :object, current_user: User.system }.freeze
+    { mode: :object, unpublish_all: true, current_user: User.system }.freeze
 
   # Duplicate the objects with the duplicator.
   #

--- a/app/views/course/object_duplications/new.html.slim
+++ b/app/views/course/object_duplications/new.html.slim
@@ -1,0 +1,1 @@
+#course-duplication

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -1,0 +1,17 @@
+json.currentHost current_tenant.host
+
+json.targetCourses @target_courses do |course|
+  json.(course, :id, :title)
+  json.path course_path(course)
+  json.host course.instance.host
+end
+
+json.assessmentsComponent @categories do |category|
+  json.(category, :id, :title)
+  json.tabs category.tabs do |tab|
+    json.(tab, :id, :title)
+    json.assessments tab.assessments do |assessment|
+      json.(assessment, :id, :title, :published)
+    end
+  end
+end

--- a/client/app/api/course/Duplication.js
+++ b/client/app/api/course/Duplication.js
@@ -1,0 +1,39 @@
+import BaseCourseAPI from './Base';
+
+export default class DuplicationAPI extends BaseCourseAPI {
+  /**
+  * Fetches a list of all objects in course
+  *
+  * @return {Promise}
+  * success response: {
+  *   assessmentComponent: Array.<categoryShape>,
+  *   currentHost: string,
+  *   targetCourses: Array.<courseShape>,
+  * }
+  *
+  * See course/duplication/propTypes.js for categoryShape and courseShape.
+  */
+  fetch() {
+    return this.getClient().get(`${this._getUrlPrefix()}/new`);
+  }
+
+  /**
+  * Duplicates selected items to the target course.
+  *
+  * @param {object} params in the form {
+  *   items: { TAB: Array.<number>, ASSESSMENT: Array.<number>, ... },
+  *   target_course_id: number,
+  * }
+  * @return {Promise}
+  * success response: { redirect_url: string }
+  * error response: {}
+  */
+
+  duplicateItems(params) {
+    return this.getClient().post(this._getUrlPrefix(), params);
+  }
+
+  _getUrlPrefix() {
+    return `/courses/${this.getCourseId()}/object_duplication`;
+  }
+}

--- a/client/app/api/course/index.js
+++ b/client/app/api/course/index.js
@@ -5,6 +5,7 @@ import VirtualClassroomsAPI from './VirtualClassrooms';
 import MaterialsAPI from './Materials';
 import MaterialFoldersAPI from './MaterialFolders';
 import LessonPlanAPI from './LessonPlan';
+import DuplicationAPI from './Duplication';
 import SurveyAPI from './Survey';
 import AdminAPI from './Admin';
 import ScribingQuestionAPI from './Assessment/question/scribing';
@@ -17,6 +18,7 @@ const CourseAPI = {
   materials: new MaterialsAPI(),
   materialFolders: new MaterialFoldersAPI(),
   lessonPlan: new LessonPlanAPI(),
+  duplication: new DuplicationAPI(),
   survey: SurveyAPI,
   admin: AdminAPI,
   question: {

--- a/client/app/bundles/course/admin/pages/NotificationSettings/index.jsx
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/index.jsx
@@ -7,7 +7,7 @@ import Toggle from 'material-ui/Toggle';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import NotificationPopup from 'lib/containers/NotificationPopup';
 import { updateNotificationSetting } from 'course/admin/actions/notifications';
-import adminTranslations, { defaultComponentTitles } from 'course/admin/translations.intl';
+import adminTranslations, { defaultComponentTitles } from 'course/translations.intl';
 import translations, { settingTitles, settingDescriptions } from './translations.intl';
 
 const styles = {

--- a/client/app/bundles/course/duplication/actions.js
+++ b/client/app/bundles/course/duplication/actions.js
@@ -1,0 +1,83 @@
+import CourseAPI from 'api/course';
+import actionTypes from 'course/duplication/constants';
+import { setNotification } from 'lib/actions';
+
+export function fetchObjectsList() {
+  return (dispatch) => {
+    dispatch({ type: actionTypes.LOAD_OBJECTS_LIST_REQUEST });
+    return CourseAPI.duplication.fetch()
+      .then((response) => {
+        dispatch({
+          type: actionTypes.LOAD_OBJECTS_LIST_SUCCESS,
+          duplicationData: response.data,
+        });
+      })
+      .catch(() => {
+        dispatch({ type: actionTypes.LOAD_OBJECTS_LIST_FAILURE });
+      });
+  };
+}
+
+export function setItemSelectedBoolean(itemType, id, value) {
+  return {
+    type: actionTypes.SET_ITEM_SELECTED_BOOLEAN,
+    itemType,
+    id,
+    value,
+  };
+}
+
+export function showDuplicateItemsConfirmation() {
+  return { type: actionTypes.SHOW_DUPLICATE_ITEMS_CONFIRMATION };
+}
+
+export function hideDuplicateItemsConfirmation() {
+  return { type: actionTypes.HIDE_DUPLICATE_ITEMS_CONFIRMATION };
+}
+
+export function setTargetCourseId(targetCourseId) {
+  return { type: actionTypes.SET_TARGET_COURSE_ID, targetCourseId };
+}
+
+/**
+* Prepares the payload containing ids and types of items selected for duplication.
+*
+* @param {object} selectedItemsHash Maps types to hashes that indicate which items have been selected, e.g.
+*    { TAB: { 3: true, 4: false }, SURVEY: { 9: true }, CATEGORY: { 10: false } }
+* @return {object} Maps types to arrays with ids of items that have been selected, e.g.
+*    { TAB: [3], SURVEY: [9] }
+*/
+function itemsPayload(selectedItemsHash) {
+  return Object.keys(selectedItemsHash).reduce((hash, key) => {
+    const idsHash = selectedItemsHash[key];
+    const idsArray = Object.keys(idsHash).reduce((selectedIds, id) => {
+      if (idsHash[id]) { selectedIds.push(id); }
+      return selectedIds;
+    }, []);
+    if (idsArray.length > 0) { hash[key] = idsArray; } // eslint-disable-line no-param-reassign
+    return hash;
+  }, {});
+}
+
+export function duplicateItems(targetCourseId, selectedItems, failureMessage) {
+  const payload = {
+    object_duplication: {
+      target_course_id: targetCourseId,
+      items: itemsPayload(selectedItems),
+    },
+  };
+
+  return (dispatch) => {
+    dispatch({ type: actionTypes.DUPLICATE_ITEMS_REQUEST });
+    return CourseAPI.duplication.duplicateItems(payload)
+      .then((response) => {
+        dispatch({ type: actionTypes.DUPLICATE_ITEMS_SUCCESS });
+        window.location = response.data.redirect_url;
+      })
+      .catch(() => {
+        dispatch({ type: actionTypes.DUPLICATE_ITEMS_FAILURE });
+        dispatch(hideDuplicateItemsConfirmation());
+        setNotification(failureMessage)(dispatch);
+      });
+  };
+}

--- a/client/app/bundles/course/duplication/components/TypeBadge/index.jsx
+++ b/client/app/bundles/course/duplication/components/TypeBadge/index.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { duplicableItemTypes } from 'course/duplication/constants';
+
+const styles = {
+  badge: {
+    padding: '2px 5px',
+    marginRight: 10,
+    borderStyle: 'solid',
+    borderRadius: 5,
+    borderWidth: 1,
+    fontSize: 12,
+  },
+};
+
+const translations = defineMessages({
+  [duplicableItemTypes.ASSESSMENT]: {
+    id: 'course.duplication.TypeBadge.assessment',
+    defaultMessage: 'Assessment',
+  },
+  [duplicableItemTypes.CATEGORY]: {
+    id: 'course.duplication.TypeBadge.category',
+    defaultMessage: 'Category',
+  },
+  [duplicableItemTypes.TAB]: {
+    id: 'course.duplication.TypeBadge.tab',
+    defaultMessage: 'Tab',
+  },
+});
+
+const TypeBadge = ({ text, itemType }) => (
+  <span style={styles.badge}>
+    { text || <FormattedMessage {...translations[itemType]} /> }
+  </span>
+  );
+
+TypeBadge.propTypes = {
+  text: PropTypes.string,
+  itemType: PropTypes.string,
+};
+
+export default TypeBadge;

--- a/client/app/bundles/course/duplication/constants.js
+++ b/client/app/bundles/course/duplication/constants.js
@@ -1,0 +1,22 @@
+import mirrorCreator from 'mirror-creator';
+
+export const duplicableItemTypes = mirrorCreator([
+  'ASSESSMENT',
+  'TAB',
+  'CATEGORY',
+]);
+
+const actionTypes = mirrorCreator([
+  'LOAD_OBJECTS_LIST_REQUEST',
+  'LOAD_OBJECTS_LIST_SUCCESS',
+  'LOAD_OBJECTS_LIST_FAILURE',
+  'DUPLICATE_ITEMS_REQUEST',
+  'DUPLICATE_ITEMS_SUCCESS',
+  'DUPLICATE_ITEMS_FAILURE',
+  'SHOW_DUPLICATE_ITEMS_CONFIRMATION',
+  'HIDE_DUPLICATE_ITEMS_CONFIRMATION',
+  'SET_ITEM_SELECTED_BOOLEAN',
+  'SET_TARGET_COURSE_ID',
+]);
+
+export default actionTypes;

--- a/client/app/bundles/course/duplication/containers/DuplicationLayout/index.jsx
+++ b/client/app/bundles/course/duplication/containers/DuplicationLayout/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import NotificationPopup from 'lib/containers/NotificationPopup';
+import ObjectDuplication from 'course/duplication/pages/ObjectDuplication';
+
+const DuplicationLayout = () => (
+  <div>
+    <NotificationPopup />
+
+    <Switch>
+      <Route exact path="/courses/:courseId/object_duplication/new" component={ObjectDuplication} />
+    </Switch>
+  </div>
+ );
+
+export default DuplicationLayout;

--- a/client/app/bundles/course/duplication/index.jsx
+++ b/client/app/bundles/course/duplication/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Router } from 'react-router-dom';
+import history from 'lib/history';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
+import DuplicationLayout from 'course/duplication/containers/DuplicationLayout';
+import storeCreator from './store';
+
+$(document).ready(() => {
+  const mountNode = document.getElementById('course-duplication');
+
+  if (mountNode) {
+    const store = storeCreator({ duplication: {} });
+
+    render(
+      <ProviderWrapper {...{ store }}>
+        <Router history={history}>
+          <DuplicationLayout />
+        </Router>
+      </ProviderWrapper>
+    , mountNode);
+  }
+});

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/AssessmentsSelector.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/AssessmentsSelector.jsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import Subheader from 'material-ui/Subheader';
+import Checkbox from 'material-ui/Checkbox';
+import Block from 'material-ui/svg-icons/content/block';
+import { defaultComponentTitles } from 'course/translations.intl';
+import { duplicableItemTypes } from 'course/duplication/constants';
+import { setItemSelectedBoolean } from 'course/duplication/actions';
+import { categoryShape } from 'course/duplication/propTypes';
+import TypeBadge from 'course/duplication/components/TypeBadge';
+
+const { TAB, ASSESSMENT, CATEGORY } = duplicableItemTypes;
+
+const styles = {
+  categoryCheckbox: {
+    width: 'auto',
+  },
+  tabCheckbox: {
+    marginLeft: 15,
+    width: 'auto',
+  },
+  assessmentCheckbox: {
+    marginLeft: 30,
+  },
+  checkboxLabel: {
+    width: 'auto',
+  },
+  checkboxLine: {
+    display: 'flex',
+  },
+  selectLink: {
+    marginLeft: 20,
+    lineHeight: '24px',
+  },
+  deselectLink: {
+    marginLeft: 10,
+    lineHeight: '24px',
+  },
+  unpublishedIcon: {
+    width: '1em',
+    height: '1em',
+    marginRight: 3,
+  },
+};
+
+const translations = defineMessages({
+  selectAll: {
+    id: 'course.duplication.AssessmentsSelector.selectAll',
+    defaultMessage: 'Select All',
+  },
+  deselectAll: {
+    id: 'course.duplication.AssessmentsSelector.deselectAll',
+    defaultMessage: 'Deselect All',
+  },
+  noItems: {
+    id: 'course.duplication.AssessmentsSelector.noItems',
+    defaultMessage: 'There are no assessment items to duplicate.',
+  },
+});
+
+class AssessmentsSelector extends React.Component {
+  static propTypes = {
+    categories: PropTypes.arrayOf(categoryShape),
+    selectedItems: PropTypes.shape(),
+
+    dispatch: PropTypes.func.isRequired,
+  }
+
+  static renderBulkSelectors(bulkSelectorMethod, item) {
+    return (
+      <div>
+        <a
+          onTouchTap={() => bulkSelectorMethod(item, true)}
+          style={styles.selectLink}
+        >
+          <FormattedMessage {...translations.selectAll} />
+        </a>
+        <a
+          onTouchTap={() => bulkSelectorMethod(item, false)}
+          style={styles.deselectLink}
+        >
+          <FormattedMessage {...translations.deselectAll} />
+        </a>
+      </div>
+    );
+  }
+
+  tabSetAll = (tab, value) => {
+    const { dispatch } = this.props;
+    dispatch(setItemSelectedBoolean(TAB, tab.id, value));
+    tab.assessments.forEach((assessment) => {
+      dispatch(setItemSelectedBoolean(ASSESSMENT, assessment.id, value));
+    });
+  }
+
+  categorySetAll = (category, value) => {
+    this.props.dispatch(setItemSelectedBoolean(CATEGORY, category.id, value));
+    category.tabs.forEach(tab => this.tabSetAll(tab, value));
+  }
+
+  renderAssessmentTree(assessment) {
+    const { dispatch, selectedItems } = this.props;
+    const { id, title, published } = assessment;
+    const checked = !!selectedItems[ASSESSMENT][id];
+    const label = (
+      <span>
+        <TypeBadge itemType={ASSESSMENT} />
+        { published || <Block style={styles.unpublishedIcon} /> }
+        { title }
+      </span>
+    );
+
+    return (
+      <Checkbox
+        key={id}
+        label={label}
+        checked={checked}
+        style={styles.assessmentCheckbox}
+        onCheck={(e, value) =>
+          dispatch(setItemSelectedBoolean(ASSESSMENT, id, value))
+        }
+      />
+    );
+  }
+
+  renderTabTree(tab) {
+    const { dispatch, selectedItems } = this.props;
+    const { id, title, assessments } = tab;
+    const checked = !!selectedItems[TAB][id];
+
+    return (
+      <div key={id}>
+        <div style={styles.checkboxLine}>
+          <Checkbox
+            checked={checked}
+            label={<span><TypeBadge itemType={TAB} />{ title }</span>}
+            style={styles.tabCheckbox}
+            labelStyle={styles.checkboxLabel}
+            onCheck={(e, value) =>
+              dispatch(setItemSelectedBoolean(TAB, id, value))
+            }
+          />
+          { AssessmentsSelector.renderBulkSelectors(this.tabSetAll, tab) }
+        </div>
+        { assessments.map(assessment => this.renderAssessmentTree(assessment)) }
+      </div>
+    );
+  }
+
+  renderCategoryTree(category) {
+    const { dispatch, selectedItems } = this.props;
+    const { id, title, tabs } = category;
+    const checked = !!selectedItems[CATEGORY][id];
+
+    return (
+      <div key={id}>
+        <div style={styles.checkboxLine}>
+          <Checkbox
+            checked={checked}
+            label={<span><TypeBadge itemType={CATEGORY} />{ title }</span>}
+            onCheck={(e, value) =>
+              dispatch(setItemSelectedBoolean(CATEGORY, id, value))
+            }
+            style={styles.categoryCheckbox}
+            labelStyle={styles.checkboxLabel}
+          />
+          { AssessmentsSelector.renderBulkSelectors(this.categorySetAll, category) }
+        </div>
+        { tabs.map(tab => this.renderTabTree(tab)) }
+      </div>
+    );
+  }
+
+  render() {
+    const { categories } = this.props;
+    if (!categories) { return null; }
+
+    return (
+      <div>
+        <h2><FormattedMessage {...defaultComponentTitles.course_assessments_component} /></h2>
+        {
+          categories.length > 0 ?
+          categories.map(category => this.renderCategoryTree(category)) :
+          <Subheader>
+            <FormattedMessage {...translations.noItems} />
+          </Subheader>
+        }
+      </div>
+    );
+  }
+}
+
+export default connect(({ objectDuplication }) => ({
+  categories: objectDuplication.assessmentsComponent,
+  selectedItems: objectDuplication.selectedItems,
+}))(AssessmentsSelector);

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateButton.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateButton.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import RaisedButton from 'material-ui/RaisedButton';
+import { showDuplicateItemsConfirmation } from 'course/duplication/actions';
+import DuplicateItemsConfirmation from './DuplicateItemsConfirmation';
+
+const translations = defineMessages({
+  duplicateItems: {
+    id: 'course.duplication.DuplicateButton.duplicateItems',
+    defaultMessage: 'Duplicate Items',
+  },
+  selectCourse: {
+    id: 'course.duplication.DuplicateButton.selectCourse',
+    defaultMessage: 'Select Target Course!',
+  },
+  selectItem: {
+    id: 'course.duplication.DuplicateButton.selectItem',
+    defaultMessage: 'Select An Item!',
+  },
+});
+
+const styles = {
+  button: {
+    marginTop: 20,
+  },
+};
+
+class DuplicateButton extends React.Component {
+  static propTypes = {
+    isCourseSelected: PropTypes.bool,
+    isItemSelected: PropTypes.bool,
+
+    dispatch: PropTypes.func.isRequired,
+  }
+
+  render() {
+    const { dispatch, isCourseSelected, isItemSelected } = this.props;
+
+    let label;
+    if (!isCourseSelected) {
+      label = 'selectCourse';
+    } else if (!isItemSelected) {
+      label = 'selectItem';
+    } else {
+      label = 'duplicateItems';
+    }
+
+    return (
+      <div>
+        <RaisedButton
+          secondary
+          disabled={!isCourseSelected || !isItemSelected}
+          label={<FormattedMessage {...translations[label]} />}
+          onClick={() => dispatch(showDuplicateItemsConfirmation())}
+          style={styles.button}
+        />
+        <DuplicateItemsConfirmation />
+      </div>
+    );
+  }
+}
+
+export default connect(({ objectDuplication }) => ({
+  isCourseSelected: !!objectDuplication.targetCourseId,
+  isItemSelected: Object.values(objectDuplication.selectedItems).some(hash => (
+    Object.values(hash).some(value => value)
+  )),
+}))(DuplicateButton);

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/AssessmentsListing.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/AssessmentsListing.jsx
@@ -5,6 +5,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import Checkbox from 'material-ui/Checkbox';
 import Subheader from 'material-ui/Subheader';
 import { Card, CardText } from 'material-ui/Card';
+import Block from 'material-ui/svg-icons/content/block';
 import { defaultComponentTitles } from 'course/translations.intl';
 import { duplicableItemTypes } from 'course/duplication/constants';
 import { categoryShape } from 'course/duplication/propTypes';
@@ -30,6 +31,15 @@ const styles = {
   indent2: {
     marginLeft: 30,
   },
+  unpublishedIcon: {
+    width: '1em',
+    height: '1em',
+    marginRight: 3,
+
+    // Allow tooltip to be triggered
+    zIndex: 3,
+    position: 'relative',
+  },
 };
 
 class AssessmentsListing extends React.Component {
@@ -43,7 +53,13 @@ class AssessmentsListing extends React.Component {
       <Checkbox
         checked
         key={assessment.id}
-        label={<span><TypeBadge itemType={ASSESSMENT} />{assessment.title}</span>}
+        label={
+          <span>
+            <TypeBadge itemType={ASSESSMENT} />
+            <Block data-tip data-for="itemUnpublished" style={styles.unpublishedIcon} />
+            {assessment.title}
+          </span>
+        }
         style={styles.indent2}
       />
     );

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/AssessmentsListing.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/AssessmentsListing.jsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import Checkbox from 'material-ui/Checkbox';
+import Subheader from 'material-ui/Subheader';
+import { Card, CardText } from 'material-ui/Card';
+import { defaultComponentTitles } from 'course/translations.intl';
+import { duplicableItemTypes } from 'course/duplication/constants';
+import { categoryShape } from 'course/duplication/propTypes';
+import TypeBadge from 'course/duplication/components/TypeBadge';
+
+const { TAB, ASSESSMENT, CATEGORY } = duplicableItemTypes;
+
+const translations = defineMessages({
+  defaultCategory: {
+    id: 'course.duplication.AssessmentsListing.defaultCategory',
+    defaultMessage: 'Default Category',
+  },
+  defaultTab: {
+    id: 'course.duplication.AssessmentsListing.defaultTab',
+    defaultMessage: 'Default Tab',
+  },
+});
+
+const styles = {
+  indent1: {
+    marginLeft: 15,
+  },
+  indent2: {
+    marginLeft: 30,
+  },
+};
+
+class AssessmentsListing extends React.Component {
+  static propTypes = {
+    categories: PropTypes.arrayOf(categoryShape),
+    selectedItems: PropTypes.shape(),
+  }
+
+  static renderAssessmentRow(assessment) {
+    return (
+      <Checkbox
+        checked
+        key={assessment.id}
+        label={<span><TypeBadge itemType={ASSESSMENT} />{assessment.title}</span>}
+        style={styles.indent2}
+      />
+    );
+  }
+
+  static renderDefaultTabRow() {
+    return (
+      <Checkbox
+        disabled
+        label={<FormattedMessage {...translations.defaultTab} />}
+        style={styles.indent1}
+      />
+    );
+  }
+
+  static renderTabRow(tab) {
+    return (
+      <Checkbox
+        checked
+        label={<span><TypeBadge itemType={TAB} />{tab.title}</span>}
+        style={styles.indent1}
+      />
+    );
+  }
+
+  static renderTabTree(tab, children) {
+    return (
+      <div key={tab ? tab.id : 'default'}>
+        { tab ? AssessmentsListing.renderTabRow(tab) : AssessmentsListing.renderDefaultTabRow() }
+        {
+          children && (children.length > 0)
+          && children.map(AssessmentsListing.renderAssessmentRow)
+        }
+      </div>
+    );
+  }
+
+  static renderDefaultCategoryRow() {
+    return (
+      <Checkbox
+        disabled
+        label={<FormattedMessage {...translations.defaultCategory} />}
+      />
+    );
+  }
+
+  static renderCategoryRow(category) {
+    return (
+      <Checkbox
+        checked
+        label={<span><TypeBadge itemType={CATEGORY} />{category.title}</span>}
+      />
+    );
+  }
+
+  static renderCategoryCard(category, orphanTabs, orphanAssessments) {
+    const hasOrphanAssessments = orphanAssessments && orphanAssessments.length > 0;
+    const hasOrphanTabs = orphanTabs && orphanTabs.length > 0;
+    const categoryRow = category ?
+      AssessmentsListing.renderCategoryRow(category) :
+      AssessmentsListing.renderDefaultCategoryRow();
+    const tabsTrees = tabs => tabs &&
+      tabs.map(tab => AssessmentsListing.renderTabTree(tab, tab.assessments));
+
+    return (
+      <Card key={category ? category.id : 'default'}>
+        <CardText>
+          { categoryRow }
+          { hasOrphanAssessments && AssessmentsListing.renderTabTree(null, orphanAssessments) }
+          { hasOrphanTabs && tabsTrees(orphanTabs) }
+          { category && tabsTrees(category.tabs) }
+        </CardText>
+      </Card>
+    );
+  }
+
+  /**
+  * Organises selected assessment component items into trees and returns a list of Cards - one for each tree
+  * with a category at its root. This should mirror what the backend does - items come under their parents
+  * only if their parents have been duplicated, otherwise, they are placed under a default parent.
+  */
+  renderCards() {
+    const { categories, selectedItems } = this.props;
+    const categoriesTrees = [];
+    const tabTrees = [];
+    const assessmentTrees = [];
+
+    // Identify connected sub-trees and push them into categoriesTrees, tabTrees, assessmentTrees
+    // depending on the type of item at the root of the connected sub-tree.
+    categories.forEach((category) => {
+      const selectedTabs = [];
+      category.tabs.forEach((tab) => {
+        const selectedAssessments = tab.assessments.filter(assessment =>
+          selectedItems[ASSESSMENT][assessment.id]
+        );
+
+        if (selectedItems[TAB][tab.id]) {
+          selectedTabs.push({ ...tab, assessments: selectedAssessments });
+        } else {
+          assessmentTrees.push(...selectedAssessments);
+        }
+      });
+
+      if (selectedItems[CATEGORY][category.id]) {
+        categoriesTrees.push({ ...category, tabs: selectedTabs });
+      } else {
+        tabTrees.push(...selectedTabs);
+      }
+    });
+
+    const hasOrphanedItems = (tabTrees.length > 0) || (assessmentTrees.length > 0);
+    return (
+      <div>
+        {
+          categoriesTrees.map(category => (
+            AssessmentsListing.renderCategoryCard(category, null, null))
+          )
+        }
+        { hasOrphanedItems && AssessmentsListing.renderCategoryCard(null, tabTrees, assessmentTrees) }
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <Subheader>
+          <FormattedMessage {...defaultComponentTitles.course_assessments_component} />
+        </Subheader>
+        { this.renderCards() }
+      </div>
+    );
+  }
+}
+
+export default connect(({ objectDuplication }) => ({
+  categories: objectDuplication.assessmentsComponent,
+  selectedItems: objectDuplication.selectedItems,
+}))(AssessmentsListing);

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/index.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import ReactTooltip from 'react-tooltip';
 import Subheader from 'material-ui/Subheader';
 import { Card, CardText } from 'material-ui/Card';
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
@@ -25,6 +26,10 @@ const translations = defineMessages({
   failureMessage: {
     id: 'course.duplication.DuplicateItemsConfirmation.failureMessage',
     defaultMessage: 'Duplication Failed.',
+  },
+  itemUnpublished: {
+    id: 'course.duplication.DuplicateItemsConfirmation.itemUnpublished',
+    defaultMessage: 'Items are duplicated as unpublished when duplicating to an existing course.',
   },
 });
 
@@ -66,6 +71,10 @@ class DuplicateItemsConfirmation extends React.Component {
         <p><FormattedMessage {...translations.confirmationQuestion} /></p>
         { this.renderTargetCourseCard() }
         <AssessmentsListing />
+
+        <ReactTooltip id="itemUnpublished">
+          <FormattedMessage {...translations.itemUnpublished} />
+        </ReactTooltip>
       </div>
     );
   }

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/TargetCourseSelector.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/TargetCourseSelector.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import DropDownMenu from 'material-ui/DropDownMenu';
+import MenuItem from 'material-ui/MenuItem';
+import { setTargetCourseId } from 'course/duplication/actions';
+import TypeBadge from 'course/duplication/components/TypeBadge';
+import { courseShape } from 'course/duplication/propTypes';
+
+const translations = defineMessages({
+  targetCourse: {
+    id: 'course.duplication.ObjectDuplication.targetCourse',
+    defaultMessage: 'Target Course',
+  },
+  prompt: {
+    id: 'course.duplication.ObjectDuplication.prompt',
+    defaultMessage: 'Which course would you like to duplicate items to?',
+  },
+});
+
+const styles = {
+  dropDown: {
+    width: '100%',
+  },
+};
+
+class TargetCourseSelector extends React.Component {
+  static propTypes = {
+    currentHost: PropTypes.string,
+    targetCourseId: PropTypes.number,
+    courses: PropTypes.arrayOf(courseShape),
+
+    dispatch: PropTypes.func.isRequired,
+  }
+
+  renderCourseMenuItem = (course) => {
+    const { currentHost } = this.props;
+    const title = currentHost === course.host ? course.title :
+    (<span>
+      <TypeBadge text={course.host} />
+      {course.title}
+    </span>);
+
+    return <MenuItem key={course.id} value={course.id} primaryText={title} />;
+  }
+
+  render() {
+    const { courses, targetCourseId, dispatch } = this.props;
+
+    return (
+      <div>
+        <h2><FormattedMessage {...translations.targetCourse} /></h2>
+        <p><FormattedMessage {...translations.prompt} /></p>
+        <DropDownMenu
+          autoWidth={false}
+          style={styles.dropDown}
+          value={targetCourseId}
+          onChange={(e, index, value) => dispatch(setTargetCourseId(value))}
+        >
+          { courses.map(this.renderCourseMenuItem) }
+        </DropDownMenu>
+      </div>
+    );
+  }
+}
+
+export default connect(({ objectDuplication }) => ({
+  courses: objectDuplication.targetCourses,
+  currentHost: objectDuplication.currentHost,
+  targetCourseId: objectDuplication.targetCourseId,
+}))(TargetCourseSelector);

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/__test__/DuplicateButton.test.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/__test__/DuplicateButton.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount, ReactWrapper } from 'enzyme';
+import ReactTestUtils from 'react-dom/test-utils';
+import CourseAPI from 'api/course';
+import storeCreator from 'course/duplication/store';
+import { duplicableItemTypes } from 'course/duplication/constants';
+import DuplicateButton from '../DuplicateButton';
+
+const data = {
+  duplication: {
+    objectDuplication: {
+      targetCourseId: 9,
+      targetCourses: [{
+        id: 9,
+        title: 'target',
+        host: 'example.org',
+        path: '/courses/9',
+      }],
+      selectedItems: {
+        [duplicableItemTypes.TAB]: { 3: true, 4: true, 5: false },
+        [duplicableItemTypes.CATEGORY]: { 6: false },
+        [duplicableItemTypes.ASSESSMENT]: { 7: true },
+      },
+      assessmentsComponent: [
+        {
+          id: 6,
+          title: 'Category 6',
+          tabs: [
+            {
+              id: 3,
+              title: 'Tab 3',
+              assessments: [{
+                title: 'Assessment 7',
+                id: 7,
+              }],
+            },
+            {
+              id: 4,
+              title: 'Tab 4',
+              assessments: [],
+            },
+            {
+              id: 5,
+              title: 'Tab 5',
+              assessments: [],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+describe('<DuplicateButton />', () => {
+  it('allows duplication to be triggered with the correct parameters', () => {
+    const spy = jest.spyOn(CourseAPI.duplication, 'duplicateItems');
+    const duplicateButton = mount(<DuplicateButton />, buildContextOptions(storeCreator(data)));
+    const duplicateButtonNode = duplicateButton.find('button').first().node;
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(duplicateButtonNode));
+
+    const confirmButton = duplicateButton.find('ConfirmationDialog').first().node.confirmButton;
+    const confirmButtonNode = new ReactWrapper(confirmButton, true).find('button').first().node;
+    ReactTestUtils.Simulate.touchTap(ReactDOM.findDOMNode(confirmButtonNode));
+
+    const expectedPayload = {
+      object_duplication: {
+        items: {
+          ASSESSMENT: ['7'],
+          TAB: ['3', '4'],
+        },
+        target_course_id: 9,
+      },
+    };
+    expect(spy).toHaveBeenCalledWith(expectedPayload);
+  });
+});

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/index.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/index.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import TitleBar from 'lib/components/TitleBar';
+import LoadingIndicator from 'lib/components/LoadingIndicator';
+import { fetchObjectsList } from 'course/duplication/actions';
+import TargetCourseSelector from './TargetCourseSelector';
+import AssessmentsSelector from './AssessmentsSelector';
+import DuplicateButton from './DuplicateButton';
+
+const translations = defineMessages({
+  duplicateItems: {
+    id: 'course.duplication.ObjectDuplication.duplicateItems',
+    defaultMessage: 'Duplicate Items',
+  },
+});
+
+class ObjectDuplication extends React.Component {
+  static propTypes = {
+    isLoading: PropTypes.bool.isRequired,
+    dispatch: PropTypes.func.isRequired,
+  }
+
+  static renderBody() {
+    return (
+      <div>
+        <TargetCourseSelector />
+        <AssessmentsSelector />
+        <DuplicateButton />
+      </div>
+    );
+  }
+
+  componentDidMount() {
+    this.props.dispatch(fetchObjectsList());
+  }
+
+  render() {
+    return (
+      <div>
+        <TitleBar title={<FormattedMessage {...translations.duplicateItems} />} />
+        { this.props.isLoading ? <LoadingIndicator /> : ObjectDuplication.renderBody() }
+      </div>
+    );
+  }
+}
+
+export default connect(({ objectDuplication }) => ({
+  isLoading: objectDuplication.isLoading,
+}))(ObjectDuplication);

--- a/client/app/bundles/course/duplication/propTypes.js
+++ b/client/app/bundles/course/duplication/propTypes.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+
+export const courseShape = PropTypes.shape({
+  id: PropTypes.number,
+  host: PropTypes.string,
+  path: PropTypes.string,
+  title: PropTypes.string,
+});
+
+export const assessmentShape = PropTypes.shape({
+  id: PropTypes.number,
+  title: PropTypes.string,
+  published: PropTypes.bool,
+});
+
+export const tabShape = PropTypes.shape({
+  id: PropTypes.number,
+  title: PropTypes.string,
+  assessments: PropTypes.arrayOf(assessmentShape),
+});
+
+export const categoryShape = PropTypes.shape({
+  id: PropTypes.number,
+  title: PropTypes.string,
+  tabs: PropTypes.arrayOf(tabShape),
+});

--- a/client/app/bundles/course/duplication/reducers/index.js
+++ b/client/app/bundles/course/duplication/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import notificationPopup from 'lib/reducers/notificationPopup';
+import objectDuplication from './objectDuplication';
+
+export default combineReducers({
+  notificationPopup,
+  objectDuplication,
+});

--- a/client/app/bundles/course/duplication/reducers/objectDuplication.js
+++ b/client/app/bundles/course/duplication/reducers/objectDuplication.js
@@ -1,0 +1,67 @@
+import actionTypes, { duplicableItemTypes } from 'course/duplication/constants';
+
+const initialState = {
+  confirmationOpen: false,
+  selectedItems: {
+    ...Object.keys(duplicableItemTypes).reduce((hash, type) => {
+      hash[type] = {};  // eslint-disable-line no-param-reassign
+      return hash;
+    }, {}),
+  },
+  targetCourseId: null,
+  targetCourses: [],
+  assessmentsComponent: [],
+  isLoading: false,
+  isDuplicatingObjects: false,
+};
+
+export default function (state = initialState, action) {
+  const { type } = action;
+
+  switch (type) {
+    case actionTypes.LOAD_OBJECTS_LIST_REQUEST: {
+      return { ...state, isLoading: true };
+    }
+    case actionTypes.LOAD_OBJECTS_LIST_SUCCESS: {
+      const sortedTargetCourses = action.duplicationData.targetCourses.sort(
+        (a, b) => a.title.localeCompare(b.title)
+      );
+      return {
+        ...state,
+        ...action.duplicationData,
+        isLoading: false,
+        targetCourses: sortedTargetCourses,
+      };
+    }
+    case actionTypes.LOAD_OBJECTS_LIST_FAILURE: {
+      return { ...state, isLoading: false };
+    }
+
+    case actionTypes.SET_TARGET_COURSE_ID: {
+      return { ...state, targetCourseId: action.targetCourseId };
+    }
+    case actionTypes.SET_ITEM_SELECTED_BOOLEAN: {
+      const selectedItems = { ...state.selectedItems };
+      selectedItems[action.itemType][action.id] = action.value;
+      return { ...state, selectedItems };
+    }
+
+    case actionTypes.SHOW_DUPLICATE_ITEMS_CONFIRMATION: {
+      return { ...state, confirmationOpen: true };
+    }
+    case actionTypes.HIDE_DUPLICATE_ITEMS_CONFIRMATION: {
+      return { ...state, confirmationOpen: false };
+    }
+
+    case actionTypes.DUPLICATE_ITEMS_REQUEST: {
+      return { ...state, isDuplicatingObjects: true };
+    }
+    case actionTypes.DUPLICATE_ITEMS_FAILURE:
+    case actionTypes.DUPLICATE_ITEMS_SUCCESS: {
+      return { ...state, isDuplicatingObjects: false };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/duplication/store.js
+++ b/client/app/bundles/course/duplication/store.js
@@ -1,0 +1,13 @@
+import { compose, createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import rootReducer from './reducers';
+
+export default ({ duplication }) => {
+  const initialStates = duplication;
+  const storeCreator = (process.env.NODE_ENV === 'development') ?
+    // eslint-disable-next-line global-require
+    compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :
+    compose(applyMiddleware(thunkMiddleware))(createStore);
+
+  return storeCreator(rootReducer, initialStates);
+};

--- a/client/app/bundles/course/object-duplications.js
+++ b/client/app/bundles/course/object-duplications.js
@@ -1,0 +1,1 @@
+import 'course/duplication';

--- a/client/app/bundles/course/translations.intl.js
+++ b/client/app/bundles/course/translations.intl.js
@@ -8,6 +8,10 @@ const translations = defineMessages({
 });
 
 export const defaultComponentTitles = defineMessages({
+  course_assessments_component: {
+    id: 'course.componentTitles.course_assessments_component',
+    defaultMessage: 'Assessments',
+  },
   course_announcements_component: {
     id: 'course.componentTitles.course_announcements_component',
     defaultMessage: 'Announcements',

--- a/client/app/bundles/course/translations.intl.js
+++ b/client/app/bundles/course/translations.intl.js
@@ -2,26 +2,26 @@ import { defineMessages } from 'react-intl';
 
 const translations = defineMessages({
   component: {
-    id: 'course.admin.component',
+    id: 'course.component',
     defaultMessage: 'Component',
   },
 });
 
 export const defaultComponentTitles = defineMessages({
   course_announcements_component: {
-    id: 'course.admin.componentTitles.course_announcements_component',
+    id: 'course.componentTitles.course_announcements_component',
     defaultMessage: 'Announcements',
   },
   course_survey_component: {
-    id: 'course.admin.componentTitles.course_survey_component',
+    id: 'course.componentTitles.course_survey_component',
     defaultMessage: 'Surveys',
   },
   course_users_component: {
-    id: 'course.admin.componentTitles.course_users_component',
+    id: 'course.componentTitles.course_users_component',
     defaultMessage: 'Users',
   },
   course_forums_component: {
-    id: 'course.admin.componentTitles.course_forums_component',
+    id: 'course.componentTitles.course_forums_component',
     defaultMessage: 'Forums',
   },
 });

--- a/client/app/lib/components/ConfirmationDialog.jsx
+++ b/client/app/lib/components/ConfirmationDialog.jsx
@@ -15,8 +15,8 @@ class ConfirmationDialog extends React.Component {
     onCancel: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
     message: PropTypes.node,
-    cancelButtonText: PropTypes.string,
-    confirmButtonText: PropTypes.string,
+    cancelButtonText: PropTypes.node,
+    confirmButtonText: PropTypes.node,
     confirmDiscard: PropTypes.bool,
     confirmDelete: PropTypes.bool,
     confirmSubmit: PropTypes.bool,
@@ -89,6 +89,7 @@ class ConfirmationDialog extends React.Component {
           modal={false}
           onRequestClose={onCancel}
           style={{ zIndex: 9999 }}
+          autoScrollBodyContent
         >
           { confirmationMessage }
         </Dialog>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,7 @@ Rails.application.routes.draw do
       end
       resources :levels, except: [:show, :edit, :update]
       resource :duplication, only: [:show, :create]
+      resource :object_duplication, only: [:new, :create]
 
       resources :user_invitations, only: [:index, :new, :create, :destroy] do
         post 'resend_invitation'

--- a/spec/controllers/course/object_duplication_controller_spec.rb
+++ b/spec/controllers/course/object_duplication_controller_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::ObjectDuplicationsController do
+  let(:admin) { create(:administrator) }
+  let(:json_response) { JSON.parse(response.body) }
+  let(:instance) { Instance.default }
+  let(:other_instance) { create(:instance) }
+  let!(:other_instance_course) do
+    ActsAsTenant.with_tenant(other_instance) { create(:course, creator: admin) }
+  end
+
+  with_tenant(:instance) do
+    let(:course) { create(:course, creator: admin) }
+    let(:assessment) { create(:course_assessment_assessment, course: course) }
+    let(:unenrolled_course) { create(:course) }
+    let(:unenrolled_course_assessment) { create(:course_assessment_assessment, course: unenrolled_course) }
+
+    let(:user) { admin }
+    before { sign_in(user) }
+
+    describe '#new' do
+      render_views
+
+      subject { get :new, format: :json, course_id: course.id }
+      before { subject }
+
+      it "includes user's courses from other instances in targetCourses" do
+        course_ids = json_response['targetCourses'].map { |course| course['id'] }
+        expect(course_ids).to contain_exactly(course.id, other_instance_course.id)
+      end
+    end
+
+    describe '#create' do
+      subject do
+        post :create, format: :json, course_id: course.id, object_duplication: {
+          target_course_id: other_instance_course.id, items: items_params
+        }
+      end
+
+      context 'when valid parameters are provided' do
+        let(:items_params) { { 'ASSESSMENT' => [assessment.id] } }
+
+        it 'duplicates selected items' do
+          expect do
+            subject
+            wait_for_job
+          end.to change { other_instance_course.assessments.count }.by(1)
+        end
+      end
+
+      context 'when invalid parameters are provided' do
+        let(:items_params) { { 'ASSESSMENT' => [unenrolled_course_assessment.id] } }
+
+        it 'duplicates selected items' do
+          expect do
+            subject
+            wait_for_job
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -48,10 +48,11 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
         context 'when only a category is selected' do
           let(:source_objects) { category }
 
-          it 'duplicates it without any tabs' do
+          it 'creates a default tab for it' do
             expect { duplicate_objects }.to change { destination_course.assessment_categories.count }.by(1)
             expect(duplicate_objects.title).to eq(category.title)
-            expect(duplicate_objects.tabs.length).to eq(0)
+            default_title = Course::Assessment::Tab.human_attribute_name('title.default')
+            expect(duplicate_objects.tabs.first.title).to eq(default_title)
           end
         end
 

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
   with_tenant(:instance) do
     let(:source_course) { create(:course) }
     let(:destination_course) { create(:course) }
-    let(:options) { { current_course: source_course, target_course: destination_course } }
     let(:source_objects) { [] }
     let(:excluded_objects) { [] }
 
     describe '#duplicate_objects' do
       let(:duplicate_objects) do
-        Course::Duplication::ObjectDuplicationService.duplicate_objects(source_objects, options)
+        Course::Duplication::ObjectDuplicationService.
+          duplicate_objects(source_course, destination_course, source_objects, {})
       end
 
       context 'when an item fails to duplicate' do


### PR DESCRIPTION
- Duplication status reporting to come in a future PR. Perhaps add a 'logs' column to the `job` table?
- Allowed user to duplicate items back to the same course
- ~Right now, duplicated items have the same `published` status at the original copy. Might add a "duplicate as unpublished" boolean later.~ Objects are duplicated as unpublished.