### PR TITLE
Yichenshen/fix video submission links

### DIFF
--- a/spec/controllers/course/video/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/video/submission/submissions_controller_spec.rb
@@ -34,5 +34,21 @@ RSpec.describe Course::Video::Submission::SubmissionsController do
         end
       end
     end
+
+    describe '#edit' do
+      subject do
+        get :edit, params: { course_id: course, video_id: video, id: submission }
+      end
+
+      context "when student accesses another student's submission" do
+        let(:student1) { create(:course_student, course: course) }
+        let(:student2) { create(:course_student, course: course) }
+        let(:submission) { create(:video_submission, video: video, creator: student2.user) }
+
+        before { sign_in(student1.user) }
+
+        it { is_expected.to redirect_to(course_video_path(course, video)) }
+      end
+    end
   end
 end


### PR DESCRIPTION
If a user is not authorized to edit a submission, then he is redirected
to the video show page so he can click through to his own submission
instead.

The rationale behind this behaviour is that since one can only watch a
video on a submission edit page when sharing links, the submission edit
URL is often copied in place of the video URL. This error leads to dead
links in emails.