### PR TITLE
Implement view for creating TextResponse comprehension questions

### DIFF
--- a/app/inputs/array_input.rb
+++ b/app/inputs/array_input.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# https://railsguides.net/simple-form-array-text-input/
+# https://tenforward.consulting/blog/integrating-an-array-column-in-rails-with-simple-form
+class ArrayInput < SimpleForm::Inputs::StringInput
+  def input(wrapper_options)
+    input_html_options[:type] ||= input_type
+    existing_values = Array(object.public_send(attribute_name)).map do |array_el|
+      @builder.text_field(nil, input_html_options.merge(value: array_el, name: "#{object_name}[#{attribute_name}][]"))
+    end
+    if existing_values.empty?
+      existing_values.push @builder.text_field(nil, input_html_options.merge(value: nil, name: "#{object_name}[#{attribute_name}][]"))
+    end
+    existing_values.join.html_safe
+  end
+
+  def input_type
+    :text
+  end
+end

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -75,6 +75,11 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
     end
   end
 
+  def build_at_least_one_group_one_point
+    groups.build if groups.empty?
+    groups.first.points.build if groups.first.points.empty?
+  end
+
   private
 
   def validate_grade

--- a/app/models/course/assessment/question/text_response_comprehension_solution.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_solution.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::Question::TextResponseComprehensionSolution < ApplicationRecord
   self.table_name = 'course_assessment_question_text_response_compre_solutions'
 
-  enum solution_type: [:compre_lifted_word, :compre_keyword]
+  enum solution_type: [:compre_keyword, :compre_lifted_word]
 
   before_validation :remove_blank_solution,
                     :strip_whitespace_solution,

--- a/app/models/course/assessment/question/text_response_comprehension_solution.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_solution.rb
@@ -5,6 +5,7 @@ class Course::Assessment::Question::TextResponseComprehensionSolution < Applicat
   enum solution_type: [:compre_keyword, :compre_lifted_word]
 
   before_validation :remove_blank_solution,
+                    :set_dummy_solution_lemma,
                     :strip_whitespace_solution,
                     :strip_whitespace_solution_lemma
 
@@ -25,6 +26,11 @@ class Course::Assessment::Question::TextResponseComprehensionSolution < Applicat
 
   def remove_blank_solution
     solution.reject!(&:blank?)
+  end
+
+  # TODO: Remove this function when lemmatiser is implemented
+  def set_dummy_solution_lemma
+    self.solution_lemma = solution
   end
 
   def strip_whitespace_solution

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -90,6 +90,12 @@
             = link_to(t('.new_question.scribing'),
                       new_course_assessment_question_scribing_path(current_course, @assessment),
                       role: 'menuitem')
+          / TODO: Uncomment the line below when TextResponseComprehension is ready
+          / li role='presentation' id='comprehension-link'
+          /   = link_to(t('.new_question.comprehension'),
+          /             new_course_assessment_question_text_response_path(current_course, @assessment,
+          /                                                               { comprehension: true }),
+          /             role: 'menuitem')
 
     h3 = t('.questions')
     br

--- a/app/views/course/assessment/question/text_responses/_comprehension_group_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_comprehension_group_fields.html.slim
@@ -1,0 +1,22 @@
+= content_tag_for(:tr, f.object, class: 'nested-fields') do
+  td
+    b = t('.group')
+    br
+    = link_to_remove_association t('.remove_group'), f
+    br
+    br
+    = f.input :maximum_group_grade, label: t('.maximum_group_grade'),
+              input_html: { class: ['text-response-group-maximum-group-grade'] }
+
+    - group_id = f.object_name
+
+    table.table.table-hover
+      thead
+        tr
+          th = link_to_add_association t('.add_point'), f, :points,
+                                       partial: 'comprehension_point_fields',
+                                       find_selector: 'tbody.tbody-groups.'+group_id,
+                                       insert_using: 'append'
+      tbody.tbody-groups *{:class => group_id}
+        = f.simple_fields_for :points do |comprehension_points_form|
+          = render 'comprehension_point_fields', f: comprehension_points_form

--- a/app/views/course/assessment/question/text_responses/_comprehension_point_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_comprehension_point_fields.html.slim
@@ -1,0 +1,31 @@
+= content_tag_for(:tr, f.object.group, class: 'nested-fields') do
+  td
+    b = t('.point')
+    br
+    = link_to_remove_association t('.remove_point'), f
+    br
+    br
+    = f.input :point_grade, label: t('.point_grade'),
+              input_html: { class: ['text-response-group-point-grade'] }
+
+    - point_id = f.object_name
+
+    .has-error
+      = f.error :solutions
+
+    table.table.table-striped.table-hover.table-points
+      thead
+        tr
+          th = t('.solution_type')
+          th = t('.solution')
+          th
+          th = t('.explanation')
+          th
+            div.pull-right
+              = link_to_add_association t('.add_solution'), f, :solutions,
+                                        partial: 'comprehension_solution_fields',
+                                        find_selector: 'tbody.tbody-points.'+point_id,
+                                        insert_using: 'append'
+      tbody.tbody-points *{:class => point_id}
+        = f.simple_fields_for :solutions do |comprehension_solutions_form|
+          = render 'comprehension_solution_fields', f: comprehension_solutions_form

