### PR TITLE
Publish submissions for assessments with 0 questions

### DIFF
--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -14,6 +14,8 @@ module Course::Assessment::Submission::WorkflowEventConcern
   def finalise(_ = nil)
     self.submitted_at = Time.zone.now
     current_answers.select(&:attempting?).each(&:finalise!)
+
+    assign_zero_experience_points if assessment.questions.empty?
   end
 
   # Handles the marking of a submission.
@@ -63,6 +65,13 @@ module Course::Assessment::Submission::WorkflowEventConcern
 
   def submission_graded_email_enabled?
     Course::Settings::AssessmentsComponent.email_enabled?(assessment.tab.category, :grades_released)
+  end
+
+  # finalise event (from attempting) - Assign 0 points as there are no questions.
+  def assign_zero_experience_points
+    self.points_awarded = 0
+    self.awarded_at = Time.zone.now
+    self.awarder = User.stamper || User.system
   end
 
   # Defined outside of the workflow transition as points_awarded and draft_points_awarded are

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -12,6 +12,9 @@ class Course::Assessment::Submission < ApplicationRecord
 
   workflow do
     state :attempting do
+      # TODO: Change the if condition to use a symbol when the Workflow gem is upgraded to 1.3.0.
+      event :finalise, transitions_to: :published,
+                       if: proc { |submission| submission.assessment.questions.empty? }
       event :finalise, transitions_to: :submitted
     end
     state :submitted do

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -92,8 +92,6 @@ FactoryBot.define do
       # TODO: To add scribing question once it is completed
     end
 
-    # Note: Not to be used alone, as a published assessment requires at
-    #   least 1 other question. Use the other published traits intead.
     trait :published do
       after(:build) do |assessment|
         assessment.published = true

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
       auto_grade true # Used only with any of the submitted or finalised traits.
       creator
     end
-    assessment { build(:assessment, course: course) }
+    assessment { create(:assessment, :with_mcq_question, course: course) }
     points_awarded nil
 
     trait :attempting do

--- a/spec/features/course/assessment/submissions_viewing_spec.rb
+++ b/spec/features/course/assessment/submissions_viewing_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe 'Course: Submissions Viewing' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, :published_with_mcq_question, course: course) }
-    let(:autograded_assessment) { create(:assessment, :autograded, course: course) }
+    let(:autograded_assessment) do
+      create(:assessment, :autograded, :with_mcq_question, course: course)
+    end
     before { login_as(user, scope: :user) }
 
     context 'As a Course Manager' do
@@ -132,7 +134,8 @@ RSpec.describe 'Course: Submissions Viewing' do
 
       scenario 'I can view my submitted, graded and published submissions' do
         # Attach a submission of each trait to a unique assessment
-        assessments = create_list(:course_assessment_assessment, 4, course: course)
+        assessments = create_list(:course_assessment_assessment, 4, :with_mcq_question,
+                                  course: course)
         attempting_submission, submitted_submission, graded_submission, published_submission =
           assessments.zip([:attempting, :submitted, :graded, :published]).map do |assessment, trait|
             create(:submission, trait, assessment: assessment, creator: user)

--- a/spec/features/course/staff_statistics_spec.rb
+++ b/spec/features/course/staff_statistics_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Course: Statistics: Staff' do
       let!(:tutor1_submissions) do
         submitted_at = 1.day.ago
         published_at = submitted_at + 1.day + 1.hour + 1.minute + 1.second
-        assessment = create(:assessment, course: course)
+        assessment = create(:assessment, :with_mcq_question, course: course)
         submission = create(:submission, :published,
                             assessment: assessment, course: course, publisher: tutor1.user,
                             published_at: published_at, submitted_at: submitted_at)
@@ -36,7 +36,7 @@ RSpec.feature 'Course: Statistics: Staff' do
       let!(:tutor2_submissions) do
         submitted_at = 2.days.ago
         published_at = submitted_at + 2.days
-        assessment = create(:assessment, course: course)
+        assessment = create(:assessment, :with_mcq_question, course: course)
         submission = create(:submission, :published,
                             assessment: assessment, course: course, publisher: tutor2.user,
                             published_at: published_at, submitted_at: submitted_at)
@@ -47,7 +47,7 @@ RSpec.feature 'Course: Statistics: Staff' do
 
       let!(:tutor3_submissions) do
         submitted_at, published_at = 2.days.ago, 2.days.ago
-        assessment = create(:assessment, course: course)
+        assessment = create(:assessment, :with_mcq_question, course: course)
         submission = create(:submission, :published,
                             assessment: assessment, course: course, publisher: tutor3.user,
                             published_at: published_at, submitted_at: submitted_at,

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Course::Assessment::Answer do
     describe '#auto_grade!' do
       let(:course) { create(:course) }
       let(:student_user) { create(:course_student, course: course).user }
-      let(:assessment) { create(:assessment, course: course) }
+      let(:assessment) { create(:assessment, :with_mcq_question, course: course) }
       let(:question) do
         build(:course_assessment_question_multiple_response, assessment: assessment).question
       end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Course::Assessment::Submission do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, *assessment_traits, course: course) }
-    let(:assessment_traits) { [] }
+    let(:assessment_traits) { [:with_mcq_question] }
 
     let(:course_student1) { create(:course_student, *course_student1_traits, course: course) }
     let(:user1) { course_student1.user }
@@ -368,6 +368,18 @@ RSpec.describe Course::Assessment::Submission do
           expect(not_current_answer).to be_attempting
           submission.finalise!
           expect(not_current_answer).to be_attempting
+        end
+      end
+
+      context 'when there are no questions' do
+        let(:assessment_traits) { [:published] }
+
+        it 'publishes the submission with 0 points' do
+          submission.finalise!
+          submission.save!
+
+          expect(submission.workflow_state).to eq 'published'
+          expect(submission.points_awarded).to eq 0
         end
       end
     end

--- a/spec/services/course/assessment/question/answers_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/question/answers_evaluation_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Course::Assessment::Question::AnswersEvaluationService do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     # Used MCQ question here because we are not able to run programming auto grading in tests
-    let(:assessment) { create(:assessment) }
+    let(:assessment) { create(:assessment, :with_mcq_question) }
     let(:question) { create(:course_assessment_question_multiple_response, assessment: assessment) }
     let(:student) { create(:course_student, course: assessment.course).user }
     let!(:submission) do


### PR DESCRIPTION
Some assessment are meant to have 0 questions. https://github.com/Coursemology/coursemology2/pull/2496 allows students to submit submissions with 0 questions, but only transitions them to `published` state if the assessment has been set to autograded.

This PR transitions submissions to the `published` state even if the lecturer has forgotten to make the assessment autograded.

This is done by adding a new conditional transition. To prevent validation from failing, exp points have to be awarded during the transition.