### PR TITLE
Rescue ActionController::InvalidAuthenticityToken error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
   include ApplicationSignInCallbacksConcern
 
   rescue_from IllegalStateError, with: :handle_illegal_state_error
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_csrf_error
 
   protected
 
@@ -58,5 +59,10 @@ class ApplicationController < ActionController::Base
   def handle_illegal_state_error(exception)
     @exception = exception
     render file: 'public/422', layout: false, status: 422
+  end
+
+  def handle_csrf_error(exception)
+    @exception = exception
+    render file: 'public/403', layout: false, status: 403
   end
 end

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Can't verify CSRF token authenticity (422)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/403.html -->
+  <div class="dialog">
+    <div>
+      <h1>Can't verify CSRF token authenticity.</h1>
+      <p>Please refresh the page and try again.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/public/403.json
+++ b/public/403.json
@@ -1,0 +1,5 @@
+{
+  "error": {
+    "title": "Can't verify CSRF token authenticity"
+  }
+}

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -197,4 +197,24 @@ RSpec.describe ApplicationController, type: :controller do
       expect(response.status).to eq(422)
     end
   end
+
+  context 'when the action raises ActionController::InvalidAuthenticityToken' do
+    run_rescue
+
+    before do
+      def controller.index
+        raise ActionController::InvalidAuthenticityToken
+      end
+    end
+
+    it 'renders the request rejected page /public/403' do
+      get :index
+      expect(response).to render_template(file: '403.html')
+    end
+
+    it 'returns HTTP status 403' do
+      expect { get :index }.to_not raise_error ActionController::InvalidAuthenticityToken
+      expect(response.status).to eq(403)
+    end
+  end
 end


### PR DESCRIPTION
#2788 

Handle the exception in ApplicationController, referencing [this](https://stackoverflow.com/questions/36509300/gracefully-handling-invalidauthenticitytoken-exceptions-in-rails-4) from #2788. However, `redirect_to` doesn't work for non-`GET` requests. Render a 403 error page in the exception handler instead.

![screen shot 2018-01-31 at 3 36 02 pm](https://user-images.githubusercontent.com/4056819/35610508-7a481154-069c-11e8-9010-68978e9b753a.png)
