### PR TITLE
Fix video counter bug in sidebar

### DIFF
--- a/app/controllers/components/course/videos_component.rb
+++ b/app/controllers/components/course/videos_component.rb
@@ -45,7 +45,7 @@ class Course::VideosComponent < SimpleDelegator
   end
 
   def unread_count
-    return 0 if current_course_user.staff?
+    return 0 unless current_course_user&.student?
 
     Course::Video.
       from_course(current_course).


### PR DESCRIPTION
Current implementation of unread_count assumes an existing
current_course_user. This does not always hold true for
super admins who can freely access courses without a
course_user object.

The fix is to use a safe navigation operator in the case
where current_course_user is nil.
 

cc: @yichenshen 