### PR TITLE
Video tracking models

### DIFF
--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -20,6 +20,7 @@ module Course::VideosAbilityComponent
     allow_student_update_own_video_submission
     allow_student_show_video_topics
     allow_student_create_video_topics
+    allow_student_update_own_video_session
   end
 
   def define_staff_video_permissions
@@ -59,6 +60,10 @@ module Course::VideosAbilityComponent
 
   def allow_student_update_own_video_submission
     can :update, Course::Video::Submission, video_submission_own_course_user_hash
+  end
+
+  def allow_student_update_own_video_session
+    can :update, Course::Video::Session, submission: video_submission_own_course_user_hash
   end
 
   def allow_staff_manage_video

--- a/app/models/course/video/event.rb
+++ b/app/models/course/video/event.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Course::Video::Event < ApplicationRecord
+  belongs_to :session, inverse_of: :events
+
+  validates :event_type, presence: true
+  validates :video_time_initial, presence: true
+  validates :video_time_initial, numericality: { greater_than_or_equal_to: 0 }
+  validates :event_time, presence: true
+  validates :sequence_num, uniqueness: { scope: :session_id }
+
+  enum event_type: [:play, :pause, :seek, :speed_change]
+end

--- a/app/models/course/video/session.rb
+++ b/app/models/course/video/session.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class Course::Video::Session < ApplicationRecord
+  belongs_to :submission, inverse_of: :sessions
+  has_many :events, inverse_of: :session, dependent: :destroy
+
+  validates :session_start, presence: true
+  validates :session_end, presence: true
+  validate :validate_start_before_end
+
+  private
+
+  def validate_start_before_end
+    return unless session_start > session_end
+    errors.add(:session_start, :cannot_be_after_session_end)
+  end
+end

--- a/app/models/course/video/submission.rb
+++ b/app/models/course/video/submission.rb
@@ -11,6 +11,8 @@ class Course::Video::Submission < ApplicationRecord
 
   belongs_to :video, inverse_of: :submissions
 
+  has_many :sessions, inverse_of: :submission, dependent: :destroy
+
   # @!method self.ordered_by_date
   #   Orders the submissions by date of creation. This defaults to reverse chronological order
   #   (newest submission first).

--- a/config/locales/en/activerecord/course/video/session.yml
+++ b/config/locales/en/activerecord/course/video/session.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/video/session:
+          attributes:
+            session_start:
+              cannot_be_after_session_end: 'Session cannot start after ending'

--- a/db/migrate/20171212063353_create_course_video_sessions.rb
+++ b/db/migrate/20171212063353_create_course_video_sessions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class CreateCourseVideoSessions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :course_video_sessions do |t|
+      t.references :submission, null: false,
+                                type: :integer,
+                                foreign_key: { to_table: :course_video_submissions }
+
+      t.timestamp :session_start, null: false
+      t.timestamp :session_end, null: false
+
+      t.timestamps null: false
+    end
+
+    add_reference :course_video_sessions,
+                  :creator,
+                  references: :users,
+                  type: :integer,
+                  foreign_key: { to_table: :users }
+    add_reference :course_video_sessions,
+                  :updater,
+                  references: :users,
+                  type: :integer,
+                  foreign_key: { to_table: :users }
+  end
+end

