### PR TITLE
Fix Video watch title

### DIFF
--- a/app/views/course/video/submission/submissions/edit.html.slim
+++ b/app/views/course/video/submission/submissions/edit.html.slim
@@ -1,4 +1,4 @@
-= page_header t('.header', title: format_inline_text(@video.title))
+= page_header t('.header', title: @video.title)
 
 - unless @video.description.blank?
   h3 = t('.description')


### PR DESCRIPTION
Previously title was double escaped so it renders & for example as &amp;