### PR TITLE
Implement read/unread comments for student

### DIFF
--- a/app/controllers/components/course/discussion/topics_component.rb
+++ b/app/controllers/components/course/discussion/topics_component.rb
@@ -40,7 +40,7 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
   def sidebar_path
     if staff_with_students?
       my_students_pending_course_topics_path(current_course)
-    elsif staff?
+    elsif current_course_user&.staff? || current_course_user&.student?
       pending_course_topics_path(current_course)
     else
       course_topics_path(current_course)
@@ -50,8 +50,10 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
   def unread_count
     if staff_with_students?
       my_students_unread_count
-    elsif staff?
-      all_unread_count
+    elsif current_course_user&.staff?
+      all_staff_unread_count
+    elsif current_course_user&.student?
+      all_student_unread_count
     else
       0
     end
@@ -59,9 +61,5 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
 
   def staff_with_students?
     current_course_user && current_course_user.staff? && !current_course_user.my_students.empty?
-  end
-
-  def staff?
-    current_course_user && current_course_user.staff?
   end
 end

--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -11,8 +11,10 @@ module Course::Discussion::PostsConcern
   protected
 
   # Update pending status of the topic:
-  # If the student replies to the topic, set to true.
-  # If the staff replies the post, set to false.
+  #   If the student replies to the topic, set to true.
+  #   If the staff replies the post, set to false.
+  #
+  # @return [Boolean] Boolean on whether the update is successful.
   def update_topic_pending_status
     return true if !current_course_user || skip_update_topic_status
 

--- a/app/controllers/course/assessment/submission_question/comments_controller.rb
+++ b/app/controllers/course/assessment/submission_question/comments_controller.rb
@@ -7,8 +7,6 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
                               class: Course::Assessment::SubmissionQuestion.name
   include Course::Discussion::PostsConcern
 
-  delegate :discussion_topic, to: :@submission_question
-
   def create
     result = @submission_question.class.transaction do
       @post.title = @assessment.title
@@ -17,6 +15,7 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
 
       raise ActiveRecord::Rollback unless @post.save && create_topic_subscription && update_topic_pending_status
       raise ActiveRecord::Rollback unless @submission_question.save
+
       true
     end
 
@@ -50,6 +49,10 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
   def last_post_from(submission_question)
     # @post is in submission_question.posts, so we filter out @post, which has no id yet.
     submission_question.posts.ordered_topologically.flatten.select(&:id).last
+  end
+
+  def discussion_topic
+    @submission_question.discussion_topic
   end
 
   def render_create_response

--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -13,8 +13,15 @@ class Course::Discussion::TopicsController < Course::ComponentController
     end
   end
 
+  # Loads topics pending staff reply for course_staff, and unread topics for students.
   def pending
-    @topics = all_topics.pending_staff_reply
+    @topics = begin
+      if current_course_user&.student?
+        unread_topics_for_student
+      else
+        all_topics.pending_staff_reply
+      end
+    end
   end
 
   def my_students
@@ -40,6 +47,10 @@ class Course::Discussion::TopicsController < Course::ComponentController
   def all_topics
     @topics.globally_displayed.ordered_by_updated_at.includes(:actable).page(page_param).
       per(@settings.pagination)
+  end
+
+  def unread_topics_for_student
+    all_topics.from_user(current_user.id).unread_by(current_user)
   end
 
   def my_students_topics

--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -42,6 +42,11 @@ class Course::Discussion::TopicsController < Course::ComponentController
     head :bad_request unless success
   end
 
+  def mark_as_read
+    @topic.mark_as_read! for: current_user
+    redirect_back fallback_location: course_topics_path(current_course)
+  end
+
   private
 
   def all_topics

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -19,8 +19,11 @@ module Course::Discussion::TopicsHelper
     format_code_block(code, file.answer.question.actable.language, [line_start, 1].max)
   end
 
-  def all_unread_count
-    @unread ||= current_course.discussion_topics.
+  # Returns the count of topics pending staff reply.
+  #
+  # @return [Fixnum] Returns the count of topics pending staff reply.
+  def all_staff_unread_count
+    @staff_unread ||= current_course.discussion_topics.
                 globally_displayed.pending_staff_reply.distinct.count
   end
 
@@ -30,6 +33,19 @@ module Course::Discussion::TopicsHelper
         my_student_ids = current_course_user.my_students.pluck(:user_id)
         current_course.discussion_topics.globally_displayed.
           from_user(my_student_ids).pending_staff_reply.distinct.count
+      else
+        0
+      end
+  end
+
+  # Returns the count of unread topics for student course users. Otherwise, return 0.
+  #
+  # @return [Fixnum] Returns the count of unread topics
+  def all_student_unread_count
+    @student_unread ||=
+      if current_course_user&.student?
+        current_course.discussion_topics.globally_displayed.from_user(current_user.id).
+          unread_by(current_user).distinct.count
       else
         0
       end

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -62,4 +62,10 @@ module Course::Discussion::TopicsHelper
               method: :patch, remote: true
     end
   end
