### PR TITLE
Coursemology/coursemology2#2875 video duplication

### DIFF
--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -58,7 +58,7 @@ class Course::ObjectDuplicationsController < Course::ComponentController
   end
 
   def load_videos_component_data
-    @videos = current_course.videos
+    @video_tabs = current_course.video_tabs.includes(:videos)
   end
 
   def create_duplication_params
@@ -87,6 +87,7 @@ class Course::ObjectDuplicationsController < Course::ComponentController
       'ACHIEVEMENT' => ->(ids) { current_course.achievements.find(ids) },
       'FOLDER' => ->(ids) { current_course.material_folders.concrete.find(ids) },
       'MATERIAL' => ->(ids) { current_course.materials.in_concrete_folder.find(ids) },
+      'VIDEO_TAB' => ->(ids) { current_course.video_tabs.find(ids) },
       'VIDEO' => ->(ids) { current_course.videos.find(ids) }
     }
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -175,6 +175,7 @@ class Course < ApplicationRecord
       *assessment_skill_branches,
       *achievements,
       *surveys,
+      *video_tabs,
       *videos,
       *lesson_plan_events,
       *lesson_plan_milestones,

--- a/app/models/course/video/tab.rb
+++ b/app/models/course/video/tab.rb
@@ -24,6 +24,13 @@ class Course::Video::Tab < ApplicationRecord
     course.video_tabs.count > 1
   end
 
+  def initialize_duplicate(duplicator, other)
+    self.course = duplicator.options[:target_course]
+    other.videos.each do |video|
+      videos << duplicator.duplicate(video) if duplicator.duplicated?(video)
+    end
+  end
+
   private
 
   def validate_before_destroy

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -41,6 +41,9 @@ json.materialsComponent @folders do |folder|
   end
 end
 
-json.videosComponent @videos do |video|
-  json.(video, :id, :title, :published)
+json.videosComponent @video_tabs do |tab|
+  json.(tab, :id, :title)
+  json.videos tab.videos do |video|
+    json.(video, :id, :title, :published)
+  end
 end

--- a/client/app/bundles/course/duplication/components/TypeBadge/index.jsx
+++ b/client/app/bundles/course/duplication/components/TypeBadge/index.jsx
@@ -47,6 +47,10 @@ const translations = defineMessages({
     id: 'course.duplication.TypeBadge.video',
     defaultMessage: 'Video',
   },
+  [duplicableItemTypes.VIDEO_TAB]: {
+    id: 'course.duplication.TypeBadge.video_tab',
+    defaultMessage: 'Tab',
+  },
 });
 
 const TypeBadge = ({ text, itemType }) => (

--- a/client/app/bundles/course/duplication/constants.js
+++ b/client/app/bundles/course/duplication/constants.js
@@ -14,6 +14,7 @@ export const duplicableItemTypes = mirrorCreator([
   'FOLDER',
   'MATERIAL',
   'VIDEO',
+  'VIDEO_TAB',
 ]);
 
 export const itemSelectorPanels = mirrorCreator([

--- a/client/app/bundles/course/duplication/pages/Duplication/__test__/DuplicateButton.test.jsx
+++ b/client/app/bundles/course/duplication/pages/Duplication/__test__/DuplicateButton.test.jsx
@@ -49,6 +49,7 @@ const data = {
           ],
         },
       ],
+      videosComponent: [],
     },
   },
 };

--- a/client/app/bundles/course/duplication/propTypes.js
+++ b/client/app/bundles/course/duplication/propTypes.js
@@ -42,6 +42,12 @@ export const videoShape = PropTypes.shape({
   published: PropTypes.bool,
 });
 
+export const videoTabShape = PropTypes.shape({
+  id: PropTypes.number,
+  title: PropTypes.string,
+  videos: PropTypes.arrayOf(videoShape),
+});
+
 export const achievementShape = PropTypes.shape({
   id: PropTypes.number,
   title: PropTypes.string,

--- a/db/migrate/20180321141117_remove_incorrectly_cloned_videos.rb
+++ b/db/migrate/20180321141117_remove_incorrectly_cloned_videos.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class RemoveIncorrectlyClonedVideos < ActiveRecord::Migration[5.1]
+  def change
+    Course::Video.
+      joins(:tab).
+      joins(:lesson_plan_item).
+      where('course_video_tabs.course_id <> course_lesson_plan_items.course_id').
+      destroy_all
+
+    ActsAsTenant.without_tenant do
+      Course.
+        where('NOT EXISTS(SELECT 1 FROM course_video_tabs WHERE course_video_tabs.course_id = courses.id)').
+        find_each do |course|
+        
+        course.video_tabs.create(title: 'Default', weight: 0,
+                                 creator_id: course.creator.id, updater_id: course.creator.id)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180220010332) do
+ActiveRecord::Schema.define(version: 20180321141117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/course_video_tabs.rb
+++ b/spec/factories/course_video_tabs.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
   factory :course_video_tab, class: Course::Video::Tab.name,
                              aliases: [:video_tab] do
     course
-    title { generate(:course_video_title) }
+    title { generate(:course_video_tab_title) }
     weight { generate(:course_video_tab_weight) }
   end
 end

--- a/spec/services/course/duplication/course_duplication_service_spec.rb
+++ b/spec/services/course/duplication/course_duplication_service_spec.rb
@@ -122,6 +122,13 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
           end
         end
 
+        it 'duplicates video tabs' do
+          new_tab = new_course.video_tabs.first
+          expect(new_tab.title).to eq video.tab.title
+          expect(new_tab.weight).to eq video.tab.weight
+          expect(new_tab.creator).to eq video.tab.creator
+        end
+
         it 'duplicates videos' do
           new_video = new_course.videos.first
 
@@ -129,6 +136,7 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
           expect(new_video.url).to eq video.url
           expect(new_video.creator).to eq video.creator
           expect(new_video.start_at).to be_within(1.second).of video.start_at + time_shift
+          expect(new_video.tab).to eq new_course.video_tabs.first
         end
       end
 


### PR DESCRIPTION
Fixes #2875. 

Previously video tabs are not cloned, So videos get tagged to the tabs in the old course.

The last commit includes a migration to remove any potential videos that were cloned wrongly. These videos would not have showed up in the UI in any case.