### PR TITLE
[Assessment Password] Schema changes

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -80,7 +80,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
     if autograded?
       base_params += [:skippable]
     else
-      base_params += [:password, :tabbed_view, :delayed_grade_publication]
+      base_params += [:session_password, :tabbed_view, :delayed_grade_publication]
     end
     params.require(:assessment).permit(*base_params, folder_params)
   end

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -38,7 +38,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   def create
     @submission.session_id = authentication_service.generate_authentication_token!
     if @submission.save
-      log_service.log_submission_access(request) if @assessment.password_protected?
+      log_service.log_submission_access(request) if @assessment.session_password_protected?
       redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission,
                                                          new_submission: true)
     else
@@ -164,7 +164,7 @@ class Course::Assessment::Submission::SubmissionsController < \
 
   def check_password
     return unless @submission.attempting?
-    return if !@assessment.password_protected? || can?(:manage, @assessment)
+    return if !@assessment.session_password_protected? || can?(:manage, @assessment)
     return if authentication_service.authenticated?
 
     log_service.log_submission_access(request)

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -142,8 +142,9 @@ class Course::Assessment < ApplicationRecord
     published?
   end
 
-  def password_protected?
-    password.present?
+  # The password to preventing attempting submission from multiple sessions.
+  def session_password_protected?
+    submission_password.present?
   end
 
   def downloadable?

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -113,7 +113,7 @@ class Course::Assessment < ApplicationRecord
 
     if target_mode == true
       self.autograded = true
-      self.password = nil
+      self.session_password = nil
       self.delayed_grade_publication = false
     elsif target_mode == false # Ignore the case when the params is empty.
       self.autograded = false
@@ -144,7 +144,7 @@ class Course::Assessment < ApplicationRecord
 
   # The password to preventing attempting submission from multiple sessions.
   def session_password_protected?
-    submission_password.present?
+    session_password.present?
   end
 
   def downloadable?

--- a/app/services/course/assessment/session_authentication_service.rb
+++ b/app/services/course/assessment/session_authentication_service.rb
@@ -20,7 +20,7 @@ class Course::Assessment::SessionAuthenticationService
   def authenticate(password)
     return true unless @assessment.session_password_protected?
 
-    if password == @assessment.password
+    if password == @assessment.session_password
       update_session_id if @submission
       true
     else

--- a/app/services/course/assessment/session_authentication_service.rb
+++ b/app/services/course/assessment/session_authentication_service.rb
@@ -18,7 +18,7 @@ class Course::Assessment::SessionAuthenticationService
   # @param [String] password
   # @return [Boolean] true if matches
   def authenticate(password)
-    return true unless @assessment.password_protected?
+    return true unless @assessment.session_password_protected?
 
     if password == @assessment.password
       update_session_id if @submission

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -2,7 +2,7 @@
 json.attributes do
   json.(@assessment, :id, :title, :description, :start_at, :end_at, :bonus_end_at, :base_exp,
     :time_bonus_exp, :published, :autograded, :show_private, :show_evaluation, :skippable,
-    :tabbed_view, :password, :delayed_grade_publication, :tab_id)
+    :tabbed_view, :session_password, :delayed_grade_publication, :tab_id)
 end
 
 json.tab_attributes do

--- a/app/views/course/assessment/assessments/_todo_assessment_button.html.slim
+++ b/app/views/course/assessment/assessments/_todo_assessment_button.html.slim
@@ -1,6 +1,6 @@
 - assessment = todo_assessment_button
 - if todo.not_started?
-  - if assessment.password_protected?
+  - if assessment.session_password_protected?
     = link_to t('.attempt'), new_course_assessment_session_path(current_course, assessment),
               class: ['btn', 'btn-info']
   - else

--- a/app/views/course/assessment/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/edit.json.jbuilder
@@ -14,7 +14,7 @@ json.assessment do
   json.showPrivate @assessment.show_private
   json.showEvaluation @assessment.show_evaluation
   json.questionIds @assessment.questions.map(&:id)
-  json.passwordProtected @assessment.password_protected?
+  json.passwordProtected @assessment.session_password_protected?
   json.gamified @assessment.course.gamified?
   json.files @assessment.folder.materials do |material|
     json.url url_for([@assessment.course, @assessment.folder, material])

--- a/app/views/course/assessment/submission/submissions/index.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/index.json.jbuilder
@@ -6,7 +6,7 @@ json.assessment do
   json.maximumGrade @assessment.maximum_grade.to_f
   json.gamified current_course.gamified?
   json.downloadable @assessment.downloadable?
-  json.passwordProtected @assessment.password_protected?
+  json.passwordProtected @assessment.session_password_protected?
 end
 
 my_students_set = Set.new(@my_students.map(&:id))

