### PR TITLE
[Do not merge] Testing only

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -43,9 +43,8 @@ module Capybara::TestGroupHelpers
     end
 
     def accept_confirm_dialog
-      find('.confirm-btn').click
-
       Timeout.timeout(Capybara.default_max_wait_time) do
+        find('.confirm-btn').click
         sleep 0.1 until page.all('.confirm-btn').empty?
       end
     end


### PR DESCRIPTION
Trying to fix the random failure in Travis. 
  
----
**Shifting `find('.confirm-btn').click` into the Timeout block**
Ran original code 8 times, 2 failures.
Ran new code 8 times, 2 failures.
  