### PR TITLE
Change TextResponse models to support comprehension questions

### DIFF
--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -7,10 +7,19 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
   has_many :solutions, class_name: Course::Assessment::Question::TextResponseSolution.name,
                        dependent: :destroy, foreign_key: :question_id, inverse_of: :question
 
+  has_many :groups, class_name: Course::Assessment::Question::TextResponseComprehensionGroup.name,
+                    dependent: :destroy, foreign_key: :question_id, inverse_of: :question
+
   accepts_nested_attributes_for :solutions, allow_destroy: true
 
+  accepts_nested_attributes_for :groups, allow_destroy: true
+
   def auto_gradable?
-    !solutions.empty?
+    if comprehension_question?
+      groups.map(&:auto_gradable_group?).any?
+    else
+      !solutions.empty?
+    end
   end
 
   # Method provides readability to identifying whether a question is a file upload question.
@@ -19,9 +28,17 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
     hide_text
   end
 
+  # Method provides readability to identifying whether a question is a
+  # (GCE A-Level General Paper) comprehension question.
+  def comprehension_question?
+    is_comprehension
+  end
+
   def question_type
     if file_upload_question?
       I18n.t('activerecord.attributes.models.course/assessment/question/text_response.file_upload')
+    elsif comprehension_question?
+      I18n.t('activerecord.attributes.models.course/assessment/question/text_response.comprehension')
     else
       I18n.t('activerecord.attributes.models.course/assessment/question/text_response.text_response')
     end
@@ -51,12 +68,18 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
     copy_attributes(other)
     associate_duplicated_skills(duplicator, other)
 
-    self.solutions = duplicator.duplicate(other.solutions)
+    if comprehension_question?
+      self.groups = duplicator.duplicate(other.groups)
+    else
+      self.solutions = duplicator.duplicate(other.solutions)
+    end
   end
 
   private
 
   def validate_grade
-    errors.add(:maximum_grade, :invalid_grade) if solutions.any? { |s| s.grade > maximum_grade }
+    if !comprehension_question? && solutions.any? { |s| s.grade > maximum_grade }
+      errors.add(:maximum_grade, :invalid_grade)
+    end
   end
 end

--- a/app/models/course/assessment/question/text_response_comprehension_group.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_group.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+#
+# For (GCE A-Level General Paper) comprehension questions, grades are mainly
+# awarded by the number of correct points, TextResponseComprehensionPoint.
+# There is an intermediary model, TextResponseComprehensionGroup, which stores
+# the points.
+#
+# TextResponse
+# ├── TextResponseSolution (no change)
+# └── TextResponseComprehensionGroup *
+#     └── TextResponseComprehensionPoint *
+#         └── TextResponseComprehensionSolution *
+#
+# * table name prefix: `course_assessment_question_text_response_compre_`
+#
+# A question may have multiple groups of points.
+# The +maximum_group_grade+ in each group caps the maximum possible grade for that group.
+#
+# For example, given points W, X, Y and Z, each point worth 1 mark, and
+# the +maximum_grade+ of the question is 2 marks.
+# If the answer scheme requires at least one point from (W or X) to score one mark,
+# _and_ at least one point from (Y or Z) to score another one mark,
+# then there must be TWO groups created.
+# For the first group, the +points+ will be [W, X], +maximum_group_grade+ will be 1.
+# For the second group, the +points+ will be [X, Y], +maximum_group_grade+ will be 1.
+#
+# For each point, there are keywords and lifted words (words that must not be used
+# -- if used, the point will instantly score ZERO), collectively known as
+# TextResponseComprehensionSolution.
+#
+# All lifted words for a point should be stored in ONE Solution, with the
+# +solution_type+ as :compre_lifted_word, and all the lifted words in the +solution+ string array.
+# +solution+ string array.
+#
+# The keywords for a point should be stored in one _or more_ Solutions, with the
+# +solution_type+ as :compre_keyword, and the keywords in the +solution+ string array.
+#
+# The +solution_lemma+ string array stores the lemma form of each word in the
+# +solution+ string array, which will be generated automatically whenever the question
+# is saved.
+# Instructors will only see the words in +solution+ in their view.
+#
+# For example, given keywords A, B, C, D and E, of which a point can only score
+# if it has at least one keyword from (A, B or C), _and_ at least one keyword from (D or E),
+# then there must be TWO solutions created.
+# For the first solution, the +solution+ will be [A, B, C].
+# For the second solution, the +solution+ will be [D, E].
+
+class Course::Assessment::Question::TextResponseComprehensionGroup < ApplicationRecord
+  self.table_name = 'course_assessment_question_text_response_compre_groups'
+
+  validate :validate_group_grade
+
+  has_many :points, class_name: Course::Assessment::Question::TextResponseComprehensionPoint.name,
+                    dependent: :destroy, foreign_key: :group_id, inverse_of: :group
+
+  belongs_to :question, class_name: Course::Assessment::Question::TextResponse.name,
+                        inverse_of: :groups
+
+  accepts_nested_attributes_for :points, allow_destroy: true
+
+  def auto_gradable_group?
+    points.map(&:auto_gradable_point?).any?
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.question = duplicator.duplicate(other.question)
+    self.points = duplicator.duplicate(other.points)
+  end
+
+  private
+
+  def validate_group_grade
+    errors.add(:maximum_group_grade, :invalid_group_grade) if maximum_group_grade > question.maximum_grade
+  end
+end

