### PR TITLE
Video duration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -234,3 +234,6 @@ gem 'rails-controller-testing'
 gem 'rwordnet', git: 'https://github.com/makqien/rwordnet'
 gem 'loofah', '>= 2.2.1'
 gem 'rails-html-sanitizer', '>= 1.0.4'
+
+# YouTube API helper for Videos
+gem 'yt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -555,6 +555,10 @@ GEM
     xpath (3.0.0)
       nokogiri (~> 1.8)
     yard (0.9.12)
+    yt (0.32.1)
+      activesupport
+      yt-support (>= 0.1)
+    yt-support (0.1.3)
 
 PLATFORMS
   ruby
@@ -663,7 +667,7 @@ DEPENDENCIES
   webpacker (<= 3.0.2)
   workflow
   yard
-
+  yt
 
 BUNDLED WITH
    1.16.1

--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -106,12 +106,19 @@ module ApplicationFormattersHelper
     date.to_formatted_s(format)
   end
 
-  # @return the duration in the format of "HH:MM:SS", eg 04H05M11S
+  # @return [String] The duration in the format of "HH:MM:SS", eg 04H05M11S
   def format_duration(total_seconds)
     seconds = total_seconds % 60
     minutes = (total_seconds / 60) % 60
     hours = total_seconds / (60 * 60)
     format('%02dH%02dM%02dS', hours, minutes, seconds)
+  end
+
+  # @return [String] The duration in the format for displaying, eg 02:45:12, works for for
+  #                  durations less than 24hrs
+  def format_duration_for_display(total_seconds)
+    format_string = total_seconds < 3600 ? '%M:%S' : '%H:%M:%S'
+    Time.at(total_seconds).utc.strftime(format_string)
   end
 
   # A helper for generating CSS classes, based on the time-bounded status of the item.

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -5,6 +5,8 @@ class Course::Video < ApplicationRecord
   include Course::ClosingReminderConcern
   include Course::Video::UrlConcern
 
+  before_validation :set_duration, if: :new_record?
+
   belongs_to :tab, class_name: Course::Video::Tab.name, inverse_of: :videos
   has_many :submissions, class_name: Course::Video::Submission.name,
                          inverse_of: :video, dependent: :destroy
@@ -94,5 +96,12 @@ class Course::Video < ApplicationRecord
                else
                  duplicator.options[:target_course].video_tabs.first
                end
+  end
+
+  def set_duration
+    return if duration
+
+    youtube_id = youtube_video_id_from_link(url)
+    self.duration = Yt::Video.new(id: youtube_id).duration
   end
 end

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -13,6 +13,9 @@ class Course::Video < ApplicationRecord
   has_many :topics, class_name: Course::Video::Topic.name,
                     dependent: :destroy, foreign_key: :video_id, inverse_of: :video
 
+  validate :url_unchanged
+  validate :duration_unchanged
+
   scope :from_course, ->(course) { where(course_id: course) }
 
   scope :from_tab, ->(tab) { where(tab_id: tab) }
@@ -103,5 +106,15 @@ class Course::Video < ApplicationRecord
 
     youtube_id = youtube_video_id_from_link(url)
     self.duration = Yt::Video.new(id: youtube_id).duration
+  end
+
+  def url_unchanged
+    errors.add(:url, 'should not be updated for existing videos') if url_changed? &&
+                                                                     persisted?
+  end
+
+  def duration_unchanged
+    errors.add(:duration, 'should not be updated for existing videos') if duration_changed? &&
+                                                                          persisted?
   end
 end

--- a/app/views/course/video/submission/submissions/show.html.slim
+++ b/app/views/course/video/submission/submissions/show.html.slim
@@ -2,9 +2,12 @@
 
 table.table.table-bordered.details-table
   tbody
+    tr.duration
+      th = t('.duration')
+      td = format_duration_for_display(@video.duration)
     tr.watched_at
       th = t('.watched_at')
-      td = @submission.created_at
+      td = format_datetime(@submission.created_at)
 
 br
 h4 = t('.sessions_header')

--- a/app/views/course/video/submission/submissions/show.json.jbuilder
+++ b/app/views/course/video/submission/submissions/show.json.jbuilder
@@ -7,3 +7,4 @@ json.sessions do
 end
 
 json.submissionUrl edit_course_video_submission_url(current_course, @video, @submission)
+json.videoDuration @video.duration

