### PR TITLE
Minor refactor of announcement with added validations

### DIFF
--- a/app/models/concerns/announcement_concern.rb
+++ b/app/models/concerns/announcement_concern.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+#
+# Concern of common methods for the announcements - GenericAnnouncement and Course::Announcement.
+module AnnouncementConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_initialize :set_defaults, if: :new_record?
+    after_create :mark_as_read_by_creator
+    after_update :mark_as_read_by_updater
+  end
+
+  private
+
+  # Set default values
+  def set_defaults
+    self.start_at ||= Time.zone.now
+    self.end_at ||= 7.days.from_now
+  end
+
+  # Mark announcement as read for the creator
+  def mark_as_read_by_creator
+    mark_as_read! for: creator
+  end
+
+  # Mark announcement as read for the updater
+  def mark_as_read_by_updater
+    mark_as_read! for: updater
+  end
+end

--- a/app/models/concerns/announcement_concern.rb
+++ b/app/models/concerns/announcement_concern.rb
@@ -8,6 +8,8 @@ module AnnouncementConcern
     after_initialize :set_defaults, if: :new_record?
     after_create :mark_as_read_by_creator
     after_update :mark_as_read_by_updater
+
+    validate :validate_start_at_cannot_be_after_end_at
   end
 
   private
@@ -26,5 +28,10 @@ module AnnouncementConcern
   # Mark announcement as read for the updater
   def mark_as_read_by_updater
     mark_as_read! for: updater
+  end
+
+  def validate_start_at_cannot_be_after_end_at
+    return unless end_at && start_at && start_at > end_at
+    errors.add(:start_at, :cannot_be_after_end_at)
   end
 end

--- a/app/models/course/announcement.rb
+++ b/app/models/course/announcement.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 class Course::Announcement < ApplicationRecord
+  include AnnouncementConcern
+
   acts_as_readable on: :updated_at
   has_many_attachments on: :content
 
   after_create :send_notification
-
-  after_initialize :set_defaults, if: :new_record?
-  after_create :mark_as_read_by_creator
-  after_update :mark_as_read_by_updater
 
   belongs_to :course, inverse_of: :announcements
 
@@ -19,22 +17,6 @@ class Course::Announcement < ApplicationRecord
   end
 
   private
-
-  # Set default values
-  def set_defaults
-    self.start_at ||= Time.zone.now
-    self.end_at ||= 7.days.from_now
-  end
-
-  # Mark announcement as read for the creator
-  def mark_as_read_by_creator
-    mark_as_read! for: creator
-  end
-
-  # Mark announcement as read for the updater
-  def mark_as_read_by_updater
-    mark_as_read! for: updater
-  end
 
   def send_notification
     Course::AnnouncementNotifier.new_announcement(creator, self)

--- a/app/models/generic_announcement.rb
+++ b/app/models/generic_announcement.rb
@@ -3,10 +3,9 @@
 #
 # This is the abstract single-table inheritance table used for both announcement types.
 class GenericAnnouncement < ApplicationRecord
-  after_initialize :set_defaults, if: :new_record?
+  include AnnouncementConcern
+
   acts_as_readable on: :updated_at
-  after_create :mark_as_read_by_creator
-  after_update :mark_as_read_by_updater
 
   belongs_to :instance, inverse_of: :announcements
 
@@ -29,23 +28,5 @@ class GenericAnnouncement < ApplicationRecord
 
   def sticky?
     false
-  end
-
-  private
-
-  # Set default values
-  def set_defaults
-    self.start_at ||= Time.zone.now
-    self.end_at ||= 7.days.from_now
-  end
-
-  # Mark announcement as read for the creator
-  def mark_as_read_by_creator
-    mark_as_read! for: creator
-  end
-
-  # Mark announcement as read for the updater
-  def mark_as_read_by_updater
-    mark_as_read! for: updater
   end
 end

--- a/config/locales/en/activerecord/course/announcement.yml
+++ b/config/locales/en/activerecord/course/announcement.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/announcement:
+          attributes:
+            start_at:
+              cannot_be_after_end_at: 'cannot be after end at'

--- a/config/locales/en/activerecord/generic_announcement.yml
+++ b/config/locales/en/activerecord/generic_announcement.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        generic_announcement:
+          attributes:
+            start_at:
+              cannot_be_after_end_at: 'cannot be after end at'

--- a/spec/features/global_announcements_spec.rb
+++ b/spec/features/global_announcements_spec.rb
@@ -49,8 +49,9 @@ RSpec.feature 'Global announcements' do
         announcements = 2.downto(-1).flat_map do |i|
           now = Time.zone.now
           [
-            create(:instance_announcement, end_at: now + i.minutes, instance: instance),
-            create(:system_announcement, start_at: now + i.minutes)
+            create(:instance_announcement,
+                   start_at: now - 1.week, end_at: now + i.minutes, instance: instance),
+            create(:system_announcement, start_at: now + i.minutes, end_at: now + 1.week)
           ]
         end
 

--- a/spec/models/course/announcement_spec.rb
+++ b/spec/models/course/announcement_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe Course::Announcement, type: :model do
     let!(:user) { create(:user) }
     let(:course) { create(:course) }
 
+    describe 'validations' do
+      subject { build(:course_announcement) }
+      context 'when start date is after end date' do
+        before { subject.start_at = subject.end_at + 3.days }
+        it 'is invalid' do
+          expect(subject).to be_invalid
+          expect(subject.errors[:start_at]).to include(I18n.t('activerecord.errors.models.' \
+            'course/announcement.attributes.start_at.cannot_be_after_end_at'))
+        end
+      end
+    end
+
     describe 'create an announcement' do
       context 'when announcement is created' do
         subject { Course::Announcement.new }

--- a/spec/models/generic_announcement_spec.rb
+++ b/spec/models/generic_announcement_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe GenericAnnouncement, type: :model do
     let!(:active_system_announcements) { create_list(:system_announcement, 1) }
     let!(:active_instance_announcements) { create_list(:instance_announcement, 1) }
 
+    describe 'validations' do
+      subject { build(:generic_announcement) }
+      context 'when start date is after end date' do
+        before { subject.start_at = subject.end_at + 3.days }
+        it 'is invalid' do
+          expect(subject).to be_invalid
+          expect(subject.errors[:start_at]).to include(I18n.t('activerecord.errors.models.' \
+            'generic_announcement.attributes.start_at.cannot_be_after_end_at'))
+        end
+      end
+    end
+
     describe '.currently_active' do
       let!(:now) { Time.zone.now }
       let!(:inactive_announcements) do


### PR DESCRIPTION
This PR helps to group some of the common logic of announcements into a concern, as well as add a validation that `start_at` has to be before `end_at`. 