### PR TITLE
Respond to 422 and 403 with json or html format

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,11 +58,17 @@ class ApplicationController < ActionController::Base
   # Handles +IllegalStateError+s with a HTTP 422.
   def handle_illegal_state_error(exception)
     @exception = exception
-    render file: 'public/422', layout: false, status: 422
+    respond_to do |format|
+      format.html { render file: 'public/422', layout: false, status: 422 }
+      format.json { render file: 'public/422.json', status: 422 }
+    end
   end
 
   def handle_csrf_error(exception)
     @exception = exception
-    render file: 'public/403', layout: false, status: 403
+    respond_to do |format|
+      format.html { render file: 'public/403', layout: false, status: 403 }
+      format.json { render file: 'public/403.json', status: 403 }
+    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -189,12 +189,21 @@ RSpec.describe ApplicationController, type: :controller do
 
     it 'renders the request rejected page /public/422' do
       get :index
-      expect(response).to render_template(file: '422.html')
+      expect(response).to render_template(file: Rails.root.join('public', '422.html').to_s)
     end
 
     it 'returns HTTP status 422' do
       get :index
       expect(response.status).to eq(422)
+    end
+
+    context 'when the request only accepts a json response' do
+      before { request.accept = 'application/json' }
+
+      it 'renders the correct template' do
+        get :index
+        expect(response).to render_template(file: Rails.root.join('public', '422.json').to_s)
+      end
     end
   end
 
@@ -209,12 +218,21 @@ RSpec.describe ApplicationController, type: :controller do
 
     it 'renders the request rejected page /public/403' do
       get :index
-      expect(response).to render_template(file: '403.html')
+      expect(response).to render_template(file: Rails.root.join('public', '403.html').to_s)
     end
 
     it 'returns HTTP status 403' do
       expect { get :index }.to_not raise_error ActionController::InvalidAuthenticityToken
       expect(response.status).to eq(403)
+    end
+
+    context 'when the request only accepts a json response' do
+      before { request.accept = 'application/json' }
+
+      it 'renders the correct template' do
+        get :index
+        expect(response).to render_template(file: Rails.root.join('public', '403.json').to_s)
+      end
     end
   end
 end


### PR DESCRIPTION
Previous implementation ignored json responses and rails was unable to find a json response. To explicitly declare the json response in the public folder.

Specs were also changed to handle this.