### PR TITLE
Fix deprecated controller test params style

### DIFF
--- a/spec/controllers/course/achievement/achievements_controller_spec.rb
+++ b/spec/controllers/course/achievement/achievements_controller_spec.rb
@@ -22,8 +22,10 @@ RSpec.describe Course::Achievement::AchievementsController, type: :controller do
 
     describe '#update' do
       subject do
-        patch :update, course_id: course, id: achievement_stub,
-                       achievement: { course_user_ids: [course_user.id] }
+        patch :update, params: {
+          course_id: course, id: achievement_stub,
+          achievement: { course_user_ids: [course_user.id] }
+        }
       end
 
       context 'when the achievement is automatically awarded' do

--- a/spec/controllers/course/achievement/condition/assessments_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/assessments_controller_spec.rb
@@ -86,11 +86,12 @@ RSpec.describe Course::Achievement::Condition::AssessmentsController, type: :con
       end
 
       subject do
-        patch :update,
-              course_id: course,
-              achievement_id: achievement,
-              id: assessment_condition,
-              condition_assessment: { minimum_grade_percentage: minimum_grade_percentage }
+        patch :update, params: {
+          course_id: course,
+          achievement_id: achievement,
+          id: assessment_condition,
+          condition_assessment: { minimum_grade_percentage: minimum_grade_percentage }
+        }
       end
 
       context 'when update fails' do

--- a/spec/controllers/course/achievement/condition/levels_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/levels_controller_spec.rb
@@ -87,11 +87,12 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
       end
 
       subject do
-        patch :update,
-              course_id: course,
-              achievement_id: achievement,
-              id: level_condition,
-              condition_level: { minimum_level: min_level }
+        patch :update, params: {
+          course_id: course,
+          achievement_id: achievement,
+          id: level_condition,
+          condition_level: { minimum_level: min_level }
+        }
       end
 
       context 'when update fails' do

--- a/spec/controllers/course/admin/admin_controller_spec.rb
+++ b/spec/controllers/course/admin/admin_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Course::Admin::AdminController do
 
     describe '#update' do
       let(:title) { 'New Title' }
-      subject { patch :update, course_id: course, course: { title: title } }
+      subject { patch :update, params: { course_id: course, course: { title: title } } }
 
       context 'when the user is a Course Manager' do
         let(:user) { create(:course_manager, course: course).user }

--- a/spec/controllers/course/admin/assessment_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/assessment_settings_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Admin::AssessmentSettingsController, type: :controller do
         allow(controller).to receive(:category_params).and_return(nil)
       end
       context 'upon update failure' do
-        subject { patch :update, course_id: course }
+        subject { patch :update, params: { course_id: course } }
         it { is_expected.to render_template(:edit) }
       end
     end

--- a/spec/controllers/course/admin/component_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/component_settings_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Course::Admin::ComponentSettingsController, type: :controller do
       end
 
       subject do
-        patch :update, settings_components: components_params, course_id: course
+        patch :update, params: { settings_components: components_params, course_id: course }
       end
 
       it 'enables the specified component and disables all other components' do

--- a/spec/controllers/course/admin/discussion/topic_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/discussion/topic_settings_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Admin::Discussion::TopicSettingsController do
       end
 
       context 'when course cannot be saved' do
-        subject { patch :update, course_id: course, settings_topics_component: { title: '' } }
+        subject { patch :update, params: { course_id: course, settings_topics_component: { title: '' } } }
         it { is_expected.to render_template(:edit) }
       end
     end

--- a/spec/controllers/course/admin/forum_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/forum_settings_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Course::Admin::ForumSettingsController, type: :controller do
         allow(controller).to receive(:current_course).and_return(course)
       end
       context 'when course cannot be saved' do
-        subject { patch :update, course_id: course, settings_forums_component: { title: '' } }
+        subject { patch :update, params: { course_id: course, settings_forums_component: { title: '' } } }
         it { is_expected.to render_template(:edit) }
       end
     end

--- a/spec/controllers/course/admin/leaderboard_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/leaderboard_settings_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Course::Admin::LeaderboardSettingsController, type: :controller d
         allow(controller).to receive(:current_course).and_return(course)
       end
       context 'when course cannot be saved' do
-        subject { patch :update, course_id: course, settings_leaderboard_component: { title: '' } }
+        subject { patch :update, params: { course_id: course, settings_leaderboard_component: { title: '' } } }
         it { is_expected.to render_template(:edit) }
       end
     end

--- a/spec/controllers/course/admin/material_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/material_settings_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Course::Admin::MaterialSettingsController, type: :controller do
         allow(controller).to receive(:current_course).and_return(course)
       end
       context 'when course cannot be saved' do
