### PR TITLE
Text Response submission view: answer input for students, solutions for staff in student view

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/Answers.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Answers.jsx
@@ -123,7 +123,7 @@ export default class Answers extends Component {
     /* eslint-enable react/no-array-index-key */
   }
 
-  static renderTextResponse(question, readOnly, answerId) {
+  static renderTextResponse(question, readOnly, answerId, graderView) {
     const allowUpload = question.allowAttachment;
 
     const readOnlyAnswer = (<Field
@@ -149,7 +149,7 @@ export default class Answers extends Component {
     return (
       <div>
         { readOnly ? readOnlyAnswer : editableAnswer }
-        {question.solutions ? Answers.renderTextResponseSolutions(question) : null}
+        {question.solutions && graderView ? Answers.renderTextResponseSolutions(question) : null}
         {allowUpload ? <UploadedFileView questionId={question.id} /> : null}
         {allowUpload && !readOnly ? Answers.renderFileUploader(question, readOnly, answerId) : null}
       </div>

--- a/client/app/bundles/course/assessment/submission/components/Answers.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Answers.jsx
@@ -144,7 +144,7 @@ export default class Answers extends Component {
       rows={5}
     />);
 
-    const editableAnswer = question.solutions ? plaintextAnswer : richtextAnswer;
+    const editableAnswer = question.autogradable ? plaintextAnswer : richtextAnswer;
 
     return (
       <div>

--- a/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
+++ b/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
@@ -25,6 +25,7 @@ class SubmissionAnswer extends Component {
     readOnly: PropTypes.bool,
     question: questionShape,
     answerId: PropTypes.number,
+    graderView: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -80,7 +81,7 @@ class SubmissionAnswer extends Component {
   }
 
   render() {
-    const { readOnly, question, answerId } = this.props;
+    const { readOnly, question, answerId, graderView } = this.props;
 
     const renderer = this.getRenderer(question);
 
@@ -89,7 +90,7 @@ class SubmissionAnswer extends Component {
         <h3>{question.displayTitle}</h3>
         <div dangerouslySetInnerHTML={{ __html: question.description }} />
         <hr />
-        { answerId ? renderer(question, readOnly, answerId) : this.renderMissingAnswerPanel() }
+        { answerId ? renderer(question, readOnly, answerId, graderView) : this.renderMissingAnswerPanel() }
       </div>
     );
   }

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -190,7 +190,7 @@ class SubmissionEditForm extends Component {
   }
 
   renderQuestions() {
-    const { attempting, questionIds, questions, topics } = this.props;
+    const { attempting, questionIds, questions, topics, graderView } = this.props;
     return (
       <div>
         {questionIds.map((id, index) => {
@@ -199,7 +199,7 @@ class SubmissionEditForm extends Component {
           const topic = topics[topicId];
           return (
             <Element name={`step${index}`} key={id} style={styles.questionContainer}>
-              <SubmissionAnswer {...{ readOnly: !attempting, answerId, question }} />
+              <SubmissionAnswer {...{ readOnly: !attempting, answerId, question, graderView }} />
               {question.type === questionTypes.Programming ? this.renderExplanationPanel(id) : null}
               {this.renderQuestionGrading(id)}
               {this.renderProgrammingQuestionActions(id)}

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -316,7 +316,7 @@ class SubmissionEditStepForm extends Component {
 
   renderStepQuestion() {
     const { stepIndex } = this.state;
-    const { attempting, questionIds, questions, topics } = this.props;
+    const { attempting, questionIds, questions, topics, graderView } = this.props;
 
     const id = questionIds[stepIndex];
     const question = questions[id];
@@ -324,7 +324,7 @@ class SubmissionEditStepForm extends Component {
     const topic = topics[topicId];
     return (
       <div>
-        <SubmissionAnswer {...{ readOnly: !attempting, answerId, question }} />
+        <SubmissionAnswer {...{ readOnly: !attempting, answerId, question, graderView }} />
         {this.renderAutogradingErrorPanel(id)}
         {this.renderExplanationPanel(question)}
         {this.renderQuestionGrading(id)}


### PR DESCRIPTION
Reference #2630 (specifically f4a34483700b0d55638898114d83f511e72621a7).

Existing React view for students shows summernote input (should be plaintext input) for Text Response question despite having solution(s) being configured.

Existing React view for staff shows the solutions table (should be hidden) when Student View is enabled.