### PR TITLE
View course user's phantom status on group edit page.

### DIFF
--- a/app/views/course/groups/_group_user_fields.html.slim
+++ b/app/views/course/groups/_group_user_fields.html.slim
@@ -1,5 +1,6 @@
 = content_tag_for(:tr, f.object, class: 'nested-fields') do
   td = f.association :course_user, collection: current_course.course_users.order_alphabetically,
-                                   label:  false
+                                   label: false,
+                                   label_method: lambda { |cu| cu.phantom ? t('.phantom_user_label', name: cu.name) : cu.name }
   td = f.input :role, as: :select, label: false, collection: Course::GroupUser.roles.keys
   td = link_to_remove_association  t('.remove'), f

--- a/config/locales/en/course/groups.yml
+++ b/config/locales/en/course/groups.yml
@@ -24,3 +24,4 @@ en:
         success: 'Group %{name} was deleted.'
       group_user_fields:
         remove: 'Remove'
+        phantom_user_label: '%{name} (Phantom User)'


### PR DESCRIPTION
## With Ghost Icon
![phantom-icon](https://user-images.githubusercontent.com/1902527/36718993-b9b13508-1bde-11e8-8a1d-7d986e788090.png)

## Without Ghost Icon
The icon remains even if a non-phantom user is selected, which might cause confusion to users.
The 2nd commit removes the ghost icon.

![phantom-no-icon](https://user-images.githubusercontent.com/1902527/36719761-fb8764b4-1be0-11e8-832c-1018b4a3a0e5.png)

Will remove the 2nd commit, or squash them together depending on what the final decision is.

