### PR TITLE
Increase screensize for Chrome headless.

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,7 +7,8 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: %w(headless disable-gpu) })
+  chrome_options = %w(headless disable-gpu window-size=2500,1600)
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: chrome_options })
   Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
 end
 


### PR DESCRIPTION
Capybara cannot click outside the screen, this causes some feature specs
to fail when run locally. Make the screen bigger so the specs can pass
when run locally.