--- a/app/models/course/assessment/question/text_response_comprehension_point.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_point.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::TextResponseComprehensionPoint < ApplicationRecord
+  self.table_name = 'course_assessment_question_text_response_compre_points'
+
+  validate :validate_point_grade
+
+  has_many :solutions, class_name: Course::Assessment::Question::TextResponseComprehensionSolution.name,
+                       dependent: :destroy, foreign_key: :point_id, inverse_of: :point
+
+  belongs_to :group, class_name: Course::Assessment::Question::TextResponseComprehensionGroup.name,
+                     inverse_of: :points
+
+  accepts_nested_attributes_for :solutions, allow_destroy: true
+
+  def auto_gradable_point?
+    solutions.map(&:auto_gradable_solution?).any?
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.group = duplicator.duplicate(other.group)
+    self.solutions = duplicator.duplicate(other.solutions)
+  end
+
+  private
+
+  def validate_point_grade
+    errors.add(:point_grade, :invalid_point_grade) if point_grade > group.maximum_group_grade
+  end
+end

--- a/app/models/course/assessment/question/text_response_comprehension_solution.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_solution.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::TextResponseComprehensionSolution < ApplicationRecord
+  self.table_name = 'course_assessment_question_text_response_compre_solutions'
+
+  enum solution_type: [:compre_lifted_word, :compre_keyword]
+
+  before_validation :remove_blank_solution,
+                    :strip_whitespace_solution,
+                    :strip_whitespace_solution_lemma
+
+  belongs_to :point, class_name: Course::Assessment::Question::TextResponseComprehensionPoint.name,
+                     inverse_of: :solutions
+
+  def auto_gradable_solution?
+    !solution.empty?
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.point = duplicator.duplicate(other.point)
+  end
+
+  private
+
+  def comprehension_solution?
+    compre_keyword? || compre_lifted_word?
+  end
+
+  def remove_blank_solution
+    solution.reject!(&:blank?)
+  end
+
+  def strip_whitespace_solution
+    solution.each(&:strip!)
+  end
+
+  def strip_whitespace_solution_lemma
+    solution_lemma.each(&:strip!)
+  end
+end

--- a/config/locales/en/activerecord/course/assessment/question/text_response.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_response.yml
@@ -5,6 +5,7 @@ en:
         course/assessment/question/text_response:
           text_response: 'text response question'
           file_upload: 'file upload question'
+          comprehension: 'comprehension question'
     errors:
       models:
         course/assessment/question/text_response:

