### PR TITLE
Declare #current_tab for video topics controller

### DIFF
--- a/app/controllers/course/video/topics_controller.rb
+++ b/app/controllers/course/video/topics_controller.rb
@@ -37,4 +37,8 @@ class Course::Video::TopicsController < Course::Video::Controller
   def create_topic_subscription
     @topic.ensure_subscribed_by(current_user)
   end
+
+  def current_tab
+    @tab ||= @video.tab
+  end
 end


### PR DESCRIPTION
I think this was missing from #2828. Because of this the topics controller cannot be called. 