### PR TITLE
Fix video links

### DIFF
--- a/app/views/course/video/videos/_video_lesson_plan_item.json.jbuilder
+++ b/app/views/course/video/videos/_video_lesson_plan_item.json.jbuilder
@@ -1,6 +1,6 @@
 json.partial! 'course/lesson_plan/items/item.json.jbuilder', item: item
 
-json.item_path course_videos_path(current_course)
+json.item_path course_video_path(current_course, item)
 json.description item.description
 json.edit_path edit_course_video_path(current_course, item) if can?(:update, item)
 json.delete_path course_video_path(current_course, item) if can?(:destroy, item)

--- a/app/views/course/video/videos/show.html.slim
+++ b/app/views/course/video/videos/show.html.slim
@@ -1,7 +1,10 @@
 - add_breadcrumb @video.title
 = page_header @video.title do
-  - if can?(:manage, @video)
-    div.pull-right
+  div.pull-right
+    - if can?(:attempt, @video)
+      = render partial: 'course/video/videos/video_attempt_button',
+        locals: { video: @video }
+    - if can?(:manage, @video)
       = render partial: 'video_management_buttons', locals: { video: @video }
 
 = div_for(@video) do

--- a/app/views/notifiers/course/video_notifier/attempted/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/video_notifier/attempted/course_notifications/_feed.html.slim
@@ -4,8 +4,7 @@
 = div_for(notification) do
   // TODO: Display user image here.
   - user_link = link_to_user(activity.actor)
-  // TODO: Enable video_link when routes are fixed
-  // - video_link = link_to video.title, course_video_path(notification.course, video)
-  - video_link = video.title
+  - video_link = link_to(video.title,
+                         course_video_path(notification.course, video))
   => t('.attempted_video_html', user: user_link, video: video_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/video_notifier/closing/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/video_notifier/closing/user_notifications/email.html.slim
@@ -5,7 +5,6 @@
 
 - message.subject = t('.subject', course: course.title, video: video.title)
 
-/ TODO: Re-enable when routes are updated
-/= simple_format(t('.message', time: time,
-/                video: link_to(video.title,
-/                               course_video_url(course, video, host: host))))
+= simple_format(t('.message', time: time,
+                video: link_to(video.title,
+                               course_video_url(video.course, video))))

--- a/app/views/notifiers/course/video_notifier/opening/course_notifications/email.html.slim
+++ b/app/views/notifiers/course/video_notifier/opening/course_notifications/email.html.slim
@@ -4,7 +4,6 @@
 
 - message.subject = t('.subject', course: course.title, video: video.title)
 
-/ TODO: Re-enable when routes are updated
-/= simple_format(t('.message',
-/                video: link_to(video.title,
-/                               course_video_url(course, video, host: host))))
+= simple_format(t('.message',
+                video: link_to(video.title,
+                               course_video_url(video.course, video))))

--- a/config/locales/en/notifiers/course/video_notifier/video_notifier.yml
+++ b/config/locales/en/notifiers/course/video_notifier/video_notifier.yml
@@ -6,13 +6,11 @@ en:
           course_notifications:
             email:
               subject: '%{course} New Video Available'
-# TODO: To re-enable when paths are fixed.
-#              message: >
-#                New Video Available : %{video}
+              message: >
+                New Video Available : %{video}
         closing:
           user_notifications:
             email:
               subject: '%{course} Reminder for %{video}'
-# TODO: To re-enable when paths are fixed.
-#              message: >
-#                Please be reminded that %{video} is due on %{time}
+              message: >
+                Please be reminded that %{video} is due on %{time}


### PR DESCRIPTION
The link in the email for the video component was turned off because the video viewing route is actually an edit submission route, which requires a submission.

As a compromise, I made use of the new route to redirect as necessary (we can't push a post method link in an email).

Patched for email, feed, and lesson plan item.
