### PR TITLE
Move video state into Redux

### DIFF
--- a/client/app/bundles/course/video/submission/actions/video.js
+++ b/client/app/bundles/course/video/submission/actions/video.js
@@ -1,0 +1,124 @@
+import { videoActionTypes } from 'lib/constants/videoConstants';
+
+/**
+ * Creates action to change the playing state of the video player.
+ *
+ * @param playerState Should be one of playerStates in 'lib/constants/videoConstants.js'
+ * @returns {{type: videoActionTypes, playerState: playerStates}} A change player state Redux action
+ */
+export function changePlayerState(playerState) {
+  return {
+    type: videoActionTypes.CHANGE_PLAYER_STATE,
+    playerState,
+  };
+}
+
+/**
+ * Creates action to change the volume of the video player.
+ *
+ * @param playerVolume The new player volume, between 0 and 1.
+ * @returns {{type: videoActionTypes, playerVolume: number}} A change volume Redux action
+ */
+export function changePlayerVolume(playerVolume) {
+  let checkedPlayerVolume = playerVolume;
+  checkedPlayerVolume = checkedPlayerVolume > 1 ? 1 : checkedPlayerVolume;
+  checkedPlayerVolume = checkedPlayerVolume < 0 ? 0 : checkedPlayerVolume;
+
+  return {
+    type: videoActionTypes.CHANGE_PLAYER_VOLUME,
+    playerVolume: checkedPlayerVolume,
+  };
+}
+
+/**
+ * Creates an action to change the playback rate.
+ *
+ * The playback rate should be one of videoDefaults.availablePlaybackRates, or any
+ * playback rate supported by the intended player.
+ *
+ * @param playBackRate The new playback rate
+ * @returns {{type: videoActionTypes, playBackRate: number}} A change playback rate Redux action
+ */
+export function changePlayBackRate(playBackRate) {
+  return {
+    type: videoActionTypes.CHANGE_PLAYBACK_RATE,
+    playBackRate,
+  };
+}
+
+/**
+ * Creates an action to update the player progress.
+ *
+ * @param playerProgress The new player progress in seconds
+ * @param forceSeek If the forceSeek flag should be set to force a player progress seek
+ * @returns {{type: videoActionTypes, playerProgress: number, forceSeek: boolean}} An update player progress Redux
+ * action
+ */
+export function updatePlayerProgress(playerProgress, forceSeek = false) {
+  return {
+    type: videoActionTypes.UPDATE_PLAYER_PROGRESS,
+    playerProgress,
+    forceSeek,
+  };
+}
+
+/**
+ * Creates an action to update the player buffer progress.
+ *
+ * @param bufferProgress The buffer progress in seconds
+ * @returns {{type: videoActionTypes, bufferProgress: number}} An update buffer progress Redux action
+ */
+function updateBufferProgress(bufferProgress) {
+  return {
+    type: videoActionTypes.UPDATE_BUFFER_PROGRESS,
+    bufferProgress,
+  };
+}
+
+/**
+ * Creates a thunk that updates both player progress and buffer progress as one.
+ *
+ * If either of the progress statistics are undefined, the corresponding action will not be dispatched.
+ * @param playerProgress The new player progress in seconds
+ * @param bufferProgress The buffer progress in seconds
+ * @param forceSeek If the forceSeek flag should be set to force a player progress seek
+ * @returns {function(dispatch)} The thunk to update player progress and buffer progress
+ */
+export function updateProgressAndBuffer(playerProgress, bufferProgress, forceSeek = false) {
+  return (dispatch) => {
+    if (playerProgress !== undefined) {
+      dispatch(updatePlayerProgress(playerProgress, forceSeek));
+    }
+
+    if (bufferProgress !== undefined) {
+      dispatch(updateBufferProgress(bufferProgress));
+    }
+  };
+}
+
+/**
+ * Creates an action to update the total duration of the video.
+ *
+ * Video durations are not known at the start, and this action allows it to be updated dynamically.
+ * @param duration The duration of the video
+ * @returns {{type: videoActionTypes, duration: number}} A update duration Redux action
+ */
+export function updatePlayerDuration(duration) {
+  return {
+    type: videoActionTypes.UPDATE_PLAYER_DURATION,
+    duration,
+  };
+}
+
+/**
+ * Creates an action to update the restricted time of the video.
+ *
+ * @param restrictContentAfter The point to restrict the video's content after in seconds
+ * @returns {{type: videoActionTypes, restrictContentAfter: number}} A update restricted time Redux action
+ */
+export function updateRestrictedTime(restrictContentAfter) {
+  return {
+    type: videoActionTypes.UPDATE_RESTRICTED_TIME,
+    restrictContentAfter,
+  };
+}