--- a/app/views/course/video/videos/_form.html.slim
+++ b/app/views/course/video/videos/_form.html.slim
@@ -3,7 +3,9 @@
   = f.input :title
   = f.association :tab, collection: current_course.video_tabs
   = f.input :description, as: :text
-  = f.input :url, placeholder: t('.url_placeholder')
+  = f.input :url,
+            placeholder: t('.url_placeholder'),
+            disabled: @video.persisted?
   = f.input :start_at,
             as: :bootstrap_date_time,
             input_html: { value: f.object.start_at || Date.today }

--- a/app/views/course/video/videos/show.html.slim
+++ b/app/views/course/video/videos/show.html.slim
@@ -18,3 +18,6 @@
       tr.start_at
         th = t('.start_at')
         td = format_datetime(@video.start_at)
+      tr.duration
+        th = t('.duration')
+        td = format_duration_for_display(@video.duration)

--- a/client/app/bundles/course/video/submission/containers/Statistics/ProgressGraph.jsx
+++ b/client/app/bundles/course/video/submission/containers/Statistics/ProgressGraph.jsx
@@ -8,7 +8,7 @@ import { formatTimestamp } from 'lib/helpers/videoHelpers';
 
 import translations from '../../translations';
 
-const graphGlobalOptions = intl => ({
+const graphGlobalOptions = (intl, videoDuration) => ({
   legend: {
     display: false,
   },
@@ -44,6 +44,7 @@ const graphGlobalOptions = intl => ({
       },
       ticks: {
         suggestedMin: 0,
+        max: videoDuration,
         callback: formatTimestamp,
       },
     }],
@@ -73,6 +74,7 @@ const propTypes = {
     })),
   })).isRequired,
   submissionUrl: PropTypes.string.isRequired,
