### PR TITLE
Migrate only java packages for multiple_file_submission

### DIFF
--- a/db/migrate/20180117025350_add_multiple_file_submission_to_question_programming.rb
+++ b/db/migrate/20180117025350_add_multiple_file_submission_to_question_programming.rb
@@ -2,10 +2,15 @@ class AddMultipleFileSubmissionToQuestionProgramming < ActiveRecord::Migration[5
   def up
     add_column :course_assessment_question_programming, :multiple_file_submission, :boolean, default: false, null: false
 
-    Course::Assessment::Question::Programming.find_each do |question|
-      service = Course::Assessment::Question::Programming::ProgrammingPackageService.new(question, nil)
-      meta = service.extract_meta
-      question.update_attribute(:multiple_file_submission, true) if meta && meta[:data] && meta[:data]['submit_as_file']
+    # Finds all Coursemology::Polyglot::Language::Java programming questions
+    language_id = Coursemology::Polyglot::Language::Java.ids.first
+    Course::Assessment::Question::Programming.where(language_id: language_id).find_each do |question|
+      begin
+        service = Course::Assessment::Question::Programming::ProgrammingPackageService.new(question, nil)
+        meta = service.extract_meta
+        question.update_column(:multiple_file_submission, true) if meta && meta[:data] && meta[:data]['submit_as_file']
+      rescue
+      end
     end
   end
 


### PR DESCRIPTION
Modifications to migration for #2436
1) Ensure that migration only checks java packages
2) Catch errors if file not found 