### PR TITLE
Optimise TextResponseComprehension question models

### DIFF
--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -16,7 +16,7 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
 
   def auto_gradable?
     if comprehension_question?
-      groups.map(&:auto_gradable_group?).any?
+      groups.any?(&:auto_gradable_group?)
     else
       !solutions.empty?
     end

--- a/app/models/course/assessment/question/text_response_comprehension_group.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_group.rb
@@ -60,7 +60,7 @@ class Course::Assessment::Question::TextResponseComprehensionGroup < Application
   accepts_nested_attributes_for :points, allow_destroy: true
 
   def auto_gradable_group?
-    points.map(&:auto_gradable_point?).any?
+    points.any?(&:auto_gradable_point?)
   end
 
   def initialize_duplicate(duplicator, other)

--- a/app/models/course/assessment/question/text_response_comprehension_point.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_point.rb
@@ -13,7 +13,7 @@ class Course::Assessment::Question::TextResponseComprehensionPoint < Application
   accepts_nested_attributes_for :solutions, allow_destroy: true
 
   def auto_gradable_point?
-    solutions.map(&:auto_gradable_solution?).any?
+    solutions.any?(&:auto_gradable_solution?)
   end
 
   def initialize_duplicate(duplicator, other)

--- a/app/models/course/assessment/question/text_response_comprehension_solution.rb
+++ b/app/models/course/assessment/question/text_response_comprehension_solution.rb
@@ -21,10 +21,6 @@ class Course::Assessment::Question::TextResponseComprehensionSolution < Applicat
 
   private
 
-  def comprehension_solution?
-    compre_keyword? || compre_lifted_word?
-  end
-
   def remove_blank_solution
     solution.reject!(&:blank?)
   end


### PR DESCRIPTION
- Remove `map` from `auto_gradable[_...]?`. https://github.com/Coursemology/coursemology2/pull/2644#discussion_r163433751
- Remove unused `comprehension_solution?` function. https://github.com/Coursemology/coursemology2/pull/2644#discussion_r163159824