### PR TITLE
Allow topics to be deleted

### DIFF
--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -6,7 +6,7 @@ class Course::Discussion::Topic < ActiveRecord::Base
 
   belongs_to :course, inverse_of: :discussion_topics
   # Delete all the children and skip reparent callbacks
-  has_many :posts, dependent: :delete_all, inverse_of: :topic do
+  has_many :posts, dependent: :destroy, inverse_of: :topic do
     include Course::Discussion::Topic::PostsConcern
   end
   has_many :subscriptions, dependent: :destroy, inverse_of: :topic

--- a/spec/factories/course_discussion_posts.rb
+++ b/spec/factories/course_discussion_posts.rb
@@ -1,10 +1,25 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :course_discussion_post, class: Course::Discussion::Post.name do
+    transient do
+      upvoted_by []
+      downvoted_by []
+    end
+
     creator
     updater
     parent nil
     association :topic, factory: :course_discussion_topic
     text 'This is a test post'
+
+    after(:create) do |post, evaluator|
+      [*evaluator.upvoted_by].each do |user|
+        post.cast_vote!(user, 1)
+      end
+
+      [*evaluator.downvoted_by].each do |user|
+        post.cast_vote!(user, -1)
+      end
+    end
   end
 end

--- a/spec/models/course/discussion/post_spec.rb
+++ b/spec/models/course/discussion/post_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe Course::Discussion::Post, type: :model do
 
     describe '.destroy' do
       let(:topic) { create(:course_discussion_topic) }
-      let(:parent_post) { create(:course_discussion_post, topic: topic) }
-      let(:post) { create(:course_discussion_post, parent: parent_post, topic: topic) }
+      let!(:parent_post) { create(:course_discussion_post, topic: topic) }
+      let!(:post) { create(:course_discussion_post, parent: parent_post, topic: topic) }
 
       context 'when the post has children' do
         let!(:children_posts) do
@@ -175,6 +175,15 @@ RSpec.describe Course::Discussion::Post, type: :model do
 
           expect(children_posts.all? { |child| child.reload.parent_id == parent_post.id }).
             to be_truthy
+        end
+
+        context 'when the post is destroyed by association' do
+          it 'destroys together with all children' do
+            expect(topic.reload.destroy).to be_truthy
+            all_posts_ids = topic.posts.map(&:id)
+            expect(Course::Discussion::Post.where(id: all_posts_ids).exists?).
+              to be_falsey
+          end
         end
       end
     end

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe Course::Discussion::Topic, type: :model do
   it { is_expected.to be_actable }
-  it { is_expected.to have_many(:posts).inverse_of(:topic).dependent(:delete_all) }
+  it { is_expected.to have_many(:posts).inverse_of(:topic).dependent(:destroy) }
   it { is_expected.to have_many(:subscriptions).inverse_of(:topic).dependent(:destroy) }
 
   let!(:instance) { Instance.default }

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -155,5 +155,62 @@ RSpec.describe Course::Discussion::Topic, type: :model do
         it { is_expected.to contain_exactly(annotation, comment) }
       end
     end
+
+    describe '.destroy' do
+      it 'destroys successfully' do
+        expect(topic.destroy).to be_truthy
+      end
+
+      context 'when it has multiple posts' do
+        let!(:post) { create(:course_discussion_post, topic: topic.discussion_topic) }
+        let!(:children_posts) do
+          create_list(:course_discussion_post, 2, parent: post, topic: topic.discussion_topic)
+        end
+
+        it 'destroys successfully with posts' do
+          expect(topic.reload.destroy).to be_truthy
+          all_post_ids = [post, *children_posts].map(&:id)
+          expect(Course::Discussion::Post.where(id: all_post_ids).exists?).to be_falsey
+        end
+      end
+
+      context 'when the posts have votes' do
+        let(:upvoters) do
+          create_list(:user, 2)
+        end
+        let(:downvoters) do
+          create_list(:user, 3)
+        end
+
+        let!(:post) do
+          create(
+            :course_discussion_post,
+            topic: topic.discussion_topic,
+            upvoted_by: user
+          )
+        end
+
+        let!(:children_posts) do
+          create_list(
+            :course_discussion_post,
+            2,
+            parent: post,
+            topic: topic.discussion_topic,
+            upvoted_by: upvoters,
+            downvoted_by: downvoters
+          )
+        end
+
+        it 'destroys successfully together with votes' do
+          expect(topic.reload.destroy).to be_truthy
+          all_posts = [post, *children_posts]
+          all_post_ids = all_posts.map(&:id)
+          all_vote_ids = all_posts.map(&:votes).inject(:+).map(&:id)
+
+          expect(Course::Discussion::Post.where(id: all_post_ids).exists?).to be_falsey
+          expect(Course::Discussion::Post::Vote.where(id: all_vote_ids).exists?).to be_falsey
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Deleting topics with posts that have votes previously causes a foreign
key error.

Because we originally expect posts to be reparented, children are not destroyed by association. As such, it has to be done manually.