### PR TITLE
Blur number input on mouse wheel scroll

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/QuestionGrade.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/QuestionGrade.jsx
@@ -61,6 +61,10 @@ class VisibleQuestionGrade extends Component {
           step={1}
           value={initialGrade === null ? '' : initialGrade}
           onChange={e => this.handleGradingField(e.target.value)}
+          ref={(ref) => {
+            this.inputRef = ref;
+          }}
+          onWheel={() => this.inputRef.blur()}
         />
         {` / ${maxGrade}`}
       </div>


### PR DESCRIPTION
Prevents accidentally changing grading marks when the intention is to scroll to the next part.
I doubt anyone ever intentionally used mouse scroll to alter the number input anyway.