### PR TITLE
Speed up read_marks insertion for discussion topics.

### DIFF
--- a/db/migrate/20180111081847_add_read_status_to_topics.rb
+++ b/db/migrate/20180111081847_add_read_status_to_topics.rb
@@ -5,7 +5,10 @@ class AddReadStatusToTopics < ActiveRecord::Migration[5.1]
     #
     # This does not affect Forums because ReadMarks are declared on those
     # models rather than on Course::Discussion::Topic.
-    User.find_each { |user| Course::Discussion::Topic.mark_as_read! :all, for: user }
+    execute <<-SQL
+      INSERT INTO read_marks(readable_type, reader_id, timestamp, reader_type)
+        SELECT 'Course::Discussion::Topic', id, NOW(), 'User' FROM users
+    SQL
   end
 
   def down


### PR DESCRIPTION
```
rake db:migrate
== 20180111081847 AddReadStatusToTopics: migrating ============================
-- execute("      INSERT INTO read_marks(readable_type, reader_id, timestamp, reader_type)\n        SELECT 'Course::Discussion::Topic', id, NOW(), 'User' FROM users\n")
   -> 1.6598s
== 20180111081847 AddReadStatusToTopics: migrated (1.6600s) ===================
```

Speeds up the migration for #2743 to prevent the database being blocked for around 5 minutes.