### PR TITLE
 Add achievement gained and level reached popup notifications

### DIFF
--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -16,6 +16,17 @@ class Course::Controller < ApplicationController
     sidebar_items_of_type(type).sort_by { |item| weights_hash[item[:key]] || item[:weight] }
   end
 
+  # Fetches the first unread popup `UserNotification` for the current course and returns JSON data
+  # for the frontend to display it.
+  #
+  # @return [String] JSON data for the next notification, if there is one.
+  # @return [nil] if there are no unread notifications for current user and course.
+  def next_popup_notification
+    notification = UserNotification.next_unread_popup_for_course_user(current_course, current_user)
+    notification && render_to_string("#{helpers.notification_view_path(notification)}.json",
+                                     locals: { notification: notification })
+  end
+
   # Gets the current course.
   # @return [Course] The current course that the user is browsing.
   def current_course

--- a/app/controllers/course/user_notifications_controller.rb
+++ b/app/controllers/course/user_notifications_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class Course::UserNotificationsController < Course::ComponentController
+  load_and_authorize_resource :user_notification, class: UserNotification.name
+
+  def mark_as_read
+    @user_notification.mark_as_read! for: current_user
+    render json: next_popup_notification, status: :ok
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -27,6 +27,16 @@ class Activity < ApplicationRecord
     end
   end
 
+  # Checks if activity is from the given course. Ensure that `object` has `#course` defined on it
+  # for the current activity to be displayed as an in-course popup user notification.
+  #
+  # @param [Course] course The course to check.
+  # @return [Boolean] true if activity is from the given course, false otherwise.
+  def from_course?(course)
+    object_course = object&.course
+    !object_course.nil? && (object_course.id != course.id)
+  end
+
   private
 
   def notify_course(course, type)

--- a/app/models/components/user_notifications_ability_component.rb
+++ b/app/models/components/user_notifications_ability_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module UserNotificationsAbilityComponent
+  include AbilityHost::Component
+
+  def define_permissions
+    allow_user_mark_own_notification_as_read if user
+
+    super
+  end
+
+  private
+
+  def allow_user_mark_own_notification_as_read
+    can :mark_as_read, UserNotification, user_id: user.id
+  end
+end

--- a/app/models/user_notification.rb
+++ b/app/models/user_notification.rb
@@ -9,4 +9,16 @@ class UserNotification < ApplicationRecord
 
   belongs_to :activity, inverse_of: :user_notifications
   belongs_to :user, inverse_of: :notifications
+
+  scope :ordered_by_updated_at, -> { order(updated_at: :asc) }
+
+  # The oldest unread popup notification for the given course and user.
+  #
+  # @return [UserNotification] The next popup notification to be shown.
+  # @return [nil] if there are no unread notifications.
+  def self.next_unread_popup_for_course_user(course, user)
+    popup.where(user: user).unread_by(user).ordered_by_updated_at.
+      includes(activity: { object: :course }).
+      drop_while { |popup| popup.activity.from_course?(course) }.first
+  end
 end

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -24,3 +24,5 @@
 
     div.col-lg-10.col-md-9.col-sm-8 class=page_class
       = yield
+
+    #popup-notifier data=controller.next_popup_notification

--- a/app/views/notifiers/course/achievement_notifier/gained/user_notifications/popup.html.slim
+++ b/app/views/notifiers/course/achievement_notifier/gained/user_notifications/popup.html.slim
@@ -1,1 +1,0 @@
-// TODO: Implement popup notification.

--- a/app/views/notifiers/course/achievement_notifier/gained/user_notifications/popup.json.jbuilder
+++ b/app/views/notifiers/course/achievement_notifier/gained/user_notifications/popup.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+json.id notification.id
+json.notificationType 'achievementGained'
+
+achievement = notification.activity.object
+json.badgeUrl achievement.badge.url
+json.title achievement.title
+json.description achievement.description

--- a/app/views/notifiers/course/level_notifier/reached/user_notifications/popup.html.slim
+++ b/app/views/notifiers/course/level_notifier/reached/user_notifications/popup.html.slim
@@ -1,1 +1,0 @@
-// TODO: Implement popup notification.

--- a/app/views/notifiers/course/level_notifier/reached/user_notifications/popup.json.jbuilder
+++ b/app/views/notifiers/course/level_notifier/reached/user_notifications/popup.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+json.id notification.id
+json.notificationType 'levelReached'
+
+level = notification.activity.object
+json.levelNumber level.level_number

