### PR TITLE
[!] Reorganise topics

### DIFF
--- a/app/controllers/course/video/topics_controller.rb
+++ b/app/controllers/course/video/topics_controller.rb
@@ -32,10 +32,6 @@ class Course::Video::TopicsController < Course::Video::Controller
     params.permit(:timestamp, :video_id)
   end
 
-  def timestamp_param
-    topic_params[:timestamp]
-  end
-
   def parent_id_param
     params.try(:[], :discussion_post).try(:[], :parent_id)
   end
@@ -49,13 +45,8 @@ class Course::Video::TopicsController < Course::Video::Controller
   end
 
   def load_existing_topic
-    return unless timestamp_param || parent_id_param
-
-    topic = if timestamp_param
-              @video.topics.find_by(timestamp: timestamp_param.to_i)
-            elsif parent_id_param
-              Course::Discussion::Post.find(parent_id_param).topic.specific
-            end
+    return unless parent_id_param
+    topic = Course::Discussion::Post.find(parent_id_param).topic.specific
     @topic = topic unless topic.nil?
   end
 end

--- a/app/views/course/video/topics/create.json.jbuilder
+++ b/app/views/course/video/topics/create.json.jbuilder
@@ -3,8 +3,3 @@ json.topic @topic, partial: 'course/video/topics/topic', as: :topic
 
 json.postId @post.id.to_s
 json.post @post, partial: 'course/video/topics/post', as: :post
