### PR TITLE
Rewrite cancancan abilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,7 +176,7 @@ gem 'omniauth-facebook'
 
 # Use cancancan for authorization
 gem 'cancancan'
-gem 'cancancan-squeel'
+gem 'cancancan-baby_squeel', github: 'jeremyyap/cancancan-baby_squeel'
 
 # Some helpers for structuring CSS/JavaScript
 gem 'rails_utils', '>= 3.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,15 @@ GIT
       rails (>= 3.2)
 
 GIT
+  remote: git://github.com/jeremyyap/cancancan-baby_squeel.git
+  revision: e8d6c23ba93e34405652f1d85c077feca9b48b41
+  specs:
+    cancancan-baby_squeel (0.1.6)
+      activerecord (>= 4.1)
+      baby_squeel (~> 1.1.5)
+      cancancan (>= 1.10)
+
+GIT
   remote: git://github.com/lowjoel/activerecord-userstamp.git
   revision: e3c808edf57b1d388ac7082a72d0a9910fde8fab
   specs:
@@ -84,8 +93,9 @@ GEM
     autoprefixer-rails (7.1.5)
       execjs
     awesome_print (1.8.0)
-    baby_squeel (0.3.1)
-      activerecord (>= 4.0.0)
+    baby_squeel (1.1.5)
+      activerecord (>= 4.2.0)
+      polyamorous (~> 1.3)
     bcrypt (3.1.11)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -103,11 +113,7 @@ GEM
     byebug (9.1.0)
     calculated_attributes (0.2.0)
       activerecord (>= 3.2.20)
-    cancancan (1.17.0)
-    cancancan-squeel (0.1.4)
-      activerecord (>= 4.1)
-      cancancan (~> 1.10)
-      squeel (~> 1.2)
+    cancancan (2.0.0)
     capybara (2.15.4)
       addressable
       mini_mime (>= 0.1.3)
@@ -310,7 +316,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
-    polyamorous (1.1.0)
+    polyamorous (1.3.1)
       activerecord (>= 3.0)
     progress (3.4.0)
     public_suffix (3.0.0)
@@ -515,10 +521,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    squeel (1.2.3)
-      activerecord (>= 3.0)
-      activesupport (>= 3.0)
-      polyamorous (~> 1.1.0)
     summernote-rails (0.8.3.0)
       railties (>= 3.1)
     temple (0.8.0)
@@ -579,7 +581,7 @@ DEPENDENCIES
   byebug
   calculated_attributes (>= 0.1.3)
   cancancan
-  cancancan-squeel
+  cancancan-baby_squeel!
   capybara
   capybara-screenshot
   capybara-selenium

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -28,7 +28,9 @@ class Course::Controller < ApplicationController
   #   course.
   # @return [nil] If there is no user session, or no course is loaded.
   def current_course_user
-    @current_course_user ||= @course.course_users.with_course_statistics.
+    return nil unless current_course
+
+    @current_course_user ||= current_course.course_users.with_course_statistics.
                              find_by(user: current_user)
   end
   helper_method :current_course_user
@@ -46,7 +48,7 @@ class Course::Controller < ApplicationController
 
   # Override of Cancancan#current_ability to provide current course.
   def current_ability
-    @current_ability ||= Ability.new(current_user, current_course)
+    @current_ability ||= Ability.new(current_user, current_course, current_course_user)
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,6 +3,7 @@ class Ability
   include CanCan::Ability
   attr_reader :user
   attr_reader :course
+  attr_reader :course_user
 
   # Load all components which declare abilities.
   AbilityHost.components.each { |component| prepend(component) }
@@ -11,10 +12,13 @@ class Ability
   #
   # @param [User|nil] user The current user. This can be nil if the no user is logged in.
   # @param [Course|nil] course The current course. This can be nil if not inside a course.
-  def initialize(user, course = nil)
+  # @param [CourseUser|nil] course_user The current course_user. This can be nil if not inside a course
+  # or user is not part of the course
+  def initialize(user, course = nil, course_user = nil)
     @user = user
     @course = course