--- a/client/app/api/course/UserNotifications.js
+++ b/client/app/api/course/UserNotifications.js
@@ -1,0 +1,11 @@
+import BaseCourseAPI from './Base';
+
+export default class UserNotificationsAPI extends BaseCourseAPI {
+  markAsRead(userNotificationId) {
+    return this.getClient().post(`${this._getUrlPrefix()}/${userNotificationId}/mark_as_read`);
+  }
+
+  _getUrlPrefix() {
+    return `/courses/${this.getCourseId()}/user_notifications`;
+  }
+}

--- a/client/app/api/course/index.js
+++ b/client/app/api/course/index.js
@@ -11,6 +11,7 @@ import VideoAPI from './Video';
 import AdminAPI from './Admin';
 import ScribingQuestionAPI from './Assessment/question/scribing';
 import LevelAPI from './Level';
+import UserNotificationsAPI from './UserNotifications';
 
 const CourseAPI = {
   achievements: new AchievementsAPI(),
@@ -28,6 +29,7 @@ const CourseAPI = {
     scribing: ScribingQuestionAPI,
   },
   level: new LevelAPI(),
+  userNotifications: new UserNotificationsAPI(),
 };
 
 Object.freeze(CourseAPI);

--- a/client/app/bundles/course/user-notification/actions.js
+++ b/client/app/bundles/course/user-notification/actions.js
@@ -1,0 +1,19 @@
+/* eslint-disable import/prefer-default-export */
+import courseAPI from 'api/course';
+import actionTypes from './constants';
+
+export function markAsRead(userNotificationId) {
+  return (dispatch) => {
+    dispatch({ type: actionTypes.MARK_AS_READ_REQUEST });
+    return courseAPI.userNotifications.markAsRead(userNotificationId)
+      .then((response) => {
+        dispatch({
+          type: actionTypes.MARK_AS_READ_SUCCESS,
+          nextNotification: response.data,
+        });
+      })
+      .catch(() => {
+        dispatch({ type: actionTypes.MARK_AS_READ_FAILURE });
+      });
+  };
+}

--- a/client/app/bundles/course/user-notification/components/AchievementGainedPopup.jsx
+++ b/client/app/bundles/course/user-notification/components/AchievementGainedPopup.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
+import Popup from 'course/user-notification/components/Popup';
+
+const styles = {
+  badge: {
+    maxHeight: 250,
+    maxWidth: 250,
+  },
+  title: {
+    marginTop: 30,
+    marginBottom: 10,
+    fontWeight: 'bold',
+  },
+  description: {
+    textAlign: 'center',
+  },
+};
+
+const translations = defineMessages({
+  unlocked: {
+    id: 'course.userNotification.AchievementGainedPopup.unlocked',
+    defaultMessage: 'Achievement Unlocked!',
+  },
+});
+
+const AchievementGainedPopup = ({ notification, onDismiss, intl }) => (
+  <Popup
+    title={intl.formatMessage(translations.unlocked)}
+    onDismiss={onDismiss}
+  >
+    <img
+      src={notification.badgeUrl}
+      alt={notification.title}
+      style={styles.badge}
+    />
+    <span style={styles.title}>
+      { notification.title }
+    </span>
+    <span style={styles.description}>
+      { notification.description }
+    </span>
+  </Popup>
+);
+
+AchievementGainedPopup.propTypes = {
+  notification: PropTypes.shape({
+    badgeUrl: PropTypes.string,
+    title: PropTypes.string,
+    description: PropTypes.string,
+  }),
+  onDismiss: PropTypes.func,
+
+  intl: intlShape,
+};
+
+export default injectIntl(AchievementGainedPopup);

--- a/client/app/bundles/course/user-notification/components/LevelReachedPopup.jsx
+++ b/client/app/bundles/course/user-notification/components/LevelReachedPopup.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
+import Avatar from 'material-ui/Avatar';
+import StarIcon from 'material-ui/svg-icons/toggle/star';
+import { deepOrange400, yellow500 } from 'material-ui/styles/colors';
+import Popup from 'course/user-notification/components/Popup';
+
+const translations = defineMessages({
+  reached: {
+    id: 'course.userNotification.LevelReachedPopup.reached',
+    defaultMessage: 'Level {levelNumber} Reached!',
+  },
+});
+
+const LevelReachedPopup = ({ notification, onDismiss, intl }) => (
+  <Popup
+    title={intl.formatMessage(translations.reached, { levelNumber: notification.levelNumber })}
+    onDismiss={onDismiss}
+  >
+    <Avatar
+      size={200}
+      color={yellow500}
+      backgroundColor={deepOrange400}
+      icon={<StarIcon />}
+    />
+  </Popup>
+);
+
+LevelReachedPopup.propTypes = {
+  notification: PropTypes.shape({
+    levelNumber: PropTypes.number,
+  }),
+  onDismiss: PropTypes.func,
+
+  intl: intlShape,
+};
+
+export default injectIntl(LevelReachedPopup);

