### PR TITLE
Video local storage

### DIFF
--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -4,8 +4,12 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
 
   def update
     # We received a message from client, so time is updated regardless of how event records turn out
-    @session.update_attributes!(session_end: Time.zone.now,
-                                last_video_time: session_params[:last_video_time])
+    if params[:is_old_session]
+      @session.update_attributes!(last_video_time: session_params[:last_video_time])
+    else
+      @session.update_attributes!(session_end: Time.zone.now,
+                                  last_video_time: session_params[:last_video_time])
+    end
     @session.merge_in_events!(session_params[:events])
   rescue ArgumentError => _
     head :bad_request

--- a/app/views/course/video/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/video/submission/submissions/edit.json.jbuilder
@@ -1,7 +1,7 @@
 json.video do
   json.videoUrl @video.url
   json.partial! 'watch_next_video_url', locals: { next_video: @video.next_video }
-  json.sessionId @session.try(:id)
+  json.sessionId @session&.id&.to_s
 end
 
 json.discussion do

--- a/app/views/course/video/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/video/submission/submissions/edit.json.jbuilder
@@ -11,3 +11,5 @@ json.discussion do
     json.scrollTopicId @scroll_topic_id
   end
 end
+
+json.courseUserId current_course_user&.id&.to_s

--- a/client/.eslintrc.test
+++ b/client/.eslintrc.test
@@ -9,6 +9,7 @@
     "intlShape": true,
     "sleep": true,
     "buildContextOptions": true,