--- a/config/locales/en/activerecord/course/assessment/question/text_response_comprehension_group.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_response_comprehension_group.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/question/text_response_comprehension_group:
+          attributes:
+            maximum_group_grade:
+              invalid_group_grade: 'must be no more than the maximum grade of the question'

--- a/config/locales/en/activerecord/course/assessment/question/text_response_comprehension_point.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_response_comprehension_point.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/assessment/question/text_response_comprehension_point:
+          attributes:
+            point_grade:
+              invalid_point_grade: 'must be no more than the maximum grade of the group'

--- a/db/migrate/20171225012500_create_question_text_response_comprehension.rb
+++ b/db/migrate/20171225012500_create_question_text_response_comprehension.rb
@@ -1,0 +1,44 @@
+class CreateQuestionTextResponseComprehension < ActiveRecord::Migration[5.0]
+  def change
+    add_column :course_assessment_question_text_responses, :is_comprehension, :boolean, default: false
+
+    create_table :course_assessment_question_text_response_compre_groups do |t|
+      t.references :question,
+                   null: false,
+                   index: {
+                     name: :fk__course_assessment_text_response_compre_group_question
+                   },
+                   foreign_key: {
+                     to_table: :course_assessment_question_text_responses
+                   }
+      t.decimal :maximum_group_grade, precision: 4, scale: 1, null: false, default: 0.0
+    end
+
+    create_table :course_assessment_question_text_response_compre_points do |t|
+      t.references :group,
+                   null: false,
+                   index: {
+                     name: :fk__course_assessment_text_response_compre_point_group
+                   },
+                   foreign_key: {
+                     to_table: :course_assessment_question_text_response_compre_groups
+                   }
+      t.decimal :point_grade, precision: 4, scale: 1, null: false, default: 0.0
+    end
+
+    create_table :course_assessment_question_text_response_compre_solutions do |t|
+      t.references :point,
+                   null: false,
+                   index: {
+                     name: :fk__course_assessment_text_response_compre_solution_point
+                   },
+                   foreign_key: {
+                     to_table: :course_assessment_question_text_response_compre_points
+                   }
+      t.integer :solution_type, null: false, default: 0
+      t.string :solution, array: true, null: false, default: []
+      t.string :solution_lemma, array: true, null: false, default: []
+      t.text :explanation, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171221155021) do
+ActiveRecord::Schema.define(version: 20171225012500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -317,6 +317,7 @@ ActiveRecord::Schema.define(version: 20171221155021) do
   create_table "course_assessment_question_text_responses", force: :cascade do |t|
     t.boolean "allow_attachment", :default=>false
     t.boolean "hide_text",        :default=>false
+    t.boolean "is_comprehension", :default=>false
   end
 
   create_table "course_assessment_question_text_response_solutions", force: :cascade do |t|
@@ -324,6 +325,24 @@ ActiveRecord::Schema.define(version: 20171221155021) do
     t.integer "solution_type", :default=>0, :null=>false
     t.text    "solution",      :null=>false
     t.decimal "grade",         :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+    t.text    "explanation"
+  end
+
+  create_table "course_assessment_question_text_response_compre_groups", force: :cascade do |t|
+    t.integer "question_id",         :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_group_question"}, :foreign_key=>{:references=>"course_assessment_question_text_responses", :name=>"fk_course_assessment_questi_792d801a492f8d93953ae5cff87fd4bb", :on_update=>:no_action, :on_delete=>:no_action}
+    t.decimal "maximum_group_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+  end
+
+  create_table "course_assessment_question_text_response_compre_points", force: :cascade do |t|
+    t.integer "group_id",            :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_point_group"}, :foreign_key=>{:references=>"course_assessment_question_text_response_compre_groups", :name=>"fk_course_assessment_questi_e4a0264da8f9965399c5856fb50f8946", :on_update=>:no_action, :on_delete=>:no_action}
+    t.decimal "point_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+  end
+
+  create_table "course_assessment_question_text_response_compre_solutions", force: :cascade do |t|
+    t.integer "point_id",       :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_solution_point"}, :foreign_key=>{:references=>"course_assessment_question_text_response_compre_points", :name=>"fk_course_assessment_questi_27cbcefda94a9f05138e779fd2c2bf39", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "solution_type",  :default=>0, :null=>false
+    t.string  "solution",       :default=>[], :null=>false, :array=>true
+    t.string  "solution_lemma", :default=>[], :null=>false, :array=>true
     t.text    "explanation"
   end
 

--- a/spec/factories/course_assessment_answer_text_responses.rb
+++ b/spec/factories/course_assessment_answer_text_responses.rb
@@ -30,6 +30,14 @@ FactoryBot.define do
       answer_text "hello world\nsecond line"
     end
 
+    trait :comprehension_lifted_word do
+      answer_text '<p>my answer contains lifting from text passage</p>'
+    end
+
+    trait :comprehension_keyword do
+      answer_text '<p>my answer contains keyword</p>'
+    end
+
     trait :no_match do
       # use default text, nothing to do
     end

--- a/spec/factories/course_assessment_question_text_response_comprehension_groups.rb
+++ b/spec/factories/course_assessment_question_text_response_comprehension_groups.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_question_text_response_comprehension_group,
+          class: Course::Assessment::Question::TextResponseComprehensionGroup do
+    question { build(:course_assessment_question_text_response) }
+    maximum_group_grade 2
+
+    points do
+      [
+        build(:course_assessment_question_text_response_comprehension_point, group: nil)
+      ]
+    end
+
+    trait :multiple_comprehension_points do
+      points do
+        [
+          build(:course_assessment_question_text_response_comprehension_point, group: nil),
+          build(:course_assessment_question_text_response_comprehension_point, group: nil)
+        ]
+      end
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_text_response_comprehension_points.rb
+++ b/spec/factories/course_assessment_question_text_response_comprehension_points.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_question_text_response_comprehension_point,
+          class: Course::Assessment::Question::TextResponseComprehensionPoint do
+    group { build(:course_assessment_question_text_response_comprehension_group) }
+    point_grade 2
+
+    solutions do
+      [
+        build(:course_assessment_question_text_response_comprehension_solution, :compre_lifted_word, point: nil),
+        build(:course_assessment_question_text_response_comprehension_solution, :compre_keyword, point: nil)
+      ]
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_text_response_comprehension_solutions.rb
+++ b/spec/factories/course_assessment_question_text_response_comprehension_solutions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_question_text_response_comprehension_solution,
+          class: Course::Assessment::Question::TextResponseComprehensionSolution do
+    point { build(:course_assessment_question_text_response_comprehension_point) }
+    solution ['keyword']
+    solution_lemma ['keyword']
+    explanation 'explanation'
+    solution_type :compre_keyword
+
+    trait :compre_lifted_word do
+      solution_type :compre_lifted_word
+      solution ['lifted']
+      solution_lemma ['lift']
+    end
+
+    trait :compre_keyword do
+      solution_type :compre_keyword
+      solution ['keyword']
+      solution_lemma ['keyword']
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_text_responses.rb
+++ b/spec/factories/course_assessment_question_text_responses.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       ]
     end
 
