### PR TITLE
Sort email settings by multiple keys.

### DIFF
--- a/app/models/course/settings/notifications.rb
+++ b/app/models/course/settings/notifications.rb
@@ -32,7 +32,9 @@ class Course::Settings::Notifications
     all_settings = settings_interfaces_hash.values.map do |settings|
       settings.respond_to?(:email_settings) ? settings.email_settings : nil
     end
-    all_settings.compact.flatten.sort_by { |item| item[:component] }
+    all_settings.compact.flatten.sort_by do |item|
+      [item[:component], item[:component_title], item[:key]]
+    end
   end
 
   # Updates a single email setting. It delegates the updating to the appropriate settings model.


### PR DESCRIPTION
Sort by component, component title and the setting key itself.

![screen shot 2017-12-21 at 3 00 33 pm](https://user-images.githubusercontent.com/1902527/34244325-ba3b0260-e65f-11e7-9a83-d59b74570066.png)

Properly separates out the assessment categories, and ensures that the setting within each category is sorted the same way.
