### PR TITLE
Fix TextResponseComprehension explanation feedback empty horizontal line

### DIFF
--- a/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
@@ -416,25 +416,20 @@ class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < 
   #   for that Point.
   # @return [Array<String>] The explanations for the correct keywords.
   def explanations_for_correct_paraphrase(answer_text_array, keyword_status, hash_point_serial)
-    explanations = []
     hash_keywords = {} # point_id => [word in answer_text, information]
-
     keyword_status.each_with_index do |s, index|
       unless s.nil?
         hash_keywords[s.point.id] = [] unless hash_keywords.key?(s.point.id)
         hash_keywords[s.point.id].push([answer_text_array[index], s.information])
       end
     end
-
-    explanations.push(explanations_for_correct_paraphrase_by_points(hash_keywords, hash_point_serial))
-
+    explanations = explanations_for_correct_paraphrase_by_points(hash_keywords, hash_point_serial)
     unless explanations.empty?
       explanations.push(
         I18n.t('course.assessment.answer.text_response_comprehension_auto_grading.explanations.horizontal_break_html'),
         I18n.t('course.assessment.answer.text_response_comprehension_auto_grading.explanations.line_break_html')
       )
     end
-
     explanations
   end
 

--- a/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
@@ -312,8 +312,6 @@ class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < 
         I18n.t('course.assessment.answer.text_response_comprehension_auto_grading.explanations.line_break_html')
       )
     end
-
-    explanations
   end
 
   # Returns the explanations for an incorrect Point.
@@ -326,18 +324,14 @@ class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < 
   # @return [Array<String>] The explanations for the incorrect Point.
   def explanations_for_incorrect_point(answer_text_array, answer_text_lemma_status, point)
     explanations = []
-
     if answer_text_lemma_status[:compre_lifted_word].include?(point)
       explanations.push(
         explanations_for_incorrect_point_lifted_words(answer_text_array, answer_text_lemma_status, point)
       )
     end
-
     explanations.push(
       explanations_for_incorrect_point_missing_keywords(answer_text_lemma_status, point)
     )
-
-    explanations
   end
 
   # Returns the lifted words explanations for an incorrect Point.
@@ -430,7 +424,6 @@ class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < 
         I18n.t('course.assessment.answer.text_response_comprehension_auto_grading.explanations.line_break_html')
       )
     end
-    explanations
   end
 
   # Returns the explanations for correctly paraphrased keywords, split by each Point.


### PR DESCRIPTION
Remove the extraneous horizontal line when there is no correctly paraphrased keyword to display in the second section of the explanation feedback.