-        subject { patch :update, course_id: course, settings_materials_component: { title: '' } }
+        subject { patch :update, params: { course_id: course, settings_materials_component: { title: '' } } }
         it { is_expected.to render_template(:edit) }
       end
     end

--- a/spec/controllers/course/admin/notification_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/notification_settings_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Course::Admin::NotificationSettingsController, type: :controller 
     end
 
     describe '#update' do
-      subject { patch :update, course_id: course, notification_settings: payload }
+      subject { patch :update, params: { course_id: course, notification_settings: payload } }
 
       context 'when valid parameters are received' do
         render_views

--- a/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/sidebar_settings_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Course::Admin::SidebarSettingsController, type: :controller do
         sidebar_item_attributes = { id => { id: sample_item[:key], weight: weight } }
         { sidebar_items_attributes: sidebar_item_attributes }
       end
-      subject { patch :update, settings_sidebar: sidebar_item_attributes, course_id: course }
+      subject { patch :update, params: { settings_sidebar: sidebar_item_attributes, course_id: course } }
 
       context 'when the weight is greater than 0' do
         it 'updates the weight' do

--- a/spec/controllers/course/assessment/assessments_controller_spec.rb
+++ b/spec/controllers/course/assessment/assessments_controller_spec.rb
@@ -21,10 +21,12 @@ RSpec.describe Course::Assessment::AssessmentsController do
       context 'when a category is given' do
         before do
           post :index,
-               course_id: course,
-               id: immutable_assessment,
-               assessment: { title: '' },
-               category: category
+               params: {
+                 course_id: course,
+                 id: immutable_assessment,
+                 assessment: { title: '' },
+                 category: category
+               }
         end
         it { expect(controller.instance_variable_get(:@category)).to eq(category) }
       end
@@ -32,11 +34,13 @@ RSpec.describe Course::Assessment::AssessmentsController do
       context 'when a tab is given' do
         before do
           post :index,
-               course_id: course,
-               id: immutable_assessment,
-               assessment: { title: '' },
-               category: category,
-               tab: tab
+               params: {
+                 course_id: course,
+                 id: immutable_assessment,
+                 assessment: { title: '' },
+                 category: category,
+                 tab: tab
+               }
         end
         it { expect(controller.instance_variable_get(:@tab)).to eq(tab) }
       end
@@ -50,7 +54,7 @@ RSpec.describe Course::Assessment::AssessmentsController do
 
       context 'when update fails' do
         it 'renders JSON errors' do
-          patch :update, course_id: course, id: assessment, assessment: { title: '' }
+          patch :update, params: { course_id: course, id: assessment, assessment: { title: '' } }
 
           body = JSON.parse(response.body)
           expect(body['errors']).to be_present
@@ -60,8 +64,10 @@ RSpec.describe Course::Assessment::AssessmentsController do
       it 'updates the start_at and end_at' do
         student
 
-        patch :update, course_id: course, id: assessment,
-                       assessment: { start_at: Time.zone.now, end_at: Time.zone.now + 1.hour }
+        patch :update, params: {
+          course_id: course, id: assessment,
+          assessment: { start_at: Time.zone.now, end_at: Time.zone.now + 1.hour }
+        }
 
         perform_enqueued_jobs
         wait_for_job
@@ -81,8 +87,10 @@ RSpec.describe Course::Assessment::AssessmentsController do
       context 'when the assessment is autograded' do
         let(:assessment) { create(:assessment, :autograded, course: course) }
         it 'does not update attributes tabbed_view and password' do
-          patch :update, course_id: course, id: assessment,
-                         assessment: { skippable: true, tabbed_view: true, password: 'password' }
+          patch :update, params: {
+            course_id: course, id: assessment,
+            assessment: { skippable: true, tabbed_view: true, password: 'password' }
+          }
 
           expect(assessment).not_to be_skippable
           assessment.reload
@@ -96,8 +104,10 @@ RSpec.describe Course::Assessment::AssessmentsController do
       context 'when the assessment is not autograded' do
         let(:assessment) { create(:assessment, course: course) }
         it 'does not update attribute skippable' do
-          patch :update, course_id: course, id: assessment,
-                         assessment: { skippable: true, tabbed_view: true, password: 'password' }
+          patch :update, params: {
+            course_id: course, id: assessment,
+            assessment: { skippable: true, tabbed_view: true, password: 'password' }
+          }
 
           expect(assessment).not_to be_skippable
           expect(assessment.tabbed_view).not_to be_truthy

