### PR TITLE
Add models for new TextInput question type

### DIFF
--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -41,6 +41,9 @@ class Course::Assessment < ApplicationRecord
   has_many :voice_response_questions,
            through: :questions, inverse_through: :question, source: :actable,
            source_type: Course::Assessment::Question::VoiceResponse.name
+  has_many :text_input_questions,
+           through: :questions, inverse_through: :question, source: :actable,
+           source_type: Course::Assessment::Question::TextInput.name
   has_many :assessment_conditions, class_name: Course::Condition::Assessment.name,
                                    inverse_of: :assessment, dependent: :destroy
 

--- a/app/models/course/assessment/answer/text_input.rb
+++ b/app/models/course/assessment/answer/text_input.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+class Course::Assessment::Answer::TextInput < ApplicationRecord
+  acts_as :answer, class_name: Course::Assessment::Answer.name
+  has_many_attachments
+
+  after_initialize :set_default
+  before_validation :strip_whitespace
+  validate :validate_filenames_are_unique, if: :attachments_changed?
+
+  # Specific implementation of Course::Assessment::Answer#reset_answer
+  def reset_answer
+    self.answer_text = ''
+    save
+    acting_as
+  end
+
+  def sanitized_answer_text
+    Sanitize.fragment(answer_text).strip
+  end
+
+  def download(dir)
+    download_answer(dir) unless question.actable.file_upload_question?
+    attachments.each { |a| download_attachment(a, dir) }
+  end
+
+  def download_answer(dir)
+    answer_path = File.join(dir, 'answer.txt')
+    File.open(answer_path, 'w') do |file|
+      file.write(sanitized_answer_text)
+    end
+  end
+
+  def download_attachment(attachment, dir)
+    name_generator = FileName.new(File.join(dir, attachment.name), position: :middle,
+                                                                   format: '(%d)',
+                                                                   delimiter: ' ')
+    attachment_path = name_generator.create
+    File.open(attachment_path, 'wb') do |file|
+      attachment.open(binmode: true) do |attachment_stream|
+        FileUtils.copy_stream(attachment_stream, file)
+      end
+    end
+  end
+
+  def assign_params(params)
+    acting_as.assign_params(params)
+    self.answer_text = params[:answer_text] if params[:answer_text]
+    self.files = params[:files] if params[:files]
+  end
+
+  private
+
+  def set_default
+    self.answer_text ||= ''
+  end
+
+  def strip_whitespace
+    answer_text.strip!
+  end
+
+  def validate_filenames_are_unique
+    return if attachments.map(&:name).uniq.count == attachments.size
+
+    errors.add(:attachments, :unique)
+  end
+end

--- a/app/models/course/assessment/question/text_input.rb
+++ b/app/models/course/assessment/question/text_input.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::TextInput < ActiveRecord::Base
+  acts_as :question, class_name: Course::Assessment::Question.name
+
+  validate :validate_grade
+
+  has_many :groups, class_name: Course::Assessment::Question::TextInputGroup.name,
+                    dependent: :destroy, foreign_key: :question_id, inverse_of: :question
+
+  accepts_nested_attributes_for :groups, allow_destroy: true
+
+  def auto_gradable?
+    groups.map(&:auto_gradable_group?).any?
+  end
+
+  # Method provides readability to identifying whether a question is a file upload question.
+  #  Used with the front-end translations.
+  def file_upload_question?
+    hide_text
+  end
+
+  # Method provides readability to identifying whether a question is a
+  # (GCE A-Level General Paper) comprehension question.
+  def comprehension_question?
+    is_comprehension
+  end
+
+  def question_type
+    if file_upload_question?
+      I18n.t('activerecord.attributes.models.course/assessment/question/text_input.file_upload')
+    elsif comprehension_question?
+      I18n.t('activerecord.attributes.models.course/assessment/question/text_response.comprehension')
+    else
+      I18n.t('activerecord.attributes.models.course/assessment/question/text_input.text_input')
+    end
+  end
+
+  def auto_grader
+    Course::Assessment::Answer::TextInputAutoGradingService.new
+  end
+
+  def attempt(submission, last_attempt = nil)
+    answer =
+      Course::Assessment::Answer::TextInput.new(submission: submission, question: question)
+    if last_attempt
+      answer.answer_text = last_attempt.answer_text
+      if last_attempt.attachment_references.any?
+        answer.attachment_references = last_attempt.attachment_references.map(&:dup)
+      end
+    end
+    answer.acting_as
+  end
+
+  def downloadable?
+    true
+  end
+
+  def initialize_duplicate(duplicator, other)
+    copy_attributes(other)
+    associate_duplicated_skills(duplicator, other)
+
+    self.groups = duplicator.duplicate(other.groups)
+  end
+
+  private
+
+  def validate_grade
+    groups.each do |group|
+      group.points.each do |point|
+        point.solutions.each do |s|
+          return errors.add(:maximum_grade, :invalid_grade) if s.grade > maximum_grade
+        end
+      end
+    end
+  end
+end