-    can :manage, :all if user && user.administrator?
+    @course_user = course_user
+    can :manage, :all if user&.administrator?
 
     define_permissions
   end

--- a/app/models/components/course/achievements_ability_component.rb
+++ b/app/models/components/course/achievements_ability_component.rb
@@ -3,38 +3,35 @@ module Course::AchievementsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_student_show_achievements
-      allow_students_with_achievement_show_badges
-      allow_staff_manage_achievements
-      do_not_allow_staff_award_automatically_awarded_achievements
+    if course_user
+      allow_read_achievements
+      allow_user_with_achievement_show_badges
     end
+
+    allow_manage_achievements if course_user&.staff?
+
+    do_not_allow_award_automatically_awarded_achievements
 
     super
   end
 
   private
 
-  def allow_student_show_achievements
-    can :read, Course::Achievement,
-        course_all_course_users_hash.reverse_merge(published_achievement_hash)
+  def allow_read_achievements
+    can :read, Course::Achievement, course_id: course.id, published: true
   end
 
-  def allow_staff_manage_achievements
-    can :manage, Course::Achievement, course_staff_hash
+  def allow_user_with_achievement_show_badges
+    can :display_badge, Course::Achievement, course_user_achievements: { course_user_id: course_user.id }
   end
 
-  def do_not_allow_staff_award_automatically_awarded_achievements
+  def allow_manage_achievements
+    can :manage, Course::Achievement, course_id: course.id
+  end
+
+  def do_not_allow_award_automatically_awarded_achievements
     cannot :award, Course::Achievement do |achievement|
       !achievement.manually_awarded?
     end
-  end
-
-  def allow_students_with_achievement_show_badges
-    can :display_badge, Course::Achievement, course_user_hash
-  end
-
-  def published_achievement_hash
-    { published: true }
   end
 end

--- a/app/models/components/course/experience_points_records_ability_component.rb
+++ b/app/models/components/course/experience_points_records_ability_component.rb
@@ -3,21 +3,19 @@ module Course::ExperiencePointsRecordsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_staff_manage_experience_points_records
-      allow_student_read_own_experience_points_records
-    end
+    allow_manage_experience_points_records if course_user&.staff?
+    allow_read_own_experience_points_records if user
 
     super
   end
 
   private
 
-  def allow_staff_manage_experience_points_records
-    can :manage, Course::ExperiencePointsRecord, course_user: course_staff_hash
+  def allow_manage_experience_points_records
+    can :manage, Course::ExperiencePointsRecord, course_user: { course_id: course.id }
   end
 
-  def allow_student_read_own_experience_points_records
+  def allow_read_own_experience_points_records
     can :read, Course::ExperiencePointsRecord, course_user: { user_id: user.id }
   end
 end

--- a/spec/models/course/achievement_ability_spec.rb
+++ b/spec/models/course/achievement_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Achievement do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let!(:achievement) { create(:course_achievement, course: course) }
     let!(:draft_achievement) { create(:course_achievement, course: course, published: false) }
@@ -31,7 +31,8 @@ RSpec.describe Course::Achievement do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, achievement) }
       it { is_expected.to be_able_to(:manage, draft_achievement) }

--- a/spec/models/course/experience_points_record_ability_spec.rb
+++ b/spec/models/course/experience_points_record_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::ExperiencePointsRecord do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:course_student) { create(:course_student, course: course) }
     let(:points_record) do
@@ -12,6 +12,7 @@ RSpec.describe Course::ExperiencePointsRecord do
     end
 
     context 'when the user is a Course Student' do
+      let(:course_user) { course_student }
       let(:user) { course_student.user }
       let(:classmate) { create(:course_student, course: course) }
       let(:classmate_points_record) do
@@ -42,7 +43,8 @@ RSpec.describe Course::ExperiencePointsRecord do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
       let(:foreign_points_record) { create(:course_experience_points_record) }
 
       context 'when record belongs to a student from the same course' do


### PR DESCRIPTION
Changed the abilities to accept additional parameter `course_user` which can then be used to check the current course user's role. Achievement and EXP record abilities have been rewritten accordingly.

Other ability components will be rewritten later.

Part of Rails 5 upgrade #2271 