### PR TITLE
Parse multiple test report files.

### DIFF
--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -10,14 +10,14 @@ class Course::Assessment::ProgrammingEvaluationService
   MEMORY_LIMIT_RATIO = 1.megabyte / 1.kilobyte
 
   # Represents a result of evaluating a package.
-  Result = Struct.new(:stdout, :stderr, :test_report, :exit_code, :evaluation_id) do
+  Result = Struct.new(:stdout, :stderr, :test_reports, :exit_code, :evaluation_id) do
     # Checks if the evaluation errored.
     #
     # This does not count failing test cases as an error, although the exit code is nonzero.
     #
     # @return [Boolean]
     def error?
-      test_report.nil? && exit_code != 0
+      test_reports.values.all?(&:nil?) && exit_code != 0
     end
 
     # Checks if the evaluation exceeded its time limit.
@@ -99,8 +99,8 @@ class Course::Assessment::ProgrammingEvaluationService
   # @return [Result]
   # @raise [Timeout::Error] When the evaluation timeout has elapsed.
   def execute
-    stdout, stderr, test_report, exit_code = Timeout.timeout(@timeout) { evaluate_in_container }
-    Result.new(stdout, stderr, test_report, exit_code)
+    stdout, stderr, test_reports, exit_code = Timeout.timeout(@timeout) { evaluate_in_container }
+    Result.new(stdout, stderr, test_reports, exit_code)
   end
 
   def create_container(image)

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -73,7 +73,7 @@ class Course::Assessment::Question::ProgrammingImportService
   def save!(template_files, evaluation_result)
     @question.imported_attachment = @attachment
     @question.template_files = build_template_file_records(template_files)
-    @question.test_cases = build_test_case_records(evaluation_result.test_report)
+    @question.test_cases = build_combined_test_case_records(evaluation_result.test_reports)
 
     @question.save!
   end
@@ -89,7 +89,23 @@ class Course::Assessment::Question::ProgrammingImportService
     end
   end
 
-  # Builds the test case records from the test report.
+  # Goes through each test report file and combines all the test cases contained in them.
+  #
+  # @param [Hash<String, String>] test_reports The test reports from evaluating the package.
+  #   Hash key is the report type, followed by the contents of the report.
+  #   e.g. { 'public': <XML from public tests>, 'private': <XML from private tests> }
+  # @return [Array<Course::Assessment::Question::ProgrammingTestCase>]
+  def build_combined_test_case_records(test_reports)
+    test_cases = []
+
+    test_reports.values.each do |test_report|
+      test_cases += build_test_case_records(test_report)
+    end
+
+    test_cases
+  end
+
+  # Builds the test case records from a single test report.
   #
   # @param [String] test_report The test case report from evaluating the package.
   # @return [Array<Course::Assessment::Question::ProgrammingTestCase>]

--- a/spec/libraries/coursemology_docker_container_spec.rb
+++ b/spec/libraries/coursemology_docker_container_spec.rb
@@ -121,20 +121,20 @@ RSpec.describe CoursemologyDockerContainer do
 
     it 'returns the test report' do
       copy_report(report_contents)
-      test_report = subject.send(:extract_test_report)
+      test_report = subject.send(:extract_test_report, CoursemologyDockerContainer::REPORT_PATH)
       expect(test_report).to eq(report_contents)
       expect(test_report.encoding).to eq Encoding::UTF_8
     end
 
     it 'does not crash when report is nil' do
       copy_report(nil)
-      test_report = subject.send(:extract_test_report)
+      test_report = subject.send(:extract_test_report, CoursemologyDockerContainer::REPORT_PATH)
       expect(test_report).to be_nil
     end
 
     context 'when running the tests fails' do
       it 'returns nil' do
-        expect(subject.send(:extract_test_report)).to be_nil
+        expect(subject.send(:extract_test_report, CoursemologyDockerContainer::REPORT_PATH)).to be_nil
       end
     end
   end

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
           allow(Course::Assessment::ProgrammingEvaluationService).to \
             receive(:execute).and_wrap_original do |original, *args|
               result = original.call(*args)
-              result.test_report = File.read(question_test_report_path)
+              result.test_reports = { public: File.read(question_test_report_path) }
               result
             end
         end
