### PR TITLE
Video tracking models

### DIFF
--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -20,6 +20,8 @@ module Course::VideosAbilityComponent
     allow_student_update_own_video_submission
     allow_student_show_video_topics
     allow_student_create_video_topics
+    allow_student_create_video_watch_interval
+    allow_student_update_own_video_watch_interval
   end
 
   def define_staff_video_permissions
@@ -59,6 +61,14 @@ module Course::VideosAbilityComponent
 
   def allow_student_update_own_video_submission
     can :update, Course::Video::Submission, video_submission_own_course_user_hash
+  end
+
+  def allow_student_create_video_watch_interval
+    can :create, Course::Video::WatchInterval, submission: video_submission_own_course_user_hash
+  end
+
+  def allow_student_update_own_video_watch_interval
+    can :update, Course::Video::WatchInterval, submission: video_submission_own_course_user_hash
   end
 
   def allow_staff_manage_video

--- a/app/models/course/video/submission.rb
+++ b/app/models/course/video/submission.rb
@@ -11,6 +11,8 @@ class Course::Video::Submission < ApplicationRecord
 
   belongs_to :video, inverse_of: :submissions
 
+  has_many :watch_intervals, inverse_of: :submission, dependent: :destroy
+
   # @!method self.ordered_by_date
   #   Orders the submissions by date of creation. This defaults to reverse chronological order
   #   (newest submission first).

--- a/app/models/course/video/watch_interval.rb
+++ b/app/models/course/video/watch_interval.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class Course::Video::WatchInterval < ApplicationRecord
+  belongs_to :submission, inverse_of: :watch_intervals
+
+  validates :video_start, numericality: { greater_than_or_equal_to: 0 }
+  validates :video_end, numericality: { greater_than_or_equal_to: :video_start }
+end

--- a/db/migrate/20171212063353_create_course_video_watch_intervals.rb
+++ b/db/migrate/20171212063353_create_course_video_watch_intervals.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class CreateCourseVideoWatchIntervals < ActiveRecord::Migration[5.0]
+  def change
+    create_table :course_video_watch_intervals do |t|
+      t.references :submission, null: false,
+                                type: :integer,
+                                foreign_key: { to_table: :course_video_submissions }
+
+      t.integer :video_start, null: false
+      t.integer :video_end, null: false
+      t.timestamp :end_recorded_at, null: false
+
+      t.timestamps null: false
+    end
+
+    add_reference :course_video_watch_intervals,
+                  :creator,
+                  references: :users,
+                  type: :integer,
+                  foreign_key: { to_table: :users }
+    add_reference :course_video_watch_intervals,
+                  :updater,
+                  references: :users,
+                  type: :integer,
+                  foreign_key: { to_table: :users }
+  end
+end

--- a/spec/factories/course_video_watch_intervals.rb
+++ b/spec/factories/course_video_watch_intervals.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_video_watch_interval, class: Course::Video::WatchInterval.name,
+                                        aliases: [:video_watch_interval] do
+    transient do
+      course { build(:course, :with_video_component_enabled) }
+      video { build(:video, :published, course: course) }
+      student { build(:course_student, course: course) }
+    end
+
+    submission do
+      build(:video_submission, video: video, creator: student.user, course_user: student)
+    end
+
+    creator { build(:course_student, course: course).user }
+    updater { creator }
+
+    video_start 0
+    video_end 100
+    end_recorded_at Time.zone.now
+  end
+end

--- a/spec/models/course/video/watch_interval_spec.rb
+++ b/spec/models/course/video/watch_interval_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Video::WatchInterval do
+  it { is_expected.to belong_to(:submission).inverse_of(:watch_intervals) }
+
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
+  with_tenant(:instance) do
+    describe 'validations' do
+      context 'when interval start is less than 0' do
+        subject do
+          build(:video_watch_interval,
+                video_start: -1)
+        end
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context 'when interval end is smaller than start' do
+        subject do
+          build(:video_watch_interval,
+                video_start: 200,
+                video_end: 100)
+        end
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are models to allow for the recording of video views.

As mentioned on Slack, there seems to be a problem with `schema.rb` after migration, so I did not include it here as of now. Any advice on that?