### PR TITLE
Fix bugs in SingleFileInput

### DIFF
--- a/app/controllers/course/achievement/achievements_controller.rb
+++ b/app/controllers/course/achievement/achievements_controller.rb
@@ -55,9 +55,11 @@ class Course::Achievement::AchievementsController < Course::Achievement::Control
   private
 
   def achievement_params #:nodoc:
-    @achievement_params ||= params.require(:achievement).
-                            permit(:title, :description, :weight, :published, :badge,
-                                   course_user_ids: [])
+    @achievement_params ||= begin
+      result = params.require(:achievement).
+               permit(:title, :description, :weight, :published, :badge, course_user_ids: [])
+      result[:badge].is_a?(ActionDispatch::Http::UploadedFile) ? result : result.except(:badge)
+    end
   end
 
   def achievement_order_params

--- a/client/app/bundles/course/achievement/pages/AchievementEdit/__test__/index.test.js
+++ b/client/app/bundles/course/achievement/pages/AchievementEdit/__test__/index.test.js
@@ -46,7 +46,7 @@ describe('<AchievementEdit />', () => {
     formData.append('achievement[title]', newTitle);
     formData.append('achievement[description]', 'Awesome achievement');
     formData.append('achievement[published]', false);
-    formData.append('achievement[badge]', undefined);
+    formData.append('achievement[badge]', '');
     expect(spy).toHaveBeenCalledWith(id, formData);
   });
 });

--- a/client/app/bundles/course/achievement/store.jsx
+++ b/client/app/bundles/course/achievement/store.jsx
@@ -4,9 +4,10 @@ import rootReducer from './reducers';
 
 export default ({ achievements }) => {
   const initialStates = achievements;
-  const storeCreator = compose(
-    applyMiddleware(thunkMiddleware)
-  )(createStore);
+  const storeCreator = (process.env.NODE_ENV === 'development') ?
+    // eslint-disable-next-line global-require
+    compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :
+    compose(applyMiddleware(thunkMiddleware))(createStore);
 
   return storeCreator(rootReducer, initialStates);
 };

--- a/client/app/lib/components/redux-form/SingleFileInput.jsx
+++ b/client/app/lib/components/redux-form/SingleFileInput.jsx
@@ -60,6 +60,7 @@ const translations = defineMessages({
  *   },
  * }
  */
+// TODO: Use the input element as a controller component - https://reactjs.org/docs/forms.html
 class SingleFileInput extends React.Component {
   static propTypes = {
     value: PropTypes.shape({
@@ -77,6 +78,7 @@ class SingleFileInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = { file: null };
+    this.updateStore('');
   }
 
   onDrop = (files) => {
@@ -84,7 +86,7 @@ class SingleFileInput extends React.Component {
   }
 
   onCancel = () => {
-    this.setState({ file: null }, this.updateStore(undefined));
+    this.setState({ file: null }, this.updateStore(''));
   }
 
   updateStore = (file) => {


### PR DESCRIPTION
Fixes #2682. 

### The issue
When editing existing achievements, updating fields other than the badge caused  the badge to be lost. I've traced the cause to the image uploader. 

### The cause
There are a few states for the image uploader when no file is selected: `null` initially, and `undefined` when a file was selected, then cancelled. When the submit button is clicked, react (or redux-form) casts that into a string and sends that in as a param. 

When the rails controller receives it, it treats the string in an unexpected way, over-writing the previously stored image/badge, causing the issue above. 

### The Fix
There are two things in this PR to fix this: 
 - _Rails Controller_: Reject the params if a string (instead of a File) is provided. 
 - _SingleFileInput_: Standardise the state of the image uploader to an empty string (because of casting to a string, an empty string works better than `'null'` or `'undefined'`.

### Things to Do
When trying to solve this, I found a few other things to address: (Will open those as issues as this fix is more important)
 - Allow users to delete achievement badges
 - Reorganise `SingleFileInput` to adhere to the necessary react conventions (controlled inputs). 