--- a/client/app/bundles/course/video/submission/constants.js
+++ b/client/app/bundles/course/video/submission/constants.js
@@ -1,3 +1,5 @@
+import mirrorCreator from 'mirror-creator';
+
 export const youtubeOpts = {
   playerVars: {
     showinfo: false,
@@ -12,3 +14,11 @@ export const videoDefaults = {
   volume: 0.8,
   availablePlaybackRates: [0.5, 1, 1.5, 2, 2.5],
 };
+
+export const playerStates = mirrorCreator([
+  'UNSTARTED',
+  'ENDED',
+  'PLAYING',
+  'PAUSED',
+  'BUFFERING',
+]);

--- a/client/app/bundles/course/video/submission/constants.js
+++ b/client/app/bundles/course/video/submission/constants.js
@@ -15,6 +15,16 @@ export const videoDefaults = {
   availablePlaybackRates: [0.5, 1, 1.5, 2, 2.5],
 };
 
+export const videoActionTypes = mirrorCreator([
+  'CHANGE_PLAYER_STATE',
+  'CHANGE_PLAYER_VOLUME',
+  'CHANGE_PLAYBACK_RATE',
+  'UPDATE_PLAYER_PROGRESS',
+  'UPDATE_BUFFER_PROGRESS',
+  'UPDATE_PLAYER_DURATION',
+  'UPDATE_RESTRICTED_TIME',
+]);
+
 export const playerStates = mirrorCreator([
   'UNSTARTED',
   'ENDED',

--- a/client/app/bundles/course/video/submission/containers/Submission.jsx
+++ b/client/app/bundles/course/video/submission/containers/Submission.jsx
@@ -1,44 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import VideoPlayer from './VideoPlayer';
 
-function mapStateToProps({ video }) {
-  return { video };
-}
-
-const propTypes = {
-  video: PropTypes.object.isRequired,
-};
-
 class Submission extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      currentTimestamp: 0,
-    };
-  }
-
-  updateTimestamp = (newTimestamp) => {
-    this.setState({ currentTimestamp: newTimestamp });
-  };
-
+  // TODO: Rest of the components to be rendered here too
   render() {
-    const video = this.props.video;
-
-    return (
-      <div>
-        <div>
-          <VideoPlayer
-            videoUrl={video.videoUrl}
-            updateTimestamp={this.updateTimestamp}
-          />
-        </div>
-      </div>
-    );
+    return <VideoPlayer />;
   }
 }
 
-Submission.propTypes = propTypes;
-
-export default connect(mapStateToProps)(Submission);
+export default Submission;

--- a/client/app/bundles/course/video/submission/containers/VideoControls/PlayBackRateSelector.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoControls/PlayBackRateSelector.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
+import { videoDefaults } from 'lib/constants/videoConstants';
 
 import styles from '../VideoPlayer.scss';
-import { videoDefaults } from '../../constants';
+import { changePlayBackRate } from '../../actions/video';
 
 const propTypes = {
   rate: PropTypes.number.isRequired,
@@ -38,4 +40,17 @@ function PlayBackRateSelector(props) {
 PlayBackRateSelector.propTypes = propTypes;
 PlayBackRateSelector.defaultProps = defaultProps;
 
-export default PlayBackRateSelector;
+function mapStateToProps(state, ownProps) {
+  return {
+    rate: state.video.playBackRate,
+    availableRates: ownProps.availableRates,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    rateChanged: newRate => dispatch(changePlayBackRate(newRate)),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PlayBackRateSelector);

--- a/client/app/bundles/course/video/submission/containers/VideoControls/PlayButton.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoControls/PlayButton.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { playerStates } from 'lib/constants/videoConstants';
+import { isPlayingState } from 'lib/helpers/videoHelpers';
 
 import styles from '../VideoPlayer.scss';
+import { changePlayerState } from '../../actions/video';
 
 const propTypes = {
   playing: PropTypes.bool.isRequired,
@@ -11,7 +15,7 @@ const propTypes = {
 function PlayButton(props) {
   const playIconClass = props.playing ? 'fa fa-pause' : 'fa fa-play';
   return (
-    <span className={styles.playButton} onClick={props.onClick}>
+    <span className={styles.playButton} onClick={() => props.onClick(props.playing)}>
       <i className={playIconClass} />
     </span>
   );
@@ -19,4 +23,20 @@ function PlayButton(props) {
 
 PlayButton.propTypes = propTypes;
 
-export default PlayButton;
+function mapStateToProps(state) {
+  return { playing: isPlayingState(state.video.playerState) };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onClick: (playing) => {
+      if (playing) {
+        dispatch(changePlayerState(playerStates.PAUSED));
+      } else {
+        dispatch(changePlayerState(playerStates.PLAYING));
+      }
+    },
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PlayButton);

--- a/client/app/bundles/course/video/submission/containers/VideoControls/VideoPlayerSlider.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoControls/VideoPlayerSlider.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'rc-slider/assets/index.css';
+import { connect } from 'react-redux';
 import { formatTimestamp } from 'lib/helpers/videoHelpers';
+import 'rc-slider/assets/index.css';
 
 import styles from '../VideoPlayer.scss';
+import { updatePlayerProgress } from '../../actions/video';
 
 const unbufferedColour = '#e9e9e9';
 const bufferedColour = '#afe9ff';
@@ -29,7 +31,6 @@ const propTypes = {
   duration: PropTypes.number.isRequired,
   playerProgress: PropTypes.number,
   bufferProgress: PropTypes.number,
-  onDragStart: PropTypes.func,
   onDragged: PropTypes.func,
 };
 
@@ -64,7 +65,6 @@ class VideoPlayerSlider extends React.Component {
           railStyle={generateRailStyle(this.props.bufferProgress, this.props.duration)}
           tipFormatter={formatTimestamp}
           onChange={this.props.onDragged}
-          onBeforeChange={this.props.onDragStart}
         />
       </span>
     );
@@ -74,5 +74,19 @@ class VideoPlayerSlider extends React.Component {
 VideoPlayerSlider.propTypes = propTypes;
 VideoPlayerSlider.defaultProps = defaultProps;
 
-export default VideoPlayerSlider;
+function mapStateToProps(state) {
+  return {
+    duration: state.video.duration,
+    playerProgress: state.video.playerProgress,
+    bufferProgress: state.video.bufferProgress,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onDragged: newValue => dispatch(updatePlayerProgress(newValue, true)),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(VideoPlayerSlider);
 

--- a/client/app/bundles/course/video/submission/containers/VideoControls/VolumeButton.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoControls/VolumeButton.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { videoDefaults } from 'lib/constants/videoConstants';
 
 import styles from '../VideoPlayer.scss';
+import { changePlayerVolume } from '../../actions/video';
 
 const propTypes = {
   volume: PropTypes.number.isRequired,
@@ -18,7 +21,7 @@ function VolumeButton(props) {
   }
 
   return (
-    <span className={styles.volumeButton} onClick={props.onClick}>
+    <span className={styles.volumeButton} onClick={() => props.onClick(props.volume)}>
       <i className={className} />
     </span>
   );
@@ -26,4 +29,17 @@ function VolumeButton(props) {
 
 VolumeButton.propTypes = propTypes;
 
-export default VolumeButton;
+function mapStateToProps(state) {
+  return { volume: state.video.playerVolume };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onClick: (currentVolume) => {
+      const newVolume = (currentVolume === 0 ? videoDefaults.volume : 0);
+      dispatch(changePlayerVolume(newVolume));
+    },
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(VolumeButton);

--- a/client/app/bundles/course/video/submission/containers/VideoControls/VolumeSlider.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoControls/VolumeSlider.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import Slider from 'material-ui/Slider';
 
 import styles from '../VideoPlayer.scss';
+import { changePlayerVolume } from '../../actions/video';
 
 const propTypes = {
   volume: PropTypes.number.isRequired,
@@ -34,4 +36,17 @@ function VolumeSlider(props) {
 VolumeSlider.propTypes = propTypes;
 VolumeSlider.defaultProps = defaultProps;
 
-export default VolumeSlider;
+function mapStateToProps(state, ownProps) {
+  return {
+    volume: state.video.playerVolume,
+    fineTuningScale: ownProps.fineTuningScale,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onVolumeChange: newVolume => dispatch(changePlayerVolume(newVolume)),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(VolumeSlider);

--- a/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
@@ -4,7 +4,7 @@ import Paper from 'material-ui/Paper';
 import { timeIsPastRestricted } from 'lib/helpers/videoHelpers';
 
 import styles from './VideoPlayer.scss';
-import { videoDefaults, youtubeOpts } from '../constants';
+import { playerStates, videoDefaults, youtubeOpts } from '../constants';
 
 import {
   PlayBackRateSelector,
@@ -22,28 +22,14 @@ const propTypes = {
 };
 
 class VideoPlayer extends React.Component {
-  /**
-   * Expose PlayerState constants for convenience. These constants can also be
-   * accessed through the global YT object after the YouTube IFrame API is instantiated.
-   * https://developers.google.com/youtube/iframe_api_reference#onStateChange
-   */
-  static PlayerState = {
-    UNSTARTED: -1,
-    ENDED: 0,
-    PLAYING: 1,
-    PAUSED: 2,
-    BUFFERING: 3,
-    CUED: 5,
-  };
-
   constructor(props) {
     super(props);
 
     this.player = null;
-    this.preDragState = VideoPlayer.PlayerState.PLAYING;
+    this.preDragState = playerStates.PLAYING;
 
     this.state = {
-      playerState: VideoPlayer.PlayerState.UNSTARTED,
+      playerState: playerStates.UNSTARTED,
       playerProgress: 0,
       duration: 600,
       bufferProgress: 0,
@@ -77,7 +63,7 @@ class VideoPlayer extends React.Component {
     let playerState = this.state.playerState;
     if (timeIsPastRestricted(this.props.restrictContentAfter, playedSeconds)) {
       targetTime = this.props.restrictContentAfter;
-      playerState = VideoPlayer.PlayerState.PAUSED;
+      playerState = playerStates.PAUSED;
       this.player.seekTo(targetTime);
     }
 
@@ -94,9 +80,9 @@ class VideoPlayer extends React.Component {
 
   onPlayButtonClick = () => {
     if (this.isPlayingState()) {
-      this.setState({ playerState: VideoPlayer.PlayerState.PAUSED });
+      this.setState({ playerState: playerStates.PAUSED });
     } else if (!timeIsPastRestricted(this.props.restrictContentAfter, this.state.playerProgress)) {
-      this.setState({ playerState: VideoPlayer.PlayerState.PLAYING });
+      this.setState({ playerState: playerStates.PLAYING });
     }
   };
 
@@ -118,7 +104,7 @@ class VideoPlayer extends React.Component {
     let playerState = this.preDragState;
     if (timeIsPastRestricted(this.props.restrictContentAfter, newPlayerProgress)) {
       newPlayerProgress = this.props.restrictContentAfter;
-      playerState = VideoPlayer.PlayerState.PAUSED;
+      playerState = playerStates.PAUSED;
     }
     this.player.seekTo(newPlayerProgress);
     this.setState({ playerProgress: newPlayerProgress, playerState });
@@ -141,8 +127,8 @@ class VideoPlayer extends React.Component {
    */
   isPlayingState() {
     switch (this.state.playerState) {
-      case VideoPlayer.PlayerState.PLAYING:
-      case VideoPlayer.PlayerState.BUFFERING:
+      case playerStates.PLAYING:
+      case playerStates.BUFFERING:
         return true;
       default:
         return false;
@@ -165,15 +151,15 @@ class VideoPlayer extends React.Component {
         progressFrequency={this.state.progressFrequency}
         onProgress={this.onPlayerProgress}
         onDuration={duration => this.setState({ duration })}
-        onPlay={() => this.setState({ playerState: VideoPlayer.PlayerState.PLAYING })}
-        onPause={() => this.setState({ playerState: VideoPlayer.PlayerState.PAUSED })}
+        onPlay={() => this.setState({ playerState: playerStates.PLAYING })}
+        onPause={() => this.setState({ playerState: playerStates.PAUSED })}
         onBuffer={() => {
           // It doesn't matter if video is buffering if we aren't even playing it
           if (this.isPlayingState()) {
-            this.setState({ playerState: VideoPlayer.PlayerState.BUFFERING });
+            this.setState({ playerState: playerStates.BUFFERING });
           }
         }}
-        onEnded={() => this.setState({ playerState: VideoPlayer.PlayerState.ENDED })}
+        onEnded={() => this.setState({ playerState: playerStates.ENDED })}
         config={{ youtube: youtubeOpts }}
       />
     );

--- a/client/app/bundles/course/video/submission/reducers/index.js
+++ b/client/app/bundles/course/video/submission/reducers/index.js
@@ -1,4 +1,5 @@
+import { combineReducers } from 'redux';
 import video from './video';
 
 // TODO: More reducers will need to be combined here
-export default video;
+export default combineReducers({ video });

--- a/client/app/bundles/course/video/submission/reducers/video.js
+++ b/client/app/bundles/course/video/submission/reducers/video.js
@@ -1,7 +1,107 @@
+import { playerStates, videoActionTypes, videoDefaults } from 'lib/constants/videoConstants';
+import { isPlayingState, timeIsPastRestricted } from 'lib/helpers/videoHelpers';
+
 export const initialState = {
+  videoId: null,
   videoUrl: null,
+  playerState: playerStates.UNSTARTED,
+  playerProgress: 0,
+  duration: videoDefaults.placeHolderDuration,
+  bufferProgress: 0,
+  playerVolume: videoDefaults.volume,
+  playBackRate: 1,
+  restrictContentAfter: null,
+  forceSeek: false,
 };
 
-export default function (state = initialState) {
-  return state;
+/**
+ * Calculates the state changes required for a playerProgress update.
+ *
+ * If the new suggested time exceeds the restrictContentAfter time, it is adjusted back to restrictContentAfter.
+ * Additionally, forceSeek will be set and playerState will be set to PAUSED so that the video freezes at
+ * restrictContentAfter.
+ * @param state The Redux video state
+ * @param suggestedTime The time provided by the action to adjust time to
+ * @param forceSeek If the forceSeek flag is requested to be set by an action
+ * @returns {Object} An object with states to merge into Redux
+ */
+function computeTimeAdjustChange(state, suggestedTime, forceSeek = false) {
+  const stateChange = {
+    playerProgress: suggestedTime,
+    forceSeek,
+    playerState: state.playerState,
+  };
+  if (timeIsPastRestricted(state.restrictContentAfter, stateChange.playerProgress)) {
+    stateChange.playerProgress = state.restrictContentAfter;
+    stateChange.forceSeek = true;
+    stateChange.playerState = playerStates.PAUSED;
+  }
+
+  stateChange.playerProgress = Math.max(0, Math.min(state.duration, stateChange.playerProgress));
+  // No point seeking if the progress is not changed
+  stateChange.forceSeek = stateChange.forceSeek && stateChange.playerProgress !== state.playerProgress;
+  return stateChange;
+}
+
+/**
+ * Computes the new player state based on the new state an action provides and the current player progress.
+ *
+ * If the player is past the restricted time, then the playerState will be forced into a non-playing state (either the
+ * old state or playerStates.PAUSED).
+ *
+ * If the new playing state BUFFERING but the player was not even playing to begin with, the old player state is
+ * returned instead.
+ *
+ * If neither are true, the newPlayerState returned.
+ * @param state The entire video Redux state
+ * @param newPlayerState The new playerState to be set
+ * @returns {playerStates} The new playerState to set into Redux
+ */
+function computePlayerState(state, newPlayerState) {
+  if (timeIsPastRestricted(state.restrictContentAfter, state.playerProgress) && isPlayingState(newPlayerState)) {
+    return isPlayingState(state.playerState) ? playerStates.PAUSED : state.playerState;
+  }
+
+  if (newPlayerState === playerStates.BUFFERING && !isPlayingState(state.playerState)) {
+    return state.playerState;
+  }
+
+  return newPlayerState;
+}
+
+/**
+ * Generates a state transformer function that merges changes into state and produces a new state object.
+ *
+ * The generated transformer is a pure function and does not modify original state.
+ *
+ * The forceSeek flag is always set to false by the transformer unless explicitly turned on within changes.
+ * @param state The original state object
+ * @returns {function(Object): Object} A function that produces the next state object when changes are provided
+ */
+function generateStateTransformer(state) {
+  return changes => Object.assign({}, state, { forceSeek: false }, changes);
+}
+
+export default function (state = initialState, action) {
+  // Only forceSeek if explicitly specified
+  const transformState = generateStateTransformer(state);
+
+  switch (action.type) {
+    case videoActionTypes.CHANGE_PLAYER_STATE:
+      return transformState({ playerState: computePlayerState(state, action.playerState) });
+    case videoActionTypes.CHANGE_PLAYER_VOLUME:
+      return transformState({ playerVolume: action.playerVolume });
+    case videoActionTypes.CHANGE_PLAYBACK_RATE:
+      return transformState({ playBackRate: action.playBackRate });
+    case videoActionTypes.UPDATE_PLAYER_PROGRESS:
+      return transformState(computeTimeAdjustChange(state, action.playerProgress, action.forceSeek));
+    case videoActionTypes.UPDATE_BUFFER_PROGRESS:
+      return transformState({ bufferProgress: Math.max(0, Math.min(state.duration, action.bufferProgress)) });
+    case videoActionTypes.UPDATE_PLAYER_DURATION:
+      return transformState({ duration: action.duration });
+    case videoActionTypes.UPDATE_RESTRICTED_TIME:
+      return transformState({ restrictContentAfter: action.restrictContentAfter });
+    default:
+      return state;
+  }
 }

--- a/client/app/bundles/course/video/submission/store.js
+++ b/client/app/bundles/course/video/submission/store.js
@@ -1,9 +1,12 @@
 import { applyMiddleware, compose, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import rootReducer from './reducers';
+import { initialState as videoInitialState } from './reducers/video';
 
 export default ({ video }) => {
-  const initialStates = { video };
+  const initialStates = {
+    video: Object.assign({}, videoInitialState, video),
+  };
   const storeCreator = (process.env.NODE_ENV === 'development') ?
     // eslint-disable-next-line global-require
     compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :

--- a/client/app/lib/constants/videoConstants.js
+++ b/client/app/lib/constants/videoConstants.js
@@ -13,6 +13,8 @@ export const youtubeOpts = {
 export const videoDefaults = {
   volume: 0.8,
   availablePlaybackRates: [0.5, 1, 1.5, 2, 2.5],
+  placeHolderDuration: 600,
+  progressUpdateFrequencyMs: 500,
 };
 
 export const videoActionTypes = mirrorCreator([

--- a/client/app/lib/helpers/videoHelpers.js
+++ b/client/app/lib/helpers/videoHelpers.js
@@ -6,9 +6,10 @@
  * return {string} The timestamp formatted in [hh:]mm:ss
  */
 function formatTimestamp(timestamp) {
-  const hour = Math.floor(timestamp / 3600);
-  const minute = Math.floor((timestamp % 3600) / 60);
-  const seconds = Math.round((timestamp % 3600) % 60);
+  const roundedTime = Math.round(timestamp);
+  const hour = Math.floor(roundedTime / 3600);
+  const minute = Math.floor((roundedTime % 3600) / 60);
+  const seconds = (roundedTime % 3600) % 60;
 
   return (
     `${(hour > 0 ? `${hour}:${minute < 10 ? '0' : ''}` : '') +

--- a/client/app/lib/helpers/videoHelpers.js
+++ b/client/app/lib/helpers/videoHelpers.js
@@ -1,3 +1,5 @@
+import { playerStates } from '../constants/videoConstants';
+
 /**
  * Formats a number into a timestamp string.
  *
@@ -17,12 +19,30 @@ function formatTimestamp(timestamp) {
   );
 }
 
+/**
+ * Checks if the time given is past the restricted time.
+ *
+ * If restricted time is invalid (<0 or undefined), this function will always return false.
+ * @param restrictedTimeInSec The time denoting the maximum allowed content
+ * @param timeInSec The time to test
+ * @returns {boolean} true if timeInSec exceeds restrictedTimeInSec
+ */
 function timeIsPastRestricted(restrictedTimeInSec, timeInSec) {
-  if (!restrictedTimeInSec || restrictedTimeInSec <= 0) {
+  if (restrictedTimeInSec === undefined || restrictedTimeInSec <= 0) {
     return false;
   }
 
   return timeInSec >= restrictedTimeInSec;
 }
 
-export { formatTimestamp, timeIsPastRestricted };
+/**
+ * Returns true if the playerState provided is considered a state when the  player will continue playing the video
+ * whenever possible.
+ * @param playerState The playerState to check against playerStates
+ * @returns {boolean} If the playerState provided is a playing state
+ */
+function isPlayingState(playerState) {
+  return playerState === playerStates.PLAYING || playerState === playerStates.BUFFERING;
+}
+
+export { formatTimestamp, timeIsPastRestricted, isPlayingState };


### PR DESCRIPTION
There's quite a bunch of things that may need to read from and control the video player (and vice-versa too). This PR moves all states into Redux, and make all components that can control the video player connected to the Redux store instead of having to pass callbacks around.