### PR TITLE
Show material folder visibility status.

### DIFF
--- a/app/helpers/course/material/folders_helper.rb
+++ b/app/helpers/course/material/folders_helper.rb
@@ -8,4 +8,13 @@ module Course::Material::FoldersHelper
   def display_folder(folder)
     folder.root? ? component.settings.title || t('course.material.sidebar_title') : folder.name
   end
+
+  # Display an icon when the folder's start_at is in the future, but the course's advance_start_at
+  # option already makes it visible to students.
+  #
+  # @param [Course::Material::Folder] folder The folder to be tested.
+  # @return [Boolean] Whether the icon should be displayed.
+  def show_sdl_warning?(folder)
+    folder.effective_start_at < Time.zone.now && folder.start_at > Time.zone.now
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -127,7 +127,7 @@ class Course < ApplicationRecord
   #
   # @return [ActiveSupport::Duration]
   def advance_start_at_duration
-    settings(:course).advance_start_at_duration
+    settings(:course).advance_start_at_duration || 0
   end
 
   def advance_start_at_duration=(time)

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -93,6 +93,13 @@ class Course::Material::Folder < ApplicationRecord
     parent.next_uniq_child_name(self)
   end
 
+  # Take Course#advance_start_at_duration into account when calculating folder's start datetime.
+  #
+  # @return [DateTime] The shifted start_at datetime.
+  def effective_start_at
+    start_at - course&.advance_start_at_duration
+  end
+
   def initialize_duplicate(duplicator, other)
     # Do not shift the time of root folder
     self.start_at = other.parent_id.nil? ? Time.zone.now : duplicator.time_shift(other.start_at)

--- a/app/views/course/admin/admin/index.html.slim
+++ b/app/views/course/admin/admin/index.html.slim
@@ -21,16 +21,16 @@
     .form-group.boolean.optional
       .checkbox
           = label_tag 'self_directed_learning' do
-            = check_box_tag 'self_directed_learning', max_time.present?, max_time.present?,
+            = check_box_tag 'self_directed_learning', max_time > 0, max_time > 0,
                 class: 'self-directed-learning-checkbox'
             = t('.self_directed_learning')
       p.help-block = t('.self_directed_learning_label')
 
     - input = f.input :advance_start_at_duration_days,
                       as: :integer, label: false,
-                      input_html: { value: max_time.present? ? max_time / 1.day : nil },
+                      input_html: { value: max_time > 0 ? max_time / 1.day : nil },
                       wrapper_html: { class: 'form-inline advance-start-at-time' }
-    div.advance-start-at-time style="#{ max_time.present? ? '' : 'display: none' }"
+    div.advance-start-at-time style="#{ max_time > 0 ? '' : 'display: none' }"
       = t('.self_directed_learning_time_html', input: input)
     br
     = f.button :submit

--- a/app/views/course/material/folders/_folder.slim
+++ b/app/views/course/material/folders/_folder.slim
@@ -11,7 +11,12 @@
       = format_html(folder.description)
 
   td = format_datetime(folder.updated_at)
-  td = format_datetime(folder.start_at)
+  - if can?(:edit, folder)
+    td
+      - if show_sdl_warning?(folder)
+        span title=t('.visible_because_sdl')
+          => fa_icon 'eye'.freeze
+      = format_datetime(folder.start_at)
   td
     = edit_button([current_course, folder]) if @folder.concrete? && can?(:edit, folder)
     = delete_button([current_course, folder]) if @folder.concrete? && can?(:destroy, folder)

--- a/app/views/course/material/folders/_folder.slim
+++ b/app/views/course/material/folders/_folder.slim
@@ -1,5 +1,8 @@
 = content_tag_for(:tr, folder)
   td
+    - if folder.effective_start_at > Time.zone.now
+      span title=t('.unseen_by_students')
+        => fa_icon 'ban'.freeze
     = link_to course_material_folder_path(current_course, folder) do
       => fa_icon 'folder-open'.freeze
       => format_inline_text(folder.name)
@@ -8,6 +11,7 @@
       = format_html(folder.description)
 
   td = format_datetime(folder.updated_at)
+  td = format_datetime(folder.start_at)
   td
     = edit_button([current_course, folder]) if @folder.concrete? && can?(:edit, folder)
     = delete_button([current_course, folder]) if @folder.concrete? && can?(:destroy, folder)

--- a/app/views/course/material/folders/edit.html.slim
+++ b/app/views/course/material/folders/edit.html.slim
@@ -5,7 +5,7 @@
   = f.input :name
   = f.input :description, input_html: { class: ['no-summernote'] }
   = f.input :can_student_upload
