### PR TITLE
Modify Python test package generation to run test types independently.

### DIFF
--- a/app/services/course/assessment/question/programming/python/python_autograde_pre.py
+++ b/app/services/course/assessment/question/programming/python/python_autograde_pre.py
@@ -3,9 +3,3 @@ import unittest
 import xmlrunner
 import sys
 
-class AutoGrader(unittest.TestCase):
-    def setUp(self):
-        # clears the dictionary containing meta data for each test
-        self.meta = { 'expression': '', 'expected': '', 'hint': '' }
-
-# Do not modify above this line, unless you know what you are doing

--- a/app/services/course/assessment/question/programming/python/python_makefile
+++ b/app/services/course/assessment/question/programming/python/python_makefile
@@ -1,12 +1,16 @@
 prepare:
 
-compile:
-
-test:	answer.py
-	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" $(PYTHON) answer.py
-
-answer.py:	tests/autograde.py submission/template.py tests/prepend.py tests/append.py
+compile: tests/autograde.py submission/template.py tests/prepend.py tests/append.py
 	cat tests/prepend.py submission/template.py tests/append.py tests/autograde.py > answer.py
+
+public:
+	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" $(PYTHON) answer.py PublicTestsGrader
+
+private:
+	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" $(PYTHON) answer.py PrivateTestsGrader
+
+evaluation:
+	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" $(PYTHON) answer.py EvaluationTestsGrader
 
 solution:	solution.py
 	PYTHONPATH="$(shell pwd)/solution":"$(shell pwd)/tests" $(PYTHON) solution.py

--- a/app/services/course/assessment/question/programming/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming/python/python_package_service.rb
@@ -161,6 +161,17 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
   end
 
   def zip_test_files(test_type, zip) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # Print test class preamble
+    test_class_name = "#{test_type}_tests_grader".camelize
+    class_definition = <<~PYTHON
+      class #{test_class_name}(unittest.TestCase):
+          def setUp(self):
+              # clears the dictionary containing metadata for each test
+              self.meta = { 'expression': '', 'expected': '', 'hint': '' }
+    PYTHON
+
+    zip.print class_definition
+
     tests = @test_params[:test_cases]
     tests[test_type]&.each&.with_index(1) do |test, index|
       # String types should be displayed with quotes, other types will be converted to string
@@ -180,6 +191,7 @@ class Course::Assessment::Question::Programming::Python::PythonPackageService < 
 
       zip.print test_fn
     end
+    zip.print "\n"
   end
 
   def get_data_files_meta(data_files_to_keep, new_data_files)


### PR DESCRIPTION
Add public, private, evaluation Makefile targets.
Update test script generation to produce a different class for each test
type.

References #2589.