--- a/db/migrate/20171212151525_create_course_video_events.rb
+++ b/db/migrate/20171212151525_create_course_video_events.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class CreateCourseVideoEvents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :course_video_events do |t|
+      t.references :session, null: false,
+                             type: :integer,
+                             foreign_key: { to_table: :course_video_sessions }
+
+      t.integer :event_type, null: false
+      t.integer :sequence_num, null: false
+
+      t.integer :video_time_initial, null: false
+      t.integer :video_time_final
+
+      t.datetime :event_time, null: false
+
+      t.timestamps
+    end
+
+    add_index :course_video_events, [:session_id, :sequence_num], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026141412) do
+ActiveRecord::Schema.define(version: 20171212151525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -766,6 +766,29 @@ ActiveRecord::Schema.define(version: 20171026141412) do
     t.integer "timestamp",  :null=>false
     t.integer "creator_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_topics_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer "updater_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+  end
+
+  create_table "course_video_sessions", force: :cascade do |t|
+    t.integer  "submission_id", :null=>false, :index=>{:name=>"index_course_video_sessions_on_submission_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.datetime "session_start", :null=>false
+    t.datetime "session_end",   :null=>false
+    t.datetime "created_at",    :null=>false
+    t.datetime "updated_at",    :null=>false
+    t.integer  "creator_id",    :null=>false, :index=>{:name=>"index_course_video_sessions_on_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "updater_id",    :null=>false, :index=>{:name=>"index_course_video_sessions_on_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+  end
+
+  create_table "course_video_events", force: :cascade do |t|
+    t.integer  "session_id",         :null=>false, :index=>{:name=>"index_course_video_sessions_on_session_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_session_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "event_type",         :null=>false
+    t.integer  "sequence_num",       :null=>false
+    t.integer  "video_time_initial", :null=>false
+    t.integer  "video_time_final"
+    t.datetime "event_time",         :null=>false
+    t.datetime "created_at",         :null=>false
+    t.datetime "updated_at",         :null=>false
+
+    t.index ["session_id", "sequence_num"], :name=>"index_course_video_events_on_session_id_and_sequence_num", :unique=>true, :order=>{:session_id=>:asc, :sequence_num=>:asc}
   end
 
   create_table "course_virtual_classrooms", force: :cascade do |t|

--- a/spec/factories/course_video_events.rb
+++ b/spec/factories/course_video_events.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_video_event, class: Course::Video::Event.name,
+                               aliases: [:video_event] do
+    transient do
+      course { build(:course, :with_video_component_enabled) }
+      video { build(:video, :published, course: course) }
+      student { create(:course_student, course: course) }
+      submission do
+        build(:video_submission, video: video, creator: student.user, course_user: student)
+      end
+    end
+
+    session do
+      build(:video_session, video: video, creator: student.user, student: student,
+                            submission: submission)
+    end
+
+    event_type 'pause'
+    sequence_num 1
+    video_time_initial 20
+    video_time_final nil
+    event_time Time.zone.now
+  end
+end

--- a/spec/factories/course_video_sessions.rb
+++ b/spec/factories/course_video_sessions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_video_session, class: Course::Video::Session.name,
+                                 aliases: [:video_session] do
+    transient do
+      course { build(:course, :with_video_component_enabled) }
+      video { build(:video, :published, course: course) }
+      student { create(:course_student, course: course) }
+    end
+
+    submission do
+      build(:video_submission, video: video, creator: student.user, course_user: student)
+    end
+
+    creator { student.user }
+    updater { creator }
+
+    session_start Time.zone.now - 5.minutes
+    session_end Time.zone.now + 5.minutes
+  end
+end

--- a/spec/models/course/video/event_spec.rb
+++ b/spec/models/course/video/event_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Video::Event, type: :model do
+  it { is_expected.to belong_to(:session).inverse_of(:events) }
+
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
+  with_tenant(:instance) do
+    describe 'validations' do
+      context 'when video time is negative' do
+        subject do
+          build(:video_event,
+                video_time_initial: -1)
+        end
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/video/session_spec.rb
+++ b/spec/models/course/video/session_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Video::Session do
+  it { is_expected.to belong_to(:submission).inverse_of(:sessions) }
+
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
+  with_tenant(:instance) do
+    describe 'validations' do
+      context 'when session start is after session end' do
+        subject do
+          build(:video_session,
+                session_start: Time.zone.now,
+                session_end: Time.zone.now - 5.minutes)
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when session start is the same as session end' do
+        subject do
+          time = Time.zone.now
+          build(:video_session,
+                session_start: time,
+                session_end: time)
+        end
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
These models are for the revised video tracking plan.

The idea here is we have a Session every time a user lands on the video page. Then each relevant UI event (play/pause/seek etc) is recorded.

As mentioned, there is a problem with the schema from https://github.com/SchemaPlus/schema_plus_core/issues/22. I've removed the `default: ...` parameter so that `rake db:reset` works, but running `rake db:migrate` will still revert this change. Any advice on what is preferred?