### PR TITLE
Allow filtering by roles on users listing

### DIFF
--- a/app/controllers/system/admin/users_controller.rb
+++ b/app/controllers/system/admin/users_controller.rb
@@ -4,9 +4,8 @@ class System::Admin::UsersController < System::Admin::Controller
   add_breadcrumb :index, :admin_users_path
 
   def index
-    @users = @users.human_users.includes(:emails).ordered_by_name.page(page_param).search(search_param)
-    @users = @users.active_in_past_7_days if params[:active]
-
+    load_users
+    load_counts
     @instances_preload_service = User::InstancePreloadService.new(@users.map(&:id))
   end
 
@@ -27,6 +26,19 @@ class System::Admin::UsersController < System::Admin::Controller
   end
 
   private
+
+  def load_users
+    @users = @users.human_users.includes(:emails).ordered_by_name.page(page_param).search(search_param)
+    @users = @users.active_in_past_7_days if params[:active]
+    @users = @users.where(role: params[:role]) if params[:role] && User.roles.key?(params[:role])
+  end
+
+  def load_counts
+    @counts = {
+      total: User.group(:role).count,
+      active: User.active_in_past_7_days.group(:role).count
+    }.with_indifferent_access
+  end
 
   def user_params
     params.require(:user).permit(:name, :role)

--- a/app/helpers/system/admin/instance/users_helper.rb
+++ b/app/helpers/system/admin/instance/users_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module System::Admin::Instance::UsersHelper
+  include System::Admin::UsersHelper
+end

--- a/app/helpers/system/admin/users_helper.rb
+++ b/app/helpers/system/admin/users_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module System::Admin::UsersHelper
+  # Wraps the user count in a link unless the the linked page is the current page,
+  # or the user count is nil or zero.
+  def user_count_link(page_params, user_count, link_params)
+    return 0 unless user_count
+    link_active = page_params[:active] == link_params[:active] && page_params[:role] == link_params[:role]
+    link_active ? user_count : link_to(user_count, link_params)
+  end
+end

--- a/app/views/system/admin/instance/users/index.html.slim
+++ b/app/views/system/admin/instance/users/index.html.slim
@@ -1,14 +1,21 @@
 = page_header
 
-- total_users = current_tenant.instance_users.count
-- active_users = current_tenant.instance_users.active_in_past_7_days.count
-
 - if params[:search].blank?
   .panel.panel-default
     .panel-heading = t('common.summary')
     .panel-body
-      div = t('.total_users_html', count: params[:active] ? link_to(total_users) : total_users)
-      div = t('.active_users_html', count: params[:active] ? active_users : link_to(active_users, active: true))
+      div
+        = t('.total_users_html',
+            admin_count: user_count_link(params, @counts[:total][:administrator], { role: 'administrator' }),
+            instructor_count: user_count_link(params, @counts[:total][:instructor], { role: 'instructor' }),
+            normal_count: user_count_link(params, @counts[:total][:normal], { role: 'normal' }),
+            all_count: user_count_link(params, @counts[:total].values.sum, {}))
+      div
+        = t('.active_users_html',
+            admin_count: user_count_link(params, @counts[:active][:administrator], { active: 'true', role: 'administrator' }),
+            instructor_count: user_count_link(params, @counts[:active][:instructor], { active: 'true', role: 'instructor' }),
+            normal_count: user_count_link(params, @counts[:active][:normal], { active: 'true', role: 'normal' }),
+            all_count: user_count_link(params, @counts[:active].values.sum, { active: 'true' }))
 
 = render partial: 'layouts/search_form', locals: { url: admin_instance_users_path, placeholder: t('.search_placeholder') }
 

--- a/app/views/system/admin/users/index.html.slim
+++ b/app/views/system/admin/users/index.html.slim
@@ -1,13 +1,19 @@
 = page_header
 
-- total_users = User.count
-- active_users = User.active_in_past_7_days.count
 - if params[:search].blank?
   .panel.panel-default
     .panel-heading = t('common.summary')
     .panel-body
