### PR TITLE
Video session upsert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'baby_squeel'
 gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as', branch: 'rails5'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
+# Upsert action for Postgres
+gem 'active_record_upsert'
 # Create pretty URLs and work with human-friendly strings
 gem 'friendly_id'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,10 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_record_upsert (0.7.4)
+      activerecord (>= 5.0, < 6.0)
+      arel (> 7.0, < 10.0)
+      pg (>= 0.18, < 2.0)
     activejob (5.1.5)
       activesupport (= 5.1.5)
       globalid (>= 0.3.6)
@@ -557,6 +561,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record-acts_as!
+  active_record_upsert
   activerecord-import (>= 0.2.0)
   activerecord-userstamp!
   acts_as_tenant

--- a/app/models/course/video/event.rb
+++ b/app/models/course/video/event.rb
@@ -2,11 +2,12 @@
 class Course::Video::Event < ApplicationRecord
   belongs_to :session, inverse_of: :events
 
-  validates :event_type, presence: true
-  validates :video_time, presence: true
+  upsert_keys [:session_id, :sequence_num]
+
+  schema_validations except: [:session_id, :sequence_num]
+  validates :session, presence: true
+  validates :sequence_num, presence: true
   validates :video_time, numericality: { greater_than_or_equal_to: 0 }
-  validates :event_time, presence: true
-  validates :sequence_num, uniqueness: { scope: :session_id }
 
   enum event_type: [:play, :pause, :speed_change, :seek_start, :seek_end, :buffer, :end]
 end

--- a/app/models/course/video/session.rb
+++ b/app/models/course/video/session.rb
@@ -17,8 +17,7 @@ class Course::Video::Session < ApplicationRecord
     params_list = events_attributes.respond_to?(:each) ? events_attributes : [events_attributes]
 
     params_list.each do |event_params|
-      events.find_or_initialize_by(session_id: id, sequence_num: event_params[:sequence_num]).
-        update_attributes!(event_params)
+      events.build(event_params).upsert!
     end
   end
 


### PR DESCRIPTION
Use database upsert to merge events. 

Push uniqueness checks and data merging to the database to reduce CPU usage on Rails side.

Uniqueness validations for `session_id` and `sequence_num` are turned off at the active_record level, but the unique index in the database ensures that they are indeed unique without race-conditions. 