### PR TITLE
Convert Levels page to React and allow mass update

### DIFF
--- a/app/controllers/course/levels_controller.rb
+++ b/app/controllers/course/levels_controller.rb
@@ -6,32 +6,13 @@ class Course::LevelsController < Course::ComponentController
   def index #:nodoc:
   end
 
-  def new #:nodoc:
-  end
-
   def create #:nodoc:
-    if @level.save
-      redirect_to course_levels_path(current_course),
-                  success: t('.success', threshold: @level.experience_points_threshold)
-    else
-      render 'new'
+    respond_to do |format|
+      if current_course.mass_update_levels(params[:levels])
+        format.json { render json: current_course.levels, status: :created }
+      else
+        format.json { render json: current_course.errors, status: :unprocessable_entity }
+      end
     end
-  end
-
-  def destroy #:nodoc:
-    if @level.destroy
-      redirect_to course_levels_path(current_course),
-                  success: t('.success',
-                             threshold: @level.experience_points_threshold)
-    else
-      redirect_to course_levels_path(current_course),
-                  danger: t('.failure', error: @level.errors.full_messages.to_sentence)
-    end
-  end
-
-  private
-
-  def level_params #:nodoc:
-    params.require(:level).permit(:experience_points_threshold)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,6 +83,7 @@ class Course < ApplicationRecord
   delegate :user?, to: :course_users
   delegate :level_for, to: :levels
   delegate :default_level?, to: :levels
+  delegate :mass_update_levels, to: :levels
 
   def self.use_relative_model_naming?
     true

--- a/app/models/course/level.rb
+++ b/app/models/course/level.rb
@@ -5,6 +5,8 @@ class Course::Level < ApplicationRecord
 
   belongs_to :course, inverse_of: :levels
 
+  DEFAULT_THRESHOLD = 0
+
   # By default, levels should be returned with their level_number,
   # and arranged in ascending order by experience points threshold.
   default_scope { all.calculated(:level_number).order(:experience_points_threshold) }
@@ -30,7 +32,7 @@ class Course::Level < ApplicationRecord
   def self.after_course_initialize(course)
     return if course.persisted? || course.default_level?
 
-    course.levels.build(experience_points_threshold: 0)
+    course.levels.build(experience_points_threshold: DEFAULT_THRESHOLD)
   end
 
   # Returns true if level is a default level.
@@ -38,7 +40,7 @@ class Course::Level < ApplicationRecord
   #
   # @return [Boolean]
   def default_level?
-    experience_points_threshold == 0
+    experience_points_threshold == DEFAULT_THRESHOLD
   end
 
   # Returns the next higher level in the course

--- a/app/views/course/levels/_form.html.slim
+++ b/app/views/course/levels/_form.html.slim
@@ -1,5 +1,0 @@
-= simple_form_for [current_course, @level], resource: :course_level do |f|
-  = f.error_notification
-  = f.error :course_level
-  = f.input :experience_points_threshold, hint: t('.description')
-  = f.button :submit

--- a/app/views/course/levels/_level.html.slim
+++ b/app/views/course/levels/_level.html.slim
@@ -1,4 +1,0 @@
-= content_tag_for(:tr, level)
-  th = level.level_number
-  td = level.experience_points_threshold
-  td = delete_button([current_course, level]) if can?(:destroy, level)

--- a/app/views/course/levels/index.html.slim
+++ b/app/views/course/levels/index.html.slim
@@ -1,10 +1,1 @@
-= page_header do
-  = new_button([current_course, :level]) if can?(:create, Course::Level.new(course: current_course))
-table.table.levels-list.table-hover
-  thead
-    tr
-      th = t('.level')
-      th = t('.threshold')
-      th
-  tbody
-    = render @levels
+div#course-level

--- a/app/views/course/levels/index.json.jbuilder
+++ b/app/views/course/levels/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.levels @levels do |level|
+  json.levelNumber level.level_number
+  json.experiencePointsThreshold level.experience_points_threshold
+end

--- a/app/views/course/levels/index.json.jbuilder
+++ b/app/views/course/levels/index.json.jbuilder
@@ -1,4 +1,1 @@
-json.levels @levels do |level|
-  json.levelNumber level.level_number
-  json.experiencePointsThreshold level.experience_points_threshold
-end
+json.levels @levels.pluck(:experience_points_threshold)

--- a/app/views/course/levels/new.html.slim
+++ b/app/views/course/levels/new.html.slim
@@ -1,3 +1,0 @@
-- add_breadcrumb :new
-= page_header
-= render 'form'

--- a/client/app/api/course/Level.js
+++ b/client/app/api/course/Level.js
@@ -18,6 +18,6 @@ export default class LevelAPI extends BaseCourseAPI {
   }
 
   save(levelFields) {
-    return this.getClient().post(this._getUrlPrefix(), {levels: levelFields});
+    return this.getClient().post(this._getUrlPrefix(), { levels: levelFields });
   }
 }

