### PR TITLE
Remove foreign key reference from read_marks to users table.

### DIFF
--- a/db/migrate/20180208070853_remove_read_marks_foreign_key.rb
+++ b/db/migrate/20180208070853_remove_read_marks_foreign_key.rb
@@ -1,0 +1,5 @@
+class RemoveReadMarksForeignKey < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :read_marks, column: :reader_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180130023617) do
+ActiveRecord::Schema.define(version: 20180208070853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -867,7 +867,7 @@ ActiveRecord::Schema.define(version: 20180130023617) do
   create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"
     t.string   "readable_type", :limit=>255, :null=>false
-    t.integer  "reader_id",     :null=>false, :index=>{:name=>"fk__read_marks_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_read_marks_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "reader_id",     :null=>false
     t.datetime "timestamp"
     t.string   "reader_type",   :limit=>255
 


### PR DESCRIPTION
Read marks supports multiple reader types so the ID should not be
constrained to a single table.

The migration to convert `read_marks` to support polymorphism is at https://github.com/Coursemology/coursemology2/blob/master/db/migrate/20151117141053_unread_polymorphic_reader_migration.rb