### PR TITLE
Nicholette/fix scribing styling

### DIFF
--- a/client/app/bundles/course/assessment/question/scribing/components/FileUploadComponent.jsx
+++ b/client/app/bundles/course/assessment/question/scribing/components/FileUploadComponent.jsx
@@ -32,6 +32,7 @@ const mapProps =
 const propTypes = {
   field: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string.isRequired,
   isLoading: PropTypes.bool,
   value: PropTypes.object,
   meta: PropTypes.object,
@@ -56,10 +57,10 @@ class FileUploadComponent extends Component {
     const fileName = this.props.value && this.props.value[0] && this.props.value[0].name;
     if (fileName) {
       return (<div className="fileLabel" style={style.fileLabel} >{fileName}</div>);
-    } else if (this.props.meta && this.props.meta.touched && this.props.meta.invalid && this.props.meta.error) {
+    } else if (this.props.meta && this.props.meta.touched && !fileName) {
       return (
         <div style={style.fileLabelError}>
-          { this.props.meta && this.props.meta.touched && this.props.meta.invalid && this.props.meta.error }
+          { this.props.errorMessage }
         </div>
       );
     }

--- a/client/app/bundles/course/assessment/question/scribing/components/FileUploadField.jsx
+++ b/client/app/bundles/course/assessment/question/scribing/components/FileUploadField.jsx
@@ -14,12 +14,13 @@ const mapProps = props => ({ ...mapError(props) });
 const propTypes = {
   field: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string.isRequired,
   validate: PropTypes.array,
   isLoading: PropTypes.bool,
 };
 
 const FileUploadField = (props) => {
-  const { field, label, validate, isLoading } = props;
+  const { field, label, validate, isLoading, errorMessage } = props;
 
   return (
     <Field
@@ -27,7 +28,13 @@ const FileUploadField = (props) => {
       id={questionIdPrefix + field}
       disabled={isLoading}
       validate={validate}
-      component={fuProps => (<FileUploadComponent field={field} label={label} isLoading={isLoading} {...fuProps} />)}
+      component={fuProps => (<FileUploadComponent
+        field={field}
+        label={label}
+        isLoading={isLoading}
+        errorMessage={errorMessage}
+        {...fuProps}
+      />)}
     />
   );
 };

--- a/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/ScribingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/ScribingQuestionForm.intl.js
@@ -74,4 +74,8 @@ export default defineMessages({
     id: 'course.assessment.question.scribing.scribingQuestionForm.lessThanEqualZeroValidationError',
     defaultMessage: 'Value must be greater than 0.',
   },
+  fileAttachmentRequired: {
+    id: 'course.assessment.question.scribing.scribingQuestionForm.fileAttachmentRequired',
+    defaultMessage: 'File attachment required.',
+  },
 });

--- a/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/index.jsx
+++ b/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/index.jsx
@@ -228,6 +228,7 @@ class ScribingQuestionForm extends React.Component {
                     label={this.props.intl.formatMessage(translations.chooseFileButton)}
                     isLoading={this.props.data.isLoading}
                     validate={[required]}
+                    errorMessage={this.props.intl.formatMessage(translations.fileAttachmentRequired)}
                   />
                 </div>
               }

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -175,6 +175,14 @@ export default class ScribingCanvas extends React.Component {
     };
 
     if (this.mouseCanvasDragStartPoint) {
+      if (this.props.scribing.selectedTool === scribingTools.SELECT) {
+        this.canvas.selectionBorderColor = 'gray';
+        this.canvas.selectionDashArray = [1, 3];
+      } else {
+        this.canvas.selectionBorderColor = 'transparent';
+        this.canvas.selectionDashArray = [];
+      }
+
       if (this.props.scribing.selectedTool === scribingTools.LINE) {
         const strokeDashArray = getStrokeDashArray(scribingToolLineStyle.LINE);
         this.line = new fabric.Line(
@@ -478,6 +486,7 @@ export default class ScribingCanvas extends React.Component {
         statefullCache: false,
         noScaleCache: true,
         needsItsOwnCache: false,
+        selectionColor: 'transparent',
       });
 
       this.props.setCanvasProperties(this.props.answerId, this.width, this.height, maxWidth);

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -82,6 +82,7 @@ export default class ScribingCanvas extends React.Component {
       this.canvas.isDrawingMode = nextProps.scribing.isDrawingMode;
       this.canvas.freeDrawingBrush.color = this.props.scribing.colors[scribingToolColor.DRAW];
       this.canvas.defaultCursor = nextProps.scribing.cursor;
+      this.currentCursor = nextProps.scribing.cursor;
 
       this.canvas.zoomToPoint({
         x: this.canvas.height / 2,
@@ -122,19 +123,22 @@ export default class ScribingCanvas extends React.Component {
   }
 
   disableObjectSelection() {
-    this.canvas.forEachObject(object => (
-      object.selectable = false // eslint-disable-line no-param-reassign
-    ));
+    this.canvas.forEachObject((object) => {
+      object.selectable = false; // eslint-disable-line no-param-reassign
+      object.hoverCursor = this.currentCursor; // eslint-disable-line no-param-reassign
+    });
   }
 
   // This method only enable selection for interactive texts
   enableTextSelection() {
     this.canvas.clear();
     this.initializeScribblesAndBackground(false);
-    this.canvas.forEachObject(object => (
+    this.canvas.forEachObject((object) => {
       // eslint-disable-next-line no-param-reassign
-      object.selectable = (object.type === 'i-text')
-    ));
+      object.selectable = (object.type === 'i-text');
+      // eslint-disable-next-line no-param-reassign
+      object.hoverCursor = (object.type === 'i-text') ? 'pointer' : this.currentCursor;
+    });
   }
 
   // This method clears the selection-disabled scribbles

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -486,6 +486,10 @@ export default class ScribingCanvas extends React.Component {
         this.canvas.setBackgroundImage(fabricImage, this.canvas.renderAll.bind(this.canvas))
       );
 
+      const canvasElem = document.getElementById(`canvas-container-${answerId}`);
+      const canvasContainerElem = canvasElem.getElementsByClassName('canvas-container')[0];
+      canvasContainerElem.style.margin = '0 auto';
+
       this.initializeScribblesAndBackground(true);
 
       this.canvas.on('mouse:down', this.onMouseDownCanvas);
@@ -593,7 +597,7 @@ export default class ScribingCanvas extends React.Component {
     const answerId = this.props.answerId;
     const isCanvasLoaded = this.props.scribing.isCanvasLoaded;
     return (answerId ?
-      <div style={styles.canvas_div}>
+      <div style={styles.canvas_div} id={`canvas-container-${answerId}`}>
         { !isCanvasLoaded ? <LoadingIndicator /> : null }
         <canvas style={styles.canvas} id={`canvas-${answerId}`} />
       </div> : null

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
@@ -180,8 +180,8 @@ class ScribingToolbar extends Component {
   onClickTypingMode = () => {
     this.props.setToolSelected(this.props.answerId, scribingTools.TYPE);
     this.props.setDrawingMode(this.props.answerId, false);
-    this.props.setCanvasCursor(this.props.answerId, 'pointer');
-    this.props.setEnableTextSelection();
+    this.props.setCanvasCursor(this.props.answerId, 'text');
+    this.props.setEnableTextSelection(this.props.answerId);
   }
 
   onClickTypingIcon = () => {


### PR DESCRIPTION
Add styling changes to scribing question and answer:
- Force the display of file attachment required message when redux-form is untouched during question submission
- Center the canvas when it is smaller than the canvas container
- Fix hover cursor display over canvas objects during text, line and shape tool selection
-- when in adding object mode, hovering canvas objects displays a 'move' cursor instead of their respective tool's cursor
- Hide display of selection box when not in selection tool 
-- Pan, Text tool used to display selection box during dragging