### PR TITLE
More fixes to user invitation

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -68,7 +68,7 @@ class Course::UserInvitationsController < Course::ComponentController
       params[:course] = { invitations_attributes: {} } unless params.key?(:course)
 
       params.require(:course).permit(:invitations_file, :registration_key,
-                                     invitations_attributes: [:name, :email, :role])
+                                     invitations_attributes: [:name, :email, :role, :phantom])
     end
   end
 

--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -173,4 +173,12 @@ module ApplicationFormattersHelper
       []
     end
   end
+
+  # Changes boolean values (True/False) into readable forms (Yes/No).
+  #
+  # @param [Boolean|nil] bool
+  # @return [String] A readable form of true and false, Yes and No.
+  def format_boolean(bool)
+    bool ? t('common.truthy') : t('common.falsey')
+  end
 end

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -5,10 +5,9 @@ class Course::UserInvitation < ApplicationRecord
   before_validation :set_defaults, if: :new_record?
 
   schema_validations auto_create: false
-  validates :email, uniqueness: { scope: :course_id },
-                    format: { with: Devise.email_regexp },
-                    if: :email_changed?
+  validates :email, format: { with: Devise.email_regexp }, if: :email_changed?
   validates :role, presence: true
+  validate :no_existing_unconfirmed_invitation
 
   enum role: CourseUser.roles
 
@@ -51,5 +50,13 @@ class Course::UserInvitation < ApplicationRecord
   # @return [void]
   def set_defaults
     self.role ||= Course::UserInvitation.roles[:student]
+  end
+
+  # Checks whether there are existing unconfirmed invitations with the same email.
+  # Scope excludes the own invitation object.
+  def no_existing_unconfirmed_invitation
+    return unless Course::UserInvitation.where(course_id: course_id, email: email).
+                    where.not(id: id).unconfirmed.exists?
+    errors.add(:base, :existing_invitation)
   end
 end

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -7,6 +7,7 @@ class Course::UserInvitation < ApplicationRecord
   schema_validations auto_create: false
   validates :email, format: { with: Devise.email_regexp }, if: :email_changed?
   validates :role, presence: true
+  validates :phantom, inclusion: [true, false]
   validate :no_existing_unconfirmed_invitation
 
   enum role: CourseUser.roles
@@ -45,11 +46,12 @@ class Course::UserInvitation < ApplicationRecord
   end
 
   # Sets the default for non-null fields.
-  # Currently sets the role attribute to :student is it's null.
+  # Currently sets the role attribute to :student if null, and phantom to false if null.
   #
   # @return [void]
   def set_defaults
     self.role ||= Course::UserInvitation.roles[:student]
+    self.phantom ||= false
   end
 
   # Checks whether there are existing unconfirmed invitations with the same email.

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -6,6 +6,7 @@ class Course::UserInvitation < ApplicationRecord
 
   schema_validations auto_create: false
   validates :email, format: { with: Devise.email_regexp }, if: :email_changed?
+  validates :name, presence: true
   validates :role, presence: true
   validates :phantom, inclusion: [true, false]
   validate :no_existing_unconfirmed_invitation

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -40,8 +40,9 @@ module Course::UserInvitationService::ParseInvitationConcern
   # @return [Array<Hash>] Array of users to be invited
   def parse_from_form(users)
     users.map do |(_, value)|
+      name = value[:name].presence || value[:email]
       phantom = ActiveRecord::Type::Boolean.new.cast(value[:phantom])
-      { name: value[:name], email: value[:email], role: value[:role], phantom: phantom }
+      { name: name, email: value[:email], role: value[:role], phantom: phantom }
     end
   end
 

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -7,16 +7,19 @@ class Course::UserInvitationService; end
 module Course::UserInvitationService::ParseInvitationConcern
   extend ActiveSupport::Autoload
 
+  TRUE_VALUES = ['t', 'true', 'y', 'yes'].freeze
+
   private
 
   # Invites users to the given course.
   #
   # @param [Array<Hash>|File|TempFile] users Invites the given users.
   # @return [Array<Hash{Symbol=>String}>]
-  #   A mutable array of users to add. Each hash must have three attributes:
+  #   A mutable array of users to add. Each hash must have four attributes:
   #     the +:name+,