--- a/app/models/course/assessment/question/text_input_group.rb
+++ b/app/models/course/assessment/question/text_input_group.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::TextInputGroup < ActiveRecord::Base
+  validate :validate_group_grade
+
+  has_many :points, class_name: Course::Assessment::Question::TextInputPoint.name,
+                    dependent: :destroy, foreign_key: :group_id, inverse_of: :group
+
+  accepts_nested_attributes_for :points, allow_destroy: true
+
+  belongs_to :question, class_name: Course::Assessment::Question::TextInput.name,
+                        inverse_of: :groups
+
+  def auto_gradable_group?
+    points.map(&:auto_gradable_point?).any?
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.question = duplicator.duplicate(other.question)
+    self.points = duplicator.duplicate(other.points)
+  end
+
+  private
+
+  def validate_group_grade
+    errors.add(:maximum_group_grade, :invalid_group_grade) if maximum_group_grade > question.maximum_grade
+  end
+end

--- a/app/models/course/assessment/question/text_input_point.rb
+++ b/app/models/course/assessment/question/text_input_point.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::TextInputPoint < ActiveRecord::Base
+  validate :validate_point_grade
+
+  has_many :solutions, class_name: Course::Assessment::Question::TextInputSolution.name,
+                       dependent: :destroy, foreign_key: :point_id, inverse_of: :point
+
+  accepts_nested_attributes_for :solutions, allow_destroy: true
+
+  belongs_to :group, class_name: Course::Assessment::Question::TextInputGroup.name,
+                     inverse_of: :points
+
+  def auto_gradable_point?
+    solutions.map(&:auto_gradable_solution?).any?
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.group = duplicator.duplicate(other.group)
+    self.solutions = duplicator.duplicate(other.solutions)
+  end
+
+  private
+
+  def validate_point_grade
+    errors.add(:maximum_point_grade, :invalid_point_grade) if maximum_point_grade > group.maximum_group_grade
+  end
+end

--- a/app/models/course/assessment/question/text_input_solution.rb
+++ b/app/models/course/assessment/question/text_input_solution.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::TextInputSolution < ActiveRecord::Base
+  enum solution_type: [:exact_match, :keyword, :compre_lifted_word, :compre_keyword]
+
+  before_validation :strip_whitespace_solution, :strip_whitespace_solution_lemma
+  validate :validate_solution_grade, :validate_solution_grade_is_zero_for_compre_lifted_word
+
+  belongs_to :point, class_name: Course::Assessment::Question::TextInputPoint.name,
+                     inverse_of: :solutions
+
+  def auto_gradable_solution?
+    !solution.empty?
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.point = duplicator.duplicate(other.point)
+  end
+
+  private
+
+  def strip_whitespace_solution
+    solution.each(&:strip!) unless solution.empty?
+  end
+
+  def strip_whitespace_solution_lemma
+    solution_lemma.each(&:strip!) if (compre_keyword? || compre_lifted_word?) && !solution_lemma.empty?
+  end
+
+  def validate_solution_grade
+    errors.add(:grade, :invalid_solution_grade) if grade > point.maximum_point_grade
+  end
+
+  def validate_solution_grade_is_zero_for_compre_lifted_word
+    errors.add(:grade, :invalid_solution_grade_compre_lifted_word) if
+      compre_lifted_word? && grade != 0
+  end
+end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -59,6 +59,9 @@ class Course::Assessment::Submission < ApplicationRecord
   has_many :scribing_answers,
            through: :answers, inverse_through: :answer, source: :actable,
            source_type: Course::Assessment::Answer::Scribing.name
