### PR TITLE
Switch to React-Summernote for Submission Page

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Avatar from 'material-ui/Avatar';
-import TextField from 'material-ui/TextField';
 import { Card, CardHeader, CardText } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
 import { red500, grey100 } from 'material-ui/styles/colors';
+import MaterialSummernote from 'lib/components/MaterialSummernote';
 /* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 import moment from 'lib/moment';
@@ -62,14 +62,22 @@ export default class CommentCard extends Component {
     return dateTime ? moment(dateTime).format('MMM DD, YYYY h:mma') : null;
   }
 
+  static editPostIdentifier(field) {
+    return `edit_post_${field}`;
+  }
+
+  static postIdentifier(field) {
+    return `post_${field}`;
+  }
+
   state = {
     editMode: false,
     deleteConfirmation: false,
   }
 
-  onChange(event) {
+  onChange(nextValue) {
     const { handleChange } = this.props;
-    handleChange(event.target.value);
+    handleChange(nextValue);
   }
 
   onSave() {
@@ -102,14 +110,12 @@ export default class CommentCard extends Component {
     if (editMode) {
       return (
         <React.Fragment>
-          <TextField
+          <MaterialSummernote
+            airMode
             id={id.toString()}
-            fullWidth
-            multiLine
-            rows={2}
-            rowsMax={4}
+            inputId={CommentCard.editPostIdentifier(id)}
+            onChange={nextValue => this.onChange(nextValue)}
             value={editValue}
-            onChange={event => this.onChange(event)}
           />
           <div style={styles.buttonContainer}>
             <FlatButton
@@ -134,9 +140,12 @@ export default class CommentCard extends Component {
   }
 
   render() {
-    const { creator: { name, avatar }, createdAt, canUpdate, canDestroy } = this.props.post;
+    const { creator: { name, avatar }, createdAt, canUpdate, canDestroy, id } = this.props.post;
     return (
-      <Card style={styles.card}>
+      <Card
+        id={CommentCard.postIdentifier(id)}
+        style={styles.card}
+      >
         <div style={styles.header}>
           <CardHeader
             style={styles.cardHeader}

--- a/client/app/bundles/course/assessment/submission/components/CommentField.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentField.jsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import CircularProgress from 'material-ui/CircularProgress';
+import MaterialSummernote from 'lib/components/MaterialSummernote';
 
 const translations = defineMessages({
   prompt: {
@@ -18,31 +18,30 @@ const translations = defineMessages({
 
 export default class CommentField extends Component {
   static propTypes = {
-    value: PropTypes.string,
+    inputId: PropTypes.string,
     isSubmitting: PropTypes.bool,
+    value: PropTypes.string,
 
     createComment: PropTypes.func,
     handleChange: PropTypes.func,
   };
 
-  onChange(event) {
+  onChange(nextValue) {
     const { handleChange } = this.props;
-    handleChange(event.target.value);
+    handleChange(nextValue);
   }
 
   render() {
-    const { value, createComment, isSubmitting } = this.props;
+    const { createComment, inputId, isSubmitting, value } = this.props;
     return (
       <React.Fragment>
-        <TextField
-          floatingLabelText={<h4><FormattedMessage {...translations.prompt} /></h4>}
-          fullWidth
-          multiLine
-          rows={2}
-          rowsMax={4}
-          value={value}
+        <MaterialSummernote
+          airMode
           disabled={isSubmitting}
-          onChange={event => this.onChange(event)}
+          inputId={inputId}
+          label={<h4><FormattedMessage {...translations.prompt} /></h4>}
+          onChange={nextValue => this.onChange(nextValue)}
+          value={value}
         />
         <RaisedButton
           primary

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
@@ -80,7 +80,7 @@ export default class NarrowEditor extends Component {
       >
         <OverlayTooltip
           placement={placement}
-          style={{ zIndex: activeComment === lineNumber ? 9999 : lineNumber }}
+          style={{ zIndex: activeComment === lineNumber ? 1000 : lineNumber }}
         >
           <div onClick={() => this.setState({ activeComment: lineNumber })}>
             <Annotations answerId={answerId} fileId={fileId} lineNumber={lineNumber} annotation={annotation} />

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
@@ -76,6 +76,7 @@ export default class NarrowEditor extends Component {
         show={expanded[lineNumber - 1]}
         onHide={() => collapseLine(lineNumber)}
         placement={placement}
+        rootClose
         target={() => findDOMNode(this[`comment-${lineNumber}`])} // eslint-disable-line react/no-find-dom-node
       >
         <OverlayTooltip
@@ -95,18 +96,20 @@ export default class NarrowEditor extends Component {
     const { annotations } = this.props;
     const annotation = annotations.find(a => a.line === lineNumber);
     return (
-      <div
-        style={annotation ? styles.editorLineNumberWithComments : styles.editorLineNumber}
-        onClick={() => this.toggleComment(lineNumber)}
-        onMouseOver={() => this.setState({ lineHovered: lineNumber })}
-        onMouseOut={() => this.setState({ lineHovered: 0 })}
-      >
-        <div ref={(c) => { this[`comment-${lineNumber}`] = c; }}>
-          {lineNumber}
+      <React.Fragment>
+        <div
+          style={annotation ? styles.editorLineNumberWithComments : styles.editorLineNumber}
+          onClick={() => this.toggleComment(lineNumber)}
+          onMouseOver={() => this.setState({ lineHovered: lineNumber })}
+          onMouseOut={() => this.setState({ lineHovered: 0 })}
+        >
+          <div ref={(c) => { this[`comment-${lineNumber}`] = c; }}>
+            {lineNumber}
+          </div>
+          <AddCommentIcon onClick={() => this.expandComment(lineNumber)} hovered={lineHovered === lineNumber} />
         </div>
         {this.renderComments(lineNumber)}
-        <AddCommentIcon onClick={() => this.expandComment(lineNumber)} hovered={lineHovered === lineNumber} />
-      </div>
+      </React.Fragment>
     );
   }
 

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/WideComments.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/WideComments.jsx
@@ -41,7 +41,7 @@ export default class WideComments extends Component {
           key={lineNumber}
           style={{
             ...styles.expanded,
-            zIndex: activeComment === lineNumber ? 9999 : lineNumber + styles.expanded.zIndex,
+            zIndex: activeComment === lineNumber ? 1000 : lineNumber + styles.expanded.zIndex,
           }}
           onClick={() => onClick(lineNumber)}
         >

--- a/client/app/bundles/course/assessment/submission/containers/Annotations.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/Annotations.jsx
@@ -9,6 +9,12 @@ import CommentCard from '../components/CommentCard';
 import CommentField from '../components/CommentField';
 import * as annotationActions from '../actions/annotations';
 
+const styles = {
+  card: {
+    minWidth: 250,
+  },
+};
+
 class VisibleAnnotations extends Component {
   constructor(props) {
     super(props);
@@ -24,7 +30,10 @@ class VisibleAnnotations extends Component {
     } = this.props;
 
     return (
-      <Card onClick={() => this.setState({ fieldVisible: true })}>
+      <Card
+        onClick={() => this.setState({ fieldVisible: true })}
+        style={styles.card}
+      >
         <CardText style={{ textAlign: 'left' }}>
           {posts.map(post => (
             <CommentCard

--- a/client/app/bundles/course/assessment/submission/containers/Comments.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/Comments.jsx
@@ -10,6 +10,10 @@ import * as commentActions from '../actions/comments';
 import translations from '../translations';
 
 class VisibleComments extends Component {
+  static newCommentIdentifier(field) {
+    return `topic_${field}`;
+  }
+
   render() {
     const {
       commentForms, posts, topic,
@@ -31,10 +35,11 @@ class VisibleComments extends Component {
           />
         ))}
         <CommentField
-          value={commentForms.topics[topic.id]}
-          isSubmitting={commentForms.isSubmitting}
           createComment={createComment}
           handleChange={handleCreateChange}
+          inputId={VisibleComments.newCommentIdentifier(topic.id)}
+          isSubmitting={commentForms.isSubmitting}
+          value={commentForms.topics[topic.id]}
         />
       </div>
     );

--- a/client/app/bundles/course/assessment/submission/containers/PostPreview.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/PostPreview.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { stripHtmlTags } from 'lib/helpers/htmlFormatHelpers';
 import { annotationShape } from '../propTypes';
 
 const styles = {
@@ -20,7 +21,8 @@ class VisiblePostPreview extends Component {
     const { style, creator, text } = this.props;
     return (
       <div style={{ ...styles.postPreview, ...style }}>
-        <span className="fa fa-chevron-down" style={styles.chevron} />{`${creator}: ${text}`}
+        <span className="fa fa-chevron-down" style={styles.chevron} />
+        {`${creator}: ${stripHtmlTags(text)}`}
       </div>
     );
   }

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import ReactSummernote from 'react-summernote';
 import TextFieldLabel from 'material-ui/TextField/TextFieldLabel';
 
+import { i18nLocale } from 'lib/helpers/server-context';
 import '../styles/MaterialSummernote.scss';
+
+const translations = defineMessages({
+  inlineCode: {
+    id: 'materialSummernote.InlineCode',
+    defaultMessage: 'Inline Code',
+  },
+});
 
 const propTypes = {
   field: PropTypes.string,
@@ -87,6 +96,33 @@ class MaterialSummernote extends React.Component {
     reader.readAsDataURL(image);
   };
 
+  /* eslint class-methods-use-this: "off" */
+  inlineCodeButton(context) {
+    const ui = $.summernote.ui;
+
+    const button = ui.button({
+      contents: '<i class="fa fa-code"' +
+                   'style="color: #c7254e;' +
+                   'font-weight: bold;' +
+                   'background-color: #f9f2f4"/>',
+      tooltip: <FormattedMessage {...translations.inlineCode} />,
+      click: () => {
+        const node = $(window.getSelection().getRangeAt(0).commonAncestorContainer);
+        if (node.parent().is('code')) {
+          node.unwrap();
+        } else {
+          const range = context.invoke('editor.createRange');
+          const text = range.toString();
+          if (text !== '') {
+            context.invoke('editor.insertNode', $(`<code>${text}</code>`)[0]);
+          }
+        }
+      },
+    });
+
+    return button.render();
+  }
+
   render() {
     const {
       baseTheme,
@@ -152,7 +188,7 @@ class MaterialSummernote extends React.Component {
               fontNamesIgnoreCheck: ['Roboto'],
               toolbar: [
                 ['style', ['style']],
-                ['font', ['bold', 'underline', 'clear']],
+                ['font', ['bold', 'underline', 'inlineCode', 'clear']],
                 ['script', ['superscript', 'subscript']],
                 ['fontname', ['fontname']],
                 ['color', ['color']],
@@ -164,7 +200,7 @@ class MaterialSummernote extends React.Component {
               popover: {
                 air: [
                   ['style', ['style']],
-                  ['font', ['bold', 'underline', 'clear']],
+                  ['font', ['bold', 'underline', 'inlineCode', 'clear']],
                   ['script', ['superscript', 'subscript']],
                   ['color', ['color']],
                   ['para', ['ul', 'ol', 'paragraph']],
@@ -172,6 +208,10 @@ class MaterialSummernote extends React.Component {
                   ['insert', ['link', 'picture']],
                 ],
               },
+              buttons: {
+                inlineCode: this.inlineCodeButton,
+              },
+              lang: i18nLocale,
             }}
             value={this.props.value}
             onChange={this.props.onChange}

--- a/client/app/lib/helpers/__test__/htmlFormatHelpers.test.js
+++ b/client/app/lib/helpers/__test__/htmlFormatHelpers.test.js
@@ -1,0 +1,19 @@
+import { stripHtmlTags } from '../htmlFormatHelpers';
+
+describe('stripHtmlTags', () => {
+  it('strips the html tags accurately', () => {
+    const str1 = '<p> foo <b>bar</b> baz</p> <a ref="foo.com"> Link to bar</a>';
+    const str2 = 'hello <div> </div> to more <strong> tests!</strong>';
+
+    expect(stripHtmlTags(str1)).toEqual(' foo bar baz  Link to bar');
+    expect(stripHtmlTags(str2)).toEqual('hello   to more  tests!');
+  });
+
+  it('handles empty or null strings', () => {
+    const str1 = null;
+    const str2 = '';
+
+    expect(stripHtmlTags(str1)).toEqual('');
+    expect(stripHtmlTags(str2)).toEqual('');
+  });
+});

--- a/client/app/lib/helpers/htmlFormatHelpers.js
+++ b/client/app/lib/helpers/htmlFormatHelpers.js
@@ -1,0 +1,15 @@
+/**
+ * Removes HTML tags from a specified string.
+ *
+ * @param {String} str The specified string with HTML tags.
+ * @returns {String} The string with HTML tags removed.
+ */
+function stripHtmlTags(str) {
+  if ((str === null) || (str === '')) { return ''; }
+
+  return str.replace(/<[^>]*>/g, '');
+}
+
+export {
+  stripHtmlTags,
+};

--- a/client/app/lib/initializers/webfont.js
+++ b/client/app/lib/initializers/webfont.js
@@ -6,7 +6,7 @@ import WebFont from 'webfontloader';
 
 WebFont.load({
   google: {
-    families: ['Roboto', 'Varela Round'],
+    families: ['Roboto:400,700', 'Varela Round'],
   },
   timeout: 1500,
 });

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -108,8 +108,10 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments', j
 
         # Make a first comment
         comment_post_text = 'test comment'
-        first('textarea').set(comment_post_text)
+        summernote_topic_selector = "textarea#topic_#{comment_topic.id}"
+        fill_in_react_summernote summernote_topic_selector, comment_post_text
         click_button 'Comment'
+        expect(page).to have_selector('div[id^="post_"]', count: 1)
         expect(page).to have_selector('p', text: comment_post_text)
 
         comment_post = comment_topic.reload.posts.last
@@ -118,8 +120,9 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments', j
 
         # Reply to the first comment
         comment_reply_text = 'test reply'
-        first('textarea').set(comment_reply_text)
+        fill_in_react_summernote summernote_topic_selector, comment_reply_text
         click_button 'Comment'
+        expect(page).to have_selector('div[id^="post_"]', count: 2)
         expect(page).to have_selector('p', text: comment_reply_text)
 
         comment_reply = comment_topic.reload.posts.reject { |post| post.id == comment_post.id }.last
@@ -128,8 +131,9 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments', j
         # Edit the first comment made
         first('button.edit-comment').click
         updated_post_text = 'updated comment'
-        first('textarea').set('')
-        first('textarea').set(updated_post_text)
+        summernote_post_selector = "textarea#edit_post_#{comment_topic.posts.first.id}"
+        fill_in_react_summernote summernote_post_selector, ''
+        fill_in_react_summernote summernote_post_selector, updated_post_text
         click_button 'Save'
         expect(page).to have_selector('p', text: updated_post_text)
 


### PR DESCRIPTION
This PR switches the textfields in submission page (comments and programming annotations) to react-summernote. In more detail: 
 - Fix bug to in narrow view to edit, delete and comment on programming annotations (#2796)
 - Load bolded font for roboto to display in app
 - Implement inline comment button in React-Summernote

Some screens: 
![sub-annotation](https://user-images.githubusercontent.com/4353853/36895827-4d03b1aa-1e4b-11e8-8c33-f15460fd7862.gif)
![submission](https://user-images.githubusercontent.com/4353853/36895829-4db9d8a4-1e4b-11e8-8926-18689186bbd0.gif)

