### PR TITLE
Order sidebar items by weight + key

### DIFF
--- a/app/controllers/components/course/announcements_component.rb
+++ b/app/controllers/components/course/announcements_component.rb
@@ -30,7 +30,7 @@ class Course::AnnouncementsComponent < SimpleDelegator
       {
         title: settings.title || t('layouts.course_admin.announcement_settings.title'),
         type: :settings,
-        weight: 3,
+        weight: 4,
         path: course_admin_announcements_path(current_course)
       }
     ]

--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -40,7 +40,7 @@ class Course::AssessmentsComponent < SimpleDelegator
         key: :assessments_submissions,
         icon: 'upload',
         title: t('course.assessment.submissions.sidebar_title'),
-        weight: 2,
+        weight: 3,
         path: assessment_submissions_url,
         unread: submission_count
       }
@@ -56,7 +56,7 @@ class Course::AssessmentsComponent < SimpleDelegator
         icon: 'bolt',
         title: t('course.assessment.skills.sidebar_title'),
         type: :admin,
-        weight: 7,
+        weight: 8,
         path: course_assessments_skills_path(current_course)
       }
     ]
@@ -67,7 +67,7 @@ class Course::AssessmentsComponent < SimpleDelegator
       {
         title: t('course.assessment.assessments.sidebar_title'),
         type: :settings,
-        weight: 3,
+        weight: 5,
         path: course_admin_assessments_path(current_course)
       }
     ]

--- a/app/controllers/components/course/controller_component_host.rb
+++ b/app/controllers/components/course/controller_component_host.rb
@@ -236,7 +236,7 @@ class Course::ControllerComponentHost
   #
   # The elements are rendered on all Course controller subclasses as part of a nested template.
   def sidebar_items
-    @sidebar_items ||= components.map(&:sidebar_items).tap(&:flatten!)
+    @sidebar_items ||= components.flat_map(&:sidebar_items)
   end
 
   private

--- a/app/controllers/components/course/courses_component.rb
+++ b/app/controllers/components/course/courses_component.rb
@@ -24,7 +24,7 @@ class Course::CoursesComponent < SimpleDelegator
         icon: 'gear',
         title: t('layouts.course_admin.title'),
         type: :admin,
-        weight: 10,
+        weight: 9,
         path: course_admin_path(current_course)
       }
     ]
@@ -70,7 +70,7 @@ class Course::CoursesComponent < SimpleDelegator
     {
       title: t('layouts.course_admin.notifications.title'),
       type: :settings,
-      weight: 8,
+      weight: 12,
       path: course_admin_notifications_path(current_course)
     }
   end

--- a/app/controllers/components/course/discussion/topics_component.rb
+++ b/app/controllers/components/course/discussion/topics_component.rb
@@ -31,7 +31,7 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
       {
         title: t('course.discussion.topics.sidebar_title'),
         type: :settings,
-        weight: 4,
+        weight: 7,
         path: course_admin_topics_path(current_course)
       }
     ]

--- a/app/controllers/components/course/duplication_component.rb
+++ b/app/controllers/components/course/duplication_component.rb
@@ -13,7 +13,7 @@ class Course::DuplicationComponent < SimpleDelegator
         icon: 'clone',
         title: t('layouts.duplication.title'),
         type: :admin,
-        weight: 4,
+        weight: 5,
         path: course_duplication_path(current_course)
       }
     ]

--- a/app/controllers/components/course/forums_component.rb
+++ b/app/controllers/components/course/forums_component.rb
@@ -30,7 +30,7 @@ class Course::ForumsComponent < SimpleDelegator
       {
         title: settings.title || t('course.forum.forums.sidebar_title'),
         type: :settings,
-        weight: 7,
+        weight: 11,
         path: course_admin_forums_path(current_course)
       }
     ]

--- a/app/controllers/components/course/groups_component.rb
+++ b/app/controllers/components/course/groups_component.rb
@@ -15,7 +15,7 @@ class Course::GroupsComponent < SimpleDelegator
         icon: 'share-alt',
         title: I18n.t('course.groups.sidebar_title'),
         type: :admin,
-        weight: 6,
+        weight: 7,
         path: course_groups_path(current_course)
       }
     ]

--- a/app/controllers/components/course/leaderboard_component.rb
+++ b/app/controllers/components/course/leaderboard_component.rb
@@ -33,7 +33,7 @@ class Course::LeaderboardComponent < SimpleDelegator
       {
         title: settings.title || t('course.leaderboards.title'),
         type: :settings,
-        weight: 5,
+        weight: 8,
         path: course_admin_leaderboard_path(current_course)
       }
     ]

--- a/app/controllers/components/course/levels_component.rb
+++ b/app/controllers/components/course/levels_component.rb
@@ -19,7 +19,7 @@ class Course::LevelsComponent < SimpleDelegator
         icon: 'star-half-o',
         title: I18n.t('course.levels.sidebar_title'),
         type: :admin,
-        weight: 5,
+        weight: 6,
         path: course_levels_path(current_course)
       }
     ]

--- a/app/controllers/components/course/materials_component.rb
+++ b/app/controllers/components/course/materials_component.rb
@@ -30,7 +30,7 @@ class Course::MaterialsComponent < SimpleDelegator
       {
         title: t('course.material.sidebar_title'),
         type: :settings,
-        weight: 6,
+        weight: 10,
         path: course_admin_materials_path(current_course)
       }
     ]

--- a/app/controllers/components/course/videos_component.rb
+++ b/app/controllers/components/course/videos_component.rb
@@ -26,7 +26,7 @@ class Course::VideosComponent < SimpleDelegator
         key: :videos,
         icon: 'video-camera',
         title: settings.title || t('course.video.videos.sidebar_title'),
-        weight: 4,
+        weight: 12,
         path: course_videos_path(current_course),
         unread: unread_count
       }
@@ -38,7 +38,7 @@ class Course::VideosComponent < SimpleDelegator
       {
         title: settings.title || t('course.video.videos.sidebar_title'),
         type: :settings,
-        weight: 4,
+        weight: 13,
         path: course_admin_videos_path(current_course)
       }
     ]

--- a/app/controllers/components/course/virtual_classrooms_component.rb
+++ b/app/controllers/components/course/virtual_classrooms_component.rb
@@ -33,7 +33,7 @@ class Course::VirtualClassroomsComponent < SimpleDelegator
       {
         title: settings.title || t('layouts.course_admin.virtual_classroom_settings.title'),
         type: :settings,
-        weight: 3,
+        weight: 6,
         path: course_admin_virtual_classrooms_path(current_course)
       }
     ]

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -13,7 +13,13 @@ class Course::Controller < ApplicationController
   # @return [Array] The array of ordered sidebar items of the given type.
   def sidebar_items(type: nil)
     weights_hash = sidebar_items_weights
-    sidebar_items_of_type(type).sort_by { |item| weights_hash[item[:key]] || item[:weight] }
+    items = sidebar_items_of_type(type)
+
+    items.sort do |a, b|
+      weight_a = weights_hash[a[:key]] || a[:weight]
+      weight_b = weights_hash[b[:key]] || b[:weight]
+      (weight_a <=> weight_b).nonzero? || a[:key].to_s <=> b[:key].to_s
+    end
   end
 
   # Fetches the first unread popup `UserNotification` for the current course and returns JSON data


### PR DESCRIPTION
#2789

Faced some difficulty ensuring every sidebar item has a unique weight due to the following reasons:

- Weights of sidebar items of disabled components are not updated when reordering
- Components and sidebar items use different sets of keys
- Assessments can have multiple categories and each category has its own sidebar item & weight

Instead modified the sort function to order by weight first then key