+  has_many :text_input_answers,
+           through: :answers, inverse_through: :answer, source: :actable,
+           source_type: Course::Assessment::Answer::TextInput.name
 
   # @!attribute [r] graders
   #   The graders associated with this submission.

--- a/config/locales/en/activerecord/course/assessment/answer/text_input.yml
+++ b/config/locales/en/activerecord/course/assessment/answer/text_input.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/answer/text_input:
+          attributes:
+            attachments:
+              unique: 'File names must be unique'

--- a/config/locales/en/activerecord/course/assessment/question/text_input.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_input.yml
@@ -1,0 +1,14 @@
+en:
+  activerecord:
+    attributes:
+      models:
+        course/assessment/question/text_input:
+          text_input: 'text input question'
+          file_upload: 'file upload question'
+          comprehension: 'comprehension question'
+    errors:
+      models:
+        course/assessment/question/text_input:
+          attributes:
+            maximum_grade:
+              invalid_grade: 'must be no less than the grade of any solution'

--- a/config/locales/en/activerecord/course/assessment/question/text_input_group.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_input_group.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/question/text_input_group:
+          attributes:
+            maximum_group_grade:
+              invalid_group_grade: 'must be no more than the maximum grade of the question'

--- a/config/locales/en/activerecord/course/assessment/question/text_input_point.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_input_point.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/question/text_input_point:
+          attributes:
+            maximum_point_grade:
+              invalid_point_grade: 'must be no more than the maximum grade of the group'

--- a/config/locales/en/activerecord/course/assessment/question/text_input_solution.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_input_solution.yml
@@ -1,0 +1,9 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/question/text_input_solution:
+          attributes:
+            grade:
+              invalid_solution_grade: 'must be no more than the maximum grade of the point'
+              invalid_solution_grade_compre_lifted_word: 'must be 0 for comprehension lifted word'

--- a/db/migrate/20171023060000_create_course_assessment_answer_text_inputs.rb
+++ b/db/migrate/20171023060000_create_course_assessment_answer_text_inputs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class CreateCourseAssessmentAnswerTextInputs < ActiveRecord::Migration
+  def change
+    create_table :course_assessment_answer_text_inputs do |t|
+      t.text :answer_text, null: true
+    end
+  end
+end