-  #     the +:email+ of the user to add, as well as
-  #     the intended +:role+ in the course.
+  #     the +:email+ of the user to add,
+  #     the intended +:role+ in the course, as well as
+  #     whether the user is a +:phantom:+ or not.
   #   The provided +emails+ are NOT case sensitive.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def parse_invitations(users)
@@ -37,7 +40,8 @@ module Course::UserInvitationService::ParseInvitationConcern
   # @return [Array<Hash>] Array of users to be invited
   def parse_from_form(users)
     users.map do |(_, value)|
-      { name: value[:name], email: value[:email], role: value[:role] }
+      phantom = ActiveRecord::Type::Boolean.new.cast(value[:phantom])
+      { name: value[:name], email: value[:email], role: value[:role], phantom: phantom }
     end
   end
 
@@ -94,7 +98,8 @@ module Course::UserInvitationService::ParseInvitationConcern
     row[0] = row[1] if row[0].blank?
 
     role = parse_file_role(row[2])
-    { name: row[0], email: row[1], role: role }
+    phantom = parse_file_phantom(row[3])
+    { name: row[0], email: row[1], role: role, phantom: phantom }
   end
 
   # Parses the role column from the CSV file.
@@ -108,6 +113,17 @@ module Course::UserInvitationService::ParseInvitationConcern
 
     symbol = role.parameterize(separator: '_').to_sym
     Course::UserInvitation.roles[symbol] || Course::UserInvitation.roles[:student]
+  end
+
+  # Parses file value for whether an invitation is a phantom or not.
+  # Sets phantom as false if value is not specified.
+  #
+  # @param [String|nil] Phantom column for the given user invitation.
+  # @return [Boolean] Whether the value is a true or false
+  def parse_file_phantom(phantom)
+    return false if phantom.blank?
+
+    TRUE_VALUES.include?(phantom.downcase)
   end
 
   # Removes the UTF-8 byte order mark (BOM) from the string.

--- a/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
@@ -10,8 +10,11 @@ module Course::UserInvitationService::ProcessInvitationConcern
   # Processes the invites of the given users into the course.
   #
   # @param [Array<Hash{Symbol=>String}>] users A mutable array of users to add.
-  #   Each hash must have three attributes: the +:name+, the +:email+ of the
-  #   user to add, as well as his intended +:role+ in the course.
+  #   Each hash must have four attributes:
+  #     the +:name+,
+  #     the +:email+ of the user to add,
+  #     the intended +:role+ in the course, as well as
+  #     whether the user is a +:phantom:+ or not.
   #   The provided +emails+ are NOT case sensitive.
   # @return
   #   [Array<(Array<Course::UserInvitation>, Array<Course::UserInvitation>, Array<CourseUser>, Array<CourseUser>)>]
@@ -61,7 +64,8 @@ module Course::UserInvitationService::ProcessInvitationConcern
         existing_course_users << course_user
       else
         new_course_users <<
-          @current_course.course_users.build(user: user[:user], name: user[:name], role: user[:role],
+          @current_course.course_users.build(user: user[:user], name: user[:name],
+                                             role: user[:role], phantom: user[:phantom],
                                              creator: @current_user, updater: @current_user)
       end
     end
@@ -84,7 +88,8 @@ module Course::UserInvitationService::ProcessInvitationConcern
         existing_invitations << invitation
       else
         new_invitations <<
-          @current_course.invitations.build(name: user[:name], email: user[:email], role: user[:role])
+          @current_course.invitations.build(name: user[:name], email: user[:email],
+                                            role: user[:role], phantom: user[:phantom])
       end
     end
 

--- a/app/services/course/user_registration_service.rb
+++ b/app/services/course/user_registration_service.rb
@@ -49,10 +49,11 @@ class Course::UserRegistrationService
   def find_or_create_course_user!(registration, invitation = nil)
     name = invitation.try(:name) || registration.user.name
     role = invitation.try(:role) || CourseUser.roles[:student]
+    phantom = invitation.try(:phantom) || false
 
     registration.course_user =
       CourseUser.find_or_create_by!(course: registration.course, user: registration.user,
-                                    name: name, role: role)
+                                    name: name, role: role, phantom: phantom)
   end
 
   # Claims a given registration code. The correct type of code is deduced from the code itself and

--- a/app/views/course/user_invitations/_course_user_invitation.html.slim
+++ b/app/views/course/user_invitations/_course_user_invitation.html.slim
@@ -2,6 +2,7 @@
   th = invitation.name
   td = invitation.email
   td = t("course.users.role.#{invitation.role}")
