### PR TITLE
Videos session id create

### DIFF
--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 class Course::Video::Submission::SessionsController < Course::Video::Submission::Controller
+  load_and_authorize_resource :session, class: Course::Video::Session.name, through: :submission
+
+  def create
+    time_now = Time.zone.now
+    @session.session_start = time_now
+    @session.session_end = time_now
+    head :bad_request unless @session.save
+  end
 
   def update
     # We received a message from client, so time is updated regardless of how event records turn out
     if params[:is_old_session]
-      @session.update_attributes!(last_video_time: session_params[:last_video_time])
+      @session.update_attributes!(last_video_time: update_params[:last_video_time])
     else
       @session.update_attributes!(session_end: Time.zone.now,
-                                  last_video_time: session_params[:last_video_time])
+                                  last_video_time: update_params[:last_video_time])
     end
-    @session.merge_in_events!(session_params[:events])
+    @session.merge_in_events!(update_params[:events])
   rescue ArgumentError => _
     head :bad_request
   rescue ActiveRecord::RecordInvalid => _
@@ -22,7 +30,7 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
     @video.tab
   end
 
-  def session_params
+  def update_params
     params.require(:session).permit(:last_video_time,
                                     events: [[:sequence_num, :event_type, :video_time,
                                               :playback_rate, :event_time]])

--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -3,9 +3,6 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
   load_and_authorize_resource :session, class: Course::Video::Session.name, through: :submission
 
   def create
-    time_now = Time.zone.now
-    @session.session_start = time_now
-    @session.session_end = time_now
     head :bad_request unless @session.save
   end
 

--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class Course::Video::Submission::SessionsController < Course::Video::Submission::Controller
-  load_and_authorize_resource :session, class: Course::Video::Session.name
 
   def update
     # We received a message from client, so time is updated regardless of how event records turn out
@@ -18,6 +17,10 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
   end
 
   private
