### PR TITLE
Add switches to restrict duplication interface

### DIFF
--- a/app/helpers/course/object_duplications_helper.rb
+++ b/app/helpers/course/object_duplications_helper.rb
@@ -11,6 +11,21 @@ module Course::ObjectDuplicationsHelper
     }.freeze
   end
 
+  # Map of ruby classes to tokens used by the frontend for cherry-pickable items.
+  def cherrypickable_items_hash
+    @cherrypickable_items_hash ||= {
+      Course::Assessment::Category => 'CATEGORY',
+      Course::Assessment::Tab => 'TAB',
+      Course::Assessment => 'ASSESSMENT',
+      Course::Survey => 'SURVEY',
+      Course::Achievement => 'ACHIEVEMENT',
+      Course::Material::Folder => 'FOLDER',
+      Course::Material => 'MATERIAL',
+      Course::Video => 'VIDEO',
+      Course::Video::Tab => 'VIDEO_TAB'
+    }.freeze
+  end
+
   # @param [Course] course
   # @return [Array<String>] Frontend-based strings representing the enabled components for the given course.
   def enabled_component_tokens(course)

--- a/app/helpers/course/object_duplications_helper.rb
+++ b/app/helpers/course/object_duplications_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Course::ObjectDuplicationsHelper
+  # Map of keys of components with cherry-pickable items to tokens for those components in the frontend.
+  def cherrypickable_components_hash
+    @cherrypickable_components_hash ||= {
+      course_assessments_component: 'ASSESSMENTS',
+      course_survey_component: 'SURVEYS',
+      course_achievements_component: 'ACHIEVEMENTS',
+      course_materials_component: 'MATERIALS',
+      course_videos_component: 'VIDEOS'
+    }.freeze
+  end
+
+  # @param [Course] course
+  # @return [Array<String>] Frontend-based strings representing the enabled components for the given course.
+  def enabled_component_tokens(course)
+    context = OpenStruct.new(current_course: course)
+    component_host = Course::ControllerComponentHost.new(
+      course.instance.settings(:components), course.settings(:components), context
+    )
+    map_components_to_frontend_tokens(component_host.components)
+  end
+
+  # @param [Course::ControllerComponentHost::Component] components
+  # @return [Array<String>] Frontend-based strings representing the given components.
+  def map_components_to_frontend_tokens(components)
+    components.map(&:key).map { |key| cherrypickable_components_hash[key] }.compact
+  end
+end

--- a/app/models/concerns/course/duplication_concern.rb
+++ b/app/models/concerns/course/duplication_concern.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Course::DuplicationConcern
+  extend ActiveSupport::Concern
+
+  def initialize_duplicate(duplicator, other)
+    self.start_at = duplicator.time_shift(start_at)
+    self.end_at = duplicator.time_shift(end_at)
+    self.title = duplicator.options[:new_title]
+    self.creator = duplicator.options[:current_user]
+    self.registration_key = nil
+    logo.duplicate_from(other.logo) if other.logo_url
+    material_folders << duplicator.duplicate(other.root_folder)
+  end
+
+  # List of top-level items that need to be duplicated for the whole course to be considered duplicated.
+  def duplication_manifest # rubocop:disable Metrics/MethodLength
+    [
+      *material_folders.concrete,
+      *materials.in_concrete_folder,
+      *levels,
+      *assessment_categories,
+      *assessment_tabs,
+      *assessments,
+      *assessment_skills,
+      *assessment_skill_branches,
+      *achievements,
+      *surveys,
+      *video_tabs,
+      *videos,
+      *lesson_plan_events,
+      *lesson_plan_milestones,
+      *forums
+    ]
+  end
+end

--- a/app/models/concerns/course/duplication_concern.rb
+++ b/app/models/concerns/course/duplication_concern.rb
@@ -32,4 +32,14 @@ module Course::DuplicationConcern
       *forums
     ]
   end
+
+  # Override this method to prevent duplication of the course as a whole
+  def course_duplicable?
+    true
+  end
+
+  # Override this method to prevent duplication of individual objects in the course.
+  def objects_duplicable?
+    true
+  end
 end

--- a/app/models/concerns/course/duplication_concern.rb
+++ b/app/models/concerns/course/duplication_concern.rb
@@ -42,4 +42,12 @@ module Course::DuplicationConcern
   def objects_duplicable?
     true
   end
