### PR TITLE
Support multiline solutions for text response questions.

### DIFF
--- a/app/models/course/assessment/answer/text_response.rb
+++ b/app/models/course/assessment/answer/text_response.rb
@@ -14,8 +14,9 @@ class Course::Assessment::Answer::TextResponse < ApplicationRecord
     acting_as
   end
 
-  def sanitized_answer_text
-    Sanitize.fragment(answer_text).strip
+  # Normalize the newlines to \n.
+  def normalized_answer_text
+    answer_text.strip.encode(universal_newline: true)
   end
 
   def download(dir)
@@ -26,7 +27,7 @@ class Course::Assessment::Answer::TextResponse < ApplicationRecord
   def download_answer(dir)
     answer_path = File.join(dir, 'answer.txt')
     File.open(answer_path, 'w') do |file|
-      file.write(sanitized_answer_text)
+      file.write(normalized_answer_text)
     end
   end
 

--- a/app/services/course/assessment/answer/text_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_auto_grading_service.rb
@@ -17,7 +17,7 @@ class Course::Assessment::Answer::TextResponseAutoGradingService < \
   #   assigned to the grading.
   def evaluate_answer(answer)
     question = answer.question.actable
-    answer_text = answer.sanitized_answer_text
+    answer_text = answer.normalized_answer_text
     exact_matches, keywords = question.solutions.partition(&:exact_match?)
 
     solutions = find_exact_match(answer_text, exact_matches)
@@ -41,7 +41,7 @@ class Course::Assessment::Answer::TextResponseAutoGradingService < \
   #   the answer.
   def find_exact_match(answer_text, solutions)
     # comparison is case insensitive
-    solutions.find { |s| s.solution.casecmp(answer_text) == 0 }
+    solutions.find { |s| s.solution.encode(universal_newline: true).casecmp(answer_text) == 0 }
   end
 
   # Returns the keywords found in the given answer text.

--- a/app/views/course/assessment/question/text_responses/_form.html.slim
+++ b/app/views/course/assessment/question/text_responses/_form.html.slim
@@ -7,6 +7,7 @@
     = f.hidden_field :allow_attachment
   - else
     = f.input :allow_attachment, label: t('.allow_upload_file')
+    b = t('.multiline_explanation_html')
     table.table.table-striped.table-hover
       thead
         tr

--- a/app/views/course/assessment/question/text_responses/_solution_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_solution_fields.html.slim
@@ -3,7 +3,7 @@
                collection: Course::Assessment::Question::TextResponseSolution.solution_types.keys,
                input_html: { class: ['text-response-solution-type'] },
                label: false
-  td = f.input :solution, as: :string, label: false, input_html: { class: ['text-response-solution'] }
+  td = f.input :solution, as: :text, label: false, input_html: { class: ['text-response-solution', 'no-summernote'] }
   td = f.input :grade, label: false, input_html: { class: ['text-response-grade'] }
   td = f.input :explanation, label: false, placeholder: t('.explanation_hint'),
                input_html: { class: ['text-response-explanation', 'airmode'] }

--- a/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
@@ -3,6 +3,8 @@ json.autogradable question.auto_gradable?
 
 json.solutions question.solutions.each do |solution|
   json.solutionType solution.solution_type
-  json.solution format_inline_text(solution.solution)
+  # Do not sanitize the solution here to prevent double sanitization.
+  # Sanitization will be handled automatically by the React frontend.
+  json.solution solution.solution
   json.grade solution.grade
 end if can_grade && question.auto_gradable?

--- a/client/app/bundles/course/assessment/submission/components/Answers.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Answers.jsx
@@ -132,11 +132,20 @@ export default class Answers extends Component {
       component={props => (<div dangerouslySetInnerHTML={{ __html: props.input.value }} />)}
     />);
 