--- a/app/views/course/assessment/question/text_responses/_comprehension_solution_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_comprehension_solution_fields.html.slim
@@ -1,0 +1,20 @@
+= content_tag_for(:tr, f.object, class: 'nested-fields') do
+  td = f.input :solution_type,
+               collection: Course::Assessment::Question::TextResponseComprehensionSolution.solution_types.keys,
+               label_method: lambda { |key| t(".#{key}") },
+               input_html: { class: ['text-response-solution-type'] },
+               label: false
+  / TODO: Fix text to array.
+  td.td-solution *{:class => f.object_name}
+    = f.input :solution, as: :array, label: false, required: false,
+               input_html: { class: ['text-response-solution'] }
+    .has-error
+      = f.error :solution_lemma
+  td.td-solution-button
+    = link_to 'javascript:void(0)',
+              class: ['btn', 'btn-default', 'solution-button', f.object_name],
+              title: t('.add_solution_word') do
+      = fa_icon 'plus'.freeze
+  td = f.input :explanation, label: false, placeholder: t('.explanation_hint'),
+               input_html: { class: ['text-response-explanation', 'airmode'] }
+  td = link_to_remove_association t('.remove'), f

--- a/app/views/course/assessment/question/text_responses/_form.html.slim
+++ b/app/views/course/assessment/question/text_responses/_form.html.slim
@@ -2,6 +2,7 @@
   = f.error_notification
   = render partial: 'course/assessment/questions/form', locals: { f: f }
   = f.hidden_field :hide_text
+  = f.hidden_field :is_comprehension
 
   - if f.object.file_upload_question?
     = f.hidden_field :allow_attachment

--- a/app/views/course/assessment/question/text_responses/_form_comprehension.html.slim
+++ b/app/views/course/assessment/question/text_responses/_form_comprehension.html.slim
@@ -1,0 +1,29 @@
+= simple_form_for [current_course, @assessment, @text_response_question] do |f|
+  = f.error_notification
+  = render partial: 'course/assessment/questions/form', locals: { f: f }
+  = f.hidden_field :hide_text
+  = f.hidden_field :is_comprehension
+  = f.hidden_field :allow_attachment
+
+  b = t('.multiline_explanation_comprehension_html')
+  table.table.table-hover.table-comprehension
+    thead
+      tr
+        th = link_to_add_association t('.add_group'), f, :groups,
+                                     partial: 'comprehension_group_fields',
+                                     find_selector: 'tbody.tbody-form', insert_using: 'append'
+    tbody.tbody-form
+      = f.simple_fields_for :groups do |comprehension_groups_form|
+        = render 'comprehension_group_fields', f: comprehension_groups_form
+
+  - if @assessment.autograded?
+    p
+      b = t('.text_response_autograde')
+
+  - name = t('.comprehension')
+
+  - if f.object.persisted?
+    - button_text =  t('helpers.buttons.update', model: name)
+  - else
+    - button_text =  t('helpers.buttons.create', model: name)
+  = f.button :submit, button_text

--- a/app/views/course/assessment/question/text_responses/edit.html.slim
+++ b/app/views/course/assessment/question/text_responses/edit.html.slim
@@ -1,3 +1,6 @@
 - add_breadcrumb format_inline_text(@question_assessment.display_title)
 = page_header format_inline_text(@question_assessment.display_title)
-= render partial: 'form'
+- if @text_response_question.comprehension_question?
+  = render partial: 'form_comprehension'
+- else
+  = render partial: 'form'

--- a/app/views/course/assessment/question/text_responses/new.html.slim
+++ b/app/views/course/assessment/question/text_responses/new.html.slim
@@ -1,7 +1,12 @@
 - if @text_response_question.file_upload_question?
   - add_breadcrumb :new_file_upload
   = page_header t('.file_upload')
+  = render partial: 'form'
+- elsif @text_response_question.comprehension_question?
+  - add_breadcrumb :new_comprehension
+  = page_header t('.comprehension')
+  = render partial: 'form_comprehension'
 - else
   - add_breadcrumb :new_text_response
   = page_header t('.text_response')
-= render partial: 'form'
+  = render partial: 'form'

