### PR TITLE
Video scrolling

### DIFF
--- a/app/controllers/course/video/submission/submissions_controller.rb
+++ b/app/controllers/course/video/submission/submissions_controller.rb
@@ -22,12 +22,17 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
     @topics = @video.topics.includes(posts: :children).order(:timestamp)
     @topics = @topics.reject { |topic| topic.posts.empty? }
     @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
+    @scroll_topic_id = scroll_topic_params
   end
 
   private
 
   def create_params
     { course_user: current_course_user }
+  end
+
+  def scroll_topic_params
+    params[:scroll_to_topic]
   end
 
   def authorize_video!

--- a/app/views/course/video/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/video/submission/submissions/edit.json.jbuilder
@@ -5,4 +5,7 @@ end
 json.discussion do
   json.partial! 'course/video/topics/topics', locals: { topics: @topics }
   json.partial! 'course/video/topics/posts', locals: { posts: @posts }
+  json.scrolling do
+    json.scrollTopicId @scroll_topic_id
+  end
 end

--- a/app/views/course/video/topics/_discussion_topic_topic.html.slim
+++ b/app/views/course/video/topics/_discussion_topic_topic.html.slim
@@ -8,7 +8,10 @@
   h3
     - timestamp = Time.at(video_topic.timestamp).utc.strftime("%H:%M:%S")
     = link_to t('.comment_title', title: video.title, timestamp: timestamp),
-              edit_course_video_submission_path(current_course, video, submission)
+              edit_course_video_submission_path(current_course,
+                                                video,
+                                                submission,
+                                                params: { scroll_to_topic: video_topic})
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
   h4

--- a/app/views/course/video/topics/_topic.json.jbuilder
+++ b/app/views/course/video/topics/_topic.json.jbuilder
@@ -1,4 +1,5 @@
 json.timestamp topic.timestamp