-      div = t('.total_users_html', count: params[:active] ? link_to(total_users) : total_users)
-      div = t('.active_users_html', count: params[:active] ? active_users : link_to(active_users, active: true))
+      div
+        = t('.total_users_html',
+            admin_count: user_count_link(params, @counts[:total][:administrator], { role: 'administrator' }),
+            normal_count: user_count_link(params, @counts[:total][:normal], { role: 'normal' }),
+            all_count: user_count_link(params, @counts[:total].values.sum, {}))
+      div
+        = t('.active_users_html',
+            admin_count: user_count_link(params, @counts[:active][:administrator], { active: 'true', role: 'administrator' }),
+            normal_count: user_count_link(params, @counts[:active][:normal], { active: 'true', role: 'normal' }),
+            all_count: user_count_link(params, @counts[:active].values.sum, { active: 'true' }))
 
 = render partial: 'layouts/search_form', locals: { url: admin_users_path, placeholder: t('.search_placeholder') }
 

--- a/config/locales/en/system/admin/instance/users.yml
+++ b/config/locales/en/system/admin/instance/users.yml
@@ -7,8 +7,13 @@ en:
             header: 'Users'
             related_courses: 'Related Courses'
             search_placeholder: 'Search user name or emails'
-            total_users_html: 'Total Users: <strong>%{count}</strong>'
-            active_users_html: 'Active Users (in the past 7 days): <strong>%{count}</strong>'
+            total_users_html: >
+              <strong>Total Users</strong>: <strong>%{all_count}</strong>
+              (%{admin_count} Administrators, %{instructor_count} Instructors, %{normal_count} Normal)
+            active_users_html: >
+              <strong>Active Users</strong>: <strong>%{all_count}</strong>
+              (%{admin_count} Administrators, %{instructor_count} Instructors, %{normal_count} Normal)<br>
+              (active in the past 7 days)
           update:
             success: '%{user} was updated.'
           destroy:

--- a/config/locales/en/system/admin/users.yml
+++ b/config/locales/en/system/admin/users.yml
@@ -6,8 +6,13 @@ en:
           header: 'Users'
           related_instances: 'Instances'
           search_placeholder: 'Search user name or emails'
-          total_users_html: 'Total Users: <strong>%{count}</strong>'
-          active_users_html: 'Active Users (in the past 7 days): <strong>%{count}</strong>'
+          total_users_html: >
+            <strong>Total Users</strong>: <strong>%{all_count}</strong>
+            (%{admin_count} Administrators, %{normal_count} Normal)
+          active_users_html: >
+            <strong>Active Users</strong>: <strong>%{all_count}</strong>
+            (%{admin_count} Administrators, %{normal_count} Normal)<br>
+            (active in the past 7 days)
         update:
           success: '%{user} was updated.'
         destroy:

--- a/spec/features/system/admin/instance/user_management_spec.rb
+++ b/spec/features/system/admin/instance/user_management_spec.rb
@@ -22,6 +22,18 @@ RSpec.feature 'System: Administration: Instance: Users' do
         expect(page.all('tr.instance_user').count).to eq(instance.instance_users.count)
       end
 
+      scenario 'I can filter users by role and view only administrators' do
+        visit admin_instance_users_path(role: :administrator)
+
+        instance_users.each do |instance_users|
+          expect(page).not_to have_selector('tr.instance_user th', text: instance_users.user.name)
+          expect(page).not_to have_selector('tr.instance_user td', text: instance_users.user.email)
+        end
+
+        expect(page).to have_selector('tr.instance_user th', text: instance_admin.name)
+        expect(page).to have_selector('tr.instance_user td', text: instance_admin.email)
+      end
+
       scenario "I can change a user's role", js: true do
         visit admin_instance_users_path
 

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -22,6 +22,18 @@ RSpec.feature 'System: Administration: Users' do
         end
       end
 
+      scenario 'I can filter users by role and view only administrators' do
+        visit admin_users_path(role: :administrator)
+
+        users.select(&:normal?).each do |user|
+          expect(page).not_to have_selector("tr.user input[value='#{user.name}']")
+          expect(page).not_to have_selector('tr.user td', text: user.email)
+        end
+
+        expect(page).to have_selector("tr.user input[value='#{admin.name}']")
+        expect(page).to have_selector('tr.user td', text: admin.email)
+      end
+
       scenario "I can change a user's record", js: true do
         visit admin_users_path
 


### PR DESCRIPTION
In particular, we would like to easily find out who the instance admins are.