### PR TITLE
Use CourseUser name if available for Course::Discussion::Posts.

### DIFF
--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -96,6 +96,14 @@ class Course::Discussion::Post < ApplicationRecord
     true
   end
 
+  # Use the CourseUser name if available, else fallback to the User name.
+  #
+  # @return [String] The CourseUser/User name of the post author.
+  def author_name
+    course_user = topic.course.course_users.for_user(creator).first
+    course_user&.name || creator.name
+  end
+
   private
 
   def set_topic

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -2,7 +2,7 @@ json.(post, :id, :title, :text)
 json.formattedText format_html(simple_format(post.text))
 creator = post.creator
 json.creator do
-  json.name creator.name
+  json.name post.author_name
   json.avatar creator.profile_photo.medium.url || image_url('user_silhouette.svg')
 end
 json.createdAt post.created_at

--- a/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
@@ -15,4 +15,4 @@
                                   edit_course_assessment_submission_url(course, assessment, answer.submission,
                                                                         step: step, host: host)),
                                   post: post.text,
-                                  post_author: post.creator.name))
+                                  post_author: post.author_name))

--- a/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
@@ -14,4 +14,4 @@
                                   edit_course_assessment_submission_url(course, assessment, submission_question.submission,
                                                                         step: step, host: host)),
                                   post: post.text,
-                                  post_author: post.creator.name))
+                                  post_author: post.author_name))

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -4,13 +4,10 @@
 - host = course.instance.host
 - unsubscribe_url = subscribe_course_forum_topic_url(course, topic.forum, topic, subscribe: false,
                                                      host: host)
-- post_author_user = post.creator
-- post_author_course_user = course.course_users.for_user(post_author_user).first
-- author_name = post_author_course_user&.name || post_author_user.name
 
 - course_title = format_inline_text(course.title)
 - topic_title = format_inline_text(topic.title)
-- post_author = format_inline_text(author_name)
+- post_author = format_inline_text(post.author_name)
 
 - message.subject = t('.subject', course: course_title, topic: topic_title)
 

--- a/spec/models/course/discussion/post_spec.rb
+++ b/spec/models/course/discussion/post_spec.rb
@@ -160,6 +160,25 @@ RSpec.describe Course::Discussion::Post, type: :model do
       end
     end
 
+    describe '#author_name' do
+      let(:user) { create(:user) }
+      let(:post) { create(:course_discussion_post, creator: user) }
+
+      context 'when the post creator is enrolled in the course' do
+        let!(:course_user) { create(:course_student, course: post.topic.course, user: user) }
+
+        it 'returns the CourseUser name' do
+          expect(post.author_name).to eq(course_user.name)
+        end
+      end
+
+      context 'when the post creator is not enrolled in the course' do
+        it 'returns the User name' do
+          expect(post.author_name).to eq(user.name)
+        end
+      end
+    end
+
     describe '.destroy' do
       let(:topic) { create(:course_discussion_topic) }
       let!(:parent_post) { create(:course_discussion_post, topic: topic) }


### PR DESCRIPTION
Use the CourseUser name if available for notification emails on
comment threads (SubmissionQuestion) and programming annotations.

Programming annotations themselves are actually discussion posts objects so they're also fixed.
  