+
+  def link_to_mark_as_read(topic)
+    return unless topic.unread?(current_user)
+    link_to t('course.discussion.topics.mark_as_read'),
+            mark_as_read_course_topic_path(current_course, topic), method: :patch
+  end
 end

--- a/app/models/components/course/discussions_ability_component.rb
+++ b/app/models/components/course/discussions_ability_component.rb
@@ -18,7 +18,7 @@ module Course::DiscussionsAbilityComponent
   private
 
   def allow_course_users_show_topics
-    can :read, Course::Discussion::Topic, course_all_course_users_hash
+    can [:read, :pending], Course::Discussion::Topic, course_all_course_users_hash
   end
 
   def allow_staff_manage_discussion_topics

--- a/app/models/components/course/discussions_ability_component.rb
+++ b/app/models/components/course/discussions_ability_component.rb
@@ -5,6 +5,7 @@ module Course::DiscussionsAbilityComponent
   def define_permissions
     if user
       allow_course_users_show_topics
+      allow_course_users_mark_topics_as_read
       allow_staff_manage_discussion_topics
       allow_course_users_create_posts
       allow_course_users_reply_and_vote_posts
@@ -19,6 +20,10 @@ module Course::DiscussionsAbilityComponent
 
   def allow_course_users_show_topics
     can [:read, :pending], Course::Discussion::Topic, course_all_course_users_hash
+  end
+
+  def allow_course_users_mark_topics_as_read
+    can :mark_as_read, Course::Discussion::Topic, course_all_course_users_hash
   end
 
   def allow_staff_manage_discussion_topics

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -8,6 +8,7 @@ class Course::Discussion::Post < ApplicationRecord
   has_many_attachments
 
   after_initialize :set_topic, if: :new_record?
+  after_commit :mark_topic_as_read
   before_destroy :reparent_children, unless: :destroyed_by_association
   before_destroy :unparent_children, if: :destroyed_by_association
 
@@ -127,5 +128,9 @@ class Course::Discussion::Post < ApplicationRecord
   # the post belongs to is being destroyed.
   def unparent_children
     children.update_all(parent_id: nil)
+  end
+
+  def mark_topic_as_read
+    topic.mark_as_read! for: creator
   end
 end

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -4,6 +4,8 @@ class Course::Discussion::Topic < ApplicationRecord
   class_attribute :global_topic_model_names
   self.global_topic_model_names = []
 
+  acts_as_readable on: :updated_at
+
   belongs_to :course, inverse_of: :discussion_topics
   # Delete all the children and skip reparent callbacks
   has_many :posts, dependent: :destroy, inverse_of: :topic do

--- a/app/models/course/video/topic.rb
+++ b/app/models/course/video/topic.rb
@@ -10,9 +10,9 @@ class Course::Video::Topic < ApplicationRecord
   # called directly.
   scope :from_user, (lambda do |user_id|
     unscoped.
-      joins(:discussion_topic).
-      where(creator_id: user_id).
-      select('course_discussion_topics.id')
+      joining { discussion_topic.posts }.
+      where.has { discussion_topic.posts.creator_id.in(user_id) }.
+      selecting { discussion_topic.id }
   end)
 
   private

--- a/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
+++ b/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
@@ -12,6 +12,8 @@
     = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: assessment.questions.index(question) +1)
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
+  - elsif current_course_user&.student?
+    = link_to_mark_as_read(topic)
 
   h4
     = t('.by_html', user: link_to_user(submission.creator))

--- a/app/views/course/assessment/submission_questions/_discussion_topic_submission_question.html.slim
+++ b/app/views/course/assessment/submission_questions/_discussion_topic_submission_question.html.slim
@@ -11,6 +11,9 @@
     = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: assessment.questions.index(question) + 1)
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
+  - elsif current_course_user&.student?
+    = link_to_mark_as_read(topic)
+
   h4
     = t('.by_html', user: link_to_user(submission.creator))
 

--- a/app/views/course/discussion/topics/_tabs.html.slim
+++ b/app/views/course/discussion/topics/_tabs.html.slim
@@ -1,10 +1,16 @@
-- if current_course_user && current_course_user.staff? || can?(:manage, current_course)
+- if current_course_user&.staff? || can?(:manage, current_course)
   = tabs do
     = nav_to my_students_pending_course_topics_path(current_course) do
       = t('.my_students_pending')
       =< badge(my_students_unread_count) if my_students_unread_count > 0
     = nav_to pending_course_topics_path(current_course) do
       = t('.pending')
