### PR TITLE
Refactor video topic create

### DIFF
--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -19,6 +19,10 @@ class Course::Discussion::PostsController < Course::ComponentController
 
     if result
       send_created_notification(@post)
+      respond_to do |format|
+        format.js
+        format.json { render @post }
+      end
     else
       head :bad_request
     end

--- a/app/controllers/course/video/topics_controller.rb
+++ b/app/controllers/course/video/topics_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Course::Video::TopicsController < Course::Video::Controller
   load_and_authorize_resource :topic, through: :video, class: Course::Video::Topic.name
-  before_action :load_existing_topic, only: :create
 
   include Course::Discussion::PostsConcern
   skip_load_and_authorize_resource :post, except: :create
@@ -14,8 +13,6 @@ class Course::Video::TopicsController < Course::Video::Controller
 
   def create
     result = @topic.class.transaction do
-      @post.title = @video.title
-      @post.parent = last_post_from(@topic)
       raise ActiveRecord::Rollback unless @post.save && create_topic_subscription && update_topic_pending_status
       raise ActiveRecord::Rollback unless @topic.save
       true
@@ -33,27 +30,11 @@ class Course::Video::TopicsController < Course::Video::Controller
     params.permit(:timestamp, :video_id)
   end
 
-  def reply_topic_id_params
-    params.try(:[], :discussion_post).try(:[], :topic_id)
-  end
-
   def discussion_topic
     @topic.try(:discussion_topic)
   end
 
   def create_topic_subscription
     @topic.ensure_subscribed_by(current_user)
-  end
-
-  # TODO: Refactor this properly together with the method
-  # in Course::Assessment::SubmissionQuestion::CommentsController
-  def last_post_from(topic)
-    # @post is in topic.posts, so we filter out @post, which has no id yet.
-    topic.posts.ordered_topologically.flatten.select(&:id).last
-  end
-
-  def load_existing_topic
-    return if reply_topic_id_params.blank?
-    @topic = Course::Video::Topic.find(reply_topic_id_params)
   end
 end

