### PR TITLE
Hide bonus exp instead of bonus cutoff time on medium sized devices.

### DIFF
--- a/app/assets/stylesheets/course/assessment/assessments.scss
+++ b/app/assets/stylesheets/course/assessment/assessments.scss
@@ -57,7 +57,7 @@
         margin-right: 4px;
       }
 
-      .table-bonus-cut-off,
+      .table-time-bonus-exp,
       .table-requirement-for {
         @extend .hidden-xs;
         @extend .hidden-sm;
@@ -70,7 +70,7 @@
       }
 
       .table-base-exp,
-      .table-time-bonus-exp {
+      .table-bonus-cut-off {
         @extend .hidden-xs;
         @extend .hidden-sm;
         @extend .text-center;


### PR DESCRIPTION
Fewer columns are displayed on the assessements listing page as the
viewport's width is reduced.

Hide the bonus exp amount instead of the bonus cutoff time for medium
sized devices. This keeps students on smaller devices informed that
there is a deadline for bonus experience.