### PR TITLE
Remove Coursemology Team signoff from emails.

### DIFF
--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -10,8 +10,3 @@ body
     = t('.greeting', user: @recipient.name)
 
   = yield
-
-  p
-    = t('.complimentary_close')
-    br
-    = t('.sign_off')

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,6 +1,3 @@
 <%= t('.greeting', user: @recipient.name) %>
 
 <%= yield %>
-
-<%= t('.complimentary_close') %>
-<%= t('.sign_off') %>

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -42,8 +42,6 @@ en:
       uploaded_by: 'Uploaded By: %{name}'
     mailer:
       greeting: 'Hello, %{user}:'
-      complimentary_close: 'Best Regards,'
-      sign_off: 'The Coursemology Team'
     search_form:
       search_button: :'common.search'
     course_user_badge:

--- a/spec/mailers/activity_mailer_spec.rb
+++ b/spec/mailers/activity_mailer_spec.rb
@@ -23,12 +23,8 @@ RSpec.describe ActivityMailer, type: :mailer do
 
       it 'renders the layout' do
         expect(text).to include(I18n.t('layouts.mailer.greeting', user: user.name))
-        expect(text).to include(I18n.t('layouts.mailer.complimentary_close'))
-        expect(text).to include(I18n.t('layouts.mailer.sign_off'))
 
         expect(html).to include(I18n.t('layouts.mailer.greeting', user: user.name))
-        expect(html).to include(I18n.t('layouts.mailer.complimentary_close'))
-        expect(html).to include(I18n.t('layouts.mailer.sign_off'))
       end
 
       it 'sends a multipart email' do
@@ -50,8 +46,6 @@ RSpec.describe ActivityMailer, type: :mailer do
 
       it 'does not render salutation and sign-off' do
         expect(text).not_to include(I18n.t('layouts.mailer.greeting', user: user.name))
-        expect(text).not_to include(I18n.t('layouts.mailer.complimentary_close'))
-        expect(text).not_to include(I18n.t('layouts.mailer.sign_off'))
       end
     end
   end


### PR DESCRIPTION
Emails should be sent on behalf of the course and not the dev team.