### PR TITLE
Allow can_masquerade? to be overriden

### DIFF
--- a/app/models/concerns/user_masquerade_concern.rb
+++ b/app/models/concerns/user_masquerade_concern.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module UserMasqueradeConcern
+  extend ActiveSupport::Concern
+
+  def can_masquerade?
+    primary_email_record.confirmed?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   DELETED_USER_ID = -1
 
   include UserSearchConcern
+  include UserMasqueradeConcern
   model_stamper
   acts_as_reader
   mount_uploader :profile_photo, ImageUploader

--- a/app/views/system/admin/users/_user.html.slim
+++ b/app/views/system/admin/users/_user.html.slim
@@ -12,8 +12,7 @@
       = f.button :submit, id: 'update' do
         = fa_icon 'check'.freeze
       = delete_button([:admin, user])
-      - can_masquerade = user.primary_email_record.confirmed?
-      - if can_masquerade
+      - if user.can_masquerade?
         = link_to masquerade_path(user), class: ['btn', 'btn-default'], title: t('.masquerade') do
           = fa_icon 'user-secret'.freeze
       - else


### PR DESCRIPTION
This allows the assumption that `primary_email_record` is always present to be removed.