### PR TITLE
Hide built-in users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,11 +3,15 @@ class UsersController < ApplicationController
   load_resource :user
 
   def show
-    course_users =
-      @user.course_users.with_course_statistics.from_instance(current_tenant).includes(:course)
-    @current_course_users = course_users.merge(Course.current)
-    @completed_course_users = course_users.merge(Course.completed)
-    @instances = other_instances
+    if @user.built_in?
+      render file: 'public/404', layout: false, status: :not_found
+    else
+      course_users =
+        @user.course_users.with_course_statistics.from_instance(current_tenant).includes(:course)
+      @current_course_users = course_users.merge(Course.current)
+      @completed_course_users = course_users.merge(Course.completed)
+      @instances = other_instances
+    end
   end
 
   private

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:user) }
+
+    describe '#show' do
+      before { sign_in(user) }
+      subject { get :show, id: user_id }
+
+      context 'When user is system user' do
+        let(:user_id) { User::SYSTEM_USER_ID }
+        it 'returns the 404 page' do
+          subject
+
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context 'When user is deleted user' do
+        let(:user_id) { User::DELETED_USER_ID }
+        it 'returns the 404 page' do
+          subject
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://coursemology.org/users/-1 and https://coursemology.org/users/0 access the deleted and system user respectively. To hide them from view.