### PR TITLE
Lesson Plan Enabled/Visible settings for Survey and Videos

### DIFF
--- a/app/models/concerns/course/settings/lesson_plan_settings_concern.rb
+++ b/app/models/concerns/course/settings/lesson_plan_settings_concern.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+#
+# This concern provides common defaults for querying and persisting lesson plan item settings
+# for a course component. It abstracts out common code for components which only need their items
+# fully enabled or disabled in the lesson plan.
+#
+# For more complicated settings, look at how assessment lesson plan settings are implemented.
+#
+# The lesson plan item settings for the given component is assumed to be stored in the following
+# shape in course.settings:
+#
+#  {
+#    course_component_key: {
+#      lesson_plan_items: {
+#         enabled: true,
+#         visible: false,
+#      }
+#    }
+#  }
+#
+# To use this concern:
+#   - Include the concern in the settings model for the component.
+#   - Implement `#lesson_plan_setting_items` if additional attributes are needed in the hash.
+#
+module Course::Settings::LessonPlanSettingsConcern
+  extend ActiveSupport::Concern
+
+  # A hash of concrete lesson plan settings for the component. This is used by
+  # {Course::Settings::LessonPlanItems} for the lesson plan settings page.
+  # See {Course::Settings::LessonPlanItems#lesson_plan_item_settings} for details of the hash shape.
+  #
+  # @return [Hash] Setting hash for a component.
+  def lesson_plan_item_settings
+    enabled_setting = settings.settings(:lesson_plan_items).enabled
+    visible_setting = settings.settings(:lesson_plan_items).visible
+    {
+      component: key,
+      enabled: enabled_setting.nil? ? true : enabled_setting,
+      visible: visible_setting.nil? ? true : visible_setting
+    }
+  end
+
+  # Updates a lesson plan item setting.
+  #
+  # @param [Hash] attributes New setting represented by a hash with
+  #  `'component'`, `'enabled'` and `'visible'` keys,
+  #  e.g. { 'component' => 'course_survey_component', 'enabled' => true, 'visible' => true }
+  def update_lesson_plan_item_setting(attributes)
+    settings.settings(:lesson_plan_items).enabled = ActiveRecord::Type::Boolean.new.
+                                                    cast(attributes['enabled'])
+    settings.settings(:lesson_plan_items).visible = ActiveRecord::Type::Boolean.new.
+                                                    cast(attributes['visible'])
+    true
+  end
+
+  def showable_in_lesson_plan?
+    settings.lesson_plan_items ? settings.lesson_plan_items['enabled'] : true
+  end
+end

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -32,8 +32,7 @@ class Course::LessonPlan::Item < ApplicationRecord
   #   Each actable type is further scoped to return the IDs of items for display.
   #   actable_data is provided to help the actable types figure out what should be displayed.
   #
