### PR TITLE
Video comment centre

### DIFF
--- a/app/models/course/video/topic.rb
+++ b/app/models/course/video/topic.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 class Course::Video::Topic < ApplicationRecord
-  acts_as_discussion_topic
+  acts_as_discussion_topic display_globally: true
 
   belongs_to :video, inverse_of: :topics
 
   after_initialize :set_course, if: :new_record?
+
+  # Specific implementation of Course::Discussion::Topic#from_user, this is not supposed to be
+  # called directly.
+  scope :from_user, (lambda do |user_id|
+    unscoped.
+      joins(:discussion_topic).
+      where(creator_id: user_id).
+      select('course_discussion_topics.id')
+  end)
 
   private
 

--- a/app/views/course/video/topics/_discussion_topic_topic.html.slim
+++ b/app/views/course/video/topics/_discussion_topic_topic.html.slim
@@ -1,0 +1,18 @@
+- video_topic = discussion_topic_topic
+- topic = video_topic.acting_as
+- video = video_topic.video
+- creator = video_topic.creator
+- submission = video.submissions.by_user(creator).first
+
+= div_for(topic, 'data-topic-id' => topic.id) do
+  h3
+    - timestamp = Time.at(video_topic.timestamp).utc.strftime("%H:%M:%S")
+    = link_to t('.comment_title', title: video.title, timestamp: timestamp),
+              edit_course_video_submission_path(current_course, video, submission)
+  - if can?(:manage, topic)
+    = link_to_toggle_pending(topic)
+  h4
+    = t('.by_html', user: link_to_user(creator))
+
+  = display_topic video_topic.acting_as, post_partial: 'course/discussion/post',
+    footer: 'course/discussion/posts/form'

--- a/config/locales/en/course/video/topics.yml
+++ b/config/locales/en/course/video/topics.yml
@@ -1,0 +1,7 @@
+en:
+  course:
+    video:
+      topics:
+        discussion_topic_topic:
+          by_html: 'By: %{user}'
+          comment_title: '%{title}: %{timestamp}'

--- a/db/migrate/20171026141412_add_user_stamps_to_course_video_topics.rb
+++ b/db/migrate/20171026141412_add_user_stamps_to_course_video_topics.rb
@@ -1,0 +1,38 @@
+class AddUserStampsToCourseVideoTopics < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :course_video_topics,
+                  :creator,
+                  references: :users,
+                  foreign_key: { to_table: :users }
+    add_reference :course_video_topics,
+                  :updater,
+                  references: :users,
+                  foreign_key: { to_table: :users }
+
+    Course::Video::Topic.reset_column_information
+    infer_topic_creator
+
+    change_column :course_video_topics, :creator_id, :integer, null: false
+    change_column :course_video_topics, :updater_id, :integer, null: false
+  end
+
+  def infer_topic_creator
+    ActsAsTenant.without_tenant do
+      Course::Video::Topic.all.each do |topic|
+        posts = topic.acting_as.posts
+
+        if posts.empty?
+          topic.destroy!
+          next
+        end
+
+        creator_id = posts.ordered_topologically.first.first.creator_id
+        updater_id = posts.ordered_topologically.first.first.updater_id
+
+        topic.creator_id = creator_id
+        topic.updater_id = updater_id
+        topic.save!
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171014154130) do
+ActiveRecord::Schema.define(version: 20171026141412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -756,8 +756,10 @@ ActiveRecord::Schema.define(version: 20171014154130) do
   end
 
   create_table "course_video_topics", force: :cascade do |t|
-    t.integer "video_id",  :null=>false, :index=>{:name=>"fk__course_video_topics_video_id"}, :foreign_key=>{:references=>"course_videos", :name=>"fk_course_video_topics_video_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "timestamp", :null=>false
+    t.integer "video_id",   :null=>false, :index=>{:name=>"fk__course_video_topics_video_id"}, :foreign_key=>{:references=>"course_videos", :name=>"fk_course_video_topics_video_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "timestamp",  :null=>false
+    t.integer "creator_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_topics_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "updater_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
   end
 
   create_table "course_virtual_classrooms", force: :cascade do |t|

--- a/spec/factories/course_video_topics.rb
+++ b/spec/factories/course_video_topics.rb
@@ -3,13 +3,19 @@ FactoryGirl.define do
   factory :course_video_topic, class: Course::Video::Topic.name,
                                parent: :course_discussion_topic,
                                aliases: [:video_topic] do
-    transient do
-      creator { build(:course_student, course: course).user }
-    end
 
     course { create(:course) }
     video { build(:video, course: course) }
+    creator { build(:course_student, course: course).user }
+    updater { creator }
     timestamp 5
-    posts { [build(:course_discussion_post, creator: creator, updater: creator)] }
+    posts { [build(:course_discussion_post, creator: creator, updater: updater)] }
+
+    trait :with_submission do
+      after(:build) do |topic|
+        topic.video.submissions =
+          [build(:course_video_submission, video: topic.video, creator: topic.creator)]
+      end
+    end
   end
 end

--- a/spec/models/course/video/topic_spec.rb
+++ b/spec/models/course/video/topic_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Video::Topic do
+  it { is_expected.to act_as(Course::Discussion::Topic) }
+  it { is_expected.to belong_to(:video).inverse_of(:topics) }
+
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
+  with_tenant(:instance) do
+    let(:course) { create(:course, :with_video_component_enabled) }
+    let(:student1) { create(:course_student, course: course) }
+    let(:student2) { create(:course_student, course: course) }
+    let(:student3) { create(:course_student, course: course) }
+    let(:video) { create(:video, :published, course: course) }
+    let(:topic1) do
+      create(:video_topic,
+             course: course,
+             video: video,
+             creator: student1.user,
+             posts: [build(:course_discussion_post, creator: student1.user)])
+    end
+    let(:topic2) do
+      create(:video_topic,
+             course: course,
+             video: video,
+             creator: student2.user,
+             posts: [build(:course_discussion_post, creator: student2.user)])
+    end
+
+    describe '.from_user' do
+      it 'only returns discussion_topic ids of the given user' do
+        topic1_id = topic1.acting_as.id
+        expect(video.topics.from_user(student1.user).map(&:id)).to match_array([topic1_id])
+
+        topic2_id = topic2.acting_as.id
+        expect(video.topics.from_user(student2.user).map(&:id)).to match_array([topic2_id])
+
+        expect(video.topics.from_user(student3.user).empty?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
After #2626 the comment centre framework can be used for video comments without too many issues.

Notifications for tutors are based on the creator of root post in a topic (the one without parents) and we expect only one such root post per topic. Similarly, the link also redirects to the video submission of this creator.