### PR TITLE
Set eager_load to false in development.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,8 +7,7 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # TODO: The active job behaves weirdly and failed to resolve certain constants if the eager load is not enabled.
-  config.eager_load = true
+  config.eager_load = false
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
Stop `"unknown firstpos: Nilclass"` error when reloading the application
after a code change.

Active job seems fine. Tested by creating a programming question and running a couple of evaluations.

This is a development config change and has no effect on production.

See https://stackoverflow.com/questions/44465118/rails-5-1-unknown-firstpos-nilclass-issue-reloading-application. `spring stop` did not work for me.

  