-  # @param actable_types [Array<String>] Array of strings with the actable type names.
-  # @param settings [SettingsOnRails::Settings] Course settings object.
+  # @param actable_hash [Hash{String => Array<String> or nil}] Hash of actable_names to data.
   scope :with_actable_types, lambda { |actable_hash|
     where(
       actable_hash.map do |actable_type, actable_data|

--- a/app/models/course/settings/survey_component.rb
+++ b/app/models/course/settings/survey_component.rb
@@ -14,6 +14,10 @@ class Course::Settings::SurveyComponent < Course::Settings::Component
     super.merge(component_title: I18n.t('components.surveys.name'))
   end
 
+  def showable_in_lesson_plan?
+    settings.lesson_plan_items ? settings.lesson_plan_items['enabled'] : true
+  end
+
   def self.component_class
     Course::SurveyComponent
   end

--- a/app/models/course/settings/survey_component.rb
+++ b/app/models/course/settings/survey_component.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 class Course::Settings::SurveyComponent < Course::Settings::Component
   include Course::Settings::EmailSettingsConcern
+  include Course::Settings::LessonPlanSettingsConcern
 
   def self.email_setting_items
     {
       survey_opening: { enabled_by_default: true },
       survey_closing: { enabled_by_default: true }
     }
+  end
+
+  def lesson_plan_item_settings
+    super.merge(component_title: I18n.t('components.surveys.name'))
   end
 
   def self.component_class

--- a/app/models/course/settings/videos_component.rb
+++ b/app/models/course/settings/videos_component.rb
@@ -2,6 +2,7 @@
 class Course::Settings::VideosComponent < Course::Settings::Component
   include ActiveModel::Conversion
   include Course::Settings::EmailSettingsConcern
+  include Course::Settings::LessonPlanSettingsConcern
 
   def self.email_setting_items
     {
@@ -12,6 +13,10 @@ class Course::Settings::VideosComponent < Course::Settings::Component
 
   def self.component_class
     Course::VideosComponent
+  end
+
+  def lesson_plan_item_settings
+    super.merge(component_title: I18n.t('course.video.videos.index.header'))
   end
 
   # Returns the title of video component

--- a/app/models/course/settings/videos_component.rb
+++ b/app/models/course/settings/videos_component.rb
@@ -19,6 +19,10 @@ class Course::Settings::VideosComponent < Course::Settings::Component
     super.merge(component_title: I18n.t('course.video.videos.index.header'))
   end
 
+  def showable_in_lesson_plan?
+    settings.lesson_plan_items ? settings.lesson_plan_items['enabled'] : true
+  end
+
   # Returns the title of video component
   #
   # @return [String] The custom or default title of video component

--- a/app/views/course/lesson_plan/items/index.json.jbuilder
+++ b/app/views/course/lesson_plan/items/index.json.jbuilder
@@ -4,7 +4,7 @@ json.items @items.map(&:specific) do |actable|
   json.partial! "#{actable.to_partial_path}_lesson_plan_item.json.jbuilder", item: actable
 end
 
-json.visibilitySettings @assessment_tabs_visibility_hash do |setting_key, visible|
+json.visibilitySettings @visibility_hash do |setting_key, visible|
   json.setting_key setting_key
   json.visible visible
 end

--- a/app/views/course/surveys/_survey_lesson_plan_item.json.jbuilder
+++ b/app/views/course/surveys/_survey_lesson_plan_item.json.jbuilder
@@ -1,3 +1,3 @@
 json.partial! 'course/lesson_plan/items/item.json.jbuilder', item: item
-json.lesson_plan_item_type [Course::Survey.model_name.human]
+json.lesson_plan_item_type [t('components.surveys.name')]
 json.item_path course_survey_path(current_course, item)

--- a/client/app/bundles/course/admin/pages/LessonPlanItemSettings/__test__/index.test.jsx
+++ b/client/app/bundles/course/admin/pages/LessonPlanItemSettings/__test__/index.test.jsx
@@ -6,7 +6,7 @@ import LessonPlanItemSettings from '../index';
 
 const itemSettings = [
   {
-    component: 'sample_component',
+    component: 'course_assessments_component',
     category_title: 'assessment_category_name',
     tab_title: 'tab title',
     enabled: false,
@@ -33,7 +33,7 @@ describe('<LessonPlanItemSettings />', () => {
     const expectedPayload = {
       lesson_plan_settings: {
         lesson_plan_item_settings: {
-          component: 'sample_component',
+          component: 'course_assessments_component',
           tab_title: 'tab title',
           enabled: true,
           options: { category_id: 8, tab_id: 145 },

--- a/client/app/bundles/course/admin/pages/LessonPlanItemSettings/index.jsx
+++ b/client/app/bundles/course/admin/pages/LessonPlanItemSettings/index.jsx
@@ -26,11 +26,11 @@ class LessonPlanItemSettings extends React.Component {
   // Send the current value for visible when changing enabled.
   handleLessonPlanItemEnabledUpdate = (setting) => {
     const { dispatch } = this.props;
-    const { component, tab_title, options } = setting;
+    const { component, tab_title, component_title, options } = setting;
     return (_, enabled) => {
       const payload = { component, tab_title, enabled, visible: setting.visible, options };
-      const successMessage = <FormattedMessage {...translations.updateSuccess} values={{ setting: tab_title }} />;
-      const failureMessage = <FormattedMessage {...translations.updateFailure} values={{ setting: tab_title }} />;
+      const successMessage = <FormattedMessage {...translations.updateSuccess} values={{ setting: tab_title || component_title }} />;
+      const failureMessage = <FormattedMessage {...translations.updateFailure} values={{ setting: tab_title || component_title }} />;
       dispatch(updateLessonPlanItemSetting(payload, successMessage, failureMessage));
     };
   }
@@ -39,16 +39,16 @@ class LessonPlanItemSettings extends React.Component {
   // Send the current value for enabled when changing visible.
   handleLessonPlanItemVisibleUpdate = (setting) => {
     const { dispatch } = this.props;
-    const { component, tab_title, options } = setting;
+    const { component, tab_title, component_title, options } = setting;
     return (_, visible) => {
       const payload = { component, tab_title, visible, enabled: setting.enabled, options };
-      const successMessage = <FormattedMessage {...translations.updateSuccess} values={{ setting: tab_title }} />;
-      const failureMessage = <FormattedMessage {...translations.updateFailure} values={{ setting: tab_title }} />;
+      const successMessage = <FormattedMessage {...translations.updateSuccess} values={{ setting: tab_title || component_title }} />;
+      const failureMessage = <FormattedMessage {...translations.updateFailure} values={{ setting: tab_title || component_title }} />;
       dispatch(updateLessonPlanItemSetting(payload, successMessage, failureMessage));
     };
   }
 
-  renderRow(setting) {
+  renderAssessmentSettingRow(setting) {
     const categoryTitle = setting.category_title || setting.component;
     const tabTitle = setting.tab_title;
 
@@ -76,40 +76,110 @@ class LessonPlanItemSettings extends React.Component {
     );
   }
 
-  renderLessonPlanItemSettingsTable() {
-    const { lessonPlanItemSettings } = this.props;
+  renderComponentSettingRow(setting) {
+    const componentTitle = setting.component_title || setting.component;
 
-    if (lessonPlanItemSettings.length < 1) {
+    return (
+      <TableRow key={setting.component}>
+        <TableRowColumn colSpan={5}>
+          { componentTitle }
+        </TableRowColumn>
+        <TableRowColumn>
+          <Toggle
+            toggled={setting.enabled}
+            onToggle={this.handleLessonPlanItemEnabledUpdate(setting)}
+          />
+        </TableRowColumn>
+        <TableRowColumn>
+          <Toggle
+            toggled={setting.visible}
+            onToggle={this.handleLessonPlanItemVisibleUpdate(setting)}
+          />
+        </TableRowColumn>
+      </TableRow>
+    );
+  }
+
+  // For the assessments component, as settings are for categories and tabs.
+  renderLessonPlanItemAssessmentSettingsTable() {
+    const { lessonPlanItemSettings } = this.props;
+    const assessmentItemSettings = lessonPlanItemSettings.filter(setting =>
+      setting.component === 'course_assessments_component');
+
+    if (assessmentItemSettings.length < 1) {
       return <Subheader><FormattedMessage {...translations.noLessonPlanItems} /></Subheader>;
     }
 
     return (
-      <Table>
-        <TableHeader
-          adjustForCheckbox={false}
-          displaySelectAll={false}
-        >
-          <TableRow>
-            <TableHeaderColumn colSpan={2}>
-              <FormattedMessage {...translations.assessmentCategory} />
-            </TableHeaderColumn>
-            <TableHeaderColumn colSpan={3}>
-              <FormattedMessage {...translations.assessmentTab} />
-            </TableHeaderColumn>
-            <TableHeaderColumn>
-              <FormattedMessage {...translations.enabled} />
-            </TableHeaderColumn>
-            <TableHeaderColumn>
-              <FormattedMessage {...translations.visible} />
-            </TableHeaderColumn>
-          </TableRow>
-        </TableHeader>
-        <TableBody
-          displayRowCheckbox={false}
-        >
-          { lessonPlanItemSettings.map(item => this.renderRow(item)) }
-        </TableBody>
-      </Table>
+      <div>
+        <h3><FormattedMessage {...translations.lessonPlanAssessmentItemSettings} /></h3>
+        <Table>
+          <TableHeader
+            adjustForCheckbox={false}
+            displaySelectAll={false}
+          >
+            <TableRow>
+              <TableHeaderColumn colSpan={2}>
+                <FormattedMessage {...translations.assessmentCategory} />
+              </TableHeaderColumn>
+              <TableHeaderColumn colSpan={3}>
+                <FormattedMessage {...translations.assessmentTab} />
+              </TableHeaderColumn>
+              <TableHeaderColumn>
+                <FormattedMessage {...translations.enabled} />
+              </TableHeaderColumn>
+              <TableHeaderColumn>
+                <FormattedMessage {...translations.visible} />
+              </TableHeaderColumn>
+            </TableRow>
+          </TableHeader>
+          <TableBody
+            displayRowCheckbox={false}
+          >
+            { assessmentItemSettings.map(item => this.renderAssessmentSettingRow(item)) }
+          </TableBody>
+        </Table>
+      </div>
+    );
+  }
+
+  // For the video and survey components, as settings are for component only.
+  renderLessonPlanItemSettingsForComponentsTable() {
+    const { lessonPlanItemSettings } = this.props;
+    const componentItemSettings = lessonPlanItemSettings.filter(setting =>
+      ['course_videos_component', 'course_survey_component'].includes(setting.component));
+
+    if (componentItemSettings.length < 1) {
+      return <Subheader><FormattedMessage {...translations.noLessonPlanItems} /></Subheader>;
+    }
+
+    return (
+      <div>
+        <h3><FormattedMessage {...translations.lessonPlanComponentItemSettings} /></h3>
+        <Table>
+          <TableHeader
+            adjustForCheckbox={false}
+            displaySelectAll={false}
+          >
+            <TableRow>
+              <TableHeaderColumn colSpan={5}>
+                <FormattedMessage {...translations.component} />
+              </TableHeaderColumn>
+              <TableHeaderColumn>
+                <FormattedMessage {...translations.enabled} />
+              </TableHeaderColumn>
+              <TableHeaderColumn>
+                <FormattedMessage {...translations.visible} />
+              </TableHeaderColumn>
+            </TableRow>
+          </TableHeader>
+          <TableBody
+            displayRowCheckbox={false}
+          >
+            { componentItemSettings.map(item => this.renderComponentSettingRow(item)) }
+          </TableBody>
+        </Table>
+      </div>
     );
   }
 
@@ -117,7 +187,8 @@ class LessonPlanItemSettings extends React.Component {
     return (
       <div>
         <h2><FormattedMessage {...translations.lessonPlanItemSettings} /></h2>
-        {this.renderLessonPlanItemSettingsTable()}
+        {this.renderLessonPlanItemAssessmentSettingsTable()}
+        {this.renderLessonPlanItemSettingsForComponentsTable()}
 
         <NotificationPopup />
       </div>

--- a/client/app/bundles/course/admin/pages/LessonPlanItemSettings/translations.intl.js
+++ b/client/app/bundles/course/admin/pages/LessonPlanItemSettings/translations.intl.js
@@ -1,6 +1,22 @@
 import { defineMessages } from 'react-intl';
 
 const translations = defineMessages({
+  lessonPlanItemSettings: {
+    id: 'course.admin.lessonPlanSettings.lessonPlanItemSettings',
+    defaultMessage: 'Lesson Plan Item Settings',
+  },
+  lessonPlanAssessmentItemSettings: {
+    id: 'course.admin.lessonPlanSettings.lessonPlanAssessmentItemSettings',
+    defaultMessage: 'Assessment Item Settings',
+  },
+  lessonPlanComponentItemSettings: {
+    id: 'course.admin.lessonPlanSettings.lessonPlanComponentItemSettings',
+    defaultMessage: 'Component Item Settings',
+  },
+  assessmentCategory: {
+    id: 'course.admin.LessonPlanItemSettings.assessmentCategory',
+    defaultMessage: 'Assessment Category',
+  },
   assessmentTab: {
     id: 'course.admin.LessonPlanItemSettings.assessmentTab',
     defaultMessage: 'Assessment Tab',
@@ -9,13 +25,13 @@ const translations = defineMessages({
     id: 'course.admin.LessonPlanItemSettings.enabled',
     defaultMessage: 'Show on Lesson Plan',
   },
-  lessonPlanItemSettings: {
-    id: 'course.admin.lessonPlanSettings.lessonPlanItemSettings',
-    defaultMessage: 'Lesson Plan Item Settings',
-  },
   visible: {
     id: 'course.admin.LessonPlanItemSettings.visible',
     defaultMessage: 'Visible by Default',
+  },
+  component: {
+    id: 'course.admin.LessonPlanItemSettings.component',
+    defaultMessage: 'Component',
   },
   updateSuccess: {
     id: 'course.admin.LessonPlanItemSettings.updateSuccess',
@@ -28,10 +44,6 @@ const translations = defineMessages({
   noLessonPlanItems: {
     id: 'course.admin.LessonPlanItemSettings.noLessonPlanItems',
     defaultMessage: 'There are no lesson plan items to configure for lesson plan display.',
-  },
-  assessmentCategory: {
-    id: 'course.admin.LessonPlanItemSettings.assessmentCategory',
-    defaultMessage: 'Assessment Category',
   },
 });
 

--- a/spec/models/course/settings/survey_component_spec.rb
+++ b/spec/models/course/settings/survey_component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Settings::SurveyComponent do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:settings) do
+      context = OpenStruct.new(current_course: course, key: Course::SurveyComponent.key)
+      Course::Settings::SurveyComponent.new(context)
+    end
+
+    describe '#update_lesson_plan_item_settings' do
+      let(:payload) do
+        { 'enabled' => false, 'visible' => false, 'component' => 'course_survey_component' }
+      end
+      subject { settings.update_lesson_plan_item_setting(payload) && course.save! }
+
+      it 'persists the settings' do
+        subject
+        lesson_plan_setting = settings.lesson_plan_item_settings
+
+        expect(lesson_plan_setting[:enabled]).to eq(payload['enabled'])
+        expect(lesson_plan_setting[:visible]).to eq(payload['visible'])
+      end
+    end
+  end
+end

--- a/spec/models/course/settings/videos_component_spec.rb
+++ b/spec/models/course/settings/videos_component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Settings::VideosComponent do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:settings) do
+      context = OpenStruct.new(current_course: course, key: Course::VideosComponent.key)
+      Course::Settings::VideosComponent.new(context)
+    end
+
+    describe '#update_lesson_plan_item_settings' do
+      let(:payload) do
+        { 'enabled' => false, 'visible' => false, 'component' => 'course_videos_component' }
+      end
+      subject { settings.update_lesson_plan_item_setting(payload) && course.save! }
+
+      it 'persists the settings' do
+        subject
+        lesson_plan_setting = settings.lesson_plan_item_settings
+
+        expect(lesson_plan_setting[:enabled]).to eq(payload['enabled'])
+        expect(lesson_plan_setting[:visible]).to eq(payload['visible'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement `Enabled` and `Visible` settings for Survey and Video lesson plan items.

![screen shot 2018-01-12 at 2 56 20 pm](https://user-images.githubusercontent.com/1902527/34901823-93547cce-f84a-11e7-8bf3-63fd68dc93f9.png)