--- a/client/app/api/course/Level.js
+++ b/client/app/api/course/Level.js
@@ -6,10 +6,8 @@ export default class LevelAPI extends BaseCourseAPI {
   *
   * @return {Promise}
   * success response: {
-  *   levels: Array.<levelShape>,
+  *   levels: Array,
   * }
-  *
-  * See course/level/propTypes.js for levelShape.
   */
   fetch() {
     return this.getClient().get(`${this._getUrlPrefix()}`);

--- a/client/app/api/course/Level.js
+++ b/client/app/api/course/Level.js
@@ -1,0 +1,21 @@
+import BaseCourseAPI from './Base';
+
+export default class LevelAPI extends BaseCourseAPI {
+  /**
+  * Fetches a list of all levels in course
+  *
+  * @return {Promise}
+  * success response: {
+  *   levels: Array.<levelShape>,
+  * }
+  *
+  * See course/level/propTypes.js for levelShape.
+  */
+  fetch() {
+    return this.getClient().get(`${this._getUrlPrefix()}`);
+  }
+
+  _getUrlPrefix() {
+    return `/courses/${this.getCourseId()}/levels`;
+  }
+}

--- a/client/app/api/course/Level.js
+++ b/client/app/api/course/Level.js
@@ -16,4 +16,8 @@ export default class LevelAPI extends BaseCourseAPI {
   _getUrlPrefix() {
     return `/courses/${this.getCourseId()}/levels`;
   }
+
+  save(levelFields) {
+    return this.getClient().post(this._getUrlPrefix(), {levels: levelFields});
+  }
 }

--- a/client/app/api/course/index.js
+++ b/client/app/api/course/index.js
@@ -10,6 +10,7 @@ import SurveyAPI from './Survey';
 import VideoAPI from './Video';
 import AdminAPI from './Admin';
 import ScribingQuestionAPI from './Assessment/question/scribing';
+import LevelAPI from './Level';
 
 const CourseAPI = {
   achievements: new AchievementsAPI(),
@@ -26,6 +27,7 @@ const CourseAPI = {
   question: {
     scribing: ScribingQuestionAPI,
   },
+  level: new LevelAPI(),
 };
 
 Object.freeze(CourseAPI);

--- a/client/app/bundles/course/level/actions.js
+++ b/client/app/bundles/course/level/actions.js
@@ -1,0 +1,19 @@
+import CourseAPI from 'api/course';
+import actionTypes from 'course/level/constants';
+import { setNotification } from 'lib/actions';
+
+export function fetchLevels() {
+  return (dispatch) => {
+    dispatch({ type: actionTypes.LOAD_LEVELS_REQUEST });
+    return CourseAPI.level.fetch()
+      .then((response) => {
+        dispatch({
+          type: actionTypes.LOAD_LEVELS_SUCCESS,
+          levelData: response.data,
+        });
+      })
+      .catch(() => {
+        dispatch({ type: actionTypes.LOAD_LEVELS_FAILURE });
+      });
+  };
+}

--- a/client/app/bundles/course/level/actions.js
+++ b/client/app/bundles/course/level/actions.js
@@ -41,3 +41,18 @@ export function deleteLevel(levelNumber) {
     dispatch({type: actionTypes.DELETE_LEVEL, payload: {levelNumber}});
   };
 }
+
+export function saveLevels(levels, successMessage, failureMessage) {
+  return (dispatch) => {
+    dispatch({type: actionTypes.SAVE_LEVELS });
+    return CourseAPI.level.save(levels)
+      .then(() => {
+        setNotification(successMessage)(dispatch);
+        dispatch({ type: actionTypes.SAVE_LEVELS_SUCCESS });
+      })
+      .catch(() => {
+        setNotification(failureMessage)(dispatch);
+        dispatch({ type: actionTypes.SAVE_LEVELS_FAILURE });
+      });
+  };
+}

--- a/client/app/bundles/course/level/actions.js
+++ b/client/app/bundles/course/level/actions.js
@@ -17,3 +17,27 @@ export function fetchLevels() {
       });
   };
 }
+
+export function updateExpThreshold(levelNumber, newValue) {
+  return (dispatch) => {
+    dispatch({type: actionTypes.UPDATE_EXP_THRESHOLD, payload: {levelNumber, newValue}});
+  };
+}
+
+export function sortLevels() {
+  return (dispatch) => {
+    dispatch({type: actionTypes.SORT_LEVELS});
+  };
+}
+
+export function addLevel() {
+  return (dispatch) => {
+    dispatch({type: actionTypes.ADD_LEVEL});
+  };
+}
+
+export function deleteLevel(levelNumber) {
+  return (dispatch) => {
+    dispatch({type: actionTypes.DELETE_LEVEL, payload: {levelNumber}});
+  };
+}