@@ -144,7 +144,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
           allow(Course::Assessment::ProgrammingEvaluationService).to \
             receive(:execute).and_wrap_original do |original, *args|
               result = original.call(*args)
-              result.test_report = nil
+              result.test_reports = {}
               result.stdout = "Makefile:6: recipe for target 'test' failed"
               result.stderr = "ImportError: No module named 'simulation'"
               result.exit_code = 2

--- a/spec/services/course/assessment/programming_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_evaluation_service_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
   describe Course::Assessment::ProgrammingEvaluationService::Result do
     self::TIME_LIMIT_EXCEEDED_EXIT_CODE = 137
     let(:exit_code) { 0 }
-    let(:test_report) { '' }
+    let(:test_reports) { { report: '' } }
     subject do
-      Course::Assessment::ProgrammingEvaluationService::Result.new('', '', test_report, exit_code)
+      Course::Assessment::ProgrammingEvaluationService::Result.new('', '', test_reports, exit_code)
     end
 
     describe '#error' do
-      context 'when the test report is not nil' do
+      context 'when the test reports have values' do
         context 'when the exit code is 0' do
           it { is_expected.not_to be_error }
         end
@@ -22,8 +22,8 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
         end
       end
 
-      context 'when the test_report is nil' do
-        let(:test_report) { nil }
+      context 'when the test_reports are an empty hash' do
+        let(:test_reports) { {} }
         context 'when the exit code is 0' do
           it { is_expected.not_to be_error }
         end
@@ -56,7 +56,7 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
 
       context 'when the time limit is exceeded' do
         let(:exit_code) { self.class::TIME_LIMIT_EXCEEDED_EXIT_CODE }
-        let(:test_report) { nil }
+        let(:test_reports) { {} }
         it 'returns TimeLimitExceededError' do
           expect(subject).to be_time_limit_exceeded
           expect(subject.exception).to \
@@ -66,7 +66,7 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
 
       context 'when there are all other errors' do
         let(:exit_code) { 2 }
-        let(:test_report) { nil }
+        let(:test_reports) { {} }
         it 'returns Error' do
           expect(subject).to be_error
           expect(subject.exception).to be_a(Course::Assessment::ProgrammingEvaluationService::Error)

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
 
       context 'when the evaluation fails' do
         it 'raises an Course::Assessment::ProgrammingEvaluationService::Error' do
-          mock_result = Course::Assessment::ProgrammingEvaluationService::Result.new('', '', nil, 1)
+          mock_result = Course::Assessment::ProgrammingEvaluationService::Result.new('', '', {}, 1)
           expect(subject).to receive(:evaluate_package).and_return(mock_result)
 
           expect { subject.send(:import) }.to \
@@ -57,7 +57,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
     describe '#save' do
       it 'does not trigger another attachment import' do
         expect(question).to receive(:imported_attachment=).with(attachment)
-        mock_result = Course::Assessment::ProgrammingEvaluationService::Result.new('', '', nil, 1)
+        mock_result = Course::Assessment::ProgrammingEvaluationService::Result.new('', '', {}, 1)
         subject.send(:save!, {}, mock_result)
       end
     end

--- a/spec/support/stubs/course/assessment/stubbed_programming_evaluation_service.rb
+++ b/spec/support/stubs/course/assessment/stubbed_programming_evaluation_service.rb
@@ -5,13 +5,15 @@ module Course::Assessment::StubbedProgrammingEvaluationService
   def evaluate_in_container
     attributes = { stdout: '',
                    stderr: '',
-                   test_report: File.read(Rails.root.join('spec/fixtures/course/' \
-                                                          'programming_multiple_test_suite_report.xml')),
+                   test_reports: { report: File.read(
+                     Rails.root.join('spec/fixtures/course/' \
+                                     'programming_multiple_test_suite_report.xml')
+                   ) },
                    exit_code: 0 }
     # For timeout testing
     sleep(0.2)
 
-    [attributes[:stdout], attributes[:stderr], attributes[:test_report], attributes[:exit_code]]
+    [attributes[:stdout], attributes[:stderr], attributes[:test_reports], attributes[:exit_code]]
   end
 end
 


### PR DESCRIPTION
Fixes #2586.

For this to have a visible effect, evaluations must be done by images built after https://github.com/Coursemology/evaluator-images/pull/18, with Makefiles that use the new targets.