### PR TITLE
Send announcement emails at the announcement start_at time

### DIFF
--- a/app/jobs/course/announcement/opening_reminder_job.rb
+++ b/app/jobs/course/announcement/opening_reminder_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class Course::Announcement::OpeningReminderJob < ApplicationJob
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # Prevent the job from retrying due to deleted records
+  end
+
+  protected
+
+  def perform(user, announcement, token)
+    instance = Course.unscoped { announcement.course.instance }
+    ActsAsTenant.with_tenant(instance) do
+      Course::Announcement::ReminderService.opening_reminder(user, announcement, token)
+    end
+  end
+end

--- a/app/models/concerns/course/closing_reminder_concern.rb
+++ b/app/models/concerns/course/closing_reminder_concern.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# This concern provides common reminder methods for lesson_plan_items, specifically reminders:
+#   - When the lesson_plan_item is about to close
+#
+# When including this concern, the model is to implement the following for the reminders:
+#   - #{Model-Name}::CloseReminderJob
+#
+# Note that to prevent duplicate jobs, a random number of milliseconds is added to the date fields
+# for each change to uniquely identify the most current set of jobs.
+module Course::ClosingReminderConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :setup_closing_reminders, if: :end_at_changed?
+  end
+
+  private
+
+  def class_name
+    self.class.name
+  end
+
+  def closing_reminder_job_class
+    "#{class_name}::ClosingReminderJob".constantize
+  end
+
+  def setup_closing_reminders
+    # Use current time as token to prevent duplicate notification.
+    self.closing_reminder_token = Time.zone.now.to_f.round(5)
+
+    execute_after_commit do
+      # Send notification one day before the closing date
+      if end_at && end_at > Time.zone.now
+        closing_reminder_job_class.set(wait_until: end_at - 1.day).
+          perform_later(self, closing_reminder_token)
+      end
+    end
+  end
+end

--- a/app/models/concerns/course/opening_reminder_concern.rb
+++ b/app/models/concerns/course/opening_reminder_concern.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+#
+# This concern provides common reminder methods for lesson_plan_items, specifically reminders:
+#   - When the lesson_plan_item is open for students to attempt
+#
+# When including this concern, the model is to implement the following for the reminders:
+#   - #{Model-Name}::OpeningReminderJob
+#
+# Note that to prevent duplicate jobs, a random number of milliseconds is added to the date fields
+# for each change to uniquely identify the most current set of jobs.
+module Course::OpeningReminderConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :setup_opening_reminders, if: :start_at_changed?
+  end
+
+  private
+
+  def class_name
+    self.class.name
+  end
+
+  def opening_reminder_job_class
+    "#{class_name}::OpeningReminderJob".constantize
+  end
+
+  def setup_opening_reminders
+    # Use current time as token to prevent duplicate notification. The float need to be round so
+    # that the value stores in database will be consistent with the value passed to the job.
+    self.opening_reminder_token = Time.zone.now.to_f.round(5)
+
+    # Determine whether or not to send the opening reminder.
+    send_opening_reminder = start_at && should_send_opening_reminder
+
+    execute_after_commit do
+      if send_opening_reminder
+        opening_reminder_job_class.set(wait_until: start_at).
+          perform_later(updater, self, opening_reminder_token)
+      end
+    end
+  end
+
+  # Determines whether the opening reminder should be sent. Reminders always should be sent unless
+  # the start_at and the old start_at dates are both in the past.
+  #
+  # Note: This should be invoked outside of the +execute_after_commit+ block, as
+  # ActiveRecord::Dirty methods and attributes are not applied as the record has been saved.
+  #
+  # @return [Boolean] True if an opening reminder should be sent
+  def should_send_opening_reminder
+    time_now = Time.zone.now
+    return false if start_at && start_at_was && start_at < time_now && start_at_was < time_now
+    true
+  end
+end

--- a/app/models/concerns/course/reminder_concern.rb
+++ b/app/models/concerns/course/reminder_concern.rb
@@ -13,64 +13,6 @@
 module Course::ReminderConcern
   extend ActiveSupport::Concern
 
-  included do
-    before_save :setup_opening_reminders, if: :start_at_changed?
-    before_save :setup_closing_reminders, if: :end_at_changed?
-  end
-
-  private
-
-  def class_name
-    self.class.name
-  end
-
-  def opening_reminder_job_class
-    "#{class_name}::OpeningReminderJob".constantize
-  end
-
-  def closing_reminder_job_class
-    "#{class_name}::ClosingReminderJob".constantize
-  end
-
-  def setup_opening_reminders
-    # Use current time as token to prevent duplicate notification. The float need to be round so
-    # that the value stores in database will be consistent with the value passed to the job.
-    self.opening_reminder_token = Time.zone.now.to_f.round(5)
-
-    # Determine whether or not to send the opening reminder.
-    send_opening_reminder = start_at && should_send_opening_reminder
-
-    execute_after_commit do
-      if send_opening_reminder
-        opening_reminder_job_class.set(wait_until: start_at).
-          perform_later(updater, self, opening_reminder_token)
-      end
-    end
-  end
-
-  def setup_closing_reminders
-    # Use current time as token to prevent duplicate notification.
-    self.closing_reminder_token = Time.zone.now.to_f.round(5)
-
-    execute_after_commit do
-      # Send notification one day before the closing date
-      if end_at && end_at > Time.zone.now
-        closing_reminder_job_class.set(wait_until: end_at - 1.day).
-          perform_later(self, closing_reminder_token)
-      end
-    end
-  end
-
-  # Determines whether the opening reminder should be sent. Reminders always should be sent unless
-  # the start_at and the old start_at dates are both in the past.
-  #
-  # Note: This should be invoked outside of the +execute_after_commit+ block, as
-  # ActiveRecord::Dirty methods and attributes are not applied as the record has been saved.
-  #
-  # @return [Boolean] True if an opening reminder should be sent
-  def should_send_opening_reminder
-    time_now = Time.zone.now
-    return false if start_at && start_at_was && start_at < time_now && start_at_was < time_now
-    true
-  end
+  include Course::OpeningReminderConcern
+  include Course::ClosingReminderConcern
 end