-    const editableAnswer = (<Field
+    const richtextAnswer = (<Field
       name={`${answerId}[answer_text]`}
       component={RichTextField}
       multiLine
     />);
+
+    const plaintextAnswer = (<Field
+      name={`${answerId}[answer_text]`}
+      component="textarea"
+      style={{ width: '100%' }}
+      rows={5}
+    />);
+
+    const editableAnswer = question.solutions ? plaintextAnswer : richtextAnswer;
 
     return (
       <div>

--- a/client/app/bundles/course/assessment/submission/components/Answers.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Answers.jsx
@@ -113,7 +113,7 @@ export default class Answers extends Component {
             {question.solutions.map((solution, index) => (
               <TableRow key={index}>
                 <TableRowColumn>{solution.solutionType}</TableRowColumn>
-                <TableRowColumn>{solution.solution}</TableRowColumn>
+                <TableRowColumn style={{ whiteSpace: 'pre-wrap' }}>{solution.solution}</TableRowColumn>
                 <TableRowColumn>{solution.grade}</TableRowColumn>
               </TableRow>
             ))}

--- a/config/locales/en/course/assessment/question/text_response.yml
+++ b/config/locales/en/course/assessment/question/text_response.yml
@@ -15,6 +15,11 @@ en:
             failure: 'Could not delete %{name}: %{error}'
           form:
             allow_upload_file: 'Allow file upload in the answer'
+            multiline_explanation_html: >
+              Adding solutions allows the question to be autograded. Students can only input plaintext.
+              <br/>
+              If exact_match is selected, solutions with multiple lines must match student answers exactly for the
+              answer to be graded as correct.
             solution_type: 'Type'
             solution: 'Solution'
             grade: 'Grade'

--- a/db/migrate/20171024074942_convert_autograded_text_response_answers_to_plaintext.rb
+++ b/db/migrate/20171024074942_convert_autograded_text_response_answers_to_plaintext.rb
@@ -1,0 +1,23 @@
+class ConvertAutogradedTextResponseAnswersToPlaintext < ActiveRecord::Migration[5.0]
+  # For autograded text response questions, a plaintext textarea input box is shown instead of
+  # the rich text editor.
+  #
+  # Convert existing answers to autograded questions from HTML to plaintext.
+  def up
+    auto_gradable_tr_question_ids = Course::Assessment::Question::TextResponse.includes(:solutions).
+                                    select(&:auto_gradable?).map(&:acting_as).map(&:id)
+
+    Course::Assessment::Answer.where(question_id: auto_gradable_tr_question_ids).includes(:actable).
+      find_each do |ans|
+      answer_text = ans.actable.answer_text
+      next if answer_text.empty?
+      sanitized_answer = Sanitize.fragment(answer_text).strip.encode(universal_newline: true)
+      ans.actable.update_column(:answer_text, sanitized_answer)
+    end
+  end
+
+  # Formatting can't be restored.
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/factories/course_assessment_answer_text_responses.rb
+++ b/spec/factories/course_assessment_answer_text_responses.rb
@@ -15,11 +15,19 @@ FactoryGirl.define do
     answer_text '<p>xxx</p>'
 
     trait :exact_match do
-      answer_text '<p>exact match</p>'
+      answer_text 'exact match'
     end
 
     trait :keyword do
       answer_text '<p>my answer contains keyword match</p>'
+    end
+
+    trait :multiline_windows do
+      answer_text "hello world\r\nsecond line"
+    end
+
+    trait :multiline_linux do
+      answer_text "hello world\nsecond line"
     end
 
     trait :no_match do

--- a/spec/factories/course_assessment_question_text_response_solutions.rb
+++ b/spec/factories/course_assessment_question_text_response_solutions.rb
@@ -18,5 +18,17 @@ FactoryGirl.define do
       solution 'Exact Match'
       grade 2
     end
+
+    trait :multiline_windows do
+      solution_type :exact_match
+      solution "hello world\r\nsecond line"
+      grade 2
+    end
+
+    trait :multiline_linux do
+      solution_type :exact_match
+      solution "hello world\nsecond line"
+      grade 2
+    end
   end
 end

--- a/spec/factories/course_assessment_question_text_responses.rb
+++ b/spec/factories/course_assessment_question_text_responses.rb
@@ -33,5 +33,21 @@ FactoryGirl.define do
       allow_attachment true
       hide_text true
     end
+
+    trait :multiline_windows do
+      solutions do
+        [
+          build(:course_assessment_question_text_response_solution, :multiline_windows, question: nil)
+        ]
+      end
+    end
+
+    trait :multiline_linux do
+      solutions do
+        [
+          build(:course_assessment_question_text_response_solution, :multiline_linux, question: nil)
+        ]
+      end
+    end
   end
 end

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
             # This works only if +click_link+ is executed before each option.
             fill_in_rails_summernote '.question_text_response_solutions_explanation:last',
                                      solution[:explanation]
-            find('input.text-response-solution').set solution[:solution]
+            find('textarea.text-response-solution').set solution[:solution]
 
             solution_type = find('select.text-response-solution-type', visible: :all)
             # Twitter Bootstrap hides <select> element and creates a div.

--- a/spec/models/course/assessment/answer/text_response_spec.rb
+++ b/spec/models/course/assessment/answer/text_response_spec.rb
@@ -31,5 +31,29 @@ RSpec.describe Course::Assessment::Answer::TextResponse, type: :model do
         expect(subject).to be_a(Course::Assessment::Answer)
       end
     end
+
+    describe '#normalized_answer_text' do
+      subject { answer.normalized_answer_text }
+
+      context 'with Windows newlines' do
+        let(:answer) do
+          create(:course_assessment_answer_text_response, :multiline_windows)
+        end
+
+        it 'normalizes newlines' do
+          expect(subject). to eq("hello world\nsecond line")
+        end
+      end
+
+      context 'with Linux newlines' do
+        let(:answer) do
+          create(:course_assessment_answer_text_response, :multiline_linux)
+        end
+
+        it 'normalizes newlines' do
+          expect(subject). to eq("hello world\nsecond line")
+        end
+      end
+    end
   end
 end

--- a/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
@@ -34,6 +34,32 @@ RSpec.describe Course::Assessment::Answer::TextResponseAutoGradingService do
         end
       end
 
+      context 'when the solution contains Windows newlines' do
+        let(:question_traits) { :multiline_windows }
+        let(:answer_traits) { :multiline_linux }
+
+        it 'treats different answer and question newlines as equivalent' do
+          subject.grade(answer)
+          expect(answer).to be_correct
+          expect(answer.grade).to eq(question.solutions.exact_match.first.grade)
+          expect(grading.result['messages']).to \
+            contain_exactly(question.solutions.exact_match.first.explanation)
+        end
+      end
+
+      context 'when the solution contains Linux newlines' do
+        let(:question_traits) { :multiline_linux }
+        let(:answer_traits) { :multiline_windows }
+
+        it 'treats different answer and question newlines as equivalent' do
+          subject.grade(answer)
+          expect(answer).to be_correct
+          expect(answer.grade).to eq(question.solutions.exact_match.first.grade)
+          expect(grading.result['messages']).to \
+            contain_exactly(question.solutions.exact_match.first.explanation)
+        end
+      end
+
       context 'when one keyword is present' do
         let(:answer_traits) { :keyword }
 


### PR DESCRIPTION
Convert autograded text response answers to plaintext as that is how they're compared.

Show plaintext input fields for autograded text response questions.

Fixes #2608.