### PR TITLE
Video comments integration

### DIFF
--- a/app/controllers/course/video/submission/submissions_controller.rb
+++ b/app/controllers/course/video/submission/submissions_controller.rb
@@ -18,7 +18,11 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
     end
   end
 
-  def edit; end
+  def edit
+    @topics = @video.topics.includes(posts: :children).order(:timestamp)
+    @topics = @topics.reject { |topic| topic.posts.empty? }
+    @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
+  end
 
   private
 

--- a/app/controllers/course/video/topics_controller.rb
+++ b/app/controllers/course/video/topics_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+class Course::Video::TopicsController < Course::Video::Controller
+  load_and_authorize_resource :topic, through: :video, class: Course::Video::Topic.name
+  before_action :load_existing_topic, only: :create
+
+  include Course::Discussion::PostsConcern
+  skip_load_and_authorize_resource :post, except: :create
+
+  def index
+    @topics = @video.topics.includes(posts: :children).order(:timestamp)
+    @topics = @topics.reject { |topic| topic.posts.empty? }
+    @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
+  end
+
+  def create
+    result = @topic.class.transaction do
+      @post.title = @video.title
+      raise ActiveRecord::Rollback unless @post.save && create_topic_subscription && update_topic_pending_status
+      raise ActiveRecord::Rollback unless @topic.save
+      true
+    end
+
+    head :bad_request unless result
+  end
+
+  def show
+  end
+
+  private
+
+  def topic_params
+    params.permit(:timestamp, :video_id)
+  end
+
+  def timestamp_param
+    topic_params[:timestamp]
+  end
+
+  def parent_id_param
+    params.try(:[], :discussion_post).try(:[], :parent_id)
+  end
+
+  def discussion_topic
+    @topic.try(:discussion_topic)
+  end
+
+  def create_topic_subscription
+    @topic.ensure_subscribed_by(current_user)
+  end
+
+  def load_existing_topic
+    return unless timestamp_param || parent_id_param
+
+    topic = if timestamp_param
+              @video.topics.find_by(timestamp: timestamp_param.to_i)
+            elsif parent_id_param
+              Course::Discussion::Post.find(parent_id_param).topic.specific
+            end
+    @topic = topic unless topic.nil?
+  end
+end

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -18,6 +18,8 @@ module Course::VideosAbilityComponent
     allow_student_attempt_video
     allow_student_create_video_submission
     allow_student_update_own_video_submission
+    allow_student_show_video_topics
+    allow_student_create_video_topics
   end
 
   def define_staff_video_permissions
@@ -65,5 +67,13 @@ module Course::VideosAbilityComponent
 
   def allow_staff_read_and_update_video_submission
     can [:read, :update], Course::Video::Submission, video: video_all_course_staff_hash
+  end
+
+  def allow_student_show_video_topics
+    can :read, Course::Video::Topic, video: video_all_course_users_hash
+  end
+
+  def allow_student_create_video_topics
+    can :create, Course::Video::Topic, video: video_all_course_users_hash
   end
 end

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -7,6 +7,8 @@ class Course::Video < ApplicationRecord
 
   has_many :submissions, class_name: Course::Video::Submission.name,
                          inverse_of: :video, dependent: :destroy
+  has_many :topics, class_name: Course::Video::Topic.name,
+                    dependent: :destroy, foreign_key: :video_id, inverse_of: :video
 
   # TODO: Refactor this together with assessments.
   # @!method self.ordered_by_date_and_title

--- a/app/models/course/video/topic.rb
+++ b/app/models/course/video/topic.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class Course::Video::Topic < ActiveRecord::Base
+  acts_as_discussion_topic
+
+  belongs_to :video, inverse_of: :topics
+
+  after_initialize :set_course, if: :new_record?
+
+  private
+
+  # Set the course as the same course of the lesson plan item.
+  def set_course
+    self.course ||= video.lesson_plan_item.course if video
+  end
+end

--- a/app/views/course/users/_user.json.jbuilder
+++ b/app/views/course/users/_user.json.jbuilder
@@ -1,0 +1,3 @@
+json.userName user.name
+json.userLink link_to_user(user)
+json.userPicElement display_user_image(user)

--- a/app/views/course/video/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/video/submission/submissions/edit.json.jbuilder
@@ -1,3 +1,8 @@
 json.video do
   json.videoUrl @video.url
 end
+
+json.discussion do
+  json.partial! 'course/video/topics/topics', locals: { topics: @topics }
+  json.partial! 'course/video/topics/posts', locals: { posts: @posts }
+end

--- a/app/views/course/video/topics/_post.json.jbuilder
+++ b/app/views/course/video/topics/_post.json.jbuilder
@@ -1,0 +1,9 @@
+json.partial! 'course/users/user', locals: { user: post.creator }
+
+json.createdAt format_datetime(post.created_at)
+json.content format_html(post.text)
+json.canUpdate can?(:update, post)
+json.canDelete can?(:destroy, post)
+json.topicId post.topic.specific.id.to_s
+json.discussionTopicId post.topic.id.to_s
+json.childrenIds post.children.map(&:id).map(&:to_s)

--- a/app/views/course/video/topics/_posts.json.jbuilder
+++ b/app/views/course/video/topics/_posts.json.jbuilder
@@ -1,0 +1,7 @@
+json.posts do
+  posts.each do |post|
+    json.set! post.id do
+      json.partial! 'course/video/topics/post', locals: { post: post }
+    end
+  end
+end

--- a/app/views/course/video/topics/_topic.json.jbuilder
+++ b/app/views/course/video/topics/_topic.json.jbuilder
@@ -1,0 +1,8 @@
+json.timestamp topic.timestamp
+json.topLevelPostIds(
+  topic.
+    discussion_topic.
+    posts.
+    ordered_topologically.
+    map { |post, _| post.id.to_s }
+)

--- a/app/views/course/video/topics/_topics.json.jbuilder
+++ b/app/views/course/video/topics/_topics.json.jbuilder
@@ -1,0 +1,7 @@
+json.topics do
+  topics.each do |topic|
+    json.set! topic.id do
+      json.partial! topic
+    end
+  end
+end

--- a/app/views/course/video/topics/create.json.jbuilder
+++ b/app/views/course/video/topics/create.json.jbuilder
@@ -1,0 +1,10 @@
+json.topicId @topic.id.to_s
+json.topic @topic, partial: 'course/video/topics/topic', as: :topic
+
+json.postId @post.id.to_s
+json.post @post, partial: 'course/video/topics/post', as: :post
+
+if @post.parent.present?
+  json.parentPostId @post.parent.id.to_s
+  json.parentPost @post.parent, partial: 'course/video/topics/post', as: :post
+end

--- a/app/views/course/video/topics/index.json.jbuilder
+++ b/app/views/course/video/topics/index.json.jbuilder
@@ -1,0 +1,2 @@
+json.partial! 'course/video/topics/topics', locals: { topics: @topics }
+json.partial! 'course/video/topics/posts', locals: { posts: @posts }

--- a/app/views/course/video/topics/show.json.jbuilder
+++ b/app/views/course/video/topics/show.json.jbuilder
@@ -1,0 +1,10 @@
+json.topicId @topic.id.to_s
+json.topic @topic, partial: 'course/video/topics/topic', as: :topic
+
+json.posts do
+  @topic.posts.each do |post|
+    json.set! post.id do
+      json.partial! 'course/video/topics/post', locals: { post: post }
+    end
+  end
+end