--- a/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe Course::Assessment::Question::MultipleResponsesController do
         question_multiple_response_attributes =
           attributes_for(:course_assessment_question_multiple_response).
           slice(:description, :maximum_grade)
-        patch :update, course_id: course, assessment_id: assessment, id: multiple_response,
-                       question_multiple_response: question_multiple_response_attributes
+        patch :update, params: {
+          course_id: course, assessment_id: assessment, id: multiple_response,
+          question_multiple_response: question_multiple_response_attributes
+        }
       end
 
       it do
@@ -77,8 +79,10 @@ RSpec.describe Course::Assessment::Question::MultipleResponsesController do
                     }
                 }
             }
-          patch :update, course_id: course, assessment_id: assessment, id: multiple_response,
-                         question_multiple_response: question_multiple_response_attributes
+          patch :update, params: {
+            course_id: course, assessment_id: assessment, id: multiple_response,
+            question_multiple_response: question_multiple_response_attributes
+          }
         end
 
         it 'updates a valid weight' do

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -79,8 +79,10 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
     describe '#update' do
       subject do
         request.accept = 'application/json'
-        patch :update, course_id: course, assessment_id: assessment, id: programming_question,
-                       question_programming: question_programming_attributes
+        patch :update, params: {
+          course_id: course, assessment_id: assessment, id: programming_question,
+          question_programming: question_programming_attributes
+        }
       end
 
       context 'when the question cannot be saved' do

--- a/spec/controllers/course/assessment/question/scribing_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/scribing_controller_spec.rb
@@ -114,8 +114,10 @@ RSpec.describe Course::Assessment::Question::ScribingController do
     describe '#update' do
       subject do
         request.accept = 'application/json'
-        patch :update, course_id: course, assessment_id: assessment, id: scribing_question,
-                       question_scribing: question_scribing_update_attributes
+        patch :update, params: {
+          course_id: course, assessment_id: assessment, id: scribing_question,
+          question_scribing: question_scribing_update_attributes
+        }
       end
 
       context 'when the question cannot be saved' do

--- a/spec/controllers/course/assessment/question/text_responses_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/text_responses_controller_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe Course::Assessment::Question::TextResponsesController do
         question_text_response_attributes =
           attributes_for(:course_assessment_question_text_response).
           slice(:description, :maximum_grade)
-        patch :update, course_id: course, assessment_id: assessment, id: text_response,
-                       question_text_response: question_text_response_attributes
+        patch :update, params: {
+          course_id: course, assessment_id: assessment, id: text_response,
+          question_text_response: question_text_response_attributes
+        }
       end
 
       it do

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -121,8 +121,11 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
       describe '#submit_answer' do
         subject do
           put :submit_answer,
-              course_id: course, assessment_id: assessment, id: submission, answer_id: current_answer.id,
-              answer: { id: current_answer.id }, format: :json
+              as: :json,
+              params: {
+                course_id: course, assessment_id: assessment, id: submission, answer_id: current_answer.id,
+                answer: { id: current_answer.id }
+              }
         end
 
         context 'when update fails' do

--- a/spec/controllers/course/controller_spec.rb
+++ b/spec/controllers/course/controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Controller, type: :controller do
 
     describe '#current_course' do
       it 'returns the current course' do
-        get(:show, id: course.id)
+        get :show, params: { id: course.id }
         expect(controller.current_course).to eq(course)
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe Course::Controller, type: :controller do
     describe '#current_course_user' do
       context 'when there is no user logged in' do
         let(:user) { nil }
-        subject { get(:show, id: course.id) }
+        subject { get :show, params: { id: course.id } }
         it 'raises an error' do
           expect { subject }.to raise_error(CanCan::AccessDenied)
         end
@@ -37,7 +37,7 @@ RSpec.describe Course::Controller, type: :controller do
       context 'when the user is logged in' do
         context 'when the user is not registered in the course' do
           it 'returns nil' do
-            get(:show, id: course.id)
+            get :show, params: { id: course.id }
             expect(controller.current_course_user).to be_nil
           end
         end
@@ -45,7 +45,7 @@ RSpec.describe Course::Controller, type: :controller do
         context 'when the user is registered in the course' do
           let!(:course_user) { create(:course_user, course: course, user: user) }
           it 'returns the correct user' do
-            get(:show, id: course.id)
+            get :show, params: { id: course.id }
             expect(controller.current_course_user.user).to eq(user)
             expect(controller.current_course_user.course).to eq(controller.current_course)
           end

