### PR TITLE
Upgrade active_record-acts_as to support rails5/5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'calculated_attributes', '>= 0.1.3'
 gem 'baby_squeel'
 # For multiple table inheritance
 #   TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
-gem 'active_record-acts_as', github: 'Coursemology/active_record-acts_as'
+gem 'active_record-acts_as', github: 'Coursemology/active_record-acts_as', branch: 'rails5'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Create pretty URLs and work with human-friendly strings

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: git://github.com/Coursemology/active_record-acts_as.git
-  revision: 098b5405c6d74275ba8035fa9e88b0f7cf6c422d
+  revision: 712cf95c93fe1f4209893a25df6fc1862e9a6276
+  branch: rails5
   specs:
-    active_record-acts_as (2.0.1)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
+    active_record-acts_as (2.5.0.1)
+      activerecord (>= 4.2, <= 5.1)
+      activesupport (>= 4.2, <= 5.1)
 
 GIT
   remote: git://github.com/Coursemology/themes_on_rails.git
@@ -657,7 +658,6 @@ DEPENDENCIES
   webpacker
   workflow
   yard
-
 
 BUNDLED WITH
    1.15.4

--- a/spec/libraries/acts_as_condition_spec.rb
+++ b/spec/libraries/acts_as_condition_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe 'Extension: Acts as Condition', type: :model do
 
         context 'when there are no changes' do
           it 'does not rebuild satisfiability graph' do
+            allow(subject).to receive(:changed?).and_return(false)
             expect(subject).to_not receive(:rebuild_satisfiability_graph)
             subject.run_callbacks(:save)
           end


### PR DESCRIPTION
REF #2271

Detailed changes can be found at: https://github.com/Coursemology/active_record-acts_as/commits/rails5
