### PR TITLE
Update attributes on the lesson plan item actable

### DIFF
--- a/app/controllers/course/lesson_plan/items_controller.rb
+++ b/app/controllers/course/lesson_plan/items_controller.rb
@@ -18,7 +18,7 @@ class Course::LessonPlan::ItemsController < Course::LessonPlan::Controller
   end
 
   def update
-    if @item.update_attributes(item_params)
+    if @item.actable.update_attributes(item_params)
       head :ok
     else
       head :bad_request

--- a/db/migrate/20180130023617_reset_reminder_jobs.rb
+++ b/db/migrate/20180130023617_reset_reminder_jobs.rb
@@ -1,0 +1,41 @@
+class ResetReminderJobs < ActiveRecord::Migration[5.1]
+  def up
+    reset_opening_reminders
+    reset_closing_reminders
+  end
+
+  def down; end
+
+  private
+
+  def reset_opening_reminders
+    system_user = User.find(0)
+
+    ActsAsTenant.without_tenant do
+      Course::LessonPlan::Item.
+        where("start_at > NOW() AND actable_type != 'Course::LessonPlan::Event'").find_each do |item|
+        opening_reminder_token = Time.zone.now.to_f.round(5)
+        item.opening_reminder_token = opening_reminder_token
+        item.save!
+
+        "#{item.actable_type}::OpeningReminderJob".constantize.set(wait_until: item.start_at).
+          perform_later(system_user, item.actable, opening_reminder_token)
+      end
+    end
+  end
+
+  def reset_closing_reminders
+    ActsAsTenant.without_tenant do
+      Course::LessonPlan::Item.where("end_at > ? AND actable_type != 'Course::LessonPlan::Event'",
+                                      Time.zone.now - 1.day).
+                                find_each do |item|
+        closing_reminder_token = Time.zone.now.to_f.round(5)
+        item.closing_reminder_token = closing_reminder_token
+        item.save!
+
+        "#{item.actable_type}::ClosingReminderJob".constantize.set(wait_until: item.end_at - 1.day).
+          perform_later(item.actable, closing_reminder_token)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180119064953) do
+ActiveRecord::Schema.define(version: 20180130023617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
.. so `after_save` callbacks on the models get called.

This function is used when items are edited directly on the lesson plan
edit view. To ensure that the opening and closing reminders are setup
properly if there is a change in start_at or end_at, the actable must be
modified, not just the lesson plan item.

~~This still does not solve the problem of existing opening and closing reminder jobs which have already been scheduled and were not updated when start/end times were edited through the lesson plan edit page.~~

Migration recreates new opening and closing reminder jobs and resets the opening and closing reminder tokens.

It might take about 5 minutes to run so it will be best to deploy this when there is low traffic.