### PR TITLE
Fix breakage caused by updating of bundler in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_install:
   - npm list -g yarn --depth=0 || npm install -g yarn
   - yarn --version
   - docker --version
-  - gem update bundler
   - cd client && yarn install --production && cd -
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   except:
     - /^bundle-update-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}+$/
 rvm:
-  - 2.4.1
+  - 2.4.2
 services:
   - docker
 addons:


### PR DESCRIPTION
- See rubygems/rubygems#2123
- When bundler is updated from 1.16.0 to 1.16.1 in travis, bundler is not able to execute gems.
- Updating of bundler is removed for the before_install scripts; to update ruby versions as travis updates bundler versions automatically.
- Fixes #2713