### PR TITLE
Lemmatiser and autograder for TextResponse comprehension questions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -226,3 +226,6 @@ gem 'activerecord-import', '>= 0.2.0'
 
 gem 'record_tag_helper'
 gem 'rails-controller-testing'
+
+# WordNet corpus to obtain lemma form of words, for comprehension questions.
+gem "rwordnet", git: 'https://github.com/makqien/rwordnet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,12 @@ GIT
     activerecord-userstamp (3.0.5)
       rails (>= 4.1)
 
+GIT
+  remote: https://github.com/makqien/rwordnet
+  revision: 6342db3c2acb85de98ff422d7c55f4a1f561dd5c
+  specs:
+    rwordnet (2.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -622,6 +628,7 @@ DEPENDENCIES
   rspec-rails
   rspec-retry
   rubyzip
+  rwordnet!
   sanitize
   sass-rails
   schema_monkey

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -45,7 +45,11 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
   end
 
   def auto_grader
-    Course::Assessment::Answer::TextResponseAutoGradingService.new
+    if comprehension_question?
+      Course::Assessment::Answer::TextResponseComprehensionAutoGradingService.new
+    else
+      Course::Assessment::Answer::TextResponseAutoGradingService.new
+    end
   end
 
   def attempt(submission, last_attempt = nil)

--- a/app/models/course/assessment/question/text_response_comprehension_solution.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_solution.rb
@@ -5,7 +5,6 @@ class Course::Assessment::Question::TextResponseComprehensionSolution < Applicat
   enum solution_type: [:compre_keyword, :compre_lifted_word]
 
   before_validation :remove_blank_solution,
-                    :set_dummy_solution_lemma,
                     :strip_whitespace_solution,
                     :strip_whitespace_solution_lemma
 
@@ -26,11 +25,6 @@ class Course::Assessment::Question::TextResponseComprehensionSolution < Applicat
 
   def remove_blank_solution
     solution.reject!(&:blank?)
-  end
-
-  # TODO: Remove this function when lemmatiser is implemented
-  def set_dummy_solution_lemma
-    self.solution_lemma = solution
   end
 
   def strip_whitespace_solution

--- a/app/models/course/assessment/question/text_response_comprehension_solution.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_solution.rb
@@ -4,9 +4,7 @@ class Course::Assessment::Question::TextResponseComprehensionSolution < Applicat
 
   enum solution_type: [:compre_keyword, :compre_lifted_word]
 
-  before_validation :remove_blank_solution,
-                    :strip_whitespace_solution,
-                    :strip_whitespace_solution_lemma
+  before_validation :sanitise_solution_and_derive_lemma
 
   validate :validate_solution_lemma_empty
 
@@ -23,12 +21,24 @@ class Course::Assessment::Question::TextResponseComprehensionSolution < Applicat
 
   private
 
+  def sanitise_solution_and_derive_lemma
+    remove_blank_solution
+    strip_whitespace_solution
+    convert_solution_to_lemma
+    strip_whitespace_solution_lemma
+  end
+
   def remove_blank_solution
     solution.reject!(&:blank?)
   end
 
   def strip_whitespace_solution
     solution.each(&:strip!)
+  end
+
+  def convert_solution_to_lemma
+    lemmatiser = Course::Assessment::Question::TextResponseLemmaService.new
+    self.solution_lemma = lemmatiser.lemmatise(solution)
   end
 
   def strip_whitespace_solution_lemma

--- a/app/services/course/assessment/answer/text_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_auto_grading_service.rb
@@ -60,10 +60,12 @@ class Course::Assessment::Answer::TextResponseAutoGradingService < \
   #
   # The grade is considered to be the sum of grades assigned to all matched solutions, but not
   # exceeding the maximum grade of the question.
+  #
   # @param [Course::Assessment::Question::TextResponse] question The question answered by the
   #   student.
   # @param [Array<Course::Assessment::Question::TextResponseSolution>] solutions The solutions that
   #   matches the student's answer.
+  # @return [Integer] The grade for the question.
   def grade_for(question, solutions)
     [solutions.map(&:grade).reduce(0, :+), question.maximum_grade].min
   end
@@ -77,12 +79,13 @@ class Course::Assessment::Answer::TextResponseAutoGradingService < \
     solutions.map(&:explanation).tap(&:compact!)
   end
 
-  # Mark the correctness of the answer based on solutions
+  # Mark the correctness of the answer based on solutions.
   #
   # @param [Course::Assessment::Question::TextResponse] question The question answered by the
   #   student.
   # @param [Array<Course::Assessment::Question::TextResponseSolution>] solutions The solutions that
   #   matches the student's answer.
+  # @return [Boolean] correct True if the answer is correct.
   def correctness_for(question, solutions)
     solutions.map(&:grade).sum >= question.maximum_grade
   end

--- a/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+require 'rwordnet'
+class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < \
+  Course::Assessment::Answer::AutoGradingService
+  def evaluate(answer)
+    answer.correct, grade, messages = evaluate_answer(answer.actable)
+    answer.auto_grading.result = { messages: messages }
+    grade
+  end
+
+  private
+
+  # Grades the given answer.
+  #
+  # @param [Course::Assessment::Answer::TextResponse] answer The answer specified by the
+  #   student.
+  # @return [Array<(Boolean, Integer, Object)>] The correct status, grade and the messages to be
+  #   assigned to the grading.
+  def evaluate_answer(answer)
+    question = answer.question.actable
+    answer_text_array = answer.normalized_answer_text.downcase.gsub(/([^a-z ])/, ' ').split(' ')
+    answer_text_lemma_array = []
+    answer_text_array.each { |a| answer_text_lemma_array.push(WordNet::Synset.morphy_all(a).first || a) }
+
+    hash_lifted_word_points = hash_compre_lifted_word(question)
+    hash_keyword_solutions = hash_compre_keyword(question)
+
+    lifted_word_status = find_compre_lifted_word_in_answer(answer_text_lemma_array, hash_lifted_word_points)
+    keyword_status = find_compre_keyword_in_answer(answer_text_lemma_array, lifted_word_status, hash_keyword_solutions)
+
+    answer_text_lemma_status = {
+      'compre_lifted_word': lifted_word_status,
+      'compre_keyword': keyword_status
+    }
+
+    answer_grade = grade_for(question, answer_text_lemma_status)
+
+    [
+      correctness_for(question, answer_grade),
+      answer_grade,
+      explanations_for(question, answer_grade, answer_text_array, answer_text_lemma_status)
+    ]
+  end
+
+  # All lifted words in a question as keys and
+  # an array of Points where words are found as values.
+  #
+  # @param [Course::Assessment::Question::TextResponse] question The question answered by the
+  #   student.
+  # @return [Hash{String=>Array<Course::Assessment::Question::TextResponseComprehensionPoint>}]
+  #   The mapping from lifted words to Points.
+  def hash_compre_lifted_word(question)
+    hash = {}
+    question.groups.each do |group|
+      group.points.each do |point|
+        # for all TextResponseComprehensionSolution where solution_type == compre_lifted_word
+        point.solutions.select(&:compre_lifted_word?).each do |s|
+          s.solution_lemma.each do |solution_key|
+            if hash.key?(solution_key)
+              hash_value = hash[solution_key]
+              hash_value.push(point) unless hash_value.include?(point)
+            else
+              hash[solution_key] = [point]
+            end
+          end
+        end
+      end
+    end
+    hash
+  end
+
+  # All keywords in a question as keys and
+  # an array of Solutions where words are found as values.
+  #
+  # @param [Course::Assessment::Question::TextResponse] question The question answered by the
+  #   student.
+  # @return [Hash{String=>Array<Course::Assessment::Question::TextResponseComprehensionSolution>}]
+  #   The mapping from keywords to Solutions.
+  def hash_compre_keyword(question)
+    hash = {}
+    question.groups.each do |group|
+      group.points.each do |point|
+        # for all TextResponseComprehensionSolution where solution_type == compre_keyword
+        point.solutions.select(&:compre_keyword?).each do |s|
+          s.solution_lemma.each do |solution_key|
+            if hash.key? solution_key
+              hash_value = hash[solution_key]
+              hash_value.push(s) unless hash_value.include?(s)
+            else
+              hash[solution_key] = [s]
+            end
+          end
+        end
+      end
+    end
+    hash
+  end
+
+  # Find for all compre_lifted_word in answer.
+  # If word is found, set +answer_text_lemma_status["compre_lifted_word"][index]+ to the
+  # corresponding Point.
+  #
+  # @param [Array<String>] answer_text_lemma_array The lemmatised answer text in array form.
+  # @param [Hash{String=>Array<Course::Assessment::Question::TextResponseComprehensionPoint>}] hash
+  #   The mapping from lifted words to Points.
+  # @return [Array<nil or TextResponseComprehensionPoint>}] lifted_word
+  #   The lifted word status of each element in +answer_text_lemma+.
+  def find_compre_lifted_word_in_answer(answer_text_lemma_array, hash)
+    lifted_word_status = Array.new(answer_text_lemma_array.length, nil)
+
+    answer_text_lemma_array.each_with_index do |answer_text_lemma_word, index|
+      next unless hash.key?(answer_text_lemma_word) && !hash[answer_text_lemma_word].empty?
+
+      # lifted word found in answer
+      first_point = hash[answer_text_lemma_word].shift
+      lifted_word_status[index] = first_point
+
+      # for same Point, remove from all other values in hash
+      hash.each_value do |point_array|
+        point_array.delete_if { |point| point.equal? first_point }
+      end
+    end
+
+    lifted_word_status
+  end
+
+  # Find for all compre_keyword in answer.
+  # If word is found, set +answer_text_lemma_status["compre_keyword"][index]+ to the
+  # corresponding Solution.
+  # and collate an array of all Solutions where keywords are found in answer.
+  #
+  # @param [Array<String>] answer_text_lemma_array The lemmatised answer text in array form.
+  # @param [Array<nil or TextResponseComprehensionPoint>] lifted_word_status
+  #   The lifted word status of each element in +answer_text_lemma+.
+  # @param [Hash{String=>Array<Course::Assessment::Question::TextResponseComprehensionSolution>}] hash
+  #   The mapping from keywords to Solutions.
+  # @return [Array<nil or TextResponseComprehensionSolution>}] keyword_status
+  #   The keyword status of each element in +answer_text_lemma+.
+  def find_compre_keyword_in_answer(answer_text_lemma_array, lifted_word_status, hash)
+    keyword_status = Array.new(answer_text_lemma_array.length, nil)
+
+    answer_text_lemma_array.each_with_index do |answer_text_lemma_word, index|
+      next unless lifted_word_status[index].nil? ||
+                  (hash.key?(answer_text_lemma_word) && !hash[answer_text_lemma_word].empty?)
+
+      # keyword found in answer
+      until !hash.key?(answer_text_lemma_word) || hash[answer_text_lemma_word].empty?
+        first_solution = hash[answer_text_lemma_word].shift
+        first_solution_point = first_solution.point
+
+        # for same Solution, remove from all other values in hash
+        hash.each_value do |solution_array|
+          solution_array.delete_if { |solution| solution.equal? first_solution }
+        end
+
+        unless lifted_word_status.include?(first_solution_point)
+          # keyword (Solution) does NOT belong to a "lifted" Point
+          keyword_status[index] = first_solution
+          break
+        end
+      end
+
+      keyword_status
+    end
+
+    keyword_status
+  end
+
+  # Returns the grade for a question with all matched solutions.
+  #
+  # The grade is considered to be the sum of grades assigned to all matched solutions, but not
+  # exceeding the maximum grade of the point, group and question.
+  #
+  # @param [Course::Assessment::Question::TextResponse] question The question answered by the
+  #   student.
+  # @param [Hash{String=>Array<nil or TextResponseComprehensionPoint or TextResponseComprehensionSolution>}]
+  #   answer_text_lemma_status The status of each element in +answer_text_lemma+.
+  # @return [Integer] The grade of the student answer for the question.
+  def grade_for(question, answer_text_lemma_status)
+    lifted_word_points = answer_text_lemma_status[:compre_lifted_word]
+    keyword_solutions = answer_text_lemma_status[:compre_keyword]
+
+    question_grade = question.groups.reduce(0) do |question_sum, group|
+      group_grade = group.points.
+                    reject { |point| lifted_word_points.include?(point) }.
+                    select { |point| point.solutions.select(&:compre_keyword?).all? { |s| keyword_solutions.include?(s) } }.
+                    reduce(0) { |group_sum, point| group_sum + point.point_grade }
+      question_sum + [group_grade, group.maximum_group_grade].min
+    end
+
+    [question_grade, question.maximum_grade].min
+  end
+
+  # Mark the correctness of the answer based on grade.
+  #
+  # @param [Course::Assessment::Question::TextResponse] question The question answered by the
+  #   student.
+  # @param [Integer] grade The grade of the student answer for the question.
+  # @return [Boolean] correct True if the answer is correct.
+  def correctness_for(question, grade)
+    grade >= question.maximum_grade
+  end
+
+  # Returns the explanations for the given status.
+  #
+  # @param [Course::Assessment::Question::TextResponse] question The question answered by the
+  #   student.
+  # @param [Integer] grade The grade of the student answer for the question.
+  # @param [Array<String>] answer_text_array The normalized, downcased, letters-only answer text
+  #   in array form.
+  # @param [Hash{String=>Array<nil or TextResponseComprehensionPoint or TextResponseComprehensionSolution>}]
+  #   answer_text_lemma_status The status of each element in +answer_text_lemma+.
+  # @return [Array<String>] The explanations for the given question.
+  def explanations_for(question, grade, answer_text_array, answer_text_lemma_status)
+    [
+      explanations_for_keyword(answer_text_array, answer_text_lemma_status[:compre_keyword]),
+      explanations_for_lifted_word(answer_text_array, answer_text_lemma_status[:compre_lifted_word]),
+      explanations_for_grade(question, grade)
+    ].flatten
+  end
+
+  # @param [Array<String>] answer_text_array The normalized, downcased, letters-only answer text
+  #   in array form.
+  # @param [Array<nil or TextResponseComprehensionPoint or TextResponseComprehensionSolution>] status
+  #   A particular hash value in +answer_text_lemma_status+.
+  # @return [Array<String>] The explanations for keywords.
+  def explanations_for_keyword(answer_text_array, status)
+    if status.any?
+      explanations = []
+      status.each_index do |index|
+        next if status[index].nil?
+
+        word_explanation = answer_text_array[index]
+        word_explanation += " (#{status[index].explanation})" unless status[index].explanation.nil?
+        explanations.push(word_explanation)
+      end
+      ['Keywords correctly expressed:', explanations.join(', ')]
+    else
+      []
+    end
+  end
+
+  # @param [Array<String>] answer_text_array The normalized, downcased, letters-only answer text
+  #   in array form.
+  # @param [Array<nil or TextResponseComprehensionPoint or TextResponseComprehensionSolution>] status
+  #   A particular hash value in +answer_text_lemma_status+.
+  # @return [Array<String>] The explanations for lifted words.
+  def explanations_for_lifted_word(answer_text_array, status)
+    if status.any?
+      explanations = []
+      status.each_index do |index|
+        explanations.push(answer_text_array[index]) unless status[index].nil?
+      end
+      ['Lifted words:', explanations.join(', ')]
+    else
+      []
+    end
+  end
+
+  # @param [Course::Assessment::Question::TextResponse] question The question answered by the
+  #   student.
+  # @param [Integer] grade The grade of the student answer for the question.
+  # @return [Array<String>] The explanations for grade.
+  def explanations_for_grade(question, grade)
+    ["Grade: #{grade} / #{question.maximum_grade}"]
+  end
+end

--- a/app/services/course/assessment/question/text_response_lemma_service.rb
+++ b/app/services/course/assessment/question/text_response_lemma_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+require 'rwordnet'
+class Course::Assessment::Question::TextResponseLemmaService
+  # @param [Array<String>] word_array Words to lemmatise
+  # @return [Array<String>] Words in lemma form
+  def lemmatise(word_array)
+    word_array.flat_map { |word| WordNet::Synset.morphy_all(word) || word }.uniq
+  end
+end

--- a/spec/factories/course_assessment_answer_text_responses.rb
+++ b/spec/factories/course_assessment_answer_text_responses.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
       answer_text '<p>my answer contains key word</p>'
     end
 
+    trait :comprehension_lifted_word_keyword do
+      answer_text '<p>my answer contains lifting from text passage and key word</p>'
+    end
+
     trait :no_match do
       # use default text, nothing to do
     end

--- a/spec/factories/course_assessment_answer_text_responses.rb
+++ b/spec/factories/course_assessment_answer_text_responses.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     end
 
     trait :comprehension_keyword do
-      answer_text '<p>my answer contains keyword</p>'
+      answer_text '<p>my answer contains key word</p>'
     end
 
     trait :no_match do

--- a/spec/factories/course_assessment_question_text_response_comprehension_solutions.rb
+++ b/spec/factories/course_assessment_question_text_response_comprehension_solutions.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
   factory :course_assessment_question_text_response_comprehension_solution,
           class: Course::Assessment::Question::TextResponseComprehensionSolution do
     point { build(:course_assessment_question_text_response_comprehension_point) }
-    solution ['keyword']
-    solution_lemma ['keyword']
+    solution ['key']
+    solution_lemma ['key']
     explanation 'explanation'
     solution_type :compre_keyword
 
@@ -16,8 +16,8 @@ FactoryBot.define do
 
     trait :compre_keyword do
       solution_type :compre_keyword
-      solution ['keyword']
-      solution_lemma ['keyword']
+      solution ['key']
+      solution_lemma ['key']
     end
   end
 end

--- a/spec/models/course/assessment/question/text_response_comprehension_solution_spec.rb
+++ b/spec/models/course/assessment/question/text_response_comprehension_solution_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Assessment::Question::TextResponseComprehensionSolution, 
       describe '#answer_text' do
         subject do
           build_stubbed(:course_assessment_question_text_response_comprehension_solution, \
-                        solution: ['  content  '], solution_lemma: ['  content  '])
+                        solution: ['  content  '])
         end
 
         it 'strips whitespaces when validated' do