+
+  def current_tab
+    @video.tab
+  end
 
   def session_params
     params.require(:session).permit(:last_video_time,

--- a/app/controllers/course/video/submission/submissions_controller.rb
+++ b/app/controllers/course/video/submission/submissions_controller.rb
@@ -33,7 +33,7 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
     @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
     @scroll_topic_id = scroll_topic_params
     # TODO: Re-enable when video sessions are fixed
-    # create_session
+    # set_monitoring
   rescue CanCan::AccessDenied
     redirect_to course_video_path(current_course, @video)
   end
@@ -52,10 +52,9 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
     authorize!(:attempt, @video)
   end
 
-  def create_session
-    return unless current_course_user.student? && @submission.course_user == current_course_user
-    time_now = Time.zone.now
-    @session = @submission.sessions.create!(session_start: time_now, session_end: time_now)
+  def set_monitoring
+    @enable_monitoring =
+      current_course_user.student? && @submission.course_user == current_course_user
   end
 
   def current_tab

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -16,11 +16,11 @@ module Course::VideosAbilityComponent
   def define_student_video_permissions
     allow_student_show_video
     allow_student_attempt_video
-    allow_student_create_video_submission
+    allow_student_create_and_read_video_submission
     allow_student_update_own_video_submission
     allow_student_show_video_topics
     allow_student_create_video_topics
-    allow_student_update_own_video_session
+    allow_student_create_and_update_own_video_session
   end
 
   def define_staff_video_permissions
@@ -54,15 +54,17 @@ module Course::VideosAbilityComponent
     end
   end
 
-  def allow_student_create_video_submission
+  def allow_student_create_and_read_video_submission
     can :create, Course::Video::Submission, video_submission_own_course_user_hash
+    can :read, Course::Video::Submission, video_submission_own_course_user_hash
   end
 
   def allow_student_update_own_video_submission
     can :update, Course::Video::Submission, video_submission_own_course_user_hash
   end
 
-  def allow_student_update_own_video_session
+  def allow_student_create_and_update_own_video_session
+    can :create, Course::Video::Session, submission: video_submission_own_course_user_hash
     can :update, Course::Video::Session, submission: video_submission_own_course_user_hash
   end
 

--- a/app/models/course/video/session.rb
+++ b/app/models/course/video/session.rb
@@ -3,6 +3,8 @@ class Course::Video::Session < ApplicationRecord
   belongs_to :submission, inverse_of: :sessions
   has_many :events, inverse_of: :session, dependent: :destroy
 
+  before_validation :set_session_time, if: :new_record?
+
   validates :session_start, presence: true
   validates :session_end, presence: true
   validate :validate_start_before_end
@@ -25,5 +27,12 @@ class Course::Video::Session < ApplicationRecord
   def validate_start_before_end
     return unless session_start > session_end
     errors.add(:session_start, :cannot_be_after_session_end)
+  end
+
+  # Sets the initial session start and end time
+  def set_session_time
+    time_now = Time.zone.now
+    self.session_start ||= time_now
+    self.session_end ||= time_now
   end
 end

--- a/app/views/course/video/submission/sessions/create.json.jbuilder
+++ b/app/views/course/video/submission/sessions/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.id @session.id.to_s

--- a/app/views/course/video/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/video/submission/submissions/edit.json.jbuilder
@@ -1,7 +1,6 @@
 json.video do
   json.videoUrl @video.url
   json.partial! 'watch_next_video_url', locals: { next_video: @video.next_video }
-  json.sessionId @session&.id&.to_s
 end
 
 json.discussion do
@@ -13,3 +12,4 @@ json.discussion do
 end
 
 json.courseUserId current_course_user&.id&.to_s
+json.enableMonitoring @enable_monitoring || false

--- a/client/app/api/course/Video/Sessions.js
+++ b/client/app/api/course/Video/Sessions.js
@@ -1,5 +1,5 @@
+import { getVideoId, getVideoSubmissionId } from 'lib/helpers/url-helpers';
 import BaseVideoAPI from './Base';
-import { getVideoId } from '../../../lib/helpers/url-helpers';
 
 export default class SessionsAPI extends BaseVideoAPI {
   /**
@@ -15,6 +15,17 @@ export default class SessionsAPI extends BaseVideoAPI {
    *   playback_rate: float
    *     - The video playback rate
    */
+
+  /**
+   * Creates a new video session.
+   * @return {Promise} The response from the server.
+   * success response: {
+   *    id: string,
+   * }
+   */
+  create() {
+    return this.getClient().post(this._getUrlPrefix());
+  }
 
   /**
    * Updates a video session.
@@ -35,6 +46,6 @@ export default class SessionsAPI extends BaseVideoAPI {
   }
 
   _getUrlPrefix() {
-    return `/courses/${this.getCourseId()}/videos/${getVideoId()}/sessions`;
+    return `/courses/${this.getCourseId()}/videos/${getVideoId()}/submissions/${getVideoSubmissionId()}/sessions`;
   }
 }

--- a/client/app/bundles/course/video/submission/actions/__test__/video.test.js
+++ b/client/app/bundles/course/video/submission/actions/__test__/video.test.js
@@ -36,14 +36,14 @@ const oldSessionsFixtures = makeImmutableMap({
 beforeAll(() => {
   Object.defineProperty(window.location, 'pathname', {
     configurable: true,
-    value: `/courses/${courseId}/videos/${videoId}/submission/1/edit`,
+    value: `/courses/${courseId}/videos/${videoId}/submissions/1/edit`,
   });
 });
 
 beforeEach(() => {
   mock.reset();
-  mock.onPatch(`/courses/${courseId}/videos/${videoId}/sessions/32`).reply(200);
-  mock.onPatch(`/courses/${courseId}/videos/${videoId}/sessions/25`).reply(200);
+  mock.onPatch(`/courses/${courseId}/videos/${videoId}/submissions/1/sessions/32`).reply(200);
+  mock.onPatch(`/courses/${courseId}/videos/${videoId}/submissions/1/sessions/25`).reply(200);
 });
 
 function createStore(oldSessions = {}) {

--- a/client/app/bundles/course/video/submission/submissions.jsx
+++ b/client/app/bundles/course/video/submission/submissions.jsx
@@ -1,21 +1,46 @@
 import React from 'react';
 import { render } from 'react-dom';
 import ProviderWrapper from 'lib/components/ProviderWrapper';
+import LoadingIndicator from 'lib/components/LoadingIndicator';
+import CourseAPI from 'api/course';
 import Submission from './containers/Submission';
 import storeCreator from './store';
+
+function renderSubmission(state, node) {
+  render(
+    <ProviderWrapper {...storeCreator(state)}>
+      <Submission />
+    </ProviderWrapper>
+    , node
+  );
+}
 
 $(document).ready(() => {
   const mountNode = document.getElementById('video-component');
 
   if (mountNode) {
-    const data = mountNode.getAttribute('data');
-    const initialState = JSON.parse(data);
+    const submissionData = mountNode.getAttribute('data');
+    const initialState = JSON.parse(submissionData);
+    const { enableMonitoring } = initialState;
 
-    render(
-      <ProviderWrapper {...storeCreator(initialState)}>
-        <Submission />
-      </ProviderWrapper>
-      , mountNode
-    );
+    if (enableMonitoring) {
+      render(
+        <ProviderWrapper>
+          <LoadingIndicator />
+        </ProviderWrapper>
+        , mountNode
+      );
+
+      CourseAPI.video.sessions.create()
+        .then(({ data }) => {
+          initialState.video.sessionId = data.id;
+          renderSubmission(initialState, mountNode);
+        })
+        .catch(() => {
+          renderSubmission(initialState, mountNode);
+        });
+    } else {
+      renderSubmission(initialState, mountNode);
+    }
   }
 });

--- a/client/app/lib/helpers/url-helpers.js
+++ b/client/app/lib/helpers/url-helpers.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+
 /* Get the given parameter from the URL.
 * e.g. With this URL -> http://dummy.com/?technology=jquery&blog=jquerybyexample
 *
@@ -82,5 +83,24 @@ function getVideoId() {
   return match && match[1];
 }
 
+/**
+ * Get the video submission id from URL.
+ *
+ * return {number}
+ */
+function getVideoSubmissionId() {
+  const match = window.location.pathname.match(/^\/courses\/\d+\/videos\/\d+\/submissions\/(\d+)/);
+  return match && match[1];
+}
+
 /* eslint-disable import/prefer-default-export */
-export { getUrlParameter, getCourseId, getSurveyId, getAssessmentId, getSubmissionId, getScribingId, getVideoId };
+export {
+  getUrlParameter,
+  getCourseId,
+  getSurveyId,
+  getAssessmentId,
+  getSubmissionId,
+  getScribingId,
+  getVideoId,
+  getVideoSubmissionId,
+};

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,8 +342,9 @@ Rails.application.routes.draw do
         resources :videos do
           resources :topics, only: [:index, :create, :show]
           scope module: :submission do
-            resources :submissions, only: [:index, :create, :edit]
-            resources :sessions, only: :update
+            resources :submissions, only: [:index, :create, :edit] do
+              resources :sessions, only: [:create, :update]
+            end
           end
         end
       end

--- a/spec/controllers/course/video/submission/sessions_controller_spec.rb
+++ b/spec/controllers/course/video/submission/sessions_controller_spec.rb
@@ -17,10 +17,32 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
 
     before { sign_in(student.user) }
 
+    describe 'POST #create' do
+      subject do
+        post :create, as: :json, params: {
+          course_id: course.id, video_id: video.id, submission_id: session.submission.id
+        }
+      end
+
+      it 'creates a new session' do
+        expect { subject }.to change(Course::Video::Session, :count).by(1)
+      end
+
+      context "when student creates under another student's submission" do
+        let(:other_student) { create(:course_student, course: course) }
+        before { sign_in(other_student.user) }
+
+        it 'denies access' do
+          expect { subject }.to raise_error(CanCan::AccessDenied)
+        end
+      end
+    end
+
     describe 'PUT/PATCH #update' do
       subject do
         patch :update, as: :json, params: {
-          course_id: course.id, video_id: video.id, id: session.id,
+          course_id: course.id, video_id: video.id,
+          submission_id: session.submission.id, id: session.id,
           session: { last_video_time: 6, events: events }
         }
       end


### PR DESCRIPTION
Create sessions on page load.

This change will prevent the `sessionId` from being reused when the user clicks the back button after navigating away from the watch video page.