### PR TITLE
Video tracking frontend

### DIFF
--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -4,7 +4,8 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
 
   def update
     # We received a message from client, so time is updated regardless of how event records turn out
-    @session.update_attributes!(session_end: Time.zone.now)
+    @session.update_attributes!(session_end: Time.zone.now,
+                                last_video_time: session_params[:last_video_time])
     @session.merge_in_events!(session_params[:events])
   rescue ArgumentError => _
     head :bad_request
@@ -15,7 +16,8 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
   private
 
   def session_params
-    params.require(:session).permit(events: [[:sequence_num, :event_type, :video_time_initial,
-                                              :video_time_final, :event_time]])
+    params.require(:session).permit(:last_video_time,
+                                    events: [[:sequence_num, :event_type, :video_time,
+                                              :playback_rate, :event_time]])
   end
 end

--- a/app/controllers/course/video/submission/submissions_controller.rb
+++ b/app/controllers/course/video/submission/submissions_controller.rb
@@ -23,6 +23,7 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
     @topics = @topics.reject { |topic| topic.posts.empty? }
     @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
     @scroll_topic_id = scroll_topic_params
+    create_session
   end
 
   private
@@ -37,5 +38,11 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
 
   def authorize_video!
     authorize!(:attempt, @video)
+  end
+
+  def create_session
+    return unless current_course_user.student? && @submission.course_user == current_course_user
+    time_now = Time.zone.now
+    @session = @submission.sessions.create!(session_start: time_now, session_end: time_now)
   end
 end

--- a/app/models/course/video/event.rb
+++ b/app/models/course/video/event.rb
@@ -3,10 +3,10 @@ class Course::Video::Event < ApplicationRecord
   belongs_to :session, inverse_of: :events
 
   validates :event_type, presence: true
-  validates :video_time_initial, presence: true
-  validates :video_time_initial, numericality: { greater_than_or_equal_to: 0 }
+  validates :video_time, presence: true
+  validates :video_time, numericality: { greater_than_or_equal_to: 0 }
   validates :event_time, presence: true
   validates :sequence_num, uniqueness: { scope: :session_id }
 
-  enum event_type: [:play, :pause, :seek, :speed_change]
+  enum event_type: [:play, :pause, :speed_change, :seek_start, :seek_end, :buffer, :end]
 end

--- a/app/views/course/video/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/video/submission/submissions/edit.json.jbuilder
@@ -1,5 +1,6 @@
 json.video do
   json.videoUrl @video.url
+  json.sessionId @session.try(:id)
 end
 
 json.discussion do

