### PR TITLE
Switch order of password fields on change password page.

### DIFF
--- a/app/views/user/registrations/edit.html.slim
+++ b/app/views/user/registrations/edit.html.slim
@@ -5,9 +5,9 @@
   = f.error_notification
 
   div.form-inputs
-    = f.input :password, autocomplete: 'off', hint: t('.new_password_hint'), required: false
-    = f.input :password_confirmation, required: false
     = f.input :current_password, hint: t('.current_password_required_hint'), required: true
+    = f.input :password, label: t('.new_password'), autocomplete: 'off', hint: t('.new_password_hint'), required: false
+    = f.input :password_confirmation, label: t('.new_password_confirmation'), required: false
 
   div.form-actions
     = f.button :submit

--- a/config/locales/en/user/registrations.yml
+++ b/config/locales/en/user/registrations.yml
@@ -13,5 +13,7 @@ en:
           The provided invitation code has been claimed by %{email}, please use that account to log in instead.
       edit:
         header: 'Account Settings'
+        new_password: 'New password'
+        new_password_confirmation: 'Confirm your new password'
         new_password_hint: "Leave blank if you don't want to change it"
         current_password_required_hint: 'We need your current password to confirm your changes'


### PR DESCRIPTION
Other web services ask for the current password as the first field. Make
Coursemology's change password page consistent with those of other web
services.

Add more descriptive labels for the new password fields.