+
+  # Override this method to prevent certain items from being cherry-picked for duplication for
+  # the current course. See {Course::ObjectDuplicationsHelper} for list of cherrypickable items.
+  #
+  # @return [Array<Class>] Classes of disabled items
+  def disabled_cherrypickable_types
+    []
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,6 +2,7 @@
 class Course < ApplicationRecord
   include Course::LessonPlanConcern
   include Course::SearchConcern
+  include Course::DuplicationConcern
   include TimeZoneConcern
 
   acts_as_tenant :instance, inverse_of: :courses
@@ -150,37 +151,6 @@ class Course < ApplicationRecord
   # @return [Course::Video::Tab]
   def default_video_tab
     video_tabs.first
-  end
-
-  def initialize_duplicate(duplicator, other)
-    self.start_at = duplicator.time_shift(start_at)
-    self.end_at = duplicator.time_shift(end_at)
-    self.title = duplicator.options[:new_title]
-    self.creator = duplicator.options[:current_user]
-    self.registration_key = nil
-    logo.duplicate_from(other.logo) if other.logo_url
-    material_folders << duplicator.duplicate(other.root_folder)
-  end
-
-  # List of top-level items that need to be duplicated for the whole course to be considered duplicated.
-  def duplication_manifest
-    [
-      *material_folders.concrete,
-      *materials.in_concrete_folder,
-      *levels,
-      *assessment_categories,
-      *assessment_tabs,
-      *assessments,
-      *assessment_skills,
-      *assessment_skill_branches,
-      *achievements,
-      *surveys,
-      *video_tabs,
-      *videos,
-      *lesson_plan_events,
-      *lesson_plan_milestones,
-      *forums
-    ]
   end
 
   # TODO: Need to replace this with an assessment settings adapter in future

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -7,6 +7,7 @@ json.currentCourse do
     modes << 'COURSE' if current_course.course_duplicable?
     modes << 'OBJECT' if current_course.objects_duplicable?
   end)
+  json.enabledComponents map_components_to_frontend_tokens(current_component_host.enabled_components)
 end
 
 json.targetCourses @target_courses do |course|
@@ -18,6 +19,7 @@ json.targetCourses @target_courses do |course|
     json.subfolders root_folder.children.map(&:name)
     json.materials root_folder.materials.map(&:name)
   end
+  json.enabledComponents enabled_component_tokens(course)
 end
 
 json.assessmentsComponent @categories do |category|

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -8,6 +8,9 @@ json.currentCourse do
     modes << 'OBJECT' if current_course.objects_duplicable?
   end)
   json.enabledComponents map_components_to_frontend_tokens(current_component_host.enabled_components)
+  json.unduplicableObjectTypes (current_course.disabled_cherrypickable_types.map do |klass|
+    cherrypickable_items_hash[klass]
+  end)
 end
 
 json.targetCourses @target_courses do |course|

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -3,6 +3,10 @@ json.currentHost current_tenant.host
 
 json.currentCourse do
   json.(current_course, :title, :start_at)
+  json.duplicationModesAllowed ([].tap do |modes|
+    modes << 'COURSE' if current_course.course_duplicable?
+    modes << 'OBJECT' if current_course.objects_duplicable?
+  end)
 end
 
 json.targetCourses @target_courses do |course|

--- a/client/app/bundles/course/duplication/constants.js
+++ b/client/app/bundles/course/duplication/constants.js
@@ -17,6 +17,7 @@ export const duplicableItemTypes = mirrorCreator([
   'VIDEO_TAB',
 ]);
 