--- a/db/migrate/20171023065500_create_course_assessment_question_text_inputs.rb
+++ b/db/migrate/20171023065500_create_course_assessment_question_text_inputs.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+class CreateCourseAssessmentQuestionTextInputs < ActiveRecord::Migration
+  def change
+    create_table :course_assessment_question_text_inputs do |t|
+      t.boolean 'allow_attachment', default: false
+      t.boolean 'hide_text',        default: false
+      t.boolean 'is_comprehension', default: false
+    end
+
+    create_table :course_assessment_question_text_input_groups do |t|
+      t.references :question,
+                   null: false,
+                   index: {
+                     name: :fk__course_assessment_text_input_group_question
+                   },
+                   foreign_key: {
+                     references: :course_assessment_question_text_inputs
+                   }
+      t.decimal :maximum_group_grade, precision: 4, scale: 1, null: false, default: 0.0
+    end
+
+    create_table :course_assessment_question_text_input_points do |t|
+      t.references :group,
+                   null: false,
+                   index: {
+                     name: :fk__course_assessment_text_input_point_group
+                   },
+                   foreign_key: {
+                     references: :course_assessment_question_text_input_groups
+                   }
+      t.decimal :maximum_point_grade, precision: 4, scale: 1, null: false, default: 0.0
+    end
+
+    create_table :course_assessment_question_text_input_solutions do |t|
+      t.references :point,
+                   null: false,
+                   index: {
+                     name: :fk__course_assessment_text_input_solution_point
+                   },
+                   foreign_key: {
+                     references: :course_assessment_question_text_input_points
+                   }
+      t.integer :solution_type, null: false, default: 0
+      t.text :solution, array: true, null: false, default: []
+      t.text :solution_lemma, array: true, null: false, default: []
+      t.decimal :grade, precision: 4, scale: 1, null: false, default: 0.0
+      t.text :explanation, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171014154130) do
+ActiveRecord::Schema.define(version: 20171023060000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -296,6 +296,10 @@ ActiveRecord::Schema.define(version: 20171014154130) do
     t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessment_answer_scribing_scribbles_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_answer_scribing_scribbles_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at", :null=>false
     t.datetime "updated_at", :null=>false
+  end
+
+  create_table "course_assessment_answer_text_inputs", force: :cascade do |t|
+    t.text "answer_text"
   end
 
   create_table "course_assessment_answer_text_responses", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023060000) do
