### PR TITLE
Apply webkit-scrollbar to React modals

### DIFF
--- a/client/app/bundles/course/achievement/pages/AchievementIndex/index.jsx
+++ b/client/app/bundles/course/achievement/pages/AchievementIndex/index.jsx
@@ -9,6 +9,7 @@ import FlatButton from 'material-ui/FlatButton';
 import NotificationBar, { notificationShape } from 'lib/components/NotificationBar';
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 import formTranslations from 'lib/translations/form';
+import modalFormStyles from 'lib/styles/ModalForm.scss';
 import AchievementForm from '../../containers/AchievementForm';
 import * as actions from '../../actions';
 import translations from './translations.intl';
@@ -102,6 +103,7 @@ class PopupDialog extends React.Component {
           onRequestClose={this.handleClose}
           autoScrollBodyContent
           contentStyle={styles.dialog}
+          bodyClassName={modalFormStyles.modalForm}
         >
           <AchievementForm
             onSubmit={this.onFormSubmit}

--- a/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
@@ -9,6 +9,7 @@ import FlatButton from 'material-ui/FlatButton';
 import NotificationBar, { notificationShape } from 'lib/components/NotificationBar';
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 import formTranslations from 'lib/translations/form';
+import modalFormStyles from 'lib/styles/ModalForm.scss';
 import AssessmentForm from '../../containers/AssessmentForm';
 import * as actions from '../../actions';
 import translations from './translations.intl';
@@ -109,6 +110,7 @@ class PopupDialog extends React.Component {
           onRequestClose={this.handleClose}
           autoScrollBodyContent
           contentStyle={styles.dialog}
+          bodyClassName={modalFormStyles.modalForm}
         >
           <AssessmentForm
             gamified={this.props.gamified}

--- a/client/app/lib/components/FormDialogue.jsx
+++ b/client/app/lib/components/FormDialogue.jsx
@@ -5,6 +5,7 @@ import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import formTranslations from 'lib/translations/form';
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
+import modalFormStyles from '../styles/ModalForm.scss';
 
 const propTypes = {
   title: PropTypes.string,
@@ -75,6 +76,7 @@ class FormDialogue extends React.Component {
           modal={false}
           onRequestClose={this.handleFormClose}
           autoScrollBodyContent
+          bodyClassName={modalFormStyles.modalForm}
         >
           { children }
         </Dialog>

--- a/client/app/lib/styles/ModalForm.scss
+++ b/client/app/lib/styles/ModalForm.scss
@@ -1,0 +1,31 @@
+// The styles here force scrollbars to display in Dialog modals regardless of the user's
+// OS X scrollbar settings. This makes it more obvious if a modal can't fit fully into
+// the screen and needs to be scrolled.
+// Styles were taken from http://blog.0100.tv/2012/11/webkit-scrollbars-on-os-x/
+.modalForm {
+  $base-scrollbar-color: #000000;
+
+  &::-webkit-scrollbar {
+    width: 9px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba($base-scrollbar-color, 0.1);
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba($base-scrollbar-color, 0.2);
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: rgba($base-scrollbar-color, 0.4);
+  }
+
+  &::-webkit-scrollbar-thumb:window-inactive {
+    background: rgba($base-scrollbar-color, 0.05);
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -41,11 +41,11 @@
       "<rootDir>/node_modules/enzyme-to-json/serializer"
     ],
     "moduleNameMapper": {
+      ".scss$": "<rootDir>/SassStub.js",
       "^api(.*)$": "<rootDir>/app/api$1",
       "^lib(.*)$": "<rootDir>/app/lib$1",
       "^utils(.*)$": "<rootDir>/app/__test__/utils$1",
-      "^course(.*)$": "<rootDir>/app/bundles/course$1",
-      ".scss$": "<rootDir>/SassStub.js"
+      "^course(.*)$": "<rootDir>/app/bundles/course$1"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",


### PR DESCRIPTION
Ensure that scrollbars show up in the create assessment modal,
create survey form modal and the create achievement modal
regardless of OS X's scrollbar settings.

The missing scrollbar has caused user confusion.

Fixes #2689.