### PR TITLE
Show member count breakdown on group index page.

### DIFF
--- a/app/views/course/groups/_group.html.slim
+++ b/app/views/course/groups/_group.html.slim
@@ -1,5 +1,7 @@
 = content_tag_for(:tr, group) do
   th = format_inline_text(group.name)
+  td = group.course_users.without_phantom_users.count
+  td = group.course_users.phantom.count
   td = group.course_users.count
   td
     - group.group_users.select(&:manager?).map(&:course_user).each do |manager|

--- a/app/views/course/groups/index.html.slim
+++ b/app/views/course/groups/index.html.slim
@@ -6,6 +6,8 @@ table.table.table-hover
     tr
       th = t('.name')
       th = t('.members')
+      th = t('.phantom')
+      th = t('.total')
       th = t('.managers')
       th
 

--- a/config/locales/en/course/groups.yml
+++ b/config/locales/en/course/groups.yml
@@ -6,6 +6,8 @@ en:
         header: 'Groups'
         name: 'Name'
         members: 'Members'
+        phantom: 'Phantom'
+        total: 'Total'
         managers: 'Managers'
       new:
         header: 'New Group'


### PR DESCRIPTION
Split out the number of real and phantom members into separate columns.

<img width="990" alt="group_index" src="https://user-images.githubusercontent.com/1902527/36244592-e041e95a-1261-11e8-817f-614c050324fb.png">
