### PR TITLE
Use CourseUser name in forum post reply notification

### DIFF
--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -99,6 +99,10 @@ class CourseUser < ApplicationRecord
     where.has { course.instance_id == instance.id }
   end)
 
+  scope :for_user, (lambda do |user|
+    where.has { user_id == user.id }
+  end)
+
   # Test whether the current scope includes the current user.
   #
   # @param [User] user The user to check

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -4,10 +4,13 @@
 - host = course.instance.host
 - unsubscribe_url = subscribe_course_forum_topic_url(course, topic.forum, topic, subscribe: false,
                                                      host: host)
+- post_author_user = post.creator
+- post_author_course_user = course.course_users.for_user(post_author_user).first
+- author_name = post_author_course_user&.name || post_author_user.name
 
 - course_title = format_inline_text(course.title)
 - topic_title = format_inline_text(topic.title)
-- post_author = format_inline_text(post.creator.name)
+- post_author = format_inline_text(author_name)
 
 - message.subject = t('.subject', course: course_title, topic: topic_title)
 

--- a/spec/notifiers/course/forum/post_notifier_spec.rb
+++ b/spec/notifiers/course/forum/post_notifier_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Course::Forum::PostNotifier, type: :notifier do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:forum) { create(:forum, course: course) }
-    let!(:topic) { create(:forum_topic, forum: forum) }
-    let(:post) { create(:course_discussion_post, topic: topic.acting_as) }
+    let!(:topic) { create(:forum_topic, forum: forum, course: course) }
+    let(:post) { create(:course_discussion_post, topic: topic.acting_as, creator: user) }
     let!(:user) do
       user = create(:course_user, course: course).user
       topic.subscriptions.create(user: user)


### PR DESCRIPTION
A user's name could be different from his `CourseUser` name. Instructors will expect to see the `CourseUser` name as that's the name they encounter in their course.

Use the `CourseUser` name for the post author in the forum reply notifications instead of the post author's `User` name, which might be totally different.