--- a/spec/services/course/assessment/answer/text_response_comprehension_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/text_response_comprehension_auto_grading_service_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Answer::TextResponseComprehensionAutoGradingService do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:answer) do
+      arguments = *answer_traits
+      options = arguments.extract_options!
+      options[:question_traits] = question_traits
+      options[:submission_traits] = submission_traits
+      create(:course_assessment_answer_text_response, :submitted, *arguments, options).answer
+    end
+    let(:question) { answer.question.actable }
+    let(:question_traits) { nil }
+    let(:submission_traits) { [{ auto_grade: false }] }
+    let(:answer_traits) { nil }
+    let!(:grading) do
+      create(:course_assessment_answer_auto_grading, answer: answer)
+    end
+
+    describe '#grade' do
+      before { allow(answer.submission.assessment).to receive(:autograded?).and_return(true) }
+
+      let(:question_traits) { :comprehension_question }
+
+      context 'when answer only contains lifted words' do
+        let(:answer_traits) { :comprehension_lifted_word }
+
+        it 'matches lifted word and grades as zero' do
+          subject.grade(answer)
+          expect(answer.grade).to eq(0)
+        end
+      end
+
+      context 'when answer contains only keywords' do
+        let(:answer_traits) { :comprehension_keyword }
+
+        it 'matches keyword' do
+          subject.grade(answer)
+          expect(answer.grade).to eq(2)
+        end
+      end
+
+      context 'when answer contains lifted words and keywords from same point' do
+        let(:answer_traits) { :comprehension_lifted_word_keyword }
+
+        it 'matches lifted word and grades as zero' do
+          subject.grade(answer)
+          expect(answer.grade).to eq(0)
+        end
+      end
+
+      context 'when answer contains keywords from multiple groups' do
+        let(:question_traits) { :multiple_comprehension_groups }
+
+        it 'matches keywords' do
+          question.maximum_grade = 4
+          answer.actable.answer_text = 'key word key word'
+          subject.grade(answer)
+          expect(answer.grade).to eq(4)
+        end
+
+        it 'matches keywords with cap on question maximum_grade' do
+          answer.actable.answer_text = 'key word key word'
+          subject.grade(answer)
+          expect(answer.grade).to eq(2)
+        end
+      end
+
+      context 'when answer contains lifted words and keywords from multiple groups' do
+        let(:question_traits) { :multiple_comprehension_groups }
+
+        it 'matches lifted word and grades partial marks' do
+          answer.actable.answer_text = 'lifted key word key word'
+          subject.grade(answer)
+          expect(answer.grade).to eq(2)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
References #2644.

**Lemmatiser**

- Uses the WordNet 3.1 corpus by Princeton University.
- Uses the `rwordnet` gem.

**Autograder**

1. Replaces all non-alphabetic characters in student answer with `' '` (space).

2. Converts to lowercase.

3. Splits into array form where each element of the array contains one word.

4. From the comprehension question:
a. Generate a hash of all `compre_lifted_word`s, with each lifted word as key and the associated TextResponseComprehensionPoints as value.
b. Generate a hash of all `compre_keyword`s, with each keyword as key and the associated TextResponseComprehensionSolutions as value.

5. For each element/word in student answer array:
a. If word is found in hash of all `compre_lifted_word`s, the associated TextResponseComprehensionPoint will instantly score 0 (regardless of any `compre_keyword`s subsequently matched).
b. Otherwise, if word is found in hash of all `compre_keyword`s, mark the associated TextResponseComprehensionSolution as 'satisfied'.

6. Assign grade:
a. For each TextResponseComprehensionPoint to score `point_grade`, all TextResponseComprehensionSolution `compre_keyword`s must be 'satisfied' and no `compre_lifted_word`s found.
b. For each TextResponseComprehensionGroup, cap at `maximum_group_grade`.
c. For each question, cap at `maximum_grade`.