--- a/app/models/course/announcement.rb
+++ b/app/models/course/announcement.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 class Course::Announcement < ApplicationRecord
   include AnnouncementConcern
+  include Course::ReminderConcern
 
   acts_as_readable on: :updated_at
   has_many_attachments on: :content
-
-  after_create :send_notification
 
   belongs_to :course, inverse_of: :announcements
 
@@ -18,7 +17,7 @@ class Course::Announcement < ApplicationRecord
 
   private
 
-  def send_notification
-    Course::AnnouncementNotifier.new_announcement(creator, self)
-  end
+  # Override this function from the ReminderConcern as we don't want closing reminders
+  # from announcements
+  def setup_closing_reminders; end
 end

--- a/app/models/course/announcement.rb
+++ b/app/models/course/announcement.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::Announcement < ApplicationRecord
   include AnnouncementConcern
-  include Course::ReminderConcern
+  include Course::OpeningReminderConcern
 
   acts_as_readable on: :updated_at
   has_many_attachments on: :content
@@ -14,10 +14,4 @@ class Course::Announcement < ApplicationRecord
   def to_partial_path
     'course/announcements/announcement'
   end
-
-  private
-
-  # Override this function from the ReminderConcern as we don't want closing reminders
-  # from announcements
-  def setup_closing_reminders; end
 end

--- a/app/services/course/announcement/reminder_service.rb
+++ b/app/services/course/announcement/reminder_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Course::Announcement::ReminderService
+  class << self
+    delegate :opening_reminder, to: :new
+  end
+
+  def opening_reminder(user, announcement, token)
+    return unless announcement.opening_reminder_token == token
+
+    Course::AnnouncementNotifier.new_announcement(user, announcement)
+  end
+end

--- a/db/migrate/20180119064953_add_tokens_to_course_announcements.rb
+++ b/db/migrate/20180119064953_add_tokens_to_course_announcements.rb
@@ -1,0 +1,10 @@
+class AddTokensToCourseAnnouncements < ActiveRecord::Migration[5.1]
+  def change
+    add_column :course_announcements, :opening_reminder_token, :float
+
+    # This is similar to adding tokens to lesson plan items for assessments in
+    # db/migrate/20170116103602_add_tokens_to_course_lesson_plan_items.rb.
+    # There are currently no future announcements, even if there are, the emails have already
+    # been sent so don't create new jobs to send them again.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180117025350) do
+ActiveRecord::Schema.define(version: 20180119064953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20180117025350) do
     t.boolean  "sticky",     :default=>false, :null=>false
     t.datetime "start_at",   :null=>false
     t.datetime "end_at",     :null=>false
+    t.float    "opening_reminder_token"
     t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_announcements_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_announcements_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_announcements_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_announcements_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at", :null=>false

--- a/spec/jobs/course/announcement/opening_reminder_job_spec.rb
+++ b/spec/jobs/course/announcement/opening_reminder_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Announcement::OpeningReminderJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:announcement) { create(:course_announcement, start_at: old_start_at) }
+    let(:time_now) { Time.zone.now }
+    before { announcement.start_at = new_start_at }
+    subject { announcement.save }
+
+    context 'when old start_at is in the past' do
+      let(:old_start_at) { time_now - 2.days }
+
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Announcement::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 3.days }
+        it { expect { subject }.not_to have_enqueued_job(Course::Announcement::OpeningReminderJob) }
+      end
+    end
+
+    context 'when old start_at is in the future' do
+      let(:old_start_at) { time_now + 2.days }
+
+      context 'when new start_at is in the future' do
+        let(:new_start_at) { time_now + 3.days }
+        it { expect { subject }.to have_enqueued_job(Course::Announcement::OpeningReminderJob) }
+      end
+
+      context 'when new start_at is in the past' do
+        let(:new_start_at) { time_now - 2.days }
+        it { expect { subject }.to have_enqueued_job(Course::Announcement::OpeningReminderJob) }
+      end
+    end
+  end
+end

--- a/spec/notifiers/course/announcement_notifier_spec.rb
+++ b/spec/notifiers/course/announcement_notifier_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Course::AnnouncementNotifier, type: :notifier do
       let(:announcement) { create(:course_announcement, course: course) }
 
       before do
-        allow_any_instance_of(Course::Announcement).to receive(:send_notification)
+        allow_any_instance_of(Course::Announcement).to receive(:setup_opening_reminders)
       end
 
       subject { Course::AnnouncementNotifier.new_announcement(user, announcement) }

--- a/spec/services/course/announcement/reminder_service_spec.rb
+++ b/spec/services/course/announcement/reminder_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Announcement::ReminderService do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+
+    describe '#opening_reminder' do
+      let!(:now) { Time.zone.now }
+      let(:user) { create(:course_user, course: course).user }
+      let!(:announcement) { create(:course_announcement, start_at: now) }
+
+      context 'when announcement is created' do
+        it 'notify the users' do
+          expect_any_instance_of(Course::AnnouncementNotifier).to receive(:new_announcement).once
+          subject.opening_reminder(user, announcement, announcement.opening_reminder_token)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of sending announcement emails immediately, send them when the announcement starts.

This implements the same concept of using a token as lesson plan item reminders.

Fixes #2761.

Can review first, will add tests.

