### PR TITLE
Modify Java test package generation to run test types independently.

### DIFF
--- a/app/services/course/assessment/question/programming/java/RunTests.java
+++ b/app/services/course/assessment/question/programming/java/RunTests.java
@@ -21,6 +21,7 @@ public class RunTests {
 		XmlTest test = new XmlTest(suite);
 		test.setName("tests");
 		test.setXmlClasses(classes);
+		test.addIncludedGroup(args[0]);
 
 		List<XmlSuite> suites = new ArrayList<XmlSuite>();
 		suites.add(suite);

--- a/app/services/course/assessment/question/programming/java/java_build.xml
+++ b/app/services/course/assessment/question/programming/java/java_build.xml
@@ -43,19 +43,45 @@
 		</java>
 	</target>
 
+	<taskdef name="testpublic" classname="org.testng.TestNGAntTask" classpathref="classpath"></taskdef>
+
+	<target name="testpublic" depends="test-compile">
+		<java classname="RunTests">
+			<arg value="public" />
+			<classpath refid="classpath"></classpath>
+		</java>
+	</target>
+
+	<taskdef name="testprivate" classname="org.testng.TestNGAntTask" classpathref="classpath"></taskdef>
+
+	<target name="testprivate" depends="test-compile">
+		<java classname="RunTests">
+			<arg value="private" />
+			<classpath refid="classpath"></classpath>
+		</java>
+	</target>
+
+	<taskdef name="testevaluation" classname="org.testng.TestNGAntTask" classpathref="classpath"></taskdef>
+
+	<target name="testevaluation" depends="test-compile">
+		<java classname="RunTests">
+			<arg value="evaluation" />
+			<classpath refid="classpath"></classpath>
+		</java>
+	</target>
 
 	<!-- To compile the solution files -->
 	<target name="sol-compile" depends="aux-compile">
 		<mkdir dir="${build}"/>
 		<javac srcdir="${soln}" destdir="${build}" includeantruntime="false">
-		    <classpath refid="classpath"></classpath>
+			<classpath refid="classpath"></classpath>
 		</javac>
 	</target>
 
 	<target name="testsol-compile" depends="sol-compile">
 		<mkdir dir="${build}"/>
 		<javac srcdir="${test}" destdir="${build}" includeantruntime="false">
-		    <classpath refid="classpath"></classpath>
+			<classpath refid="classpath"></classpath>
 		</javac>
 	</target>
 

--- a/app/services/course/assessment/question/programming/java/java_package_service.rb
+++ b/app/services/course/assessment/question/programming/java/java_package_service.rb
@@ -241,7 +241,7 @@ class Course::Assessment::Question::Programming::Java::JavaPackageService < \
       hint = test[:hint].blank? ? String(nil) : "result.setAttribute(\"hint\", #{test[:hint].inspect});"
 
       test_fn = <<-Java
-        @Test
+        @Test(groups = { "#{test_type}" })
         public void test_#{test_type}_#{format('%02i', index)}() {
           ITestResult result = Reporter.getCurrentTestResult();
           result.setAttribute("expression", #{test[:expression].inspect});

--- a/app/services/course/assessment/question/programming/java/java_simple_makefile
+++ b/app/services/course/assessment/question/programming/java/java_simple_makefile
@@ -1,12 +1,21 @@
 prepare:
-
-compile:
-
-Autograder.java:
 	cat tests/prepend tests/append submission/template tests/autograde >> tests/Autograder.java
 
-test: Autograder.java
-	ant testng
+compile:
+	ant test-compile
+
+public:
+	ant testpublic
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+private:
+	ant testprivate
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+evaluation:
+	ant testevaluation
 	# Change the filename of the output file for Coursemology to extract
 	mv testng-results.xml report.xml
 
@@ -16,6 +25,6 @@ solution:
 	mv testng-results.xml report.xml
 
 clean:
-	rm -rf report.xml test-output build tests/Autograder.java
+	rm -rf report.xml report-public.xml report-private.xml report-evaluation.xml test-output build tests/Autograder.java
 
-.PHONY: prepare compile test solution clean
+.PHONY: prepare compile public private evaluation solution clean

--- a/app/services/course/assessment/question/programming/java/java_standard_makefile
+++ b/app/services/course/assessment/question/programming/java/java_standard_makefile
@@ -1,12 +1,21 @@
 prepare:
-
-compile:
-
-Autograder.java:
 	cat tests/prepend tests/append tests/autograde >> tests/Autograder.java
 
-test: Autograder.java
-	ant testng
+compile:
+	ant test-compile
+
+public:
+	ant testpublic
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+private:
+	ant testprivate
+	# Change the filename of the output file for Coursemology to extract
+	mv testng-results.xml report.xml
+
+evaluation:
+	ant testevaluation
 	# Change the filename of the output file for Coursemology to extract
 	mv testng-results.xml report.xml
 
@@ -16,6 +25,6 @@ solution:
 	mv testng-results.xml report.xml
 
 clean:
-	rm -rf report.xml test-output build tests/Autograder.java
+	rm -rf report.xml report-public.xml report-private.xml report-evaluation.xml test-output build tests/Autograder.java
 
-.PHONY: prepare compile test solution clean
+.PHONY: prepare compile public private evaluation solution clean


### PR DESCRIPTION
Add Include group element to testng's virtual XML using a command line
argument.

Add public, private, evaluation targets to Makefile.
Rearrange commands in Makefile to use prepare and compile targets.
Add separate report XML files to clean target.

Add testpublic, testprivate, testevaluation tasks to ant build file.
These invoke the RunTests program with the correct argument.

Indicate which group each test function belongs to.

Fixes #2589.