### PR TITLE
Convert text response questions maximum grade to float in json partial

### DIFF
--- a/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
@@ -1,7 +1,7 @@
 json.allowAttachment question.allow_attachment? unless question.hide_text?
 json.comprehension question.comprehension_question?
 json.autogradable question.auto_gradable?
-json.maximumGrade question.maximum_grade
+json.maximumGrade question.maximum_grade.to_f
 
 json.solutions question.solutions.each do |solution|
   json.id solution.id

--- a/client/app/bundles/course/assessment/submission/reducers/grading.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading.js
@@ -11,7 +11,7 @@ function sum(array) {
 
 function computeExp(questions, maximumGrade, basePoints, expMultiplier) {
   const totalGrade = sum(Object.values(questions).map(q => q.grade));
-  return parseInt((totalGrade / maximumGrade) * basePoints * expMultiplier, 10);
+  return Math.round((totalGrade / maximumGrade) * basePoints * expMultiplier);
 }
 
 export default function (state = initialState, action) {


### PR DESCRIPTION
Fix a bug where if an autograded assessment has a text response question, the exp calculation will not be performed correctly. This bug was introduced in #2905 as the maximum grade for text response question was passed to the frontend as string instead of number.