-      =< badge(all_unread_count) if all_unread_count > 0
+      =< badge(all_staff_unread_count) if all_staff_unread_count > 0
     = nav_to t('.my_students'), my_students_course_topics_path(current_course)
+    = nav_to t('.all'), course_topics_path(current_course)
+- elsif current_course_user&.student?
+  = tabs do
+    = nav_to pending_course_topics_path(current_course) do
+      = t('.unread')
+      =< badge(all_student_unread_count) if all_student_unread_count > 0
     = nav_to t('.all'), course_topics_path(current_course)

--- a/app/views/course/video/topics/_discussion_topic_topic.html.slim
+++ b/app/views/course/video/topics/_discussion_topic_topic.html.slim
@@ -14,6 +14,9 @@
                                                 params: { scroll_to_topic: video_topic})
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
+  - elsif current_course_user&.student?
+    = link_to_mark_as_read(topic)
+
   h4
     = t('.by_html', user: link_to_user(creator))
 

--- a/config/locales/en/course/discussion/topics.yml
+++ b/config/locales/en/course/discussion/topics.yml
@@ -6,6 +6,7 @@ en:
         tabs:
           my_students_pending: 'My Students Pending'
           pending: 'Pending'
+          unread: 'Unread'
           my_students: 'My Students'
           all: 'All'
         index:
@@ -18,3 +19,4 @@ en:
           header: :'course.discussion.topics.index.header'
         mark_as_pending: 'Mark as pending'
         unmark_as_pending: 'Unmark as pending'
+        mark_as_read: 'Mark as read'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -319,6 +319,7 @@ Rails.application.routes.draw do
           get 'my_students', on: :collection
           get 'my_students_pending', on: :collection
           patch 'toggle_pending', on: :member
+          patch 'mark_as_read', on: :member
           resources :posts, only: [:create, :update, :destroy]
         end
       end

