### PR TITLE
Switch to webpack's server timezone-aware moment lib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,7 +190,6 @@ gem 'simple_form'
 gem 'simple_form-bootstrap'
 # Dynamic nested forms
 gem 'cocoon'
-gem 'momentjs-rails', '>= 2.8.1'
 gem 'bootstrap3-datetimepicker-rails'
 gem 'bootstrap-select-rails'
 gem 'bootstrap_tokenfield_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,7 +615,6 @@ DEPENDENCIES
   lol_dba
   migration_comments
   mini_magick
-  momentjs-rails (>= 2.8.1)
   nokogiri (>= 1.8.1)
   omniauth
   omniauth-facebook
@@ -657,7 +656,6 @@ DEPENDENCIES
   webpacker
   workflow
   yard
-
 
 BUNDLED WITH
    1.15.4

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require i18n/translations
 //= require js-routes
 //= require bootstrap-sprockets
-//= require moment
 //= require bootstrap-datetimepicker
 //= require bootstrap-select
 //= require twitter/typeahead

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -11,7 +11,6 @@
   in the path that matches the controller path if you want it to be required automatically.
  */
 
-
 function loadCurrentModule() {
   const { modulePath } = require('./lib/helpers/server-context');
   try {

--- a/client/app/lib/moment-timezone.js
+++ b/client/app/lib/moment-timezone.js
@@ -1,0 +1,2 @@
+// Intermediate module for loading as a global in Webpack
+module.exports = require('lib/moment').default;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -11,7 +11,7 @@ const devServerPort = 8080;
 
 const config = {
   entry: {
-    coursemology: ['babel-polyfill', './app/index'],
+    coursemology: ['babel-polyfill', './app/index', './app/lib/moment-timezone'],
     lib: [
       'babel-polyfill',
       'axios',
@@ -130,6 +130,13 @@ const config = {
         }, {
           loader: 'expose-loader',
           options: '$',
+        }],
+      },
+      {
+        test: require.resolve('./app/lib/moment-timezone'),
+        use: [{
+          loader: 'expose-loader',
+          options: 'moment',
         }],
       },
       {


### PR DESCRIPTION
With this, all Rails-rendered datetime inputs will use the server-side timezone. This fixes the case where client browser timezone and server-set timezone are different.