+ActiveRecord::Schema.define(version: 20171023065500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -318,6 +318,31 @@ ActiveRecord::Schema.define(version: 20171023060000) do
   end
 
   create_table "course_assessment_question_scribings", force: :cascade do |t|
+  end
+
+  create_table "course_assessment_question_text_inputs", force: :cascade do |t|
+    t.boolean "allow_attachment", :default=>false
+    t.boolean "hide_text",        :default=>false
+    t.boolean "is_comprehension", :default=>false
+  end
+
+  create_table "course_assessment_question_text_input_groups", force: :cascade do |t|
+    t.integer "question_id",         :null=>false, :index=>{:name=>"fk__course_assessment_text_input_group_question"}, :foreign_key=>{:references=>"course_assessment_question_text_inputs", :name=>"fk_course_assessment_question_text_input_groups_question_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.decimal "maximum_group_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+  end
+
+  create_table "course_assessment_question_text_input_points", force: :cascade do |t|
+    t.integer "group_id",            :null=>false, :index=>{:name=>"fk__course_assessment_text_input_point_group"}, :foreign_key=>{:references=>"course_assessment_question_text_input_groups", :name=>"fk_course_assessment_question_text_input_points_group_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.decimal "maximum_point_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+  end
+
+  create_table "course_assessment_question_text_input_solutions", force: :cascade do |t|
+    t.integer "point_id",       :null=>false, :index=>{:name=>"fk__course_assessment_text_input_solution_point"}, :foreign_key=>{:references=>"course_assessment_question_text_input_points", :name=>"fk_course_assessment_question_text_input_solutions_point_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "solution_type",  :default=>0, :null=>false
+    t.text    "solution",       :default=>[], :null=>false, :array=>true
+    t.text    "solution_lemma", :default=>[], :null=>false, :array=>true
+    t.decimal "grade",          :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+    t.text    "explanation"
   end
 
   create_table "course_assessment_question_text_responses", force: :cascade do |t|

--- a/spec/factories/course_assessment_answer_text_inputs.rb
+++ b/spec/factories/course_assessment_answer_text_inputs.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_answer_text_input,
+          class: Course::Assessment::Answer::TextInput,
+          parent: :course_assessment_answer do
+    transient do
+      question_traits nil
+    end
+
+    question do
+      build(:course_assessment_question_text_input, *question_traits,
+            assessment: assessment).question
+    end
+
+    answer_text '<p>xxx</p>'
+
+    trait :exact_match do
+      answer_text '<p>exact match</p>'
+    end
+
+    trait :keyword do
+      answer_text '<p>my answer contains keyword match</p>'
+    end
+
+    trait :compre_lifted_word do
+      answer_text '<p>my answer contains lifting from text passage</p>'
+    end
+
+    trait :compre_keyword do
+      answer_text '<p>my answer contains keyword</p>'
+    end
+
+    trait :no_match do
+      # use default text, nothing to do
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_text_input_groups.rb
+++ b/spec/factories/course_assessment_question_text_input_groups.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_question_text_input_group,
+          class: Course::Assessment::Question::TextInputGroup do
+    question { build(:course_assessment_question_text_input) }
+    maximum_group_grade 2
+
+    points do
+      [
+        build(:course_assessment_question_text_input_point, group: nil)
+      ]
+    end
+
+    trait :comprehension_group do
+      points do
+        [
+          build(:course_assessment_question_text_input_point, :comprehension_point, group: nil)
+        ]
+      end
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_text_input_points.rb
+++ b/spec/factories/course_assessment_question_text_input_points.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_question_text_input_point,
+          class: Course::Assessment::Question::TextInputPoint do
+    group { build(:course_assessment_question_text_input_group) }
+    maximum_point_grade 2
+
+    solutions do
+      [
+        build(:course_assessment_question_text_input_solution, :exact_match, point: nil),
+        build(:course_assessment_question_text_input_solution, :keyword, point: nil)
+      ]
+    end
+
+    trait :comprehension_point do
+      group nil
+      solutions do
+        [
+          build(:course_assessment_question_text_input_solution, :compre_lifted_word, point: nil),
+          build(:course_assessment_question_text_input_solution, :compre_keyword, point: nil)
+        ]
+      end
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_text_input_solutions.rb
+++ b/spec/factories/course_assessment_question_text_input_solutions.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_question_text_input_solution,
+          class: Course::Assessment::Question::TextInputSolution do
+    point { build(:course_assessment_question_text_input_point) }
+    solution ['sample exact match']
+    explanation 'explanation'
+    solution_type :exact_match
+
+    trait :keyword do
+      solution_type :keyword
+      solution ['Keyword']
+      grade 1
+    end
+
+    trait :exact_match do
+      solution_type :exact_match
+      solution ['Exact Match']
+      grade 2
+    end
+
+    trait :compre_lifted_word do
+      solution_type :compre_lifted_word
+      solution ['lifted']
+      solution_lemma ['lift']
+      grade 0.0
+    end
+
+    trait :compre_keyword do
+      solution_type :compre_keyword
+      solution ['keyword']
+      solution_lemma ['keyword']
+      grade 0.5
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_text_inputs.rb
+++ b/spec/factories/course_assessment_question_text_inputs.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_assessment_question_text_input,
+          class: Course::Assessment::Question::TextInput,
+          parent: :course_assessment_question do
+    allow_attachment false
+    hide_text false
+    is_comprehension false
+
+    groups do
+      [
+        build(:course_assessment_question_text_input_group, question: nil)
+      ]
+    end
+
+    trait :allow_attachment do
+      allow_attachment true
+    end
+
+    trait :file_upload_question do
+      allow_attachment true
+      hide_text true
+    end
+
+    trait :comprehension_question do
+      is_comprehension true
+      groups do
+        [
+          build(:course_assessment_question_text_input_group, :comprehension_group, question: nil)
+        ]
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/answer/text_input_spec.rb
+++ b/spec/models/course/assessment/answer/text_input_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Answer::TextInput, type: :model do
+  it { is_expected.to act_as(Course::Assessment::Answer) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe 'validations' do
+      subject do
+        create(:course_assessment_answer_text_input, answer_text: '  content  ')
+      end
+
+      describe '#answer_text' do
+        it 'strips whitespaces when validated' do
+          expect(subject.valid?).to be(true)
+          expect(subject.answer_text).to eq('content')
+        end
+      end
+    end
+
+    describe '#reset_answer' do
+      let(:answer) { create(:course_assessment_answer_text_input) }
+      subject { answer.reset_answer }
+
+      it 'sets the text input answer to a blank' do
+        expect(subject.specific.answer_text).to be_blank
+      end
+
+      it 'returns an Answer' do
+        expect(subject).to be_a(Course::Assessment::Answer)
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/text_input_group_spec.rb
+++ b/spec/models/course/assessment/question/text_input_group_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextInputGroup, type: :model do
+  it 'belongs to question' do
+    expect(subject).to belong_to(:question).
+      class_name(Course::Assessment::Question::TextInput.name)
+  end
+  it 'has many points' do
+    expect(subject).to have_many(:points).
+      class_name(Course::Assessment::Question::TextInputPoint.name).
+      dependent(:destroy)
+  end
+  it { is_expected.to accept_nested_attributes_for(:points) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable_group?' do
+      subject { build_stubbed(:course_assessment_question_text_input_group) }
+      it 'returns true' do
+        expect(subject.auto_gradable_group?).to be(true)
+      end
+    end
+
+    describe 'validations' do
+      describe '#maximum_group_grade' do
+        subject do
+          build_stubbed(:course_assessment_question_text_input_group, maximum_group_grade: 5)
+        end
+
+        it 'validates that maximum group grade does not exceed maximum grade of the question' do
+          subject.question.maximum_grade = 2
+
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:maximum_group_grade]).to include(I18n.t('activerecord.errors.models.' \
+              'course/assessment/question/text_input_group.attributes.' \
+              'maximum_group_grade.invalid_group_grade'))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/text_input_point_spec.rb
+++ b/spec/models/course/assessment/question/text_input_point_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextInputPoint, type: :model do
+  it 'belongs to point' do
+    expect(subject).to belong_to(:group).
+      class_name(Course::Assessment::Question::TextInputGroup.name)
+  end
+  it 'has many solutions' do
+    expect(subject).to have_many(:solutions).
+      class_name(Course::Assessment::Question::TextInputSolution.name).
+      dependent(:destroy)
+  end
+  it { is_expected.to accept_nested_attributes_for(:solutions) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable_point?' do
+      subject { build_stubbed(:course_assessment_question_text_input_point) }
+      it 'returns true' do
+        expect(subject.auto_gradable_point?).to be(true)
+      end
+    end
+
+    describe 'validations' do
+      describe '#maximum_point_grade' do
+        subject do
+          build_stubbed(:course_assessment_question_text_input_point, maximum_point_grade: 5)
+        end
+
+        it 'validates that maximum point grade does not exceed maximum grade of the group' do
+          subject.group.maximum_group_grade = 2
+
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:maximum_point_grade]).to include(I18n.t('activerecord.errors.models.' \
+              'course/assessment/question/text_input_point.attributes.' \
+              'maximum_point_grade.invalid_point_grade'))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/text_input_solution_spec.rb
+++ b/spec/models/course/assessment/question/text_input_solution_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextInputSolution, type: :model do
+  it 'belongs to point' do
+    expect(subject).to belong_to(:point).
+      class_name(Course::Assessment::Question::TextInputPoint.name)
+  end
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable_solution?' do
+      subject { build_stubbed(:course_assessment_question_text_input_solution) }
+      it 'returns true' do
+        expect(subject.auto_gradable_solution?).to be(true)
+      end
+    end
+
+    describe 'validations' do
+      describe '#answer_text' do
+        subject do
+          build_stubbed(:course_assessment_question_text_input_solution, \
+                          solution: ['  content  '], solution_lemma: ['  content  '])
+        end
+
+        it 'strips whitespaces when validated' do
+          expect(subject.valid?).to be(true)
+          expect(subject.solution).to eq(['content'])
+          expect(subject.solution_lemma).to eq(['content'])
+        end
+      end
+
+      describe '#grade' do
+        subject { build_stubbed(:course_assessment_question_text_input_solution, grade: 5) }
+
+        it 'validates that solution grade does not exceed maximum grade of the point' do
+          subject.point.maximum_point_grade = 2
+
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:grade]).to include(I18n.t('activerecord.errors.models.' \
+              'course/assessment/question/text_input_solution.attributes.' \
+              'grade.invalid_solution_grade'))
+        end
+      end
+
+      describe '#grade_compre_lifted_word' do
+        subject do
+          build_stubbed(:course_assessment_question_text_input_solution, grade: 1, \
+                          solution_type: :compre_lifted_word)
+        end
+
+        it 'validates that solution grade of comprehension lifted word must be 0' do
+          subject.point.maximum_point_grade = 2
+
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:grade]).to include(I18n.t('activerecord.errors.models.' \
+              'course/assessment/question/text_input_solution.attributes.' \
+              'grade.invalid_solution_grade_compre_lifted_word'))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/text_input_spec.rb
+++ b/spec/models/course/assessment/question/text_input_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextInput, type: :model do
+  it { is_expected.to act_as(Course::Assessment::Question) }
+  it 'has many groups' do
+    expect(subject).to have_many(:groups).
+      class_name(Course::Assessment::Question::TextInputGroup.name).
+      dependent(:destroy)
+  end
+  it { is_expected.to accept_nested_attributes_for(:groups) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable?' do
+      subject { build_stubbed(:course_assessment_question_text_input) }
+      it 'returns true' do
+        expect(subject.auto_gradable?).to be(true)
+      end
+    end
+
+    describe '#attempt' do
+      let(:course) { create(:course) }
+      let(:student_user) { create(:course_student, course: course).user }
+      let(:assessment) { create(:assessment, course: course) }
+      let(:question) { build_stubbed(:course_assessment_question_text_input, assessment: assessment) }
+      let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
+      subject { question }
+
+      it 'returns an Answer' do
+        expect(subject.attempt(submission)).to be_a(Course::Assessment::Answer)
+      end
+
+      context 'when last_attempt is given' do
+        let(:last_attempt) { build(:course_assessment_answer_text_input) }
+
+        it 'builds a new answer with old answer_text' do
+          answer = subject.attempt(submission, last_attempt).actable
+          answer.save!
+
+          expect(last_attempt.answer_text).to eq(answer.answer_text)
+        end
+      end
+    end
+
+    describe '#file_upload_question?' do
+      subject { question.file_upload_question? }
+
+      context 'when hide_text is enabled' do
+        let(:question) { build(:course_assessment_question_text_input, :file_upload_question) }
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when hide_text is disabled' do
+        let(:question) { build(:course_assessment_question_text_input) }
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe 'validations' do
+      # TODO: the cascade creation of qn -> group -> point -> solution
+      subject { build_stubbed(:course_assessment_question_text_input, maximum_grade: 2) }
+
+      it 'validates that solution grade does not exceed maximum grade' do
+        subject.groups.first.points.first.solutions.first.grade = 5
+
+        expect(subject.valid?).to be(false)
+        expect(subject.errors[:maximum_grade]).to include(
+          I18n.t('activerecord.errors.models.' \
+            'course/assessment/question/text_input.attributes' \
+            '.maximum_grade.invalid_grade')
+        )
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Course::Assessment::Submission do
   it { is_expected.to have_many(:multiple_response_answers).through(:answers) }
   it { is_expected.to have_many(:text_response_answers).through(:answers) }
   it { is_expected.to have_many(:programming_answers).through(:answers) }
+  it { is_expected.to have_many(:text_input_answers).through(:answers) }
   it { is_expected.to accept_nested_attributes_for(:answers) }
 
   let(:instance) { Instance.default }

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Course::Assessment do
   it { is_expected.to have_many(:text_response_questions).through(:questions) }
   it { is_expected.to have_many(:programming_questions).through(:questions) }
   it { is_expected.to have_many(:scribing_questions).through(:questions) }
+  it { is_expected.to have_many(:text_input_questions).through(:questions) }
   it { is_expected.to have_many(:submissions).dependent(:destroy) }
   it { is_expected.to have_many(:conditions) }
   it { is_expected.to have_many(:assessment_conditions).dependent(:destroy) }


### PR DESCRIPTION
Creation of a new TextInput question type to support GCE A-Level General Paper Comprehension questions.

Possibly to migrate TextResponse questions and answers over to TextInput once TextInput is complete.