### PR TITLE
Fix announcement ordering in course homepage

### DIFF
--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -11,7 +11,7 @@ class Course::CoursesController < Course::Controller
 
   def show # :nodoc:
     @registration = Course::Registration.new
-    @currently_active_announcements = current_course.announcements.currently_active
+    @currently_active_announcements = current_course.announcements.currently_active.sorted_by_sticky.sorted_by_date
     @activity_feeds = recent_activity_feeds.limit(20).includes(activity: [:object, :actor])
     render layout: 'course'
   end


### PR DESCRIPTION
Course homepage will display active announcements with stickies first, then sorted by date in descending order.