### PR TITLE
Fix random test failures

### DIFF
--- a/spec/features/course/achievement_listing_spec.rb
+++ b/spec/features/course/achievement_listing_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Course: Achievements' do
 
         # Ensure no 'New' button for achievement creation
         expect(page).not_to have_selector('.page-header .new-btn')
-        expect(page).not_to have_content_tag_for(draft_achievement)
+        expect(page).to have_no_content_tag_for(draft_achievement)
 
         expect(page).not_to have_link(nil, href: edit_course_achievement_path(course, achievement1))
         expect(page).not_to have_link(nil, href: edit_course_achievement_path(course, achievement2))
@@ -71,9 +71,9 @@ RSpec.feature 'Course: Achievements' do
           not_obtained = course.course_users - obtained
 
           obtained.each { |course_user| expect(page).to have_content_tag_for(course_user) }
-          not_obtained.each { |course_user| expect(page).not_to have_content_tag_for(course_user) }
+          not_obtained.each { |course_user| expect(page).to have_no_content_tag_for(course_user) }
 
-          expect(page).not_to have_content_tag_for(phantom_user)
+          expect(page).to have_no_content_tag_for(phantom_user)
         end
       end
     end

--- a/spec/features/course/announcement_management_spec.rb
+++ b/spec/features/course/announcement_management_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Course: Announcements' do
           expect(page).not_to have_link(nil, href: course_announcement_path(course, announcement))
         end
 
-        expect(page).not_to have_content_tag_for(not_started_announcement)
+        expect(page).to have_no_content_tag_for(not_started_announcement)
       end
     end
   end

--- a/spec/features/course/assessment/answer/programming_file_submission_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_file_submission_answer_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming File Submission An
         delete_button = file_view.find('svg')
         delete_button.click
         click_button('Continue')
+        expect(page).to have_no_button('Continue')
 
         # It should indicate that there are no files uploaded
         # Original programming file in the question should have been deleted

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         empty_assessment
         visit course_assessments_path(course)
 
-        expect(page).not_to have_content_tag_for(empty_assessment)
+        expect(page).to have_no_content_tag_for(empty_assessment)
       end
 
       scenario 'I cannot attempt unsatisfied assessments' do

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         find_link(nil, href: delete_path).click
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
-        expect(page).not_to have_content_tag_for(mrq)
+        expect(page).to have_no_content_tag_for(mrq)
       end
     end
 

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         find_link(nil, href: delete_path).click
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
-        expect(page).not_to have_content_tag_for(question)
+        expect(page).to have_no_content_tag_for(question)
       end
 
       scenario 'I can create a new question and upload the template package', js: true do

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
         find_link(nil, href: delete_path).click
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
-        expect(page).not_to have_content_tag_for(question)
+        expect(page).to have_no_content_tag_for(question)
       end
     end
 

--- a/spec/features/course/assessment/skill_branch_management_spec.rb
+++ b/spec/features/course/assessment/skill_branch_management_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Course: Skill Branches' do
         end
 
         expect(current_path).to eq(course_assessments_skills_path(course))
-        expect(page).not_to have_content_tag_for(skill_branch)
+        expect(page).to have_no_content_tag_for(skill_branch)
       end
     end
   end

--- a/spec/features/course/assessment/skill_management_spec.rb
+++ b/spec/features/course/assessment/skill_management_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Course: Skills' do
         end
 
         expect(current_path).to eq(course_assessments_skills_path(course))
-        expect(page).not_to have_content_tag_for(skill)
+        expect(page).to have_no_content_tag_for(skill)
       end
     end
   end

--- a/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
+++ b/spec/features/course/assessment/submission/programming_answer_comment_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Course: Assessment: Submissions: Programming Answers: Commenting
         accept_confirm_dialog
 
         wait_for_ajax
-        expect(page).not_to have_content_tag_for(post)
+        expect(page).to have_no_content_tag_for(post)
       end
     end
   end

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'Course: Submissions Viewing' do
         expect(page).to have_selector('div.submissions-filter')
 
         # Submissions page should not show attempting submissions or staff submissions.
