### PR TITLE
Change Video comments' editor

### DIFF
--- a/app/views/course/video/topics/_post.json.jbuilder
+++ b/app/views/course/video/topics/_post.json.jbuilder
@@ -1,7 +1,8 @@
 json.partial! 'course/users/user', locals: { user: post.creator }
 
 json.createdAt format_datetime(post.created_at)
-json.content format_html(post.text)
+json.content format_html(simple_format(post.text))
+json.rawContent post.text
 json.canUpdate can?(:update, post)
 json.canDelete can?(:destroy, post)
 json.topicId post.topic.specific.id.to_s

--- a/client/app/bundles/course/video/submission/actions/discussion.js
+++ b/client/app/bundles/course/video/submission/actions/discussion.js
@@ -364,7 +364,8 @@ export function updatePostOnServer(postId) {
           editedContent: null,
           editMode: false,
           status: postRequestingStatuses.LOADED,
-          content: data.text,
+          content: data.formattedText,
+          rawContent: data.text,
         }));
         dispatch(setNotification('Comment edited'));
       })

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/EditPostContainer.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/EditPostContainer.jsx
@@ -21,7 +21,7 @@ const propTypes = {
 function mapStateToProps(state, ownProps) {
   const postObject = state.discussion.posts.get(ownProps.postId);
   return {
-    content: postObject.editedContent || postObject.content,
+    content: postObject.editedContent || postObject.rawContent,
     disabled: postObject.status === postRequestingStatuses.LOADING,
     submitButtonText: (<FormattedMessage {...translations.edit} />),
   };

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Editor.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Editor.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import ReactSummernote from 'react-summernote';
 import RaisedButton from 'material-ui/RaisedButton';
+import TextField from 'material-ui/TextField';
 
 import style from '../Discussion.scss';
 
@@ -16,22 +16,6 @@ const translations = defineMessages({
     defaultMessage: 'Cancel',
   },
 });
-
-const editorOptions = {
-  airMode: true,
-  dialogsInBody: false,
-  popover: {
-    air: [
-      ['style', ['style']],
-      ['font', ['bold', 'underline', 'clear']],
-      ['script', ['superscript', 'subscript']],
-      ['color', ['color']],
-      ['para', ['ul', 'ol', 'paragraph']],
-      ['table', ['table']],
-      ['insert', ['link', 'picture']],
-    ],
-  },
-};
 
 const propTypes = {
   content: PropTypes.string.isRequired,
@@ -55,10 +39,14 @@ const defaultProps = {
 function Editor(props) {
   return (
     <div>
-      <ReactSummernote
-        options={Object.assign({}, editorOptions, { disabled: props.disabled })}
+      <TextField
+        fullWidth
+        multiLine
+        floatingLabelText="Enter your comment here"
+        rows={2}
+        rowsMax={4}
         value={props.content}
-        onChange={props.onContentUpdate}
+        onChange={event => props.onContentUpdate(event.target.value)}
       />
       <div className={style.editorExtraElement}>
         {props.children}

--- a/db/migrate/20180117025349_convert_video_posts_to_plain_text.rb
+++ b/db/migrate/20180117025349_convert_video_posts_to_plain_text.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class ConvertVideoPostsToPlainText < ActiveRecord::Migration[5.1]
+  def up
+    Course::Discussion::Post.
+      joins(:topic).
+      where(course_discussion_topics: { actable_type: Course::Video::Topic.name }).
+      find_each do |post|
+      post_text = post.text.
+                  gsub('<p>', '').
+                  gsub('</p>', "\n").
+                  gsub('<br>', "\n").
+                  gsub('<br />', "\n").
+                  strip
+
+      next if post_text.empty?
+      sanitized_text = Sanitize.
+                       fragment(post_text, Sanitize::Config::BASIC).
+                       strip.
+                       encode(universal_newline: true)
+
+      post.update_column(:text, sanitized_text)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180111081847) do
+ActiveRecord::Schema.define(version: 20180117025349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Changed from Summernote to a regular text field. This change makes the
formatting for video comments similar to that of assessment comments.

Context is that we want `<code></code>` formatting in video comments.

Tested on old comments entered by Summernote. As long as old comments do not have complex elements like a full table, the difference is minimal. (Unfortunately the old `<code></code>` are already escaped, so we can't do anything here.

The `<p>` tags inserted by summernote however, will show up in the comment edit field. I feel that it's an okay compromise since I expect edits on old comments to be minimal, but I'm open to suggestions.