--- a/client/app/bundles/course/user-notification/components/Popup.jsx
+++ b/client/app/bundles/course/user-notification/components/Popup.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
+import translations from 'lib/translations/form';
+
+const styles = {
+  dialog: {
+    width: 400,
+  },
+  centralise: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+};
+
+class Popup extends React.Component {
+  static propTypes = {
+    title: PropTypes.string,
+    onDismiss: PropTypes.func,
+    children: PropTypes.node,
+  }
+
+  render() {
+    const { title, children } = this.props;
+    const actions = [
+      <FlatButton
+        primary
+        label={<FormattedMessage {...translations.dismiss} />}
+        onClick={this.props.onDismiss}
+      />,
+    ];
+
+    return (
+      <Dialog
+        open
+        title={title}
+        actions={actions}
+        contentStyle={styles.dialog}
+        titleStyle={styles.centralise}
+        bodyStyle={styles.centralise}
+      >
+        { children }
+      </Dialog>
+    );
+  }
+}
+
+export default Popup;

--- a/client/app/bundles/course/user-notification/constants.js
+++ b/client/app/bundles/course/user-notification/constants.js
@@ -1,0 +1,9 @@
+import mirrorCreator from 'mirror-creator';
+
+const actionTypes = mirrorCreator([
+  'MARK_AS_READ_REQUEST',
+  'MARK_AS_READ_SUCCESS',
+  'MARK_AS_READ_FAILURE',
+]);
+
+export default actionTypes;

--- a/client/app/bundles/course/user-notification/containers/PopupNotifier/index.jsx
+++ b/client/app/bundles/course/user-notification/containers/PopupNotifier/index.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import AchievementGainedPopup from 'course/user-notification/components/AchievementGainedPopup';
+import LevelReachedPopup from 'course/user-notification/components/LevelReachedPopup';
+import { markAsRead } from 'course/user-notification/actions';
+
+class PopupNotifier extends React.Component {
+  static propTypes = {
+    dispatch: PropTypes.func,
+    notification: PropTypes.shape(),
+    open: PropTypes.bool,
+  }
+
+  static popupsHash = {
+    achievementGained: AchievementGainedPopup,
+    levelReached: LevelReachedPopup,
+  };
+
+  render() {
+    const { dispatch, notification, open } = this.props;
+    if (!open) { return null; }
+    const PopupContent = PopupNotifier.popupsHash[notification.notificationType];
+    return (
+      <PopupContent
+        notification={notification}
+        onDismiss={() => { dispatch(markAsRead(notification.id)); }}
+      />
+    );
+  }
+}
+
+export default connect(state => ({
+  notification: state.popupNotification,
+  open: state.popupOpen,
+}))(PopupNotifier);

