### PR TITLE
Set CSS properties for ExpandableText component.

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView.jsx
@@ -198,12 +198,14 @@ class VisibleTestCaseView extends Component {
       <TableRowColumn style={styles.testCaseCell}>{field}</TableRowColumn>
     );
 
+    const outputStyle = { whiteSpace: 'pre-wrap', fontFamily: 'monospace' };
+
     return (
       <TableRow key={testCase.identifier} style={styles.testCaseRow[testCaseResult]}>
         { canGrade ? tableRowColumnFor(testCase.identifier) : null }
         {tableRowColumnFor(testCase.expression)}
-        {tableRowColumnFor(<ExpandableText text={testCase.expected || ''} /> || '')}
-        { canGrade ? tableRowColumnFor(<ExpandableText text={testCase.output || ''} /> || '') : null }
+        {tableRowColumnFor(<ExpandableText style={outputStyle} text={testCase.expected || ''} /> || '')}
+        { canGrade ? tableRowColumnFor(<ExpandableText style={outputStyle} text={testCase.output || ''} /> || '') : null }
         {tableRowColumnFor(testCaseIcon)}
       </TableRow>
     );

--- a/client/app/lib/components/ExpandableText.jsx
+++ b/client/app/lib/components/ExpandableText.jsx
@@ -17,6 +17,7 @@ const propTypes = {
   text: PropTypes.string.isRequired,
   maxChars: PropTypes.number,
   intl: intlShape.isRequired,
+  style: PropTypes.object,
 };
 
 class ExpandableText extends React.Component {
@@ -40,17 +41,17 @@ class ExpandableText extends React.Component {
   }
 
   render() {
-    const { text, maxChars, intl } = this.props;
+    const { text, maxChars, intl, style } = this.props;
     const showAll = intl.formatMessage(translations.showAll);
     const showLess = intl.formatMessage(translations.showLess);
     const maxLength = maxChars && maxChars > showAll.length ? maxChars : this.defaultMaxChars;
 
     if (text.length <= maxLength) {
-      return <span>{ text }</span>;
+      return <span style={style}>{ text }</span>;
     }
 
     return (
-      <span>
+      <span style={style}>
         { this.state.expanded ?
           text :
           `${text.substr(0, maxLength - showAll.length)}\u2026`


### PR DESCRIPTION
Set 'white-space' to 'pre-wrap' so whitespace is preserved by the browser.
Text will wrap when necessary, and on line breaks.

Set 'font-family' to 'monospace' for alignment, especially over multiple
lines.

Fixes #2512.

## Current View
<img width="604" alt="test-case-orig" src="https://user-images.githubusercontent.com/1902527/30844293-f1e57de0-a2c0-11e7-9608-6544460341ab.png">

## New View
<img width="614" alt="test-case-wide" src="https://user-images.githubusercontent.com/1902527/30844294-f1ea0162-a2c0-11e7-8fa9-fe33f759e931.png">

## New View with narrower screen
<img width="448" alt="test-case-narrow" src="https://user-images.githubusercontent.com/1902527/30844295-f1f3b63a-a2c0-11e7-935b-f2584acb241b.png">

Note that a line break occurs when the line needs to wrap, as well as when there's a newline character.
