### PR TITLE
Update pencil width and color with nextProps

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -82,8 +82,8 @@ export default class ScribingCanvas extends React.Component {
   shouldComponentUpdate(nextProps) {
     if (this.canvas) {
       this.canvas.isDrawingMode = nextProps.scribing.isDrawingMode;
-      this.canvas.freeDrawingBrush.color = this.props.scribing.colors[scribingToolColor.DRAW];
-      this.canvas.freeDrawingBrush.width = this.props.scribing.thickness[scribingToolThickness.DRAW];
+      this.canvas.freeDrawingBrush.color = nextProps.scribing.colors[scribingToolColor.DRAW];
+      this.canvas.freeDrawingBrush.width = nextProps.scribing.thickness[scribingToolThickness.DRAW];
       this.canvas.defaultCursor = nextProps.scribing.cursor;
       this.currentCursor = nextProps.scribing.cursor;
 


### PR DESCRIPTION
Use `nextProps` instead of `this.props` for updating of pencil width and color