--- a/client/app/bundles/course/assessment/assessments-edit.jsx
+++ b/client/app/bundles/course/assessment/assessments-edit.jsx
@@ -27,7 +27,7 @@ $(document).ready(() => {
           initialValues={{
             ...data.attributes,
             tabs: [currentTab],
-            password_protected: !!data.attributes.password,
+            password_protected: !!(data.attributes.view_password || data.attributes.session_password),
           }}
         />
       </ProviderWrapper>

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -39,6 +39,8 @@ const styles = {
 
 const isFieldBlank = str => str === undefined || str === '' || str === null;
 
+const isEndDatePassedStartDate = (startAt, endAt) => startAt && endAt && new Date(startAt) >= new Date(endAt);
+
 const validate = (values) => {
   const errors = {};
 
@@ -59,7 +61,7 @@ const validate = (values) => {
     }
   }
 
-  if (values.start_at && values.end_at && new Date(values.start_at) >= new Date(values.end_at)) {
+  if (isEndDatePassedStartDate(values.start_at, values.end_at)) {
     errors.end_at = translations.startEndValidationError;
   }
 

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -37,6 +37,8 @@ const styles = {
   },
 };
 
+const isFieldBlank = str => str === undefined || str === '' || str === null;
+
 const validate = (values) => {
   const errors = {};
 
@@ -45,15 +47,17 @@ const validate = (values) => {
     requiredFields.push('tabbed_view');
   }
 
-  if (values.password_protected) {
-    requiredFields.push('password');
-  }
-
   requiredFields.forEach((field) => {
-    if (values[field] === undefined || values[field] === '' || values[field] === null) {
+    if (isFieldBlank(values[field])) {
       errors[field] = formTranslations.required;
     }
   });
+
+  if (values.password_protected) {
+    if (isFieldBlank(values.view_password) && isFieldBlank(values.session_password)) {
+      errors.password_protected = translations.passwordRequired;
+    }
+  }
 
   if (values.start_at && values.end_at && new Date(values.start_at) >= new Date(values.end_at)) {
     errors.end_at = translations.startEndValidationError;
@@ -224,11 +228,11 @@ class AssessmentForm extends React.Component {
         {
           this.props.password_protected &&
           <Field
-            name="password"
+            name="submission_password"
             component={TextField}
-            hintText={<FormattedMessage {...translations.password} />}
+            hintText={<FormattedMessage {...translations.submissionPassword} />}
             fullWidth
-            autoComplete={false}
+            autoComplete="off"
             disabled={submitting}
           />
         }

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
@@ -91,6 +91,10 @@ const translations = defineMessages({
       not be immediately shown to the student. To publish all gradings for this assessment, click \
       on the 'Publish Grades' button on the top right of the submissions listing for this assessment.",
   },
+  passwordRequired: {
+    id: 'course.assessment.form.passwordRequired',
+    defaultMessage: 'At least one password is required',
+  },
   passwordProtection: {
     id: 'course.assessment.form.passwordProtection',
     defaultMessage: 'Password Protection',
@@ -102,8 +106,8 @@ const translations = defineMessages({
       not allowed unless the password is provided by the staff. This can be used to prevent \
       students from accessing each other's submissions in exams.",
   },
-  password: {
-    id: 'course.assessment.form.password',
+  submissionPassword: {
+    id: 'course.assessment.form.submissionPassword',
     defaultMessage: 'Input Password',
   },
   startEndValidationError: {

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/__test__/index.test.js
@@ -52,7 +52,7 @@ describe('<AssessmentEdit />', () => {
     const form = editPage.find('form');
     form.simulate('submit');
     expect(spy).toHaveBeenCalledWith(id,
-      { assessment: { ...intitialValues, title: newTitle, autograded: true, password: null } });
+      { assessment: { ...intitialValues, title: newTitle, autograded: true, view_password: null, session_password: null } });
   });
 
   it('renders the gamified fields by default', () => {

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
@@ -39,9 +39,10 @@ class EditPage extends React.Component {
   };
 
   onFormSubmit = (data) => {
-    // Remove password field if password is disabled
-    const password = data.password_protected ? data.password : null;
-    const atrributes = Object.assign({}, data, { password });
+    // Remove view_password and session_password field if password is disabled
+    const view_password = data.password_protected ? data.view_password : null;
+    const session_password = data.password_protected ? data.session_password : null;
+    const atrributes = Object.assign({}, data, { view_password, session_password });
 
     const { intl } = this.props;
 

--- a/db/migrate/20180414144225_add_password_to_assessments.rb
+++ b/db/migrate/20180414144225_add_password_to_assessments.rb
@@ -1,0 +1,6 @@
+class AddPasswordToAssessments < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :course_assessments, :password, :session_password
+    add_column :course_assessments, :view_password, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,32 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180403011936) do
+ActiveRecord::Schema.define(version: 20180414144225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "users", force: :cascade do |t|
-    t.string   "name",                   :limit=>255, :null=>false
-    t.integer  "role",                   :default=>0, :null=>false
-    t.string   "time_zone",              :limit=>255
-    t.text     "profile_photo"
-    t.string   "encrypted_password",     :limit=>255, :default=>"", :null=>false
-    t.string   "reset_password_token",   :limit=>255, :index=>{:name=>"index_users_on_reset_password_token", :unique=>true}
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          :default=>0, :null=>false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",             :null=>false
-    t.datetime "updated_at",             :null=>false
-  end
-
   create_table "activities", force: :cascade do |t|
-    t.integer  "actor_id",      :null=>false, :index=>{:name=>"fk__activities_actor_id"}, :foreign_key=>{:references=>"users", :name=>"fk_activities_actor_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "actor_id",      :null=>false, :index=>{:name=>"fk__activities_actor_id", :order=>{:actor_id=>:asc}}
     t.integer  "object_id",     :null=>false
     t.string   "object_type",   :limit=>255, :null=>false
     t.string   "event",         :limit=>255, :null=>false
@@ -44,194 +26,70 @@ ActiveRecord::Schema.define(version: 20180403011936) do
     t.datetime "updated_at",    :null=>false
   end
 
+  create_table "attachment_references", id: :uuid, default: %q{uuid_generate_v4()}, force: :cascade do |t|
+    t.integer  "attachable_id"
+    t.string   "attachable_type", :limit=>255, :index=>{:name=>"fk__attachment_references_attachable_id", :with=>["attachable_id"], :order=>{:attachable_type=>:asc, :attachable_id=>:asc}}
+    t.integer  "attachment_id",   :null=>false, :index=>{:name=>"fk__attachment_references_attachment_id", :order=>{:attachment_id=>:asc}}
+    t.string   "name",            :limit=>255, :null=>false
+    t.datetime "expires_at"
+    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__attachment_references_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__attachment_references_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",      :null=>false
+    t.datetime "updated_at",      :null=>false
+  end
+
   create_table "attachments", force: :cascade do |t|
-    t.string   "name",        :limit=>255, :null=>false, :index=>{:name=>"index_attachments_on_name", :unique=>true}
+    t.string   "name",        :limit=>255, :null=>false, :index=>{:name=>"index_attachments_on_name", :unique=>true, :order=>{:name=>:asc}}
     t.text     "file_upload", :null=>false
     t.datetime "created_at",  :null=>false
     t.datetime "updated_at",  :null=>false
   end
 
-  create_table "attachment_references", id: :uuid, default: %q{uuid_generate_v4()}, force: :cascade do |t|
-    t.integer  "attachable_id"
-    t.string   "attachable_type", :limit=>255, :index=>{:name=>"fk__attachment_references_attachable_id", :with=>["attachable_id"]}
-    t.integer  "attachment_id",   :null=>false, :index=>{:name=>"fk__attachment_references_attachment_id"}, :foreign_key=>{:references=>"attachments", :name=>"fk_attachment_references_attachment_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "name",            :limit=>255, :null=>false
-    t.datetime "expires_at"
-    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__attachment_references_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_attachment_references_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__attachment_references_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_attachment_references_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",      :null=>false
-    t.datetime "updated_at",      :null=>false
-  end
-
-  create_table "instances", force: :cascade do |t|
-    t.string "name",     :limit=>255, :null=>false
-    t.string "host",     :limit=>255, :null=>false, :comment=>"Stores the host name of the instance. The www prefix is automatically handled by the application", :index=>{:name=>"index_instances_on_host", :unique=>true, :case_sensitive=>false}
-    t.text   "settings"
-  end
-
-  create_table "courses", force: :cascade do |t|
-    t.integer  "instance_id",      :null=>false, :index=>{:name=>"fk__courses_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_courses_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",            :limit=>255, :null=>false
-    t.text     "description"
-    t.text     "logo"
-    t.boolean  "published",        :default=>false, :null=>false
-    t.boolean  "enrollable",       :default=>false, :null=>false
-    t.string   "registration_key", :limit=>16, :index=>{:name=>"index_courses_on_registration_key", :unique=>true}
-    t.text     "settings"
-    t.boolean  "gamified",         :default=>true, :null=>false
-    t.datetime "start_at",         :null=>false
-    t.datetime "end_at",           :null=>false
-    t.string   "time_zone",        :limit=>255
-    t.integer  "creator_id",       :null=>false, :index=>{:name=>"fk__courses_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_courses_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",       :null=>false, :index=>{:name=>"fk__courses_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_courses_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",       :null=>false
-    t.datetime "updated_at",       :null=>false
-  end
-
   create_table "course_achievements", force: :cascade do |t|
-    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_achievements_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_achievements_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_achievements_course_id", :order=>{:course_id=>:asc}}
     t.string   "title",       :limit=>255, :null=>false
     t.text     "description"
     t.text     "badge"
     t.integer  "weight",      :null=>false
     t.boolean  "published",   :null=>false
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_achievements_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_achievements_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_achievements_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_achievements_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_achievements_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_achievements_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",  :null=>false
     t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_announcements", force: :cascade do |t|
-    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_announcements_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_announcements_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",      :limit=>255, :null=>false
+    t.integer  "course_id",              :null=>false, :index=>{:name=>"fk__course_announcements_course_id", :order=>{:course_id=>:asc}}
+    t.string   "title",                  :limit=>255, :null=>false
     t.text     "content"
-    t.boolean  "sticky",     :default=>false, :null=>false
-    t.datetime "start_at",   :null=>false
-    t.datetime "end_at",     :null=>false
+    t.boolean  "sticky",                 :default=>false, :null=>false
+    t.datetime "start_at",               :null=>false
+    t.datetime "end_at",                 :null=>false
     t.float    "opening_reminder_token"
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_announcements_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_announcements_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_announcements_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_announcements_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-  end
-
-  create_table "course_assessment_questions", force: :cascade do |t|
-    t.integer  "actable_id"
-    t.string   "actable_type",        :limit=>255, :index=>{:name=>"index_course_assessment_questions_actable", :with=>["actable_id"], :unique=>true}
-    t.string   "title",               :limit=>255
-    t.text     "description"
-    t.text     "staff_only_comments"
-    t.decimal  "maximum_grade",       :precision=>4, :scale=>1, :null=>false
-    t.integer  "creator_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_questions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_questions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",          :null=>false
-    t.datetime "updated_at",          :null=>false
-  end
-
-  create_table "course_assessment_categories", force: :cascade do |t|
-    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_assessment_categories_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_categories_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",      :limit=>255, :null=>false
-    t.integer  "weight",     :null=>false
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessment_categories_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_categories_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_assessment_categories_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_categories_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-  end
-
-  create_table "course_assessment_tabs", force: :cascade do |t|
-    t.integer  "category_id", :null=>false, :index=>{:name=>"fk__course_assessment_tabs_category_id"}, :foreign_key=>{:references=>"course_assessment_categories", :name=>"fk_course_assessment_tabs_category_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",       :limit=>255, :null=>false
-    t.integer  "weight",      :null=>false
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessment_tabs_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_tabs_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessment_tabs_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_tabs_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",  :null=>false
-    t.datetime "updated_at",  :null=>false
-  end
-
-  create_table "course_assessments", force: :cascade do |t|
-    t.integer  "tab_id",                    :null=>false, :index=>{:name=>"fk__course_assessments_tab_id"}, :foreign_key=>{:references=>"course_assessment_tabs", :name=>"fk_course_assessments_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.boolean  "tabbed_view",               :default=>false, :null=>false
-    t.boolean  "autograded",                :null=>false
-    t.boolean  "show_private",              :default=>false, :comment=>"Show private test cases after students answer correctly"
-    t.boolean  "show_evaluation",           :default=>false, :comment=>"Show evaluation test cases after students answer correctly"
-    t.boolean  "skippable",                 :default=>false
-    t.boolean  "delayed_grade_publication", :default=>false
-    t.string   "password",                  :limit=>255
-    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_assessments_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_assessments_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessments_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",                :null=>false
-    t.datetime "updated_at",                :null=>false
-  end
-
-  create_table "course_assessment_submissions", force: :cascade do |t|
-    t.integer  "assessment_id",  :null=>false, :index=>{:name=>"fk__course_assessment_submissions_assessment_id"}, :foreign_key=>{:references=>"course_assessments", :name=>"fk_course_assessment_submissions_assessment_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "workflow_state", :limit=>255, :null=>false
-    t.string   "session_id",     :limit=>255
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_submissions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_submissions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",     :null=>false
-    t.datetime "updated_at",     :null=>false
-    t.integer  "publisher_id",   :index=>{:name=>"fk__course_assessment_submissions_publisher_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_submissions_publisher_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "published_at"
-    t.datetime "submitted_at"
-
-    t.index ["assessment_id", "creator_id"], :name=>"unique_assessment_id_and_creator_id", :unique=>true
-  end
-
-  create_table "course_assessment_answers", force: :cascade do |t|
-    t.integer  "actable_id"
-    t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_assessment_answers_actable", :with=>["actable_id"], :unique=>true}
-    t.integer  "submission_id",  :null=>false, :index=>{:name=>"fk__course_assessment_answers_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_answers_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "question_id",    :null=>false, :index=>{:name=>"fk__course_assessment_answers_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_answers_question_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.boolean  "current_answer", :default=>false, :null=>false
-    t.string   "workflow_state", :limit=>255, :null=>false
-    t.datetime "submitted_at"
-    t.decimal  "grade",          :precision=>4, :scale=>1
-    t.boolean  "correct",        :comment=>"Correctness is independent of the grade (depends on the grading schema)"
-    t.integer  "grader_id",      :index=>{:name=>"fk__course_assessment_answers_grader_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_answers_grader_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "graded_at"
-    t.datetime "created_at",     :null=>false
-    t.datetime "updated_at",     :null=>false
-  end
-
-  create_table "jobs", id: :uuid, default: nil, force: :cascade do |t|
-    t.integer  "status",      :default=>0, :null=>false
-    t.string   "redirect_to", :limit=>255
-    t.json     "error"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.integer  "creator_id",             :null=>false, :index=>{:name=>"fk__course_announcements_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",             :null=>false, :index=>{:name=>"fk__course_announcements_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",             :null=>false
+    t.datetime "updated_at",             :null=>false
   end
 
   create_table "course_assessment_answer_auto_gradings", force: :cascade do |t|
-    t.integer  "actable_id",   :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_actable", :with=>["actable_type"], :unique=>true}
+    t.integer  "actable_id",   :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_actable", :with=>["actable_type"], :unique=>true, :order=>{:actable_id=>:asc, :actable_type=>:asc}}
     t.string   "actable_type", :limit=>255
-    t.integer  "answer_id",    :null=>false, :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_answer_id", :unique=>true}, :foreign_key=>{:references=>"course_assessment_answers", :name=>"fk_course_assessment_answer_auto_gradings_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.uuid     "job_id",       :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_job_id", :unique=>true}, :foreign_key=>{:references=>"jobs", :name=>"fk_course_assessment_answer_auto_gradings_job_id", :on_update=>:no_action, :on_delete=>:nullify}
+    t.integer  "answer_id",    :null=>false, :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_answer_id", :unique=>true, :order=>{:answer_id=>:asc}}
+    t.uuid     "job_id",       :index=>{:name=>"index_course_assessment_answer_auto_gradings_on_job_id", :unique=>true, :order=>{:job_id=>:asc}}
     t.json     "result"
     t.datetime "created_at",   :null=>false
     t.datetime "updated_at",   :null=>false
   end
 
-  create_table "course_assessment_answer_multiple_responses", force: :cascade do |t|
-  end
-
-  create_table "course_assessment_question_multiple_responses", force: :cascade do |t|
-    t.integer "grading_scheme", :default=>0, :null=>false
-  end
-
-  create_table "course_assessment_question_multiple_response_options", force: :cascade do |t|
-    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_question"}, :foreign_key=>{:references=>"course_assessment_question_multiple_responses", :name=>"fk_course_assessment_question_multiple_response_options_questio", :on_update=>:no_action, :on_delete=>:no_action}
-    t.boolean "correct",     :null=>false
-    t.text    "option",      :null=>false
-    t.text    "explanation"
-    t.integer "weight",      :null=>false
-  end
-
   create_table "course_assessment_answer_multiple_response_options", force: :cascade do |t|
-    t.integer "answer_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_answer"}, :foreign_key=>{:references=>"course_assessment_answer_multiple_responses", :name=>"fk_course_assessment_answer_multiple_response_options_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "option_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_question_option"}, :foreign_key=>{:references=>"course_assessment_question_multiple_response_options", :name=>"fk_course_assessment_answer_multiple_response_options_option_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "answer_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_answer", :order=>{:answer_id=>:asc}}
+    t.integer "option_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_question_option", :order=>{:option_id=>:asc}}
 
-    t.index ["answer_id", "option_id"], :name=>"index_multiple_response_answer_on_answer_id_and_option_id", :unique=>true
+    t.index ["answer_id", "option_id"], :name=>"index_multiple_response_answer_on_answer_id_and_option_id", :unique=>true, :order=>{:answer_id=>:asc, :option_id=>:asc}
+  end
+
+  create_table "course_assessment_answer_multiple_responses", force: :cascade do |t|
   end
 
   create_table "course_assessment_answer_programming", force: :cascade do |t|
@@ -243,60 +101,35 @@ ActiveRecord::Schema.define(version: 20180403011936) do
     t.integer "exit_code"
   end
 
+  create_table "course_assessment_answer_programming_file_annotations", force: :cascade do |t|
+    t.integer "file_id", :null=>false, :index=>{:name=>"fk__course_assessment_answe_09c4b638af92d0f8252d7cdef59bd6f3", :order=>{:file_id=>:asc}}
+    t.integer "line",    :null=>false
+  end
+
   create_table "course_assessment_answer_programming_files", force: :cascade do |t|
-    t.integer "answer_id", :null=>false, :index=>{:name=>"fk__course_assessment_answer_programming_files_answer_id"}, :foreign_key=>{:references=>"course_assessment_answer_programming", :name=>"fk_course_assessment_answer_programming_files_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "answer_id", :null=>false, :index=>{:name=>"fk__course_assessment_answer_programming_files_answer_id", :order=>{:answer_id=>:asc}}
     t.string  "filename",  :limit=>255, :null=>false
     t.text    "content",   :default=>"", :null=>false
 
     t.index ["answer_id", "filename"], :name=>"index_course_assessment_answer_programming_files_filename", :unique=>true, :case_sensitive=>false
   end
 
-  create_table "course_assessment_answer_programming_file_annotations", force: :cascade do |t|
-    t.integer "file_id", :null=>false, :index=>{:name=>"fk__course_assessment_answe_09c4b638af92d0f8252d7cdef59bd6f3"}, :foreign_key=>{:references=>"course_assessment_answer_programming_files", :name=>"fk_course_assessment_answer_ed21459e7a2a5034dcf43a14812cb17d", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "line",    :null=>false
-  end
-
-  create_table "polyglot_languages", force: :cascade do |t|
-    t.string  "type",      :limit=>255, :null=>false, :comment=>"The class of language, as perceived by the application."
-    t.string  "name",      :limit=>255, :null=>false, :index=>{:name=>"index_polyglot_languages_on_name", :unique=>true, :case_sensitive=>false}
-    t.integer "parent_id", :index=>{:name=>"fk__polyglot_languages_parent_id"}, :foreign_key=>{:references=>"polyglot_languages", :name=>"fk_polyglot_languages_parent_id", :on_update=>:no_action, :on_delete=>:no_action}
-  end
-
-  create_table "course_assessment_question_programming", force: :cascade do |t|
-    t.integer "language_id",   :null=>false, :index=>{:name=>"fk__course_assessment_question_programming_language_id"}, :foreign_key=>{:references=>"polyglot_languages", :name=>"fk_course_assessment_question_programming_language_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "memory_limit",  :comment=>"Memory limit, in MiB"
-    t.integer "time_limit",    :comment=>"Time limit, in seconds"
-    t.integer "attempt_limit"
-    t.uuid    "import_job_id", :comment=>"The ID of the importing job", :index=>{:name=>"index_course_assessment_question_programming_on_import_job_id", :unique=>true}, :foreign_key=>{:references=>"jobs", :name=>"fk_course_assessment_question_programming_import_job_id", :on_update=>:no_action, :on_delete=>:nullify}
-    t.integer "package_type",  :default=>0, :null=>false
-    t.boolean "multiple_file_submission", :default=>false, :null=>false
-  end
-
-  create_table "course_assessment_question_programming_test_cases", force: :cascade do |t|
-    t.integer "question_id",    :null=>false, :index=>{:name=>"fk__course_assessment_quest_18b37224652fc59d955122a17ba20d07"}, :foreign_key=>{:references=>"course_assessment_question_programming", :name=>"fk_course_assessment_questi_ee00a2daf4389c4c2ddba3041a15c35f", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string  "identifier",     :limit=>255, :null=>false, :comment=>"Test case identifier generated by the testing framework", :index=>{:name=>"index_course_assessment_question_programming_test_case_ident", :with=>["question_id"], :unique=>true}
-    t.integer "test_case_type", :null=>false
-    t.text    "expression"
-    t.text    "expected"
-    t.text    "hint"
-  end
-
   create_table "course_assessment_answer_programming_test_results", force: :cascade do |t|
-    t.integer "auto_grading_id", :null=>false, :index=>{:name=>"fk__course_assessment_answe_3d4bf9a99ed787551e4454c7106971fc"}, :foreign_key=>{:references=>"course_assessment_answer_programming_auto_gradings", :name=>"fk_course_assessment_answer_e3d785447112439bb306849be8690102", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "test_case_id",    :index=>{:name=>"fk__course_assessment_answe_ca0d5ba368869806d2a9cb8717feed4f"}, :foreign_key=>{:references=>"course_assessment_question_programming_test_cases", :name=>"fk_course_assessment_answer_bbb492885b1e3dca4433b8af8cb95906", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "auto_grading_id", :null=>false, :index=>{:name=>"fk__course_assessment_answe_3d4bf9a99ed787551e4454c7106971fc", :order=>{:auto_grading_id=>:asc}}
+    t.integer "test_case_id",    :index=>{:name=>"fk__course_assessment_answe_ca0d5ba368869806d2a9cb8717feed4f", :order=>{:test_case_id=>:asc}}
     t.boolean "passed",          :null=>false
     t.jsonb   "messages",        :default=>{}, :null=>false
   end
 
-  create_table "course_assessment_answer_scribings", force: :cascade do |t|
-  end
-
   create_table "course_assessment_answer_scribing_scribbles", force: :cascade do |t|
     t.text     "content"
-    t.integer  "answer_id",  :index=>{:name=>"fk__course_assessment_answer_scribing_scribbles_scribing_answer"}, :foreign_key=>{:references=>"course_assessment_answer_scribings", :name=>"fk_course_assessment_answer_scribing_scribbles_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessment_answer_scribing_scribbles_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_answer_scribing_scribbles_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "answer_id",  :index=>{:name=>"fk__course_assessment_answer_scribing_scribbles_scribing_answer", :order=>{:answer_id=>:asc}}
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessment_answer_scribing_scribbles_creator_id", :order=>{:creator_id=>:asc}}
     t.datetime "created_at", :null=>false
     t.datetime "updated_at", :null=>false
+  end
+
+  create_table "course_assessment_answer_scribings", force: :cascade do |t|
   end
 
   create_table "course_assessment_answer_text_responses", force: :cascade do |t|
@@ -306,15 +139,98 @@ ActiveRecord::Schema.define(version: 20180403011936) do
   create_table "course_assessment_answer_voice_responses", force: :cascade do |t|
   end
 
+  create_table "course_assessment_answers", force: :cascade do |t|
+    t.integer  "actable_id"
+    t.string   "actable_type",   :limit=>255, :index=>{:name=>"index_course_assessment_answers_actable", :with=>["actable_id"], :unique=>true, :order=>{:actable_type=>:asc, :actable_id=>:asc}}
+    t.integer  "submission_id",  :null=>false, :index=>{:name=>"fk__course_assessment_answers_submission_id", :order=>{:submission_id=>:asc}}
+    t.integer  "question_id",    :null=>false, :index=>{:name=>"fk__course_assessment_answers_question_id", :order=>{:question_id=>:asc}}
+    t.boolean  "current_answer", :default=>false, :null=>false
+    t.string   "workflow_state", :limit=>255, :null=>false
+    t.datetime "submitted_at"
+    t.decimal  "grade",          :precision=>4, :scale=>1
+    t.boolean  "correct",        :comment=>"Correctness is independent of the grade (depends on the grading schema)"
+    t.integer  "grader_id",      :index=>{:name=>"fk__course_assessment_answers_grader_id", :order=>{:grader_id=>:asc}}
+    t.datetime "graded_at"
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
+  end
+
+  create_table "course_assessment_categories", force: :cascade do |t|
+    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_assessment_categories_course_id", :order=>{:course_id=>:asc}}
+    t.string   "title",      :limit=>255, :null=>false
+    t.integer  "weight",     :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_assessment_categories_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_assessment_categories_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
+  end
+
+  create_table "course_assessment_question_multiple_response_options", force: :cascade do |t|
+    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_assessment_multiple_response_option_question", :order=>{:question_id=>:asc}}
+    t.boolean "correct",     :null=>false
+    t.text    "option",      :null=>false
+    t.text    "explanation"
+    t.integer "weight",      :null=>false
+  end
+
+  create_table "course_assessment_question_multiple_responses", force: :cascade do |t|
+    t.integer "grading_scheme", :default=>0, :null=>false
+  end
+
+  create_table "course_assessment_question_programming", force: :cascade do |t|
+    t.integer "language_id",              :null=>false, :index=>{:name=>"fk__course_assessment_question_programming_language_id", :order=>{:language_id=>:asc}}
+    t.integer "memory_limit",             :comment=>"Memory limit, in MiB"
+    t.integer "time_limit",               :comment=>"Time limit, in seconds"
+    t.integer "attempt_limit"
+    t.uuid    "import_job_id",            :comment=>"The ID of the importing job", :index=>{:name=>"index_course_assessment_question_programming_on_import_job_id", :unique=>true, :order=>{:import_job_id=>:asc}}
+    t.integer "package_type",             :default=>0, :null=>false
+    t.boolean "multiple_file_submission", :default=>false, :null=>false
+  end
+
   create_table "course_assessment_question_programming_template_files", force: :cascade do |t|
-    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_assessment_quest_dbf3aed51f19fcc63a25d296a057dd1f"}, :foreign_key=>{:references=>"course_assessment_question_programming", :name=>"fk_course_assessment_questi_0788633b496294e558f55f2b41bc7c45", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_assessment_quest_dbf3aed51f19fcc63a25d296a057dd1f", :order=>{:question_id=>:asc}}
     t.string  "filename",    :limit=>255, :null=>false
     t.text    "content",     :null=>false
 
     t.index ["question_id", "filename"], :name=>"index_course_assessment_question_programming_template_filenames", :unique=>true, :case_sensitive=>false
   end
 
+  create_table "course_assessment_question_programming_test_cases", force: :cascade do |t|
+    t.integer "question_id",    :null=>false, :index=>{:name=>"fk__course_assessment_quest_18b37224652fc59d955122a17ba20d07", :order=>{:question_id=>:asc}}
+    t.string  "identifier",     :limit=>255, :null=>false, :comment=>"Test case identifier generated by the testing framework", :index=>{:name=>"index_course_assessment_question_programming_test_case_ident", :with=>["question_id"], :unique=>true, :order=>{:identifier=>:asc, :question_id=>:asc}}
+    t.integer "test_case_type", :null=>false
+    t.text    "expression"
+    t.text    "expected"
+    t.text    "hint"
+  end
+
   create_table "course_assessment_question_scribings", force: :cascade do |t|
+  end
+
+  create_table "course_assessment_question_text_response_compre_groups", force: :cascade do |t|
+    t.integer "question_id",         :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_group_question", :order=>{:question_id=>:asc}}
+    t.decimal "maximum_group_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+  end
+
+  create_table "course_assessment_question_text_response_compre_points", force: :cascade do |t|
+    t.integer "group_id",    :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_point_group", :order=>{:group_id=>:asc}}
+    t.decimal "point_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+  end
+
+  create_table "course_assessment_question_text_response_compre_solutions", force: :cascade do |t|
+    t.integer "point_id",       :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_solution_point", :order=>{:point_id=>:asc}}
+    t.integer "solution_type",  :default=>0, :null=>false
+    t.string  "solution",       :default=>[], :null=>false, :array=>true
+    t.string  "solution_lemma", :default=>[], :null=>false, :array=>true
+    t.string  "information",    :limit=>255
+  end
+
+  create_table "course_assessment_question_text_response_solutions", force: :cascade do |t|
+    t.integer "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_text_response_solution_question", :order=>{:question_id=>:asc}}
+    t.integer "solution_type", :default=>0, :null=>false
+    t.text    "solution",      :null=>false
+    t.decimal "grade",         :precision=>4, :scale=>1, :default=>"0.0", :null=>false
+    t.text    "explanation"
   end
 
   create_table "course_assessment_question_text_responses", force: :cascade do |t|
@@ -323,82 +239,110 @@ ActiveRecord::Schema.define(version: 20180403011936) do
     t.boolean "is_comprehension", :default=>false
   end
 
-  create_table "course_assessment_question_text_response_solutions", force: :cascade do |t|
-    t.integer "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_text_response_solution_question"}, :foreign_key=>{:references=>"course_assessment_question_text_responses", :name=>"fk_course_assessment_questi_2fbeabfad04f21c2d05c8b2d9100d1c4", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "solution_type", :default=>0, :null=>false
-    t.text    "solution",      :null=>false
-    t.decimal "grade",         :precision=>4, :scale=>1, :default=>"0.0", :null=>false
-    t.text    "explanation"
-  end
-
-  create_table "course_assessment_question_text_response_compre_groups", force: :cascade do |t|
-    t.integer "question_id",         :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_group_question"}, :foreign_key=>{:references=>"course_assessment_question_text_responses", :name=>"fk_course_assessment_questi_792d801a492f8d93953ae5cff87fd4bb", :on_update=>:no_action, :on_delete=>:no_action}
-    t.decimal "maximum_group_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
-  end
-
-  create_table "course_assessment_question_text_response_compre_points", force: :cascade do |t|
-    t.integer "group_id",            :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_point_group"}, :foreign_key=>{:references=>"course_assessment_question_text_response_compre_groups", :name=>"fk_course_assessment_questi_e4a0264da8f9965399c5856fb50f8946", :on_update=>:no_action, :on_delete=>:no_action}
-    t.decimal "point_grade", :precision=>4, :scale=>1, :default=>"0.0", :null=>false
-  end
-
-  create_table "course_assessment_question_text_response_compre_solutions", force: :cascade do |t|
-    t.integer "point_id",       :null=>false, :index=>{:name=>"fk__course_assessment_text_response_compre_solution_point"}, :foreign_key=>{:references=>"course_assessment_question_text_response_compre_points", :name=>"fk_course_assessment_questi_27cbcefda94a9f05138e779fd2c2bf39", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "solution_type",  :default=>0, :null=>false
-    t.string  "solution",       :default=>[], :null=>false, :array=>true
-    t.string  "solution_lemma", :default=>[], :null=>false, :array=>true
-    t.string  "information",    :limit=>255
-  end
-
   create_table "course_assessment_question_voice_responses", force: :cascade do |t|
   end
 
+  create_table "course_assessment_questions", force: :cascade do |t|
+    t.integer  "actable_id"
+    t.string   "actable_type",        :limit=>255, :index=>{:name=>"index_course_assessment_questions_actable", :with=>["actable_id"], :unique=>true, :order=>{:actable_type=>:asc, :actable_id=>:asc}}
+    t.string   "title",               :limit=>255
+    t.text     "description"
+    t.text     "staff_only_comments"
+    t.decimal  "maximum_grade",       :precision=>4, :scale=>1, :null=>false
+    t.integer  "creator_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",          :null=>false, :index=>{:name=>"fk__course_assessment_questions_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",          :null=>false
+    t.datetime "updated_at",          :null=>false
+  end
+
+  create_table "course_assessment_questions_skills", force: :cascade do |t|
+    t.integer "question_id", :null=>false, :index=>{:name=>"course_assessment_question_skills_question_index", :order=>{:question_id=>:asc}}
+    t.integer "skill_id",    :null=>false, :index=>{:name=>"course_assessment_question_skills_skill_index", :order=>{:skill_id=>:asc}}
+  end
+
   create_table "course_assessment_skill_branches", force: :cascade do |t|
-    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_skill_branches_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_course_id", :order=>{:course_id=>:asc}}
     t.string   "title",       :limit=>255, :null=>false
     t.text     "description"
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skill_branches_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skill_branches_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",  :null=>false
     t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_assessment_skills", force: :cascade do |t|
-    t.integer  "course_id",       :null=>false, :index=>{:name=>"fk__course_assessment_skills_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_assessment_skills_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "skill_branch_id", :index=>{:name=>"fk__course_assessment_skills_skill_branch_id"}, :foreign_key=>{:references=>"course_assessment_skill_branches", :name=>"fk_course_assessment_skills_skill_branch_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",       :null=>false, :index=>{:name=>"fk__course_assessment_skills_course_id", :order=>{:course_id=>:asc}}
+    t.integer  "skill_branch_id", :index=>{:name=>"fk__course_assessment_skills_skill_branch_id", :order=>{:skill_branch_id=>:asc}}
     t.string   "title",           :limit=>255, :null=>false
     t.text     "description"
-    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skills_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_assessment_skills_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",      :null=>false
     t.datetime "updated_at",      :null=>false
   end
 
-  create_table "course_assessment_questions_skills", force: :cascade do |t|
-    t.integer "question_id", :null=>false, :index=>{:name=>"course_assessment_question_skills_question_index"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_questions_skills_question_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "skill_id",    :null=>false, :index=>{:name=>"course_assessment_question_skills_skill_index"}, :foreign_key=>{:references=>"course_assessment_skills", :name=>"fk_course_assessment_questions_skills_skill_id", :on_update=>:no_action, :on_delete=>:no_action}
-  end
-
   create_table "course_assessment_submission_logs", force: :cascade do |t|
-    t.integer  "submission_id", :null=>false, :index=>{:name=>"fk__course_assessment_submission_logs_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_submission_logs_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "submission_id", :null=>false, :index=>{:name=>"fk__course_assessment_submission_logs_submission_id", :order=>{:submission_id=>:asc}}
     t.jsonb    "request"
     t.datetime "created_at",    :null=>false
   end
 
   create_table "course_assessment_submission_questions", force: :cascade do |t|
-    t.integer  "submission_id", :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_submission_id"}, :foreign_key=>{:references=>"course_assessment_submissions", :name=>"fk_course_assessment_submission_questions_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_assessment_submission_questions_question_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "submission_id", :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_submission_id", :order=>{:submission_id=>:asc}}
+    t.integer  "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_submission_questions_question_id", :order=>{:question_id=>:asc}}
     t.datetime "created_at",    :null=>false
     t.datetime "updated_at",    :null=>false
 
-    t.index ["submission_id", "question_id"], :name=>"idx_course_assessment_submission_questions_on_sub_and_qn", :unique=>true
+    t.index ["submission_id", "question_id"], :name=>"idx_course_assessment_submission_questions_on_sub_and_qn", :unique=>true, :order=>{:submission_id=>:asc, :question_id=>:asc}
+  end
+
+  create_table "course_assessment_submissions", force: :cascade do |t|
+    t.integer  "assessment_id",  :null=>false, :index=>{:name=>"fk__course_assessment_submissions_assessment_id", :order=>{:assessment_id=>:asc}}
+    t.string   "workflow_state", :limit=>255, :null=>false
+    t.string   "session_id",     :limit=>255
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_assessment_submissions_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
+    t.integer  "publisher_id",   :index=>{:name=>"fk__course_assessment_submissions_publisher_id", :order=>{:publisher_id=>:asc}}
+    t.datetime "published_at"
+    t.datetime "submitted_at"
+
+    t.index ["assessment_id", "creator_id"], :name=>"unique_assessment_id_and_creator_id", :unique=>true, :order=>{:assessment_id=>:asc, :creator_id=>:asc}
+  end
+
+  create_table "course_assessment_tabs", force: :cascade do |t|
+    t.integer  "category_id", :null=>false, :index=>{:name=>"fk__course_assessment_tabs_category_id", :order=>{:category_id=>:asc}}
+    t.string   "title",       :limit=>255, :null=>false
+    t.integer  "weight",      :null=>false
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_assessment_tabs_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_assessment_tabs_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
+  end
+
+  create_table "course_assessments", force: :cascade do |t|
+    t.integer  "tab_id",                    :null=>false, :index=>{:name=>"fk__course_assessments_tab_id", :order=>{:tab_id=>:asc}}
+    t.boolean  "tabbed_view",               :default=>false, :null=>false
+    t.boolean  "autograded",                :null=>false
+    t.boolean  "show_private",              :default=>false, :comment=>"Show private test cases after students answer correctly"
+    t.boolean  "show_evaluation",           :default=>false, :comment=>"Show evaluation test cases after students answer correctly"
+    t.boolean  "skippable",                 :default=>false
+    t.boolean  "delayed_grade_publication", :default=>false
+    t.string   "session_password",          :limit=>255
+    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_assessments_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_assessments_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",                :null=>false
+    t.datetime "updated_at",                :null=>false
+    t.string   "view_password",             :limit=>255
   end
 
   create_table "course_condition_achievements", force: :cascade do |t|
-    t.integer "achievement_id", :null=>false, :index=>{:name=>"fk__course_condition_achievements_achievement_id"}, :foreign_key=>{:references=>"course_achievements", :name=>"fk_course_condition_achievements_achievement_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "achievement_id", :null=>false, :index=>{:name=>"fk__course_condition_achievements_achievement_id", :order=>{:achievement_id=>:asc}}
   end
 
   create_table "course_condition_assessments", force: :cascade do |t|
-    t.integer "assessment_id",            :null=>false, :index=>{:name=>"fk__course_condition_assessments_assessment_id"}, :foreign_key=>{:references=>"course_assessments", :name=>"fk_course_condition_assessments_assessment_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "assessment_id",            :null=>false, :index=>{:name=>"fk__course_condition_assessments_assessment_id", :order=>{:assessment_id=>:asc}}
     t.float   "minimum_grade_percentage"
   end
 
@@ -408,160 +352,150 @@ ActiveRecord::Schema.define(version: 20180403011936) do
 
   create_table "course_conditions", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",     :limit=>255, :index=>{:name=>"index_course_conditions_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
-    t.integer  "course_id",        :null=>false, :index=>{:name=>"fk__course_conditions_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_conditions_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "actable_type",     :limit=>255, :index=>{:name=>"index_course_conditions_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true, :order=>{:actable_type=>:asc, :actable_id=>:asc}}
+    t.integer  "course_id",        :null=>false, :index=>{:name=>"fk__course_conditions_course_id", :order=>{:course_id=>:asc}}
     t.integer  "conditional_id",   :null=>false
-    t.string   "conditional_type", :limit=>255, :null=>false, :index=>{:name=>"index_course_conditions_on_conditional_type_and_conditional_id", :with=>["conditional_id"]}
-    t.integer  "creator_id",       :null=>false, :index=>{:name=>"fk__course_conditions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_conditions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",       :null=>false, :index=>{:name=>"fk__course_conditions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_conditions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "conditional_type", :limit=>255, :null=>false, :index=>{:name=>"index_course_conditions_on_conditional_type_and_conditional_id", :with=>["conditional_id"], :order=>{:conditional_type=>:asc, :conditional_id=>:asc}}
+    t.integer  "creator_id",       :null=>false, :index=>{:name=>"fk__course_conditions_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",       :null=>false, :index=>{:name=>"fk__course_conditions_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",       :null=>false
     t.datetime "updated_at",       :null=>false
   end
 
+  create_table "course_discussion_post_votes", force: :cascade do |t|
+    t.integer  "post_id",    :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_post_id", :order=>{:post_id=>:asc}}
+    t.boolean  "vote_flag",  :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
+
+    t.index ["post_id", "creator_id"], :name=>"index_course_discussion_post_votes_on_post_id_and_creator_id", :unique=>true, :order=>{:post_id=>:asc, :creator_id=>:asc}
+  end
+
+  create_table "course_discussion_posts", force: :cascade do |t|
+    t.integer  "parent_id",  :index=>{:name=>"fk__course_discussion_posts_parent_id", :order=>{:parent_id=>:asc}}
+    t.integer  "topic_id",   :null=>false, :index=>{:name=>"fk__course_discussion_posts_topic_id", :order=>{:topic_id=>:asc}}
+    t.string   "title",      :limit=>255
+    t.text     "text"
+    t.boolean  "answer",     :default=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
+  end
+
+  create_table "course_discussion_topic_subscriptions", force: :cascade do |t|
+    t.integer "topic_id", :null=>false, :index=>{:name=>"fk__course_discussion_topic_subscriptions_topic_id", :order=>{:topic_id=>:asc}}
+    t.integer "user_id",  :null=>false, :index=>{:name=>"fk__course_discussion_topic_subscriptions_user_id", :order=>{:user_id=>:asc}}
+
+    t.index ["topic_id", "user_id"], :name=>"index_topic_subscriptions_on_topic_id_and_user_id", :unique=>true, :order=>{:topic_id=>:asc, :user_id=>:asc}
+  end
+
   create_table "course_discussion_topics", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",        :limit=>255, :index=>{:name=>"index_course_discussion_topics_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
-    t.integer  "course_id",           :null=>false, :index=>{:name=>"fk__course_discussion_topics_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_discussion_topics_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "actable_type",        :limit=>255, :index=>{:name=>"index_course_discussion_topics_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true, :order=>{:actable_type=>:asc, :actable_id=>:asc}}
+    t.integer  "course_id",           :null=>false, :index=>{:name=>"fk__course_discussion_topics_course_id", :order=>{:course_id=>:asc}}
     t.boolean  "pending_staff_reply", :default=>false, :null=>false
     t.datetime "created_at",          :null=>false
     t.datetime "updated_at",          :null=>false
   end
 
-  create_table "course_discussion_posts", force: :cascade do |t|
-    t.integer  "parent_id",  :index=>{:name=>"fk__course_discussion_posts_parent_id"}, :foreign_key=>{:references=>"course_discussion_posts", :name=>"fk_course_discussion_posts_parent_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "topic_id",   :null=>false, :index=>{:name=>"fk__course_discussion_posts_topic_id"}, :foreign_key=>{:references=>"course_discussion_topics", :name=>"fk_course_discussion_posts_topic_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",      :limit=>255
-    t.text     "text"
-    t.boolean  "answer",     :default=>false
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_posts_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_discussion_posts_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_posts_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-  end
-
-  create_table "course_discussion_post_votes", force: :cascade do |t|
-    t.integer  "post_id",    :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_post_id"}, :foreign_key=>{:references=>"course_discussion_posts", :name=>"fk_course_discussion_post_votes_post_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.boolean  "vote_flag",  :null=>false
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_post_votes_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_discussion_post_votes_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_post_votes_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-
-    t.index ["post_id", "creator_id"], :name=>"index_course_discussion_post_votes_on_post_id_and_creator_id", :unique=>true
-  end
-
-  create_table "course_discussion_topic_subscriptions", force: :cascade do |t|
-    t.integer "topic_id", :null=>false, :index=>{:name=>"fk__course_discussion_topic_subscriptions_topic_id"}, :foreign_key=>{:references=>"course_discussion_topics", :name=>"fk_course_discussion_topic_subscriptions_topic_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "user_id",  :null=>false, :index=>{:name=>"fk__course_discussion_topic_subscriptions_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_discussion_topic_subscriptions_user_id", :on_update=>:no_action, :on_delete=>:no_action}
-
-    t.index ["topic_id", "user_id"], :name=>"index_topic_subscriptions_on_topic_id_and_user_id", :unique=>true
-  end
-
   create_table "course_enrol_requests", force: :cascade do |t|
-    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_enrol_requests_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_enrol_requests_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__course_enrol_requests_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_enrol_requests_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_enrol_requests_course_id", :order=>{:course_id=>:asc}}
+    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__course_enrol_requests_user_id", :order=>{:user_id=>:asc}}
     t.datetime "created_at"
     t.datetime "updated_at"
 
-    t.index ["course_id", "user_id"], :name=>"index_course_enrol_requests_on_course_id_and_user_id", :unique=>true
-  end
-
-  create_table "course_users", force: :cascade do |t|
-    t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_users_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_users_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "user_id",        :null=>false, :index=>{:name=>"fk__course_users_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_users_user_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "role",           :default=>0, :null=>false
-    t.string   "name",           :limit=>255, :null=>false
-    t.boolean  "phantom",        :default=>false, :null=>false
-    t.datetime "last_active_at"
-    t.datetime "created_at",     :null=>false
-    t.datetime "updated_at",     :null=>false
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_users_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_users_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_users_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_users_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-
-    t.index ["course_id", "user_id"], :name=>"index_course_users_on_course_id_and_user_id", :unique=>true
+    t.index ["course_id", "user_id"], :name=>"index_course_enrol_requests_on_course_id_and_user_id", :unique=>true, :order=>{:course_id=>:asc, :user_id=>:asc}
   end
 
   create_table "course_experience_points_records", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",         :limit=>255, :index=>{:name=>"index_course_experience_points_records_on_actable", :with=>["actable_id"], :unique=>true}
+    t.string   "actable_type",         :limit=>255, :index=>{:name=>"index_course_experience_points_records_on_actable", :with=>["actable_id"], :unique=>true, :order=>{:actable_type=>:asc, :actable_id=>:asc}}
     t.integer  "draft_points_awarded"
     t.integer  "points_awarded"
-    t.integer  "course_user_id",       :null=>false, :index=>{:name=>"fk__course_experience_points_records_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_experience_points_records_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_user_id",       :null=>false, :index=>{:name=>"fk__course_experience_points_records_course_user_id", :order=>{:course_user_id=>:asc}}
     t.string   "reason",               :limit=>255
-    t.integer  "creator_id",           :null=>false, :index=>{:name=>"fk__course_experience_points_records_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",           :null=>false, :index=>{:name=>"fk__course_experience_points_records_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",           :null=>false, :index=>{:name=>"fk__course_experience_points_records_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",           :null=>false, :index=>{:name=>"fk__course_experience_points_records_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",           :null=>false
     t.datetime "updated_at",           :null=>false
-    t.integer  "awarder_id",           :index=>{:name=>"fk__course_experience_points_records_awarder_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_experience_points_records_awarder_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "awarder_id",           :index=>{:name=>"fk__course_experience_points_records_awarder_id", :order=>{:awarder_id=>:asc}}
     t.datetime "awarded_at"
   end
 
-  create_table "course_forums", force: :cascade do |t|
-    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_forums_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_forums_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "name",        :limit=>255, :null=>false
-    t.string   "slug",        :limit=>255
-    t.text     "description"
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_forums_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forums_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_forums_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forums_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",  :null=>false
-    t.datetime "updated_at",  :null=>false
+  create_table "course_forum_subscriptions", force: :cascade do |t|
+    t.integer "forum_id", :null=>false, :index=>{:name=>"fk__course_forum_subscriptions_forum_id", :order=>{:forum_id=>:asc}}
+    t.integer "user_id",  :null=>false, :index=>{:name=>"fk__course_forum_subscriptions_user_id", :order=>{:user_id=>:asc}}
 
-    t.index ["course_id", "slug"], :name=>"index_course_forums_on_course_id_and_slug", :unique=>true
+    t.index ["forum_id", "user_id"], :name=>"index_course_forum_subscriptions_on_forum_id_and_user_id", :unique=>true, :order=>{:forum_id=>:asc, :user_id=>:asc}
   end
 
-  create_table "course_forum_subscriptions", force: :cascade do |t|
-    t.integer "forum_id", :null=>false, :index=>{:name=>"fk__course_forum_subscriptions_forum_id"}, :foreign_key=>{:references=>"course_forums", :name=>"fk_course_forum_subscriptions_forum_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "user_id",  :null=>false, :index=>{:name=>"fk__course_forum_subscriptions_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_subscriptions_user_id", :on_update=>:no_action, :on_delete=>:no_action}
-
-    t.index ["forum_id", "user_id"], :name=>"index_course_forum_subscriptions_on_forum_id_and_user_id", :unique=>true
+  create_table "course_forum_topic_views", force: :cascade do |t|
+    t.integer  "topic_id",   :null=>false, :index=>{:name=>"fk__course_forum_topic_views_topic_id", :order=>{:topic_id=>:asc}}
+    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__course_forum_topic_views_user_id", :order=>{:user_id=>:asc}}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "course_forum_topics", force: :cascade do |t|
-    t.integer  "forum_id",       :null=>false, :index=>{:name=>"fk__course_forum_topics_forum_id"}, :foreign_key=>{:references=>"course_forums", :name=>"fk_course_forum_topics_forum_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "forum_id",       :null=>false, :index=>{:name=>"fk__course_forum_topics_forum_id", :order=>{:forum_id=>:asc}}
     t.string   "title",          :limit=>255, :null=>false
     t.string   "slug",           :limit=>255
     t.boolean  "locked",         :default=>false
     t.boolean  "hidden",         :default=>false
     t.integer  "topic_type",     :default=>0
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_forum_topics_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_forum_topics_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_forum_topics_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_forum_topics_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",     :null=>false
     t.datetime "updated_at",     :null=>false
     t.boolean  "resolved",       :default=>false, :null=>false
     t.datetime "latest_post_at", :null=>false
 
-    t.index ["forum_id", "slug"], :name=>"index_course_forum_topics_on_forum_id_and_slug", :unique=>true
+    t.index ["forum_id", "slug"], :name=>"index_course_forum_topics_on_forum_id_and_slug", :unique=>true, :order=>{:forum_id=>:asc, :slug=>:asc}
   end
 
-  create_table "course_forum_topic_views", force: :cascade do |t|
-    t.integer  "topic_id",   :null=>false, :index=>{:name=>"fk__course_forum_topic_views_topic_id"}, :foreign_key=>{:references=>"course_forum_topics", :name=>"fk_course_forum_topic_views_topic_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__course_forum_topic_views_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_forum_topic_views_user_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-  end
-
-  create_table "course_groups", force: :cascade do |t|
-    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_groups_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_groups_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+  create_table "course_forums", force: :cascade do |t|
+    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_forums_course_id", :order=>{:course_id=>:asc}}
     t.string   "name",        :limit=>255, :null=>false
+    t.string   "slug",        :limit=>255
     t.text     "description"
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_groups_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_groups_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_groups_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_groups_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_forums_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_forums_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",  :null=>false
     t.datetime "updated_at",  :null=>false
 
-    t.index ["course_id", "name"], :name=>"index_course_groups_on_course_id_and_name", :unique=>true
+    t.index ["course_id", "slug"], :name=>"index_course_forums_on_course_id_and_slug", :unique=>true, :order=>{:course_id=>:asc, :slug=>:asc}
   end
 
   create_table "course_group_users", force: :cascade do |t|
-    t.integer  "group_id",       :null=>false, :index=>{:name=>"fk__course_group_users_course_group_id"}, :foreign_key=>{:references=>"course_groups", :name=>"fk_course_group_users_course_group_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "course_user_id", :null=>false, :index=>{:name=>"fk__course_group_users_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_group_users_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "group_id",       :null=>false, :index=>{:name=>"fk__course_group_users_course_group_id", :order=>{:group_id=>:asc}}
+    t.integer  "course_user_id", :null=>false, :index=>{:name=>"fk__course_group_users_course_user_id", :order=>{:course_user_id=>:asc}}
     t.integer  "role",           :null=>false
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_group_users_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_group_users_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_group_users_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_group_users_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_group_users_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_group_users_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",     :null=>false
     t.datetime "updated_at",     :null=>false
 
-    t.index ["course_user_id", "group_id"], :name=>"index_course_group_users_on_course_user_id_and_course_group_id", :unique=>true
+    t.index ["course_user_id", "group_id"], :name=>"index_course_group_users_on_course_user_id_and_course_group_id", :unique=>true, :order=>{:course_user_id=>:asc, :group_id=>:asc}
+  end
+
+  create_table "course_groups", force: :cascade do |t|
+    t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_groups_course_id", :order=>{:course_id=>:asc}}
+    t.string   "name",        :limit=>255, :null=>false
+    t.text     "description"
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_groups_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_groups_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
+
+    t.index ["course_id", "name"], :name=>"index_course_groups_on_course_id_and_name", :unique=>true, :order=>{:course_id=>:asc, :name=>:asc}
+  end
+
+  create_table "course_lesson_plan_event_materials", force: :cascade do |t|
+    t.integer "lesson_plan_event_id", :null=>false, :index=>{:name=>"fk__course_lesson_plan_event_materials_lesson_plan_event_id", :order=>{:lesson_plan_event_id=>:asc}}
+    t.integer "material_id",          :null=>false, :index=>{:name=>"fk__course_lesson_plan_event_materials_material_id", :order=>{:material_id=>:asc}}
   end
 
   create_table "course_lesson_plan_events", force: :cascade do |t|
@@ -569,45 +503,10 @@ ActiveRecord::Schema.define(version: 20180403011936) do
     t.string "event_type", :limit=>255, :null=>false
   end
 
-  create_table "course_material_folders", force: :cascade do |t|
-    t.integer  "parent_id",          :index=>{:name=>"fk__course_material_folders_parent_id"}, :foreign_key=>{:references=>"course_material_folders", :name=>"fk_course_material_folders_parent_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "course_id",          :null=>false, :index=>{:name=>"fk__course_material_folders_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_material_folders_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "owner_id",           :index=>{:name=>"index_course_material_folders_on_owner_id_and_owner_type", :with=>["owner_type"], :unique=>true}
-    t.string   "owner_type",         :limit=>255, :index=>{:name=>"fk__course_material_folders_owner_id", :with=>["owner_id"]}
-    t.string   "name",               :limit=>255, :null=>false
-    t.text     "description"
-    t.boolean  "can_student_upload", :default=>false, :null=>false
-    t.datetime "start_at",           :null=>false
-    t.datetime "end_at"
-    t.integer  "creator_id",         :null=>false, :index=>{:name=>"fk__course_material_folders_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_material_folders_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",         :null=>false, :index=>{:name=>"fk__course_material_folders_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_material_folders_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",         :null=>false
-    t.datetime "updated_at",         :null=>false
-
-    t.index ["parent_id", "name"], :name=>"index_course_material_folders_on_parent_id_and_name", :unique=>true, :case_sensitive=>false
-  end
-
-  create_table "course_materials", force: :cascade do |t|
-    t.integer  "folder_id",   :null=>false, :index=>{:name=>"fk__course_materials_folder_id"}, :foreign_key=>{:references=>"course_material_folders", :name=>"fk_course_materials_folder_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "name",        :limit=>255, :null=>false
-    t.text     "description"
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_materials_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_materials_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_materials_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_materials_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",  :null=>false
-    t.datetime "updated_at",  :null=>false
-
-    t.index ["folder_id", "name"], :name=>"index_course_materials_on_folder_id_and_name", :unique=>true, :case_sensitive=>false
-  end
-
-  create_table "course_lesson_plan_event_materials", force: :cascade do |t|
-    t.integer "lesson_plan_event_id", :null=>false, :index=>{:name=>"fk__course_lesson_plan_event_materials_lesson_plan_event_id"}, :foreign_key=>{:references=>"course_lesson_plan_events", :name=>"fk_course_lesson_plan_event_materials_lesson_plan_event_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "material_id",          :null=>false, :index=>{:name=>"fk__course_lesson_plan_event_materials_material_id"}, :foreign_key=>{:references=>"course_materials", :name=>"fk_course_lesson_plan_event_materials_material_id", :on_update=>:no_action, :on_delete=>:no_action}
-  end
-
   create_table "course_lesson_plan_items", force: :cascade do |t|
     t.integer  "actable_id"
-    t.string   "actable_type",           :limit=>255, :index=>{:name=>"index_course_lesson_plan_items_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true}
-    t.integer  "course_id",              :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_items_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.string   "actable_type",           :limit=>255, :index=>{:name=>"index_course_lesson_plan_items_on_actable_type_and_actable_id", :with=>["actable_id"], :unique=>true, :order=>{:actable_type=>:asc, :actable_id=>:asc}}
+    t.integer  "course_id",              :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_course_id", :order=>{:course_id=>:asc}}
     t.string   "title",                  :limit=>255, :null=>false
     t.text     "description"
     t.boolean  "published",              :default=>false, :null=>false
@@ -617,81 +516,114 @@ ActiveRecord::Schema.define(version: 20180403011936) do
     t.datetime "bonus_end_at"
     t.datetime "end_at"
     t.float    "closing_reminder_token"
-    t.integer  "creator_id",             :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",             :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_items_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",             :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",             :null=>false, :index=>{:name=>"fk__course_lesson_plan_items_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",             :null=>false
     t.datetime "updated_at",             :null=>false
   end
 
   create_table "course_lesson_plan_milestones", force: :cascade do |t|
-    t.integer  "course_id",   :index=>{:name=>"fk__course_lesson_plan_milestones_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_lesson_plan_milestones_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",   :index=>{:name=>"fk__course_lesson_plan_milestones_course_id", :order=>{:course_id=>:asc}}
     t.string   "title",       :limit=>255, :null=>false
     t.text     "description"
     t.datetime "start_at",    :null=>false
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_milestones_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_milestones_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",  :null=>false
     t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_lesson_plan_todos", force: :cascade do |t|
-    t.integer  "item_id",        :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_item_id"}, :foreign_key=>{:references=>"course_lesson_plan_items", :name=>"fk_course_lesson_plan_todos_item_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "user_id",        :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_todos_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "item_id",        :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_item_id", :order=>{:item_id=>:asc}}
+    t.integer  "user_id",        :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_user_id", :order=>{:user_id=>:asc}}
     t.string   "workflow_state", :limit=>255, :null=>false
     t.boolean  "ignore",         :default=>false, :null=>false
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_todos_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_lesson_plan_todos_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_lesson_plan_todos_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at"
     t.datetime "updated_at"
 
-    t.index ["item_id", "user_id"], :name=>"index_course_lesson_plan_todos_on_item_id_and_user_id", :unique=>true
+    t.index ["item_id", "user_id"], :name=>"index_course_lesson_plan_todos_on_item_id_and_user_id", :unique=>true, :order=>{:item_id=>:asc, :user_id=>:asc}
   end
 
   create_table "course_levels", force: :cascade do |t|
-    t.integer  "course_id",                   :null=>false, :index=>{:name=>"fk__course_levels_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_levels_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",                   :null=>false, :index=>{:name=>"fk__course_levels_course_id", :order=>{:course_id=>:asc}}
     t.integer  "experience_points_threshold", :null=>false
     t.datetime "created_at",                  :null=>false
     t.datetime "updated_at",                  :null=>false
 
-    t.index ["course_id", "experience_points_threshold"], :name=>"index_experience_points_threshold_on_course_id", :unique=>true
+    t.index ["course_id", "experience_points_threshold"], :name=>"index_experience_points_threshold_on_course_id", :unique=>true, :order=>{:course_id=>:asc, :experience_points_threshold=>:asc}
+  end
+
+  create_table "course_material_folders", force: :cascade do |t|
+    t.integer  "parent_id",          :index=>{:name=>"fk__course_material_folders_parent_id", :order=>{:parent_id=>:asc}}
+    t.integer  "course_id",          :null=>false, :index=>{:name=>"fk__course_material_folders_course_id", :order=>{:course_id=>:asc}}
+    t.integer  "owner_id",           :index=>{:name=>"index_course_material_folders_on_owner_id_and_owner_type", :with=>["owner_type"], :unique=>true, :order=>{:owner_id=>:asc, :owner_type=>:asc}}
+    t.string   "owner_type",         :limit=>255, :index=>{:name=>"fk__course_material_folders_owner_id", :with=>["owner_id"], :order=>{:owner_type=>:asc, :owner_id=>:asc}}
+    t.string   "name",               :limit=>255, :null=>false
+    t.text     "description"
+    t.boolean  "can_student_upload", :default=>false, :null=>false
+    t.datetime "start_at",           :null=>false
+    t.datetime "end_at"
+    t.integer  "creator_id",         :null=>false, :index=>{:name=>"fk__course_material_folders_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",         :null=>false, :index=>{:name=>"fk__course_material_folders_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",         :null=>false
+    t.datetime "updated_at",         :null=>false
+
+    t.index ["parent_id", "name"], :name=>"index_course_material_folders_on_parent_id_and_name", :unique=>true, :case_sensitive=>false
+  end
+
+  create_table "course_materials", force: :cascade do |t|
+    t.integer  "folder_id",   :null=>false, :index=>{:name=>"fk__course_materials_folder_id", :order=>{:folder_id=>:asc}}
+    t.string   "name",        :limit=>255, :null=>false
+    t.text     "description"
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_materials_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_materials_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",  :null=>false
+    t.datetime "updated_at",  :null=>false
+
+    t.index ["folder_id", "name"], :name=>"index_course_materials_on_folder_id_and_name", :unique=>true, :case_sensitive=>false
   end
 
   create_table "course_notifications", force: :cascade do |t|
-    t.integer  "activity_id",       :null=>false, :index=>{:name=>"index_course_notifications_on_activity_id"}, :foreign_key=>{:references=>"activities", :name=>"fk_course_notifications_activity_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "course_id",         :null=>false, :index=>{:name=>"index_course_notifications_on_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_notifications_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "activity_id",       :null=>false, :index=>{:name=>"index_course_notifications_on_activity_id", :order=>{:activity_id=>:asc}}
+    t.integer  "course_id",         :null=>false, :index=>{:name=>"index_course_notifications_on_course_id", :order=>{:course_id=>:asc}}
     t.integer  "notification_type", :default=>0, :null=>false
     t.datetime "created_at",        :null=>false
     t.datetime "updated_at",        :null=>false
   end
 
   create_table "course_question_assessments", force: :cascade do |t|
-    t.integer "question_id",   :null=>false, :index=>{:name=>"index_course_question_assessments_on_question_id"}, :foreign_key=>{:references=>"course_assessment_questions", :name=>"fk_course_question_assessments_question_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "assessment_id", :null=>false, :index=>{:name=>"index_course_question_assessments_on_assessment_id"}, :foreign_key=>{:references=>"course_assessments", :name=>"fk_course_question_assessments_assessment_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer "question_id",   :null=>false, :index=>{:name=>"index_course_question_assessments_on_question_id", :order=>{:question_id=>:asc}}
+    t.integer "assessment_id", :null=>false, :index=>{:name=>"index_course_question_assessments_on_assessment_id", :order=>{:assessment_id=>:asc}}
     t.integer "weight",        :null=>false
 
-    t.index ["question_id", "assessment_id"], :name=>"index_question_assessments_on_question_id_and_assessment_id", :unique=>true
+    t.index ["question_id", "assessment_id"], :name=>"index_question_assessments_on_question_id_and_assessment_id", :unique=>true, :order=>{:question_id=>:asc, :assessment_id=>:asc}
   end
 
-  create_table "course_surveys", force: :cascade do |t|
-    t.boolean  "anonymous",                 :default=>false, :null=>false
-    t.boolean  "allow_modify_after_submit", :default=>false, :null=>false
-    t.boolean  "allow_response_after_end",  :default=>false, :null=>false
-    t.datetime "closing_reminded_at"
-    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_surveys_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_surveys_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_surveys_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_surveys_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",                :null=>false
-    t.datetime "updated_at",                :null=>false
+  create_table "course_survey_answer_options", force: :cascade do |t|
+    t.integer "answer_id",          :null=>false, :index=>{:name=>"fk__course_survey_answer_options_answer_id", :order=>{:answer_id=>:asc}}
+    t.integer "question_option_id", :null=>false, :index=>{:name=>"fk__course_survey_answer_options_question_option_id", :order=>{:question_option_id=>:asc}}
   end
 
-  create_table "course_survey_sections", force: :cascade do |t|
-    t.integer "survey_id",   :null=>false, :index=>{:name=>"fk__course_survey_sections_survey_id"}, :foreign_key=>{:references=>"course_surveys", :name=>"fk_course_survey_sections_survey_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string  "title",       :limit=>255, :null=>false
-    t.text    "description"
+  create_table "course_survey_answers", force: :cascade do |t|
+    t.integer  "question_id",   :null=>false, :index=>{:name=>"fk__course_survey_answers_question_id", :order=>{:question_id=>:asc}}
+    t.integer  "response_id",   :null=>false, :index=>{:name=>"fk__course_survey_answers_response_id", :order=>{:response_id=>:asc}}
+    t.text     "text_response"
+    t.integer  "creator_id",    :null=>false, :index=>{:name=>"fk__course_survey_answers_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",    :null=>false, :index=>{:name=>"fk__course_survey_answers_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",    :null=>false
+    t.datetime "updated_at",    :null=>false
+  end
+
+  create_table "course_survey_question_options", force: :cascade do |t|
+    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_survey_question_options_question_id", :order=>{:question_id=>:asc}}
+    t.text    "option"
     t.integer "weight",      :null=>false
   end
 
   create_table "course_survey_questions", force: :cascade do |t|
-    t.integer  "section_id",    :null=>false, :index=>{:name=>"index_course_survey_questions_on_section_id"}, :foreign_key=>{:references=>"course_survey_sections", :name=>"fk_course_survey_questions_section_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "section_id",    :null=>false, :index=>{:name=>"index_course_survey_questions_on_section_id", :order=>{:section_id=>:asc}}
     t.integer  "question_type", :default=>0, :null=>false
     t.text     "description",   :null=>false
     t.integer  "weight",        :null=>false
@@ -699,164 +631,195 @@ ActiveRecord::Schema.define(version: 20180403011936) do
     t.boolean  "grid_view",     :default=>false, :null=>false
     t.integer  "max_options"
     t.integer  "min_options"
-    t.integer  "creator_id",    :null=>false, :index=>{:name=>"fk__course_survey_questions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_survey_questions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",    :null=>false, :index=>{:name=>"fk__course_survey_questions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_survey_questions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",    :null=>false, :index=>{:name=>"fk__course_survey_questions_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",    :null=>false, :index=>{:name=>"fk__course_survey_questions_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",    :null=>false
     t.datetime "updated_at",    :null=>false
   end
 
   create_table "course_survey_responses", force: :cascade do |t|
-    t.integer  "survey_id",    :null=>false, :index=>{:name=>"fk__course_survey_responses_survey_id"}, :foreign_key=>{:references=>"course_surveys", :name=>"fk_course_survey_responses_survey_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "survey_id",    :null=>false, :index=>{:name=>"fk__course_survey_responses_survey_id", :order=>{:survey_id=>:asc}}
     t.datetime "submitted_at"
-    t.integer  "creator_id",   :null=>false, :index=>{:name=>"fk__course_survey_responses_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_survey_responses_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",   :null=>false, :index=>{:name=>"fk__course_survey_responses_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_survey_responses_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",   :null=>false, :index=>{:name=>"fk__course_survey_responses_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",   :null=>false, :index=>{:name=>"fk__course_survey_responses_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",   :null=>false
     t.datetime "updated_at",   :null=>false
 
-    t.index ["survey_id", "creator_id"], :name=>"index_course_survey_responses_on_survey_id_and_creator_id", :unique=>true
+    t.index ["survey_id", "creator_id"], :name=>"index_course_survey_responses_on_survey_id_and_creator_id", :unique=>true, :order=>{:survey_id=>:asc, :creator_id=>:asc}
   end
 
-  create_table "course_survey_answers", force: :cascade do |t|
-    t.integer  "question_id",   :null=>false, :index=>{:name=>"fk__course_survey_answers_question_id"}, :foreign_key=>{:references=>"course_survey_questions", :name=>"fk_course_survey_answers_question_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "response_id",   :null=>false, :index=>{:name=>"fk__course_survey_answers_response_id"}, :foreign_key=>{:references=>"course_survey_responses", :name=>"fk_course_survey_answers_response_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.text     "text_response"
-    t.integer  "creator_id",    :null=>false, :index=>{:name=>"fk__course_survey_answers_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_survey_answers_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",    :null=>false, :index=>{:name=>"fk__course_survey_answers_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_survey_answers_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",    :null=>false
-    t.datetime "updated_at",    :null=>false
-  end
-
-  create_table "course_survey_question_options", force: :cascade do |t|
-    t.integer "question_id", :null=>false, :index=>{:name=>"fk__course_survey_question_options_question_id"}, :foreign_key=>{:references=>"course_survey_questions", :name=>"fk_course_survey_question_options_question_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.text    "option"
+  create_table "course_survey_sections", force: :cascade do |t|
+    t.integer "survey_id",   :null=>false, :index=>{:name=>"fk__course_survey_sections_survey_id", :order=>{:survey_id=>:asc}}
+    t.string  "title",       :limit=>255, :null=>false
+    t.text    "description"
     t.integer "weight",      :null=>false
   end
 
-  create_table "course_survey_answer_options", force: :cascade do |t|
-    t.integer "answer_id",          :null=>false, :index=>{:name=>"fk__course_survey_answer_options_answer_id"}, :foreign_key=>{:references=>"course_survey_answers", :name=>"fk_course_survey_answer_options_answer_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "question_option_id", :null=>false, :index=>{:name=>"fk__course_survey_answer_options_question_option_id"}, :foreign_key=>{:references=>"course_survey_question_options", :name=>"fk_course_survey_answer_options_question_option_id", :on_update=>:no_action, :on_delete=>:no_action}
+  create_table "course_surveys", force: :cascade do |t|
+    t.boolean  "anonymous",                 :default=>false, :null=>false
+    t.boolean  "allow_modify_after_submit", :default=>false, :null=>false
+    t.boolean  "allow_response_after_end",  :default=>false, :null=>false
+    t.datetime "closing_reminded_at"
+    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_surveys_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_surveys_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",                :null=>false
+    t.datetime "updated_at",                :null=>false
   end
 
   create_table "course_user_achievements", force: :cascade do |t|
-    t.integer  "course_user_id", :index=>{:name=>"fk__course_user_achievements_course_user_id"}, :foreign_key=>{:references=>"course_users", :name=>"fk_course_user_achievements_course_user_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "achievement_id", :index=>{:name=>"fk__course_user_achievements_achievement_id"}, :foreign_key=>{:references=>"course_achievements", :name=>"fk_course_user_achievements_achievement_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_user_id", :index=>{:name=>"fk__course_user_achievements_course_user_id", :order=>{:course_user_id=>:asc}}
+    t.integer  "achievement_id", :index=>{:name=>"fk__course_user_achievements_achievement_id", :order=>{:achievement_id=>:asc}}
     t.datetime "obtained_at",    :null=>false
     t.datetime "created_at",     :null=>false
     t.datetime "updated_at",     :null=>false
 
-    t.index ["course_user_id", "achievement_id"], :name=>"index_user_achievements_on_course_user_id_and_achievement_id", :unique=>true
+    t.index ["course_user_id", "achievement_id"], :name=>"index_user_achievements_on_course_user_id_and_achievement_id", :unique=>true, :order=>{:course_user_id=>:asc, :achievement_id=>:asc}
   end
 
   create_table "course_user_invitations", force: :cascade do |t|
-    t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_user_invitations_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_user_invitations_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_user_invitations_course_id", :order=>{:course_id=>:asc}}
     t.string   "name",           :limit=>255, :null=>false
     t.string   "email",          :limit=>255, :null=>false, :index=>{:name=>"index_course_user_invitations_on_email", :case_sensitive=>false}
     t.integer  "role",           :default=>0, :null=>false
     t.boolean  "phantom",        :default=>false, :null=>false
-    t.string   "invitation_key", :limit=>32, :null=>false, :index=>{:name=>"index_course_user_invitations_on_invitation_key", :unique=>true}
+    t.string   "invitation_key", :limit=>32, :null=>false, :index=>{:name=>"index_course_user_invitations_on_invitation_key", :unique=>true, :order=>{:invitation_key=>:asc}}
     t.datetime "sent_at"
     t.datetime "confirmed_at"
-    t.integer  "confirmer_id",   :index=>{:name=>"fk__course_user_invitations_confirmer_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_confirmer_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_user_invitations_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "confirmer_id",   :index=>{:name=>"fk__course_user_invitations_confirmer_id", :order=>{:confirmer_id=>:asc}}
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_user_invitations_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",     :null=>false
     t.datetime "updated_at",     :null=>false
 
-    t.index ["course_id", "email"], :name=>"index_course_user_invitations_on_course_id_and_email", :unique=>true
+    t.index ["course_id", "email"], :name=>"index_course_user_invitations_on_course_id_and_email", :unique=>true, :order=>{:course_id=>:asc, :email=>:asc}
   end
 
-  create_table "course_videos", force: :cascade do |t|
-    t.integer  "tab_id",      :null=>false, :index=>{:name=>"fk__course_videos_tab_id"}, :foreign_key=>{:references=>"course_video_tabs", :name=>"fk_course_videos_tab_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "url",         :limit=>255, :null=>false
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_videos_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_videos_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_videos_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_videos_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at",  :null=>false
-    t.datetime "updated_at",  :null=>false
-  end
+  create_table "course_users", force: :cascade do |t|
+    t.integer  "course_id",      :null=>false, :index=>{:name=>"fk__course_users_course_id", :order=>{:course_id=>:asc}}
+    t.integer  "user_id",        :null=>false, :index=>{:name=>"fk__course_users_user_id", :order=>{:user_id=>:asc}}
+    t.integer  "role",           :default=>0, :null=>false
+    t.string   "name",           :limit=>255, :null=>false
+    t.boolean  "phantom",        :default=>false, :null=>false
+    t.datetime "last_active_at"
+    t.datetime "created_at",     :null=>false
+    t.datetime "updated_at",     :null=>false
+    t.integer  "creator_id",     :null=>false, :index=>{:name=>"fk__course_users_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",     :null=>false, :index=>{:name=>"fk__course_users_updater_id", :order=>{:updater_id=>:asc}}
 
-  create_table "course_video_tabs", force: :cascade do |t|
-    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_video_tabs_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_video_tabs_course_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "title",      :limit=>255, :null=>false
-    t.integer  "weight",     :null=>false
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_video_tabs_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_tabs_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_video_tabs_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_tabs_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-  end
-
-  create_table "course_video_submissions", force: :cascade do |t|
-    t.integer  "video_id",   :null=>false, :index=>{:name=>"fk__course_video_submissions_video_id"}, :foreign_key=>{:references=>"course_videos", :name=>"fk_course_video_submissions_video_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_video_submissions_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_submissions_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_video_submissions_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_submissions_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "created_at", :null=>false
-    t.datetime "updated_at", :null=>false
-
-    t.index ["video_id", "creator_id"], :name=>"index_course_video_submissions_on_video_id_and_creator_id", :unique=>true
-  end
-
-  create_table "course_video_topics", force: :cascade do |t|
-    t.integer "video_id",   :null=>false, :index=>{:name=>"fk__course_video_topics_video_id"}, :foreign_key=>{:references=>"course_videos", :name=>"fk_course_video_topics_video_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "timestamp",  :null=>false
-    t.integer "creator_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_topics_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer "updater_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_topics_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
-  end
-
-  create_table "course_video_sessions", force: :cascade do |t|
-    t.integer  "submission_id", :null=>false, :index=>{:name=>"index_course_video_sessions_on_submission_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_submission_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.datetime "session_start", :null=>false
-    t.datetime "session_end",   :null=>false
-    t.integer  "last_video_time"
-    t.datetime "created_at",    :null=>false
-    t.datetime "updated_at",    :null=>false
-    t.integer  "creator_id",    :null=>false, :index=>{:name=>"index_course_video_sessions_on_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",    :null=>false, :index=>{:name=>"index_course_video_sessions_on_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_video_sessions_on_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.index ["course_id", "user_id"], :name=>"index_course_users_on_course_id_and_user_id", :unique=>true, :order=>{:course_id=>:asc, :user_id=>:asc}
   end
 
   create_table "course_video_events", force: :cascade do |t|
-    t.integer  "session_id",         :null=>false, :index=>{:name=>"index_course_video_events_on_session_id"}, :foreign_key=>{:references=>"course_video_sessions", :name=>"fk_course_video_events_on_session_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "event_type",         :null=>false
-    t.integer  "sequence_num",       :null=>false
-    t.integer  "video_time",         :null=>false
+    t.integer  "session_id",    :null=>false, :index=>{:name=>"index_course_video_events_on_session_id", :order=>{:session_id=>:asc}}
+    t.integer  "event_type",    :null=>false
+    t.integer  "sequence_num",  :null=>false
+    t.integer  "video_time",    :null=>false
     t.float    "playback_rate"
-    t.datetime "event_time",         :null=>false
-    t.datetime "created_at",         :null=>false
-    t.datetime "updated_at",         :null=>false
+    t.datetime "event_time",    :null=>false
+    t.datetime "created_at",    :null=>false
+    t.datetime "updated_at",    :null=>false
 
     t.index ["session_id", "sequence_num"], :name=>"index_course_video_events_on_session_id_and_sequence_num", :unique=>true, :order=>{:session_id=>:asc, :sequence_num=>:asc}
   end
 
+  create_table "course_video_sessions", force: :cascade do |t|
+    t.integer  "submission_id",   :null=>false, :index=>{:name=>"index_course_video_sessions_on_submission_id", :order=>{:submission_id=>:asc}}
+    t.datetime "session_start",   :null=>false
+    t.datetime "session_end",     :null=>false
+    t.integer  "last_video_time"
+    t.datetime "created_at",      :null=>false
+    t.datetime "updated_at",      :null=>false
+    t.integer  "creator_id",      :null=>false, :index=>{:name=>"index_course_video_sessions_on_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",      :null=>false, :index=>{:name=>"index_course_video_sessions_on_updater_id", :order=>{:updater_id=>:asc}}
+  end
+
+  create_table "course_video_submissions", force: :cascade do |t|
+    t.integer  "video_id",   :null=>false, :index=>{:name=>"fk__course_video_submissions_video_id", :order=>{:video_id=>:asc}}
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_video_submissions_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_video_submissions_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
+
+    t.index ["video_id", "creator_id"], :name=>"index_course_video_submissions_on_video_id_and_creator_id", :unique=>true, :order=>{:video_id=>:asc, :creator_id=>:asc}
+  end
+
+  create_table "course_video_tabs", force: :cascade do |t|
+    t.integer  "course_id",  :null=>false, :index=>{:name=>"fk__course_video_tabs_course_id", :order=>{:course_id=>:asc}}
+    t.string   "title",      :limit=>255, :null=>false
+    t.integer  "weight",     :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_video_tabs_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_video_tabs_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
+  end
+
+  create_table "course_video_topics", force: :cascade do |t|
+    t.integer "video_id",   :null=>false, :index=>{:name=>"fk__course_video_topics_video_id", :order=>{:video_id=>:asc}}
+    t.integer "timestamp",  :null=>false
+    t.integer "creator_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer "updater_id", :null=>false, :index=>{:name=>"index_course_video_topics_on_updater_id", :order=>{:updater_id=>:asc}}
+  end
+
+  create_table "course_videos", force: :cascade do |t|
+    t.integer  "tab_id",     :null=>false, :index=>{:name=>"fk__course_videos_tab_id", :order=>{:tab_id=>:asc}}
+    t.string   "url",        :limit=>255, :null=>false
+    t.integer  "creator_id", :null=>false, :index=>{:name=>"fk__course_videos_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id", :null=>false, :index=>{:name=>"fk__course_videos_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
+  end
+
   create_table "course_virtual_classrooms", force: :cascade do |t|
-    t.integer  "course_id",                 :null=>false, :index=>{:name=>"fk__course_virtual_classrooms_course_id"}, :foreign_key=>{:references=>"courses", :name=>"fk_course_virtual_classrooms_course_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "course_id",                 :null=>false, :index=>{:name=>"fk__course_virtual_classrooms_course_id", :order=>{:course_id=>:asc}}
     t.text     "instructor_classroom_link"
     t.integer  "classroom_id"
     t.string   "title",                     :limit=>255, :null=>false
     t.text     "content"
     t.datetime "start_at",                  :null=>false
     t.datetime "end_at",                    :null=>false
-    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_virtual_classrooms_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_virtual_classrooms_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_virtual_classrooms_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_virtual_classrooms_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",                :null=>false, :index=>{:name=>"fk__course_virtual_classrooms_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",                :null=>false, :index=>{:name=>"fk__course_virtual_classrooms_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",                :null=>false
     t.datetime "updated_at",                :null=>false
-    t.integer  "instructor_id",             :index=>{:name=>"index_course_virtual_classrooms_on_instructor_id"}, :foreign_key=>{:references=>"users", :name=>"fk_course_virtual_classrooms_instructor_id", :on_update=>:cascade, :on_delete=>:nullify}
+    t.integer  "instructor_id",             :index=>{:name=>"index_course_virtual_classrooms_on_instructor_id", :order=>{:instructor_id=>:asc}}
     t.jsonb    "recorded_videos"
+  end
+
+  create_table "courses", force: :cascade do |t|
+    t.integer  "instance_id",      :null=>false, :index=>{:name=>"fk__courses_instance_id", :order=>{:instance_id=>:asc}}
+    t.string   "title",            :limit=>255, :null=>false
+    t.text     "description"
+    t.text     "logo"
+    t.boolean  "published",        :default=>false, :null=>false
+    t.boolean  "enrollable",       :default=>false, :null=>false
+    t.string   "registration_key", :limit=>16, :index=>{:name=>"index_courses_on_registration_key", :unique=>true, :order=>{:registration_key=>:asc}}
+    t.text     "settings"
+    t.boolean  "gamified",         :default=>true, :null=>false
+    t.datetime "start_at",         :null=>false
+    t.datetime "end_at",           :null=>false
+    t.string   "time_zone",        :limit=>255
+    t.integer  "creator_id",       :null=>false, :index=>{:name=>"fk__courses_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",       :null=>false, :index=>{:name=>"fk__courses_updater_id", :order=>{:updater_id=>:asc}}
+    t.datetime "created_at",       :null=>false
+    t.datetime "updated_at",       :null=>false
   end
 
   create_table "generic_announcements", force: :cascade do |t|
     t.string   "type",        :limit=>255, :null=>false
-    t.integer  "instance_id", :comment=>"The instance this announcement is associated with. This only applies to instance announcements.", :index=>{:name=>"fk__generic_announcements_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_generic_announcements_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "instance_id", :comment=>"The instance this announcement is associated with. This only applies to instance announcements.", :index=>{:name=>"fk__generic_announcements_instance_id", :order=>{:instance_id=>:asc}}
     t.string   "title",       :limit=>255, :null=>false
     t.text     "content"
     t.datetime "start_at",    :null=>false
     t.datetime "end_at",      :null=>false
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__generic_announcements_creator_id"}, :foreign_key=>{:references=>"users", :name=>"fk_generic_announcements_creator_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__generic_announcements_updater_id"}, :foreign_key=>{:references=>"users", :name=>"fk_generic_announcements_updater_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__generic_announcements_creator_id", :order=>{:creator_id=>:asc}}
+    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__generic_announcements_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",  :null=>false
     t.datetime "updated_at",  :null=>false
   end
 
   create_table "instance_user_role_requests", force: :cascade do |t|
-    t.integer  "instance_id",  :null=>false, :index=>{:name=>"fk__instance_user_role_requests_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_instance_user_role_requests_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "user_id",      :null=>false, :index=>{:name=>"fk__instance_user_role_requests_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_instance_user_role_requests_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "instance_id",  :null=>false, :index=>{:name=>"fk__instance_user_role_requests_instance_id", :order=>{:instance_id=>:asc}}
+    t.integer  "user_id",      :null=>false, :index=>{:name=>"fk__instance_user_role_requests_user_id", :order=>{:user_id=>:asc}}
     t.integer  "role",         :null=>false
     t.string   "organization", :limit=>255
     t.string   "designation",  :limit=>255
@@ -866,50 +829,86 @@ ActiveRecord::Schema.define(version: 20180403011936) do
   end
 
   create_table "instance_users", force: :cascade do |t|
-    t.integer  "instance_id",    :null=>false, :index=>{:name=>"fk__instance_users_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_instance_users_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "user_id",        :null=>false, :foreign_key=>{:references=>"users", :name=>"fk_instance_users_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "instance_id",    :null=>false, :index=>{:name=>"fk__instance_users_instance_id", :order=>{:instance_id=>:asc}}
+    t.integer  "user_id",        :null=>false
     t.integer  "role",           :default=>0, :null=>false
     t.datetime "last_active_at"
     t.datetime "created_at",     :null=>false
     t.datetime "updated_at",     :null=>false
 
-    t.index ["instance_id", "user_id"], :name=>"index_instance_users_on_instance_id_and_user_id", :unique=>true
+    t.index ["instance_id", "user_id"], :name=>"index_instance_users_on_instance_id_and_user_id", :unique=>true, :order=>{:instance_id=>:asc, :user_id=>:asc}
+  end
+
+  create_table "instances", force: :cascade do |t|
+    t.string "name",     :limit=>255, :null=>false
+    t.string "host",     :limit=>255, :null=>false, :comment=>"Stores the host name of the instance. The www prefix is automatically handled by the application", :index=>{:name=>"index_instances_on_host", :unique=>true, :case_sensitive=>false}
+    t.text   "settings"
+  end
+
+  create_table "jobs", id: :uuid, default: nil, force: :cascade do |t|
+    t.integer  "status",      :default=>0, :null=>false
+    t.string   "redirect_to", :limit=>255
+    t.json     "error"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "polyglot_languages", force: :cascade do |t|
+    t.string  "type",      :limit=>255, :null=>false, :comment=>"The class of language, as perceived by the application."
+    t.string  "name",      :limit=>255, :null=>false, :index=>{:name=>"index_polyglot_languages_on_name", :unique=>true, :case_sensitive=>false}
+    t.integer "parent_id", :index=>{:name=>"fk__polyglot_languages_parent_id", :order=>{:parent_id=>:asc}}
   end
 
   create_table "read_marks", force: :cascade do |t|
     t.integer  "readable_id"
     t.string   "readable_type", :limit=>255, :null=>false
-    t.integer  "reader_id",     :null=>false
+    t.integer  "reader_id",     :null=>false, :index=>{:name=>"read_marks_reader_readable_index", :with=>["reader_type", "readable_type", "readable_id"], :unique=>true, :order=>{:reader_id=>:asc, :reader_type=>:asc, :readable_type=>:asc, :readable_id=>:asc}}
     t.datetime "timestamp"
     t.string   "reader_type",   :limit=>255
-
-    t.index ["reader_id", "reader_type", "readable_type", "readable_id"], :name=>"read_marks_reader_readable_index", :unique=>true
   end
 
   create_table "user_emails", force: :cascade do |t|
     t.boolean  "primary",              :default=>false, :null=>false
-    t.integer  "user_id",              :index=>{:name=>"index_user_emails_on_user_id_and_primary", :with=>["primary"], :unique=>true, :where=>"(\"primary\" <> false)"}, :foreign_key=>{:references=>"users", :name=>"fk_user_emails_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "user_id",              :index=>{:name=>"index_user_emails_on_user_id_and_primary", :with=>["primary"], :unique=>true, :where=>"(\"primary\" <> false)"}
     t.string   "email",                :limit=>255, :null=>false, :index=>{:name=>"index_user_emails_on_email", :unique=>true, :case_sensitive=>false}
-    t.string   "confirmation_token",   :limit=>255, :index=>{:name=>"index_user_emails_on_confirmation_token", :unique=>true}
+    t.string   "confirmation_token",   :limit=>255, :index=>{:name=>"index_user_emails_on_confirmation_token", :unique=>true, :order=>{:confirmation_token=>:asc}}
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email",    :limit=>255
   end
 
   create_table "user_identities", force: :cascade do |t|
-    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__user_identities_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_user_identities_user_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.string   "provider",   :limit=>255, :null=>false, :index=>{:name=>"index_user_identities_on_provider_and_uid", :with=>["uid"], :unique=>true}
+    t.integer  "user_id",    :null=>false, :index=>{:name=>"fk__user_identities_user_id", :order=>{:user_id=>:asc}}
+    t.string   "provider",   :limit=>255, :null=>false, :index=>{:name=>"index_user_identities_on_provider_and_uid", :with=>["uid"], :unique=>true, :order=>{:provider=>:asc, :uid=>:asc}}
     t.string   "uid",        :limit=>255, :null=>false
     t.datetime "created_at", :null=>false
     t.datetime "updated_at", :null=>false
   end
 
   create_table "user_notifications", force: :cascade do |t|
-    t.integer  "activity_id",       :null=>false, :index=>{:name=>"index_user_notifications_on_activity_id"}, :foreign_key=>{:references=>"activities", :name=>"fk_user_notifications_activity_id", :on_update=>:no_action, :on_delete=>:no_action}
-    t.integer  "user_id",           :null=>false, :index=>{:name=>"index_user_notifications_on_user_id"}, :foreign_key=>{:references=>"users", :name=>"fk_user_notifications_user_id", :on_update=>:no_action, :on_delete=>:no_action}
+    t.integer  "activity_id",       :null=>false, :index=>{:name=>"index_user_notifications_on_activity_id", :order=>{:activity_id=>:asc}}
+    t.integer  "user_id",           :null=>false, :index=>{:name=>"index_user_notifications_on_user_id", :order=>{:user_id=>:asc}}
     t.integer  "notification_type", :default=>0, :null=>false
     t.datetime "created_at",        :null=>false
     t.datetime "updated_at",        :null=>false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string   "name",                   :limit=>255, :null=>false
+    t.integer  "role",                   :default=>0, :null=>false
+    t.string   "time_zone",              :limit=>255
+    t.text     "profile_photo"
+    t.string   "encrypted_password",     :limit=>255, :default=>"", :null=>false
+    t.string   "reset_password_token",   :limit=>255, :index=>{:name=>"index_users_on_reset_password_token", :unique=>true, :order=>{:reset_password_token=>:asc}}
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          :default=>0, :null=>false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at",             :null=>false
+    t.datetime "updated_at",             :null=>false
   end
 
 end

--- a/spec/controllers/course/assessment/assessments_controller_spec.rb
+++ b/spec/controllers/course/assessment/assessments_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Course::Assessment::AssessmentsController do
         it 'does not update attributes tabbed_view and password' do
           patch :update, params: {
             course_id: course, id: assessment,
-            assessment: { skippable: true, tabbed_view: true, password: 'password' }
+            assessment: { skippable: true, tabbed_view: true, session_password: 'password' }
           }
 
           expect(assessment).not_to be_skippable
@@ -94,7 +94,7 @@ RSpec.describe Course::Assessment::AssessmentsController do
 
           expect(assessment).to be_skippable
           expect(assessment.tabbed_view).to be_falsy
-          expect(assessment.password).to be_blank
+          expect(assessment.session_password).to be_blank
         end
       end
 
@@ -103,17 +103,17 @@ RSpec.describe Course::Assessment::AssessmentsController do
         it 'does not update attribute skippable' do
           patch :update, params: {
             course_id: course, id: assessment,
-            assessment: { skippable: true, tabbed_view: true, password: 'password' }
+            assessment: { skippable: true, tabbed_view: true, session_password: 'password' }
           }
 
           expect(assessment).not_to be_skippable
           expect(assessment.tabbed_view).not_to be_truthy
-          expect(assessment.password).not_to be_present
+          expect(assessment.session_password).not_to be_present
           assessment.reload
 
           expect(assessment).not_to be_skippable
           expect(assessment.tabbed_view).to be_truthy
-          expect(assessment.password).to be_present
+          expect(assessment.session_password).to be_present
         end
       end
     end

--- a/spec/features/course/assessment/submission/log_spec.rb
+++ b/spec/features/course/assessment/submission/log_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Course: Assessment: Submissions: Logs' do
     let(:assessment) { create(:assessment, :published_with_mrq_question, course: course) }
     let(:protected_assessment) do
       create(:assessment, :published_with_mrq_question,
-             course: course, password: 'super_secret')
+             course: course, session_password: 'super_secret')
     end
     let(:student) { create(:course_student, course: course).user }
     let(:submission) do
@@ -52,7 +52,7 @@ RSpec.describe 'Course: Assessment: Submissions: Logs' do
         expect(submission.logs.last.valid_attempt?).to be(false)
 
         expect do
-          fill_in 'session_password', with: protected_assessment.password
+          fill_in 'session_password', with: protected_assessment.session_password
           click_button I18n.t('course.assessment.sessions.new.continue')
         end.to change { submission.logs.count }.by(1)
         expect(submission.logs.last.valid_attempt?).to be(true)

--- a/spec/features/course/assessment/submission/password_protected_and_delayed_publishing_spec.rb
+++ b/spec/features/course/assessment/submission/password_protected_and_delayed_publishing_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
     let(:course) { create(:course) }
     let(:assessment) do
       create(:assessment, :published_with_mrq_question, :delay_grade_publication,
-             course: course, password: 'super_secret')
+             course: course, session_password: 'super_secret')
     end
     let(:mrq_questions) { assessment.reload.questions.map(&:specific) }
     let(:student) { create(:course_student, course: course).user }
@@ -47,7 +47,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
         click_button I18n.t('course.assessment.sessions.new.continue')
         expect(current_path).to eq(new_course_assessment_session_path(course, assessment))
 
-        fill_in 'session_password', with: assessment.password
+        fill_in 'session_password', with: assessment.session_password
         click_button I18n.t('course.assessment.sessions.new.continue')
 
         expect(page).to have_selector('div#course-assessment-submission')
@@ -57,7 +57,7 @@ RSpec.describe 'Course: Assessment: Submissions: Exam' do
         submission
         visit edit_course_assessment_submission_path(course, assessment, submission)
 
-        fill_in 'session_password', with: assessment.password
+        fill_in 'session_password', with: assessment.session_password
         click_button I18n.t('course.assessment.sessions.new.continue')
         expect(page).to have_selector('h1', text: assessment.title)
 

--- a/spec/models/course/assessment_spec.rb
+++ b/spec/models/course/assessment_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe Course::Assessment do
       end
 
       let(:manually_graded_assessment) do
-        build(:assessment, password: 'LOL')
+        build(:assessment, session_password: 'LOL')
       end
 
       it 'switches to autograded mode' do
@@ -379,7 +379,7 @@ RSpec.describe Course::Assessment do
         manually_graded_assessment.update_mode(params)
 
         expect(manually_graded_assessment).to be_autograded
-        expect(manually_graded_assessment.password).to be_nil
+        expect(manually_graded_assessment.session_password).to be_nil
       end
 
       it 'switches to manually graded mode' do


### PR DESCRIPTION
Rename `password` to `submission_password`
Add a new `password` column, this one is used for assessment password.

It looks like the format of schema.rb changed a lot after `rails db:migrate`, is it outdated? or I did something wrong?  I did a `db:reset` before migration, so the schema should be in the latest state.