### PR TITLE
Remove Squeel and cancancan-squeel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -169,8 +169,7 @@ gem 'http_accept_language'
 # User authentication
 gem 'devise'
 gem 'devise_masquerade'
-# TODO: To remove restriction once v2.0 stabilises.
-gem 'devise-multi_email', '~>1.0.5'
+gem 'devise-multi_email'
 
 gem 'omniauth'
 gem 'omniauth-facebook'

--- a/Gemfile
+++ b/Gemfile
@@ -177,7 +177,8 @@ gem 'omniauth-facebook'
 
 # Use cancancan for authorization
 gem 'cancancan'
-gem 'cancancan-squeel'
+# Cancancan adapter. TODO: transfer to Coursemology organization
+gem 'cancancan-baby_squeel', github: 'jeremyyap/cancancan-baby_squeel'
 
 # Some helpers for structuring CSS/JavaScript
 gem 'rails_utils', '>= 3.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       activemodel (= 4.2.9)
       activesupport (= 4.2.9)
       arel (~> 6.0)
-    activerecord-import (0.20.0)
+    activerecord-import (0.20.1)
       activerecord (>= 3.2)
     activerecord-userstamp (3.0.4)
       activerecord (~> 4.2)
@@ -149,7 +149,7 @@ GEM
       railties (>= 4.1.0, < 5.2)
       responders
       warden (~> 1.2.3)
-    devise-multi_email (1.0.5)
+    devise-multi_email (2.0.1)
       devise
     devise_masquerade (0.6.0)
       devise (>= 2.1.0)
@@ -587,7 +587,7 @@ DEPENDENCIES
   consistency_fail
   coursemology-polyglot (>= 0.2.9)
   devise
-  devise-multi_email (~> 1.0.5)
+  devise-multi_email
   devise_masquerade
   docker-api
   edge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,15 @@ GIT
       rails (>= 3.2)
 
 GIT
+  remote: git://github.com/jeremyyap/cancancan-baby_squeel.git
+  revision: 7f9cf9f4180bfe7b58a02b642cc263df720c9f07
+  specs:
+    cancancan-baby_squeel (0.1.5)
+      activerecord (>= 4.1)
+      baby_squeel (~> 1.1.5)
+      cancancan (~> 1.10)
+
+GIT
   remote: git://github.com/thedarkone/rails-dev-boost.git
   revision: a709a10b06b7d9fc4a9846bc613c60c86af9dd7c
   specs:
@@ -79,8 +88,9 @@ GEM
     autoprefixer-rails (7.1.4)
       execjs
     awesome_print (1.8.0)
-    baby_squeel (0.3.1)
-      activerecord (>= 4.0.0)
+    baby_squeel (1.1.5)
+      activerecord (>= 4.2.0)
+      polyamorous (~> 1.3)
     bcrypt (3.1.11)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -99,10 +109,6 @@ GEM
     calculated_attributes (0.2.0)
       activerecord (>= 3.2.20)
     cancancan (1.17.0)
