### PR TITLE
Revert "Remove cancancan-squeel"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,8 +176,7 @@ gem 'omniauth-facebook'
 
 # Use cancancan for authorization
 gem 'cancancan'
-# Cancancan adapter. TODO: transfer to Coursemology organization
-gem 'cancancan-baby_squeel', github: 'jeremyyap/cancancan-baby_squeel'
+gem 'cancancan-squeel'
 
 # Some helpers for structuring CSS/JavaScript
 gem 'rails_utils', '>= 3.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,15 +15,6 @@ GIT
       rails (>= 3.2)
 
 GIT
-  remote: git://github.com/jeremyyap/cancancan-baby_squeel.git
-  revision: 7f9cf9f4180bfe7b58a02b642cc263df720c9f07
-  specs:
-    cancancan-baby_squeel (0.1.5)
-      activerecord (>= 4.1)
-      baby_squeel (~> 1.1.5)
-      cancancan (~> 1.10)
-
-GIT
   remote: git://github.com/lowjoel/activerecord-userstamp.git
   revision: e3c808edf57b1d388ac7082a72d0a9910fde8fab
   specs:
@@ -92,9 +83,8 @@ GEM
     autoprefixer-rails (7.1.4)
       execjs
     awesome_print (1.8.0)
-    baby_squeel (1.1.5)
-      activerecord (>= 4.2.0)
-      polyamorous (~> 1.3)
+    baby_squeel (0.3.1)
+      activerecord (>= 4.0.0)
     bcrypt (3.1.11)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -113,6 +103,10 @@ GEM
     calculated_attributes (0.2.0)
       activerecord (>= 3.2.20)
     cancancan (1.17.0)
+    cancancan-squeel (0.1.4)
+      activerecord (>= 4.1)
+      cancancan (~> 1.10)
+      squeel (~> 1.2)
     capybara (2.15.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -314,7 +308,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
-    polyamorous (1.3.1)
+    polyamorous (1.1.0)
       activerecord (>= 3.0)
     progress (3.3.1)
     public_suffix (3.0.0)
@@ -519,6 +513,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    squeel (1.2.3)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      polyamorous (~> 1.1.0)
     summernote-rails (0.8.3.0)
       railties (>= 3.1)
     temple (0.8.0)
@@ -579,7 +577,7 @@ DEPENDENCIES
   byebug
   calculated_attributes (>= 0.1.3)
   cancancan
-  cancancan-baby_squeel!
+  cancancan-squeel
   capybara
   capybara-screenshot
   capybara-selenium


### PR DESCRIPTION
This reverts commit 28651f57ddc973e58b9c758ddf9beaa200f3635b.

Experience points records listings were broken. With the sample seed data, visit something like http://localhost:3000/courses/2/users/35/experience_points_records to reproduce.

### Queries

```
CourseUser Load (2.9ms)  
	SELECT
		"course_users" . *
		,(
			SELECT
					COALESCE (
						SUM( "course_experience_points_records" . "points_awarded" )
						,0
					)
				FROM
					"course_experience_points_records"
				WHERE
					(
						course_experience_points_records.course_user_id = course_users.id
					)
		) AS experience_points
		,(
			SELECT
					COUNT( '*' )
				FROM
					"course_user_achievements"
				WHERE
					(
						course_user_achievements.course_user_id = course_users.id
					)
		) AS achievement_count
	FROM
		"course_users"
	WHERE
		"course_users" . "course_id" = $1
		AND "course_users" . "user_id" = 1 LIMIT 1  [["course_id", 2]]
  CourseUser Load (0.3ms)  
	SELECT
		"course_users" . *
	FROM
		"course_users"
	WHERE
		"course_users" . "course_id" = $1
		AND "course_users" . "id" = $2 LIMIT 1  [["course_id", 2], ["id", 35]]
Completed 500 Internal Server Error in 239ms (ActiveRecord: 17.4ms)

NoMethodError (undefined method `children' for nil:NilClass)
```