### PR TITLE
Remove bundler warnings by using secure gem sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'validates_hostname'
 # A Ruby state machine library
 gem 'workflow'
 # Add creator_id and updater_id attributes to models
-gem 'activerecord-userstamp', github: 'lowjoel/activerecord-userstamp'
+gem 'activerecord-userstamp', git: 'https://github.com/lowjoel/activerecord-userstamp'
 # Allow actions to be deferred until after a record is committed.
 gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
@@ -38,7 +38,7 @@ gem 'calculated_attributes'
 gem 'baby_squeel'
 # For multiple table inheritance
 #   TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
-gem 'active_record-acts_as', github: 'Coursemology/active_record-acts_as', branch: 'rails5'
+gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as', branch: 'rails5'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Create pretty URLs and work with human-friendly strings
@@ -62,7 +62,7 @@ gem 'js-routes'
 gem 'jquery-rails'
 # Our Coursemology will be themed using Bootstrap
 gem 'bootstrap-sass'
-gem 'bootstrap-sass-extras', '>= 0.0.7', github: 'doabit/bootstrap-sass-extras'
+gem 'bootstrap-sass-extras', '>= 0.0.7', git: 'https://github.com/doabit/bootstrap-sass-extras'
 gem 'autoprefixer-rails'
 # Use font-awesome for icons
 gem 'font-awesome-rails'
@@ -189,12 +189,12 @@ gem 'cancancan-baby_squeel'
 gem 'rails_utils', '>= 3.3.3'
 
 # Themes for instances
-gem 'themes_on_rails', '>= 0.3.1', github: 'Coursemology/themes_on_rails',
+gem 'themes_on_rails', '>= 0.3.1', git: 'https://github.com/Coursemology/themes_on_rails',
                                    branch: 'cache-theme-templates'
 
 # Forms made easy for Rails
 gem 'simple_form'
-gem 'simple_form-bootstrap', github: 'Coursemology/simple_form-bootstrap'
+gem 'simple_form-bootstrap', git: 'https://github.com/Coursemology/simple_form-bootstrap'
 # Dynamic nested forms
 gem 'cocoon'
 gem 'bootstrap3-datetimepicker-rails'
@@ -216,7 +216,7 @@ gem 'rubyzip', require: 'zip'
 gem 'nokogiri', '>= 1.8.1'
 
 # Polyglot support
-gem 'coursemology-polyglot', github: 'Coursemology/polyglot'
+gem 'coursemology-polyglot', git: 'https://github.com/Coursemology/polyglot'
 
 # To assist with bulk inserts into database
 gem 'activerecord-import', '>= 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/Coursemology/active_record-acts_as.git
+  remote: https://github.com/Coursemology/active_record-acts_as
   revision: 84a2b5f0329870c6c4a72b097b6d7f1344b536e4
   branch: rails5
   specs:
@@ -8,14 +8,14 @@ GIT
       activesupport (>= 4.2, < 5.2)
 
 GIT
-  remote: git://github.com/Coursemology/polyglot.git
+  remote: https://github.com/Coursemology/polyglot
   revision: b946657046bdd8e0a51e18b82bded9b71ffde596
   specs:
     coursemology-polyglot (0.2.9.2)
       activesupport (>= 4.2, < 5.2)
 
 GIT
-  remote: git://github.com/Coursemology/simple_form-bootstrap.git
+  remote: https://github.com/Coursemology/simple_form-bootstrap
   revision: ba048ab714904d9e4fc1407bee33e7b5a1f832b9
   specs:
     simple_form-bootstrap (1.6.0)
@@ -26,7 +26,7 @@ GIT
       simple_form (>= 3.1.0)
 
 GIT
-  remote: git://github.com/Coursemology/themes_on_rails.git
+  remote: https://github.com/Coursemology/themes_on_rails
   revision: c96d43d479fc307b5227ad18e891fcf347d1e22b
   branch: cache-theme-templates
   specs:
@@ -34,14 +34,14 @@ GIT
       rails (>= 3.2)
 
 GIT
-  remote: git://github.com/doabit/bootstrap-sass-extras.git
+  remote: https://github.com/doabit/bootstrap-sass-extras
   revision: 6aa549b91a66055a5f5e37400dbe44f4d17f09c3
   specs:
     bootstrap-sass-extras (0.0.7)
       rails (>= 3.1.0)
 
 GIT
-  remote: git://github.com/lowjoel/activerecord-userstamp.git
+  remote: https://github.com/lowjoel/activerecord-userstamp
   revision: 752f1e30ed8a2f0b09408bcdfa2c2dad1e5523c4
   specs:
     activerecord-userstamp (3.0.5)


### PR DESCRIPTION
As mentioned in [bundler security](http://bundler.io/v1.12/git.html#security) using `github` for gem sources is prone to man-in-the-middle attack.