### PR TITLE
Only use active videos for counter

### DIFF
--- a/app/controllers/components/course/videos_component.rb
+++ b/app/controllers/components/course/videos_component.rb
@@ -51,6 +51,7 @@ class Course::VideosComponent < SimpleDelegator
       from_course(current_course).
       unwatched_by(current_user).
       published.
+      active.
       count
   end
 end

--- a/lib/extensions/acts_as_helpers/active_record/base.rb
+++ b/lib/extensions/acts_as_helpers/active_record/base.rb
@@ -30,6 +30,9 @@ module Extensions::ActsAsHelpers::ActiveRecord::Base
         attr_accessor :has_todo
       end
       self.has_todo = has_todo ? true : false
+
+      scope :active, -> { joins(:lesson_plan_item).merge(Course::LessonPlan::Item.currently_active) }
+
       extend LessonPlanItemClassMethods
       include LessonPlanItemInstanceMethods
     end


### PR DESCRIPTION
Video counter will only include videos that have officially started.

Previously included everything, which was not correct.