### PR TITLE
UI enhancements to survey modal

### DIFF
--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, injectIntl, intlShape } from 'react-intl';
+import { defineMessages, injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import { reduxForm, Field, Form } from 'redux-form';
+import ReactTooltip from 'react-tooltip';
 import TextField from 'lib/components/redux-form/TextField';
 import DateTimePicker from 'lib/components/redux-form/DateTimePicker';
 import Toggle from 'lib/components/redux-form/Toggle';
@@ -51,6 +52,10 @@ const surveyFormTranslations = defineMessages({
   hasStudentResponse: {
     id: 'course.surveys.SurveyForm.hasStudentResponse',
     defaultMessage: 'At least one student has responded to this survey. You may not remove anonymity.',
+  },
+  timeBonusExpTooltip: {
+    id: 'course.surveys.SurveyForm.timeBonusExpTooltip',
+    defaultMessage: 'You must allow responses after the survey expires to set bonus points.',
   },
 });
 
@@ -136,18 +141,23 @@ const SurveyForm = ({
           {...{ disabled }}
         />
       </div>
-      {
-        formValues && formValues.allow_response_after_end &&
-        <div style={styles.oneColumn}>
-          <Field
-            name="time_bonus_exp"
-            floatingLabelText={intl.formatMessage(translations.bonusPoints)}
-            component={TextField}
-            type="number"
-            {...{ disabled }}
-          />
-        </div>
-      }
+      <div
+        style={styles.oneColumn}
+        data-tip
+        data-for="timeBonusExpTooltip"
+        data-tip-disable={formValues && formValues.allow_response_after_end}
+      >
+        <Field
+          name="time_bonus_exp"
+          floatingLabelText={intl.formatMessage(translations.bonusPoints)}
+          component={TextField}
+          type="number"
+          disabled={formValues && !formValues.allow_response_after_end}
+        />
+        <ReactTooltip id="timeBonusExpTooltip">
+          <FormattedMessage {...surveyFormTranslations.timeBonusExpTooltip} />
+        </ReactTooltip>
+      </div>
     </div>
     <Field
       name="allow_response_after_end"

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
@@ -32,6 +32,7 @@ const propTypes = {
     start_at: PropTypes.instanceOf(Date),
     end_at: PropTypes.instanceOf(Date),
     base_exp: PropTypes.number,
+    allow_response_after_end: PropTypes.bool,
   }).isRequired,
   formValues: PropTypes.object,
 };

--- a/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
@@ -54,7 +54,7 @@ class NewSurveyButton extends React.Component {
     return dispatch(showSurveyForm({
       onSubmit: this.createSurveyHandler,
       formTitle: intl.formatMessage(translations.newSurvey),
-      initialValues: Object.assign({ base_exp: 0 }, aWeekStartingTomorrow()),
+      initialValues: Object.assign({ base_exp: 0, allow_response_after_end: true }, aWeekStartingTomorrow()),
     }));
   }
 

--- a/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/__test__/NewSurveyButton.test.jsx
@@ -23,11 +23,11 @@ describe('<NewSurveyButton />', () => {
 
     // Fill survey form
     const survey = {
+      allow_response_after_end: true,
       base_exp: 0,
-      time_bonus_exp: 0,
       start_at: new Date('2016-12-31T16:00:00.000Z'),
       end_at: new Date('2017-01-07T15:59:00.000Z'),
-      bonus_end_at: null,
+      bonus_end_at: new Date('2017-01-07T15:59:00.000Z'),
       title: 'Funky survey title',
     };
 


### PR DESCRIPTION
Gray out the bonus exp field for surveys instead of hiding it when the option is invalid.

Provide a tooltip, and set 'Allow responses after survey expires' to true when new surveys are created.

Fixes #2686.

![screen shot 2017-12-01 at 11 20 46 am](https://user-images.githubusercontent.com/1902527/33466565-b6769030-d689-11e7-87c2-917f3d4d6ae0.png)