+  videoDuration: PropTypes.number.isRequired,
 };
 
 class ProgressGraph extends React.Component {
@@ -185,7 +187,7 @@ class ProgressGraph extends React.Component {
     return (<Scatter
       data={data}
       options={{
-        ...graphGlobalOptions(this.props.intl),
+        ...graphGlobalOptions(this.props.intl, this.props.videoDuration),
         ...this.generateMouseOptions(data),
         ...this.generateToolTipOptions(),
       }}

--- a/client/app/bundles/course/video/submission/submissions-show.jsx
+++ b/client/app/bundles/course/video/submission/submissions-show.jsx
@@ -13,7 +13,7 @@ $(document).ready(() => {
 
   render(
     <ProviderWrapper>
-      <ProgressGraph sessions={initialState.sessions} submissionUrl={initialState.submissionUrl} />
+      <ProgressGraph {...initialState} />
     </ProviderWrapper>
     , mountNode
   );

--- a/config/initializers/yt.rb
+++ b/config/initializers/yt.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+Yt.configure do |config|
+  config.api_key = ENV['YT_API_KEY']
+end

--- a/config/locales/en/course/video/submissions.yml
+++ b/config/locales/en/course/video/submissions.yml
@@ -13,6 +13,7 @@ en:
           show:
             header: 'Statistics: %{title} for %{student}'
             watched_at: 'Watched at'
+            duration: :'course.video.videos.index.duration'
             sessions_header: 'Sessions Statistics'
             no_sessions: 'No watch statistics available for this submission'
           edit:

--- a/config/locales/en/course/video/videos.yml
+++ b/config/locales/en/course/video/videos.yml
@@ -7,6 +7,7 @@ en:
           header: 'Videos'
           title: 'Title'
           start_at: 'Start At'
+          duration: 'Duration'
         new:
           header: 'New Video'
         create:
@@ -14,6 +15,7 @@ en:
         show:
           description: 'Description'
           start_at: :'course.video.videos.index.start_at'
+          duration: :'course.video.videos.index.duration'
         edit:
           header: 'Edit Video'
         update:

--- a/db/migrate/20180403164109_add_duration_to_course_video.rb
+++ b/db/migrate/20180403164109_add_duration_to_course_video.rb
@@ -1,0 +1,19 @@
+class AddDurationToCourseVideo < ActiveRecord::Migration[5.1]
+  def up
+    add_column :course_videos, :duration, :integer
+    Course::Video.reset_column_information
+
+    ActsAsTenant.without_tenant do
+      Course::Video.where('course_videos.duration IS NULL').find_each do |video|
+        video.send(:set_duration)
+        video.save!(validate: false)
+      end
+    end
+
+    change_column_null :course_videos, :duration, false
+  end
+
+  def down
+    remove_column :course_videos, :duration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180403011936) do
+ActiveRecord::Schema.define(version: 20180403164109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -768,6 +768,7 @@ ActiveRecord::Schema.define(version: 20180403011936) do
   create_table "course_videos", force: :cascade do |t|
     t.integer  "tab_id",      :null=>false, :index=>{:name=>"fk__course_videos_tab_id"}, :foreign_key=>{:references=>"course_video_tabs", :name=>"fk_course_videos_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.string   "url",         :limit=>255, :null=>false
+    t.integer  "duration",    :null => false
     t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_videos_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_videos_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_videos_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_videos_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
     t.datetime "created_at",  :null=>false

--- a/spec/factories/course_video_videos.rb
+++ b/spec/factories/course_video_videos.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     tab { course.default_video_tab }
     title { generate(:course_video_title) }
     description { generate(:course_video_description) }
+    duration 200
     url 'https://www.youtube.com/embed/i_YiovUyMds'
     published false
 

--- a/spec/features/course/video/video_management_spec.rb
+++ b/spec/features/course/video/video_management_spec.rb
@@ -11,6 +11,15 @@ RSpec.feature 'Course: Videos: Management' do
     context 'As a Course Teaching Assistant' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
 
+      before do
+        # Override the set_duration method to avoid an API call
+        Course::Video.class_eval do
+          def set_duration
+            self.duration = 123
+          end
+        end
+      end
+
       scenario 'I can create a video' do
         video = build_stubbed(:video)
         visit course_videos_path(course)

--- a/spec/models/course/video_spec.rb
+++ b/spec/models/course/video_spec.rb
@@ -99,6 +99,43 @@ RSpec.describe Course::Video, type: :model do
       end
     end
 
+    describe 'validations' do
+      let(:youtube_embedded_url) { "https://www.youtube.com/embed/#{youtube_video_id}" }
+      let(:youtube_video_id) { 'dQw4w9WgXcQ' }
+
+      context 'when video is new' do
+        it 'allows url to be changed' do
+          video = build(:video, course: course)
+          video.url = youtube_embedded_url
+          expect(video.valid?).to be_truthy
+          expect(video.save).to be_truthy
+        end
+
+        it 'allows duration to be changed' do
+          video = build(:video, course: course)
+          video.duration = 123
+          expect(video.valid?).to be_truthy
+          expect(video.save).to be_truthy
+        end
+      end
+
+      context 'when video exists ' do
+        it 'prevents the url from being changed' do
+          video1.url = youtube_embedded_url
+          expect(video1.valid?).to be_falsey
+          expect(video1.save).to be_falsey
+          expect { video1.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+        end
+
+        it 'prevents the duration from being changed' do
+          video1.duration = 123
+          expect(video1.valid?).to be_falsey
+          expect(video1.save).to be_falsey
+          expect { video1.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+
     describe 'callbacks' do
       context 'when updating video url' do
         let(:youtube_embedded_url) { "https://www.youtube.com/embed/#{youtube_video_id}" }
@@ -119,9 +156,10 @@ RSpec.describe Course::Video, type: :model do
 
         it 'updates to the youtube embed url' do
           youtube_valid_urls.each do |url|
-            video1.reload.url = url
-            expect(video1.save).to be_truthy
-            expect(video1.reload.url).to eq(youtube_embedded_url)
+            video = build(:video, course: course)
+            video.url = url
+            expect(video.save).to be_truthy
+            expect(video.reload.url).to eq(youtube_embedded_url)
           end
         end
 
@@ -130,9 +168,10 @@ RSpec.describe Course::Video, type: :model do
 
           it ' does not update and returns an error' do
             invalid_urls.each do |url|
-              video1.reload.url = url
-              expect(video1.save).to be_falsey
-              expect { video1.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+              video = build(:video, course: course)
+              video.url = url
+              expect(video.save).to be_falsey
+              expect { video.save! }.to raise_exception(ActiveRecord::RecordInvalid)
             end
           end
         end


### PR DESCRIPTION
Store the duration of the video in the database.

Add displays for the duration, as well as scale the watch graph accordingly.

The video duration allows more complete data visualizations, like a heatmap of the video.

Will require the YoutTube Data API. The API key is currently assumed to stored as environment variable: `YT_API_KEY`.
The key can be obtained from the instructions in:
https://github.com/Fullscreen/yt#configuring-your-app
Only a normal (public) API key is needed.

The YouTube API can also be used for other features, such as auto-populating the video details on the #new page

Dependent on #2900
