### PR TITLE
Do not show “Duplicate Data” sidebar item if super-user is not a manager

### DIFF
--- a/app/models/components/course/duplication_ability_component.rb
+++ b/app/models/components/course/duplication_ability_component.rb
@@ -17,6 +17,7 @@ module Course::DuplicationAbilityComponent
   # Include in the list of target courses only courses which superusers can duplicate to.
   # Without this, the list will consist of all courses in the instance.
   def disallow_superusers_duplicate_via_frontend
+    cannot :duplicate, Course
     cannot :duplicate_to, Course
   end
 

--- a/spec/features/course/duplication_spec.rb
+++ b/spec/features/course/duplication_spec.rb
@@ -14,10 +14,22 @@ RSpec.feature 'Course: Duplication' do
     context 'As a System Administrator' do
       let(:user) { create(:administrator) }
 
-      scenario 'I can view the Duplication Sidebar item' do
-        visit course_path(course)
+      context "When I'm a course manager" do
+        let!(:manager) { create(:course_manager, user: user, course: course) }
 
-        expect(page).to have_selector('li', text: 'layouts.duplication.title')
+        scenario 'I can view the Duplication Sidebar item' do
+          visit course_path(course)
+
+          expect(page).to have_selector('li', text: 'layouts.duplication.title')
+        end
+      end
+
+      context "When I'm not a course manager" do
+        scenario 'I cannot view the Duplication Sidebar item' do
+          visit course_path(course)
+
+          expect(page).not_to have_selector('li', text: 'layouts.duplication.title')
+        end
       end
     end
 

--- a/spec/models/duplication_ability_spec.rb
+++ b/spec/models/duplication_ability_spec.rb
@@ -12,24 +12,35 @@ RSpec.describe Course, type: :model do
       let(:user) { create(:user) }
 
       it { is_expected.not_to be_able_to(:duplicate, course) }
+      it { is_expected.not_to be_able_to(:duplicate_to, course) }
     end
 
     context 'when the user is a Course Student' do
       let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.not_to be_able_to(:duplicate, course) }
+      it { is_expected.not_to be_able_to(:duplicate_to, course) }
     end
 
     context 'when the user is a Course Teaching Assistant' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
 
       it { is_expected.not_to be_able_to(:duplicate, course) }
+      it { is_expected.not_to be_able_to(:duplicate_to, course) }
     end
 
     context 'when the user is a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
 
       it { is_expected.to be_able_to(:duplicate, course) }
+      it { is_expected.to be_able_to(:duplicate_to, course) }
+    end
+
+    context 'when administrator is not a part of the course' do
+      let(:user) { create(:administrator) }
+
+      it { is_expected.not_to be_able_to(:duplicate, course) }
+      it { is_expected.not_to be_able_to(:duplicate_to, course) }
     end
   end
 end


### PR DESCRIPTION
Fixes #2648. 

If there is a real need, administrators may duplicate data via the backend instead of the UI.