-  = f.input :start_at
+  = f.input :start_at, label: t('.start_at', count: current_course.advance_start_at_duration / 1.day)
   = f.input :end_at
 
   = f.button :submit

--- a/app/views/course/material/folders/show.html.slim
+++ b/app/views/course/material/folders/show.html.slim
@@ -6,6 +6,8 @@ table.table.table-hover
     tr
       th = t('.name')
       th = t('.modified')
+      - if can?(:edit, @subfolders)
+        th = t('.start_at')
       th
   tbody
     - if @folder.parent

--- a/config/locales/en/course/material/folders.yml
+++ b/config/locales/en/course/material/folders.yml
@@ -29,3 +29,4 @@ en:
           failure: 'Failed to upload files: %{error}'
         folder:
           unseen_by_students: "Hidden from students as folder's start time has not been reached."
+          visible_because_sdl: 'Visible to students before the start time because of Self-Directed Learning.'

--- a/config/locales/en/course/material/folders.yml
+++ b/config/locales/en/course/material/folders.yml
@@ -12,6 +12,9 @@ en:
           success: 'Folder %{name} was created.'
         edit:
           header: 'Edit Folder'
+          start_at:
+            one: "Start at (Students can access materials 1 day ahead of the start at time)"
+            other: "Start at (Students can access materials %{count} days ahead of the start at time)"
         update:
           success: 'Folder %{name} was updated.'
         destroy:

--- a/config/locales/en/course/material/folders.yml
+++ b/config/locales/en/course/material/folders.yml
@@ -5,6 +5,7 @@ en:
         show:
           modified: 'Last Modified'
           name: 'Name'
+          start_at: 'Start At'
         new_subfolder:
           header: 'New Subfolder'
         create_subfolder:
@@ -26,3 +27,5 @@ en:
         upload_materials:
           success: 'Files were uploaded.'
           failure: 'Failed to upload files: %{error}'
+        folder:
+          unseen_by_students: "Hidden from students as folder's start time has not been reached."

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Course: Administration: Administration' do
         click_button 'submit'
 
         expect(page).to have_selector('div.alert-success')
-        expect(course.reload.advance_start_at_duration).to be_nil
+        expect(course.reload.advance_start_at_duration).to eq 0
       end
 
       scenario 'I can delete the course' do

--- a/spec/helpers/course/material/folders_helper_spec.rb
+++ b/spec/helpers/course/material/folders_helper_spec.rb
@@ -27,4 +27,31 @@ RSpec.describe Course::Material::FoldersHelper, type: :helper do
       end
     end
   end
+
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    describe '#show_sdl_warning?' do
+      let(:course) { build(:course, advance_start_at_duration_days: 3) }
+      subject { helper.show_sdl_warning?(folder) }
+
+      context 'when folder starts after the self directed learning period' do
+        let(:folder) { build(:folder, course: course, start_at: 7.days.from_now) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when folder starts in the self directed learning period' do
+        let(:folder) { build(:folder, course: course, start_at: 2.days.from_now) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when folder has already started' do
+        let(:folder) { build(:folder, course: course, start_at: 7.days.ago) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
 end

--- a/spec/models/course/material/folder_spec.rb
+++ b/spec/models/course/material/folder_spec.rb
@@ -89,5 +89,25 @@ RSpec.describe Course::Material::Folder, type: :model do
         expect(folder.children_count).to eq(count)
       end
     end
+
+    describe '#effective_start_at' do
+      context 'when course has no advance start date' do
+        let(:course) { create(:course) }
+        let(:folder) { create(:course_material_folder, course: course) }
+
+        it 'returns the same datetime as start_at' do
+          expect(folder.effective_start_at).to eq folder.start_at
+        end
+      end
+
+      context 'when course has advance start date set' do
+        let(:course) { create(:course, advance_start_at_duration_days: 3) }
+        let(:folder) { create(:course_material_folder, course: course) }
+
+        it "returns folder.start_at shifted by the course's advance_start_at_duration" do
+          expect(folder.effective_start_at).to eq(folder.start_at - 3.days)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add icon if a folder's start time is in the future so staff can quickly
see which folders have future start times.

Add folder start at times to folder show page.

Takes self directed learning advanced start at option into account.

![screen shot 2018-04-23 at 11 12 03 am](https://user-images.githubusercontent.com/1902527/39108510-31835844-46fb-11e8-8f3d-fc22cfbf28e4.png)
