### PR TITLE
Fix inline code button omitting HTML or HTML-like tags

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -20,7 +20,9 @@
         } else {
           var range = context.invoke('editor.createRange'), text = range.toString();
           if (text !== '') {
-            context.invoke('editor.insertNode', $('<code>'+text+'</code>')[0]);
+            const newNode = $('<code></code>').eq(0);
+            newNode.text(text);
+            context.invoke('editor.insertNode', newNode.get(0));
           }
         }
       },

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -114,7 +114,9 @@ class MaterialSummernote extends React.Component {
           const range = context.invoke('editor.createRange');
           const text = range.toString();
           if (text !== '') {
-            context.invoke('editor.insertNode', $(`<code>${text}</code>`)[0]);
+            const newNode = $('<code></code>').eq(0);
+            newNode.text(text);
+            context.invoke('editor.insertNode', newNode.get(0));
           }
         }
       },


### PR DESCRIPTION
Inline code button was not properly escaping angled brackets, which caused them to not be displayed.

Affected sample input: `#include <stdio.h>`