--- a/client/app/bundles/course/user-notification/reducers/index.js
+++ b/client/app/bundles/course/user-notification/reducers/index.js
@@ -1,0 +1,23 @@
+import actionTypes from '../constants';
+
+const initialState = {
+  popupNotification: {},
+  popupOpen: true,
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case actionTypes.MARK_AS_READ_REQUEST: {
+      return { ...state, popupOpen: false };
+    }
+    case actionTypes.MARK_AS_READ_SUCCESS: {
+      return {
+        popupNotification: action.nextNotification,
+        popupOpen: !!action.nextNotification,
+      };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/user-notification/store.js
+++ b/client/app/bundles/course/user-notification/store.js
@@ -1,0 +1,13 @@
+import { compose, createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import rootReducer from './reducers';
+
+export default ({ popupNotification }) => {
+  const initialStates = { popupNotification, popupOpen: true };
+  const storeCreator = (process.env.NODE_ENV === 'development') ?
+    // eslint-disable-next-line global-require
+    compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :
+    compose(applyMiddleware(thunkMiddleware))(createStore);
+
+  return storeCreator(rootReducer, initialStates);
+};

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -28,6 +28,7 @@ function loadModules() {
   // Initializers
   require('lib/initializers/ace-editor.js');
   require('lib/initializers/confirm-dialog');
+  require('lib/initializers/popup-notifier');
   loadCurrentModule();
   // Require web font last so that it doesn't block the load of current module.
   require('lib/initializers/webfont');

--- a/client/app/lib/initializers/popup-notifier.jsx
+++ b/client/app/lib/initializers/popup-notifier.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Router } from 'react-router-dom';
+import history from 'lib/history';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
+import PopupNotifier from 'course/user-notification/containers/PopupNotifier';
+import storeCreator from 'course/user-notification/store';
+
+$(document).ready(() => {
+  const mountNode = document.getElementById('popup-notifier');
+
+  if (mountNode) {
+    const dataAttr = mountNode.getAttribute('data');
+    const data = JSON.parse(dataAttr);
+    if (data === null) { return; }
+    const store = storeCreator({ popupNotification: data });
+
+    render(
+      <ProviderWrapper {...{ store }}>
+        <Router history={history}>
+          <PopupNotifier />
+        </Router>
+      </ProviderWrapper>
+      , mountNode
+    );
+  }
+});

--- a/client/app/lib/translations/form.jsx
+++ b/client/app/lib/translations/form.jsx
@@ -25,6 +25,10 @@ const translations = defineMessages({
     id: 'lib.form.buttons.discard',
     defaultMessage: 'Discard',
   },
+  dismiss: {
+    id: 'lib.form.buttons.dismiss',
+    defaultMessage: 'Dismiss',
+  },
   continue: {
     id: 'lib.form.buttons.continue',
     defaultMessage: 'Continue',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -349,6 +349,10 @@ Rails.application.routes.draw do
           resources :sections, only: [:create, :update, :destroy]
         end
       end
+
+      resources :user_notifications do
+        post 'mark_as_read', on: :member
+      end
     end
   end
 

--- a/db/migrate/20180111081846_mark_old_user_notification_popups_as_read.rb
+++ b/db/migrate/20180111081846_mark_old_user_notification_popups_as_read.rb
@@ -1,0 +1,6 @@
+class MarkOldUserNotificationPopupsAsRead < ActiveRecord::Migration[5.1]
+  def change
+    User.find_each { |user| UserNotification.mark_as_read! :all, for: user }
+    UserNotification.cleanup_read_marks!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171225012500) do
+ActiveRecord::Schema.define(version: 20180111081846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/course/user_notifications_controller_spec.rb
+++ b/spec/controllers/course/user_notifications_controller_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::UserNotificationsController, type: :controller do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:json_response) { JSON.parse(response.body) }
+    let(:course) { create(:course) }
+    let(:user) { create(:user) }
+    let!(:course_student) { create(:course_student, course: course, user: user) }
+
+    describe '#mark_as_read' do
+      context 'when there are some more unread popups' do
+        render_views
+
+        let(:level) { create(:course_level, course: course) }
+        let(:level_reached_activity) do
+          create(:activity, :level_reached, object: level, actor: user)
+        end
+        let!(:level_reached_popup) do
+          create(:user_notification, :popup, user: user, activity: level_reached_activity)
+        end
+        let(:achievement) { create(:achievement, :with_badge, course: course) }
+        let(:achievement_gained_activity) do
+          create(:activity, :achievement_gained, object: achievement, actor: user)
+        end
+        let!(:achievement_gained_popup) do
+          create(:user_notification, :popup, user: user, activity: achievement_gained_activity)
+        end
+        let(:expected_payload) do
+          {
+            'id' => achievement_gained_popup.id,
+            'notificationType' => 'achievementGained',
+            'badgeUrl' => achievement.badge.url,
+            'description' => achievement.description,
+            'title' => achievement.title
+          }
+        end
+
+        subject do
+          post :mark_as_read,
+               params: { course_id: course.id, id: level_reached_popup.id },
+               format: :json
+        end
+        before do
+          sign_in(user)
+          subject
+        end
+
+        it 'marks it current popup as read and renders JSON for the next popup' do
+          expect(level_reached_popup).not_to be_unread(user)
+          expect(achievement_gained_popup).to be_unread(user)
+          expect(json_response).to eq(expected_payload)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
![jan-11-2018 17-45-46](https://user-images.githubusercontent.com/6252919/34819088-c6d8eb06-f6f7-11e7-891b-0c542e93299d.gif)

1. When a student is viewing a page from a course, s/he will see only popups for that course, not other courses. Users will not see popups when they are outside a context of a course, e.g. while viewing the list of all courses.
1. The `UserNotification` model is not namespaced under `Course` since it is possible to have `UserNotification`s that are not tied to a course. However, due to the restriction in (1), we namespace the route/controller/views under `course`. This might have to change if the need for popup notifications outside a course arises.
1. All email `UserNotification` are left as unread.

Will add frontend tests only after #2729. Open to suggestions of aesthetic improvements.