--- a/client/app/api/course/Posts.js
+++ b/client/app/api/course/Posts.js
@@ -1,0 +1,32 @@
+import BaseCourseAPI from './Base';
+
+export default class PostsAPI extends BaseCourseAPI {
+
+  /**
+   * Updates a discussion post
+   *
+   * @param {number} topicId
+   * @param {number} postId
+   * @param {object} fields
+   *   - params in the format of { :discussion_post }
+   * @return {Promise}
+   */
+  update(topicId, postId, fields) {
+    return this.getClient().patch(this._getUrl(topicId, postId), fields);
+  }
+
+  /**
+   * Deletes a discussion post
+   *
+   * @param {number} topicId
+   * @param {number} postId
+   * @return {Promise}
+   */
+  delete(topicId, postId) {
+    return this.getClient().delete(this._getUrl(topicId, postId));
+  }
+
+  _getUrl(topicId, postId) {
+    return `/courses/${this.getCourseId()}/comments/${topicId}/posts/${postId}`;
+  }
+}

--- a/client/app/api/course/Video/Base.js
+++ b/client/app/api/course/Video/Base.js
@@ -1,0 +1,11 @@
+/* eslint class-methods-use-this: "off" */
+import { getVideoId as getVideoIdFromUrl } from 'lib/helpers/url-helpers';
+import BaseCourseAPI from '../Base';
+
+/** Video level Api helpers should be defined here */
+export default class BaseVideoAPI extends BaseCourseAPI {
+  getVideoId() {
+    // TODO: Read the id from redux state or server context
+    return getVideoIdFromUrl();
+  }
+}

--- a/client/app/api/course/Video/Topics.js
+++ b/client/app/api/course/Video/Topics.js
@@ -1,0 +1,90 @@
+import { getVideoId } from 'lib/helpers/url-helpers';
+
+import BaseCourseAPI from '../Base';
+
+export default class TopicsAPI extends BaseCourseAPI {
+
+  /**
+   * topic = {
+   *    timestamp: int
+   *      - the video progress for this topic
+   *    topLevelPostIds: Array.<int>
+   *      - ids are for posts directly under the topic without parent posts
+   */
+
+  /**
+   * post = {
+   *   userName: string.
+   *   userLink: string,
+   *     - HTML <a> tag
+   *   userPicElement: string
+   *     - HTML element with image
+   *   createdAt: string
+   *     - Formatted datetime
+   *   content: string
+   *     - content in HTML
+   *   canUpdate: bool
+   *     - true if server allows current user to update the post
+   *   canDelete: bool
+   *     - true if server allows current user to delete the post
+   *   topicId:
+   *     - id for the Course::Video::Topic
+   *   discussionTopicId:
+   *     - id for the Course::Discussion::Topic
+   *   childrenIds:
+   *     - ids for children posts
+   * }
+   */
+
+  /**
+   * Creates a video discussion post
+   *
+   * @param {object} fields
+   *   - params in the format of { :timestamp, :discussion_topic } }
+   * @return {Promise} A promise for the server's response.
+   * success response: {
+   *    topicId: string.
+   *    topic: topic.
+   *    postId: string,
+   *    post: post,
+   *    parentPostId: string,
+   *    parentPost: post
+   *      - parentPostId and parentPost are only shown if the post created has a parent
+   * }
+   */
+  create(fields) {
+    return this.getClient().post(this._getUrlPrefix(), fields);
+  }
+
+  /**
+   * Retrieves a video discussion topic
+   *
+   * @param {number} topicId The id of the topic to retrieve
+   * @return {Promise} A promise for the server's response.
+   * success response: {
+   *    topicId: string,
+   *    topic: topic
+   *    posts: { <postId>: post, ... }
+   * }
+   */
+  show(topicId) {
+    return this.getClient().get(`${this._getUrlPrefix()}/${topicId}`);
+  }
+
+  /**
+   * Retrieves all topics and discussion for this video.
+   *
+   * @return {Promise} A promise for the server's response.
+   * success response: {
+   *    topics: { <topicId>: topic, ... }
+   *    posts: { <postId>: post, ... }
+   * }
+   */
+  index() {
+    return this.getClient().get(this._getUrlPrefix());
+  }
+
+  _getUrlPrefix() {
+    return `/courses/${this.getCourseId()}/videos/${getVideoId()}/topics`;
+  }
+}

--- a/client/app/api/course/Video/index.js
+++ b/client/app/api/course/Video/index.js
@@ -1,0 +1,9 @@
+import TopicsAPI from './Topics';
+
+const VideoAPI = {
+  topics: new TopicsAPI(),
+};
+
+Object.freeze(VideoAPI);
+
+export default VideoAPI;

--- a/client/app/api/course/index.js
+++ b/client/app/api/course/index.js
@@ -6,7 +6,9 @@ import MaterialsAPI from './Materials';
 import MaterialFoldersAPI from './MaterialFolders';
 import LessonPlanAPI from './LessonPlan';
 import DuplicationAPI from './Duplication';
+import PostsAPI from './Posts';
 import SurveyAPI from './Survey';
+import VideoAPI from './Video';
 import AdminAPI from './Admin';
 import ScribingQuestionAPI from './Assessment/question/scribing';
 
