### PR TITLE
Define .modal scss on the main body.

### DIFF
--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -6,6 +6,7 @@ import TextFieldLabel from 'material-ui/TextField/TextFieldLabel';
 
 import { i18nLocale } from 'lib/helpers/server-context';
 import '../styles/MaterialSummernote.scss';
+import '../styles/MaterialSummernoteModal.scss';
 
 const translations = defineMessages({
   inlineCode: {

--- a/client/app/lib/styles/MaterialSummernoteModal.scss
+++ b/client/app/lib/styles/MaterialSummernoteModal.scss
@@ -1,0 +1,11 @@
+// dialogsInBody is set to true in MaterialSummernote.scss. This causes modals from the
+// summernote editor to ignore the styles defined there.
+// Define the modal styles here instead, especially the z-index so it floats above the material
+// UI modal.
+.modal {
+  display: none;
+  outline: 0;
+  overflow: hidden;
+  position: fixed;
+  z-index: 1550;
+}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -101,6 +101,7 @@ const config = {
         ],
         include: [
           path.resolve(__dirname, 'app/lib/styles/MaterialSummernote.scss'),
+          path.resolve(__dirname, 'app/lib/styles/MaterialSummernoteModal.scss'),
         ],
       },
       {
@@ -120,6 +121,7 @@ const config = {
         exclude: [
           /node_modules/,
           path.resolve(__dirname, 'app/lib/styles/MaterialSummernote.scss'),
+          path.resolve(__dirname, 'app/lib/styles/MaterialSummernoteModal.scss'),
         ],
       },
       {


### PR DESCRIPTION
Add scss for `.modal` outside `.material-summernote` since `dialogsInBody` is
set to true.

`dialogsInBody` must be set to true for programming annotations to work properly.