### PR TITLE
Implement materials cherry-picking duplication

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -23,6 +23,7 @@ class Course < ApplicationRecord
   # The order needs to be preserved, this makes sure that the root_folder will be saved first
   has_many :material_folders, class_name: Course::Material::Folder.name, inverse_of: :course,
                               dependent: :destroy
+  has_many :materials, through: :material_folders
   has_many :assessment_categories, class_name: Course::Assessment::Category.name,
                                    dependent: :destroy, inverse_of: :course
   has_many :assessment_tabs, source: :tabs, through: :assessment_categories
@@ -153,6 +154,7 @@ class Course < ApplicationRecord
   def duplication_manifest
     [
       *material_folders.concrete,
+      *materials.in_concrete_folder,
       *levels,
       *assessment_categories,
       *assessment_tabs,

--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -40,6 +40,13 @@ class Course::Material < ApplicationRecord
     self.folder = if duplicator.duplicated?(other.folder)
                     duplicator.duplicate(other.folder)
                   else
+                    # If parent has not been duplicated yet, put the current duplicate under the root folder
+                    # temorarily. The material will be re-parented only afterwards when the parent folder is being
+                    # duplicated. This will be done when `#initialize_duplicate_children` is called on the
+                    # duplicated parent folder.
+                    #
+                    # If the material's folder is not selected for duplication, the current duplicated material will
+                    # remain a child of the root folder.
                     duplicator.options[:target_course].root_folder
                   end
     self.updated_at = other.updated_at

--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -28,6 +28,13 @@ class Course::Material < ApplicationRecord
     !duplicating?
   end
 
+  # Finds a unique name for the current material among its siblings.
+  #
+  # @return [String] A unique name.
+  def next_valid_name
+    folder.next_uniq_child_name(self)
+  end
+
   def initialize_duplicate(duplicator, other)
     self.attachment = duplicator.duplicate(other.attachment)
     self.folder = if duplicator.duplicated?(other.folder)
@@ -40,10 +47,15 @@ class Course::Material < ApplicationRecord
     set_duplication_flag
   end
 
+  def before_duplicate_save(_duplicator)
+    self.name = next_valid_name
+  end
+
   private
 
   # TODO: Not threadsafe, consider making all folders as materials
   # Make sure that material won't have the same name with other child folders in the folder
+  # Schema validations already ensure that it won't have the same name as other materials
   def validate_name_is_unique_among_folders
     return if folder.nil?
 

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -33,6 +33,7 @@ class Course::Material::Folder < ApplicationRecord
 
   scope :with_content_statistics, ->() { all.calculated(:material_count, :children_count) }
   scope :concrete, ->() { where(owner_id: nil) }
+  scope :root, ->() { where(parent_id: nil) }
 
   # Filter out the empty linked folders (i.e. Folder with an owner).
   def self.without_empty_linked_folder

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -70,6 +70,28 @@ class Course::Material::Folder < ApplicationRecord
     owner_id.nil?
   end
 
+  # Finds a unique name for `item` among the folder's existing contents by appending a serial number
+  # to it, if necessary. E.g. "logo.png" will be named "logo.png (1)" if the files named "logo.png"
+  # and "logo.png (0)" exist in the folder.
+  #
+  # @param [#name] item Folder or Material to find unique name for.
+  # @return [String] A unique name.
+  def next_uniq_child_name(item)
+    taken_names = contents_names(item).map(&:downcase)
+    name_generator = FileName.new(item.name, path: :relative, add: :always,
+                                             format: '(%d)', delimiter: ' ')
+    new_name = item.name
+    new_name = name_generator.create while taken_names.include?(new_name.downcase)
+    new_name
+  end
+
+  # Finds a unique name for the current folder among its siblings.
+  #
+  # @return [String] A unique name.
+  def next_valid_name
+    parent.next_uniq_child_name(self)
+  end
+
   def initialize_duplicate(duplicator, other)
     # Do not shift the time of root folder
     self.start_at = other.parent_id.nil? ? Time.zone.now : duplicator.time_shift(other.start_at)
@@ -111,6 +133,10 @@ class Course::Material::Folder < ApplicationRecord
                      end
   end
 
+  def before_duplicate_save(_duplicator)
+    self.name = next_valid_name
+  end
+
   private
 
   def set_defaults
@@ -119,6 +145,7 @@ class Course::Material::Folder < ApplicationRecord
 
   # TODO: Not threadsafe, consider making all folders as materials
   # Make sure that folder won't have the same name with other materials in the parent folder
+  # Schema validations already ensure that it won't have the same name as other folders
   def validate_name_is_unique_among_materials
     return if parent.nil?
 
@@ -126,26 +153,17 @@ class Course::Material::Folder < ApplicationRecord
     errors.add(:name, :taken) unless conflicts.empty?
   end
 
-  def sibling_names
-    parent.children.where.not(id: self).pluck(:name) + parent.materials.pluck(:name)
-  end
-
-  # Find the next valid name whose format is based on the the name given.
-  # If the base_name has been taken, the next name will be generate in the format of: base_name(0),
-  # base_name(1), etc.
-  # @param [String] base_name The name which we want to name the folder.
-  # @return [String] The next valid name that haven't been taken.
-  def next_valid_name(base_name = name)
-    return base_name unless parent && base_name
-
-    names_taken = sibling_names.map(&:downcase)
-    name_generator = FileName.new(base_name, path: :relative, add: :always,
-                                             format: '(%d)', delimiter: ' ')
-
-    new_name = base_name
-    new_name = name_generator.create while names_taken.include?(new_name.downcase)
-
-    new_name
+  # Fetches the names of the contents of the current folder, except for an excluded_item, if one is
+  # provided.
+  #
+  # @param [Object] excluded_item Item whose name to exclude from the list
+  # @return [Array<String>] List of names of contents of folder
+  def contents_names(excluded_item = nil)
+    excluded_material = excluded_item.class == Course::Material ? excluded_item : nil
+    excluded_folder = excluded_item.class == Course::Material::Folder ? excluded_item : nil
+    materials_names = materials.where.not(id: excluded_material).pluck(:name)
+    subfolders_names = children.where.not(id: excluded_folder).pluck(:name)
+    materials_names + subfolders_names
   end
 
   def assign_valid_name

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -4,6 +4,11 @@ json.targetCourses @target_courses do |course|
   json.(course, :id, :title)
   json.path course_path(course)
   json.host course.instance.host
+  json.rootFolder do
+    root_folder = @root_folder_map[course.id]
+    json.subfolders root_folder.children.map(&:name)
+    json.materials root_folder.materials.map(&:name)
+  end
 end
 
 json.assessmentsComponent @categories do |category|
@@ -23,4 +28,11 @@ end
 json.achievementsComponent @achievements do |achievement|
   json.(achievement, :id, :title, :published)
   json.url achievement_badge_path(achievement)
+end
+
+json.materialsComponent @folders do |folder|
+  json.(folder, :id, :name, :parent_id)
+  json.materials folder.materials do |material|
+    json.(material, :id, :name)
+  end
 end

--- a/client/app/bundles/course/duplication/components/BulkSelectors.jsx
+++ b/client/app/bundles/course/duplication/components/BulkSelectors.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+const translations = defineMessages({
+  selectAll: {
+    id: 'course.duplication.BulkSelectors.selectAll',
+    defaultMessage: 'Select All',
+  },
+  deselectAll: {
+    id: 'course.duplication.BulkSelectors.deselectAll',
+    defaultMessage: 'Deselect All',
+  },
+});
+
+const styles = {
+  selectLink: {
+    marginLeft: 20,
+    lineHeight: '24px',
+  },
+  deselectLink: {
+    marginLeft: 10,
+    lineHeight: '24px',
+  },
+};
+
+const BulkSelectors = ({ callback }) => (
+  <div>
+    <a
+      onClick={() => callback(true)}
+      style={styles.selectLink}
+    >
+      <FormattedMessage {...translations.selectAll} />
+    </a>
+    <a
+      onClick={() => callback(false)}
+      style={styles.deselectLink}
+    >
+      <FormattedMessage {...translations.deselectAll} />
+    </a>
+  </div>
+);
+
+BulkSelectors.propTypes = {
+  callback: PropTypes.func,
+};
+
+export default BulkSelectors;

--- a/client/app/bundles/course/duplication/components/TypeBadge/index.jsx
+++ b/client/app/bundles/course/duplication/components/TypeBadge/index.jsx
@@ -35,6 +35,14 @@ const translations = defineMessages({
     id: 'course.duplication.TypeBadge.achievement',
     defaultMessage: 'Achievement',
   },
+  [duplicableItemTypes.FOLDER]: {
+    id: 'course.duplication.TypeBadge.folder',
+    defaultMessage: 'Folder',
+  },
+  [duplicableItemTypes.MATERIAL]: {
+    id: 'course.duplication.TypeBadge.material',
+    defaultMessage: 'Material',
+  },
 });
 
 const TypeBadge = ({ text, itemType }) => (

--- a/client/app/bundles/course/duplication/constants.js
+++ b/client/app/bundles/course/duplication/constants.js
@@ -6,6 +6,8 @@ export const duplicableItemTypes = mirrorCreator([
   'CATEGORY',
   'SURVEY',
   'ACHIEVEMENT',
+  'FOLDER',
+  'MATERIAL',
 ]);
 
 const actionTypes = mirrorCreator([

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/AssessmentsSelector.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/AssessmentsSelector.jsx
@@ -10,29 +10,11 @@ import { categoryShape } from 'course/duplication/propTypes';
 import TypeBadge from 'course/duplication/components/TypeBadge';
 import UnpublishedIcon from 'course/duplication/components/UnpublishedIcon';
 import IndentedCheckbox from 'course/duplication/components/IndentedCheckbox';
+import BulkSelectors from 'course/duplication/components/BulkSelectors';
 
 const { TAB, ASSESSMENT, CATEGORY } = duplicableItemTypes;
 
-const styles = {
-  selectLink: {
-    marginLeft: 20,
-    lineHeight: '24px',
-  },
-  deselectLink: {
-    marginLeft: 10,
-    lineHeight: '24px',
-  },
-};
-
 const translations = defineMessages({
-  selectAll: {
-    id: 'course.duplication.AssessmentsSelector.selectAll',
-    defaultMessage: 'Select All',
-  },
-  deselectAll: {
-    id: 'course.duplication.AssessmentsSelector.deselectAll',
-    defaultMessage: 'Deselect All',
-  },
   noItems: {
     id: 'course.duplication.AssessmentsSelector.noItems',
     defaultMessage: 'There are no assessment items to duplicate.',
@@ -47,25 +29,6 @@ class AssessmentsSelector extends React.Component {
     dispatch: PropTypes.func.isRequired,
   }
 
-  static renderBulkSelectors(bulkSelectorMethod, item) {
-    return (
-      <div>
-        <a
-          onClick={() => bulkSelectorMethod(item, true)}
-          style={styles.selectLink}
-        >
-          <FormattedMessage {...translations.selectAll} />
-        </a>
-        <a
-          onClick={() => bulkSelectorMethod(item, false)}
-          style={styles.deselectLink}
-        >
-          <FormattedMessage {...translations.deselectAll} />
-        </a>
-      </div>
-    );
-  }
-
   tabSetAll = (tab, value) => {
     const { dispatch } = this.props;
     dispatch(setItemSelectedBoolean(TAB, tab.id, value));
@@ -74,9 +37,9 @@ class AssessmentsSelector extends React.Component {
     });
   }
 
-  categorySetAll = (category, value) => {
+  categorySetAll = category => (value) => {
     this.props.dispatch(setItemSelectedBoolean(CATEGORY, category.id, value));
-    category.tabs.forEach(tab => this.tabSetAll(tab, value));
+    category.tabs.forEach(tab => this.tabSetAll(tab)(value));
   }
 
   renderAssessmentTree(assessment) {
@@ -119,7 +82,7 @@ class AssessmentsSelector extends React.Component {
             dispatch(setItemSelectedBoolean(TAB, id, value))
           }
         >
-          { AssessmentsSelector.renderBulkSelectors(this.tabSetAll, tab) }
+          <BulkSelectors callback={this.tabSetAll(tab)} />
         </IndentedCheckbox>
         { assessments.map(assessment => this.renderAssessmentTree(assessment)) }
       </div>
@@ -140,7 +103,7 @@ class AssessmentsSelector extends React.Component {
             dispatch(setItemSelectedBoolean(CATEGORY, id, value))
           }
         >
-          { AssessmentsSelector.renderBulkSelectors(this.categorySetAll, category) }
+          <BulkSelectors callback={this.categorySetAll(category)} />
         </IndentedCheckbox>
         { tabs.map(tab => this.renderTabTree(tab)) }
       </div>

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/MaterialsListing.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/MaterialsListing.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import Subheader from 'material-ui/Subheader';
+import { Card, CardText } from 'material-ui/Card';
+import { defaultComponentTitles } from 'course/translations.intl';
+import { duplicableItemTypes } from 'course/duplication/constants';
+import { folderShape } from 'course/duplication/propTypes';
+import TypeBadge from 'course/duplication/components/TypeBadge';
+import IndentedCheckbox from 'course/duplication/components/IndentedCheckbox';
+
+const { FOLDER, MATERIAL } = duplicableItemTypes;
+const ROOT_CHILDREN_LEVEL = 1;
+
+const flatten = arr => arr.reduce((a, b) => a.concat(b), []);
+
+const translations = defineMessages({
+  root: {
+    id: 'course.duplication.MaterialsListing.root',
+    defaultMessage: 'Root Folder',
+  },
+  nameConflictWarning: {
+    id: 'course.duplication.MaterialsListing.nameConflictWarning',
+    defaultMessage: "Warning: Naming conflict exists. A serial number will be appended to the duplicated item's name.",
+  },
+});
+
+class MaterialsListing extends React.Component {
+  static propTypes = {
+    folders: PropTypes.arrayOf(folderShape),
+    selectedItems: PropTypes.shape(),
+    targetRootFolder: PropTypes.shape({
+      subfolders: PropTypes.arrayOf(PropTypes.string),
+      materials: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }
+
+  static renderRootRow() {
+    return (
+      <IndentedCheckbox
+        disabled
+        label={<FormattedMessage {...translations.root} />}
+      />
+    );
+  }
+
+  static renderRow(item, itemType, indentLevel, nameConflict) {
+    return (
+      <IndentedCheckbox
+        checked
+        key={item.id}
+        label={
+          <span>
+            <TypeBadge itemType={itemType} />
+            {item.name}
+            {
+              nameConflict &&
+              <div><FormattedMessage {...translations.nameConflictWarning} tagName="small" /></div>
+            }
+          </span>
+        }
+        indentLevel={indentLevel}
+      />
+    );
+  }
+
+  renderFolderTree(folder, indentLevel) {
+    const { selectedItems, targetRootFolder } = this.props;
+    const checked = !!selectedItems[FOLDER][folder.id];
+    // Children will be duplicated under the target course root folder if current folder is not checked
+    const childrenIndentLevel = checked ? indentLevel + 1 : ROOT_CHILDREN_LEVEL;
+    const exisitingNames = targetRootFolder.subfolders.concat(targetRootFolder.materials)
+      .map(name => name.toLowerCase());
+    const nameConflict = indentLevel === ROOT_CHILDREN_LEVEL &&
+      exisitingNames.includes(folder.name.toLowerCase());
+
+    const folderNode = checked ? MaterialsListing.renderRow(folder, FOLDER, indentLevel, nameConflict) : [];
+    const materialNodes = folder.materials
+      .filter(material => !!selectedItems[MATERIAL][material.id])
+      .map((material) => {
+        const materialNameConflict = childrenIndentLevel === ROOT_CHILDREN_LEVEL &&
+          exisitingNames.includes(material.name.toLowerCase());
+        return MaterialsListing.renderRow(material, MATERIAL, childrenIndentLevel, materialNameConflict);
+      });
+    const subfolderNodes = flatten(folder.subfolders.map(subfolder => (
+      this.renderFolderTree(subfolder, childrenIndentLevel)
+    )));
+    return flatten([folderNode, materialNodes, subfolderNodes]);
+  }
+
+  render() {
+    const { folders } = this.props;
+    const folderTrees = flatten(folders.map(folder => this.renderFolderTree(folder, ROOT_CHILDREN_LEVEL)));
+    if (folderTrees.length < 1) { return null; }
+
+    return (
+      <div>
+        <Subheader>
+          <FormattedMessage {...defaultComponentTitles.course_materials_component} />
+        </Subheader>
+        <Card>
+          <CardText>
+            { MaterialsListing.renderRootRow() }
+            { folderTrees }
+          </CardText>
+        </Card>
+      </div>
+    );
+  }
+}
+
+export default connect(({ objectDuplication }) => ({
+  folders: objectDuplication.materialsComponent,
+  selectedItems: objectDuplication.selectedItems,
+  targetRootFolder: objectDuplication.targetCourses
+    .find(course => course.id === objectDuplication.targetCourseId).rootFolder,
+}))(MaterialsListing);

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/index.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/DuplicateItemsConfirmation/index.jsx
@@ -11,6 +11,7 @@ import { courseShape } from 'course/duplication/propTypes';
 import AssessmentsListing from './AssessmentsListing';
 import SurveyListing from './SurveyListing';
 import AchievementsListing from './AchievementsListing';
+import MaterialsListing from './MaterialsListing';
 
 const translations = defineMessages({
   confirmationQuestion: {
@@ -75,6 +76,7 @@ class DuplicateItemsConfirmation extends React.Component {
         <AssessmentsListing />
         <SurveyListing />
         <AchievementsListing />
+        <MaterialsListing />
 
         <ReactTooltip id="itemUnpublished">
           <FormattedMessage {...translations.itemUnpublished} />

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/MaterialsSelector.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/MaterialsSelector.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import Subheader from 'material-ui/Subheader';
+import { defaultComponentTitles } from 'course/translations.intl';
+import { duplicableItemTypes } from 'course/duplication/constants';
+import { setItemSelectedBoolean } from 'course/duplication/actions';
+import { folderShape } from 'course/duplication/propTypes';
+import TypeBadge from 'course/duplication/components/TypeBadge';
+import IndentedCheckbox from 'course/duplication/components/IndentedCheckbox';
+import BulkSelectors from 'course/duplication/components/BulkSelectors';
+
+const { FOLDER, MATERIAL } = duplicableItemTypes;
+
+const translations = defineMessages({
+  noItems: {
+    id: 'course.duplication.MaterialsSelector.noItems',
+    defaultMessage: 'There are no materials to duplicate.',
+  },
+});
+
+class MaterialsSelector extends React.Component {
+  static propTypes = {
+    folders: PropTypes.arrayOf(folderShape),
+    selectedItems: PropTypes.shape(),
+
+    dispatch: PropTypes.func.isRequired,
+  }
+
+  folderSetAll = folder => (value) => {
+    this.props.dispatch(setItemSelectedBoolean(FOLDER, folder.id, value));
+    folder.subfolders.forEach(subfolder => this.folderSetAll(subfolder)(value));
+    folder.materials.forEach((material) => {
+      this.props.dispatch(setItemSelectedBoolean(MATERIAL, material.id, value));
+    });
+  }
+
+  renderMaterial(material, indentLevel) {
+    const { dispatch, selectedItems } = this.props;
+    const checked = !!selectedItems[MATERIAL][material.id];
+
+    return (
+      <IndentedCheckbox
+        key={material.id}
+        label={
+          <span>
+            <TypeBadge itemType={MATERIAL} />
+            { material.name }
+          </span>
+        }
+        onCheck={(e, value) => dispatch(setItemSelectedBoolean(MATERIAL, material.id, value))}
+        {...{ checked, indentLevel }}
+      />
+    );
+  }
+
+  renderFolder(folder, indentLevel) {
+    const { dispatch, selectedItems } = this.props;
+    const { id, name, materials, subfolders } = folder;
+    const checked = !!selectedItems[FOLDER][folder.id];
+    const hasChildren = (materials.length + subfolders.length) > 0;
+
+    return (
+      <div key={id}>
+        <IndentedCheckbox
+          label={
+            <span>
+              <TypeBadge itemType={FOLDER} />
+              { name }
+            </span>
+          }
+          onCheck={(e, value) => dispatch(setItemSelectedBoolean(FOLDER, id, value))}
+          {...{ checked, indentLevel }}
+        >
+          { hasChildren ? <BulkSelectors callback={this.folderSetAll(folder)} /> : null }
+        </IndentedCheckbox>
+        { materials.map(material => this.renderMaterial(material, indentLevel + 1)) }
+        { subfolders.map(subfolder => this.renderFolder(subfolder, indentLevel + 1)) }
+      </div>
+    );
+  }
+
+  render() {
+    const { folders } = this.props;
+    if (!folders) { return null; }
+
+    return (
+      <div>
+        <h2><FormattedMessage {...defaultComponentTitles.course_materials_component} /></h2>
+        {
+          folders.length > 0 ?
+          folders.map(rootFolder => this.renderFolder(rootFolder, 0)) :
+          <Subheader><FormattedMessage {...translations.noItems} /></Subheader>
+        }
+      </div>
+    );
+  }
+}
+
+export default connect(({ objectDuplication }) => ({
+  folders: objectDuplication.materialsComponent,
+  selectedItems: objectDuplication.selectedItems,
+}))(MaterialsSelector);

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/__test__/DuplicateButton.test.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/__test__/DuplicateButton.test.jsx
@@ -22,6 +22,7 @@ const data = {
         [duplicableItemTypes.CATEGORY]: { 6: false },
         [duplicableItemTypes.ASSESSMENT]: { 7: true },
       },
+      materialsComponent: [],
       assessmentsComponent: [
         {
           id: 6,

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/__test__/ObjectDuplication.test.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/__test__/ObjectDuplication.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import CourseAPI from 'api/course';
+import MockAdapter from 'axios-mock-adapter';
+import storeCreator from 'course/duplication/store';
+import ObjectDuplication from '../index';
+
+const client = CourseAPI.duplication.getClient();
+const mock = new MockAdapter(client);
+
+const responseData = {
+  targetCourses: [
+    { id: 54, title: 'Course B', path: '/courses/54' },
+    { id: 55, title: 'Course A', path: '/courses/55' },
+    { id: 56, title: 'Course C', path: '/courses/56' },
+  ],
+  materialsComponent: [
+    { id: 91, parent_id: 93, name: 'L2' },
+    { id: 92, parent_id: null, name: 'Root' },
+    { id: 93, parent_id: 92, name: 'L1' },
+  ],
+};
+
+beforeEach(() => {
+  mock.reset();
+});
+
+describe('<ObjectDuplication />', () => {
+  it('fetches and receives sorted data', async () => {
+    const store = storeCreator({});
+    const spy = jest.spyOn(CourseAPI.duplication, 'fetch');
+    const url = `/courses/${courseId}/object_duplication/new`;
+    mock.onGet(url).reply(200, responseData);
+
+    mount(
+      <MemoryRouter>
+        <ObjectDuplication />
+      </MemoryRouter>,
+      buildContextOptions(store)
+    );
+    await sleep(1);
+    expect(spy).toHaveBeenCalled();
+
+    const sortedData = store.getState().objectDuplication;
+    const courseTitles = sortedData.targetCourses.map(course => course.title);
+    const rootFolder = sortedData.materialsComponent[0];
+    expect(courseTitles).toEqual(['Course A', 'Course B', 'Course C']);
+    expect(sortedData.materialsComponent.length).toBe(1);
+    expect(rootFolder.name).toBe('Root');
+    expect(rootFolder.subfolders[0].name).toBe('L1');
+    expect(rootFolder.subfolders[0].subfolders[0].name).toBe('L2');
+  });
+});

--- a/client/app/bundles/course/duplication/pages/ObjectDuplication/index.jsx
+++ b/client/app/bundles/course/duplication/pages/ObjectDuplication/index.jsx
@@ -24,15 +24,17 @@ import TargetCourseSelector from './TargetCourseSelector';
 import AssessmentsSelector from './AssessmentsSelector';
 import SurveysSelector from './SurveysSelector';
 import AchievementsSelector from './AchievementsSelector';
+import MaterialsSelector from './MaterialsSelector';
 import DuplicateButton from './DuplicateButton';
 
-const { TAB, ASSESSMENT, CATEGORY, SURVEY, ACHIEVEMENT } = duplicableItemTypes;
+const { TAB, ASSESSMENT, CATEGORY, SURVEY, ACHIEVEMENT, FOLDER, MATERIAL } = duplicableItemTypes;
 
 const panels = mirrorCreator([
   'TARGET_COURSE',
   'ASSESSMENTS',
   'SURVEYS',
   'ACHIEVEMENTS',
+  'MATERIALS',
 ]);
 
 const translations = defineMessages({
@@ -170,6 +172,13 @@ class ObjectDuplication extends React.Component {
               () => this.setState({ panel: panels.ACHIEVEMENTS })
             )
           }
+          {
+            ObjectDuplication.renderSidebarItem(
+              defaultComponentTitles.course_materials_component,
+              counts[FOLDER] + counts[MATERIAL],
+              () => this.setState({ panel: panels.MATERIALS })
+            )
+          }
 
           <ListItem disabled style={styles.duplicateButton}>
             <DuplicateButton />
@@ -185,6 +194,7 @@ class ObjectDuplication extends React.Component {
       [panels.ASSESSMENTS]: AssessmentsSelector,
       [panels.SURVEYS]: SurveysSelector,
       [panels.ACHIEVEMENTS]: AchievementsSelector,
+      [panels.MATERIALS]: MaterialsSelector,
     }[this.state.panel];
 
     return (

--- a/client/app/bundles/course/duplication/propTypes.js
+++ b/client/app/bundles/course/duplication/propTypes.js
@@ -37,3 +37,15 @@ export const achievementShape = PropTypes.shape({
   published: PropTypes.bool,
   url: PropTypes.string,
 });
+
+export const materialShape = PropTypes.shape({
+  id: PropTypes.number,
+  name: PropTypes.string,
+});
+
+export const folderShape = PropTypes.shape({
+  id: PropTypes.number,
+  parent_id: PropTypes.number,
+  name: PropTypes.string,
+  materials: PropTypes.arrayOf(materialShape),
+});

--- a/client/app/bundles/course/duplication/reducers/objectDuplication.js
+++ b/client/app/bundles/course/duplication/reducers/objectDuplication.js
@@ -1,4 +1,5 @@
 import actionTypes, { duplicableItemTypes } from 'course/duplication/constants';
+import { nestFolders } from 'course/duplication/utils';
 
 const initialState = {
   confirmationOpen: false,
@@ -10,8 +11,12 @@ const initialState = {
   },
   targetCourseId: null,
   targetCourses: [],
+
   assessmentsComponent: [],
   surveyComponent: [],
+  achievementsComponent: [],
+  materialsComponent: [],
+
   isLoading: false,
   isDuplicatingObjects: false,
 };
@@ -24,14 +29,17 @@ export default function (state = initialState, action) {
       return { ...state, isLoading: true };
     }
     case actionTypes.LOAD_OBJECTS_LIST_SUCCESS: {
-      const sortedTargetCourses = action.duplicationData.targetCourses.sort(
+      const { targetCourses, materialsComponent, ...data } = action.duplicationData;
+      const sortedTargetCourses = targetCourses.sort(
         (a, b) => a.title.localeCompare(b.title)
       );
+      const nestedFolders = nestFolders(materialsComponent);
       return {
         ...state,
-        ...action.duplicationData,
+        ...data,
         isLoading: false,
         targetCourses: sortedTargetCourses,
+        materialsComponent: nestedFolders,
       };
     }
     case actionTypes.LOAD_OBJECTS_LIST_FAILURE: {

--- a/client/app/bundles/course/duplication/utils.jsx
+++ b/client/app/bundles/course/duplication/utils.jsx
@@ -1,0 +1,22 @@
+/* eslint no-param-reassign: ["error", { "props": false }] */
+/* eslint-disable import/prefer-default-export */
+
+export function nestFolders(folders) {
+  const rootFolders = [];
+
+  const idFolderHash = folders.reduce((hash, folder) => {
+    folder.subfolders = [];
+    hash[folder.id] = folder;
+    return hash;
+  }, {});
+
+  folders.forEach((folder) => {
+    if (folder.parent_id === null) {
+      rootFolders.push(folder);
+    } else {
+      idFolderHash[folder.parent_id].subfolders.push(folder);
+    }
+  });
+
+  return rootFolders;
+}

--- a/client/app/bundles/course/translations.intl.js
+++ b/client/app/bundles/course/translations.intl.js
@@ -36,6 +36,10 @@ export const defaultComponentTitles = defineMessages({
     id: 'course.componentTitles.course_videos_component',
     defaultMessage: 'Videos',
   },
+  course_materials_component: {
+    id: 'course.componentTitles.course_materials_component',
+    defaultMessage: 'Materials',
+  },
 });
 
 export default translations;

--- a/lib/autoload/duplicator.rb
+++ b/lib/autoload/duplicator.rb
@@ -16,8 +16,23 @@ class Duplicator
     @mode = options[:mode]
   end
 
-  # Deep copy the arguments to this function. Objects must provide an +initialize_duplicate+
-  # method which duplicates its children.
+  # Deep copies the given item(s) and initializes the duplicates by calling `initialize_duplicate`
+  # on the duplicates.
+  #
+  # `initialize_duplicate` may further trigger duplication of the source item's
+  # children. If a collection is given, some of the items to be duplicated might be associated.
+  # `initialize_duplicate` may be used to associate the duplicates of associated items.
+  #
+  # Since the duplicator does not have any knowledge of what these items are, expect for the fact that
+  # they respond to `initialize_duplicate`, the duplicator does not impose an order on which items are
+  # duplicated first. To simplify the process of associating duplicated objects, we give the responsibility
+  # of forming the association to the object that is duplicated later.
+  #
+  # E.g. Suppose that `Group` has many `Student`s and the instance `student_a` belongs to the instance 'group_a'.
+  # If `group_a` is duplicated first, then calling `duplicate_student_a.initialize_duplicate` should add
+  # `duplicate_student_a` to `duplicate_group_a`'s list of students. If `student_a` is duplicated first, then
+  # vice versa. Thus, the code to form the association can be found in both `Student#initialize_duplicate` and
+  # `Group#initialize_duplicate`.
   #
   # @overload duplicate(array_of_stuff)
   #   @param [Enumerable<#initialize_duplicate>] array_of_stuff Enumerable of objects
@@ -64,8 +79,7 @@ class Duplicator
     item_or_collection.respond_to?(:to_ary) ? item_or_collection.map(&block) : yield(item_or_collection)
   end
 
-  # Deep copy +source_object+ and its children. +source_object+ must provide a
-  # +initialize_duplicate+ method which duplicates its children.
+  # See `#duplicate`.
   #
   # @param [#initialize_duplicate] source_object The object to be duplicated.
   # @return duplicated_object A reference to the duplicated object.

--- a/spec/controllers/course/object_duplication_controller_spec.rb
+++ b/spec/controllers/course/object_duplication_controller_spec.rb
@@ -51,10 +51,21 @@ RSpec.describe Course::ObjectDuplicationsController do
         end
       end
 
-      context 'when invalid parameters are provided' do
+      context 'when invalid assessment id is provided' do
         let(:items_params) { { 'ASSESSMENT' => [unenrolled_course_assessment.id] } }
 
-        it 'duplicates selected items' do
+        it 'does not duplicate selected item' do
+          expect do
+            subject
+            wait_for_job
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'when virtual folder id is provided but not its owner' do
+        let(:items_params) { { 'FOLDER' => [assessment.folder.id] } }
+
+        it 'does not duplicate selected item' do
           expect do
             subject
             wait_for_job

--- a/spec/models/course/material/folder_spec.rb
+++ b/spec/models/course/material/folder_spec.rb
@@ -56,16 +56,15 @@ RSpec.describe Course::Material::Folder, type: :model do
       let(:other_child_folder) { build(:folder, parent: parent_folder, name: common_name.downcase) }
       let(:material) { build(:material, folder: parent_folder, name: common_name + ' (0)') }
 
-      subject { folder.next_valid_name }
-      it 'finds the proper name' do
-        # When there is no name conflicts
+      it 'returns a unique name' do
+        # When there are no name conflicts
         expect(folder.send(:next_valid_name)).to eq(common_name)
 
-        # When is is a name conflict
+        # When there is a name conflict with another folder
         other_child_folder.save
         expect(folder.send(:next_valid_name)).to eq(common_name + ' (0)')
 
-        # When there is another name conflict with lower case
+        # When there is another name conflict with a material
         material.save
         expect(folder.send(:next_valid_name)).to eq(common_name + ' (1)')
       end

--- a/spec/models/course/material_spec.rb
+++ b/spec/models/course/material_spec.rb
@@ -32,5 +32,27 @@ RSpec.describe Course::Material, type: :model do
         expect(subject).to be_invalid
       end
     end
+
+    describe '#next_valid_name' do
+      let(:common_name) { 'Common Name' }
+      let(:parent_folder) { create(:folder) }
+      let(:material) { build(:material, folder: parent_folder, name: common_name) }
+
+      let(:other_material) { build(:material, folder: parent_folder, name: common_name.downcase) }
+      let(:sibling_folder) { build(:folder, parent: parent_folder, name: common_name + ' (0)') }
+
+      it 'returns a unique name' do
+        # When there are no name conflicts
+        expect(material.send(:next_valid_name)).to eq(common_name)
+
+        # When there is a name conflict with another material
+        other_material.save
+        expect(material.send(:next_valid_name)).to eq(common_name + ' (0)')
+
+        # When there is another name conflict with a sibling folder
+        sibling_folder.save
+        expect(material.send(:next_valid_name)).to eq(common_name + ' (1)')
+      end
+    end
   end
 end

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -424,6 +424,30 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
             end
           end
         end
+
+        context 'when there are items with conflicting filenames' do
+          let(:source_objects) { [material, parent_folder] }
+          let(:conflicting_folder) do
+            create(:course_material_folder, course: destination_course,
+                                            parent: destination_course.root_folder, name: parent_folder.name)
+          end
+          let(:conflicting_material) do
+            create(:course_material, folder: destination_course.root_folder, name: material.name)
+          end
+
+          before do
+            conflicting_folder
+            conflicting_material
+          end
+
+          it 'gives the duplicated items unique names' do
+            expect { duplicate_objects }.to change { destination_course.material_folders.count }.by(1)
+
+            duplicate_material, duplicate_folder = duplicate_objects
+            expect(duplicate_material.name).not_to eq(material.name)
+            expect(duplicate_folder.name).not_to eq(parent_folder.name)
+          end
+        end
       end
 
       context 'when a survey is selected' do


### PR DESCRIPTION
v1 only allows duplication of top-level folder. This implementation allows users to select which folders and materials they would like to duplicate.