@@ -19,7 +21,9 @@ const CourseAPI = {
   materialFolders: new MaterialFoldersAPI(),
   lessonPlan: new LessonPlanAPI(),
   duplication: new DuplicationAPI(),
+  posts: new PostsAPI(),
   survey: SurveyAPI,
+  video: VideoAPI,
   admin: AdminAPI,
   question: {
     scribing: ScribingQuestionAPI,

--- a/client/app/bundles/course/video/submission/actions/discussion.js
+++ b/client/app/bundles/course/video/submission/actions/discussion.js
@@ -1,6 +1,6 @@
 import CourseAPI from 'api/course';
 import { discussionActionTypes, postRequestingStatuses } from 'lib/constants/videoConstants';
-import { setNotification } from './notification';
+import setNotification from './notification';
 
 /**
  * Creates an action to update the new post being created with the main comment box.

--- a/client/app/bundles/course/video/submission/actions/discussion.js
+++ b/client/app/bundles/course/video/submission/actions/discussion.js
@@ -1,0 +1,395 @@
+import CourseAPI from 'api/course';
+import { discussionActionTypes, postRequestingStatuses } from 'lib/constants/videoConstants';
+import { setNotification } from './notification';
+
+/**
+ * Creates an action to update the new post being created with the main comment box.
+ *
+ * The new properties provided are meant to be merged in, and any omitted properties will not be affected.
+ * @param postProps The new properties for the new post
+ * @returns {{type: discussionActionTypes, postProps: Object}} The update action
+ */
+export function updateNewPost(postProps) {
+  return {
+    type: discussionActionTypes.UPDATE_NEW_POST,
+    postProps,
+  };
+}
+
+/**
+ * Creates an action to add a new post.
+ *
+ * Note that this action does not update the children associations for the parent topic/post of this post. They have
+ * to be changed via another action separately.
+ *
+ * Defaults in the reducer will be applied to the new post's properties if they are not specified.
+ *
+ * If a post with the id already exists, it will be totally replaced by this new post. Attributes will not be merged.
+ * @param postId The id of the new post
+ * @param postProps The state properties of the new post
+ * @returns {{type: discussionActionTypes, postId: string, postProps: Object}} The add post action
+ */
+function addPost(postId, postProps) {
+  return {
+    type: discussionActionTypes.ADD_POST,
+    postId,
+    postProps,
+  };
+}
+
+/**
+ * Creates an action that will update the properties of an existing post.
+ *
+ * The new properties provided are meant to be merged in, and any omitted properties will not be affected.
+ * @param postId The id of the post as a string
+ * @param postProps The properties to update
+ * @returns {{type: discussionActionTypes, postId: string, postProps: Object}} The update post action
+ */
+export function updatePost(postId, postProps) {
+  return {
+    type: discussionActionTypes.UPDATE_POST,
+    postId,
+    postProps,
+  };
+}
+
+/**
+ * Creates an action to remove a post from the state.
+ *
+ * This action will simply remove the post from the state dictionary. It will NOT update any associations. They have to
+ * be updated via upsertTopic and updatePost.
+ *
+ * Also note that removing a post with children will produce orphans if no re-parenting operations are carried out.
+ *
+ * @param postId The id of the post to remove as a string
+ * @returns {{type: discussionActionTypes, postId: string}} The remove post action
+ */
+function removePost(postId) {
+  return {
+    type: discussionActionTypes.REMOVE_POST,
+    postId,
+  };
+}
+
+/**
+ * Creates an action to add a topic to the store.
+ *
+ * Defaults for a topic properties will be applied if they are not set.
+ *
+ * If a topic with the id already exists, it will be totally replaced by this new topic. Attributes will not be merged.
+ * @param topicId The id of the new topic
+ * @param topicProps The properties of the new topic
+ * @returns {{type: discussionActionTypes, topicId: string, topicProps: Object}} The create topic action
+ */
+function addTopic(topicId, topicProps) {
+  return {
+    type: discussionActionTypes.ADD_TOPIC,
+    topicId,
+    topicProps,
+  };
+}
+
+/**
+ * Creates an action that will update the properties of an existing topic.
+ *
+ * The new properties provided are meant to be merged in, and any omitted properties will not be affected.
+ * @param topicId The id of the post as a string
+ * @param topicProps The properties to update
+ * @returns {{type: discussionActionTypes, topicId: string, topicProps: Object}} The update topic action
+ */
+function updateTopic(topicId, topicProps) {
+  return {
+    type: discussionActionTypes.UPDATE_TOPIC,
+    topicId,
+    topicProps,
+  };
+}
+
+/**
+ * Creates an action to remove a topic.
+ *
+ * When a topic is removed, the posts that are nested under the topic will NOT be removed. Instead they will persist
+ * in the state as orphaned entries.
+ * @param topicId The id of the topic to remove
+ * @returns {{type: discussionActionTypes, topicId: string}} The remove topic action
+ */
+function removeTopic(topicId) {
+  return {
+    type: discussionActionTypes.REMOVE_TOPIC,
+    topicId,
+  };
+}
+
+/**
+ * Creates and action to add a reply to a post.
+ *
+ * The reply will be created with default reply properties.
+ * @param parentId The id of the post the reply is for
+ * @returns {{type: discussionActionTypes, parentId: string}} The add reply action
+ */
+export function addReply(parentId) {
+  return {
+    type: discussionActionTypes.ADD_REPLY,
+    parentId,
+  };
+}
+
+/**
+ * Creates and action to update a reply.
+ *
+ * The properties provided will be merged into the original reply state. Properties that are not specified will not
+ * be touched.
+ * @param parentId The post id of the post the reply is for
+ * @param replyProps The properties of the reply
+ * @returns {{type: discussionActionTypes, parentId: string, replyProps: Object}} The update reply action
+ */
+export function updateReply(parentId, replyProps) {
+  return {
+    type: discussionActionTypes.UPDATE_REPLY,
+    parentId,
+    replyProps,
+  };
+}
+
+/**
+ * Creates an action to remove a reply.
+ * @param parentId The post id the reply is for, used as a key
+ * @returns {{type: discussionActionTypes, parentId: string}} The remove reply action
+ */
+function removeReply(parentId) {
+  return {
+    type: discussionActionTypes.REMOVE_REPLY,
+    parentId,
+  };
+}
+
+/**
+ * Creates an action to change the auto scrolling state for the comments.
+ *
+ * If enabled, the comments in the comments box should be displayed only as the video plays and surpasses the timestamp.
+ * @param autoScroll The new autoscroll state
+ * @returns {{type: discussionActionTypes, autoScroll: bool}}
+ */
+export function changeAutoScroll(autoScroll) {
+  return {
+    type: discussionActionTypes.CHANGE_AUTO_SCROLL,
+    autoScroll,
+  };
+}
+
+/**
+ * Creates an action to refresh all topics and posts.
+ *
+ * The parameters expected are pure JS objects mapping id to the actually object, not Immutable maps. The reducer
+ * will convert them.
+ *
+ * @param topics A JS object mapping of topicId to topic
+ * @param posts A JS object mapping of postId to post
+ * @returns {{type: discussionActionTypes, topics: Object, posts: Object}}
+ */
+function refreshAll(topics, posts) {
+  return {
+    type: discussionActionTypes.REFRESH_ALL,
+    topics,
+    posts,
+  };
+}
+
+/**
+ * Creates a thunk to refresh a topic, replacing all it's properties as well as the posts under it.
+ *
+ * This thunk will NOT remove posts that have been orphaned, indicies will be updated according to what was
+ * returned from the server, regardless of whether the actual entity exists or not. Checks for invalid indicies
+ * should be done elsewhere.
+ * @param topicId The id of the topic to refresh
+ * @returns {function(*=)} The thunk to refresh a topic
+ */
+function refreshTopic(topicId) {
+  return (dispatch) => {
+    CourseAPI.video.topics
+      .show(topicId)
+      .then(({ data }) => {
+        const { topic, posts } = data;
+        if (topic !== undefined && topic.topLevelPostIds.length !== 0) {
+          dispatch(updateTopic(topicId, topic));
+          if (posts !== undefined) {
+            Object.entries(posts).forEach(([postId, post]) => dispatch(updatePost(postId, post)));
+          }
+        } else {
+          dispatch(removeTopic(topicId));
+        }
+      })
+      .catch(() => {
+        dispatch(setNotification('Failed to refresh comments, try again later.'));
+      });
+  };
+}
+
+/**
+ * Creates a thunk to refresh everything in discussions.
+ *
+ * This thunk will query the server for all topics and posts and replaces them in the state.
+ *
+ * @returns {function(*)} The thunk to refresh discussions
+ */
+export function refreshDiscussion() {
+  return (dispatch) => {
+    CourseAPI.video.topics
+      .index()
+      .then(({ data }) => {
+        const { topics, posts } = data;
+        dispatch(refreshAll(topics || {}, posts || {}));
+        dispatch(setNotification('Discussion refreshed.'));
+      })
+      .catch(() => {
+        dispatch(setNotification('Error refreshing, please try again later.'));
+      });
+  };
+}
+
+/**
+ * Produces a thunk to submit a reply to the server and waits for a reponse.
+ *
+ * The new reply is then added to the application state with addReply(..).
+ *
+ * Sets the notification and status for the new post object created accordingly too.
+ * @param parentId The parent post id for which the reply is for
+ * @returns {function(*, *)} The thunk that submits the request
+ */
+export function submitNewReplyToServer(parentId) {
+  return (dispatch, getState) => {
+    dispatch(updateReply(parentId, { status: postRequestingStatuses.LOADING }));
+
+    const state = getState();
+    const text = state.discussion.pendingReplyPosts.get(parentId).content;
+
+    if (text === '') {
+      dispatch(setNotification('Comment cannot be blank!'));
+      return;
+    }
+
+    CourseAPI.video.topics
+      .create({ discussion_post: { parent_id: parentId, text } })
+      .then(({ data }) => {
+        const { topicId, topic, postId, post, parentPostId, parentPost } = data;
+
+        dispatch(addPost(postId, post));
+        dispatch(updatePost(parentPostId, parentPost));
+        dispatch(updateTopic(topicId, topic)); // Topic may be new, we just overwrite anyway
+        dispatch(removeReply(parentId));
+      })
+      .catch(() => {
+        dispatch(updateReply(parentId, { status: postRequestingStatuses.ERROR }));
+        dispatch(setNotification('Error replying, please try again later.'));
+      });
+  };
+}
+
+/**
+ * Produces a thunk to submit the new post to the server and waits for a response.
+ *
+ * Sets the notification and status of newTopicPost accordingly too.
+ * @returns {function(*, *)} The thunk that submits the post
+ */
+export function submitNewPostToServer() {
+  return (dispatch, getState) => {
+    dispatch(updateNewPost({ status: postRequestingStatuses.LOADING }));
+
+    const state = getState();
+    const text = state.discussion.newTopicPost.content;
+    const timestamp = Math.round(state.video.playerProgress);
+
+    if (text === '') {
+      dispatch(setNotification('Comment cannot be blank!'));
+      return;
+    }
+
+    CourseAPI.video.topics
+      .create({ timestamp, discussion_post: { text } })
+      .then(({ data }) => {
+        const { topicId, topic, postId, post } = data;
+
+        dispatch(addPost(postId, post));
+        dispatch(addTopic(topicId, topic)); // Topic may be new, we just overwrite anyway
+
+        dispatch(updateNewPost({ content: '', status: postRequestingStatuses.LOADED }));
+        dispatch(setNotification('Comment Added'));
+      })
+      .catch(() => {
+        dispatch(updateNewPost({ status: postRequestingStatuses.ERROR }));
+        dispatch(setNotification('Error adding new comment, please try again later.'));
+      });
+  };
+}
+
+/**
+ * Produces a thunk to update a post on the server.
+ *
+ * The content to update will be retrieved from the application state via the editedContent property of a post.
+ * @param postId The id of the post to update
+ * @returns {function(*, *)} The thunk to update a post
+ */
+export function updatePostOnServer(postId) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const post = state.discussion.posts.get(postId);
+    const text = post.editedContent;
+    const discussionTopicId = post.discussionTopicId;
+
+    if (text === null) {
+      dispatch(updatePost(postId, { editMode: false }));
+      return;
+    } else if (text === '') {
+      dispatch(setNotification('Comment cannot be blank!'));
+      return;
+    }
+
+    dispatch(updatePost(postId, { status: postRequestingStatuses.LOADING }));
+    CourseAPI.posts
+      .update(discussionTopicId, postId, { discussion_post: { text } })
+      .then(({ data }) => {
+        dispatch(updatePost(postId, {
+          editedContent: null,
+          editMode: false,
+          status: postRequestingStatuses.LOADED,
+          content: data.text,
+        }));
+        dispatch(setNotification('Comment edited'));
+      })
+      .catch(() => {
+        dispatch(updatePost(postId, { status: postRequestingStatuses.ERROR }));
+        dispatch(setNotification('Failed to edit comment, please try again later.'));
+      });
+  };
+}
+
+/**
+ * Produces a thunk to delete a post from the server.
+ *
+ * This thunk might remove posts, as well as topics (if they become empty) from the application state.
+ *
+ * Removals are done via removeTopic(..) and removePost(..) and their limitations apply.
+ * @param postId The id of the post to remove
+ * @returns {function(*, *)} The thunk to delete posts from the server
+ */
+export function deletePostFromServer(postId) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const post = state.discussion.posts.get(postId);
+    const discussionTopicId = post.discussionTopicId;
+    const topicId = post.topicId;
+
+    dispatch(updatePost(postId, { status: postRequestingStatuses.LOADING }));
+    CourseAPI.posts
+      .delete(discussionTopicId, postId)
+      .then(() => {
+        dispatch(refreshTopic(topicId));
+        dispatch(removePost(postId));
+        dispatch(setNotification('Comment has been deleted.'));
+      })
+      .catch(() => {
+        dispatch(updatePost(postId, { status: postRequestingStatuses.ERROR }));
+        dispatch(setNotification('Failed to delete comment, please try again later.'));
+      });
+  };
+}

