### PR TITLE
Check if notify exists before invoking

### DIFF
--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -69,7 +69,8 @@ class Course::Discussion::PostsController < Course::ComponentController
 
   def send_created_notification(post)
     if current_course_user && !current_course_user.phantom?
-      post.topic.actable.notify(post)
+      topic_actable = post.topic.actable
+      topic_actable.notify(post) if topic_actable.respond_to?(:notify)
     end
   end
 end


### PR DESCRIPTION
The default notify function was removed in Rails 5.

Previously discussion post could call the default method which was empty if no notification is set to be sent.