+// These are mirrored in app/helpers/course/object_duplications_helper.rb
 export const itemSelectorPanels = mirrorCreator([
   'TARGET_COURSE',
   'ASSESSMENTS',

--- a/client/app/bundles/course/duplication/constants.js
+++ b/client/app/bundles/course/duplication/constants.js
@@ -5,6 +5,7 @@ export const duplicationModes = mirrorCreator([
   'COURSE',
 ]);
 
+// These are mirrored in app/helpers/course/object_duplications_helper.rb
 export const duplicableItemTypes = mirrorCreator([
   'ASSESSMENT',
   'TAB',

--- a/client/app/bundles/course/duplication/pages/Duplication/ItemsSelector/AssessmentsSelector.jsx
+++ b/client/app/bundles/course/duplication/pages/Duplication/ItemsSelector/AssessmentsSelector.jsx
@@ -25,20 +25,23 @@ class AssessmentsSelector extends React.Component {
   static propTypes = {
     categories: PropTypes.arrayOf(categoryShape),
     selectedItems: PropTypes.shape({}),
+    tabDisabled: PropTypes.bool,
+    categoryDisabled: PropTypes.bool,
 
     dispatch: PropTypes.func.isRequired,
   }
 
   tabSetAll = tab => (value) => {
-    const { dispatch } = this.props;
-    dispatch(setItemSelectedBoolean(TAB, tab.id, value));
+    const { dispatch, tabDisabled } = this.props;
+    if (!tabDisabled) { dispatch(setItemSelectedBoolean(TAB, tab.id, value)); }
     tab.assessments.forEach((assessment) => {
       dispatch(setItemSelectedBoolean(ASSESSMENT, assessment.id, value));
     });
   }
 
   categorySetAll = category => (value) => {
-    this.props.dispatch(setItemSelectedBoolean(CATEGORY, category.id, value));
+    const { dispatch, categoryDisabled } = this.props;
+    if (!categoryDisabled) { dispatch(setItemSelectedBoolean(CATEGORY, category.id, value)); }
     category.tabs.forEach(tab => this.tabSetAll(tab)(value));
   }
 
@@ -68,7 +71,7 @@ class AssessmentsSelector extends React.Component {
   }
 
   renderTabTree(tab) {
-    const { dispatch, selectedItems } = this.props;
+    const { dispatch, selectedItems, tabDisabled } = this.props;
     const { id, title, assessments } = tab;
     const checked = !!selectedItems[TAB][id];
 
@@ -76,6 +79,7 @@ class AssessmentsSelector extends React.Component {
       <div key={id}>
         <IndentedCheckbox
           checked={checked}
+          disabled={tabDisabled}
           indentLevel={1}
           label={<span><TypeBadge itemType={TAB} />{ title }</span>}
           onCheck={(e, value) =>
@@ -90,7 +94,7 @@ class AssessmentsSelector extends React.Component {
   }
 
   renderCategoryTree(category) {
-    const { dispatch, selectedItems } = this.props;
+    const { dispatch, selectedItems, categoryDisabled } = this.props;
     const { id, title, tabs } = category;
     const checked = !!selectedItems[CATEGORY][id];
 
@@ -98,6 +102,7 @@ class AssessmentsSelector extends React.Component {
       <div key={id}>
         <IndentedCheckbox
           checked={checked}
+          disabled={categoryDisabled}
           label={<span><TypeBadge itemType={CATEGORY} />{ title }</span>}
           onCheck={(e, value) =>
             dispatch(setItemSelectedBoolean(CATEGORY, id, value))
@@ -132,4 +137,6 @@ class AssessmentsSelector extends React.Component {
 export default connect(({ duplication }) => ({
   categories: duplication.assessmentsComponent,
   selectedItems: duplication.selectedItems,
+  tabDisabled: duplication.currentCourse.unduplicableObjectTypes.includes(TAB),
+  categoryDisabled: duplication.currentCourse.unduplicableObjectTypes.includes(CATEGORY),
 }))(AssessmentsSelector);

--- a/client/app/bundles/course/duplication/pages/Duplication/ItemsSelector/index.jsx
+++ b/client/app/bundles/course/duplication/pages/Duplication/ItemsSelector/index.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { itemSelectorPanels } from 'course/duplication/constants';
+import targetCourseSelector from 'course/duplication/selectors/targetCourse';
+import { courseShape } from 'course/duplication/propTypes';
 import AssessmentsSelector from './AssessmentsSelector';
 import SurveysSelector from './SurveysSelector';
 import AchievementsSelector from './AchievementsSelector';
@@ -14,10 +16,14 @@ const translations = defineMessages({
     id: 'course.duplication.ItemsSelector.pleaseSelectItems',
     defaultMessage: 'Please select items to duplicate via the sidebar.',
   },
+  componentDisabled: {
+    id: 'course.duplication.ItemsSelector.componentDisabled',
+    defaultMessage: 'This component is not enabled for the destination course.',
+  },
 });
 
 const styles = {
-  pleaseSelectItems: {
+  message: {
     marginTop: 25,
   },
 };
@@ -25,6 +31,7 @@ const styles = {
 class ItemsSelector extends React.Component {
   static propTypes = {
     currentPanel: PropTypes.string,
+    targetCourse: courseShape,
   }
 
   static panelComponentMap = {
@@ -36,12 +43,20 @@ class ItemsSelector extends React.Component {
   }
 
   render() {
-    const { currentPanel } = this.props;
+    const { currentPanel, targetCourse } = this.props;
 
     if (!currentPanel) {
       return (
-        <div style={styles.pleaseSelectItems}>
+        <div style={styles.message}>
           <FormattedMessage {...translations.pleaseSelectItems} />
+        </div>
+      );
+    }
+
+    if (!targetCourse.enabledComponents.includes(currentPanel)) {
+      return (
+        <div style={styles.message}>
+          <FormattedMessage {...translations.componentDisabled} />
         </div>
       );
     }
@@ -51,6 +66,7 @@ class ItemsSelector extends React.Component {
   }
 }
 
-export default connect(({ duplication }) => ({
-  currentPanel: duplication.currentItemSelectorPanel,
+export default connect(state => ({
+  currentPanel: state.duplication.currentItemSelectorPanel,
+  targetCourse: targetCourseSelector(state),
 }))(ItemsSelector);

--- a/client/app/bundles/course/duplication/pages/Duplication/ItemsSelectorMenu/index.jsx
+++ b/client/app/bundles/course/duplication/pages/Duplication/ItemsSelectorMenu/index.jsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import Avatar from 'material-ui/Avatar';
 import { List, ListItem } from 'material-ui/List';
 import { cyan500 } from 'material-ui/styles/colors';
-import { duplicableItemTypes, itemSelectorPanels } from 'course/duplication/constants';
+import { duplicableItemTypes, itemSelectorPanels as panels } from 'course/duplication/constants';
 import { setItemSelectorPanel } from 'course/duplication/actions';
 import { defaultComponentTitles } from 'course/translations.intl';
 import DuplicateButton from '../DuplicateButton';
@@ -25,10 +25,17 @@ const styles = {
 class ItemsSelectorMenu extends React.Component {
   static propTypes = {
     selectedItems: PropTypes.shape({}),
+    enabledComponents: PropTypes.arrayOf(PropTypes.string),
     dispatch: PropTypes.func.isRequired,
   }
 
-  static renderSidebarItem(translation, count, onClick) {
+  renderSidebarItem(panelKey, titleKey, count) {
+    const { dispatch, enabledComponents } = this.props;
+    if (!enabledComponents.includes(panelKey)) { return null; }
+    if (enabledComponents.length === 1) {
+      dispatch(setItemSelectorPanel(panelKey));
+    }
+
     return (
       <ListItem
         leftAvatar={
@@ -40,15 +47,15 @@ class ItemsSelectorMenu extends React.Component {
             { count }
           </Avatar>
         }
-        onClick={onClick}
+        onClick={() => dispatch(setItemSelectorPanel(panelKey))}
       >
-        <FormattedMessage {...translation} />
+        <FormattedMessage {...defaultComponentTitles[titleKey]} />
       </ListItem>
     );
   }
 
   render() {
-    const { dispatch, selectedItems } = this.props;
+    const { selectedItems } = this.props;
 
     const counts = {};
     Object.keys(selectedItems).forEach((key) => {
@@ -62,38 +69,28 @@ class ItemsSelectorMenu extends React.Component {
     return (
       <List>
         {
-          ItemsSelectorMenu.renderSidebarItem(
-            defaultComponentTitles.course_assessments_component,
-            assessmentsComponentCount,
-            () => dispatch(setItemSelectorPanel(itemSelectorPanels.ASSESSMENTS))
+          this.renderSidebarItem(
+            panels.ASSESSMENTS, 'course_assessments_component', assessmentsComponentCount
           )
         }
         {
-          ItemsSelectorMenu.renderSidebarItem(
-            defaultComponentTitles.course_survey_component,
-            counts[SURVEY],
-            () => dispatch(setItemSelectorPanel(itemSelectorPanels.SURVEYS))
+          this.renderSidebarItem(
+            panels.SURVEYS, 'course_survey_component', counts[SURVEY]
           )
         }
         {
-          ItemsSelectorMenu.renderSidebarItem(
-            defaultComponentTitles.course_achievements_component,
-            counts[ACHIEVEMENT],
-            () => dispatch(setItemSelectorPanel(itemSelectorPanels.ACHIEVEMENTS))
+          this.renderSidebarItem(
+            panels.ACHIEVEMENTS, 'course_achievements_component', counts[ACHIEVEMENT]
           )
         }
         {
-          ItemsSelectorMenu.renderSidebarItem(
-            defaultComponentTitles.course_materials_component,
-            counts[FOLDER] + counts[MATERIAL],
-            () => dispatch(setItemSelectorPanel(itemSelectorPanels.MATERIALS))
+          this.renderSidebarItem(
+            panels.MATERIALS, 'course_materials_component', counts[FOLDER] + counts[MATERIAL]
           )
         }
         {
-          ItemsSelectorMenu.renderSidebarItem(
-            defaultComponentTitles.course_videos_component,
-            videosComponentCount,
-            () => dispatch(setItemSelectorPanel(itemSelectorPanels.VIDEOS))
+          this.renderSidebarItem(
+            panels.VIDEOS, 'course_videos_component', videosComponentCount
           )
         }
         <ListItem disabled style={styles.duplicateButton}>
@@ -106,4 +103,5 @@ class ItemsSelectorMenu extends React.Component {
 
 export default connect(({ duplication }) => ({
   selectedItems: duplication.selectedItems,
+  enabledComponents: duplication.currentCourse.enabledComponents,
 }))(ItemsSelectorMenu);

--- a/client/app/bundles/course/duplication/pages/Duplication/index.jsx
+++ b/client/app/bundles/course/duplication/pages/Duplication/index.jsx
@@ -56,6 +56,11 @@ const translations = defineMessages({
     id: 'course.duplication.Duplication.duplicationDisabled',
     defaultMessage: 'Duplication is disabled for this course.',
   },
+  noComponentsEnabled: {
+    id: 'course.duplication.Duplication.noComponentsEnabled',
+    defaultMessage: 'All components with duplicable items are disabled. \
+      You may enable them under course settings.',
+  },
 });
 
 const styles = {
@@ -88,6 +93,7 @@ class Duplication extends React.Component {
     isCourseSelected: PropTypes.bool.isRequired,
     duplicationMode: PropTypes.string.isRequired,
     modesAllowed: PropTypes.arrayOf(PropTypes.string),
+    enabledComponents: PropTypes.arrayOf(PropTypes.string),
     currentCourse: PropTypes.shape({
       title: PropTypes.string,
       start_at: PropTypes.string,
@@ -183,12 +189,16 @@ class Duplication extends React.Component {
   }
 
   renderBody() {
-    const { isLoading, isCourseSelected, duplicationMode, modesAllowed } = this.props;
+    const { isLoading, isCourseSelected, duplicationMode, modesAllowed, enabledComponents } = this.props;
     if (isLoading) { return <LoadingIndicator />; }
 
     if (!modesAllowed || modesAllowed.length < 1) {
       return <Subheader><FormattedMessage {...translations.duplicationDisabled} /></Subheader>;
     }
+    if (!enabledComponents || enabledComponents.length < 1) {
+      return <Subheader><FormattedMessage {...translations.noComponentsEnabled} /></Subheader>;
+    }
+
     return (
       <div style={styles.bodyGrid}>
         <div style={styles.sidebar}>
@@ -231,5 +241,6 @@ export default connect(({ duplication }) => ({
   isCourseSelected: !!duplication.targetCourseId,
   duplicationMode: duplication.duplicationMode,
   modesAllowed: duplication.currentCourse.duplicationModesAllowed,
+  enabledComponents: duplication.currentCourse.enabledComponents,
   currentCourse: duplication.currentCourse,
 }))(injectIntl(Duplication));

--- a/client/app/bundles/course/duplication/propTypes.js
+++ b/client/app/bundles/course/duplication/propTypes.js
@@ -10,6 +10,7 @@ export const courseShape = PropTypes.shape({
 export const currentCourseShape = PropTypes.shape({
   title: PropTypes.string,
   start_at: PropTypes.string,
+  duplicationModesAllowed: PropTypes.arrayOf(PropTypes.string),
 });
 
 export const assessmentShape = PropTypes.shape({

--- a/client/app/bundles/course/duplication/propTypes.js
+++ b/client/app/bundles/course/duplication/propTypes.js
@@ -5,11 +5,13 @@ export const courseShape = PropTypes.shape({
   host: PropTypes.string,
   path: PropTypes.string,
   title: PropTypes.string,
+  enabledComponents: PropTypes.arrayOf(PropTypes.string),
 });
 
 export const currentCourseShape = PropTypes.shape({
   title: PropTypes.string,
   start_at: PropTypes.string,
+  enabledComponents: PropTypes.arrayOf(PropTypes.string),
   duplicationModesAllowed: PropTypes.arrayOf(PropTypes.string),
 });
 

--- a/client/app/bundles/course/duplication/propTypes.js
+++ b/client/app/bundles/course/duplication/propTypes.js
@@ -12,6 +12,7 @@ export const currentCourseShape = PropTypes.shape({
   title: PropTypes.string,
   start_at: PropTypes.string,
   enabledComponents: PropTypes.arrayOf(PropTypes.string),
+  unduplicableObjectTypes: PropTypes.arrayOf(PropTypes.string),
   duplicationModesAllowed: PropTypes.arrayOf(PropTypes.string),
 });
 

--- a/client/app/bundles/course/duplication/reducers/duplication.js
+++ b/client/app/bundles/course/duplication/reducers/duplication.js
@@ -1,14 +1,14 @@
 import actionTypes, { duplicableItemTypes, duplicationModes } from 'course/duplication/constants';
 import { nestFolders } from 'course/duplication/utils';
 
+const emptySelectedItemsHash = () => Object.keys(duplicableItemTypes).reduce((hash, type) => {
+  hash[type] = {}; // eslint-disable-line no-param-reassign
+  return hash;
+}, {});
+
 const initialState = {
   confirmationOpen: false,
-  selectedItems: {
-    ...Object.keys(duplicableItemTypes).reduce((hash, type) => {
-      hash[type] = {}; // eslint-disable-line no-param-reassign
-      return hash;
-    }, {}),
-  },
+  selectedItems: emptySelectedItemsHash(),
   targetCourseId: null,
   targetCourses: [],
   duplicationMode: duplicationModes.COURSE,
@@ -56,7 +56,11 @@ export default function (state = initialState, action) {
     }
 
     case actionTypes.SET_TARGET_COURSE_ID: {
-      return { ...state, targetCourseId: action.targetCourseId };
+      return {
+        ...state,
+        targetCourseId: action.targetCourseId,
+        selectedItems: emptySelectedItemsHash(),
+      };
     }
     case actionTypes.SET_ITEM_SELECTED_BOOLEAN: {
       const selectedItems = { ...state.selectedItems };

--- a/client/app/bundles/course/duplication/selectors/targetCourse.js
+++ b/client/app/bundles/course/duplication/selectors/targetCourse.js
@@ -1,0 +1,15 @@
+import { createSelector } from 'reselect';
+
+const targetCourseIdSelector = state => state.duplication.targetCourseId;
+const targetCoursesSelector = state => state.duplication.targetCourses;
+
+const targetCourseSelector = createSelector(
+  targetCourseIdSelector,
+  targetCoursesSelector,
+  (id, courses) => {
+    if (id === null || !courses) { return null; }
+    return courses.find(course => course.id === id);
+  }
+);
+
+export default targetCourseSelector;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -40,6 +40,7 @@ const config = {
       'redux-persist',
       'redux-promise',
       'redux-thunk',
+      'reselect',
       'webfontloader',
     ],
     // Vendor contains the libraries that are not in a single bundle (size could change depends on


### PR DESCRIPTION
Addresses moexmen/coursemology-sls#6.

- This change does not benefit Main Coursemology much, except perhaps in the very hypothetical situation where we have a course marketplace and need more switches for the duplication mechanism. I'm making the PR here for the sake of maintainability, in order to minimise the diff between Main and SLS Coursemology.
- This PR only does the 'disabling' in the frontend.