### PR TITLE
Fix user time_zone for invalid and nil time_zones

### DIFF
--- a/app/controllers/concerns/application_user_time_zone_concern.rb
+++ b/app/controllers/concerns/application_user_time_zone_concern.rb
@@ -10,6 +10,6 @@ module ApplicationUserTimeZoneConcern
 
   # Set the time_zone for current request.
   def set_time_zone(&block) # rubocop:disable Style/AccessorMethodName
-    Time.use_zone(current_user.time_zone || Application.config.x.default_user_time_zone, &block)
+    Time.use_zone(current_user.time_zone, &block)
   end
 end

--- a/config/locales/en/activerecord/user.yml
+++ b/config/locales/en/activerecord/user.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            time_zone:
+              invalid_time_zone: 'The time zone selected is invalid'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,6 +74,35 @@ RSpec.describe User do
       end
     end
 
+    describe '#time_zone' do
+      subject { create(:user) }
+      before { subject.update_column(:time_zone, persisted_time_zone) }
+
+      context 'when time_zone is not set' do
+        let(:persisted_time_zone) { nil }
+
+        it 'defaults to application default' do
+          expect(subject.time_zone).to eq(Application.config.x.default_user_time_zone)
+        end
+      end
+
+      context 'when persisted time_zone was set correctly' do
+        let(:persisted_time_zone) { 'Tokyo' }
+
+        it 'returns that time_zone' do
+          expect(subject.time_zone).to eq(persisted_time_zone)
+        end
+      end
+
+      context 'when persisted time_zone is incorrect' do
+        let(:persisted_time_zone) { 'Foo' }
+
+        it 'returns the application default' do
+          expect(subject.time_zone).to eq(Application.config.x.default_user_time_zone)
+        end
+      end
+    end
+
     describe '.new_with_session' do
       context 'when facebook data is provided' do
         let(:params) { {} }
@@ -161,7 +190,7 @@ RSpec.describe User do
       end
 
       describe '#time_zone' do
-        subject { build(:user) }
+        subject { create(:user) }
 
         context 'when time_zone is not set' do
           before { subject.time_zone = nil }
@@ -172,7 +201,12 @@ RSpec.describe User do
         context 'when time_zone is invalid' do
           before { subject.time_zone = 'LOL' }
 
-          it { is_expected.not_to be_valid }
+          it 'is not valid' do
+            expect(subject).not_to be_valid
+            expect(subject.errors[:time_zone]).to include(
+              I18n.t('activerecord.errors.models.user.attributes.time_zone.invalid_time_zone')
+            )
+          end
         end
 
         context 'when time_zone is valid' do


### PR DESCRIPTION
This PR fixes an issue where users who did not set a time-zone will see GMT time in emailers instead of the Application Default (SGP).

Commit Details:
- Also fixes #1215 where timezones might be removed from ActiveSupport::TimeZone, rendering persisted time_zones unusable.
- Shift validation into private method, to validate that user's time_zone can be nil or some valid value.
- If persisted time_zone is invalid or nil, return application default timezone, otherwise, return that timezone.