### PR TITLE
Fix CSS for comment box

### DIFF
--- a/client/app/bundles/course/video/submission/containers/Submission.scss
+++ b/client/app/bundles/course/video/submission/containers/Submission.scss
@@ -20,6 +20,7 @@
 .discussion {
   flex-grow: 1;
   height: calc(95vh - 70px);
+  max-width: calc(35% - 1em);
   order: 2;
   padding-left: 5px;
   position: sticky;


### PR DESCRIPTION
If a comment got too long in the comment box, the old CSS definition caused the element to expand beyond the space of its row and causes it to snap below the video player.

A `max-width` is set to prevent that, so the box stays in place.