--- a/client/app/api/course/Comments.js
+++ b/client/app/api/course/Comments.js
@@ -2,10 +2,45 @@ import BaseCourseAPI from './Base';
 
 export default class CommentsAPI extends BaseCourseAPI {
 
+  /**
+   * post = {
+   *   id: number, title: string, text: string, createdAt: datetime,
+   *      - Post attributes
+   *   formattedText: string,
+   *      - same as text attribute but formatted for html
+   *   creator = {
+   *     name: string, avatar: string
+   *       - user attributes for creator, avatar is an url
+   *   },
+   *   topicId:
+   *     - the id of the discussion topic the post belongs to
+   *   canUpdate: bool, canDelete: bool,
+   *      - true if user can update and delete this post respectively
+   * }
+   */
+
+  /**
+   * Updates a comment (discussion post)
+   *
+   * @param {string} topicId
+   * @param {string} postId
+   * @param {object} params
+   *   - params in the format of { :discussion_post }
+   * @return {Promise}
+   * success response: post
+   */
   update(topicId, postId, params) {
     return this.getClient().patch(`${this._getUrlPrefix()}/${topicId}/posts/${postId}`, params);
   }
 
+  /**
+   * Deletes a comment (discussion post)
+   *
+   * @param {string} topicId
+   * @param {string} postId
+   * @return {Promise}
+   * success response: {}
+   */
   delete(topicId, postId) {
     return this.getClient().delete(`${this._getUrlPrefix()}/${topicId}/posts/${postId}`);
   }

--- a/client/app/api/course/Comments.js
+++ b/client/app/api/course/Comments.js
@@ -20,6 +20,19 @@ export default class CommentsAPI extends BaseCourseAPI {
    */
 
   /**
+   * Creates a comment (discussion post)
+   *
+   * @param {string} topicId
+   * @param {object} params
+   *    - params in the format of { :discussion_post }
+   * @return {Promise}
+   * success response: post
+   */
+  create(topicId, params) {
+    return this.getClient().post(`${this._getUrlPrefix()}/${topicId}/posts/`, params);
+  }
+
+  /**
    * Updates a comment (discussion post)
    *
    * @param {string} topicId

--- a/client/app/api/course/index.js
+++ b/client/app/api/course/index.js
@@ -6,7 +6,6 @@ import MaterialsAPI from './Materials';
 import MaterialFoldersAPI from './MaterialFolders';
 import LessonPlanAPI from './LessonPlan';
 import DuplicationAPI from './Duplication';
-import PostsAPI from './Posts';
 import SurveyAPI from './Survey';
 import VideoAPI from './Video';
 import AdminAPI from './Admin';
@@ -21,7 +20,6 @@ const CourseAPI = {
   materialFolders: new MaterialFoldersAPI(),
   lessonPlan: new LessonPlanAPI(),
   duplication: new DuplicationAPI(),
-  posts: new PostsAPI(),
   survey: SurveyAPI,
   video: VideoAPI,
   admin: AdminAPI,

--- a/client/app/bundles/course/video/submission/actions/discussion.js
+++ b/client/app/bundles/course/video/submission/actions/discussion.js
@@ -341,7 +341,7 @@ export function updatePostOnServer(postId) {
     }
 
     dispatch(updatePost(postId, { status: postRequestingStatuses.LOADING }));
-    CourseAPI.posts
+    CourseAPI.comments
       .update(discussionTopicId, postId, { discussion_post: { text } })
       .then(({ data }) => {
         dispatch(updatePost(postId, {
@@ -376,7 +376,7 @@ export function deletePostFromServer(postId) {
     const topicId = post.topicId;
 
     dispatch(updatePost(postId, { status: postRequestingStatuses.LOADING }));
-    CourseAPI.posts
+    CourseAPI.comments
       .delete(discussionTopicId, postId)
       .then(() => {
         dispatch(refreshTopic(topicId));

--- a/client/app/bundles/course/video/submission/actions/discussion.js
+++ b/client/app/bundles/course/video/submission/actions/discussion.js
@@ -268,8 +268,8 @@ export function submitNewReplyToServer(topicId) {
       return;
     }
 
-    CourseAPI.video.topics
-      .create({ discussion_post: { topic_id: topicId, text } })
+    CourseAPI.comments
+      .create(topicId, { discussion_post: { text } })
       .then(() => {
         dispatch(refreshTopic(topicId));
         dispatch(removeReply(topicId));

--- a/spec/controllers/course/video/topic/topics_controller_spec.rb
+++ b/spec/controllers/course/video/topic/topics_controller_spec.rb
@@ -18,10 +18,7 @@ RSpec.describe Course::Video::TopicsController do
         post :create, as: :json, params: {
           course_id: course, video_id: video,
           timestamp: 5,
-          discussion_post: {
-            text: comment,
-            topic_id: topic_id
-          }
+          discussion_post: { text: comment }
         }
       end
 
@@ -48,28 +45,6 @@ RSpec.describe Course::Video::TopicsController do
 
         it 'adds a new topic' do
           expect { subject }.to change(Course::Video::Topic, :count).by(1)
-        end
-
-        context 'when existing topic is provided' do
-          let(:root_post) { build(:course_discussion_post) }
-          let(:child_post) { build(:course_discussion_post, parent: root_post) }
-          let(:posts) { [root_post, child_post] }
-          let!(:topic) do
-            create(:video_topic, course: course, video: video, creator: user, posts: posts)
-          end
-          let(:topic_id) { topic.id }
-
-          it 'does not create a new topic' do
-            expect { subject }.to change(Course::Video::Topic, :count).by(0)
-          end
-
-          it 'creates only one new post' do
-            expect { subject }.to change(Course::Discussion::Post, :count).by(1)
-          end
-
-          it 'creates a post under the last child post' do
-            expect { subject }.to change(child_post.children, :count).by(1)
-          end
         end
       end
     end


### PR DESCRIPTION
As mentioned in #2626, the feature inside `Video::TopicsController#create` to create posts on existing topics is no longer required, given that `Discussion::PostsController#create` can be used now. The PR switches the frontend API call over and removes the dead code left behind.

I also realised that the `Posts.js` API library that I've added earlier is a duplicate of `Comments.js`. I've merged the two and added the new create API.