### PR TITLE
Fix broken java editor in non-autograded mode

### DIFF
--- a/app/services/course/assessment/question/programming/java/java_package_service.rb
+++ b/app/services/course/assessment/question/programming/java/java_package_service.rb
@@ -69,7 +69,8 @@ class Course::Assessment::Question::Programming::Java::JavaPackageService < \
 
     return meta if template_files.blank?
 
-    meta[:submission] = template_files
+    # TODO: Refactor to support multiple files in non-autograded mode
+    meta[:submission] = template_files.first&.content
 
     meta.as_json
   end

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -10,7 +10,7 @@ json.question do
     json.(skill, :id, :title)
   end
 
-  has_submissions = @programming_question.answers.without_attempting_state.count
+  has_submissions = @programming_question.answers.without_attempting_state.count > 0
   json.autograded @programming_question.persisted? ?
     @programming_question.attachment.present? : @assessment.autograded?
   json.has_auto_gradings @programming_question.auto_gradable? && has_submissions

--- a/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Java/OnlineEditorJavaView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/OnlineEditor/Java/OnlineEditorJavaView.jsx
@@ -436,6 +436,7 @@ class OnlineEditorJavaView extends React.Component {
     return (
       <div id="java-online-editor">
         {
+          autograded &&
           <div className={styles.submitAsFileToggle}>
             <Toggle
               label={toggleLabel}


### PR DESCRIPTION
- `@meta[:submission]` expects a string in the frontend, AR object `template_files` was passed to frontend, and the editor breaks in that case.
- Disable file submission in non-autograded mode, it's an evaluation mode and thus not applicable if the question is non-autograded

TODO:  Supporting of multiple files in non-autograded  programming questions is not done in this PR. Will need some refactoring, currently both the service and views assumes `:submission` to be a single file.

cc @zhengwei143 @fonglh 