+    "localStorage": true,
   },
   "rules": {
     "react/no-find-dom-node": "off",

--- a/client/app/api/course/Video/Sessions.js
+++ b/client/app/api/course/Video/Sessions.js
@@ -23,12 +23,14 @@ export default class SessionsAPI extends BaseVideoAPI {
    * @param {number} lastVideoTime The last video playback time as of function call
    * @param {Array} events The array of new events (as per shape above) to push to the server. Omit to only update
    * session end time
+   * @param isOldSession true if we're updating a old session
    * @return {Promise} The response from the server
    * success response: 204
    */
-  update(id, lastVideoTime, events = []) {
+  update(id, lastVideoTime, events = [], isOldSession = false) {
     return this.getClient().patch(`${this._getUrlPrefix()}/${id}`, {
       session: { last_video_time: lastVideoTime, events },
+      is_old_session: isOldSession,
     });
   }
 

--- a/client/app/bundles/course/video/submission/__test__/store.test.js
+++ b/client/app/bundles/course/video/submission/__test__/store.test.js
@@ -1,0 +1,27 @@
+import store from '../store';
+
+describe('store', () => {
+  describe('when there is no session id', () => {
+    const createdStore = store({
+      video: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+      courseUserId: 1,
+    });
+
+    it('does not return a persistor', () => {
+      expect(Object.keys(createdStore)).toContain('store');
+      expect(Object.keys(createdStore)).not.toContain('persistor');
+    });
+  });
+
+  describe('when there is a session id', () => {
+    const createdStore = store({
+      video: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', sessionId: 1 },
+      courseUserId: 1,
+    });
+
+    it('returns a persistor', () => {
+      expect(Object.keys(createdStore)).toContain('store');
+      expect(Object.keys(createdStore)).toContain('persistor');
+    });
+  });
+});

--- a/client/app/bundles/course/video/submission/__test__/store.test.js
+++ b/client/app/bundles/course/video/submission/__test__/store.test.js
@@ -1,12 +1,62 @@
+import { playerStates } from 'lib/constants/videoConstants';
 import store from '../store';
+import { changePlayerState, updatePlayerProgress } from '../actions/video';
 
-describe('store', () => {
+const videoStateFixture = JSON.stringify({
+  videoUrl: 'https://www.youtube.com/watch?v=sTSA_sWGM44',
+  watchNextVideoUrl: '',
+  nextVideoSubmissionExists: false,
+  playerState: 'PLAYING',
+  playerProgress: 10,
+  duration: 295,
+  bufferProgress: 20,
+  playerVolume: 0.8,
+  playbackRate: 1,
+  restrictContentAfter: null,
+  forceSeek: false,
+  sessionId: '50',
+  sessionSequenceNum: 1,
+  sessionEvents: [{ sequence_num: 0, event_type: 'play', video_time: 0, playback_rate: 1, event_time: Date.now() }],
+  sessionClosed: false,
+});
+
+const oldSessionsFixture = JSON.stringify({
+  25: {
+    videoUrl: 'https://www.youtube.com/watch?v=hSVNbxjdvv8',
+    watchNextVideoUrl: '',
+    nextVideoSubmissionExists: false,
+    playerState: 'PAUSED',
+    playerProgress: 5,
+    duration: 164,
+    bufferProgress: 15,
+    playerVolume: 0.8,
+    playbackRate: 1,
+    restrictContentAfter: null,
+    forceSeek: false,
+    sessionId: '25',
+    sessionSequenceNum: 2,
+    sessionEvents: [
+      { sequence_num: 0, event_type: 'play', video_time: 0, playback_rate: 1, event_time: Date.now() },
+      { sequence_num: 1, event_type: 'pause', video_time: 5, playback_rate: 1, event_time: Date.now() },
+    ],
+    sessionClosed: false,
+  },
+});
+
+function createStore(courseUserId = '1', sessionId = '1') {
+  return store({
+    video: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', sessionId },
+    courseUserId,
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('persistor', () => {
   describe('when there is no session id', () => {
-    const createdStore = store({
-      video: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
-      courseUserId: 1,
-    });
-
+    const createdStore = createStore('1', null);
     it('does not return a persistor', () => {
       expect(Object.keys(createdStore)).toContain('store');
       expect(Object.keys(createdStore)).not.toContain('persistor');
@@ -14,14 +64,158 @@ describe('store', () => {
   });
 
   describe('when there is a session id', () => {
-    const createdStore = store({
-      video: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', sessionId: 1 },
-      courseUserId: 1,
-    });
-
+    const createdStore = createStore();
     it('returns a persistor', () => {
       expect(Object.keys(createdStore)).toContain('store');
       expect(Object.keys(createdStore)).toContain('persistor');
+    });
+
+    describe('when a video state change occurs', () => {
+      it('persists the state to localStorage', async () => {
+        createdStore.store.dispatch(changePlayerState(playerStates.PLAYING));
+        createdStore.store.dispatch(updatePlayerProgress(13));
+        createdStore.persistor.flush();
+
+        expect(localStorage.setItem).toHaveBeenCalled();
+        const persistedState = JSON.parse(localStorage.__STORE__['persist:videoWatchSessionStore:user-1']);
+        expect(persistedState).toHaveProperty('video');
+        const videoState = JSON.parse(persistedState.video);
+        expect(videoState.playerProgress).toBe(13);
+        expect(videoState.playerState).toBe(playerStates.PLAYING);
+        expect(videoState.sessionSequenceNum).toBe(1);
+        expect(videoState.sessionEvents).toHaveLength(1);
+      });
+    });
+  });
+});
+
+describe('store', () => {
+  describe('when no locally stored state exist', () => {
+    it('initializes the video state only', async () => {
+      const createdStore = createStore();
+      await sleep(0.5); // Wait for state to restore
+
+      const state = createdStore.store.getState();
+      const newVideoState = state.video;
+      expect(newVideoState.videoUrl).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      expect(newVideoState.sessionId).toBe('1');
+      expect(newVideoState.playerState).toBe('UNSTARTED');
+      expect(newVideoState.playerProgress).toBe(0);
+      expect(newVideoState.sessionSequenceNum).toBe(0);
+
+      expect(state.oldSessions.count()).toBe(0);
+    });
+  });
+
+  describe('when old video state exists', () => {
+    beforeEach(() => {
+      localStorage.setItem('persist:videoWatchSessionStore:user-1', JSON.stringify({ video: videoStateFixture }));
+    });
+
+    it('appends old video state into oldSessions', async () => {
+      const createdStore = createStore();
+      await sleep(0.5); // Wait for state to restore
+
+      const state = createdStore.store.getState();
+      const newVideoState = state.video;
+      expect(newVideoState.videoUrl).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      expect(newVideoState.sessionId).toBe('1');
+      expect(newVideoState.playerState).toBe(playerStates.UNSTARTED);
+      expect(newVideoState.playerProgress).toBe(0);
+      expect(newVideoState.sessionSequenceNum).toBe(0);
+
+      expect(state.oldSessions.count()).toBe(1);
+      expect(state.oldSessions.has('50')).toBeTruthy();
+      const oldVideoState = state.oldSessions.get('50');
+      expect(oldVideoState.videoUrl).toBe('https://www.youtube.com/watch?v=sTSA_sWGM44');
+      expect(oldVideoState.sessionId).toBe('50');
+      expect(oldVideoState.playerState).toBe(playerStates.PLAYING);
+      expect(oldVideoState.playerProgress).toBe(10);
+      expect(oldVideoState.sessionSequenceNum).toBe(1);
+      expect(oldVideoState.sessionEvents.count()).toBe(1);
+      const oldEvent = oldVideoState.sessionEvents.first();
+      expect(oldEvent.event_type).toBe('play');
+      expect(oldEvent.sequence_num).toBe(0);
+      expect(oldEvent.video_time).toBe(0);
+    });
+  });
+
+  describe('when other oldSessions exists in storage', () => {
+    beforeEach(() => {
+      localStorage.setItem('persist:videoWatchSessionStore:user-1', JSON.stringify({
+        video: videoStateFixture,
+        oldSessions: oldSessionsFixture,
+      }));
+    });
+
+    it('does not interfere with the existing sessions', async () => {
+      const createdStore = createStore();
+      await sleep(0.5); // Wait for state to restore
+
+      const state = createdStore.store.getState();
+      const newVideoState = state.video;
+      expect(newVideoState.videoUrl).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      expect(newVideoState.sessionId).toBe('1');
+      expect(newVideoState.playerState).toBe(playerStates.UNSTARTED);
+      expect(newVideoState.playerProgress).toBe(0);
+      expect(newVideoState.sessionSequenceNum).toBe(0);
+
+      expect(state.oldSessions.count()).toBe(2);
+
+      expect(state.oldSessions.has('50')).toBeTruthy();
+      const oldVideoStateAdded = state.oldSessions.get('50');
+      expect(oldVideoStateAdded.videoUrl).toBe('https://www.youtube.com/watch?v=sTSA_sWGM44');
+      expect(oldVideoStateAdded.sessionId).toBe('50');
+      expect(oldVideoStateAdded.playerState).toBe(playerStates.PLAYING);
+      expect(oldVideoStateAdded.playerProgress).toBe(10);
+      expect(oldVideoStateAdded.sessionSequenceNum).toBe(1);
+      expect(oldVideoStateAdded.sessionEvents.count()).toBe(1);
+      const oldEvent0 = oldVideoStateAdded.sessionEvents.first();
+      expect(oldEvent0.event_type).toBe('play');
+      expect(oldEvent0.sequence_num).toBe(0);
+      expect(oldEvent0.video_time).toBe(0);
+
+      expect(state.oldSessions.has('25')).toBeTruthy();
+      const oldVideoStateOriginal = state.oldSessions.get('25');
+      expect(oldVideoStateOriginal.videoUrl).toBe('https://www.youtube.com/watch?v=hSVNbxjdvv8');
+      expect(oldVideoStateOriginal.sessionId).toBe('25');
+      expect(oldVideoStateOriginal.playerState).toBe(playerStates.PAUSED);
+      expect(oldVideoStateOriginal.playerProgress).toBe(5);
+      expect(oldVideoStateOriginal.sessionSequenceNum).toBe(2);
+      expect(oldVideoStateOriginal.sessionEvents.count()).toBe(2);
+
+      const oldEvent1 = oldVideoStateOriginal.sessionEvents.get(0);
+      expect(oldEvent1.event_type).toBe('play');
+      expect(oldEvent1.sequence_num).toBe(0);
+      expect(oldEvent1.video_time).toBe(0);
+      const oldEvent2 = oldVideoStateOriginal.sessionEvents.get(1);
+      expect(oldEvent2.event_type).toBe('pause');
+      expect(oldEvent2.sequence_num).toBe(1);
+      expect(oldEvent2.video_time).toBe(5);
+    });
+  });
+
+  describe('when old session belongs to another user', () => {
+    beforeEach(() => {
+      localStorage.setItem('persist:videoWatchSessionStore:user-1', JSON.stringify({
+        video: videoStateFixture,
+        oldSessions: oldSessionsFixture,
+      }));
+    });
+
+    it('ignores the stored state', async () => {
+      const createdStore = createStore('2');
+      await sleep(0.5); // Wait for state to restore
+
+      const state = createdStore.store.getState();
+      const newVideoState = state.video;
+      expect(newVideoState.videoUrl).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      expect(newVideoState.sessionId).toBe('1');
+      expect(newVideoState.playerState).toBe(playerStates.UNSTARTED);
+      expect(newVideoState.playerProgress).toBe(0);
+      expect(newVideoState.sessionSequenceNum).toBe(0);
+
+      expect(state.oldSessions.count()).toBe(0);
     });
   });
 });

--- a/client/app/bundles/course/video/submission/actions/__test__/video.test.js
+++ b/client/app/bundles/course/video/submission/actions/__test__/video.test.js
@@ -1,0 +1,103 @@
+import CourseAPI from 'api/course';
+import MockAdapter from 'axios-mock-adapter';
+import { List as makeImmutableList, Map as makeImmutableMap } from 'immutable';
+import store from '../../store';
+import { changePlayerState, endSession, sendEvents } from '../video';
+import { playerStates } from '../../../../../../lib/constants/videoConstants';
+
+const videoId = '1';
+
+const client = CourseAPI.video.sessions.getClient();
+const mock = new MockAdapter(client, { delayResponse: 0 });
+
+const oldSessionsFixtures = makeImmutableMap({
+  25: {
+    videoUrl: 'https://www.youtube.com/watch?v=hSVNbxjdvv8',
+    watchNextVideoUrl: '',
+    nextVideoSubmissionExists: false,
+    playerState: 'PAUSED',
+    playerProgress: 5,
+    duration: 164,
+    bufferProgress: 15,
+    playerVolume: 0.8,
+    playbackRate: 1,
+    restrictContentAfter: null,
+    forceSeek: false,
+    sessionId: '25',
+    sessionSequenceNum: 2,
+    sessionEvents: makeImmutableList([
+      { sequence_num: 0, event_type: 'play', video_time: 0, playback_rate: 1, event_time: Date.now() },
+      { sequence_num: 1, event_type: 'pause', video_time: 5, playback_rate: 1, event_time: Date.now() },
+    ]),
+    sessionClosed: false,
+  },
+});
+
+beforeAll(() => {
+  Object.defineProperty(window.location, 'pathname', {
+    configurable: true,
+    value: `/courses/${courseId}/videos/${videoId}/submission/1/edit`,
+  });
+});
+
+beforeEach(() => {
+  mock.reset();
+  mock.onPatch(`/courses/${courseId}/videos/${videoId}/sessions/32`).reply(200);
+  mock.onPatch(`/courses/${courseId}/videos/${videoId}/sessions/25`).reply(200);
+});
+
+function createStore(oldSessions = {}) {
+  return store({
+    video: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', sessionId: 32, videoId },
+    oldSessions,
+    courseUserId: 100,
+  });
+}
+
+describe('sendEvents', () => {
+  it('sends back old sessions', async () => {
+    const createdStore = createStore(oldSessionsFixtures).store;
+    const spyUpdate = jest.spyOn(CourseAPI.video.sessions, 'update');
+    createdStore.dispatch(sendEvents());
+
+    expect(spyUpdate).toHaveBeenCalledWith('25', 5, oldSessionsFixtures.get('25').sessionEvents.toArray(), true);
+    await sleep(1);
+    expect(createdStore.getState().oldSessions.count()).toBe(0);
+  });
+
+  it('sends back current events', async () => {
+    const createdStore = createStore().store;
+    const spyUpdate = jest.spyOn(CourseAPI.video.sessions, 'update');
+    createdStore.dispatch(changePlayerState(playerStates.PLAYING));
+    expect(createdStore.getState().video.sessionEvents.count()).toBe(1); // Sanity check to ensure events are generated
+    createdStore.dispatch(sendEvents());
+
+    expect(spyUpdate).toHaveBeenCalled();
+    await sleep(1);
+    expect(createdStore.getState().video.sessionEvents.count()).toBe(0);
+  });
+});
+
+describe('endSession', () => {
+  it('sends back events', async () => {
+    const createdStore = createStore().store;
+    const spyUpdate = jest.spyOn(CourseAPI.video.sessions, 'update');
+    createdStore.dispatch(changePlayerState(playerStates.PLAYING));
+    expect(createdStore.getState().video.sessionEvents.count()).toBe(1); // Sanity check to ensure events are generated
+    createdStore.dispatch(sendEvents());
+
+    expect(spyUpdate).toHaveBeenCalled();
+    await sleep(1);
+    expect(createdStore.getState().video.sessionEvents.count()).toBe(0);
+  });
+
+  describe('when there are no events', () => {
+    it('still sends an update', async () => {
+      const createdStore = createStore().store;
+      const spyUpdate = jest.spyOn(CourseAPI.video.sessions, 'update');
+      createdStore.dispatch(endSession());
+
+      expect(spyUpdate).toHaveBeenCalledWith(32, 0, []);
+    });
+  });
+});

--- a/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
@@ -6,7 +6,13 @@ import { playerStates, videoDefaults, youtubeOpts } from 'lib/constants/videoCon
 import { isPlayingState } from 'lib/helpers/videoHelpers';
 
 import styles from './VideoPlayer.scss';
-import { changePlayerState, sendEvents, updatePlayerDuration, updateProgressAndBuffer } from '../actions/video';
+import {
+  changePlayerState,
+  endSession,
+  sendEvents,
+  updatePlayerDuration,
+  updateProgressAndBuffer,
+} from '../actions/video';
 import {
   PlayBackRateSelector,
   PlayButton,
@@ -17,7 +23,7 @@ import {
   NextVideoButton,
 } from './VideoControls';
 
-const tickMilliseconds = 1000;
+const tickMilliseconds = 5000;
 
 const reactPlayerStyle = {
   position: 'absolute',
@@ -39,6 +45,7 @@ const propTypes = {
   onDurationReceived: PropTypes.func,
   onPlayerStateChanged: PropTypes.func,
   onTick: PropTypes.func,
+  onUnmount: PropTypes.func,
 };
 
 const defaultProps = {
@@ -68,6 +75,8 @@ class VideoPlayer extends React.Component {
 
   componentDidMount() {
     if (this.props.onTick) {
+      this.props.onTick();
+      window.addEventListener('beforeunload', this.props.onUnmount);
       this.timer = setInterval(this.props.onTick, tickMilliseconds);
     }
   }
@@ -81,7 +90,8 @@ class VideoPlayer extends React.Component {
   componentWillUnmount() {
     if (this.timer) {
       this.clearInterval(this.timer);
-      this.props.onTick(); // Will not be null as long as timer exists.
+      this.props.onUnmount();
+      window.removeEventListener('beforeunload', this.props.onUnmount);
     }
   }
 
@@ -161,6 +171,7 @@ function mapDispatchToProps(dispatch) {
     onDurationReceived: duration => dispatch(updatePlayerDuration(duration)),
     onPlayerStateChanged: newState => dispatch(changePlayerState(newState)),
     onTick: () => dispatch(sendEvents()),
+    onUnmount: () => dispatch(endSession()),
   };
 }
 

--- a/client/app/bundles/course/video/submission/reducers/index.js
+++ b/client/app/bundles/course/video/submission/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import video, { initialState as videoState } from './video';
 import discussion, { initialState as discussionState, organiseDiscussionEntities } from './discussion';
 import notification, { initialState as notificationState } from './notification';
+import oldSessions, { initialState as oldSessionsState } from './oldSessions';
 
 /**
  * Creates the initial state from the props parsed in from JSON.
@@ -20,6 +21,7 @@ export function createInitialState(props) {
     video: Object.assign({}, videoState, props.video),
     discussion: Object.assign({}, discussionState, organiseDiscussionEntities(props.discussion)),
     notification: Object.assign({}, notificationState, props.notification),
+    oldSessions: oldSessionsState.merge(props.oldSessions),
   };
 }
 
@@ -27,4 +29,5 @@ export default combineReducers({
   video,
   discussion,
   notification,
+  oldSessions,
 });

--- a/client/app/bundles/course/video/submission/reducers/index.js
+++ b/client/app/bundles/course/video/submission/reducers/index.js
@@ -1,8 +1,8 @@
 import { combineReducers } from 'redux';
-import video, { initialState as videoState } from './video';
+import video, { initialState as videoState, persistTransform as videoTransform } from './video';
 import discussion, { initialState as discussionState, organiseDiscussionEntities } from './discussion';
 import notification, { initialState as notificationState } from './notification';
-import oldSessions, { initialState as oldSessionsState } from './oldSessions';
+import oldSessions, { initialState as oldSessionsState, persistTransform as oldSessionsTransform } from './oldSessions';
 
 /**
  * Creates the initial state from the props parsed in from JSON.
@@ -24,6 +24,8 @@ export function createInitialState(props) {
     oldSessions: oldSessionsState.merge(props.oldSessions),
   };
 }
+
+export const persistTransforms = [videoTransform, oldSessionsTransform];
 
 export default combineReducers({
   video,

--- a/client/app/bundles/course/video/submission/reducers/oldSessions.js
+++ b/client/app/bundles/course/video/submission/reducers/oldSessions.js
@@ -1,10 +1,15 @@
 import { List as makeImmutableList, Map as makeImmutableMap } from 'immutable';
 import { createTransform } from 'redux-persist';
+import { sessionActionTypes } from 'lib/constants/videoConstants';
 
 /**
  * oldSessions state slice is an ImmutableMap mapping a old session id to a old video state slice.
  *
  * Refer to the video reducer for the format of the video state slice.
+ *
+ * This reducer does not deal with the population of the old sessions; that is done by redux-persist using the
+ * stateReconciler() in store.js. Once populated, old sessions are immutable individually, but may be removed by the
+ * reducer function as below.
  */
 export const initialState = makeImmutableMap();
 
@@ -17,6 +22,20 @@ export const persistTransform = createTransform(
   { whitelist: ['oldSessions'] }
 );
 
-export default function (state = initialState) {
-  return state;
+function removeSessionIds(oldSessionsMap, sessionIdsArray) {
+  let oldSessionsMapFiltered = oldSessionsMap;
+  sessionIdsArray.forEach((id) => {
+    oldSessionsMapFiltered = oldSessionsMapFiltered.delete(id);
+  });
+
+  return oldSessionsMapFiltered;
+}
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case sessionActionTypes.REMOVE_OLD_SESSIONS:
+      return removeSessionIds(state, action.sessionIds);
+    default:
+      return state;
+  }
 }

--- a/client/app/bundles/course/video/submission/reducers/oldSessions.js
+++ b/client/app/bundles/course/video/submission/reducers/oldSessions.js
@@ -1,6 +1,21 @@
-import { Map as makeImmutableMap } from 'immutable';
+import { List as makeImmutableList, Map as makeImmutableMap } from 'immutable';
+import { createTransform } from 'redux-persist';
 
+/**
+ * oldSessions state slice is an ImmutableMap mapping a old session id to a old video state slice.
+ *
+ * Refer to the video reducer for the format of the video state slice.
+ */
 export const initialState = makeImmutableMap();
+
+export const persistTransform = createTransform(
+  inboundState => inboundState.toJS(),
+  outboundState => makeImmutableMap(outboundState).map(videoState => ({
+    ...videoState,
+    sessionEvents: makeImmutableList(videoState.sessionEvents),
+  })),
+  { whitelist: ['oldSessions'] }
+);
 
 export default function (state = initialState) {
   return state;

--- a/client/app/bundles/course/video/submission/reducers/oldSessions.js
+++ b/client/app/bundles/course/video/submission/reducers/oldSessions.js
@@ -1,0 +1,7 @@
+import { Map as makeImmutableMap } from 'immutable';
+
+export const initialState = makeImmutableMap();
+
+export default function (state = initialState) {
+  return state;
+}

--- a/client/app/bundles/course/video/submission/reducers/video.js
+++ b/client/app/bundles/course/video/submission/reducers/video.js
@@ -1,6 +1,7 @@
 import { List as makeImmutableList } from 'immutable';
 import { playerStates, sessionActionTypes, videoActionTypes, videoDefaults } from 'lib/constants/videoConstants';
 import { isPlayingState, timeIsPastRestricted } from 'lib/helpers/videoHelpers';
+import { createTransform } from 'redux-persist';
 
 export const initialState = {
   videoUrl: null,
@@ -18,6 +19,12 @@ export const initialState = {
   sessionSequenceNum: 0,
   sessionEvents: makeImmutableList(),
 };
+
+export const persistTransform = createTransform(
+  inboundState => ({ ...inboundState, sessionEvents: inboundState.sessionEvents.toJS() }),
+  outboundState => ({ ...outboundState, sessionEvents: makeImmutableList(outboundState.sessionEvents) }),
+  { whitelist: ['video'] }
+);
 
 /**
  * Calculates the state changes required for a playerProgress update.

--- a/client/app/bundles/course/video/submission/reducers/video.js
+++ b/client/app/bundles/course/video/submission/reducers/video.js
@@ -18,6 +18,7 @@ export const initialState = {
   sessionId: null,
   sessionSequenceNum: 0,
   sessionEvents: makeImmutableList(),
+  sessionClosed: false,
 };
 
 export const persistTransform = createTransform(
@@ -214,6 +215,7 @@ function videoSessionReducer(state = initialState, action) {
     case sessionActionTypes.REMOVE_EVENTS:
       return Object.assign({}, state, {
         sessionEvents: events.filterNot(event => action.sequenceNums.has(event.sequence_num)),
+        sessionClosed: action.sessionClosed,
       });
     default:
       return state;

--- a/client/app/bundles/course/video/submission/store.js
+++ b/client/app/bundles/course/video/submission/store.js
@@ -32,7 +32,7 @@ const stateReconciler = (inboundState, _, reducedState) => {
   const inboundOldSessions = inboundState.oldSessions || makeImmutableMap();
   let oldSessions = inboundOldSessions.merge(reducedState.oldSessions);
 
-  if (inboundState.video && inboundState.video.sessionId) {
+  if (inboundState.video && inboundState.video.sessionId && !inboundState.video.sessionClosed) {
     const inboundVideoState = inboundState.video;
     const inboundSessionId = inboundVideoState.sessionId;
     oldSessions = oldSessions.set(inboundSessionId, inboundVideoState);

--- a/client/app/bundles/course/video/submission/store.js
+++ b/client/app/bundles/course/video/submission/store.js
@@ -1,8 +1,45 @@
 import { applyMiddleware, compose, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
+import { Map as makeImmutableMap } from 'immutable';
 import { persistReducer, persistStore } from 'redux-persist';
-import storage from 'redux-persist/lib/storage'
-import rootReducer, { createInitialState } from './reducers';
+import storage from 'redux-persist/lib/storage';
+import rootReducer, { createInitialState, persistTransforms } from './reducers';
+
+/**
+ * The state reconciler for redux-persist that is called to transform the state as deserialized from localstorage to the
+ * initial redux state we desire after the restoration.
+ *
+ * Here, we expect the old deserialized state to contain the old video state slice, and any old session data that
+ * was, for one reason or another, not yet sent to the server. We extract the old video state slice and insert it
+ * into the old sessions map.
+ *
+ * The idea is that the video component will attempt to sync the video state slice, together with all session
+ * events, with the server when the user closes the window. However, since we should not block a close action, the
+ * response from the server may not always arrive in time. In such a case we move the old video state slice into the old
+ * session data state slice so that it may be resent to the server. In other words, we try to catch up on session
+ * data when a user revisits the video component.
+ *
+ * @param inboundState The state as deserialized from localstorage
+ * @param _ The initial redux state before the other reducers process it (unused)
+ * @param reducedState The initial redux state after it passes through the reducers
+ * @return {*}
+ */
+const stateReconciler = (inboundState, _, reducedState) => {
+  if (!inboundState) {
+    return reducedState;
+  }
+
+  const inboundOldSessions = inboundState.oldSessions || makeImmutableMap();
+  let oldSessions = inboundOldSessions.merge(reducedState.oldSessions);
+
+  if (inboundState.video && inboundState.video.sessionId) {
+    const inboundVideoState = inboundState.video;
+    const inboundSessionId = inboundVideoState.sessionId;
+    oldSessions = oldSessions.set(inboundSessionId, inboundVideoState);
+  }
+
+  return Object.assign({}, reducedState, { oldSessions });
+};
 
 function persistConfig(courseUserId) {
   return {

--- a/client/app/bundles/course/video/submission/submissions.jsx
+++ b/client/app/bundles/course/video/submission/submissions.jsx
@@ -10,10 +10,9 @@ $(document).ready(() => {
   if (mountNode) {
     const data = mountNode.getAttribute('data');
     const initialState = JSON.parse(data);
-    const store = storeCreator(initialState);
 
     render(
-      <ProviderWrapper {...{ store }}>
+      <ProviderWrapper {...storeCreator(initialState)}>
         <Submission />
       </ProviderWrapper>
       , mountNode

--- a/client/app/lib/components/ProviderWrapper.jsx
+++ b/client/app/lib/components/ProviderWrapper.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/lib/integration/react';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import { i18nLocale } from 'lib/helpers/server-context';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import LoadingIndicator from 'lib/components/LoadingIndicator';
 import zh from 'react-intl/locale-data/zh';
 
 import ErrorBoundary from './ErrorBoundary';
@@ -15,10 +17,11 @@ const propTypes = {
     dispatch: PropTypes.func.isRequired,
     getState: PropTypes.func.isRequired,
   }),
+  persistor: PropTypes.object,
   children: PropTypes.element.isRequired,
 };
 
-const ProviderWrapper = ({ store, children }) => {
+const ProviderWrapper = ({ store, persistor, children }) => {
   const availableForeignLocales = { zh };
   const localeWithoutRegionCode = i18nLocale.toLowerCase().split(/[_-]+/)[0];
 
@@ -28,10 +31,20 @@ const ProviderWrapper = ({ store, children }) => {
     messages = translations[localeWithoutRegionCode] || translations[i18nLocale];
   }
 
-  let providers = (
+  let providers = children;
+
+  if (store && persistor) {
+    providers = (
+      <PersistGate loading={<LoadingIndicator />} persistor={persistor}>
+        {providers}
+      </PersistGate>
+    );
+  }
+
+  providers = (
     <IntlProvider locale={i18nLocale} messages={messages}>
       <MuiThemeProvider>
-        { children }
+        { providers }
       </MuiThemeProvider>
     </IntlProvider>
   );

--- a/client/app/lib/constants/videoConstants.js
+++ b/client/app/lib/constants/videoConstants.js
@@ -61,6 +61,7 @@ export const discussionActionTypes = mirrorCreator([
 
 export const sessionActionTypes = mirrorCreator([
   'REMOVE_EVENTS',
+  'REMOVE_OLD_SESSIONS',
 ]);
 
 export const notificationActionTypes = mirrorCreator([

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,8 @@
       "json"
     ],
     "setupFiles": [
-      "<rootDir>/app/__test__/requestAnimationFrame.js"
+      "<rootDir>/app/__test__/requestAnimationFrame.js",
+      "jest-localstorage-mock"
     ],
     "setupTestFrameworkScriptFile": "<rootDir>/app/__test__/setup.js",
     "snapshotSerializers": [
@@ -131,6 +132,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.6.0",
     "jest": "^21.2.1",
+    "jest-localstorage-mock": "^2.2.0",
     "react-dnd-test-backend": "^2.4.0",
     "react-test-renderer": "^16.2.0",
     "redux-logger": "^3.0.6",

--- a/client/package.json
+++ b/client/package.json
@@ -107,6 +107,7 @@
     "redux": "^3.3.1",
     "redux-form": "^7.2.1",
     "redux-immutable": "^4.0.0",
+    "redux-persist": "^5.5.0",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.0.1",
     "reselect": "^3.0.1",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -35,6 +35,7 @@ const config = {
       'redux',
       'redux-form',
       'redux-immutable',
+      'redux-persist',
       'redux-promise',
       'redux-thunk',
       'webfontloader',

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4222,6 +4222,10 @@ jest-jasmine2@^21.2.1:
     jest-snapshot "^21.2.1"
     p-cancelable "^0.3.0"
 
+jest-localstorage-mock@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.2.0.tgz#ce9a9de01dfdde2ad8aa08adf73acc7e5cc394cf"
+
 jest-matcher-utils@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6443,6 +6443,10 @@ redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
+redux-persist@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.5.0.tgz#64b5030625cb6f863f76487975acb8bb4fe4f9bb"
+
 redux-promise@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/redux-promise/-/redux-promise-0.5.3.tgz#e97e6c9d3bf376eacb79babe6d906da20112d6d8"


### PR DESCRIPTION
Implement a mechanism to store video session data in local storage.

The high-level idea is:

1. Use `redux-persist` to mirror the `video` state into local storage. This is done using transforms (serializes and deserializes Redux state) and `stateReconciler` (merges the things in local storage with a new state).
2. Pingback to the server every 5 seconds, **only if** events are present.
3. Before a user closes the window/navigate away, we attempt to contact the server to flush all our data to the server, but a backup is nevertheless present in local storage.
4. When accessing a video page again, the old `video` state is merged into the `oldSessions` state if we did not manage to get a confirmation from the server in step 3.
5. `oldSessions` are sent to the server in the same 5secs pingback, and are removed once the server replies.

Typically, from, testing, the server rarely replies in time when closing the window. So we send one extra request once the user comes back, but almost never more. On my dev setup the server typically could receive and process the data, but the reply doesn't make it back to the client. I'm not sure how it'll be like in production.

Under normal circumstances, I expect no more than one `oldSession` entry to be preserved, since usually when the user is able to access the video page he'll be able to send the `oldSession` back to the server.

That's roughly what I have thus far but would really appreciate comments.

Also, the sessions feature is not yet enabled in this PR yet: I found a bug with how the `sessionId` is sent to the frontend (we get the same `sessionId` if the user clicks on the back button in the browser). I want to fix that part up before enabling.
