### PR TITLE
Fix adding of new group/point/solution in comprehension question form

### DIFF
--- a/app/views/course/assessment/question/text_responses/_comprehension_group_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_comprehension_group_fields.html.slim
@@ -17,6 +17,7 @@
                                        partial: 'comprehension_point_fields',
                                        find_selector: 'tbody.tbody-groups.'+group_id,
                                        insert_using: 'append'
-      tbody.tbody-groups *{:class => group_id}
+      / group_id must not be the last class so that it will be correctly substituted by cocoon
+      tbody class=[group_id, 'tbody-groups']
         = f.simple_fields_for :points do |comprehension_points_form|
           = render 'comprehension_point_fields', f: comprehension_points_form

--- a/app/views/course/assessment/question/text_responses/_comprehension_point_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_comprehension_point_fields.html.slim
@@ -26,6 +26,7 @@
                                         partial: 'comprehension_solution_fields',
                                         find_selector: 'tbody.tbody-points.'+point_id,
                                         insert_using: 'append'
-      tbody.tbody-points *{:class => point_id}
+      / point_id must not be the last class so that it will be correctly substituted by cocoon
+      tbody class=[point_id, 'tbody-points']
         = f.simple_fields_for :solutions do |comprehension_solutions_form|
           = render 'comprehension_solution_fields', f: comprehension_solutions_form

--- a/app/views/course/assessment/question/text_responses/_comprehension_solution_fields.html.slim
+++ b/app/views/course/assessment/question/text_responses/_comprehension_solution_fields.html.slim
@@ -5,7 +5,8 @@
                input_html: { class: ['text-response-solution-type'] },
                label: false
   / TODO: Fix text to array.
-  td.td-solution *{:class => f.object_name}
+  / f.object_name must not be the last class so that it will be correctly substituted by cocoon
+  td class=[f.object_name, 'td-solution']
     = f.input :solution, as: :array, label: false, required: false,
                input_html: { class: ['text-response-solution'] }
     .has-error


### PR DESCRIPTION
### Problem
When creating a new text response comprehension question, new comprehension groups could be added, but the `Add Point` button would not work for the newly added groups. This bug was only present in production environment and not in development environment.

### Cause
HTML generated by the Slim engine was being minified in production environment. This removed most of the unnecessary spacing for valid HTML. However, the regex used by Cocoon [here](https://github.com/nathanvda/cocoon/blob/05435fb34a6c23a165befa5d381f5ae32f16a6a3/app/assets/javascripts/cocoon.js#L58) to substitute `new_{model_name}` with an object id expects a space before the end of the line. This space was present in the pretty HTML template but stripped in the minified template.

### Fix
By swapping the orders of the class names such that the class name to be substituted is not last, the substitution will be performed correctly thanks to the space in between class names.