--- a/spec/controllers/course/experience_points_records_controller_spec.rb
+++ b/spec/controllers/course/experience_points_records_controller_spec.rb
@@ -22,9 +22,11 @@ RSpec.describe Course::ExperiencePointsRecordsController, type: :controller do
 
     describe '#update' do
       subject do
-        patch :update, format: :js, course_id: course,
-                       user_id: course_student, id: points_record_stub,
-                       experience_points_record: { reason: 'reason' }
+        patch :update, format: :js, params: {
+          course_id: course,
+          user_id: course_student, id: points_record_stub,
+          experience_points_record: { reason: 'reason' }
+        }
       end
 
       context 'when update fails' do

--- a/spec/controllers/course/forum/forums_controller_spec.rb
+++ b/spec/controllers/course/forum/forums_controller_spec.rb
@@ -44,8 +44,10 @@ RSpec.describe Course::Forum::ForumsController, type: :controller do
     describe '#create' do
       subject do
         post :create,
-             course_id: course,
-             forum: { name: 'test', description: '' }
+             params: {
+               course_id: course,
+               forum: { name: 'test', description: '' }
+             }
       end
 
       context 'when saving fails' do
@@ -60,10 +62,11 @@ RSpec.describe Course::Forum::ForumsController, type: :controller do
 
     describe '#update' do
       subject do
-        patch :update,
-              course_id: course,
-              id: forum_stub,
-              forum: { name: 'new name', descripiton: 'new description' }
+        patch :update, params: {
+          course_id: course,
+          id: forum_stub,
+          forum: { name: 'new name', descripiton: 'new description' }
+        }
       end
 
       context 'when update fails' do

--- a/spec/controllers/course/groups_controller_spec.rb
+++ b/spec/controllers/course/groups_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Course::GroupsController, type: :controller do
         let(:group_attributes) do
           attributes_for(:course_group, group_users_attributes: group_users_attributes)
         end
-        subject { patch :update, course_id: course, id: group, group: group_attributes }
+        subject { patch :update, params: { course_id: course, id: group, group: group_attributes } }
 
         context 'when the user and the group are in the same course' do
           let!(:course_user_to_add) { create(:course_user, course: course) }
@@ -68,7 +68,7 @@ RSpec.describe Course::GroupsController, type: :controller do
           group_users_attributes = { id_not_taken => attributes_for(:course_group_user) }
           attributes_for(:course_group, group_users_attributes: group_users_attributes)
         end
-        subject { patch :update, course_id: course, id: group, group: group_attributes }
+        subject { patch :update, params: { course_id: course, id: group, group: group_attributes } }
 
         it 'does not add the user to the group' do
           expect { subject }.to change { group.course_users.count }.by(0)

--- a/spec/controllers/course/lesson_plan/event_controller_spec.rb
+++ b/spec/controllers/course/lesson_plan/event_controller_spec.rb
@@ -40,8 +40,10 @@ RSpec.describe Course::LessonPlan::EventsController, type: :controller do
 
     describe '#update' do
       subject do
-        patch :update, format: :json, course_id: course, id: event_immutable_stub,
-                       lesson_plan_event: attributes_for(:course_lesson_plan_event)
+        patch :update, as: :json, params: {
+          course_id: course, id: event_immutable_stub,
+          lesson_plan_event: attributes_for(:course_lesson_plan_event)
+        }
       end
 
       context 'when update succeeds' do

--- a/spec/controllers/course/lesson_plan/milestones_controller_spec.rb
+++ b/spec/controllers/course/lesson_plan/milestones_controller_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe Course::LessonPlan::MilestonesController, type: :controller do
 
     describe '#update' do
       subject do
-        patch :update, format: :json, course_id: course, id: milestone_immutable_stub,
-                       lesson_plan_milestone: attributes_for(:course_lesson_plan_milestone)
+        patch :update, as: :json, params: {
+          course_id: course, id: milestone_immutable_stub,
+          lesson_plan_milestone: attributes_for(:course_lesson_plan_milestone)
+        }
       end
 
       context 'when update succeeds' do

--- a/spec/controllers/course/material/folders_controller_spec.rb
+++ b/spec/controllers/course/material/folders_controller_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Course::Material::FoldersController, type: :controller do
     describe '#upload_materials' do
       let(:file) { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'files', 'text.txt')) }
       subject do
-        patch :upload_materials, course_id: course, id: folder_stub,
-                                 material_folder: { files_attributes: [file] }
+        patch :upload_materials,
+              params: { course_id: course, id: folder_stub, material_folder: { files_attributes: [file] } }
       end
 
       context 'when files cannot be uploaded' do

