### PR TITLE
Hide greeting for announcement notification email.

### DIFF
--- a/app/notifiers/course/announcement_notifier.rb
+++ b/app/notifiers/course/announcement_notifier.rb
@@ -8,4 +8,19 @@ class Course::AnnouncementNotifier < Notifier::Base
       notify(announcement.course, :email).
       save if email_enabled
   end
+
+  private
+
+  # Create an email for the users of a course based on a given course notification record.
+  # Overrides email_course in Notifier::Base to pass a custom layout for this notifier.
+  #
+  # @param [CourseNotification] notification The notification which is used to generate emails
+  def email_course(notification)
+    notification.course.users.each do |user|
+      @pending_emails << ActivityMailer.email(recipient: user,
+                                              notification: notification,
+                                              view_path: notification_view_path(notification),
+                                              layout_path: 'no_greeting_mailer')
+    end
+  end
 end

--- a/app/notifiers/course/assessment/submission_question/comment_notifier.rb
+++ b/app/notifiers/course/assessment/submission_question/comment_notifier.rb
@@ -17,7 +17,7 @@ class Course::Assessment::SubmissionQuestion::CommentNotifier < Notifier::Base
     Course::Settings::AssessmentsComponent.email_enabled?(category, :new_comment)
   end
 
-  # Create an email for a users based on a given user notification record.
+  # Create an email for a user based on a given user notification record.
   # Overrides email_user in Notifier::Base to pass a custom layout for this notifier.
   #
   # @param [UserNotification] notification The notification which is used to generate the email

--- a/app/notifiers/notifier/base.rb
+++ b/app/notifiers/notifier/base.rb
@@ -60,7 +60,7 @@ class Notifier::Base
     end
   end
 
-  # Create an email for a users based on a given user notification record
+  # Create an email for a user based on a given user notification record
   #
   # @param [UserNotification] notification The notification which is used to generate the email
   def email_user(notification)


### PR DESCRIPTION
Also fix a couple of grammar errors in the comments.