+  td = format_boolean(invitation.phantom)
   td = invitation.invitation_key
   - if !invitation.confirmed?
     td = t('course.users.status.invited')

--- a/app/views/course/user_invitations/_course_user_invitations.html.slim
+++ b/app/views/course/user_invitations/_course_user_invitations.html.slim
@@ -5,6 +5,7 @@ table.table.table-striped.table-hover class="#{pending ? 'pending' : 'confirmed'
       th = t('common.name')
       th = t('common.email')
       th = t('common.role')
+      th = t('course.users.role.phantom')
       th = t('.invitation_code')
       th = t('.status')
       - if pending

--- a/app/views/course/user_invitations/_invitation_fields.html.slim
+++ b/app/views/course/user_invitations/_invitation_fields.html.slim
@@ -8,4 +8,5 @@
                label_method: lambda { |role_key| t("course.users.role.#{role_key}") },
                include_blank: false,
                input_html: { class: 'invitation_role' }
+  td = f.input :phantom, label: false
   td = link_to_remove_association  t('.remove'), f

--- a/app/views/course/user_invitations/_invitation_fields.html.slim
+++ b/app/views/course/user_invitations/_invitation_fields.html.slim
@@ -1,6 +1,6 @@
 = content_tag_for(:tr, f.object, class: 'nested-fields') do
   td = f.input :name, label: false, input_html: { class: 'invitation_name' }
-  td = f.input :email, label: false, input_html: { class: 'invitation_email' }
+  td = f.input :email, required: true, label: false, input_html: { class: 'invitation_email' }
   td = f.input :role,
                as: :select,
                collection: Course::UserInvitation.roles.keys,

--- a/app/views/course/user_invitations/new.html.slim
+++ b/app/views/course/user_invitations/new.html.slim
@@ -22,8 +22,9 @@ div.methods role='tabpanel'
           = t('.file.format_html')
           pre
             code
-              = "#{t('common.name')},#{t('common.email')}[,#{t('common.role')}]\n"
-              = "#{t('common.name')},test@example.org[,student]"
+              = "#{t('common.name')},#{t('common.email')}[,#{t('common.role')},#{t('course.users.role.phantom')}]\n"
+              = "John,test1@example.org[,student,y]\n"
+              = "Mary,test2@example.org[,teaching_assistant,n]"
 
       = simple_form_for current_course, url: invite_course_users_path, method: :post do |f|
         = f.error_notification
@@ -39,6 +40,7 @@ div.methods role='tabpanel'
               th = t('common.name')
               th = t('common.email')
               th = t('common.role')
+              th = t('course.users.role.phantom')
               th
                 div.pull-right
                   = link_to_add_association t('.individual.add_user'), f, :invitations,

--- a/config/locales/en/activerecord/course/user_invitation.yml
+++ b/config/locales/en/activerecord/course/user_invitation.yml
@@ -1,0 +1,7 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/user_invitation:
+          existing_invitation: 'an open invitation exists for this email address'
+

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -13,6 +13,8 @@ en:
     summary: 'Summary'
     click_here: 'Click here'
     created_at: 'Created At'
+    truthy: 'Yes'
+    falsey: 'No'
   helpers:
     submit:
       condition_level:

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -35,8 +35,12 @@ en:
         file:
           format_html: >
            Files uploaded must be in the following format below:<br />
-           Roles are optional and can be either of [student, teaching_assistant, manager, owner], and defaults to
-           student if omitted
+           <ul>
+           <li>Roles are optional and can be either of [student, teaching_assistant, manager,
+           owner], and defaults to student if omitted</li>
+           <li>Phantom is also optional with the following recognised as true values ['t',
+           'true', 'y', 'yes'] (case insenstitive), and defaults to non-phantom if omitted.</li>
+           </ul>
         individual:
           add_user: 'Add User'
         registration_code:

