### PR TITLE
Disable buttons while comment is loading

### DIFF
--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Editor.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Editor.jsx
@@ -68,12 +68,14 @@ function Editor(props) {
           <RaisedButton
             label={props.cancelButtonText}
             onClick={props.onCancel}
+            disabled={props.disabled}
           />
         )}
         <RaisedButton
           label={props.submitButtonText}
           primary
           onClick={props.onSubmit}
+          disabled={props.disabled}
         />
       </div>
       <div style={{ clear: 'both' }} />


### PR DESCRIPTION
Setting to buttons to be disabled during loading was erroneously omitted earlier.