### PR TITLE
Fixes to achievements

### DIFF
--- a/app/controllers/course/achievement/achievements_controller.rb
+++ b/app/controllers/course/achievement/achievements_controller.rb
@@ -22,9 +22,18 @@ class Course::Achievement::AchievementsController < Course::Achievement::Control
 
   def update #:nodoc:
     if @achievement.update_attributes(achievement_params)
-      head :ok
+      respond_to do |format|
+        format.html do
+          redirect_to course_achievement_path(current_course, @achievement.id),
+                      success: t('.success')
+        end
+        format.json { head :ok }
+      end
     else
-      render json: { errors: @achievement.errors }, status: :bad_request
+      respond_to do |format|
+        format.html { render 'edit' }
+        format.json { render json: { errors: @achievement.errors }, status: :bad_request }
+      end
     end
   end
 

--- a/app/models/course/user_achievement.rb
+++ b/app/models/course/user_achievement.rb
@@ -3,6 +3,8 @@ class Course::UserAchievement < ApplicationRecord
   after_initialize :set_defaults, if: :new_record?
   after_create :send_notification
 
+  validate :validate_course_user_in_course, on: :create
+
   belongs_to :course_user, inverse_of: :course_user_achievements
   belongs_to :achievement, class_name: Course::Achievement.name,
                            inverse_of: :course_user_achievements
@@ -18,5 +20,9 @@ class Course::UserAchievement < ApplicationRecord
     return unless course_user.student?
 
     Course::AchievementNotifier.achievement_gained(course_user.user, achievement)
+  end
+
+  def validate_course_user_in_course
+    errors.add(:course_user, :not_in_course) unless course_user.course_id == achievement.course_id
   end
 end

--- a/config/locales/en/activerecord/course/user_achievement.yml
+++ b/config/locales/en/activerecord/course/user_achievement.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/user_achievement:
+          attributes:
+            course_user:
+              not_in_course: 'Selected user is not in specified course'

--- a/config/locales/en/course/achievement/achievements.yml
+++ b/config/locales/en/course/achievement/achievements.yml
@@ -11,6 +11,8 @@ en:
           users_with_achievement: 'Students with this Achievement'
         edit:
           header: 'Edit Achievement'
+        update:
+          success: 'Achievement successfully updated'
         destroy:
           success: 'Achievement %{title} was deleted.'
           failure: 'Failed to delete achievement: %{error}'

--- a/spec/factories/course_user_achievements.rb
+++ b/spec/factories/course_user_achievements.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :course_user_achievement, class: Course::UserAchievement.name do
-    course_user
-    achievement
+    transient do
+      course { create(:course) }
+    end
+
+    course_user { association :course_user, course: course }
+    achievement { association :achievement, course: course }
     obtained_at '2015-10-11 23:20:07'
+
+    after(:build) do |object|
+      if object.course_user.course_id != object.achievement.course_id
+        object.achievement.course_id = object.course_user.course_id
+      end
+    end
   end
 end

--- a/spec/models/course/user_achievement_spec.rb
+++ b/spec/models/course/user_achievement_spec.rb
@@ -5,9 +5,27 @@ RSpec.describe Course::UserAchievement, type: :model do
   it { is_expected.to belong_to(:course_user).inverse_of(:course_user_achievements) }
   it { is_expected.to belong_to(:achievement).inverse_of(:course_user_achievements) }
 
-  describe '#initialize' do
-    it 'sets the obtained timestamp' do
-      expect(subject.obtained_at).to be_within(1.second).of(Time.zone.now)
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#initialize' do
+      it 'sets the obtained timestamp' do
+        expect(subject.obtained_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    describe 'validations' do
+      context 'when course_user is not from the same course as achievement' do
+        let(:course) { create(:course) }
+        subject { build(:course_user_achievement) }
+        before { subject.achievement.course = course }
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:course_user]).
+            to include(I18n.t('activerecord.errors.models.course/user_achievement.'\
+              'attributes.course_user.not_in_course'))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR solves 2 issues: 
 - Add validation to `Course::UserAchievement` (ensure `course_user` and `achievement` are in the same course)
 - Add html redirect for `achievement#update` controller action, since manually awarding achievements uses that endpoint. Fixes #2771 