### PR TITLE
Hide grade when submission status is 'Attempting'

### DIFF
--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTable.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTable.jsx
@@ -60,7 +60,8 @@ export default class SubmissionsTable extends React.Component {
   }
 
   getGradeString(submission) {
-    if (submission.grade === undefined) return null;
+    if ((submission.workflowState === workflowStates.Unstarted) ||
+      (submission.workflowState !== workflowStates.Attempting)) return null;
 
     const { assessment } = this.props;
 


### PR DESCRIPTION
Fix #2510 where grade shown as null when submission status is 'Attempting'.