-    trait :multiple do
+    trait :multiple_keywords do
       solutions do
         [
           build(:course_assessment_question_text_response_solution, :exact_match, question: nil),

--- a/spec/factories/course_assessment_question_text_responses.rb
+++ b/spec/factories/course_assessment_question_text_responses.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
           parent: :course_assessment_question do
     allow_attachment false
     hide_text false
+    is_comprehension false
 
     solutions do
       [
@@ -46,6 +47,25 @@ FactoryBot.define do
       solutions do
         [
           build(:course_assessment_question_text_response_solution, :multiline_linux, question: nil)
+        ]
+      end
+    end
+
+    trait :multiple_comprehension_groups do
+      is_comprehension true
+      groups do
+        [
+          build(:course_assessment_question_text_response_comprehension_group, question: nil),
+          build(:course_assessment_question_text_response_comprehension_group, question: nil)
+        ]
+      end
+    end
+
+    trait :comprehension_question do
+      is_comprehension true
+      groups do
+        [
+          build(:course_assessment_question_text_response_comprehension_group, question: nil)
         ]
       end
     end

--- a/spec/models/course/assessment/answer/text_response_spec.rb
+++ b/spec/models/course/assessment/answer/text_response_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Course::Assessment::Answer::TextResponse, type: :model do
         end
 
         it 'normalizes newlines' do
-          expect(subject). to eq("hello world\nsecond line")
+          expect(subject).to eq("hello world\nsecond line")
         end
       end
 
@@ -51,7 +51,7 @@ RSpec.describe Course::Assessment::Answer::TextResponse, type: :model do
         end
 
         it 'normalizes newlines' do
-          expect(subject). to eq("hello world\nsecond line")
+          expect(subject).to eq("hello world\nsecond line")
         end
       end
     end

--- a/spec/models/course/assessment/question/text_response_comprehension_group_spec.rb
+++ b/spec/models/course/assessment/question/text_response_comprehension_group_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextResponseComprehensionGroup, type: :model do
+  it 'belongs to question' do
+    expect(subject).to belong_to(:question).
+      class_name(Course::Assessment::Question::TextResponse.name)
+  end
+  it 'has many points' do
+    expect(subject).to have_many(:points).
+      class_name(Course::Assessment::Question::TextResponseComprehensionPoint.name).
+      dependent(:destroy)
+  end
+  it { is_expected.to accept_nested_attributes_for(:points) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable_group?' do
+      subject { build_stubbed(:course_assessment_question_text_response_comprehension_group) }
+      it 'returns true' do
+        expect(subject.auto_gradable_group?).to be(true)
+      end
+    end
+
+    describe 'validations' do
+      describe '#maximum_group_grade' do
+        subject do
+          build_stubbed(:course_assessment_question_text_response_comprehension_group, maximum_group_grade: 5)
+        end
+
+        it 'validates that maximum group grade does not exceed maximum grade of the question' do
+          subject.question.maximum_grade = 2
+
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:maximum_group_grade]).to include(I18n.t('activerecord.errors.models.' \
+              'course/assessment/question/text_response_comprehension_group.attributes.' \
+              'maximum_group_grade.invalid_group_grade'))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/text_response_comprehension_point_spec.rb
+++ b/spec/models/course/assessment/question/text_response_comprehension_point_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextResponseComprehensionPoint, type: :model do
+  it 'belongs to point' do
+    expect(subject).to belong_to(:group).
+      class_name(Course::Assessment::Question::TextResponseComprehensionGroup.name)
+  end
+  it 'has many solutions' do
+    expect(subject).to have_many(:solutions).
+      class_name(Course::Assessment::Question::TextResponseComprehensionSolution.name).
+      dependent(:destroy)
+  end
+  it { is_expected.to accept_nested_attributes_for(:solutions) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable_point?' do
+      subject { build_stubbed(:course_assessment_question_text_response_comprehension_point) }
+      it 'returns true' do
+        expect(subject.auto_gradable_point?).to be(true)
+      end
+    end
+
+    describe 'validations' do
+      describe '#point_grade' do
+        subject do
+          build_stubbed(:course_assessment_question_text_response_comprehension_point, point_grade: 5)
+        end
+
+        it 'validates that point grade does not exceed maximum grade of the group' do
+          subject.group.maximum_group_grade = 2
+
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:point_grade]).to include(I18n.t('activerecord.errors.models.' \
+              'course/assessment/question/text_response_comprehension_point.attributes.' \
+              'point_grade.invalid_point_grade'))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/text_response_comprehension_solution_spec.rb
+++ b/spec/models/course/assessment/question/text_response_comprehension_solution_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::TextResponseComprehensionSolution, type: :model do
+  it 'belongs to point' do
+    expect(subject).to belong_to(:point).
+      class_name(Course::Assessment::Question::TextResponseComprehensionPoint.name)
+  end
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable_solution?' do
+      subject { build_stubbed(:course_assessment_question_text_response_comprehension_solution) }
+      it 'returns true' do
+        expect(subject.auto_gradable_solution?).to be(true)
+      end
+    end
+
+    describe 'validations' do
+      describe '#answer_text' do
+        subject do
+          build_stubbed(:course_assessment_question_text_response_comprehension_solution, \
+                        solution: ['  content  '], solution_lemma: ['  content  '])
+        end
+
+        it 'strips whitespaces when validated' do
+          expect(subject.valid?).to be(true)
+          expect(subject.solution).to eq(['content'])
+          expect(subject.solution_lemma).to eq(['content'])
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/text_response_spec.rb
+++ b/spec/models/course/assessment/question/text_response_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
   it { is_expected.to act_as(Course::Assessment::Question) }