--- a/client/app/bundles/course/level/actions.js
+++ b/client/app/bundles/course/level/actions.js
@@ -20,31 +20,31 @@ export function fetchLevels() {
 
 export function updateExpThreshold(levelNumber, newValue) {
   return (dispatch) => {
-    dispatch({type: actionTypes.UPDATE_EXP_THRESHOLD, payload: {levelNumber, newValue}});
+    dispatch({ type: actionTypes.UPDATE_EXP_THRESHOLD, payload: { levelNumber, newValue } });
   };
 }
 
 export function sortLevels() {
   return (dispatch) => {
-    dispatch({type: actionTypes.SORT_LEVELS});
+    dispatch({ type: actionTypes.SORT_LEVELS });
   };
 }
 
 export function addLevel() {
   return (dispatch) => {
-    dispatch({type: actionTypes.ADD_LEVEL});
+    dispatch({ type: actionTypes.ADD_LEVEL });
   };
 }
 
 export function deleteLevel(levelNumber) {
   return (dispatch) => {
-    dispatch({type: actionTypes.DELETE_LEVEL, payload: {levelNumber}});
+    dispatch({ type: actionTypes.DELETE_LEVEL, payload: { levelNumber } });
   };
 }
 
 export function saveLevels(levels, successMessage, failureMessage) {
   return (dispatch) => {
-    dispatch({type: actionTypes.SAVE_LEVELS });
+    dispatch({ type: actionTypes.SAVE_LEVELS });
     return CourseAPI.level.save(levels)
       .then(() => {
         setNotification(successMessage)(dispatch);

--- a/client/app/bundles/course/level/components/LevelRow.jsx
+++ b/client/app/bundles/course/level/components/LevelRow.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
+import RaisedButton from 'material-ui/RaisedButton';
+import TextField from 'material-ui/TextField';
+import { grey300 } from 'material-ui/styles/colors';
+import styles from './../pages/Level/LevelView.scss';
+
+class LevelRow extends React.Component {
+  static propTypes = {
+    levelNumber: PropTypes.number.isRequired,
+    experiencePointsThreshold: PropTypes.number.isRequired,
+  }
+
+  levelDeleteHandler(levelNumber) {
+    return (e) => {
+      e.preventDefault();
+      if (!this.props.isLoading) {
+        console.log('delete ' + levelNumber);
+      }
+    };
+  }
+
+  renderInput(levelNumber, experiencePointsThreshold) {
+    return (
+      <TextField
+        type="text"
+        name={'level_' + levelNumber}
+        onChange={(e, newValue) => {
+          this.props.updateExpThreshold(levelNumber, newValue);
+        }}
+        value={experiencePointsThreshold}
+      />
+    );
+  }
+
+  render() {
+    const { levelNumber, experiencePointsThreshold } = this.props;
+    return (
+      <TableRow>
+        <TableHeaderColumn className={styles.deleteButtonCell}>
+          <RaisedButton
+            name={levelNumber}
+            backgroundColor={grey300}
+            icon={<i className="fa fa-trash" />}
+            onClick={this.levelDeleteHandler(levelNumber)}
+            style={{ minWidth: '40px', width: '40px' }}
+          />
+        </TableHeaderColumn>
+        <TableRowColumn>{ levelNumber }</TableRowColumn>
+        <TableRowColumn>{ this.renderInput(levelNumber, experiencePointsThreshold) }</TableRowColumn>
+      </TableRow>
+    );
+  }
+}
+
+export default LevelRow;

--- a/client/app/bundles/course/level/components/LevelRow.jsx
+++ b/client/app/bundles/course/level/components/LevelRow.jsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 import { grey300 } from 'material-ui/styles/colors';
+
+const translations = defineMessages({
+  zeroThresholdError: {
+    id: 'course.level.LevelRow.zeroThresholdError',
+    defaultMessage: 'Experience points threshold cannot be 0',
+  },
+});
 
 const styles = {
   deleteButtonCell: {
@@ -17,11 +25,12 @@ const styles = {
     textAlign: 'center',
     verticalAlign: 'middle',
   },
-}
+};
 
 class LevelRow extends React.Component {
   static propTypes = {
     levelNumber: PropTypes.number.isRequired,
+    disabled: PropTypes.bool.isRequired,
     experiencePointsThreshold: PropTypes.number.isRequired,
   }
 
@@ -33,7 +42,9 @@ class LevelRow extends React.Component {
         onChange={(e, newValue) => {
           this.props.updateExpThreshold(levelNumber, newValue);
         }}
-        onBlur={(e) => { this.props.sortLevels() }}
+        disabled={this.props.disabled}
+        errorText={experiencePointsThreshold === 0 ? <FormattedMessage {...translations.zeroThresholdError} /> : ''}
+        onBlur={() => { this.props.sortLevels(); }}
         value={experiencePointsThreshold}
       />
     );
@@ -51,6 +62,7 @@ class LevelRow extends React.Component {
             backgroundColor={grey300}
             icon={<i className="fa fa-trash" />}
             onClick={this.props.deleteLevel(levelNumber)}
+            disabled={this.props.disabled}
             style={{ minWidth: '40px', width: '40px' }}
           />
         </TableHeaderColumn>

--- a/client/app/bundles/course/level/components/LevelRow.jsx
+++ b/client/app/bundles/course/level/components/LevelRow.jsx
@@ -4,21 +4,25 @@ import { TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 import { grey300 } from 'material-ui/styles/colors';
-import styles from './../pages/Level/LevelView.scss';
+
+const styles = {
+  deleteButtonCell: {
+    paddingLeft: 0,
+    textAlign: 'right',
+    verticalAlign: 'middle',
+    width: '50px',
+  },
+  levelNumber: {
+    fontSize: '16px',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+  },
+}
 
 class LevelRow extends React.Component {
   static propTypes = {
     levelNumber: PropTypes.number.isRequired,
     experiencePointsThreshold: PropTypes.number.isRequired,
-  }
-
-  levelDeleteHandler(levelNumber) {
-    return (e) => {
-      e.preventDefault();
-      if (!this.props.isLoading) {
-        console.log('delete ' + levelNumber);
-      }
-    };
   }
 
   renderInput(levelNumber, experiencePointsThreshold) {
@@ -29,6 +33,7 @@ class LevelRow extends React.Component {
         onChange={(e, newValue) => {
           this.props.updateExpThreshold(levelNumber, newValue);
         }}
+        onBlur={(e) => { this.props.sortLevels() }}
         value={experiencePointsThreshold}
       />
     );
@@ -38,17 +43,17 @@ class LevelRow extends React.Component {
     const { levelNumber, experiencePointsThreshold } = this.props;
     return (
       <TableRow>
-        <TableHeaderColumn className={styles.deleteButtonCell}>
+        <TableRowColumn style={styles.levelNumber}>{ levelNumber }</TableRowColumn>
+        <TableRowColumn>{ this.renderInput(levelNumber, experiencePointsThreshold) }</TableRowColumn>
+        <TableHeaderColumn style={styles.deleteButtonCell}>
           <RaisedButton
             name={levelNumber}
             backgroundColor={grey300}
             icon={<i className="fa fa-trash" />}
-            onClick={this.levelDeleteHandler(levelNumber)}
+            onClick={this.props.deleteLevel(levelNumber)}
             style={{ minWidth: '40px', width: '40px' }}
           />
         </TableHeaderColumn>
-        <TableRowColumn>{ levelNumber }</TableRowColumn>
-        <TableRowColumn>{ this.renderInput(levelNumber, experiencePointsThreshold) }</TableRowColumn>
       </TableRow>
     );
   }

--- a/client/app/bundles/course/level/components/LevelRow.jsx
+++ b/client/app/bundles/course/level/components/LevelRow.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import RaisedButton from 'material-ui/RaisedButton';
+import DeleteIcon from 'material-ui/svg-icons/action/delete';
 import TextField from 'material-ui/TextField';
 import { grey300 } from 'material-ui/styles/colors';
 
@@ -32,13 +33,16 @@ class LevelRow extends React.Component {
     levelNumber: PropTypes.number.isRequired,
     disabled: PropTypes.bool.isRequired,
     experiencePointsThreshold: PropTypes.number.isRequired,
+    updateExpThreshold: PropTypes.func.isRequired,
+    sortLevels: PropTypes.func.isRequired,
+    deleteLevel: PropTypes.func.isRequired,
   }
 
   renderInput(levelNumber, experiencePointsThreshold) {
     return (
       <TextField
         type="text"
-        name={'level_' + levelNumber}
+        name={`level_${levelNumber}`}
         onChange={(e, newValue) => {
           this.props.updateExpThreshold(levelNumber, newValue);
         }}
@@ -58,9 +62,10 @@ class LevelRow extends React.Component {
         <TableRowColumn>{ this.renderInput(levelNumber, experiencePointsThreshold) }</TableRowColumn>
         <TableHeaderColumn style={styles.deleteButtonCell}>
           <RaisedButton
-            name={levelNumber}
+            id={`delete_${levelNumber}`}
+            name={`delete_${levelNumber}`}
             backgroundColor={grey300}
-            icon={<i className="fa fa-trash" />}
+            icon={<DeleteIcon />}
             onClick={this.props.deleteLevel(levelNumber)}
             disabled={this.props.disabled}
             style={{ minWidth: '40px', width: '40px' }}

--- a/client/app/bundles/course/level/constants.js
+++ b/client/app/bundles/course/level/constants.js
@@ -4,6 +4,10 @@ const actionTypes = mirrorCreator([
   'LOAD_LEVELS_REQUEST',
   'LOAD_LEVELS_SUCCESS',
   'LOAD_LEVELS_FAILURE',
+  'UPDATE_EXP_THRESHOLD',
+  'SORT_LEVELS',
+  'ADD_LEVEL',
+  'DELETE_LEVEL',
 ]);
 
 export default actionTypes;

--- a/client/app/bundles/course/level/constants.js
+++ b/client/app/bundles/course/level/constants.js
@@ -8,6 +8,9 @@ const actionTypes = mirrorCreator([
   'SORT_LEVELS',
   'ADD_LEVEL',
   'DELETE_LEVEL',
+  'SAVE_LEVELS',
+  'SAVE_LEVELS_SUCCESS',
+  'SAVE_LEVELS_FAILURE',
 ]);
 
 export default actionTypes;

--- a/client/app/bundles/course/level/constants.js
+++ b/client/app/bundles/course/level/constants.js
@@ -1,0 +1,9 @@
+import mirrorCreator from 'mirror-creator';
+
+const actionTypes = mirrorCreator([
+  'LOAD_LEVELS_REQUEST',
+  'LOAD_LEVELS_SUCCESS',
+  'LOAD_LEVELS_FAILURE',
+]);
+
+export default actionTypes;

--- a/client/app/bundles/course/level/index.jsx
+++ b/client/app/bundles/course/level/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
+import NotificationPopup from 'lib/containers/NotificationPopup';
+import Level from 'course/level/pages/Level';
+import storeCreator from './store';
+
+$(document).ready(() => {
+  const mountNode = document.getElementById('course-level');
+
+  if (mountNode) {
+    const store = storeCreator({ level: {} });
+
+    render(
+      <ProviderWrapper store={store}>
+        <div>
+          <NotificationPopup />
+          <Level />
+        </div>
+      </ProviderWrapper>
+    , mountNode);
+  }
+});

--- a/client/app/bundles/course/level/index.jsx
+++ b/client/app/bundles/course/level/index.jsx
@@ -18,6 +18,7 @@ $(document).ready(() => {
           <Level />
         </div>
       </ProviderWrapper>
-    , mountNode);
+      , mountNode
+    );
   }
 });

--- a/client/app/bundles/course/level/pages/Level/LevelView.scss
+++ b/client/app/bundles/course/level/pages/Level/LevelView.scss
@@ -1,0 +1,7 @@
+// scss-lint:disable ImportantRule
+.deleteButtonCell {
+  padding-left: 12px !important;
+  text-align: center;
+  vertical-align: middle !important;
+  width: 50px;
+}

--- a/client/app/bundles/course/level/pages/Level/LevelView.scss
+++ b/client/app/bundles/course/level/pages/Level/LevelView.scss
@@ -1,7 +1,0 @@
-// scss-lint:disable ImportantRule
-.deleteButtonCell {
-  padding-left: 12px !important;
-  text-align: center;
-  vertical-align: middle !important;
-  width: 50px;
-}

--- a/client/app/bundles/course/level/pages/Level/index.jsx
+++ b/client/app/bundles/course/level/pages/Level/index.jsx
@@ -6,7 +6,6 @@ import mirrorCreator from 'mirror-creator';
 import { isValid } from 'redux-form';
 
 import Paper from 'material-ui/Paper';
-import Avatar from 'material-ui/Avatar';
 import List from 'material-ui/List/List';
 import ListItem from 'material-ui/List/ListItem';
 import { red500, cyan500, grey50 } from 'material-ui/styles/colors';
@@ -17,7 +16,7 @@ import Done from 'material-ui/svg-icons/action/done';
 import TitleBar from 'lib/components/TitleBar';
 import LoadingIndicator from 'lib/components/LoadingIndicator';
 
-import { fetchLevels } from 'course/level/actions';
+import { fetchLevels, updateExpThreshold, sortLevels, addLevel, deleteLevel } from 'course/level/actions';
 import { defaultComponentTitles } from 'course/translations.intl';
 
 import FlatButton from 'material-ui/FlatButton';
@@ -46,12 +45,24 @@ const styles = {
     paddingRight: 40,
     width: '100%',
   },
-  countAvatar: {
-    margin: 5,
-  },
   duplicateButton: {
     display: 'flex',
     justifyContent: 'center',
+  },
+  formButton: {
+    marginRight: 10,
+  },
+  levelHeader: {
+    textAlign: 'center',
+  },
+  thresholdHeader: {
+    textAlign: 'left',
+  },
+  saveLevels: {
+    textAlign: 'center',
+  },
+  addNewLevel: {
+    textAlign: 'left',
   },
 };
 
@@ -68,42 +79,100 @@ class Level extends React.Component {
 
     this.state = {
     };
+
+    this.handleUpdateExpThreshold = this.handleUpdateExpThreshold.bind(this);
+    this.handleLevelTextBlur = this.handleLevelTextBlur.bind(this);
+    this.createLevelHandler = this.createLevelHandler.bind(this);
+    this.handleDeleteLevel = this.handleDeleteLevel.bind(this);
   }
 
   componentDidMount() {
     this.props.dispatch(fetchLevels());
   }
+
+  handleUpdateExpThreshold(levelNumber, newValue) {
+    this.props.dispatch(updateExpThreshold(levelNumber, newValue));
+  }
+
+  handleLevelTextBlur() {
+    this.props.dispatch(sortLevels());
+  }
+
+  createLevelHandler() {
+    return (e) => {
+      e.preventDefault();
+      if (!this.props.isLoading) {
+        this.props.dispatch(addLevel());
+      }
+    };
+  }
+
+  handleDeleteLevel(levelNumber) {
+    return (e) => {
+      e.preventDefault();
+      if(!this.props.isLoading) {
+        this.props.dispatch(deleteLevel(levelNumber));
+      }
+    };
+  }
   
   renderBody() {
-    const rows = this.props.levels.slice(1).map(level => (
+    const rows = this.props.levels.slice(1).map((experiencePointsThreshold, index) => (
       <LevelRow
-        key={level.levelNumber}
-        levelNumber={level.levelNumber}
-        experiencePointsThreshold={level.experiencePointsThreshold}
+        key={index+1}
+        levelNumber={index+1}
+        experiencePointsThreshold={experiencePointsThreshold}
+        updateExpThreshold={this.handleUpdateExpThreshold}
+        sortLevels={this.handleLevelTextBlur}
+        deleteLevel={this.handleDeleteLevel}
         isLoading={this.props.isLoading}
       />
     ));
 
     return (
       <div style={styles.body}>
-        <Table className="table levels-list">
+        <Table className="table levels-list" fixedHeader={false}>
           <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
             <TableRow>
-              <TableHeaderColumn>Level</TableHeaderColumn>
-              <TableHeaderColumn>Threshold</TableHeaderColumn>
+              <TableHeaderColumn style={styles.levelHeader} >
+                <FormattedMessage {...translations.levelHeader} />
+              </TableHeaderColumn>
+              <TableHeaderColumn style={styles.thresholdHeader}>
+                <FormattedMessage {...translations.thresholdHeader} />
+              </TableHeaderColumn>
+              <TableHeaderColumn />
             </TableRow>
           </TableHeader>
           <TableBody>
             {rows}
           </TableBody>
-          <TableFooter>
+          <TableFooter adjustForCheckbox={false}>
             <TableRow>
-              <TableRowColumn colSpan="5" style={{ textAlign: 'center' }}>
+              <TableRowColumn />
+              <TableRowColumn colSpan="1" style={styles.addNewLevel}>
                 <FlatButton
                   icon={<i className="fa fa-plus" />}
-                  label='Add new level'
+                  label={<FormattedMessage {...translations.addNewLevel} />}
+                  disabled={this.props.isSaving}
+                  onClick={this.handleCreateLevel()}
                 />
               </TableRowColumn>
+              <TableRowColumn />
+            </TableRow>
+            <TableRow>
+              <TableRowColumn style={styles.saveLevels}>
+                <RaisedButton
+                  id="save-levels"
+                  style={styles.formButton}
+                  type="submit"
+                  label={<FormattedMessage {...translations.saveLevels} />}
+                  disabled={this.props.isSaving}
+                  primary
+                  onClick={this.handleSaveLevels()}
+                />
+              </TableRowColumn>
+              <TableRowColumn />
+              <TableRowColumn />
             </TableRow>
           </TableFooter>
         </Table>

--- a/client/app/bundles/course/level/pages/Level/index.jsx
+++ b/client/app/bundles/course/level/pages/Level/index.jsx
@@ -2,16 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import mirrorCreator from 'mirror-creator';
-import { isValid } from 'redux-form';
-
-import Paper from 'material-ui/Paper';
-import List from 'material-ui/List/List';
-import ListItem from 'material-ui/List/ListItem';
-import { red500, cyan500, grey50 } from 'material-ui/styles/colors';
-import Subheader from 'material-ui/Subheader';
-import Clear from 'material-ui/svg-icons/content/clear';
-import Done from 'material-ui/svg-icons/action/done';
 
 import TitleBar from 'lib/components/TitleBar';
 import LoadingIndicator from 'lib/components/LoadingIndicator';
@@ -22,14 +12,14 @@ import { defaultComponentTitles } from 'course/translations.intl';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import {
-  Table, TableBody, TableFooter, TableHeader, TableHeaderColumn, TableRow, TableRowColumn
+  Table, TableBody, TableFooter, TableHeader, TableHeaderColumn, TableRow, TableRowColumn,
 } from 'material-ui/Table';
 
 import LevelRow from 'course/level/components/LevelRow';
 
 const translations = defineMessages({
-  levelsTitle: {
-    id: 'course.level.Level.levelsTitle',
+  levelHeader: {
+    id: 'course.level.Level.levelHeader',
     defaultMessage: 'Levels',
   },
   thresholdHeader: {
@@ -148,12 +138,12 @@ class Level extends React.Component {
       }
     };
   }
-  
+
   renderBody() {
     const rows = this.props.levels.slice(1).map((experiencePointsThreshold, index) => (
       <LevelRow
-        key={index+1}
-        levelNumber={index+1}
+        key={index + 1}
+        levelNumber={index + 1}
         experiencePointsThreshold={experiencePointsThreshold}
         updateExpThreshold={this.handleUpdateExpThreshold}
         sortLevels={this.handleLevelTextBlur}
@@ -184,6 +174,7 @@ class Level extends React.Component {
               <TableRowColumn />
               <TableRowColumn colSpan="1" style={styles.addNewLevel}>
                 <FlatButton
+                  id="add-level"
                   icon={<i className="fa fa-plus" />}
                   label={<FormattedMessage {...translations.addNewLevel} />}
                   disabled={this.props.isSaving}
@@ -216,14 +207,14 @@ class Level extends React.Component {
   render() {
     return (
       <div>
-        <TitleBar title={<FormattedMessage {...translations.levelsTitle} />} />
+        <TitleBar title={<FormattedMessage {...defaultComponentTitles.course_levels_component} />} />
         { this.props.isLoading ? <LoadingIndicator /> : this.renderBody() }
       </div>
     );
   }
 }
 
-export default connect(({ levelEdit, ...state }) => ({
+export default connect(({ levelEdit }) => ({
   isLoading: levelEdit.isLoading,
   isSaving: levelEdit.isSaving,
   levels: levelEdit.levels,

--- a/client/app/bundles/course/level/pages/Level/index.jsx
+++ b/client/app/bundles/course/level/pages/Level/index.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import mirrorCreator from 'mirror-creator';
+import { isValid } from 'redux-form';
+
+import Paper from 'material-ui/Paper';
+import Avatar from 'material-ui/Avatar';
+import List from 'material-ui/List/List';
+import ListItem from 'material-ui/List/ListItem';
+import { red500, cyan500, grey50 } from 'material-ui/styles/colors';
+import Subheader from 'material-ui/Subheader';
+import Clear from 'material-ui/svg-icons/content/clear';
+import Done from 'material-ui/svg-icons/action/done';
+
+import TitleBar from 'lib/components/TitleBar';
+import LoadingIndicator from 'lib/components/LoadingIndicator';
+
+import { fetchLevels } from 'course/level/actions';
+import { defaultComponentTitles } from 'course/translations.intl';
+
+import FlatButton from 'material-ui/FlatButton';
+import {
+  Table, TableBody, TableFooter, TableHeader, TableHeaderColumn, TableRow, TableRowColumn
+} from 'material-ui/Table';
+
+import LevelRow from 'course/level/components/LevelRow';
+
+const translations = defineMessages({
+  levelsTitle: {
+    id: 'course.level.Level.levelsTitle',
+    defaultMessage: 'Levels',
+  },
+});
+
+const styles = {
+  body: {
+    display: 'flex',
+  },
+  sidebar: {
+    width: 250,
+  },
+  mainPanel: {
+    paddingLeft: 40,
+    paddingRight: 40,
+    width: '100%',
+  },
+  countAvatar: {
+    margin: 5,
+  },
+  duplicateButton: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+};
+
+class Level extends React.Component {
+  static propTypes = {
+    isLoading: PropTypes.bool.isRequired,
+    levels: PropTypes.array.isRequired,
+
+    dispatch: PropTypes.func.isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+    };
+  }
+
+  componentDidMount() {
+    this.props.dispatch(fetchLevels());
+  }
+  
+  renderBody() {
+    const rows = this.props.levels.slice(1).map(level => (
+      <LevelRow
+        key={level.levelNumber}
+        levelNumber={level.levelNumber}
+        experiencePointsThreshold={level.experiencePointsThreshold}
+        isLoading={this.props.isLoading}
+      />
+    ));
+
+    return (
+      <div style={styles.body}>
+        <Table className="table levels-list">
+          <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
+            <TableRow>
+              <TableHeaderColumn>Level</TableHeaderColumn>
+              <TableHeaderColumn>Threshold</TableHeaderColumn>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableRowColumn colSpan="5" style={{ textAlign: 'center' }}>
+                <FlatButton
+                  icon={<i className="fa fa-plus" />}
+                  label='Add new level'
+                />
+              </TableRowColumn>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <TitleBar title={<FormattedMessage {...translations.levelsTitle} />} />
+        { this.props.isLoading ? <LoadingIndicator /> : this.renderBody() }
+      </div>
+    );
+  }
+}
+
+export default connect(({ levelEdit, ...state }) => ({
+  isLoading: levelEdit.isLoading,
+  levels: levelEdit.levels,
+}))(Level);

--- a/client/app/bundles/course/level/propTypes.js
+++ b/client/app/bundles/course/level/propTypes.js
@@ -1,6 +1,0 @@
-import PropTypes from 'prop-types';
-
-export const levelShape = PropTypes.shape({
-  levelNumber: PropTypes.number,
-  experiencePointsThreshold: PropTypes.number,
-});

--- a/client/app/bundles/course/level/propTypes.js
+++ b/client/app/bundles/course/level/propTypes.js
@@ -1,0 +1,6 @@
+import PropTypes from 'prop-types';
+
+export const levelShape = PropTypes.shape({
+  levelNumber: PropTypes.number,
+  experiencePointsThreshold: PropTypes.number,
+});

--- a/client/app/bundles/course/level/reducers/index.js
+++ b/client/app/bundles/course/level/reducers/index.js
@@ -1,0 +1,10 @@
+import { combineReducers } from 'redux';
+import { reducer as formReducer } from 'redux-form';
+import notificationPopup from 'lib/reducers/notificationPopup';
+import levelEdit from './level';
+
+export default combineReducers({
+  notificationPopup,
+  levelEdit,
+  form: formReducer,
+});

--- a/client/app/bundles/course/level/reducers/level.js
+++ b/client/app/bundles/course/level/reducers/level.js
@@ -3,6 +3,7 @@ import actionTypes from 'course/level/constants';
 const initialState = {
   levels: [],
   isLoading: false,
+  isSaving: false,
 };
 
 function isNumeric(n) {
@@ -69,6 +70,15 @@ export default function (state = initialState, action) {
       copiedLevels.splice(payload.levelNumber, 1);
 
       return { ...state, levels: copiedLevels }
+    }
+    case actionTypes.SAVE_LEVELS: {
+      return { ...state, isSaving: true };
+    }
+    case actionTypes.SAVE_LEVELS_SUCCESS: {
+      return { ...state, isSaving: false };
+    }
+    case actionTypes.SAVE_LEVELS_FAILURE: {
+      return { ...state, isSaving: false };
     }
     default:
       return state;

--- a/client/app/bundles/course/level/reducers/level.js
+++ b/client/app/bundles/course/level/reducers/level.js
@@ -5,6 +5,10 @@ const initialState = {
   isLoading: false,
 };
 
+function isNumeric(n) {
+  return Number.isFinite(parseInt(n, 10));
+}
+
 export default function (state = initialState, action) {
   const { type } = action;
 
@@ -23,6 +27,48 @@ export default function (state = initialState, action) {
     }
     case actionTypes.LOAD_LEVELS_FAILURE: {
       return { ...state, isLoading: false }
+    }
+    case actionTypes.UPDATE_EXP_THRESHOLD: {
+      const { payload } = action;
+      const { levels } = state;
+      const copiedLevels = levels.slice();
+      if (payload.newValue === "") {
+        // Allows the textbox to be empty if the user removes all the digits.
+        copiedLevels[payload.levelNumber] = "";
+      }
+      else if (isNumeric(payload.newValue)) {
+        copiedLevels[payload.levelNumber] = parseInt(payload.newValue);
+      }
+
+      return { ...state, levels: copiedLevels }
+    }
+    case actionTypes.SORT_LEVELS: {
+      const { payload } = action;
+      const { levels } = state;
+      const copiedLevels = levels.slice();
+
+      // Must specify a sort function or will get lexicographical sort.
+      const sortedLevels = copiedLevels.sort((a, b) => a - b);
+
+      return { ...state, levels: sortedLevels }
+    }
+    case actionTypes.ADD_LEVEL: {
+      const { levels } = state;
+      const copiedLevels = levels.slice();
+
+      // Add a new level with twice the exp of the previous level.
+      copiedLevels.push(levels[levels.length-1] * 2 );
+
+      return { ...state, levels: copiedLevels }
+    }
+    case actionTypes.DELETE_LEVEL: {
+      const { payload } = action;
+      const { levels } = state;
+      const copiedLevels = levels.slice();
+      // Delete 1 item from the levelNumber position.
+      copiedLevels.splice(payload.levelNumber, 1);
+
+      return { ...state, levels: copiedLevels }
     }
     default:
       return state;

--- a/client/app/bundles/course/level/reducers/level.js
+++ b/client/app/bundles/course/level/reducers/level.js
@@ -1,0 +1,30 @@
+import actionTypes from 'course/level/constants';
+
+const initialState = {
+  levels: [],
+  isLoading: false,
+};
+
+export default function (state = initialState, action) {
+  const { type } = action;
+
+  switch (type) {
+    case actionTypes.LOAD_LEVELS_REQUEST: {
+      return { ...state, isLoading: true };
+    }
+    case actionTypes.LOAD_LEVELS_SUCCESS: {
+      const { levelData } = action;
+
+      return {
+        ...state,
+        ...levelData,
+        isLoading: false
+      }
+    }
+    case actionTypes.LOAD_LEVELS_FAILURE: {
+      return { ...state, isLoading: false }
+    }
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/level/reducers/level.js
+++ b/client/app/bundles/course/level/reducers/level.js
@@ -23,44 +23,42 @@ export default function (state = initialState, action) {
       return {
         ...state,
         ...levelData,
-        isLoading: false
-      }
+        isLoading: false,
+      };
     }
     case actionTypes.LOAD_LEVELS_FAILURE: {
-      return { ...state, isLoading: false }
+      return { ...state, isLoading: false };
     }
     case actionTypes.UPDATE_EXP_THRESHOLD: {
       const { payload } = action;
       const { levels } = state;
       const copiedLevels = levels.slice();
-      if (payload.newValue === "") {
+      if (payload.newValue === '') {
         // Allows the textbox to be empty if the user removes all the digits.
-        copiedLevels[payload.levelNumber] = "";
-      }
-      else if (isNumeric(payload.newValue)) {
-        copiedLevels[payload.levelNumber] = parseInt(payload.newValue);
+        copiedLevels[payload.levelNumber] = '';
+      } else if (isNumeric(payload.newValue)) {
+        copiedLevels[payload.levelNumber] = parseInt(payload.newValue, 10);
       }
 
-      return { ...state, levels: copiedLevels }
+      return { ...state, levels: copiedLevels };
     }
     case actionTypes.SORT_LEVELS: {
-      const { payload } = action;
       const { levels } = state;
       const copiedLevels = levels.slice();
 
       // Must specify a sort function or will get lexicographical sort.
       const sortedLevels = copiedLevels.sort((a, b) => a - b);
 
-      return { ...state, levels: sortedLevels }
+      return { ...state, levels: sortedLevels };
     }
     case actionTypes.ADD_LEVEL: {
       const { levels } = state;
       const copiedLevels = levels.slice();
 
       // Add a new level with twice the exp of the previous level.
-      copiedLevels.push(levels[levels.length-1] * 2 );
+      copiedLevels.push(levels[levels.length - 1] * 2);
 
-      return { ...state, levels: copiedLevels }
+      return { ...state, levels: copiedLevels };
     }
     case actionTypes.DELETE_LEVEL: {
       const { payload } = action;
@@ -69,7 +67,7 @@ export default function (state = initialState, action) {
       // Delete 1 item from the levelNumber position.
       copiedLevels.splice(payload.levelNumber, 1);
 
-      return { ...state, levels: copiedLevels }
+      return { ...state, levels: copiedLevels };
     }
     case actionTypes.SAVE_LEVELS: {
       return { ...state, isSaving: true };

--- a/client/app/bundles/course/level/store.js
+++ b/client/app/bundles/course/level/store.js
@@ -1,0 +1,13 @@
+import { compose, createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import rootReducer from './reducers';
+
+export default ({ level }) => {
+  const initialStates = level;
+  const storeCreator = (process.env.NODE_ENV === 'development') ?
+    // eslint-disable-next-line global-require
+    compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :
+    compose(applyMiddleware(thunkMiddleware))(createStore);
+
+  return storeCreator(rootReducer, initialStates);
+};

--- a/client/app/bundles/course/levels.js
+++ b/client/app/bundles/course/levels.js
@@ -1,0 +1,1 @@
+import 'course/level';

--- a/client/app/bundles/course/translations.intl.js
+++ b/client/app/bundles/course/translations.intl.js
@@ -40,6 +40,10 @@ export const defaultComponentTitles = defineMessages({
     id: 'course.componentTitles.course_materials_component',
     defaultMessage: 'Materials',
   },
+  course_levels_component: {
+    id: 'course.componentTitles.course_levels_component',
+    defaultMessage: 'Levels',
+  },
 });
 
 export default translations;

--- a/config/locales/en/course/levels.yml
+++ b/config/locales/en/course/levels.yml
@@ -5,13 +5,5 @@ en:
       index:
         header: 'Levels'
         level: 'Level'
-        threshold: 'Threshold'
       new:
         header: 'New Level'
-      create:
-        success: 'Level created with threshold at %{threshold} experience points.'
-      destroy:
-        success: 'Level with threshold at %{threshold} experience points removed.'
-        failure: 'Failed to remove level: %{error}'
-      form:
-        description: "A student will achieve this level when the student's experience points equals or exceeds this value."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,7 +225,7 @@ Rails.application.routes.draw do
         end
         resources :categories, only: [:index]
       end
-      resources :levels, except: [:show, :edit, :update]
+      resources :levels, only: [:index, :create]
       resource :duplication, only: [:show, :create]
       resource :object_duplication, only: [:new, :create]
 


### PR DESCRIPTION
Student levels are correctly updated if the levels are mass updated. Achievements with level conditions are not re-calculated on level edit, this is the same as the old behaviour.

![screen shot 2017-11-22 at 5 37 49 pm](https://user-images.githubusercontent.com/1902527/33120072-eda897cc-cfab-11e7-9f3e-cd28513edfa4.png)
