### PR TITLE
Fix a bug where reorder questions cannot render

### DIFF
--- a/app/views/course/assessment/assessments/reorder.js.erb
+++ b/app/views/course/assessment/assessments/reorder.js.erb
@@ -1,3 +1,3 @@
 $('.course-assessment-assessments.show #sortable-questions').html(
-    '<%= j(render @assessment.reload.questions.map(&:specific)) %>'
+    '<%= j(render @assessment.reload.question_assessments) %>'
 );


### PR DESCRIPTION
This used to refer to `course/assessment/question/_question.html.slim`, but was shifted in #2629, and this was not updated. The bug does not break any functionality, but the page was not updated after a reordering, and this fix corrects that.