--- a/client/app/bundles/course/assessment/question/text-responses.js
+++ b/client/app/bundles/course/assessment/question/text-responses.js
@@ -1,0 +1,50 @@
+/* eslint-disable */
+// This ArrayInput implementation is only used for the creation of
+// multiple solution words (keywords / lifted words) in the
+// TextResponseComprehensionSolution model,
+// for the purpose of MVP testing and will be replaced with a
+// more intuitive input method (e.g. the tokens for Skills) soon.
+$(document).ready(() => {
+  function replaceBracketFromComprehensionAttributes() {
+    if (document.getElementsByClassName('table-comprehension').length == 0)
+      return; // do nothing if not comprehension question
+
+    var addFields = $('.table-comprehension a.add_fields');
+    addFields.each((index) => {
+      addFields[index].setAttribute(
+        'data-association-insertion-node',
+        replaceBracketWithUnderscore(addFields[index].getAttribute('data-association-insertion-node'))
+      );
+    });
+
+    var tbody = $('.table-comprehension tbody');
+    var tdSolution = $('.table-comprehension td.td-solution');
+    var aSolutionButton = $('.table-comprehension a.solution-button');
+    var tableElements = jQuery.merge(jQuery.merge(tbody, tdSolution), aSolutionButton);
+    tableElements.each((index) => {
+      tableElements[index].className = replaceBracketWithUnderscore(tableElements[index].className);
+    });
+  }
+
+  function replaceBracketWithUnderscore(string) {
+    return string.replace(/[\[\]']/g, '_');
+  }
+
+  function addSolutionField(event) {
+    event.preventDefault();
+    var thisClassNameArr = this.className.split(' ');
+    var thisClassNameLast = thisClassNameArr[thisClassNameArr.length - 1];
+    var tdToFind = 'td.' + thisClassNameLast;
+    $lastSolutionField = $(tdToFind + ' input:last-of-type').clone();
+    $lastSolutionField.val("");
+    $(tdToFind + ' div.form-group input:last-of-type').after($lastSolutionField);
+  };
+
+  replaceBracketFromComprehensionAttributes();
+  $('a.solution-button').on('click', addSolutionField);
+
+  $('.table-comprehension').on('cocoon:after-insert', (e, node) => {
+    replaceBracketFromComprehensionAttributes();
+    node.find('td.td-solution-button a.solution-button').on('click', addSolutionField);
+  });
+});

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -98,6 +98,7 @@ en:
           text_responses:
             new_text_response: :'course.assessment.question.text_responses.new.text_response'
             new_file_upload: :'course.assessment.question.text_responses.new.file_upload'
+            new_comprehension: :'course.assessment.question.text_responses.new.comprehension'
           programming:
             new: :'course.assessment.question.programming.new.header'
           scribing:

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -41,6 +41,8 @@ en:
             file_upload: 'File Upload'
             programming: 'Programming'
             scribing: 'Scribing'
+            # TODO: Uncomment the line below when TextResponseComprehension is ready
+            # comprehension: 'Comprehension'
           non_auto_gradable_questions: >
             Some of the questions in this assessment are not auto-gradable.
             The autograder will always award the maximum grade for these questions.

--- a/config/locales/en/course/assessment/question/text_response.yml
+++ b/config/locales/en/course/assessment/question/text_response.yml
@@ -6,6 +6,7 @@ en:
           new:
             text_response: 'New Text Response Question'
             file_upload: 'New File Upload Question'
+            comprehension: 'New Comprehension Question'
           create:
             success: 'The %{name} was created.'
           update:
@@ -32,3 +33,28 @@ en:
           solution_fields:
             explanation_hint: 'The explanation to show after the student submits his answer.'
             remove: 'Remove'
+          form_comprehension:
+            multiline_explanation_comprehension_html: >
+              Adding solutions allows the question to be autograded. Students can only input plaintext.
+            add_group: 'Add Group'
+            comprehension: 'Comprehension Question'
+            text_response_autograde: 'Note: If no solutions are provided, the autograder will always award the maximum grade.'
+          comprehension_group_fields:
+            group: 'Group'
+            remove_group: 'Remove Group'
+            maximum_group_grade: 'Maximum Grade for this Group'
+            add_point: 'Add Point'
+          comprehension_point_fields:
+            point: 'Point'
+            remove_point: 'Remove Point'
+            point_grade: 'Grade for this Point'
+            add_solution: 'Add Solution'
+            solution_type: 'Type'
+            solution: 'Solution'
+            explanation: 'Explanation'
+          comprehension_solution_fields:
+            explanation_hint: 'The explanation to show after the student submits his answer.'
+            add_solution_word: 'Add Solution Word'
+            remove: 'Remove'
+            compre_keyword: 'Keyword'
+            compre_lifted_word: 'Lifted Word'

--- a/spec/models/course/assessment/question/text_response_comprehension_solution_spec.rb
+++ b/spec/models/course/assessment/question/text_response_comprehension_solution_spec.rb
@@ -29,20 +29,6 @@ RSpec.describe Course::Assessment::Question::TextResponseComprehensionSolution, 
           expect(subject.solution_lemma).to eq(['content'])
         end
       end
-
-      describe '#solution_lemma' do
-        subject do
-          build_stubbed(:course_assessment_question_text_response_comprehension_solution, \
-                        solution_lemma: [])
-        end
-
-        it 'validates that solution_lemma is not empty' do
-          expect(subject.valid?).to be(false)
-          expect(subject.errors[:solution_lemma]).to include(I18n.t('activerecord.errors.models.' \
-              'course/assessment/question/text_response_comprehension_solution.attributes.' \
-              'solution_lemma.solution_lemma_empty'))
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
References #2644, #2746.

Dependent on #2831.

For MVP, an array of text fields is used for staff to input solution words -- each word in one field.
This will be replaced with a token/tag-like input (similar to Skills in each assessment question) in the final version.