--- a/spec/controllers/course/material/materials_controller_spec.rb
+++ b/spec/controllers/course/material/materials_controller_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
       let(:file) { fixture_file_upload('files/picture.jpg', 'image/jpeg') }
       let(:attributes) { attributes_for(:material, file: file) }
       subject do
-        patch :update, course_id: course, folder_id: folder,
-                       id: material_stub, material: attributes
+        patch :update,
+              params: { course_id: course, folder_id: folder, id: material_stub, material: attributes }
       end
 
       context 'when a different file is given' do

--- a/spec/controllers/course/survey/responses_controller_spec.rb
+++ b/spec/controllers/course/survey/responses_controller_spec.rb
@@ -177,8 +177,10 @@ RSpec.describe Course::Survey::ResponsesController do
       let(:user) { student.user }
 
       subject do
-        patch :update, format: :json, response: response_params,
-                       course_id: course.id, survey_id: survey.id, id: survey_response.id
+        patch :update, as: :json, params: {
+          response: response_params,
+          course_id: course.id, survey_id: survey.id, id: survey_response.id
+        }
       end
 
       context 'when student submits an answer for a multiple response question' do

--- a/spec/controllers/course/survey/surveys_controller_spec.rb
+++ b/spec/controllers/course/survey/surveys_controller_spec.rb
@@ -157,8 +157,10 @@ RSpec.describe Course::Survey::SurveysController do
       let(:user) { admin }
 
       subject do
-        patch :update, format: :json, course_id: course.id, id: survey.id,
-                       survey: survey_params
+        patch :update, as: :json, params: {
+          course_id: course.id, id: survey.id,
+          survey: survey_params
+        }
       end
 
       context 'when survey is anonymous' do

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -56,8 +56,7 @@ RSpec.describe Course::UsersController, type: :controller do
     describe '#update' do
       before { sign_in(user) }
       subject do
-        put :update, format: :js, course_id: course, id: course_user,
-                     course_user: updated_course_user
+        put :update, as: :js, params: { course_id: course, id: course_user, course_user: updated_course_user }
       end
       let!(:course_user_to_update) { create(:course_user) }
       let(:updated_course_user) { { role: :teaching_assistant } }

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe JobsController do
       it { is_expected.to redirect_to(redirect_path) }
     end
 
-    before { get 'show', id: job.id, format: format }
+    before { get 'show', params: { id: job.id, format: format } }
 
     context 'when the job is in progress' do
       it { is_expected.to respond_with(:accepted) }

--- a/spec/controllers/system/admin/instance/components_controller_spec.rb
+++ b/spec/controllers/system/admin/instance/components_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe System::Admin::Instance::ComponentsController, type: :controller 
         all_component_ids.sample(1 + rand(all_component_ids.count))
       end
       let(:components_params) { { enabled_component_ids: ids_to_enable } }
-      subject { patch :update, settings_components: components_params }
+      subject { patch :update, params: { settings_components: components_params } }
 
       context 'enable/disable components' do
         let(:settings) do

--- a/spec/controllers/system/admin/instance/users_controller_spec.rb
+++ b/spec/controllers/system/admin/instance/users_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe System::Admin::Instance::UsersController, type: :controller do
       let!(:instance_user) { create(:instance_user) }
 
       subject do
-        patch :update, format: :js, id: instance_user, instance_user: { role: :administrator }
+        patch :update, as: :js, params: { id: instance_user, instance_user: { role: :administrator } }
       end
 
       context 'when the user is an instance administrator' do

--- a/spec/controllers/system/admin/users_controller_spec.rb
+++ b/spec/controllers/system/admin/users_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe System::Admin::UsersController, type: :controller do
     describe '#update' do
       let!(:user_to_update) { create(:user) }
 
-      subject { patch :update, format: :js, id: user_to_update, user: { role: :administrator } }
+      subject { patch :update, as: :js, params: { id: user_to_update, user: { role: :administrator } } }
 
       context 'when the user is a system administrator' do
         before { sign_in(admin) }

--- a/spec/controllers/user/profiles_controller_spec.rb
+++ b/spec/controllers/user/profiles_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe User::ProfilesController, type: :controller do
 
     describe '#update' do
       let(:new_name) { 'New Name' }
-      subject { patch :update, user: { name: new_name } }
+      subject { patch :update, params: { user: { name: new_name } } }
 
       context 'when user is signed in' do
         before { sign_in(user) }


### PR DESCRIPTION
References https://github.com/Coursemology/coursemology2/issues/2616

Deprecated style:
get :show, { id: 1 }, nil, { notice: "This is a flash message" }

New keyword style:
get :show, params: { id: 1 }, flash: { notice: "This is a flash message" }