+json.createdTimestamp topic.created_at.to_i
 json.discussionTopicId topic.discussion_topic.id.to_s
 json.topLevelPostIds(
   topic.

--- a/client/app/bundles/course/video/submission/actions/discussion.js
+++ b/client/app/bundles/course/video/submission/actions/discussion.js
@@ -77,6 +77,9 @@ function removePost(postId) {
  * Defaults for a topic properties will be applied if they are not set.
  *
  * If a topic with the id already exists, it will be totally replaced by this new topic. Attributes will not be merged.
+ *
+ * This action will also set the topicId under for the scrolling state, signalling to the components that they
+ * should scroll to the element for this new topic after it's rendered.
  * @param topicId The id of the new topic
  * @param topicProps The properties of the new topic
  * @returns {{type: discussionActionTypes, topicId: string, topicProps: Object}} The create topic action
@@ -174,6 +177,18 @@ export function changeAutoScroll(autoScroll) {
   return {
     type: discussionActionTypes.CHANGE_AUTO_SCROLL,
     autoScroll,
+  };
+}
+
+/**
+ * Creates an action to unset the topic id in the scrolling state.
+ *
+ * Doing so will signal to the components that they should no longer snap to the topic's element on update.
+ * @return {{type: discussionActionTypes}}
+ */
+export function unsetScrollTopic() {
+  return {
+    type: discussionActionTypes.UNSET_SCROLL_TOPIC,
   };
 }
 

--- a/client/app/bundles/course/video/submission/containers/Discussion.jsx
+++ b/client/app/bundles/course/video/submission/containers/Discussion.jsx
@@ -69,17 +69,18 @@ Discussion.defaultProps = defaultProps;
 
 function mapStateToProps(state) {
   // TODO: Use reselect
+  const autoScroll = state.discussion.scrolling.autoScroll;
   const currentTime = state.video.playerProgress;
 
   const sortedKeys = state.discussion.topics
     .filter(topic => topic.topLevelPostIds.length > 0)
-    .filter(topic => !state.discussion.autoScroll || topic.timestamp <= currentTime)
+    .filter(topic => !autoScroll || topic.timestamp <= currentTime)
     .sort((topic1, topic2) => topic1.timestamp - topic2.timestamp)
     .keySeq()
     .toArray();
   return {
     topicIds: sortedKeys,
-    autoScroll: state.discussion.autoScroll,
+    autoScroll,
   };
 }
 

--- a/client/app/bundles/course/video/submission/containers/Discussion.jsx
+++ b/client/app/bundles/course/video/submission/containers/Discussion.jsx
@@ -8,15 +8,19 @@ import styles from './Discussion.scss';
 import NewPostContainer from './DiscussionElements/NewPostContainer';
 import Topic from './DiscussionElements/Topic';
 import Controls from './DiscussionElements/Controls';
+import { unsetScrollTopic } from '../actions/discussion';
 
 const propTypes = {
   topicIds: PropTypes.arrayOf(PropTypes.string),
   autoScroll: PropTypes.bool,
+  scrollTopicId: PropTypes.string,
+  onScroll: PropTypes.func,
 };
 
 const defaultProps = {
   topicIds: [],
   autoScroll: false,
+  scrollTopicId: null,
 };
 
 class Discussion extends React.Component {
@@ -36,6 +40,9 @@ class Discussion extends React.Component {
       this.topicPane.scrollTop = this.savedAutoScrollPos;
     } else if (this.props.autoScroll) {
       this.topicPane.scrollTop = this.topicPane.scrollHeight;
+    } else if (this.props.scrollTopicId !== null) {
+      const topicElem = document.getElementById(`discussion-topic-${this.props.scrollTopicId}`);
+      this.topicPane.scrollTop = topicElem.offsetTop;
     }
   }
 
@@ -46,18 +53,19 @@ class Discussion extends React.Component {
   render() {
     return (
       <Paper zDepth={2} className={styles.rootContainer}>
-        <div
-          ref={this.setRef}
-          className={styles.topicsContainer}
-          style={{ overflowY: this.props.autoScroll ? 'hidden' : 'scroll' }}
-        >
-          {this.props.topicIds.map(id => <Topic key={id.toString()} topicId={id} />)}
-        </div>
-        <Divider />
         <div className={styles.newCommentEditor}>
           <NewPostContainer>
             <Controls />
           </NewPostContainer>
+        </div>
+        <Divider />
+        <div
+          ref={this.setRef}
+          className={styles.topicsContainer}
+          style={{ overflowY: this.props.autoScroll ? 'hidden' : 'scroll' }}
+          onScroll={this.props.onScroll}
+        >
+          {this.props.topicIds.map(id => <Topic key={id.toString()} topicId={id} />)}
         </div>
       </Paper>
     );
@@ -69,19 +77,34 @@ Discussion.defaultProps = defaultProps;
 
 function mapStateToProps(state) {
   // TODO: Use reselect
-  const autoScroll = state.discussion.scrolling.autoScroll;
+  const scrolling = state.discussion.scrolling;
   const currentTime = state.video.playerProgress;
 
   const sortedKeys = state.discussion.topics
     .filter(topic => topic.topLevelPostIds.length > 0)
-    .filter(topic => !autoScroll || topic.timestamp <= currentTime)
+    .filter(topic => !scrolling.autoScroll || topic.timestamp <= currentTime)
     .sort((topic1, topic2) => topic1.timestamp - topic2.timestamp)
     .keySeq()
     .toArray();
   return {
     topicIds: sortedKeys,
-    autoScroll,
+    autoScroll: scrolling.autoScroll,
+    scrollTopicId: scrolling.topicId,
   };
 }
 
-export default connect(mapStateToProps)(Discussion);
+function mapDispatchToProps(dispatch) {
+  return {
+    onScroll: () => dispatch(unsetScrollTopic()),
+  };
+}
+
+function mergeProps(stateProps, dispatchProps) {
+  if (stateProps.scrollTopicId === null) {
+    return Object.assign({}, stateProps, dispatchProps, { onScroll: null });
+  }
+
+  return Object.assign({}, stateProps, dispatchProps);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Discussion);

--- a/client/app/bundles/course/video/submission/containers/Discussion.jsx
+++ b/client/app/bundles/course/video/submission/containers/Discussion.jsx
@@ -28,8 +28,23 @@ class Discussion extends React.Component {
     this.topicPane = null;
   }
 
+  componentDidMount() {
+    this.scrollToTopic();
+  }
+
   componentDidUpdate(prevProps) {
-    if (this.props.scrollTopicId === null || this.props.scrollTopicId === prevProps.scrollTopicId) {
+    if (this.props.scrollTopicId === prevProps.scrollTopicId) {
+      return;
+    }
+    this.scrollToTopic();
+  }
+
+  setRef = (topicPaneElement) => {
+    this.topicPane = topicPaneElement;
+  };
+
+  scrollToTopic() {
+    if (this.props.scrollTopicId === null) {
       return;
     }
 
@@ -40,10 +55,6 @@ class Discussion extends React.Component {
       this.topicPane.scrollTop = topicElem.offsetTop;
     } // Setting scrollTop will trigger the onScroll callback, which typically unsets scrollTopicId thereafter
   }
-
-  setRef = (topicPaneElement) => {
-    this.topicPane = topicPaneElement;
-  };
 
   render() {
     return (

--- a/client/app/bundles/course/video/submission/containers/Discussion.scss
+++ b/client/app/bundles/course/video/submission/containers/Discussion.scss
@@ -17,8 +17,12 @@ $comment-background: #ffffff;
 
 .topicsContainer {
   flex: 1;
-  padding: 1em 1em 0;
   overflow: scroll;
+  padding: 0 1em;
+}
+
+.topicComponent {
+  padding-top: 1em;
 }
 
 .replyContainer {

--- a/client/app/bundles/course/video/submission/containers/Discussion.scss
+++ b/client/app/bundles/course/video/submission/containers/Discussion.scss
@@ -18,6 +18,7 @@ $comment-background: #ffffff;
 .topicsContainer {
   flex: 1;
   padding: 1em 1em 0;
+  overflow: scroll;
 }
 
 .replyContainer {

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Controls.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Controls.jsx
@@ -39,7 +39,7 @@ Controls.defaultProps = defaultProps;
 
 function mapStateToProps(state) {
   return {
-    autoScroll: state.discussion.autoScroll,
+    autoScroll: state.discussion.scrolling.autoScroll,
   };
 }
 

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
@@ -24,7 +24,7 @@ function Topic(props) {
   }
 
   return (
-    <div id={`discussion-topic-${props.topicId}`}>
+    <div id={`discussion-topic-${props.topicId}`} className={styles.topicComponent}>
       <div className={styles.topicTimestamp}>
         <span className="glyphicon glyphicon-chevron-down" />
         &nbsp;
@@ -37,7 +37,7 @@ function Topic(props) {
         {props.postIds.map(id => <PostContainer key={id.toString()} postId={id} isRoot />)}
       </div>
       <Reply topicId={props.topicId} />
-      <Divider style={{ marginBottom: '1em' }} />
+      <Divider />
     </div>
   );
 }

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
@@ -24,7 +24,7 @@ function Topic(props) {
   }
 
   return (
-    <div>
+    <div id={`discussion-topic-${props.topicId}`}>
       <div className={styles.topicTimestamp}>
         <span className="glyphicon glyphicon-chevron-down" />
         &nbsp;

--- a/client/app/bundles/course/video/submission/reducers/discussion.js
+++ b/client/app/bundles/course/video/submission/reducers/discussion.js
@@ -10,7 +10,10 @@ export const initialState = {
   topics: makeImmutableMap(),
   posts: makeImmutableMap(),
   pendingReplyPosts: makeImmutableMap(),
-  autoScroll: false,
+  scrolling: {
+    scrollTopicId: null,
+    autoScroll: false,
+  },
 };
 
 const postDefaults = {
@@ -60,7 +63,7 @@ function newTopicPost(state = initialState.newTopicPost, action) {
   }
 }
 
-function topics(state = makeImmutableMap(), action) {
+function topics(state = initialState.topics, action) {
   switch (action.type) {
     case discussionActionTypes.ADD_TOPIC:
       return state.set(action.topicId, Object.assign({}, topicDefaults, action.topicProps));
@@ -75,7 +78,7 @@ function topics(state = makeImmutableMap(), action) {
   }
 }
 
-function posts(state = makeImmutableMap(), action) {
+function posts(state = initialState.posts, action) {
   switch (action.type) {
     case discussionActionTypes.ADD_POST:
       return state.set(action.postId, Object.assign({}, postDefaults, action.postProps));
@@ -90,7 +93,7 @@ function posts(state = makeImmutableMap(), action) {
   }
 }
 
-function pendingReplyPosts(state = makeImmutableMap, action) {
+function pendingReplyPosts(state = initialState.pendingReplyPosts, action) {
   switch (action.type) {
     case discussionActionTypes.ADD_REPLY:
       return state.set(action.topicId, Object.assign({}, replyDefaults));
@@ -103,10 +106,18 @@ function pendingReplyPosts(state = makeImmutableMap, action) {
   }
 }
 
-function autoScroll(state = false, action) {
+function scrolling(state = initialState.scrolling, action) {
   switch (action.type) {
     case discussionActionTypes.CHANGE_AUTO_SCROLL:
-      return action.autoScroll;
+      // We reset topic scrolling on auto scroll toggle
+      return Object.assign({}, state, {
+        autoScroll: action.autoScroll,
+        scrollTopicId: null,
+      });
+    case discussionActionTypes.ADD_TOPIC:
+      return Object.assign({}, state, { scrollTopicId: action.topicId });
+    case discussionActionTypes.UNSET_SCROLL_TOPIC:
+      return Object.assign({}, state, { scrollTopicId: null });
     default:
       return state;
   }
@@ -117,5 +128,5 @@ export default combineReducers({
   topics,
   posts,
   pendingReplyPosts,
-  autoScroll,
+  scrolling,
 });

--- a/client/app/bundles/course/video/submission/selectors/discussion.js
+++ b/client/app/bundles/course/video/submission/selectors/discussion.js
@@ -2,19 +2,48 @@ import { createSelector } from 'reselect';
 
 const topicsSelector = state => state.discussion.topics;
 
-export const orderedTopicsSelector = createSelector(
+/**
+ * A memoized selector that returns topic objects containing at least one post.
+ *
+ * Selector returns an Immutable Map from topic ids to topic objects.
+ */
+const nonEmptyTopicsSelector = createSelector(
   topicsSelector,
+  topics => topics.filter(topic => topic.topLevelPostIds.length > 0)
+);
+
+/**
+ * A memoized selector that returns the topic ids ordered according to topic timestamp, then createdAt time in ascending
+ * order.
+ *
+ * Selector will only return an array of topic ids.
+ */
+export const orderedTopicIdsSelector = createSelector(
+  nonEmptyTopicsSelector,
   topics => topics
-    .filter(topic => topic.topLevelPostIds.length > 0)
     .sort((topic1, topic2) => {
       if (topic1.timestamp === topic2.timestamp) {
         return topic1.createdTimestamp - topic2.createdTimestamp;
       }
       return topic1.timestamp - topic2.timestamp;
     })
+    .keySeq()
+    .toArray()
 );
 
-export const orderedTopicIdsSelector = createSelector(
-  orderedTopicsSelector,
-  orderedTopics => orderedTopics.keySeq().toArray()
+/**
+ * A memoized selector that return topic objects ordered in ascending order of timestamp, but descending order of
+ * createdAt time within each unique timestamp group.
+ *
+ * Selector returns an Immutable OrderedMap from topic ids to topic objects.
+ */
+export const inverseCreatedAtOrderedTopicsSelector = createSelector(
+  nonEmptyTopicsSelector,
+  topics => topics
+    .sort((topic1, topic2) => {
+      if (topic1.timestamp === topic2.timestamp) {
+        return topic2.createdTimestamp - topic1.createdTimestamp;
+      }
+      return topic1.timestamp - topic2.timestamp;
+    })
 );

--- a/client/app/bundles/course/video/submission/selectors/discussion.js
+++ b/client/app/bundles/course/video/submission/selectors/discussion.js
@@ -1,0 +1,20 @@
+import { createSelector } from 'reselect';
+
+const topicsSelector = state => state.discussion.topics;
+
+export const orderedTopicsSelector = createSelector(
+  topicsSelector,
+  topics => topics
+    .filter(topic => topic.topLevelPostIds.length > 0)
+    .sort((topic1, topic2) => {
+      if (topic1.timestamp === topic2.timestamp) {
+        return topic1.createdTimestamp - topic2.createdTimestamp;
+      }
+      return topic1.timestamp - topic2.timestamp;
+    })
+);
+
+export const orderedTopicIdsSelector = createSelector(
+  orderedTopicsSelector,
+  orderedTopics => orderedTopics.keySeq().toArray()
+);

--- a/client/app/lib/constants/videoConstants.js
+++ b/client/app/lib/constants/videoConstants.js
@@ -53,6 +53,7 @@ export const discussionActionTypes = mirrorCreator([
   'UPDATE_REPLY',
   'REMOVE_REPLY',
   'CHANGE_AUTO_SCROLL',
+  'UNSET_SCROLL_TOPIC',
   'REFRESH_ALL',
 ]);
 

--- a/client/package.json
+++ b/client/package.json
@@ -104,6 +104,7 @@
     "redux-immutable": "^4.0.0",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.0.1",
+    "reselect": "^3.0.1",
     "sass-loader": "^6.0.5",
     "script-loader": "^0.7.0",
     "style-loader": "^0.18.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6034,6 +6034,10 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
Rebased onto #2646 to avoid merge conflicts.

This PR sorts out the scrolling for videos. Roughly the following are implemented:

1. Fix the ordering of the topics: they are ordered by timestamp, then by createdAt time
2. Use reselect to avoid resorting on every state change
3. Add anchors and scrolling information to state so that component can pick it up
 - The box will now scroll to a new topic after it's created
 - Comment centre links will also scroll to the relevant topic
4. Implement autoscrolling based on a scrollbar instead of hiding elements
5. Move comment box to top

(4) and (5) are requested by Prof. Ben.

The new behaviour of the scrolling is as such:
 - If `scrollTopicId` is set in state, scroll box will programmatically scroll to that topic
   - An `onScroll` callback is set if `scrollTopicId` is set too, which will unset the `scrollTopicId` immediately after the automatic scroll
 - If not, and if autoscroll with video playback is on, the scroll box scrolls to the first topic with the largest timestamp before the current video progress
- If neither of those is set, the scroll box will not move on re-render
- Programmatic scrolling will happen on once per `scrollTopicId` set. So if the user scrolls away, the topic will not snap back, until another `scrollTopicId` is set 
  - This may cause the box to suddenly scroll away when autoscroll is on, but thus far is the least confusing UI.
