### PR TITLE
Enable sessions

### DIFF
--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -15,6 +15,8 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
                                   last_video_time: update_params[:last_video_time])
     end
     @session.merge_in_events!(update_params[:events])
+
+    head :no_content
   rescue ArgumentError => _
     head :bad_request
   rescue ActiveRecord::RecordInvalid => _

--- a/app/controllers/course/video/submission/submissions_controller.rb
+++ b/app/controllers/course/video/submission/submissions_controller.rb
@@ -32,8 +32,7 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
     @topics = @topics.reject { |topic| topic.posts.empty? }
     @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
     @scroll_topic_id = scroll_topic_params
-    # TODO: Re-enable when video sessions are fixed
-    # set_monitoring
+    set_monitoring
   rescue CanCan::AccessDenied
     redirect_to course_video_path(current_course, @video)
   end

--- a/client/app/bundles/course/video/submission/actions/video.js
+++ b/client/app/bundles/course/video/submission/actions/video.js
@@ -142,6 +142,20 @@ export function seekEnd() {
 }
 
 /**
+ * Creates an thunk to seek to the time in the video directly.
+ *
+ * @param playerProgress The new player progress in seconds
+ * @return {function(*)} The thunk to perform the the direct seek.
+ */
+export function seekToDirectly(playerProgress) {
+  return (dispatch) => {
+    dispatch(seekStart());
+    dispatch(updatePlayerProgress(playerProgress, true));
+    dispatch(seekEnd());
+  };
+}
+
+/**
  * Creates an action to remove events from the state store.
  * @param sequenceNums The event sequence numbers to remove
  * @param sessionClosed If this event is in response to the final server request before close

--- a/client/app/bundles/course/video/submission/actions/video.js
+++ b/client/app/bundles/course/video/submission/actions/video.js
@@ -212,7 +212,7 @@ function sendOldSessions(dispatch, oldSessions) {
       return CourseAPI.video.sessions
         .update(sessionId, videoTime, events.toArray(), true)
         .then(() => sessionId)
-        .catch(() => null);
+        .catch(error => (error.response.status === 404 ? sessionId : null));
     })
     .values();
 

--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
@@ -7,7 +7,7 @@ import { formatTimestamp } from 'lib/helpers/videoHelpers';
 import styles from '../Discussion.scss';
 import PostContainer from './PostContainer';
 import Reply from './Reply';
-import { updatePlayerProgress } from '../../actions/video';
+import { seekToDirectly } from '../../actions/video';
 
 const propTypes = {
   topicId: PropTypes.string.isRequired,
@@ -66,7 +66,7 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    onTimeStampClick: timestamp => (() => dispatch(updatePlayerProgress(timestamp, true))),
+    onTimeStampClick: timestamp => (() => dispatch(seekToDirectly(timestamp, true))),
   };
 }
 

--- a/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
+++ b/client/app/bundles/course/video/submission/containers/VideoPlayer.jsx
@@ -128,7 +128,7 @@ class VideoPlayer extends React.Component {
           onBuffer={() => this.props.onPlayerStateChanged(playerStates.BUFFERING)}
           onEnded={() => this.props.onPlayerStateChanged(playerStates.ENDED)}
           playsinline
-          progressFrequency={videoDefaults.progressUpdateFrequencyMs}
+          progressInterval={videoDefaults.progressUpdateFrequencyMs}
           style={reactPlayerStyle}
           width="100%"
           height="100%"


### PR DESCRIPTION
This PR fixes:
 - update action in session controller: render nothing since there is no template
 - old sessions update: remove the old session on 404 to prevent it from retrying infinitely

Then, it flips the flag to enable video sessions (i.e. monitoring)

Dependent on #2864. Might be good to delay merging until #2867 is resolved.