+
   it 'has many solutions' do
     expect(subject).to have_many(:solutions).
       class_name(Course::Assessment::Question::TextResponseSolution.name).
@@ -10,12 +11,28 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
   end
   it { is_expected.to accept_nested_attributes_for(:solutions) }
 
+  it 'has many groups' do
+    expect(subject).to have_many(:groups).
+      class_name(Course::Assessment::Question::TextResponseComprehensionGroup.name).
+      dependent(:destroy)
+  end
+  it { is_expected.to accept_nested_attributes_for(:groups) }
+
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe '#auto_gradable?' do
-      subject { create(:course_assessment_question_text_response) }
-      it 'returns true' do
-        expect(subject.auto_gradable?).to be(true)
+      context 'text response question' do
+        subject { create(:course_assessment_question_text_response) }
+        it 'returns true' do
+          expect(subject.auto_gradable?).to be(true)
+        end
+      end
+
+      context 'comprehension question' do
+        subject { create(:course_assessment_question_text_response, :comprehension_question) }
+        it 'returns true' do
+          expect(subject.auto_gradable?).to be(true)
+        end
       end
     end
 
@@ -58,16 +75,18 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
     end
 
     describe 'validations' do
-      subject { create(:course_assessment_question_text_response, maximum_grade: 10) }
+      context 'text response question' do
+        subject { create(:course_assessment_question_text_response, maximum_grade: 10) }
 