-
-if @post.parent.present?
-  json.parentPostId @post.parent.id.to_s
-  json.parentPost @post.parent, partial: 'course/video/topics/post', as: :post
-end

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/NewReplyContainer.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/NewReplyContainer.jsx
@@ -15,11 +15,11 @@ const translations = defineMessages({
 });
 
 const propTypes = {
-  parentId: PropTypes.string.isRequired,
+  topicId: PropTypes.string.isRequired,
 };
 
 function mapStateToProps(state, ownProps) {
-  const pendingReplyPost = state.discussion.pendingReplyPosts.get(ownProps.parentId);
+  const pendingReplyPost = state.discussion.pendingReplyPosts.get(ownProps.topicId);
 
   return {
     content: pendingReplyPost.content,
@@ -30,9 +30,9 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch, ownProps) {
   return {
-    onSubmit: () => dispatch(submitNewReplyToServer(ownProps.parentId)),
-    onCancel: () => dispatch(updateReply(ownProps.parentId, { editorVisible: false })),
-    onContentUpdate: content => dispatch(updateReply(ownProps.parentId, { content })),
+    onSubmit: () => dispatch(submitNewReplyToServer(ownProps.topicId)),
+    onCancel: () => dispatch(updateReply(ownProps.topicId, { editorVisible: false })),
+    onContentUpdate: content => dispatch(updateReply(ownProps.topicId, { content })),
   };
 }
 

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/PostPresentation.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/PostPresentation.jsx
@@ -25,15 +25,13 @@ const defaultProps = {
 
 function PostPresentation(props) {
   let childrenElements = null;
-  if (props.isRoot) {
-    const childrenNodes = props.childrenIds.map(childId => <PostContainer key={childId} postId={childId} />);
-    if (childrenNodes.length > 0) {
-      childrenElements = (
-        <div className={styles.replyIndent}>
-          {childrenNodes}
-        </div>
-      );
-    }
+  const childrenNodes = props.childrenIds.map(childId => <PostContainer key={childId} postId={childId} />);
+  if (childrenNodes.length > 0) {
+    childrenElements = (
+      <div className={props.isRoot && styles.replyIndent}>
+        {childrenNodes}
+      </div>
+    );
   }
 
   return (

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/PostPresentation.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/PostPresentation.jsx
@@ -5,7 +5,6 @@ import styles from '../Discussion.scss';
 import PostContainer from './PostContainer';
 import EditPostContainer from './EditPostContainer';
 import PostMenu from './PostMenu';
-import Reply from './Reply';
 
 const propTypes = {
   postId: PropTypes.string.isRequired,
@@ -52,7 +51,6 @@ function PostPresentation(props) {
         )}
       </div>
       {childrenElements}
-      {props.isRoot && <Reply parentId={props.postId} />}
     </div>
   );
 }

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Reply.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Reply.jsx
@@ -8,7 +8,7 @@ import NewReplyContainer from './NewReplyContainer';
 import { addReply } from '../../actions/discussion';
 
 const propTypes = {
-  parentId: PropTypes.string.isRequired,
+  topicId: PropTypes.string.isRequired,
   editorVisible: PropTypes.bool,
   onTriggerReply: PropTypes.func,
 };
@@ -20,7 +20,7 @@ const defaultProps = {
 function Reply(props) {
   return props.editorVisible ? (
     <div className={styles.replyContainer}>
-      <NewReplyContainer parentId={props.parentId} />
+      <NewReplyContainer topicId={props.topicId} />
     </div>
   ) : (
     <div className={styles.replyContainer}>
@@ -37,20 +37,20 @@ Reply.propTypes = propTypes;
 Reply.defaultProps = defaultProps;
 
 const containerPropTypes = {
-  parentId: PropTypes.string.isRequired,
+  topicId: PropTypes.string.isRequired,
 };
 
 function mapStateToProps(state, ownProps) {
-  const pendingReply = state.discussion.pendingReplyPosts.get(ownProps.parentId);
+  const pendingReply = state.discussion.pendingReplyPosts.get(ownProps.topicId);
   return {
-    parentId: ownProps.parentId,
+    topicId: ownProps.topicId,
     editorVisible: (pendingReply !== undefined) && pendingReply.editorVisible,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
   return {
-    onTriggerReply: () => dispatch(addReply(ownProps.parentId)),
+    onTriggerReply: () => dispatch(addReply(ownProps.topicId)),
   };
 }
 

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
@@ -6,8 +6,10 @@ import { formatTimestamp } from 'lib/helpers/videoHelpers';
 
 import styles from '../Discussion.scss';
 import PostContainer from './PostContainer';
+import Reply from './Reply';
 
 const propTypes = {
+  topicId: PropTypes.string.isRequired,
   timestamp: PropTypes.number.isRequired,
   postIds: PropTypes.arrayOf(PropTypes.string),
 };
@@ -34,6 +36,7 @@ function Topic(props) {
       <div>
         {props.postIds.map(id => <PostContainer key={id.toString()} postId={id} isRoot />)}
       </div>
+      <Reply topicId={props.topicId} />
       <Divider style={{ marginBottom: '1em' }} />
     </div>
   );
@@ -51,6 +54,7 @@ function mapStateToProps(state, ownProps) {
   const postsStore = state.discussion.posts;
   const postIds = topic.topLevelPostIds.filter(postId => postsStore.has(postId));
   return {
+    topicId: ownProps.topicId,
     timestamp: topic.timestamp,
     postIds,
   };

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
@@ -35,14 +35,6 @@ function Topic(props) {
         {props.postIds.map(id => <PostContainer key={id.toString()} postId={id} isRoot />)}
       </div>
       <Divider style={{ marginBottom: '1em' }} />
-      <div className={styles.topicTimestamp}>
-        <span className="glyphicon glyphicon-chevron-up" />
-        &nbsp;
-        <b>Time: {formatTimestamp(props.timestamp)}</b>
-        &nbsp;
-        <span className="glyphicon glyphicon-chevron-up" />
-      </div>
-      <Divider style={{ marginBottom: '1em' }} />
     </div>
   );
 }

--- a/client/app/bundles/course/video/submission/reducers/discussion.js
+++ b/client/app/bundles/course/video/submission/reducers/discussion.js
@@ -93,11 +93,11 @@ function posts(state = makeImmutableMap(), action) {
 function pendingReplyPosts(state = makeImmutableMap, action) {
   switch (action.type) {
     case discussionActionTypes.ADD_REPLY:
-      return state.set(action.parentId, Object.assign({}, replyDefaults));
+      return state.set(action.topicId, Object.assign({}, replyDefaults));
     case discussionActionTypes.UPDATE_REPLY:
-      return state.set(action.parentId, Object.assign({}, state.get(action.parentId), action.replyProps));
+      return state.set(action.topicId, Object.assign({}, state.get(action.topicId), action.replyProps));
     case discussionActionTypes.REMOVE_REPLY:
-      return state.delete(action.parentId);
+      return state.delete(action.topicId);
     default:
       return state;
   }

--- a/spec/controllers/course/video/topic/topics_controller_spec.rb
+++ b/spec/controllers/course/video/topic/topics_controller_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Video::TopicsController do
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
+
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let!(:course) { create(:course, :with_video_component_enabled, creator: user) }
+    let(:video) { create(:video, :published, course: course) }
+
+    before { sign_in(user) }
+
+    describe '#create' do
+      let(:topic_id) { nil }
+
+      subject do
+        post :create, as: :json, params: {
+          course_id: course, video_id: video,
+          timestamp: 5,
+          discussion_post: {
+            text: comment,
+            topic_id: topic_id
+          }
+        }
+      end
+
+      context 'when create fails' do
+        let(:comment) { nil }
+
+        it 'returns HTTP 400' do
+          subject
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context 'when create succeeds' do
+        let(:comment) { 'new comment' }
+
+        it 'returns HTTP 200' do
+          subject
+          expect(response.status).to eq(200)
+        end
+
+        it 'adds a new comment' do
+          expect { subject }.to change(Course::Discussion::Post, :count).by(1)
+        end
+
+        it 'adds a new topic' do
+          expect { subject }.to change(Course::Video::Topic, :count).by(1)
+        end
+
+        context 'when existing topic is provided' do
+          let(:root_post) { build(:course_discussion_post) }
+          let(:child_post) { build(:course_discussion_post, parent: root_post) }
+          let(:posts) { [root_post, child_post] }
+          let!(:topic) do
+            create(:video_topic, course: course, video: video, creator: user, posts: posts)
+          end
+          let(:topic_id) { topic.id }
+
+          it 'does not create a new topic' do
+            expect { subject }.to change(Course::Video::Topic, :count).by(0)
+          end
+
+          it 'creates only one new post' do
+            expect { subject }.to change(Course::Discussion::Post, :count).by(1)
+          end
+
+          it 'creates a post under the last child post' do
+            expect { subject }.to change(child_post.children, :count).by(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/course_video_topics.rb
+++ b/spec/factories/course_video_topics.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :course_video_topic, class: Course::Video::Topic.name,
+                               parent: :course_discussion_topic,
+                               aliases: [:video_topic] do
+    transient do
+      creator { build(:course_student, course: course).user }
+    end
+
+    course { create(:course) }
+    video { build(:video, course: course) }
+    timestamp 5
+    posts { [build(:course_discussion_post, creator: creator, updater: creator)] }
+  end
+end


### PR DESCRIPTION
The old model of grouping all comments with the same video timestamp under the same topic proves quite difficult to manage, especially for implementing the comment centre. This PR separates the root comments into different topics.

In addition, with the separated topics, video comments can now follow the nesting model as per `SubmissionQuestion`, where the comments form a single chain.

Frontend has been updated to reflect this change.

I also took the chance to add specs for topics.

**This change might make existing comments behave weirdly.**
If there are old video topics with many root comments (many comments on the same timestamp), replying to the topic will now append children only to the last comment. Right now, however, there doesn't seem to be any data that is like that.