--- a/client/app/bundles/course/video/submission/actions/notification.js
+++ b/client/app/bundles/course/video/submission/actions/notification.js
@@ -1,6 +1,6 @@
 import { notificationActionTypes } from 'lib/constants/videoConstants';
 
-export function setNotification(message) {
+export default function setNotification(message) {
   return (dispatch) => {
     dispatch({
       type: notificationActionTypes.SET_NOTIFICATION,

--- a/client/app/bundles/course/video/submission/actions/notification.js
+++ b/client/app/bundles/course/video/submission/actions/notification.js
@@ -1,0 +1,10 @@
+import { notificationActionTypes } from 'lib/constants/videoConstants';
+
+export function setNotification(message) {
+  return (dispatch) => {
+    dispatch({
+      type: notificationActionTypes.SET_NOTIFICATION,
+      message,
+    });
+  };
+}

--- a/client/app/bundles/course/video/submission/containers/Discussion.jsx
+++ b/client/app/bundles/course/video/submission/containers/Discussion.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Paper from 'material-ui/Paper';
+import Divider from 'material-ui/Divider';
+
+import styles from './Discussion.scss';
+import NewPostContainer from './DiscussionElements/NewPostContainer';
+import Topic from './DiscussionElements/Topic';
+import Controls from './DiscussionElements/Controls';
+
+const propTypes = {
+  topicIds: PropTypes.arrayOf(PropTypes.string),
+  autoScroll: PropTypes.bool,
+};
+
+const defaultProps = {
+  topicIds: [],
+  autoScroll: false,
+};
+
+class Discussion extends React.Component {
+  constructor(props) {
+    super(props);
+    this.topicPane = null;
+  }
+
+  componentWillUpdate(nextProps) {
+    if (this.props.autoScroll && !nextProps.autoScroll) {
+      this.savedAutoScrollPos = this.topicPane.scrollTop;
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!this.props.autoScroll && prevProps.autoScroll) {
+      this.topicPane.scrollTop = this.savedAutoScrollPos;
+    } else if (this.props.autoScroll) {
+      this.topicPane.scrollTop = this.topicPane.scrollHeight;
+    }
+  }
+
+  setRef = (topicPaneElement) => {
+    this.topicPane = topicPaneElement;
+  };
+
+  render() {
+    return (
+      <Paper zDepth={2} className={styles.rootContainer}>
+        <div
+          ref={this.setRef}
+          className={styles.topicsContainer}
+          style={{ overflowY: this.props.autoScroll ? 'hidden' : 'scroll' }}
+        >
+          {this.props.topicIds.map(id => <Topic key={id.toString()} topicId={id} />)}
+        </div>
+        <Divider />
+        <div className={styles.newCommentEditor}>
+          <NewPostContainer>
+            <Controls />
+          </NewPostContainer>
+        </div>
+      </Paper>
+    );
+  }
+}
+
+Discussion.propTypes = propTypes;
+Discussion.defaultProps = defaultProps;
+
+function mapStateToProps(state) {
+  // TODO: Use reselect
+  const currentTime = state.video.playerProgress;
+
+  const sortedKeys = state.discussion.topics
+    .filter(topic => topic.topLevelPostIds.length > 0)
+    .filter(topic => !state.discussion.autoScroll || topic.timestamp <= currentTime)
+    .sort((topic1, topic2) => topic1.timestamp - topic2.timestamp)
+    .keySeq()
+    .toArray();
+  return {
+    topicIds: sortedKeys,
+    autoScroll: state.discussion.autoScroll,
+  };
+}
+
+export default connect(mapStateToProps)(Discussion);

--- a/client/app/bundles/course/video/submission/containers/Discussion.scss
+++ b/client/app/bundles/course/video/submission/containers/Discussion.scss
@@ -1,0 +1,73 @@
+$pic-width: 30px;
+$pic-margin: 10px;
+$indent: $pic-width + $pic-margin;
+$comment-background: #ffffff;
+
+.rootContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.newCommentEditor {
+  background-color: $comment-background;
+  padding: 1em;
+  width: 100%;
+}
+
+.topicsContainer {
+  flex: 1;
+  padding: 1em 1em 0;
+}
+
+.replyContainer {
+  margin-bottom: 1em;
+}
+
+.contentContainer {
+  display: inline-block;
+  margin-bottom: 1em;
+  max-width: 800px;
+  width: calc(100% - 100px);
+}
+
+.userPic {
+  img {
+    border-radius: 50%;
+    height: $pic-width;
+    margin-right: $pic-margin;
+    object-fit: cover;
+    object-position: center;
+    vertical-align: top;
+    width: $pic-width;
+  }
+}
+
+.replyIndent {
+  margin-left: $indent;
+}
+
+.topicTimestamp {
+  margin-bottom: 1em;
+}
+
+.userName {
+  margin-right: 0.5em;
+}
+
+.postTimestamp {
+  display: inline-block;
+  font-size: 0.8em;
+}
+
+.editorButtons {
+  float: right;
+
+  > div {
+    margin-left: 5px;
+  }
+}
+
+.editorExtraElement {
+  float: left;
+}

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Controls.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Controls.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import IconButton from 'material-ui/IconButton';
+import OnDemandVideo from 'material-ui/svg-icons/notification/ondemand-video';
+import Refresh from 'material-ui/svg-icons/navigation/refresh';
+import { cyan500 as activeColor, grey700 as inactiveColor } from 'material-ui/styles/colors';
+
+import { changeAutoScroll, refreshDiscussion } from '../../actions/discussion';
+
+const propTypes = {
+  autoScroll: PropTypes.bool,
+  onAutoScrollToggle: PropTypes.func,
+  onRefresh: PropTypes.func,
+};
+
+const defaultProps = {
+  autoScroll: false,
+};
+
+function Controls(props) {
+  return (
+    <div>
+      <IconButton onClick={props.onRefresh}>
+        <Refresh />
+      </IconButton>
+      <IconButton
+        tooltip="Toggle Live Comments"
+        onClick={() => props.onAutoScrollToggle(!props.autoScroll)}
+      >
+        <OnDemandVideo color={props.autoScroll ? activeColor : inactiveColor} />
+      </IconButton>
+    </div>
+  );
+}
+
+Controls.propTypes = propTypes;
+Controls.defaultProps = defaultProps;
+
+function mapStateToProps(state) {
+  return {
+    autoScroll: state.discussion.autoScroll,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onAutoScrollToggle: newState => dispatch(changeAutoScroll(newState)),
+    onRefresh: () => dispatch(refreshDiscussion()),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Controls);

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/EditPostContainer.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/EditPostContainer.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
+import { postRequestingStatuses } from 'lib/constants/videoConstants';
+
+import Editor from './Editor';
+import { updatePost, updatePostOnServer } from '../../actions/discussion';
+
+const translations = defineMessages({
+  edit: {
+    id: 'course.video.DiscussionElements.EditPostContainer.edit',
+    defaultMessage: 'Edit',
+  },
+});
+
+const propTypes = {
+  postId: PropTypes.string.isRequired,
+};
+
+function mapStateToProps(state, ownProps) {
+  const postObject = state.discussion.posts.get(ownProps.postId);
+  return {
+    content: postObject.editedContent || postObject.content,
+    disabled: postObject.status === postRequestingStatuses.LOADING,
+    submitButtonText: (<FormattedMessage {...translations.edit} />),
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  return {
+    onSubmit: () => dispatch(updatePostOnServer(ownProps.postId)),
+    onCancel: () => dispatch(updatePost(ownProps.postId, { editMode: false })),
+    onContentUpdate: editedContent => dispatch(updatePost(ownProps.postId, { editedContent })),
+  };
+}
+
+const EditPostContainer = connect(mapStateToProps, mapDispatchToProps)(Editor);
+
+EditPostContainer.propTypes = propTypes;
+
+export default EditPostContainer;

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Editor.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Editor.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import ReactSummernote from 'react-summernote';
+import RaisedButton from 'material-ui/RaisedButton';
+
+import style from '../Discussion.scss';
+
+const translations = defineMessages({
+  comment: {
+    id: 'course.video.DiscussionElements.Editor.commentDefault',
+    defaultMessage: 'Comment',
+  },
+  cancel: {
+    id: 'course.video.DiscussionElements.Editor.cancelDefault',
+    defaultMessage: 'Cancel',
+  },
+});
+
+const editorOptions = {
+  airMode: true,
+  dialogsInBody: false,
+  popover: {
+    air: [
+      ['style', ['style']],
+      ['font', ['bold', 'underline', 'clear']],
+      ['script', ['superscript', 'subscript']],
+      ['color', ['color']],
+      ['para', ['ul', 'ol', 'paragraph']],
+      ['table', ['table']],
+      ['insert', ['link', 'picture']],
+    ],
+  },
+};
+
+const propTypes = {
+  content: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  showCancel: PropTypes.bool,
+  cancelButtonText: PropTypes.node,
+  submitButtonText: PropTypes.node,
+  children: React.PropTypes.element,
+  onSubmit: PropTypes.func,
+  onCancel: PropTypes.func,
+  onContentUpdate: PropTypes.func,
+};
+
+const defaultProps = {
+  disabled: false,
+  showCancel: true,
+  cancelButtonText: (<FormattedMessage {...translations.cancel} />),
+  submitButtonText: (<FormattedMessage {...translations.comment} />),
+};
+
+function Editor(props) {
+  return (
+    <div>
+      <ReactSummernote
+        options={Object.assign({}, editorOptions, { disabled: props.disabled })}
+        value={props.content}
+        onChange={props.onContentUpdate}
+      />
+      <div className={style.editorExtraElement}>
+        {props.children}
+      </div>
+      <div className={style.editorButtons}>
+        {props.showCancel && (
+          <RaisedButton
+            label={props.cancelButtonText}
+            onClick={props.onCancel}
+          />
+        )}
+        <RaisedButton
+          label={props.submitButtonText}
+          primary
+          onClick={props.onSubmit}
+        />
+      </div>
+      <div style={{ clear: 'both' }} />
+    </div>
+  );
+}
+
+Editor.propTypes = propTypes;
+Editor.defaultProps = defaultProps;
+
+export default Editor;

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/NewPostContainer.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/NewPostContainer.jsx
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux';
+import { postRequestingStatuses } from 'lib/constants/videoConstants';
+
+import Editor from './Editor';
+import { submitNewPostToServer, updateNewPost } from '../../actions/discussion';
+
+function mapStateToProps(state, ownProps) {
+  const newTopicPost = state.discussion.newTopicPost;
+  return {
+    content: newTopicPost.content,
+    disabled: newTopicPost.status === postRequestingStatuses.LOADING,
+    showCancel: false,
+    children: ownProps.children,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onSubmit: () => dispatch(submitNewPostToServer()),
+    onContentUpdate: content => dispatch(updateNewPost({ content })),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Editor);

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/NewReplyContainer.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/NewReplyContainer.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
+import { postRequestingStatuses } from 'lib/constants/videoConstants';
+
+import Editor from './Editor';
+import { submitNewReplyToServer, updateReply } from '../../actions/discussion';
+
+const translations = defineMessages({
+  reply: {
+    id: 'course.video.DiscussionElements.NewReplyContainer.reply',
+    defaultMessage: 'Reply',
+  },
+});
+
+const propTypes = {
+  parentId: PropTypes.string.isRequired,
+};
+
+function mapStateToProps(state, ownProps) {
+  const pendingReplyPost = state.discussion.pendingReplyPosts.get(ownProps.parentId);
+
+  return {
+    content: pendingReplyPost.content,
+    disabled: pendingReplyPost.status === postRequestingStatuses.LOADING,
+    submitButtonText: (<FormattedMessage {...translations.reply} />),
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  return {
+    onSubmit: () => dispatch(submitNewReplyToServer(ownProps.parentId)),
+    onCancel: () => dispatch(updateReply(ownProps.parentId, { editorVisible: false })),
+    onContentUpdate: content => dispatch(updateReply(ownProps.parentId, { content })),
+  };
+}
+
+const NewPostContainer = connect(mapStateToProps, mapDispatchToProps)(Editor);
+
+NewPostContainer.propTypes = propTypes;
+
+export default NewPostContainer;

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/PostContainer.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/PostContainer.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import PostPresentation from './PostPresentation';
+
+const propTypes = {
+  postId: PropTypes.string.isRequired,
+  isRoot: PropTypes.bool,
+};
+
+const defaultProps = {
+  isRoot: false,
+};
+
+function mapStateToProps(state, ownProps) {
+  const postsStore = state.discussion.posts;
+  const post = postsStore.get(ownProps.postId);
+  const children = post.childrenIds.filter(postId => postsStore.has(postId));
+
+  return {
+    postId: ownProps.postId,
+    userPicElement: post.userPicElement,
+    userLink: post.userLink,
+    createdAt: post.createdAt,
+    content: post.content,
+    childrenIds: children,
+    editMode: post.editMode,
+    isRoot: ownProps.isRoot,
+  };
+}
+
+const PostContainer = connect(mapStateToProps)(PostPresentation);
+
+PostContainer.propTypes = propTypes;
+PostContainer.defaultProps = defaultProps;
+
+export default PostContainer;

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/PostMenu.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/PostMenu.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import IconMenu from 'material-ui/IconMenu';
+import MenuItem from 'material-ui/MenuItem';
+import IconButton from 'material-ui/IconButton';
+import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
+
+import { deletePostFromServer, updatePost } from '../../actions/discussion';
+
+const propTypes = {
+  canUpdate: PropTypes.bool,
+  canDelete: PropTypes.bool,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+};
+
+const defaultProps = {
+  canUpdate: true,
+  canDelete: true,
+};
+
+function PostMenu(props) {
+  // Do not show if user doesn't even have options
+  if (!props.canUpdate && !props.canDelete) {
+    return null;
+  }
+
+  return (
+    <div style={{ float: 'right' }}>
+      <IconMenu
+        iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
+        anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+        targetOrigin={{ horizontal: 'right', vertical: 'top' }}
+      >
+        {props.canUpdate && <MenuItem primaryText="Edit" onClick={props.onEdit} />}
+        {props.canDelete && <MenuItem primaryText="Delete" onClick={props.onDelete} />}
+      </IconMenu>
+    </div>
+  );
+}
+
+PostMenu.propTypes = propTypes;
+PostMenu.defaultProps = defaultProps;
+
+const containerPropTypes = {
+  postId: PropTypes.string.isRequired,
+};
+
+function mapStateToProps(state, ownProps) {
+  const { canUpdate, canDelete } = state.discussion.posts.get(ownProps.postId);
+  return { canUpdate, canDelete };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  return {
+    onEdit: () => dispatch(updatePost(ownProps.postId, { editMode: true })),
+    onDelete: () => dispatch(deletePostFromServer(ownProps.postId)),
+  };
+}
+
+const PostMenuContainer = connect(mapStateToProps, mapDispatchToProps)(PostMenu);
+
+PostMenuContainer.propTypes = containerPropTypes;
+
+export default PostMenuContainer;

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/PostPresentation.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/PostPresentation.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styles from '../Discussion.scss';
+import PostContainer from './PostContainer';
+import EditPostContainer from './EditPostContainer';
+import PostMenu from './PostMenu';
+import Reply from './Reply';
+
+const propTypes = {
+  postId: PropTypes.string.isRequired,
+  userPicElement: PropTypes.string.isRequired,
+  userLink: PropTypes.string.isRequired,
+  createdAt: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  childrenIds: PropTypes.arrayOf(PropTypes.string),
+  editMode: PropTypes.bool,
+  isRoot: PropTypes.bool,
+};
+
+const defaultProps = {
+  childrenId: [],
+  editMode: false,
+  isRoot: false,
+};
+
+function PostPresentation(props) {
+  let childrenElements = null;
+  if (props.isRoot) {
+    const childrenNodes = props.childrenIds.map(childId => <PostContainer key={childId} postId={childId} />);
+    if (childrenNodes.length > 0) {
+      childrenElements = (
+        <div className={styles.replyIndent}>
+          {childrenNodes}
+        </div>
+      );
+    }
+  }
+
+  return (
+    <div className={styles.postContainer}>
+      {props.editMode || <PostMenu postId={props.postId} />}
+      <span className={styles.userPic} dangerouslySetInnerHTML={{ __html: props.userPicElement }} />
+      <div className={styles.contentContainer}>
+        <span dangerouslySetInnerHTML={{ __html: props.userLink }} />
+        &nbsp;
+        <div className={styles.postTimestamp}>{props.createdAt}</div>
+        {props.editMode ? (
+          <EditPostContainer postId={props.postId} />
+        ) : (
+          <div dangerouslySetInnerHTML={{ __html: props.content }} />
+        )}
+      </div>
+      {childrenElements}
+      {props.isRoot && <Reply parentId={props.postId} />}
+    </div>
+  );
+}
+
+PostPresentation.propTypes = propTypes;
+PostPresentation.defaultProps = defaultProps;
+
+export default PostPresentation;

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Reply.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Reply.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import FlatButton from 'material-ui/FlatButton';
+
+import styles from '../Discussion.scss';
+import NewReplyContainer from './NewReplyContainer';
+import { addReply } from '../../actions/discussion';
+
+const propTypes = {
+  parentId: PropTypes.string.isRequired,
+  editorVisible: PropTypes.bool,
+  onTriggerReply: PropTypes.func,
+};
+
+const defaultProps = {
+  editorVisible: false,
+};
+
+function Reply(props) {
+  return props.editorVisible ? (
+    <div className={styles.replyContainer}>
+      <NewReplyContainer parentId={props.parentId} />
+    </div>
+  ) : (
+    <div className={styles.replyContainer}>
+      <FlatButton
+        label="Reply"
+        primary
+        onClick={props.onTriggerReply}
+      />
+    </div>
+  );
+}
+
+Reply.propTypes = propTypes;
+Reply.defaultProps = defaultProps;
+
+const containerPropTypes = {
+  parentId: PropTypes.string.isRequired,
+};
+
+function mapStateToProps(state, ownProps) {
+  const pendingReply = state.discussion.pendingReplyPosts.get(ownProps.parentId);
+  return {
+    parentId: ownProps.parentId,
+    editorVisible: (pendingReply !== undefined) && pendingReply.editorVisible,
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  return {
+    onTriggerReply: () => dispatch(addReply(ownProps.parentId)),
+  };
+}
+
+const ReplyContainer = connect(mapStateToProps, mapDispatchToProps)(Reply);
+
+ReplyContainer.propTypes = containerPropTypes;
+
+export default ReplyContainer;

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Divider from 'material-ui/Divider';
+import { formatTimestamp } from 'lib/helpers/videoHelpers';
+
+import styles from '../Discussion.scss';
+import PostContainer from './PostContainer';
+
+const propTypes = {
+  timestamp: PropTypes.number.isRequired,
+  postIds: PropTypes.arrayOf(PropTypes.string),
+};
+
+const defaultProps = {
+  postIds: [],
+};
+
+function Topic(props) {
+  if (props.postIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className={styles.topicTimestamp}>
+        <span className="glyphicon glyphicon-chevron-down" />
+        &nbsp;
+        <b>Time: {formatTimestamp(props.timestamp)}</b>
+        &nbsp;
+        <span className="glyphicon glyphicon-chevron-down" />
+      </div>
+      <Divider style={{ marginBottom: '1em' }} />
+      <div>
+        {props.postIds.map(id => <PostContainer key={id.toString()} postId={id} isRoot />)}
+      </div>
+      <Divider style={{ marginBottom: '1em' }} />
+      <div className={styles.topicTimestamp}>
+        <span className="glyphicon glyphicon-chevron-up" />
+        &nbsp;
+        <b>Time: {formatTimestamp(props.timestamp)}</b>
+        &nbsp;
+        <span className="glyphicon glyphicon-chevron-up" />
+      </div>
+      <Divider style={{ marginBottom: '1em' }} />
+    </div>
+  );
+}
+
+Topic.propTypes = propTypes;
+Topic.defaultProps = defaultProps;
+
+const containerPropTypes = {
+  topicId: PropTypes.string.isRequired,
+};
+
+function mapStateToProps(state, ownProps) {
+  const topic = state.discussion.topics.get(ownProps.topicId);
+  const postsStore = state.discussion.posts;
+  const postIds = topic.topLevelPostIds.filter(postId => postsStore.has(postId));
+  return {
+    timestamp: topic.timestamp,
+    postIds,
+  };
+}
+
+const TopicContainer = connect(mapStateToProps)(Topic);
+
+TopicContainer.propTypes = containerPropTypes;
+
+export default TopicContainer;

--- a/client/app/bundles/course/video/submission/containers/Submission.jsx
+++ b/client/app/bundles/course/video/submission/containers/Submission.jsx
@@ -1,11 +1,35 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import NotificationBar from 'lib/components/NotificationBar';
 import VideoPlayer from './VideoPlayer';
+import Discussion from './Discussion';
+import styles from './Submission.scss';
 
-class Submission extends React.Component {
-  // TODO: Rest of the components to be rendered here too
-  render() {
-    return <VideoPlayer />;
-  }
+const propTypes = {
+  notification: PropTypes.object,
+};
+
+function Submission(props) {
+  return (
+    <div className={styles.submissionContainer}>
+      <div className={styles.videoAndAnswers}>
+        <VideoPlayer />
+      </div>
+      <div className={styles.discussion}>
+        <Discussion />
+      </div>
+      <NotificationBar notification={props.notification} />
+    </div>
+  );
 }
 
-export default Submission;
+Submission.propTypes = propTypes;
+
+function mapStateToProps(state) {
+  return {
+    notification: state.notification,
+  };
+}
+
+export default connect(mapStateToProps)(Submission);

--- a/client/app/bundles/course/video/submission/containers/Submission.scss
+++ b/client/app/bundles/course/video/submission/containers/Submission.scss
@@ -1,0 +1,27 @@
+.submissionContainer {
+  align-content: flex-start;
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.videoAndAnswers {
+  flex-shrink: 0;
+  margin-bottom: 1em;
+  margin-right: 1em;
+  min-width: 320px;
+  order: 1;
+  width: 65%;
+}
+
+.discussion {
+  flex-grow: 1;
+  height: calc(95vh - 70px);
+  order: 2;
+  padding-left: 5px;
+  position: sticky;
+  top: 60px;
+}

--- a/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
@@ -16,6 +16,14 @@ import {
   VolumeSlider,
 } from './VideoControls';
 
+const reactPlayerStyle = {
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  height: '100%',
+  width: '100%',
+};
+
 const propTypes = {
   videoUrl: PropTypes.string.isRequired,
   playerState: PropTypes.oneOf(Object.values(playerStates)),
@@ -78,24 +86,29 @@ class VideoPlayer extends React.Component {
     if (typeof VideoPlayer.ReactPlayer === 'undefined') return null;
 
     const videoPlayer = (
-      <VideoPlayer.ReactPlayer
-        ref={this.setRef}
-        url={this.props.videoUrl}
-        playing={isPlayingState(this.props.playerState)}
-        volume={this.props.playerVolume}
-        playbackRate={this.props.playbackRate}
-        onDuration={this.props.onDurationReceived}
-        onProgress={({ playedSeconds, loadedSeconds }) => {
-          this.props.onPlayerProgress(playedSeconds, loadedSeconds);
-        }}
-        onPlay={() => this.props.onPlayerStateChanged(playerStates.PLAYING)}
-        onPause={() => this.props.onPlayerStateChanged(playerStates.PAUSED)}
-        onBuffer={() => this.props.onPlayerStateChanged(playerStates.BUFFERING)}
-        onEnded={() => this.props.onPlayerStateChanged(playerStates.ENDED)}
-        playsinline
-        progressFrequency={videoDefaults.progressUpdateFrequencyMs}
-        config={{ youtube: youtubeOpts }}
-      />
+      <div className={styles.playerContainer}>
+        <VideoPlayer.ReactPlayer
+          ref={this.setRef}
+          url={this.props.videoUrl}
+          playing={isPlayingState(this.props.playerState)}
+          volume={this.props.playerVolume}
+          playbackRate={this.props.playbackRate}
+          onDuration={this.props.onDurationReceived}
+          onProgress={({ playedSeconds, loadedSeconds }) => {
+            this.props.onPlayerProgress(playedSeconds, loadedSeconds);
+          }}
+          onPlay={() => this.props.onPlayerStateChanged(playerStates.PLAYING)}
+          onPause={() => this.props.onPlayerStateChanged(playerStates.PAUSED)}
+          onBuffer={() => this.props.onPlayerStateChanged(playerStates.BUFFERING)}
+          onEnded={() => this.props.onPlayerStateChanged(playerStates.ENDED)}
+          playsinline
+          progressFrequency={videoDefaults.progressUpdateFrequencyMs}
+          style={reactPlayerStyle}
+          width="100%"
+          height="100%"
+          config={{ youtube: youtubeOpts }}
+        />
+      </div>
     );
 
     const controls = (
@@ -114,7 +127,7 @@ class VideoPlayer extends React.Component {
     );
 
     return (
-      <Paper zDepth={2} style={{ width: '640px' }}>
+      <Paper zDepth={2} className={styles.videoPaperContainer}>
         {videoPlayer}
         {controls}
       </Paper>

--- a/client/app/bundles/course/video/submission/containers/VideoPlayer.scss
+++ b/client/app/bundles/course/video/submission/containers/VideoPlayer.scss
@@ -7,6 +7,17 @@ $button-width: 30px;
   width: $width;
 }
 
+.videoPaperContainer {
+  width: 100%;
+}
+
+.playerContainer {
+  height: 0;
+  padding-bottom: 56.25%;
+  position: relative;
+  width: 100%;
+}
+
 .controlsContainer {
   padding-bottom: 5px;
 }
@@ -17,8 +28,8 @@ $button-width: 30px;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  height: 3em;
   justify-content: flex-start;
+  height: 3em;
 }
 
 .progressBar {

--- a/client/app/bundles/course/video/submission/reducers/index.js
+++ b/client/app/bundles/course/video/submission/reducers/index.js
@@ -1,5 +1,30 @@
 import { combineReducers } from 'redux';
-import video from './video';
+import video, { initialState as videoState } from './video';
+import discussion, { initialState as discussionState, organiseDiscussionEntities } from './discussion';
+import notification, { initialState as notificationState } from './notification';
 
-// TODO: More reducers will need to be combined here
-export default combineReducers({ video });
+/**
+ * Creates the initial state from the props parsed in from JSON.
+ *
+ * Note that discussion is slightly different in the sense that it makes use of ImmutableJS maps to store the
+ * topics, posts, and pending posts id-to-object maps, so that they can be managed, searched and merged more
+ * explicitly and
+ * efficiently.
+ *
+ * The rest are simply JS objects to make manipulation code terse elsewhere.
+ * @param props The props parsed from JSON
+ * @returns {{video: *, discussion: *, notification: *}} The initial store state
+ */
+export function createInitialState(props) {
+  return {
+    video: Object.assign({}, videoState, props.video),
+    discussion: Object.assign({}, discussionState, organiseDiscussionEntities(props.discussion)),
+    notification: Object.assign({}, notificationState, props.notification),
+  };
+}
+
+export default combineReducers({
+  video,
+  discussion,
+  notification,
+});

--- a/client/app/bundles/course/video/submission/reducers/notification.js
+++ b/client/app/bundles/course/video/submission/reducers/notification.js
@@ -1,0 +1,13 @@
+import { notificationActionTypes } from 'lib/constants/videoConstants';
+
+export const initialState = {};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case notificationActionTypes.SET_NOTIFICATION: {
+      return { message: action.message };
+    }
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/video/submission/store.js
+++ b/client/app/bundles/course/video/submission/store.js
@@ -1,16 +1,13 @@
 import { applyMiddleware, compose, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import rootReducer from './reducers';
-import { initialState as videoInitialState } from './reducers/video';
+import rootReducer, { createInitialState } from './reducers';
 
-export default ({ video }) => {
-  const initialStates = {
-    video: Object.assign({}, videoInitialState, video),
-  };
+export default (props) => {
+  const initialState = createInitialState(props);
   const storeCreator = (process.env.NODE_ENV === 'development') ?
     // eslint-disable-next-line global-require
     compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :
     compose(applyMiddleware(thunkMiddleware))(createStore);
 
-  return storeCreator(rootReducer, initialStates);
+  return storeCreator(rootReducer, initialState);
 };

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -17,6 +17,7 @@ const propTypes = {
   inputId: PropTypes.string,
   required: PropTypes.bool,
   value: PropTypes.string,
+  airMode: PropTypes.bool,
 };
 
 const contextTypes = {
@@ -111,7 +112,7 @@ class MaterialSummernote extends React.Component {
           backgroundColor,
           fontFamily: baseTheme.fontFamily,
           cursor: this.props.disabled ? 'not-allowed' : 'auto',
-          paddingTop: '2.5em',
+          paddingTop: this.props.label ? '2.5em' : 0,
         }}
       >
         <TextFieldLabel
@@ -137,8 +138,11 @@ class MaterialSummernote extends React.Component {
         />
         <div className="material-summernote">
           <ReactSummernote
-            ref={(ref) => { this.reactSummernote = ref; }}
+            ref={(ref) => {
+              this.reactSummernote = ref;
+            }}
             options={{
+              airMode: this.props.airMode,
               dialogsInBody: false,
               disabled: this.props.disabled,
               fontNames: [
@@ -158,11 +162,26 @@ class MaterialSummernote extends React.Component {
                 ['insert', ['link', 'picture', 'video']],
                 ['view', ['fullscreen', 'codeview', 'help']],
               ],
+              popover: {
+                air: [
+                  ['style', ['style']],
+                  ['font', ['bold', 'underline', 'clear']],
+                  ['script', ['superscript', 'subscript']],
+                  ['color', ['color']],
+                  ['para', ['ul', 'ol', 'paragraph']],
+                  ['table', ['table']],
+                  ['insert', ['link', 'picture']],
+                ],
+              },
             }}
             value={this.props.value}
             onChange={this.props.onChange}
-            onFocus={() => { this.setState({ isFocused: true }); }}
-            onBlur={() => { this.setState({ isFocused: false }); }}
+            onFocus={() => {
+              this.setState({ isFocused: true });
+            }}
+            onBlur={() => {
+              this.setState({ isFocused: false });
+            }}
             onImageUpload={this.onImageUpload}
           />
         </div>

--- a/client/app/lib/constants/videoConstants.js
+++ b/client/app/lib/constants/videoConstants.js
@@ -17,6 +17,20 @@ export const videoDefaults = {
   progressUpdateFrequencyMs: 500,
 };
 
+export const playerStates = mirrorCreator([
+  'UNSTARTED',
+  'ENDED',
+  'PLAYING',
+  'PAUSED',
+  'BUFFERING',
+]);
+
+export const postRequestingStatuses = mirrorCreator([
+  'LOADING',
+  'LOADED',
+  'ERROR',
+]);
+
 export const videoActionTypes = mirrorCreator([
   'CHANGE_PLAYER_STATE',
   'CHANGE_PLAYER_VOLUME',
@@ -27,10 +41,21 @@ export const videoActionTypes = mirrorCreator([
   'UPDATE_RESTRICTED_TIME',
 ]);
 
-export const playerStates = mirrorCreator([
-  'UNSTARTED',
-  'ENDED',
-  'PLAYING',
-  'PAUSED',
-  'BUFFERING',
+export const discussionActionTypes = mirrorCreator([
+  'UPDATE_NEW_POST',
+  'ADD_TOPIC',
+  'UPDATE_TOPIC',
+  'REMOVE_TOPIC',
+  'ADD_POST',
+  'UPDATE_POST',
+  'REMOVE_POST',
+  'ADD_REPLY',
+  'UPDATE_REPLY',
+  'REMOVE_REPLY',
+  'CHANGE_AUTO_SCROLL',
+  'REFRESH_ALL',
+]);
+
+export const notificationActionTypes = mirrorCreator([
+  'SET_NOTIFICATION',
 ]);

--- a/client/app/lib/helpers/url-helpers.js
+++ b/client/app/lib/helpers/url-helpers.js
@@ -72,5 +72,15 @@ function getScribingId() {
   return match && match[1];
 }
 
+/**
+ * Get the video id from URL.
+ *
+ * @returns {number}
+ */
+function getVideoId() {
+  const match = window.location.pathname.match(/^\/courses\/\d+\/videos\/(\d+)/);
+  return match && match[1];
+}
+
 /* eslint-disable import/prefer-default-export */
-export { getUrlParameter, getCourseId, getSurveyId, getAssessmentId, getSubmissionId, getScribingId };
+export { getUrlParameter, getCourseId, getSurveyId, getAssessmentId, getSubmissionId, getScribingId, getVideoId };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -325,6 +325,7 @@ Rails.application.routes.draw do
 
       scope module: :video do
         resources :videos do
+          resources :topics, only: [:index, :create, :show]
           scope module: :submission do
             resources :submissions, only: [:index, :create, :edit]
           end

--- a/db/migrate/20171005033946_create_course_video_topics.rb
+++ b/db/migrate/20171005033946_create_course_video_topics.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class CreateCourseVideoTopics < ActiveRecord::Migration
+  def change
+    create_table :course_video_topics do |t|
+      t.references :video, null: false, foreign_key: { references: :course_videos }
+      t.integer :timestamp, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171004053203) do
+ActiveRecord::Schema.define(version: 20171005033946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -733,6 +733,11 @@ ActiveRecord::Schema.define(version: 20171004053203) do
     t.datetime "updated_at", :null=>false
   end
   add_index "course_video_submissions", ["video_id", "creator_id"], :name=>"index_course_video_submissions_on_video_id_and_creator_id", :unique=>true
+
+  create_table "course_video_topics", force: :cascade do |t|
+    t.integer "video_id",  :null=>false, :index=>{:name=>"fk__course_video_topics_video_id"}, :foreign_key=>{:references=>"course_videos", :name=>"fk_course_video_topics_video_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "timestamp", :null=>false
+  end
 
   create_table "course_virtual_classrooms", force: :cascade do |t|
     t.integer  "course_id",                 :null=>false, :index=>{:name=>"fk__course_virtual_classrooms_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_virtual_classrooms_course_id", :on_update=>:no_action, :on_delete=>:no_action}


### PR DESCRIPTION
Integrate the comments portion of the video player.

Comments are tagged to a video timestamp. Topics are separated by the timestamp value, while each of these topics can have many posts all on the same timestamp.

For now, through the UI we only allow children to be one level deep, so as to prevent too many threads from popping up in the comment box.

There are still a few rough edges, but this PR is already huge, so they'll be addressed later:
1) Comment box should scroll to new comment (a little complicated)
2) Comment notifications are not working yet (potentially also need to change things to preserve the one level deep rule)
3) Auto refresh (again the scrolling is complicated)

The component is not yet enabled. The plan is to fix (2) first.