-    cancancan-squeel (0.1.4)
-      activerecord (>= 4.1)
-      cancancan (~> 1.10)
-      squeel (~> 1.2)
     capybara (2.15.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -304,7 +310,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
-    polyamorous (1.1.0)
+    polyamorous (1.3.1)
       activerecord (>= 3.0)
     progress (3.3.1)
     public_suffix (3.0.0)
@@ -509,10 +515,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    squeel (1.2.3)
-      activerecord (>= 3.0)
-      activesupport (>= 3.0)
-      polyamorous (~> 1.1.0)
     summernote-rails (0.8.3.0)
       railties (>= 3.1)
     temple (0.8.0)
@@ -573,7 +575,7 @@ DEPENDENCIES
   byebug
   calculated_attributes (>= 0.1.3)
   cancancan
-  cancancan-squeel
+  cancancan-baby_squeel!
   capybara
   capybara-screenshot
   capybara-selenium
@@ -652,7 +654,6 @@ DEPENDENCIES
   webpacker
   workflow
   yard
-
 
 BUNDLED WITH
    1.15.4

--- a/app/controllers/user/emails_controller.rb
+++ b/app/controllers/user/emails_controller.rb
@@ -25,7 +25,8 @@ class User::EmailsController < ApplicationController
 
   # Set an email as the primary email
   def set_primary
-    if @email.primary!
+    current_user.email = @email.email
+    if current_user.save
       redirect_to user_emails_path, success: t('.success')
     else
       redirect_to user_emails_path, error: @email.errors.full_messages.to_sentence

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -63,8 +63,8 @@ class Course < ActiveRecord::Base
   scope :ordered_by_start_at, ->(direction = :desc) { order(start_at: direction) }
   scope :ordered_by_end_at, ->(direction = :desc) { order(end_at: direction) }
   scope :publicly_accessible, -> { where(published: true) }
-  scope :current, -> { where { end_at > Time.zone.now } }
-  scope :completed, -> { where { end_at <= Time.zone.now } }
+  scope :current, -> { where.has { end_at > Time.zone.now } }
+  scope :completed, -> { where.has { end_at <= Time.zone.now } }
 
   # @!method containing_user
   #   Selects all the courses with user as one of its members

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,16 +73,6 @@ class User < ActiveRecord::Base
     id == User::SYSTEM_USER_ID || id == User::DELETED_USER_ID
   end
 
-  # Unset current primary email. This method would immediately set the attributes in the database.
-  #
-  # @return [Boolean] True if current primary emails was set as non primary or there is no
-  #   primary email, false if failed.
-  def unset_primary_email
-    return true unless default_email_record
-
-    default_email_record.update_attributes(primary: false)
-  end
-
   # Pick the default email and set it as primary email. This method would immediately set the
   # attributes in the database.
   #

--- a/app/models/user/email.rb
+++ b/app/models/user/email.rb
@@ -5,22 +5,10 @@ class User::Email < ActiveRecord::Base
 
   schema_validations except: [:primary, :email]
   validates :primary, inclusion: [true, false]
-  validates :primary, uniqueness: { scope: [:user_id], conditions: -> { where(primary: true) } }
 
   belongs_to :user, inverse_of: :emails
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
-
-  # Set the email as primary. This method would cause the email record to be directly updated.
-  #
-  # @return [Boolean] True if transaction was done successfully, otherwise nil.
-  def primary!
-    User::Email.transaction do
-      raise ActiveRecord::Rollback unless user.unset_primary_email
-      raise ActiveRecord::Rollback unless update_attributes(primary: true)
-      true
-    end
-  end
 
   private
 

--- a/lib/extensions/core_extensions.rb
+++ b/lib/extensions/core_extensions.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+module Extensions::CoreExtensions; end

--- a/lib/extensions/core_extensions/active_record.rb
+++ b/lib/extensions/core_extensions/active_record.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+module Extensions::CoreExtensions::ActiveRecord; end

--- a/lib/extensions/core_extensions/active_record/relation.rb
+++ b/lib/extensions/core_extensions/active_record/relation.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Extensions::CoreExtensions::ActiveRecord::Relation
+  # Fix for count queries involving calculated attributes
+  # To remove after upgrading to Rails 5
+  # https://github.com/aha-app/calculated_attributes#known-issues
+  def select_for_count
+    :all
+  end
+end

--- a/spec/controllers/user/emails_controller_spec.rb
+++ b/spec/controllers/user/emails_controller_spec.rb
@@ -32,20 +32,13 @@ RSpec.describe User::EmailsController, type: :controller do
     end
 
     describe '#set_primary' do
-      let!(:email_stub) do
-        stub = create(:user_email, user: user, primary: false)
-        allow(stub).to receive(:update_attributes).and_return(false)
-        stub
-      end
-      subject { post :set_primary, id: email_stub }
+      let(:email) { create(:user_email, :unconfirmed, user: user, primary: false) }
+      subject { post :set_primary, id: email }
 
-      context 'when update fails' do
-        before do
-          controller.instance_variable_set(:@email, email_stub)
-        end
+      context 'when email is not confirmed' do
         it 'does not change the primary email' do
           subject
-          expect(email_stub.reload.primary).to be_falsey
+          expect(email.reload.primary).to be_falsey
           expect(user.reload.emails.find(&:primary?)).not_to be_nil
         end
 

--- a/spec/models/user/email_spec.rb
+++ b/spec/models/user/email_spec.rb
@@ -16,20 +16,12 @@ RSpec.describe User::Email, type: :model do
     context 'when a user has multiple emails' do
       let(:user) { create(:user) }
       let(:primary_email) { user.emails.first }
-      let!(:non_primary_email) { create(:user_email, user: user, primary: false) }
 
       context 'when unset a primary email' do
         subject { primary_email }
         before { primary_email.primary = false }
 
         it { is_expected.to be_valid }
-      end
-
-      context 'when set the other email as primary' do
-        subject { non_primary_email }
-        before { non_primary_email.primary = true }
-
-        it { is_expected.not_to be_valid }
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,9 +46,14 @@ RSpec.describe User do
 
     describe '#emails' do
       let(:user) { create(:user, emails_count: 5) }
-      it 'only allows one primary email' do
-        user.emails.each.each { |email_record| email_record.primary = true }
-        expect { user.save! } .to raise_error(ActiveRecord::RecordInvalid)
+      it 'unsets other email as primary when a new email is assigned' do
+        email_record = user.emails.reject(&:primary).sample
+
+        user.email = email_record.email
+        user.save!
+
+        expect(email_record.reload).to be_primary
+        expect(user.emails.reload.to_a.count(&:primary)).to eq(1)
       end
     end
 

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -49,9 +49,12 @@ RSpec.describe Course::UserInvitationService, type: :service do
         { name: user.name, email: user.email, role: Course::UserInvitation.roles[new_roles[id]] }
       end
     end
+    let(:invalid_user_attributes) do
+      []
+    end
     let(:users) { existing_users + new_users }
     let(:roles) { existing_roles + new_roles }
-    let(:user_attributes) { existing_user_attributes + new_user_attributes }
+    let(:user_attributes) { existing_user_attributes + new_user_attributes + invalid_user_attributes }
     let(:user_form_attributes) do
       user_attributes.map do |hash|
         [generate(:nested_attribute_new_id), {
@@ -156,8 +159,8 @@ RSpec.describe Course::UserInvitationService, type: :service do
       end
 
       context 'when an invalid email is specified' do
-        before do
-          new_users.first.email = 'xxnot an email'
+        let(:invalid_user_attributes) do
+          [{ name: build(:user).name, email: 'xxnot an email', role: :student }]
         end
 
         it 'fails' do


### PR DESCRIPTION
Squeel had been replaced with baby_squeel in an earlier PR for most of the queries. This PR replaces the `cancancan-squeel` adapter with `cancancan-baby_squeel` to completely eliminate the Squeel dependency.

- [x] Remove `cancancan-squeel`
- [x] Upgrade `devise-multi_email` to 2.0 to fix error previously monkeypatched by Squeel
- [x] Disable `baby_squeel` compatibility mode