### PR TITLE
Remove extraneous characters at end of announcement email subject

### DIFF
--- a/config/locales/en/notifiers/course/announcement_notifier/new/course_notifications/email.yml
+++ b/config/locales/en/notifiers/course/announcement_notifier/new/course_notifications/email.yml
@@ -5,8 +5,7 @@ en:
         new:
           course_notifications:
             email:
-              subject: >
-                %{course} New Announcement: %{announcement}
+              subject: '%{course} New Announcement: %{announcement}'
               message: >
                 <p>New %{announcement} from course: %{course}</p>
                 %{content}


### PR DESCRIPTION
Close #2752

YAML multiline string using `>` appends a newline character at the end. In this case we reduce it to a single line since the subject is short enough. For longer strings, the newline can be avoided by using `>-`

Reference: http://yaml-multiline.info/