### PR TITLE
Allow errors on assessment base to be shown in form

### DIFF
--- a/client/app/bundles/course/assessment/actions.js
+++ b/client/app/bundles/course/assessment/actions.js
@@ -1,4 +1,4 @@
-import { SubmissionError } from 'redux-form';
+import { SubmissionError } from 'lib/redux-form';
 import CourseAPI from 'api/course';
 import { getCourseId } from 'lib/helpers/url-helpers';
 import actionTypes from './constants';

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { reduxForm, Field, Form, formValueSelector, change } from 'redux-form';
 import { connect } from 'react-redux';
 import MenuItem from 'material-ui/MenuItem';
+import ErrorText, { errorProps } from 'lib/components/ErrorText';
 import ConditionList from 'lib/components/course/ConditionList';
 import TextField from 'lib/components/redux-form/TextField';
 import RichTextField from 'lib/components/redux-form/RichTextField';
@@ -84,6 +85,7 @@ class AssessmentForm extends React.Component {
       tab_id: PropTypes.number,
       title: PropTypes.string,
     })),
+    error: errorProps,
     // Above are props from redux-form.
 
     onSubmit: PropTypes.func.isRequired,
@@ -239,10 +241,11 @@ class AssessmentForm extends React.Component {
 
   render() {
     const { handleSubmit, onSubmit, gamified, modeSwitching, submitting, editing, folderAttributes,
-      conditionAttributes } = this.props;
+      conditionAttributes, error } = this.props;
 
     return (
       <Form onSubmit={handleSubmit(onSubmit)}>
+        <ErrorText errors={error} />
         <div style={styles.flexGroup}>
           <Field
             name="title"

--- a/client/app/lib/__test__/redux-form.test.jsx
+++ b/client/app/lib/__test__/redux-form.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { createStore, combineReducers } from 'redux';
+import { mount } from 'enzyme';
+import { reduxForm, reducer as formReducer, submit } from 'redux-form';
+import { SubmissionError } from 'lib/redux-form';
+
+describe('SubmissionError', () => {
+  describe('when no ActiveModel base errors are present', () => {
+    const errors = { title: 'is absent' };
+
+    it('makes no change', () => {
+      expect(new SubmissionError(errors).errors).toEqual(errors);
+    });
+  });
+
+  describe('when ActiveModel base errors are present', () => {
+    const baseError = 'Whole form wrong!';
+    const errors = { title: 'is absent', base: baseError };
+
+    it('copies ActiveModel base errors to it', () => {
+      expect(new SubmissionError(errors).errors).toEqual({ ...errors, _error: baseError });
+    });
+
+    it('is caught and displayed by redux-form', () => {
+      const DummyForm = reduxForm({ form: 'dummy' })(({ error, handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          { error }
+        </form>
+      ));
+      const dummyStore = createStore(combineReducers({ form: formReducer }), {});
+      const wrapper = mount(
+        <DummyForm onSubmit={() => { throw new SubmissionError(errors); }} />,
+        buildContextOptions(dummyStore)
+      );
+
+      dummyStore.dispatch(submit('dummy'));
+      wrapper.update();
+      expect(wrapper.text()).toEqual(baseError);
+    });
+  });
+});

--- a/client/app/lib/components/ErrorText.jsx
+++ b/client/app/lib/components/ErrorText.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { red500 } from 'material-ui/styles/colors';
+
+/**
+ * Standardises the way errors are shown in redux forms.
+ */
+const ErrorText = ({ errors }) => {
+  if (!errors) { return null; }
+  if (errors.constructor === String) {
+    return <div style={{ color: red500 }}>{ errors }</div>;
+  }
+  if (errors.constructor === Array) {
+    return (
+      <React.Fragment>
+        { errors.map(error => <ErrorText key={error} errors={error} />) }
+      </React.Fragment>
+    );
+  }
+  return null;
+};
+
+export const errorProps = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.arrayOf(PropTypes.string),
+]);
+
+ErrorText.propTypes = {
+  errors: errorProps,
+};
+
+export default ErrorText;

--- a/client/app/lib/components/__test__/ErrorText.test.jsx
+++ b/client/app/lib/components/__test__/ErrorText.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ErrorText from '../ErrorText';
+
+describe('<ErrorText />', () => {
+  describe('when input is a string', () => {
+    const errors = 'An error.';
+
+    it('displays it', () => {
+      expect(shallow(<ErrorText errors={errors} />)).toMatchSnapshot();
+    });
+  });
+
+  describe('when input is an array', () => {
+    const errors = ['An error.', 'Another error.'];
+
+    it('displays each error', () => {
+      expect(shallow(<ErrorText errors={errors} />)).toMatchSnapshot();
+    });
+  });
+});

--- a/client/app/lib/components/__test__/__snapshots__/ErrorText.test.jsx.snap
+++ b/client/app/lib/components/__test__/__snapshots__/ErrorText.test.jsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ErrorText /> when input is a string displays it 1`] = `
+<div
+  style={
+    Object {
+      "color": "#f44336",
+    }
+  }
+>
+  An error.
+</div>
+`;
+
+exports[`<ErrorText /> when input is an array displays each error 1`] = `
+<React.Fragment>
+  <ErrorText
+    errors="An error."
+    key="An error."
+  />
+  <ErrorText
+    errors="Another error."
+    key="Another error."
+  />
+</React.Fragment>
+`;

--- a/client/app/lib/redux-form.jsx
+++ b/client/app/lib/redux-form.jsx
@@ -1,0 +1,16 @@
+/* eslint-disable import/prefer-default-export */
+import { SubmissionError as ReduxFormSubmissionError } from 'redux-form';
+
+/**
+ * For Rails ActiveModel objects, errors that belong to the top-level object itself are
+ * set on the key `base`. On the other hand, top level errors need to be set on `_error`
+ * for redux-form to display them. This wrapper does the translation.
+ */
+export class SubmissionError extends ReduxFormSubmissionError {
+  constructor(params) {
+    const { base } = params;
+    const errors = base ? { ...params, _error: base } : params;
+    // eslint-disable-next-line constructor-super
+    return super(errors);
+  }
+}


### PR DESCRIPTION
Displays rails model `base` errors as top-level form errors in assessment redux form.

In a subsequent PR, we can standardize this across existing redux forms where it makes sense, analogous to `f.error_notification` for rails `simple_form`s.