--- a/db/migrate/20180403011936_add_phantom_to_course_user_invitations.rb
+++ b/db/migrate/20180403011936_add_phantom_to_course_user_invitations.rb
@@ -1,0 +1,5 @@
+class AddPhantomToCourseUserInvitations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :course_user_invitations, :phantom, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180329205900) do
+ActiveRecord::Schema.define(version: 20180403011936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -752,6 +752,7 @@ ActiveRecord::Schema.define(version: 20180329205900) do
     t.string   "name",           :limit=>255, :null=>false
     t.string   "email",          :limit=>255, :null=>false, :index=>{:name=>"index_course_user_invitations_on_email", :case_sensitive=>false}
     t.integer  "role",           :default=>0, :null=>false
+    t.boolean  "phantom",        :default=>false, :null=>false
     t.string   "invitation_key", :limit=>32, :null=>false, :index=>{:name=>"index_course_user_invitations_on_invitation_key", :unique=>true}
     t.datetime "sent_at"
     t.datetime "confirmed_at"

--- a/spec/factories/course_user_invitations.rb
+++ b/spec/factories/course_user_invitations.rb
@@ -4,6 +4,11 @@ FactoryBot.define do
     course
     sequence(:name) { |n| "course user #{n}" }
     email { generate(:email) }
+    phantom false
+
+    trait :phantom do
+      phantom true
+    end
 
     trait :confirmed do
       confirmed_at 1.day.ago

--- a/spec/fixtures/course/invitation_fuzzy_roles.csv
+++ b/spec/fixtures/course/invitation_fuzzy_roles.csv
@@ -1,4 +1,0 @@
-name,email,role
-Foo,bar@foo.com
-Bar,foo@bar.com,Teaching Assistant
-abc,example@name.com,teaching_AssisTant

--- a/spec/fixtures/course/invitation_fuzzy_roles_and_phantom.csv
+++ b/spec/fixtures/course/invitation_fuzzy_roles_and_phantom.csv
@@ -1,0 +1,7 @@
+name,email,role,phantom
+Foo,bar@foo.com,,
+Non-Phantom Bar,foo@bar.com,Teaching Assistant,no
+Phantom Baz,example@name.com,teaching_AssisTant,y
+Phantom Student1,foo1@bar.com,student,t
+Phantom Student2,foo2@bar.com,student,yes
+Phantom Student3,foo3@bar.com,student,true

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -358,4 +358,20 @@ RSpec.describe ApplicationFormattersHelper do
       end
     end
   end
+
+  describe 'format_boolean' do
+    context 'when boolean is truthy' do
+      it 'returns the truthy value' do
+        expect(helper.format_boolean(true)).to eq(I18n.t('common.truthy'))
+        expect(helper.format_boolean(1)).to eq(I18n.t('common.truthy'))
+      end
+    end
+
+    context 'when boolean is falsey' do
+      it 'returns the falsey value' do
+        expect(helper.format_boolean(false)).to eq(I18n.t('common.falsey'))
+        expect(helper.format_boolean(nil)).to eq(I18n.t('common.falsey'))
+      end
+    end
+  end
 end

--- a/spec/models/course/user_invitation_spec.rb
+++ b/spec/models/course/user_invitation_spec.rb
@@ -7,4 +7,31 @@ RSpec.describe Course::UserInvitation, type: :model do
       expect(subject.invitation_key).to start_with('I')
     end
   end
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+
+    describe 'validations' do
+      context 'when there is a previous invitation with the same email' do
+        let(:email) { generate(:email) }
+        let!(:previous_invitation) do
+          create(:course_user_invitation, *invitation_traits, course: course, email: email)
+        end
+        subject { build(:course_user_invitation, course: course, email: email) }
+
+        context 'if the previous invitation has been confirmed' do
+          let(:invitation_traits) { [:confirmed] }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'if the previous invitation has not been confirmed' do
+          let(:invitation_traits) { [] }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
 end

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         file.write(CSV.generate do |csv|
           csv << [:name, :email, :role]
           records.zip(roles).each do |user, role|
-            csv << (role.blank? ? [user.name, user.email] : [user.name, user.email, role])
+            csv << (role.blank? ? [user.name, user.email] : [user.name, user.email, role, false])
           end
         end)
         file.rewind
@@ -35,7 +35,8 @@ RSpec.describe Course::UserInvitationService, type: :service do
     end
     let(:existing_user_attributes) do
       existing_users.each_with_index.map do |user, id|
-        { name: user.name, email: user.email, role: Course::UserInvitation.roles[existing_roles[id]] }
+        { name: user.name, email: user.email, phantom: false,
+          role: Course::UserInvitation.roles[existing_roles[id]] }
       end
     end
     let(:new_roles) { Course::UserInvitation.roles.keys.sample(3) }
@@ -46,7 +47,8 @@ RSpec.describe Course::UserInvitationService, type: :service do
     end
     let(:new_user_attributes) do
       new_users.each_with_index.map do |user, id|
-        { name: user.name, email: user.email, role: Course::UserInvitation.roles[new_roles[id]] }
+        { name: user.name, email: user.email, phantom: false,
+          role: Course::UserInvitation.roles[new_roles[id]] }
       end
     end
     let(:invalid_user_attributes) do
@@ -60,7 +62,8 @@ RSpec.describe Course::UserInvitationService, type: :service do
         [generate(:nested_attribute_new_id), {
           name: hash[:name],
           email: hash[:email],
-          role: hash[:role]
+          role: hash[:role],
+          phantom: hash[:phantom]
         }]
       end.to_h
     end
@@ -264,19 +267,30 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
       end
 
-      context 'when the provided csv file has slightly invalid role specifications' do
+      context 'when the csv file has slightly invalid role and/or phantom specifications' do
         subject do
           stubbed_user_invitation_service.
-            send(:parse_from_file, file_fixture('course/invitation_fuzzy_roles.csv'))
+            send(:parse_from_file, file_fixture('course/invitation_fuzzy_roles_and_phantom.csv'))
         end
 
-        it 'defaults blank columns to student' do
+        it 'defaults blank role column to student' do
           expect(subject[0][:role]).to eq(Course::UserInvitation.roles[:student])
+        end
+
+        it 'defaults blank phantom to false' do
+          expect(subject[0][:phantom]).to be_falsey
         end
 
         it 'parses roles correctly anyway' do
           expect(subject[1][:role]).to eq(Course::UserInvitation.roles[:teaching_assistant])
           expect(subject[2][:role]).to eq(Course::UserInvitation.roles[:teaching_assistant])
+        end
+
+        it 'parses phantom columns correctly anyway' do
+          expect(subject[1][:phantom]).to be_falsey
+          (2..5).each do |i|
+            expect(subject[i][:phantom]).to be_truthy
+          end
         end
       end
 

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -339,6 +339,21 @@ RSpec.describe Course::UserInvitationService, type: :service do
         result = subject.send(:parse_from_form, user_form_attributes)
         expect(result).to eq(user_attributes)
       end
+
+      context 'when the name is blank' do
+        let(:attributes_without_name) do
+          user_form_attributes.map do |k, v|
+            [k, v.except(:name)]
+          end.to_h
+        end
+
+        it 'sets the email as the name' do
+          results = subject.send(:parse_from_form, attributes_without_name)
+          results.each do |result|
+            expect(result[:name]).to eq(result[:email])
+          end
+        end
+      end
     end
 
     describe '#invite_users' do

--- a/spec/services/course/user_registration_service_spec.rb
+++ b/spec/services/course/user_registration_service_spec.rb
@@ -112,6 +112,30 @@ RSpec.describe Course::UserRegistrationService, type: :service do
             expect(course.course_users.find_by(user_id: user.id).role).to eq('teaching_assistant')
           end
         end
+
+        context 'when the phantom option is not specified' do
+          let!(:invitation) { create(:course_user_invitation, course: course) }
+          let(:registration) do
+            Course::Registration.new(course: course, user: user, code: invitation.invitation_key.dup)
+          end
+
+          it 'sets phantom to false' do
+            expect(subject.send(:claim_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).phantom).to be_falsey
+          end
+        end
+
+        context 'when the phantom option is specified as true' do
+          let!(:invitation) { create(:course_user_invitation, :phantom, course: course) }
+          let(:registration) do
+            Course::Registration.new(course: course, user: user, code: invitation.invitation_key.dup)
+          end
+
+          it 'sets phantom to true' do
+            expect(subject.send(:claim_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).phantom).to be_truthy
+          end
+        end
       end
 
       context 'when the code is invalid' do


### PR DESCRIPTION
Cleaning up quite a few things for user invitation, plus add support for phantom option. Commit messages explain most of the context. 

Solves #2595 and #2841.

In summary: 
 - Change invitation validation to only reject new invitations of the same email if another unconfirmed invitation exists.
 - Support phantom option for user invitations (frontend and backend) 
 - Handle blank names for form submission of new user invitations

After this I will work on #1874, which should be one of the final fixes to user invitation. 

