### PR TITLE
Nicholette/minor ui fixes 1

### DIFF
--- a/client/app/bundles/course/assessment/question/scribing/components/__test__/FileUploadComponent.test.js
+++ b/client/app/bundles/course/assessment/question/scribing/components/__test__/FileUploadComponent.test.js
@@ -9,6 +9,10 @@ describe('<FileUploadComponent />', () => {
     childContextTypes: { intl: intlShape },
   };
 
+  const props = {
+    errorMessage: 'error',
+  };
+
   it('renders with file name when provided', () => {
     const fileUploadComponent = shallowUntil(
       <FileUploadComponent
@@ -22,6 +26,7 @@ describe('<FileUploadComponent />', () => {
         }}
         field="attachment"
         label="Choose File"
+        {...props}
       />,
       options,
       'div'

--- a/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/ScribingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/ScribingQuestionForm.intl.js
@@ -78,4 +78,10 @@ export default defineMessages({
     id: 'course.assessment.question.scribing.scribingQuestionForm.fileAttachmentRequired',
     defaultMessage: 'File attachment required.',
   },
+  scribingQuestionWarning: {
+    id: 'course.assessment.question.scribing.scribingQuestionForm.scribingQuestionWarning',
+    defaultMessage: 'NOTE: Each page of a PDF file will be created as a single Scribing question \
+    with every question taking on the same question details. \
+    You can choose to leave the optional inputs blank and return to edit the questions again after creation.',
+  },
 });

--- a/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/ScribingQuestionForm.scss
+++ b/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/ScribingQuestionForm.scss
@@ -1,4 +1,4 @@
-$color-red: #f44336;
+$black: #000000;
 
 .inputContainer {
   display: flex;
@@ -25,6 +25,11 @@ $color-red: #f44336;
 
 .skillOption {
   display: none;
+}
+
+.warningText {
+  color: $black;
+  padding: 10px;
 }
 
 @media (min-width: 375px) {

--- a/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/index.jsx
+++ b/client/app/bundles/course/assessment/question/scribing/containers/ScribingQuestionForm/index.jsx
@@ -230,6 +230,9 @@ class ScribingQuestionForm extends React.Component {
                     validate={[required]}
                     errorMessage={this.props.intl.formatMessage(translations.fileAttachmentRequired)}
                   />
+                  <div className={styles.warningText}>
+                    {this.props.intl.formatMessage(translations.scribingQuestionWarning)}
+                  </div>
                 </div>
               }
             </div>

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/LayersComponent.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/LayersComponent.jsx
@@ -28,6 +28,15 @@ const popoverStyles = {
     horizontal: 'left',
     vertical: 'top',
   },
+  layersLabel: {
+    lineHeight: '22px',
+    top: '38px',
+    zIndex: 1,
+    pointerEvents: 'none',
+    userSelect: 'none',
+    color: 'rgba(0, 0, 0, 0.3)',
+    padding: '10px',
+  },
 };
 
 class LayersComponent extends Component {
@@ -60,17 +69,18 @@ class LayersComponent extends Component {
   }
 
   render() {
-    const { intl, onTouchTap, disabled } = this.props;
-    return (
-      <div>
+    const { intl, layers, onTouchTap, disabled } = this.props;
+
+    return !disabled ?
+      (<div>
+        <label style={popoverStyles.layersLabel}>{intl.formatMessage(translations.layersLabelText)}</label>
         <RaisedButton
           onTouchTap={onTouchTap}
-          label={intl.formatMessage(translations.layers)}
+          label={layers && (`${layers[0].creator_name.substring(0, 6)}...`)}
           disabled={disabled}
         />
         { this.renderLayersPopover() }
-      </div>
-    );
+      </div>) : null;
   }
 }
 

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -534,9 +534,9 @@ export default class ScribingCanvas extends React.Component {
     this.image.src = imageUrl;
 
     this.image.onload = () => {
-      // Get the calculated width of canvas, 750 is min width for scribing toolbar
+      // Get the calculated width of canvas, 800 is min width for scribing toolbar
       const element = document.getElementById(`canvas-${answerId}`);
-      const maxWidth = Math.max(element.getBoundingClientRect().width, 750);
+      const maxWidth = Math.max(element.getBoundingClientRect().width, 800);
 
       this.width = Math.min(this.image.width, maxWidth);
       this.scale = Math.min(this.width / this.image.width, 1);
@@ -566,9 +566,14 @@ export default class ScribingCanvas extends React.Component {
 
       const canvasElem = document.getElementById(`canvas-container-${answerId}`);
       canvasElem.tabIndex = 1000;
-      canvasElem.style.background = 'lightgrey';
+      // Minimise reflows
+      canvasElem.setAttribute('style',
+        `background: lightgrey;
+        max-width: ${maxWidth}px;
+        margin: 0px;
+        outline: none;`
+      );
       canvasElem.addEventListener('keydown', this.onKeyDown, false);
-      canvasElem.style.outline = 'none';
       const canvasContainerElem = canvasElem.getElementsByClassName('canvas-container')[0];
       canvasContainerElem.style.margin = '0 auto';
 

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -566,6 +566,7 @@ export default class ScribingCanvas extends React.Component {
 
       const canvasElem = document.getElementById(`canvas-container-${answerId}`);
       canvasElem.tabIndex = 1000;
+      canvasElem.style.background = 'lightgrey';
       canvasElem.addEventListener('keydown', this.onKeyDown, false);
       canvasElem.style.outline = 'none';
       const canvasContainerElem = canvasElem.getElementsByClassName('canvas-container')[0];

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -163,7 +163,7 @@ export default class ScribingCanvas extends React.Component {
   onMouseDownCanvas = (options) => {
     this.mouseCanvasDragStartPoint = this.getCanvasPoint(options.e);
 
-    // To facilitate panning
+    // To facilitate moving
     this.mouseDownFlag = true;
     this.viewportLeft = this.canvas.viewportTransform[4];
     this.viewportTop = this.canvas.viewportTransform[5];
@@ -304,15 +304,15 @@ export default class ScribingCanvas extends React.Component {
   onMouseMoveCanvas = (options) => {
     const dragPointer = this.getCanvasPoint(options.e);
 
-    // Do panning action
-    const tryPan = (left, top) => {
-      // limit panning
+    // Do moving action
+    const tryMove = (left, top) => {
+      // limit moving
       let finalLeft = Math.min(left, 0);
       finalLeft = Math.max(finalLeft, (this.canvas.getZoom() - 1) * this.canvas.getWidth() * -1);
       let finalTop = Math.min(top, 0);
       finalTop = Math.max(finalTop, (this.canvas.getZoom() - 1) * this.canvas.getHeight() * -1);
 
-      // apply calculated pan transforms
+      // apply calculated move transforms
       this.canvas.viewportTransform[4] = finalLeft;
       this.canvas.viewportTransform[5] = finalTop;
       this.canvas.renderAll();
@@ -360,17 +360,17 @@ export default class ScribingCanvas extends React.Component {
             break;
           }
         }
-      } else if (this.props.scribing.selectedTool === scribingTools.PAN) {
+      } else if (this.props.scribing.selectedTool === scribingTools.MOVE) {
         const mouseCurrentPoint = this.getMousePoint(options.e);
         const deltaLeft = mouseCurrentPoint.x - this.mouseStartPoint.x;
         const deltaTop = mouseCurrentPoint.y - this.mouseStartPoint.y;
         const newLeft = this.viewportLeft + deltaLeft;
         const newTop = this.viewportTop + deltaTop;
-        tryPan(newLeft, newTop);
+        tryMove(newLeft, newTop);
       }
     } else if (options.isForced) {
       // Facilitates zooming out
-      tryPan(this.canvas.viewportTransform[4], this.canvas.viewportTransform[5]);
+      tryMove(this.canvas.viewportTransform[4], this.canvas.viewportTransform[5]);
     }
   }
 

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -665,7 +665,7 @@ export default class ScribingCanvas extends React.Component {
         }
       case 67: // Ctrl+C
         {
-          if (event.ctrlKey) {
+          if (event.ctrlKey || event.metaKey) {
             event.preventDefault();
 
             this.copiedObjects = [];
@@ -687,7 +687,7 @@ export default class ScribingCanvas extends React.Component {
         }
       case 86: // Ctrl+V
         {
-          if (event.ctrlKey) {
+          if (event.ctrlKey || event.metaKey) {
             event.preventDefault();
 
             this.canvas.discardActiveGroup();

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -283,21 +283,19 @@ export default class ScribingCanvas extends React.Component {
     } else if (!this.isOverText
         && this.props.scribing.selectedTool === scribingTools.TYPE
         && !this.textCreated) {
-      const text = new fabric.IText('Text', {
+      const text = new fabric.IText('', {
         fontFamily: this.props.scribing.fontFamily,
         fontSize: this.props.scribing.fontSize,
         fill: this.props.scribing.colors[scribingToolColor.TYPE],
         left: this.mouseCanvasDragStartPoint.x,
         top: this.mouseCanvasDragStartPoint.y,
+        padding: 5,
       });
       this.canvas.add(text);
       this.canvas.setActiveObject(text);
       text.enterEditing();
       this.canvas.renderAll();
       this.textCreated = true;
-    } else if (!this.isOverText && this.textCreated) {
-      this.props.setToolSelected(this.props.answerId, scribingTools.SELECT);
-      this.textCreated = false;
     }
   }
 
@@ -639,7 +637,11 @@ export default class ScribingCanvas extends React.Component {
     return `{"objects": ${json}}`;
   }
 
-  onTextChanged = () => {
+  onTextChanged = (options) => {
+    if (options.target.text.trim() === '') {
+      this.canvas.remove(options.target);
+    }
+    this.textCreated = false;
     this.saveScribbles();
     this.props.setToolSelected(this.props.answerId, scribingTools.SELECT);
   }

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -705,16 +705,15 @@ export default class ScribingCanvas extends React.Component {
             this.copiedObjects = [];
             if (activeGroup) {
               activeGroup.getObjects().forEach(obj => (
-                this.copiedObjects.push(fabric.util.object.clone(obj))
+                this.copiedObjects.push(obj)
               ));
 
               this.copyLeft = activeGroup.getLeft();
               this.copyTop = activeGroup.getTop();
             } else if (activeObject) {
-              const object = fabric.util.object.clone(activeObject);
               this.copyLeft = activeObject.getLeft();
               this.copyTop = activeObject.getTop();
-              this.copiedObjects.push(object);
+              this.copiedObjects.push(activeObject);
             }
           }
           break;
@@ -728,28 +727,40 @@ export default class ScribingCanvas extends React.Component {
             this.canvas.discardActiveObject();
 
             const newObjects = [];
-            this.copiedObjects.forEach((obj) => {
-              const newObj = fabric.util.object.clone(obj);
-              newObjects.push(newObj);
-              newObj.setCoords();
+            let newObj = {};
+
+            // Don't wrap single object in group,
+            // in case it's i-text and we want it to be editable at first tap
+            if (this.copiedObjects.length === 1) {
+              const obj = this.copiedObjects[0];
+              if (obj.type === 'i-text') {
+                newObj = this.cloneText(obj);
+              } else {
+                newObj = fabric.util.object.clone(obj);
+              }
+
+              this.setCopiedCanvasObjectPosition(newObj);
               this.canvas.add(newObj);
-              newObj.set('active', true);
-            });
-            const group = new fabric.Group(newObjects, { canvas: this.canvas });
+              this.canvas.setActiveObject(newObj);
+              this.canvas.renderAll();
+            } else {  // Cloning a group of objects
+              this.copiedObjects.forEach((obj) => {
+                if (obj.type === 'i-text') {
+                  newObj = this.cloneText(obj);
+                } else {
+                  newObj = fabric.util.object.clone(obj);
+                }
+                newObj.setCoords();
+                this.canvas.add(newObj);
+                newObjects.push(newObj);
+              });
+              const group = new fabric.Group(newObjects, { canvas: this.canvas });
 
-            // Shift copied object to the left if there's space
-            this.copyLeft = (this.copyLeft + group.getWidth() > this.canvas.getWidth()) ?
-              this.copyLeft : this.copyLeft + 10;
-            group.setLeft(this.copyLeft);
-            // Shift copied object down if there's space
-            this.copyTop = (this.copyTop + group.getHeight() > this.canvas.getHeight()) ?
-              this.copyTop : this.copyTop + 10;
-            group.setTop(this.copyTop);
-
-            group.setCoords();
-            this.canvas.setActiveGroup(group);
-            group.saveCoords();
-            this.canvas.renderAll();
+              this.setCopiedCanvasObjectPosition(group);
+              this.canvas.setActiveGroup(group);
+              group.saveCoords();
+              this.canvas.renderAll();
+            }
           }
           break;
         }
@@ -758,10 +769,40 @@ export default class ScribingCanvas extends React.Component {
   }
 
   // Utility Helpers
+  cloneText = (obj) => {
+    const newObj = new fabric.IText(obj.text, {
+      left: obj.getLeft(),
+      top: obj.getTop(),
+      fontFamily: obj.fontFamily,
+      fontSize: obj.fontSize,
+      fill: obj.fill,
+      padding: 5,
+    });
+    newObj.setControlsVisibility({
+      bl: false,
+      br: false,
+      mb: false,
+      ml: false,
+      mr: false,
+      mt: false,
+      tl: false,
+      tr: false,
+    });
+    return newObj;
+  }
 
-  getRgbaHelper = json => (
-    `rgba(${json.r},${json.g},${json.b},${json.a})`
-  );
+  setCopiedCanvasObjectPosition(obj) {
+    // Shift copied object to the left if there's space
+    this.copyLeft = (this.copyLeft + obj.getWidth() > this.canvas.getWidth()) ?
+      this.copyLeft : this.copyLeft + 10;
+    obj.setLeft(this.copyLeft);
+    // Shift copied object down if there's space
+    this.copyTop = (this.copyTop + obj.getHeight() > this.canvas.getHeight()) ?
+      this.copyTop : this.copyTop + 10;
+    obj.setTop(this.copyTop);
+
+    obj.setCoords();
+  }
 
   getMousePoint = event => (
     {

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -291,6 +291,17 @@ export default class ScribingCanvas extends React.Component {
         top: this.mouseCanvasDragStartPoint.y,
         padding: 5,
       });
+      // Don't allow scaling of text object
+      text.setControlsVisibility({
+        bl: false,
+        br: false,
+        mb: false,
+        ml: false,
+        mr: false,
+        mt: false,
+        tl: false,
+        tr: false,
+      });
       this.canvas.add(text);
       this.canvas.setActiveObject(text);
       text.enterEditing();
@@ -522,7 +533,22 @@ export default class ScribingCanvas extends React.Component {
 
       // Layer for current user's scribble
       // Enables scribble selection
-      userScribble.map(obj => (this.canvas.add(obj)));
+      userScribble.forEach((obj) => {
+        // Don't allow scaling of text object
+        if (obj.type === 'i-text') {
+          obj.setControlsVisibility({
+            bl: false,
+            br: false,
+            mb: false,
+            ml: false,
+            mr: false,
+            mt: false,
+            tl: false,
+            tr: false,
+          });
+        }
+        this.canvas.add(obj);
+      });
     }
     this.canvas.setBackground();
     this.canvas.renderAll();

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
@@ -213,7 +213,7 @@ class ScribingToolbar extends Component {
   onClickSelectionMode = () => {
     this.props.setToolSelected(this.props.answerId, scribingTools.SELECT);
     this.props.setDrawingMode(this.props.answerId, false);
-    this.props.setCanvasCursor(this.props.answerId, 'pointer');
+    this.props.setCanvasCursor(this.props.answerId, 'default');
     this.props.setEnableObjectSelection(this.props.answerId);
   }
 
@@ -425,7 +425,7 @@ class ScribingToolbar extends Component {
         </ToolbarGroup>
         <ToolbarGroup>
           <FontIcon
-            className="fa fa-hand-pointer-o"
+            className="fa fa-mouse-pointer"
             style={this.props.scribing.selectedTool === scribingTools.SELECT ?
               { ...styles.tool, color: blue500 } : styles.tool}
             onClick={this.onClickSelectionMode}

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
@@ -217,8 +217,8 @@ class ScribingToolbar extends Component {
     this.props.setEnableObjectSelection(this.props.answerId);
   }
 
-  onClickPanMode = () => {
-    this.props.setToolSelected(this.props.answerId, scribingTools.PAN);
+  onClickMoveMode = () => {
+    this.props.setToolSelected(this.props.answerId, scribingTools.MOVE);
     this.props.setDrawingMode(this.props.answerId, false);
     this.props.setCanvasCursor(this.props.answerId, 'move');
     this.props.setDisableObjectSelection(this.props.answerId);
@@ -463,17 +463,17 @@ class ScribingToolbar extends Component {
         <ToolbarGroup>
           <FontIcon
             className="fa fa-arrows"
-            style={this.props.scribing.selectedTool === scribingTools.PAN ?
+            style={this.props.scribing.selectedTool === scribingTools.MOVE ?
               { color: blue500 } : {}}
-            onClick={this.onClickPanMode}
-            onMouseEnter={() => this.onMouseEnter(scribingTools.PAN)}
+            onClick={this.onClickMoveMode}
+            onMouseEnter={() => this.onMouseEnter(scribingTools.MOVE)}
             onMouseLeave={this.onMouseLeave}
             hoverColor={blue500}
           >
             <MaterialTooltip
               horizontalPosition={'center'}
-              label={intl.formatMessage(translations.pan)}
-              show={this.state.hoveredToolTip === scribingTools.PAN}
+              label={intl.formatMessage(translations.move)}
+              show={this.state.hoveredToolTip === scribingTools.MOVE}
               verticalPosition={'top'}
             />
           </FontIcon>

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingToolbar.jsx
@@ -424,22 +424,6 @@ class ScribingToolbar extends Component {
           />
         </ToolbarGroup>
         <ToolbarGroup>
-          <FontIcon
-            className="fa fa-mouse-pointer"
-            style={this.props.scribing.selectedTool === scribingTools.SELECT ?
-              { ...styles.tool, color: blue500 } : styles.tool}
-            onClick={this.onClickSelectionMode}
-            onMouseEnter={() => this.onMouseEnter(scribingTools.SELECT)}
-            onMouseLeave={this.onMouseLeave}
-            hoverColor={blue500}
-          >
-            <MaterialTooltip
-              horizontalPosition={'center'}
-              label={intl.formatMessage(translations.select)}
-              show={this.state.hoveredToolTip === scribingTools.SELECT}
-              verticalPosition={'top'}
-            />
-          </FontIcon>
           <LayersComponent
             onTouchTap={event => (this.onTouchTapPopover(event, scribingPopoverTypes.LAYER))}
             disabled={
@@ -461,6 +445,21 @@ class ScribingToolbar extends Component {
           />
         </ToolbarGroup>
         <ToolbarGroup>
+          <FontIcon
+            className="fa fa-mouse-pointer"
+            color={this.props.scribing.selectedTool === scribingTools.SELECT ? blue500 : undefined}
+            onClick={this.onClickSelectionMode}
+            onMouseEnter={() => this.onMouseEnter(scribingTools.SELECT)}
+            onMouseLeave={this.onMouseLeave}
+            hoverColor={blue500}
+          >
+            <MaterialTooltip
+              horizontalPosition={'center'}
+              label={intl.formatMessage(translations.select)}
+              show={this.state.hoveredToolTip === scribingTools.SELECT}
+              verticalPosition={'top'}
+            />
+          </FontIcon>
           <FontIcon
             className="fa fa-arrows"
             style={this.props.scribing.selectedTool === scribingTools.MOVE ?

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/fields/ShapeField.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/fields/ShapeField.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import FontIcon from 'material-ui/FontIcon';
-import IconButton from 'material-ui/IconButton';
+import FlatButton from 'material-ui/FlatButton';
 import { blue500 } from 'material-ui/styles/colors';
 
 import { scribingTranslations as translations } from '../../../translations';
@@ -19,28 +19,26 @@ const ShapeField = (props) => {
 
   return (
     <div>
-      <IconButton
-        tooltip={intl.formatMessage(translations.rectangle)}
-        tooltipPosition="top-center"
+      <FlatButton
+        label={intl.formatMessage(translations.rectangle)}
+        primary={currentShape === scribingShapes.RECT}
         onClick={() => (setSelectedShape(scribingShapes.RECT))}
-      >
-        <FontIcon
+        icon={<FontIcon
           color={currentShape === scribingShapes.RECT ?
             blue500 : 'rgba(0, 0, 0, 0.4)'}
           className="fa fa-square-o"
-        />
-      </IconButton>
-      <IconButton
-        tooltip={intl.formatMessage(translations.ellipse)}
-        tooltipPosition="top-center"
+        />}
+      />
+      <FlatButton
+        label={intl.formatMessage(translations.ellipse)}
+        primary={currentShape === scribingShapes.ELLIPSE}
         onClick={() => (setSelectedShape(scribingShapes.ELLIPSE))}
-      >
-        <FontIcon
+        icon={<FontIcon
           color={currentShape === scribingShapes.ELLIPSE ?
             blue500 : 'rgba(0, 0, 0, 0.4)'}
           className="fa fa-circle-o"
-        />
-      </IconButton>
+        />}
+      />
     </div>
   );
 };

--- a/client/app/bundles/course/assessment/submission/constants.js
+++ b/client/app/bundles/course/assessment/submission/constants.js
@@ -61,7 +61,7 @@ export const scribingTools = mirrorCreator([
   'LINE',
   'SHAPE',
   'SELECT',
-  'PAN',
+  'MOVE',
   'ZOOM_IN',
   'ZOOM_OUT',
   'DELETE',

--- a/client/app/bundles/course/assessment/submission/reducers/scribing.js
+++ b/client/app/bundles/course/assessment/submission/reducers/scribing.js
@@ -42,7 +42,7 @@ export default function (state = {}, action) {
               imageWidth: 0,
               imageHeight: 0,
               fontFamily: 'Arial',
-              fontSize: 12,
+              fontSize: 23,
               colors: initializeToolColor(),
               lineStyles: initializeLineStyles(),
               thickness: initializeToolThickness(),

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -353,7 +353,7 @@ export const scribingTranslations = defineMessages({
   },
   delete: {
     id: 'course.assessment.submission.answer.scribing.delete',
-    defaultMessage: 'Delete',
+    defaultMessage: 'Delete Object',
   },
   saving: {
     id: 'course.assessment.submission.answer.scribing.saving',

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -339,9 +339,9 @@ export const scribingTranslations = defineMessages({
     id: 'course.assessment.submission.answer.scribing.layers',
     defaultMessage: 'Layers',
   },
-  pan: {
-    id: 'course.assessment.submission.answer.scribing.pan',
-    defaultMessage: 'Pan',
+  move: {
+    id: 'course.assessment.submission.answer.scribing.move',
+    defaultMessage: 'Move',
   },
   zoomIn: {
     id: 'course.assessment.submission.answer.scribing.zoomIn',

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -335,9 +335,9 @@ export const scribingTranslations = defineMessages({
     id: 'course.assessment.submission.answer.scribing.select',
     defaultMessage: 'Select',
   },
-  layers: {
-    id: 'course.assessment.submission.answer.scribing.layers',
-    defaultMessage: 'Layers',
+  layersLabelText: {
+    id: 'course.assessment.submission.answer.scribing.layersLabelText',
+    defaultMessage: 'Show work from:',
   },
   move: {
     id: 'course.assessment.submission.answer.scribing.move',


### PR DESCRIPTION
Many minor UI changes after user testing with the teachers.

Namely,
- Rename 'Pan' tool to 'Move' tool
- Add shape name beside shape icons in shapeField (so that they won't look like checkboxes)
- Remove the default word 'text' during typing
- Changed the icon for Select tool (hand-select to mouse select)
- Demarcate non-canvas areas with grey color
- Edited the display of 'layers' to make it clearer that other people's work can be found there
- Add note to PDF uploads in new scribing question page