### PR TITLE
Allow next_unread_popup to handle deleted objects

### DIFF
--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -26,9 +26,10 @@ class Course::Controller < ApplicationController
   # for the frontend to display it.
   #
   # @return [String] JSON data for the next notification, if there is one.
-  # @return [nil] if there are no unread notifications for current user and course.
+  # @return [nil] if there are no unread notifications, or no +current_course_user+.
   def next_popup_notification
-    notification = UserNotification.next_unread_popup_for_course_user(current_course, current_user)
+    return unless current_course_user
+    notification = UserNotification.next_unread_popup_for(current_course_user)
     notification && render_to_string("#{helpers.notification_view_path(notification)}.json",
                                      locals: { notification: notification })
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -34,7 +34,7 @@ class Activity < ApplicationRecord
   # @return [Boolean] true if activity is from the given course, false otherwise.
   def from_course?(course)
     object_course = object&.course
-    !object_course.nil? && (object_course.id != course.id)
+    object_course.present? && (object_course.id == course.id)
   end
 
   private

--- a/spec/factories/user_notifications.rb
+++ b/spec/factories/user_notifications.rb
@@ -8,6 +8,20 @@ FactoryBot.define do
       notification_type :popup
     end
 
+    trait :popup_with_achievement_gained do
+      transient do
+        achievement { create(:achievement) }
+      end
+      popup
+      activity { create(:activity, :achievement_gained, object: achievement, actor: user) }
+
+      after(:build) do |user_notification|
+        course = user_notification.activity.object.course
+        course_user = CourseUser.find_by(course: course, user: user_notification.user)
+        create(:course_user, course: course) unless course_user
+      end
+    end
+
     trait :email do
       notification_type :email
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -55,5 +55,44 @@ RSpec.describe Activity, type: :model do
         end
       end
     end
+
+    describe '#from_course?' do
+      let(:course_user) { create(:course_student, course: course) }
+      let(:achievement) { create(:achievement, course: course) }
+      let(:activity) do
+        create(:activity, :achievement_gained, object: achievement, actor: user)
+      end
+
+      context 'when activity object is from course' do
+        subject { activity.from_course?(course) }
+
+        it { is_expected.to be_truthy }
+
+        context 'when activity object is deleted' do
+          before do
+            achievement.destroy
+            activity.reload
+          end
+
+          it { is_expected.to be_falsey }
+        end
+      end
+
+      context 'when activity object is not from course' do
+        let(:other_course) { create(:course) }
+        subject { activity.from_course?(other_course) }
+
+        it { is_expected.to be_falsey }
+
+        context 'when activity object is deleted' do
+          before do
+            achievement.destroy
+            activity.reload
+          end
+
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_notification_spec.rb
+++ b/spec/models/user_notification_spec.rb
@@ -4,4 +4,49 @@ require 'rails_helper'
 RSpec.describe UserNotification, type: :model do
   it { is_expected.to belong_to(:activity).inverse_of(:user_notifications) }
   it { is_expected.to belong_to(:user).inverse_of(:notifications) }
+
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '.next_unread_popup_for_course_user' do
+      let(:course) { create(:course) }
+      let(:course_user) { create(:course_student, course: course) }
+      subject { UserNotification.next_unread_popup_for(course_user) }
+
+      it { is_expected.to be_nil }
+
+      context 'when there are multiple notifications' do
+        let(:achievements) { create_list(:achievement, 2, course: course) }
+        let!(:notifications) do
+          achievements.map do |achievement|
+            create(:user_notification, :popup_with_achievement_gained,
+                   achievement: achievement, user: course_user.user)
+          end
+        end
+
+        it 'returns notifications in asending order' do
+          earliest = notifications.sort_by(&:updated_at).first
+          expect(subject).to eq(earliest)
+        end
+
+        context 'when the activity object is destroyed' do
+          before { achievements.first.destroy }
+
+          it 'returns the next notification and deletes the old activity' do
+            expect(subject).to eq(notifications[1])
+            expect(notifications.first.activity.persisted?).to be_falsey
+          end
+        end
+
+        context 'when notifications are all read' do
+          before do
+            notifications.each do |notification|
+              notification.mark_as_read! for: course_user.user
+            end
+          end
+
+          it { is_expected.to be_nil }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously popup would also return object events for
deleted objects, which broke the webserver as nil objects
cannot be rendered. This commit does the following:

- Mark UserNotifications with deleted activity objects as read,
- Change #next_unread_popup to accept 1 parameter, course_user, and
- Fix a bug in Activity#from_course? (which return inverse values).

Fixes #2806