--- a/db/migrate/20180111081847_add_read_status_to_topics.rb
+++ b/db/migrate/20180111081847_add_read_status_to_topics.rb
@@ -1,0 +1,14 @@
+# This migration initialises the read/unread models for Course::Discussion::Topic.
+class AddReadStatusToTopics < ActiveRecord::Migration[5.1]
+  def up
+    # Declare all Course::Discussion::Topic read for each user.
+    #
+    # This does not affect Forums because ReadMarks are declared on those
+    # models rather than on Course::Discussion::Topic.
+    User.find_each { |user| Course::Discussion::Topic.mark_as_read! :all, for: user }
+  end
+
+  def down
+    ReadMark.where(readable_id: nil, readable_type: Course::Discussion::Topic.name).delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180111081846) do
+ActiveRecord::Schema.define(version: 20180111081847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/course/discussion/topics_controller_spec.rb
+++ b/spec/controllers/course/discussion/topics_controller_spec.rb
@@ -71,7 +71,12 @@ RSpec.describe Course::Discussion::TopicsController do
       context 'when a course student visits the page' do
         before { sign_in(student) }
 
-        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+        it { is_expected.to render_template(:pending) }
+
+        it 'only shows the unread topics' do
+          subject
+          expect(topics).to contain_exactly(topic, pending_topic)
+        end
       end
     end
 

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -80,18 +80,26 @@ RSpec.feature 'Course: Topics: Management' do
         create(:course_assessment_answer, course: course, creator: user)
       end
       let(:student_comment) do
-        create(:course_assessment_submission_question, :with_post, course: course, user: user)
+        create(:course_assessment_submission_question,
+               course: course,
+               user: user,
+               posts: [build(:course_discussion_post, creator: user)])
       end
       let(:student_annotation) do
-        create(:course_assessment_answer_programming_file_annotation, :with_post,
-               course: course, creator: user)
+        create(:course_assessment_answer_programming_file_annotation,
+               course: course,
+               creator: user,
+               posts: [build(:course_discussion_post, creator: user)])
       end
       let(:student_reply) do
         create(:course_discussion_post, topic: student_comment.acting_as, creator: user,
                                         text: '<p>Content with html tags</p>')
       end
       let(:student_video_comment) do
-        create(:course_video_topic, :with_post, :with_submission, course: course, creator: user)
+        create(:course_video_topic, :with_submission,
+               course: course,
+               creator: user,
+               posts: [build(:course_discussion_post, creator: user)])
       end
       let(:student_video_reply) do
         create(:course_discussion_post, topic: student_video_comment.acting_as, creator: user,

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -126,18 +126,24 @@ RSpec.feature 'Course: Topics: Management' do
         end
       end
 
-      scenario 'I can see my pending comments' do
+      scenario 'I can see my pending comments and mark as read' do
         other_comments = [
           staff_response_to_comment, staff_response_to_annotation, staff_response_to_video
         ].map(&:topic)
+        mark_as_read = other_comments.sample
 
         visit pending_course_topics_path(course)
 
         expect(page).to have_selector('.nav.nav-tabs')
 
-        other_comments.each do |comment|
-          expect(page).to have_content_tag_for(comment)
+        other_comments.each { |comment| expect(page).to have_content_tag_for(comment) }
+
+        within find(content_tag_selector(mark_as_read)) do
+          click_link I18n.t('course.discussion.topics.mark_as_read')
         end
+
+        expect(page).not_to have_content_tag_for(mark_as_read)
+        expect(mark_as_read.unread?(user)).to be_falsey
       end
 
       scenario 'I can reply to and delete a comment topic', js: true do

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -97,14 +97,24 @@ RSpec.feature 'Course: Topics: Management' do
         create(:course_discussion_post, topic: student_video_comment.acting_as, creator: user,
                                         text: '<p>Content with html tags</p>')
       end
-
+      let(:staff_response_to_comment) do
+        create(:course_discussion_post, topic: student_comment.acting_as, creator: course.creator)
+      end
+      let(:staff_response_to_annotation) do
+        create(:course_discussion_post,
+               topic: student_annotation.acting_as, creator: course.creator)
+      end
+      let(:staff_response_to_video) do
+        create(:course_discussion_post,
+               topic: student_video_comment.acting_as, creator: course.creator)
+      end
 
       scenario 'I can see all my comments' do
         other_comments = [comment, code_annotation, video_comment].map(&:acting_as)
         my_comments = [student_comment, student_annotation, student_video_comment].map(&:acting_as)
         visit course_topics_path(course)
 
-        expect(page).not_to have_selector('.nav.nav-tabs')
+        expect(page).to have_selector('.nav.nav-tabs')
         expect(page).not_to have_link(I18n.t('course.discussion.topics.mark_as_pending'))
 
         other_comments.each do |comment|
@@ -112,6 +122,20 @@ RSpec.feature 'Course: Topics: Management' do
         end
 
         my_comments.each do |comment|
+          expect(page).to have_content_tag_for(comment)
+        end
+      end
+
+      scenario 'I can see my pending comments' do
+        other_comments = [
+          staff_response_to_comment, staff_response_to_annotation, staff_response_to_video
+        ].map(&:topic)
+
+        visit pending_course_topics_path(course)
+
+        expect(page).to have_selector('.nav.nav-tabs')
+
+        other_comments.each do |comment|
           expect(page).to have_content_tag_for(comment)
         end
       end

--- a/spec/models/course/video/topic_spec.rb
+++ b/spec/models/course/video/topic_spec.rb
@@ -26,16 +26,31 @@ RSpec.describe Course::Video::Topic do
              creator: student2.user,
              posts: [build(:course_discussion_post, creator: student2.user)])
     end
+    let(:topic3) do
+      create(:video_topic,
+             course: course,
+             video: video,
+             creator: student1.user,
+             posts: [
+               build(:course_discussion_post, creator: student1.user),
+               build(:course_discussion_post, creator: student2.user)
+             ])
+    end
+
 
     describe '.from_user' do
       it 'only returns discussion_topic ids of the given user' do
         topic1_id = topic1.acting_as.id
-        expect(video.topics.from_user(student1.user).map(&:id)).to match_array([topic1_id])
-
         topic2_id = topic2.acting_as.id
-        expect(video.topics.from_user(student2.user).map(&:id)).to match_array([topic2_id])
+        topic3_id = topic3.acting_as.id
 
-        expect(video.topics.from_user(student3.user).empty?).to be_truthy
+        expect(video.topics.from_user(student1.user_id).map(&:id)).
+          to match_array([topic1_id, topic3_id])
+
+        expect(video.topics.from_user(student2.user_id).map(&:id)).
+          to match_array([topic2_id, topic3_id])
+
+        expect(video.topics.from_user(student3.user_id).empty?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
This implements #1883.

In essence, the current code implements read/unread on the `Course::Discussion::Topic` model. This differs from forums, which does it at the actable models (`Course::Forum::Topic` and `Course::Forum::Post`). The implementation is a little tricky, and I've explained some of the code in comments or commit messages.

This PR does the following: 
 - Implement an unread tab under comments center for students
 - Add the number of unread topics in sidebar for students (Topics include programming file annotations, video comments, and comments in submissions)
 - Set all current topics to read for all users
 - Set topics to read if students reply to the topic.
 - Allow students to mark unread topics as read (only in comments centre)
 - Modify video topics to include all posters to that topic

### Key Things
 - Migration will be long - locally it takes 160s for 13k users, while production has 16k users. We should deploy this at night when no one is using. 
 - Currently submission and video comments are not marked as read when users assess it in assessment submissions and video submissions respectively. 

~Would like to discuss possible alternatives to this first before merge it.~

---

### Discussion points
 - ~Should I implement `mark_as_read!` within the `post` model instead of having it at the controller? (I probably should)~ Done