-      it 'validates that solution grade does not exceed maximum grade ' do
-        subject.solutions.first.grade = 20
+        it 'validates that solution grade does not exceed maximum grade ' do
+          subject.solutions.first.grade = 20
 
-        expect(subject.valid?).to be(false)
-        expect(subject.errors[:maximum_grade]).to include(
-          I18n.t('activerecord.errors.models.course/assessment/question/text_response.attributes'\
-            '.maximum_grade.invalid_grade')
-        )
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:maximum_grade]).to include(
+            I18n.t('activerecord.errors.models.course/assessment/question/text_response.attributes'\
+              '.maximum_grade.invalid_grade')
+          )
+        end
       end
     end
   end

--- a/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/text_response_auto_grading_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Course::Assessment::Answer::TextResponseAutoGradingService do
       end
 
       context 'when multiple keywords are present' do
-        let(:question_traits) { :multiple }
+        let(:question_traits) { :multiple_keywords }
 
         it 'matches all keywords' do
           answer.actable.answer_text = 'keywordA keywordB'


### PR DESCRIPTION
~Creation of a new TextInput question type to support GCE A-Level General Paper Comprehension questions.~
~Possibly to migrate TextResponse questions and answers over to TextInput once TextInput is complete.~

Upgrade existing TextResponse question type to support GCE A-Level General Paper Comprehension questions.

TODO in separate/future PRs:
- Auto_grading_service (including lemmatiser)
- Front-end view for instructors and students
- `text_response_management`
  