-        expect(page).not_to have_content_tag_for(attempting_submission)
-        expect(page).not_to have_content_tag_for(staff_submission)
+        expect(page).to have_no_content_tag_for(attempting_submission)
+        expect(page).to have_no_content_tag_for(staff_submission)
 
         within find(content_tag_selector(submitted_submission)) do
           expect(page).to have_link(
@@ -67,8 +67,8 @@ RSpec.describe 'Course: Submissions Viewing' do
         visit pending_course_submissions_path(course, my_students: false)
         expect(page).to have_content_tag_for(submitted_submission1)
         expect(page).to have_content_tag_for(submitted_submission2)
-        expect(page).not_to have_content_tag_for(attempting_submission)
-        expect(page).not_to have_content_tag_for(published_submission)
+        expect(page).to have_no_content_tag_for(attempting_submission)
+        expect(page).to have_no_content_tag_for(published_submission)
 
         # Pending submissions tab shows the tutors for the students if it exists.
         within find(content_tag_selector(submitted_submission1)) do
@@ -76,15 +76,15 @@ RSpec.describe 'Course: Submissions Viewing' do
         end
 
         # Pending submissions does not show submissions for autograded assessments
-        expect(page).not_to have_content_tag_for(autograded_submission)
+        expect(page).to have_no_content_tag_for(autograded_submission)
 
         # Staff with group view pending submissions of own group students
         visit pending_course_submissions_path(course, my_students: true)
 
         expect(page).to have_content_tag_for(submitted_submission1)
-        expect(page).not_to have_content_tag_for(submitted_submission2)
-        expect(page).not_to have_content_tag_for(attempting_submission)
-        expect(page).not_to have_content_tag_for(published_submission)
+        expect(page).to have_no_content_tag_for(submitted_submission2)
+        expect(page).to have_no_content_tag_for(attempting_submission)
+        expect(page).to have_no_content_tag_for(published_submission)
 
         # All Pending submissions can be assessed from the sidebar
         within find('.sidebar') do
@@ -140,7 +140,7 @@ RSpec.describe 'Course: Submissions Viewing' do
 
         visit course_submissions_path(course)
 
-        expect(page).not_to have_content_tag_for(attempting_submission)
+        expect(page).to have_no_content_tag_for(attempting_submission)
         expect(page).not_to have_selector('div.submissions-filter')
 
         [submitted_submission, graded_submission, published_submission].each do |submission|

--- a/spec/features/course/discussion/topic_management_spec.rb
+++ b/spec/features/course/discussion/topic_management_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature 'Course: Topics: Management' do
         expect(page).not_to have_link(I18n.t('course.discussion.topics.mark_as_pending'))
 
         other_comments.each do |comment|
-          expect(page).not_to have_content_tag_for(comment)
+          expect(page).to have_no_content_tag_for(comment)
         end
 
         my_comments.each do |comment|
@@ -150,7 +150,7 @@ RSpec.feature 'Course: Topics: Management' do
           click_link I18n.t('course.discussion.topics.mark_as_read')
         end
 
-        expect(page).not_to have_content_tag_for(mark_as_read)
+        expect(page).to have_no_content_tag_for(mark_as_read)
         expect(mark_as_read.unread?(user)).to be_falsey
       end
 
@@ -181,7 +181,7 @@ RSpec.feature 'Course: Topics: Management' do
         expect(page).to have_selector('.confirm-btn')
         accept_confirm_dialog
         wait_for_ajax
-        expect(page).not_to have_content_tag_for(post)
+        expect(page).to have_no_content_tag_for(post)
 
         # Reply when last post of topic has just been deleted
         reply_text = 'WELCOME (:'

--- a/spec/features/course/enrol_request_managmement_spec.rb
+++ b/spec/features/course/enrol_request_managmement_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Course: EnrolRequests' do
       wait_for_ajax
       course_user = course.course_users.find_by(user_id: enrol_request.user.id)
       expect(course_user).to be_present
-      expect(page).not_to have_content_tag_for(enrol_request)
+      expect(page).to have_no_content_tag_for(enrol_request)
       expect(page).to have_text('course.enrol_requests.approve.success')
 
       visit course_users_students_path(course)

--- a/spec/features/course/experience_points/disbursement_spec.rb
+++ b/spec/features/course/experience_points/disbursement_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature 'Course: Experience Points: Disbursement' do
 
         click_link group_1.name
         expect(page).to have_content_tag_for(group_1_student)
-        expect(page).not_to have_content_tag_for(group_2_student)
-        expect(page).not_to have_content_tag_for(ungrouped_student)
+        expect(page).to have_no_content_tag_for(group_2_student)
+        expect(page).to have_no_content_tag_for(ungrouped_student)
       end
 
       scenario 'I can copy points awarded for first student to all students', js: true do

--- a/spec/features/course/experience_points_record_management_spec.rb
+++ b/spec/features/course/experience_points_record_management_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
 
         expect(page).to have_content_tag_for(record)
         expect(page).to have_content_tag_for(manual_record)
-        expect(page).not_to have_content_tag_for(inactive_record)
+        expect(page).to have_no_content_tag_for(inactive_record)
         submission_path =
           edit_course_assessment_submission_path(course, submission.assessment, submission)
         expect(page).to have_link(submission.assessment.title, href: submission_path)
@@ -78,7 +78,7 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
         find_link(nil, href: manual_record_path).click
         expect(current_path).
           to eq(course_user_experience_points_records_path(course, course_student))
-        expect(page).not_to have_content_tag_for(manual_record)
+        expect(page).to have_no_content_tag_for(manual_record)
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.feature 'Courses: Experience Points Records: Management' do
 
         expect(page).to have_content_tag_for(record)
         expect(page).to have_content_tag_for(manual_record)
-        expect(page).not_to have_content_tag_for(inactive_record)
+        expect(page).to have_no_content_tag_for(inactive_record)
 
         # Can view experience points attributes but cannot edit the experience points record
         within find(content_tag_selector(manual_record)) do

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Course: Forum: Post: Management' do
         find_link(nil, href: course_forum_topic_post_path(course, forum, topic, post)).click
         expect(current_path).to eq(course_forum_topic_path(course, forum, topic))
 
-        expect(page).not_to have_content_tag_for(post)
+        expect(page).to have_no_content_tag_for(post)
       end
 
       scenario 'I can reply to a post' do

--- a/spec/features/course/forum/topic_management_spec.rb
+++ b/spec/features/course/forum/topic_management_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature 'Course: Forum: Topic: Management' do
         end
         expect(current_path).to eq(course_forum_path(course, forum))
 
-        expect(page).not_to have_content_tag_for(topic)
+        expect(page).to have_no_content_tag_for(topic)
       end
 
       scenario 'I can subscribe to a topic' do
@@ -199,7 +199,7 @@ RSpec.feature 'Course: Forum: Topic: Management' do
         expect(page).to have_content_tag_for(topic)
         expect(page).not_to have_link(hidden_topic.title,
                                       href: course_forum_topic_path(course, forum, hidden_topic))
-        expect(page).not_to have_content_tag_for(hidden_topic)
+        expect(page).to have_no_content_tag_for(hidden_topic)
       end
 
       scenario 'I can create a new topic with normal and question types' do

--- a/spec/features/course/forum_management_spec.rb
+++ b/spec/features/course/forum_management_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'Course: Forum: Management' do
         end
         expect(current_path).to eq(course_forums_path(course))
 
-        expect(page).not_to have_content_tag_for(forum)
+        expect(page).to have_no_content_tag_for(forum)
       end
 
       scenario 'I can subscribe and unsubscribe to a forum ', js: true do

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature 'Course: Homepage' do
 
         visit course_path(course)
         feed_notifications.each do |notification|
-          expect(page).not_to have_content_tag_for(notification)
+          expect(page).to have_no_content_tag_for(notification)
         end
       end
 
@@ -137,7 +137,7 @@ RSpec.feature 'Course: Homepage' do
         visit course_path(course)
 
         [:completed, :unpublished].each do |status|
-          expect(page).not_to have_content_tag_for(assessment_todos[status])
+          expect(page).to have_no_content_tag_for(assessment_todos[status])
         end
 
         within find(content_tag_selector(assessment_todos[:not_started])) do
@@ -174,7 +174,7 @@ RSpec.feature 'Course: Homepage' do
       scenario 'I am not able to see announcements in course homepage' do
         valid_announcement = create(:course_announcement, course: course)
         visit course_path(course)
-        expect(page).not_to have_content_tag_for(valid_announcement)
+        expect(page).to have_no_content_tag_for(valid_announcement)
       end
 
       scenario 'I am not able to see the activity feed in course homepage' do
@@ -182,7 +182,7 @@ RSpec.feature 'Course: Homepage' do
 
         visit course_path(course)
         feed_notifications.each do |notification|
-          expect(page).not_to have_content_tag_for(notification)
+          expect(page).to have_no_content_tag_for(notification)
         end
       end
 

--- a/spec/features/course/invitation_management_spec.rb
+++ b/spec/features/course/invitation_management_spec.rb
@@ -128,7 +128,7 @@ RSpec.feature 'Courses: Invitations', js: true do
         expect(page).to have_selector('div.alert-success',
                                       text: I18n.t('course.user_invitations.destroy.success'))
         expect(current_path).to eq(course_user_invitations_path(course))
-        expect(page).not_to have_content_tag_for(invitation_to_delete)
+        expect(page).to have_no_content_tag_for(invitation_to_delete)
       end
     end
 

--- a/spec/features/course/leaderboard_viewing_spec.rb
+++ b/spec/features/course/leaderboard_viewing_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Course: Leaderboard: View' do
           end
         end
 
-        expect(page).not_to have_content_tag_for(phantom_user)
+        expect(page).to have_no_content_tag_for(phantom_user)
       end
 
       scenario 'I can view the leaderboard sorted by achievement count' do
@@ -51,7 +51,7 @@ RSpec.describe 'Course: Leaderboard: View' do
           end
         end
 
-        expect(page).not_to have_content_tag_for(phantom_user)
+        expect(page).to have_no_content_tag_for(phantom_user)
       end
 
       context 'when the group leaderboard is enabled for the course' do

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Course: Material: Folders: Management' do
         empty_linked_folders = parent_folder.children.
                                select { |f| f.owner && f.materials.empty? && f.children.empty? }
         empty_linked_folders.each do |subfolder|
-          expect(page).not_to have_content_tag_for(subfolder)
+          expect(page).to have_no_content_tag_for(subfolder)
         end
       end
 
@@ -163,7 +163,7 @@ RSpec.feature 'Course: Material: Folders: Management' do
         end
 
         invisible_folders.each do |subfolder|
-          expect(page).not_to have_content_tag_for(subfolder)
+          expect(page).to have_no_content_tag_for(subfolder)
         end
       end
 

--- a/spec/features/course/tab_management_spec.rb
+++ b/spec/features/course/tab_management_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Course: Assessments: Management' do
         find_link(nil,
                   href: course_admin_assessments_category_tab_path(course, category, tab)).click
         expect(page).to have_selector('div.alert.alert-success')
-        expect(page).not_to have_content_tag_for(tab)
+        expect(page).to have_no_content_tag_for(tab)
         expect(page).to have_content_tag_for(tab2)
       end
 

--- a/spec/features/course/user_listing_spec.rb
+++ b/spec/features/course/user_listing_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature 'Courses: Course User Listing' do
         end
 
         # Page should not display users, phantom users and teaching assistants
-        expect(page).not_to have_content_tag_for(phantom_user)
-        expect(page).not_to have_content_tag_for(course_teaching_assistant)
+        expect(page).to have_no_content_tag_for(phantom_user)
+        expect(page).to have_no_content_tag_for(course_teaching_assistant)
       end
     end
   end

--- a/spec/features/course/video/submissions_viewing_spec.rb
+++ b/spec/features/course/video/submissions_viewing_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Course: Video: Submissions Viewing' do
         visit course_video_submissions_path(course, video)
 
         # Submissions page should not have show staff submissions.
-        expect(page).not_to have_content_tag_for(staff_submission)
+        expect(page).to have_no_content_tag_for(staff_submission)
 
         within find(content_tag_selector(submission)) do
           expect(page).

--- a/spec/features/course/video/video_viewing_and_attempting_spec.rb
+++ b/spec/features/course/video/video_viewing_and_attempting_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Course: Videos: Viewing' do
         videos
         visit course_videos_path(course)
 
-        expect(page).not_to have_content_tag_for(unpublished_video)
+        expect(page).to have_no_content_tag_for(unpublished_video)
         expect(page).to have_content_tag_for(published_video)
         expect(page).to have_content_tag_for(published_not_started_video)
 

--- a/spec/features/global_announcements_spec.rb
+++ b/spec/features/global_announcements_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Global announcements' do
           expect(page).to have_content_tag_for(s)
         end
         announcements.reject(&:currently_active?).each do |s|
-          expect(page).not_to have_content_tag_for(s)
+          expect(page).to have_no_content_tag_for(s)
         end
       end
 

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -25,13 +25,15 @@ RSpec.feature 'System: Administration: Users' do
       scenario 'I can filter users by role and view only administrators' do
         visit admin_users_path(role: :administrator)
 
-        users.select(&:normal?).each do |user|
-          expect(page).not_to have_selector("tr.user input[value='#{user.name}']")
-          expect(page).not_to have_selector('tr.user td', text: user.email)
+        User.human_users.normal.ordered_by_name.limit(3).each do |user|
+          expect(page).to have_no_selector("tr.user input[value='#{user.name}']")
+          expect(page).to have_no_selector('tr.user td', text: user.email)
         end
 
-        expect(page).to have_selector("tr.user input[value='#{admin.name}']")
-        expect(page).to have_selector('tr.user td', text: admin.email)
+        User.human_users.administrator.ordered_by_name.limit(3).each do |user|
+          expect(page).to have_selector("tr.user input[value='#{user.name}']")
+          expect(page).to have_selector('tr.user td', text: user.email)
+        end
       end
 
       scenario "I can change a user's record", js: true do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -43,11 +43,9 @@ module Capybara::TestGroupHelpers
     end
 
     def accept_confirm_dialog
-      find('.confirm-btn').click
-
-      Timeout.timeout(Capybara.default_max_wait_time) do
-        sleep 0.1 until page.all('.confirm-btn').empty?
-      end
+      expect(page).to have_selector('button.confirm-btn')
+      find('button.confirm-btn').click
+      expect(page).to have_no_selector('button.confirm-btn')
     end
 
     # Helper to fill in summernote textareas. Only to be used where javascript is enabled.

--- a/spec/support/have_content_tag_for_matcher.rb
+++ b/spec/support/have_content_tag_for_matcher.rb
@@ -20,6 +20,13 @@ RSpec::Matchers.define :have_content_tag_for do |resource|
   end
 end
 
+RSpec::Matchers.define :have_no_content_tag_for do |resource|
+  include ContentTag::TestExampleHelpers::FeatureHelpers
+  match do |page|
+    expect(page).to have_no_selector(content_tag_selector(resource))
+  end
+end
+
 RSpec.configure do |config|
   config.include ContentTag::TestExampleHelpers::FeatureHelpers, type: :feature
 end


### PR DESCRIPTION
- The user filter spec failed when the admin we are asserting on is paginated on another page because many admins were generated.
- Introduced `have_no_content_tag_for` to avoid the waiting behavior described [in the capybara readme](http://www.rubydoc.info/github/jnicklas/capybara#asynchronous-javascript-ajax-and-friends) and [here](https://blog.codeship.com/faster-rails-tests/). Another possible solution is to use a custom Capybara matcher instead of an RSpec one.
- Instead of sleeping for `accept_confirm_dialog`, use Capybara's inbuilt waiting behavior. Unlike [`wait_for_ajax`](https://robots.thoughtbot.com/automatically-wait-for-ajax-with-capybara), we remain on the same page and don't have to deal with race conditions. 
    - Other references: [use of `sleep` discouraged](https://gist.github.com/metaskills/1172519), [Capybara `wait_until` deprecated](https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/)