### PR TITLE
Migrate to new framework defaults

### DIFF
--- a/app/models/course/assessment/category.rb
+++ b/app/models/course/assessment/category.rb
@@ -67,9 +67,8 @@ class Course::Assessment::Category < ApplicationRecord
   end
 
   def validate_before_destroy
-    return true if course.destroying?
-    safe = other_categories_remaining?
-    errors.add(:base, :deletion) unless safe
-    safe
+    return true if course.destroying? || other_categories_remaining?
+    errors.add(:base, :deletion)
+    throw(:abort)
   end
 end

--- a/app/models/course/assessment/tab.rb
+++ b/app/models/course/assessment/tab.rb
@@ -35,10 +35,9 @@ class Course::Assessment::Tab < ApplicationRecord
   private
 
   def validate_before_destroy
-    return true if category.destroying?
-    safe = other_tabs_remaining?
-    errors.add(:base, :deletion) unless safe
-    safe
+    return true if category.destroying? || other_tabs_remaining?
+    errors.add(:base, :deletion)
+    throw(:abort)
   end
 
   # Reassign the assessment folders to new category if the category changed.
@@ -48,7 +47,7 @@ class Course::Assessment::Tab < ApplicationRecord
 
     folders.each do |folder|
       folder.parent = new_parent_folder
-      return false unless folder.save
+      throw(:abort) unless folder.save
     end
   end
 end

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -6,20 +6,20 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
+Rails.application.config.action_controller.raise_on_unfiltered_parameters = false
 
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+Rails.application.config.action_controller.forgery_protection_origin_check = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
+ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = false
+Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true
+ActiveSupport.halt_callback_chains_on_return_false = false


### PR DESCRIPTION
Close #2617 

The following new defaults affect our existing code

- `ActiveSupport.halt_callback_chains_on_return_false = false`

Now we need to use `throw(:abort)` to halt the callback chain