--- a/client/app/api/course/Video/Sessions.js
+++ b/client/app/api/course/Video/Sessions.js
@@ -7,26 +7,29 @@ export default class SessionsAPI extends BaseVideoAPI {
    *   sequence_num: int
    *     - Sequence of event within session
    *   event_type: string
-   *     - Either of 'play', 'pause', 'seek', or 'speed_change'
-   *   video_time_initial: int
-   *     - Video time when event started
-   *   video_time_final: int
-   *     - Video time when event ended
+   *     - Either of 'play', 'pause', 'speed_change', 'seek_start', 'seek_end', 'buffer', or 'end'
+   *   video_time: int
+   *     - Video time when event occurred
    *   event_time: Date
    *     - Timestamp when event occurred
+   *   playback_rate: float
+   *     - The video playback rate
    */
 
   /**
    * Updates a video session.
    *
    * @param {number} id The session ID
+   * @param {number} lastVideoTime The last video playback time as of function call
    * @param {Array} events The array of new events (as per shape above) to push to the server. Omit to only update
    * session end time
    * @return {Promise} The response from the server
    * success response: 204
    */
-  update(id, events = []) {
-    return this.getClient().patch(`${this._getUrlPrefix()}/${id}`, { session: { events } });
+  update(id, lastVideoTime, events = []) {
+    return this.getClient().patch(`${this._getUrlPrefix()}/${id}`, {
+      session: { last_video_time: lastVideoTime, events },
+    });
   }
 
   _getUrlPrefix() {

--- a/client/app/bundles/course/video/submission/actions/video.js
+++ b/client/app/bundles/course/video/submission/actions/video.js
@@ -122,3 +122,20 @@ export function updateRestrictedTime(restrictContentAfter) {
     restrictContentAfter,
   };
 }
+
+/**
+ * Creates an action to denote that the user has started seeking.
+ *
+ * @return {{type: videoActionTypes}}
+ */
+export function seekStart() {
+  return { type: videoActionTypes.SEEK_START };
+}
+
+/**
+ * Creates an action to denote that the user has released the seek.
+ * @return {{type: videoActionTypes}}
+ */
+export function seekEnd() {
+  return { type: videoActionTypes.SEEK_END };
+}

--- a/client/app/bundles/course/video/submission/containers/VideoControls/VideoPlayerSlider.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoControls/VideoPlayerSlider.jsx
@@ -5,7 +5,7 @@ import { formatTimestamp } from 'lib/helpers/videoHelpers';
 import 'rc-slider/assets/index.css';
 
 import styles from '../VideoPlayer.scss';
-import { updatePlayerProgress } from '../../actions/video';
+import { seekEnd, seekStart, updatePlayerProgress } from '../../actions/video';
 
 const unbufferedColour = '#e9e9e9';
 const bufferedColour = '#afe9ff';
@@ -32,6 +32,8 @@ const propTypes = {
   playerProgress: PropTypes.number,
   bufferProgress: PropTypes.number,
   onDragged: PropTypes.func,
+  onDragBegin: PropTypes.func,
+  onDragStop: PropTypes.func,
 };
 
 const defaultProps = {
@@ -64,6 +66,8 @@ class VideoPlayerSlider extends React.Component {
           railStyle={generateRailStyle(this.props.bufferProgress, this.props.duration)}
           tipFormatter={formatTimestamp}
           onChange={this.props.onDragged}
+          onBeforeChange={this.props.onDragBegin}
+          onAfterChange={this.props.onDragStop}
         />
       </span>
     );
@@ -83,7 +87,9 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
+    onDragBegin: () => dispatch(seekStart()),
     onDragged: newValue => dispatch(updatePlayerProgress(newValue, true)),
+    onDragStop: () => dispatch(seekEnd()),
   };
 }
 

--- a/client/app/bundles/course/video/submission/reducers/video.js
+++ b/client/app/bundles/course/video/submission/reducers/video.js
@@ -1,8 +1,8 @@
+import { List as makeImmutableList } from 'immutable';
 import { playerStates, videoActionTypes, videoDefaults } from 'lib/constants/videoConstants';
 import { isPlayingState, timeIsPastRestricted } from 'lib/helpers/videoHelpers';
 
 export const initialState = {
-  videoId: null,
   videoUrl: null,
   playerState: playerStates.UNSTARTED,
   playerProgress: 0,
@@ -12,6 +12,9 @@ export const initialState = {
   playbackRate: 1,
   restrictContentAfter: null,
   forceSeek: false,
+  sessionId: null,
+  sessionSequenceNum: 0,
+  sessionEvents: makeImmutableList(),
 };
 
 /**
@@ -82,7 +85,15 @@ function generateStateTransformer(state) {
   return changes => Object.assign({}, state, { forceSeek: false }, changes);
 }
 
-export default function (state = initialState, action) {
+/**
+ * The reducer to transform the video state excluding session data.
+ *
+ * This reducer changes the video's UI states, such as playback rate, volume, and player progress.
+ * @param state The original state object.
+ * @param action The action the reducer is to process
+ * @return {*} The transformed state.
+ */
+function videoStateReducer(state = initialState, action) {
   // Only forceSeek if explicitly specified
   const transformState = generateStateTransformer(state);
 
@@ -104,4 +115,98 @@ export default function (state = initialState, action) {
     default:
       return state;
   }
+}
+
+/**
+ * Generates a session event based on the event type.
+ *
+ * This function produces a base event, recording the player progress and playback rate, as well as assign a sequence
+ * number based on the value stored in the state. These parameters can be extended or overwritten with the params
+ * argument.
+ * @param state The original state object.
+ * @param type The event type.
+ * @param params The parameters to overwrite or extend the base evnt with.
+ * @return {*} The event object to record.
+ */
+function generateEvent(state, type, params = {}) {
+  const baseEvent = {
+    sequence_num: state.sessionSequenceNum,
+    event_type: type,
+    video_time: Math.round(state.playerProgress),
+    playback_rate: state.playbackRate,
+    event_time: new Date(),
+  };
+  return Object.assign(baseEvent, params);
+}
+
+/**
+ * Handles the session state change for a player state change.
+ *
+ * This function produces a new state with a new session event included on a player state change. If the player state
+ * will not change, or if the new player state does not need recording, the original state is returned.
+ * @param state The original state object.
+ * @param action The action to process.
+ * @return {*} The transformed state object.
+ */
+function handleSessionChangeState(state, action) {
+  let stateChange = null;
+  if (state.playerState === action.playerState) {
+    return state;
+  } else if (action.playerState === playerStates.PLAYING) {
+    stateChange = 'play';
+  } else if (action.playerState === playerStates.PAUSED) {
+    stateChange = 'pause';
+  } else if (action.playerState === playerStates.BUFFERING && isPlayingState(state.playerState)) {
+    stateChange = 'buffer';
+  } else if (action.playerState === playerStates.ENDED) {
+    stateChange = 'end';
+  } else {
+    return state;
+  }
+
+  return Object.assign({}, state, {
+    sessionSequenceNum: state.sessionSequenceNum + 1,
+    sessionEvents: state.sessionEvents.push(generateEvent(state, stateChange)),
+  });
+}
+
+/**
+ * The reducer to transform the session data.
+ *
+ * This reducer listens to actions that we want to record and creates a new event in state.sessionEvents. The exception
+ * is the REMOVE_EVENTS action, where specified events will be removed.
+ * @param state The original state object.
+ * @param action The action the reducer is to process
+ * @return {*} The transformed state.
+ */
+function videoSessionReducer(state = initialState, action) {
+  if (!state.sessionId) {
+    return state;
+  }
+  const events = state.sessionEvents;
+  switch (action.type) {
+    case videoActionTypes.CHANGE_PLAYBACK_RATE:
+      return Object.assign({}, state, {
+        sessionSequenceNum: state.sessionSequenceNum + 1,
+        sessionEvents: events.push(generateEvent(state, 'speed_change', { playback_rate: action.playbackRate })),
+      });
+    case videoActionTypes.CHANGE_PLAYER_STATE:
+      return handleSessionChangeState(state, action);
+    case videoActionTypes.SEEK_START:
+      return Object.assign({}, state, {
+        sessionSequenceNum: state.sessionSequenceNum + 1,
+        sessionEvents: events.push(generateEvent(state, 'seek_start')),
+      });
+    case videoActionTypes.SEEK_END:
+      return Object.assign({}, state, {
+        sessionSequenceNum: state.sessionSequenceNum + 1,
+        sessionEvents: events.push(generateEvent(state, 'seek_end')),
+      });
+    default:
+      return state;
+  }
+}
+
+export default function (state = initialState, action) {
+  return videoStateReducer(videoSessionReducer(state, action), action);
 }

--- a/client/app/bundles/course/video/submission/reducers/video.js
+++ b/client/app/bundles/course/video/submission/reducers/video.js
@@ -1,5 +1,5 @@
 import { List as makeImmutableList } from 'immutable';
-import { playerStates, videoActionTypes, videoDefaults } from 'lib/constants/videoConstants';
+import { playerStates, sessionActionTypes, videoActionTypes, videoDefaults } from 'lib/constants/videoConstants';
 import { isPlayingState, timeIsPastRestricted } from 'lib/helpers/videoHelpers';
 
 export const initialState = {
@@ -201,6 +201,10 @@ function videoSessionReducer(state = initialState, action) {
       return Object.assign({}, state, {
         sessionSequenceNum: state.sessionSequenceNum + 1,
         sessionEvents: events.push(generateEvent(state, 'seek_end')),
+      });
+    case sessionActionTypes.REMOVE_EVENTS:
+      return Object.assign({}, state, {
+        sessionEvents: events.filterNot(event => action.sequenceNums.has(event.sequence_num)),
       });
     default:
       return state;

--- a/client/app/lib/constants/videoConstants.js
+++ b/client/app/lib/constants/videoConstants.js
@@ -59,6 +59,10 @@ export const discussionActionTypes = mirrorCreator([
   'REFRESH_ALL',
 ]);
 
+export const sessionActionTypes = mirrorCreator([
+  'REMOVE_EVENTS',
+]);
+
 export const notificationActionTypes = mirrorCreator([
   'SET_NOTIFICATION',
 ]);

--- a/client/app/lib/constants/videoConstants.js
+++ b/client/app/lib/constants/videoConstants.js
@@ -39,6 +39,8 @@ export const videoActionTypes = mirrorCreator([
   'UPDATE_BUFFER_PROGRESS',
   'UPDATE_PLAYER_DURATION',
   'UPDATE_RESTRICTED_TIME',
+  'SEEK_START',
+  'SEEK_END',
 ]);
 
 export const discussionActionTypes = mirrorCreator([

--- a/db/migrate/20171221155021_add_play_back_rate_and_session_video_time.rb
+++ b/db/migrate/20171221155021_add_play_back_rate_and_session_video_time.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class AddPlayBackRateAndSessionVideoTime < ActiveRecord::Migration[5.1]
+  def change
+    add_column :course_video_events, :playback_rate, :float
+    add_column :course_video_sessions, :last_video_time, :integer
+    remove_column :course_video_events, :video_time_final
+    rename_column :course_video_events, :video_time_initial, :video_time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212151525) do
+ActiveRecord::Schema.define(version: 20171221155021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -772,6 +772,7 @@ ActiveRecord::Schema.define(version: 20171212151525) do
     t.integer  "submission_id", :null=>false, :index=>{:name=>"index_course_video_sessions_on_submission_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "session_start", :null=>false
     t.datetime "session_end",   :null=>false
+    t.integer  "last_video_time"
     t.datetime "created_at",    :null=>false
     t.datetime "updated_at",    :null=>false
     t.integer  "creator_id",    :null=>false, :index=>{:name=>"index_course_video_sessions_on_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
@@ -782,8 +783,8 @@ ActiveRecord::Schema.define(version: 20171212151525) do
     t.integer  "session_id",         :null=>false, :index=>{:name=>"index_course_video_sessions_on_session_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_session_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "event_type",         :null=>false
     t.integer  "sequence_num",       :null=>false
-    t.integer  "video_time_initial", :null=>false
-    t.integer  "video_time_final"
+    t.integer  "video_time",         :null=>false
+    t.float    "playback_rate"
     t.datetime "event_time",         :null=>false
     t.datetime "created_at",         :null=>false
     t.datetime "updated_at",         :null=>false

--- a/spec/factories/course_video_events.rb
+++ b/spec/factories/course_video_events.rb
@@ -18,8 +18,8 @@ FactoryBot.define do
 
     event_type 'pause'
     sequence_num 1
-    video_time_initial 20
-    video_time_final nil
+    video_time 20
     event_time Time.zone.now
+    playback_rate 1.0
   end
 end

--- a/spec/factories/course_video_sessions.rb
+++ b/spec/factories/course_video_sessions.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
     session_start Time.zone.now - 5.minutes
     session_end Time.zone.now + 5.minutes
 
+    last_video_time 0
+
     trait :with_events do
       after(:build) do |session|
         session.events = (1..5).map { |n| build(:video_event, sequence_num: n) }

--- a/spec/models/course/video/event_spec.rb
+++ b/spec/models/course/video/event_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Course::Video::Event, type: :model do
     describe 'validations' do
       context 'when video time is negative' do
         subject do
-          build(:video_event,
-                video_time_initial: -1)
+          build(:video_event, video_time: -1)
         end
 
         it 'is not valid' do

--- a/spec/models/course/video/session_spec.rb
+++ b/spec/models/course/video/session_spec.rb
@@ -38,9 +38,8 @@ RSpec.describe Course::Video::Session do
         let!(:time) { Time.zone.now }
         before do
           subject.merge_in_events!([{ sequence_num: 1,
-                                      video_time_initial: 2345,
-                                      video_time_final: 10,
-                                      event_type: 'seek',
+                                      video_time: 2345,
+                                      event_type: 'seek_start',
                                       event_time: time.midnight }])
         end
 
@@ -49,9 +48,8 @@ RSpec.describe Course::Video::Session do
           expect(subject.events.where(sequence_num: 1).count).to eq(1)
 
           old_event = subject.events.find_by(sequence_num: 1)
-          expect(old_event.video_time_initial).to eq(2345)
-          expect(old_event.video_time_final).to eq(10)
-          expect(old_event.event_type).to eq('seek')
+          expect(old_event.video_time).to eq(2345)
+          expect(old_event.event_type).to eq('seek_start')
           expect(old_event.event_time).to eq(time.midnight)
         end
       end
@@ -60,9 +58,8 @@ RSpec.describe Course::Video::Session do
         let!(:time) { Time.zone.now }
         before do
           subject.merge_in_events!([{ sequence_num: 100,
-                                      video_time_initial: 2345,
-                                      video_time_final: 10,
-                                      event_type: 'seek',
+                                      video_time: 2345,
+                                      event_type: 'seek_end',
                                       event_time: time.midnight }])
         end
 
@@ -71,9 +68,8 @@ RSpec.describe Course::Video::Session do
           expect(subject.events.exists?(sequence_num: 100)).to be_truthy
 
           new_event = subject.events.find_by(sequence_num: 100)
-          expect(new_event.video_time_initial).to eq(2345)
-          expect(new_event.video_time_final).to eq(10)
-          expect(new_event.event_type).to eq('seek')
+          expect(new_event.video_time).to eq(2345)
+          expect(new_event.event_type).to eq('seek_end')
           expect(new_event.event_time).to eq(time.midnight)
         end
       end


### PR DESCRIPTION
This pull request logs video events on the frontend by adding a reducer to listen to certain Redux actions we are interested in logging. These events are then collated on the client, before being periodically sent back to the server (while at the same time updating the `session_end` and `last_video_time` columns for a session as a way to denote that the session is still alive.

The models are changed slightly to fit implementation requirements.
 - We don't need a `video_time_final`, the function is fulfilled with extra event types
 - `last_video_time` helps us figure out where in the video the user has reached before closing the window/disconnecting. It is to be used in conjunction with the last recorded event.

We remove events from the client once we receive a success response from the server. Only events that were sent are removed.

Race conditions are handled by a combination of `merge_events!` on the server side, which handles events being sent again before they are removed, and reducer logic on the client (reducer functions modify the Redux state in a consistent and atomic fashion, i.e. if event 3 is present, event 2 must be present either in the client, the server, or both.