### PR TITLE
Allow assessment categories to be freely reordered in the sidebar

### DIFF
--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -20,7 +20,7 @@ class Course::AssessmentsComponent < SimpleDelegator
   def assessment_categories
     current_course.assessment_categories.select(&:persisted?).map do |category|
       {
-        key: :assessments,
+        key: "assessments_#{category.id}",
         icon: 'plane', # TODO: category.icon in db that user can select and set
         title: category.title,
         weight: 2,

--- a/db/migrate/20171004053203_rekey_sidebar_settings.rb
+++ b/db/migrate/20171004053203_rekey_sidebar_settings.rb
@@ -1,0 +1,32 @@
+class RekeySidebarSettings < ActiveRecord::Migration
+  def up
+    ActsAsTenant.without_tenant do
+      Course.all.each do |course|
+        weight = course.settings(:sidebar, :assessments).weight
+        next if !weight
+
+        course.assessment_categories.each do |c|
+          course.settings(:sidebar).settings("assessments_#{c.id}").weight = weight
+        end
+        course.settings(:sidebar).assessments = nil
+        course.save!
+      end
+    end
+  end
+
+  def down
+    ActsAsTenant.without_tenant do
+      Course.all.each do |course|
+        weights = course.assessment_categories.map do |c|
+          weight = course.settings(:sidebar).settings("assessments_#{c.id}").weight
+          course.settings(:sidebar).send("assessments_#{c.id}=", nil)
+          weight
+        end
+        next if weights.empty?
+        weight = weights.first
+        course.settings(:sidebar, :assessments).weight = weight
+        course.save!
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170925095335) do
+ActiveRecord::Schema.define(version: 20171004053203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Previously, assessment categories had to be moved together as they shared the same key. The UI did not enforce this, which led to confusing outcomes for users.

Fixes #2321.