### PR TITLE
Disable controller actions for course components if it is disabled

### DIFF
--- a/app/controllers/components/course/experience_points_component.rb
+++ b/app/controllers/components/course/experience_points_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course::PointsDisbursementComponent < SimpleDelegator
+class Course::ExperiencePointsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
   def self.gamified?
@@ -7,7 +7,7 @@ class Course::PointsDisbursementComponent < SimpleDelegator
   end
 
   def self.display_name
-    I18n.t('components.points_disbursement.name')
+    I18n.t('components.experience_points.name')
   end
 
   def sidebar_items

--- a/app/controllers/components/course/settings_component.rb
+++ b/app/controllers/components/course/settings_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course::CoursesComponent < SimpleDelegator
+class Course::SettingsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
   def self.can_be_disabled?
@@ -7,7 +7,7 @@ class Course::CoursesComponent < SimpleDelegator
   end
 
   def self.display_name
-    I18n.t('components.courses.name')
+    I18n.t('components.settings.name')
   end
 
   def sidebar_items

--- a/app/controllers/course/admin/assessment_settings_controller.rb
+++ b/app/controllers/course/admin/assessment_settings_controller.rb
@@ -21,4 +21,10 @@ class Course::Admin::AssessmentSettingsController < Course::Admin::Controller
                                    assessment_categories_attributes: [:id, :title, :weight,
                                       { tabs_attributes: [:id, :title, :weight, :category_id] }])
   end
+
+  # @return [Course::AssessmentsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_assessments_component]
+  end
 end

--- a/app/controllers/course/admin/assessments/categories_controller.rb
+++ b/app/controllers/course/admin/assessments/categories_controller.rb
@@ -38,4 +38,10 @@ class Course::Admin::Assessments::CategoriesController < Course::Admin::Controll
   def category_params
     params.require(:category).permit(:title, :weight)
   end
+
+  # @return [Course::AssessmentsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_assessments_component]
+  end
 end

--- a/app/controllers/course/admin/assessments/tabs_controller.rb
+++ b/app/controllers/course/admin/assessments/tabs_controller.rb
@@ -44,4 +44,10 @@ class Course::Admin::Assessments::TabsController < Course::Admin::Controller
   def add_category_breadcrumb
     add_breadcrumb @category.title, course_admin_assessments_path(current_course)
   end
+
+  # @return [Course::AssessmentsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_assessments_component]
+  end
 end

--- a/app/controllers/course/admin/controller.rb
+++ b/app/controllers/course/admin/controller.rb
@@ -10,4 +10,10 @@ class Course::Admin::Controller < Course::ComponentController
   def authorize_admin
     authorize!(:manage, current_course)
   end
+
+  # @return [Course::SettingsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_settings_component]
+  end
 end

--- a/app/controllers/course/admin/videos/tabs_controller.rb
+++ b/app/controllers/course/admin/videos/tabs_controller.rb
@@ -33,4 +33,10 @@ class Course::Admin::Videos::TabsController < Course::Admin::Controller
   def tab_params
     params.require(:tab).permit(:title, :weight)
   end
+
+  # @return [Course::VideosComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_videos_component]
+  end
 end

--- a/app/controllers/course/assessment/controller.rb
+++ b/app/controllers/course/assessment/controller.rb
@@ -40,4 +40,10 @@ class Course::Assessment::Controller < Course::ComponentController
     tab_path = course_assessments_path(course_id: current_course, category: category, tab: tab)
     add_breadcrumb(tab.title, tab_path)
   end
+
+  # @return [Course::AssessmentsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_assessments_component]
+  end
 end

--- a/app/controllers/course/assessment/skill_branches_controller.rb
+++ b/app/controllers/course/assessment/skill_branches_controller.rb
@@ -44,4 +44,10 @@ class Course::Assessment::SkillBranchesController < Course::ComponentController
   def skill_branch_params
     params.require(:skill_branch).permit(:title, :description)
   end
+
+  # @return [Course::AssessmentsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_assessments_component]
+  end
 end

--- a/app/controllers/course/assessment/skills_controller.rb
+++ b/app/controllers/course/assessment/skills_controller.rb
@@ -56,4 +56,10 @@ class Course::Assessment::SkillsController < Course::ComponentController
     @skill_branches = current_course.assessment_skill_branches.
                       accessible_by(current_ability).ordered_by_title
   end
+
+  # @return [Course::AssessmentsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_assessments_component]
+  end
 end

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -70,4 +70,10 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   def add_submissions_breadcrumb
     add_breadcrumb :index, course_submissions_path(current_course, category: category)
   end
+
+  # @return [Course::AssessmentsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_assessments_component]
+  end
 end

--- a/app/controllers/course/component_controller.rb
+++ b/app/controllers/course/component_controller.rb
@@ -3,10 +3,16 @@ class Course::ComponentController < Course::Controller
   layout 'course'
 
   before_action :load_current_component_host
-  before_action :check_component, if: :component_defined?
-  before_action :load_settings, if: :component_defined?
+  before_action :check_component
+  before_action :load_settings
 
-  protected
+  private
+
+  # Forces the current component host to be loaded. This is used in the Course layout to decide
+  # which navbar items to display, so count it under the Controller's execution time instead.
+  def load_current_component_host
+    current_component_host
+  end
 
   # Check if the component is enabled. We don't want to let user access the page through url if the
   # component is disabled.
@@ -21,19 +27,12 @@ class Course::ComponentController < Course::Controller
     @settings = component.settings
   end
 
-  private
-
-  # Forces the current component host to be loaded. This is used in the Course layout to decide
-  # which navbar items to display, so count it under the Controller's execution time instead.
-  def load_current_component_host
-    current_component_host
-  end
-
-  # Child controller is supposed implement a #component in order to let the enable/disable checking
-  # work.
+  # This is meant to be overriden by child classes that inherit from this class.
+  # If the controller doesn't belong to a component, it can inherit directly from Course::Controller.
   #
-  # @return [Boolean]
-  def component_defined?
-    defined?(component)
+  # @raise [Coursemology::ComponentNotFoundError]
+  # @return [Course::ControllerComponentHost::Component]
+  def component
+    raise ComponentNotFoundError
   end
 end

--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -76,4 +76,10 @@ class Course::Discussion::PostsController < Course::ComponentController
     topic_actable = post.topic.actable
     topic_actable.notify(post) if topic_actable.respond_to?(:notify)
   end
+
+  # @return [Course::Discussion::TopicsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_discussion_topics_component]
+  end
 end

--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -33,4 +33,10 @@ class Course::DuplicationsController < Course::ComponentController
   def duplication_job_options
     create_duplication_params.merge(current_user: current_user).to_h
   end
+
+  # @return [Course::DuplicationComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_duplication_component]
+  end
 end

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -56,4 +56,10 @@ class Course::EnrolRequestsController < Course::ComponentController
   def course_user_params
     params.require(:course_user).permit(:name, :role, :phantom).to_h
   end
+
+  # @return [Course::UsersComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_users_component]
+  end
 end

--- a/app/controllers/course/experience_points/disbursement_controller.rb
+++ b/app/controllers/course/experience_points/disbursement_controller.rb
@@ -47,4 +47,10 @@ class Course::ExperiencePoints::DisbursementController < Course::ComponentContro
   def recipient_count
     @disbursement.experience_points_records.length
   end
+
+  # @return [Course::ExperiencePointsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_experience_points_component]
+  end
 end

--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -53,4 +53,10 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
     add_breadcrumb @course_user.name, course_user_path(current_course, @course_user)
     add_breadcrumb :index
   end
+
+  # @return [Course::ExperiencePointsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_experience_points_component]
+  end
 end

--- a/app/controllers/course/groups_controller.rb
+++ b/app/controllers/course/groups_controller.rb
@@ -46,4 +46,10 @@ class Course::GroupsController < Course::ComponentController
       permit(:name, course_user_ids: [],
                     group_users_attributes: [:id, :course_user_id, :role, :_destroy])
   end
+
+  # @return [Course::GroupsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_groups_component]
+  end
 end

--- a/app/controllers/course/levels_controller.rb
+++ b/app/controllers/course/levels_controller.rb
@@ -15,4 +15,12 @@ class Course::LevelsController < Course::ComponentController
       end
     end
   end
+
+  private
+
+  # @return [Course::LevelsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_levels_component]
+  end
 end

--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -97,4 +97,10 @@ class Course::ObjectDuplicationsController < Course::ComponentController
       course_item_finders[item_type].call(ids)
     end.flatten
   end
+
+  # @return [Course::DuplicationComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_duplication_component]
+  end
 end

--- a/app/controllers/course/statistics_controller.rb
+++ b/app/controllers/course/statistics_controller.rb
@@ -26,4 +26,10 @@ class Course::StatisticsController < Course::ComponentController
   def preload_levels
     current_course.levels.to_a
   end
+
+  # @return [Course::StatisticsComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_statistics_component]
+  end
 end

--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -224,4 +224,10 @@ class Course::UserInvitationsController < Course::ComponentController
     end
     current_course.save
   end
+
+  # @return [Course::UsersComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_users_component]
+  end
 end

--- a/app/controllers/course/user_notifications_controller.rb
+++ b/app/controllers/course/user_notifications_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course::UserNotificationsController < Course::ComponentController
+class Course::UserNotificationsController < Course::Controller
   load_and_authorize_resource :user_notification, class: UserNotification.name
 
   def mark_as_read

--- a/app/controllers/course/user_registrations_controller.rb
+++ b/app/controllers/course/user_registrations_controller.rb
@@ -50,4 +50,10 @@ class Course::UserRegistrationsController < Course::ComponentController
 
     redirect_to course_path(current_course), success: success
   end
+
+  # @return [Course::UsersComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_users_component]
+  end
 end

--- a/app/controllers/course/users_controller.rb
+++ b/app/controllers/course/users_controller.rb
@@ -24,4 +24,10 @@ class Course::UsersController < Course::ComponentController
       @course_user ||= course_users.includes(:user).find(params[:id])
     end
   end
+
+  # @return [Course::UsersComponent]
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_users_component]
+  end
 end

--- a/config/locales/en/components.yml
+++ b/config/locales/en/components.yml
@@ -25,14 +25,14 @@ en:
         name: 'Comments Center'
     statistics:
       name: 'Statistics'
-    points_disbursement:
-      name: 'Points Disbursement'
+    experience_points:
+      name: 'Experience Points'
     duplication:
       name: 'Duplication'
     video:
       name: :'course.video.videos.index.header'
-    courses:
-      name: 'Courses'
+    settings:
+      name: 'Settings'
     users:
       name: 'Users'
     surveys:

--- a/db/migrate/20180424030829_remove_disbursement_component_settings.rb
+++ b/db/migrate/20180424030829_remove_disbursement_component_settings.rb
@@ -1,0 +1,20 @@
+class RemoveDisbursementComponentSettings < ActiveRecord::Migration[5.1]
+  def up
+    # Although CoursesComponent has been renamed to SettingsComponent,
+    # we don't need a migration because the component cannot be disabled,
+    # so no setting for it is persisted under courses settings.
+
+    # PointsDisburementComponent has been renamed at ExperiencePointsComponent.
+    # Since it is much more generic now, we remove the setting which leaves
+    # it enabled by default.
+    ActsAsTenant.without_tenant do
+      Course.all.each do |course|
+        course.settings(:components).course_points_disbursement_component = nil
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180414144225) do
+ActiveRecord::Schema.define(version: 20180424030829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/course/admin/videos/tabs_controller_spec.rb
+++ b/spec/controllers/course/admin/videos/tabs_controller_spec.rb
@@ -2,10 +2,20 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::Videos::TabsController, type: :controller do
-  let(:instance) { Instance.default }
+  let(:instance) do
+    Instance.default.tap do |instance|
+      instance.settings(:components).settings(:course_videos_component).enabled = true
+      instance.save!
+    end
+  end
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
-    let(:course) { create(:course, creator: user) }
+    let(:course) do
+      create(:course, creator: user).tap do |course|
+        course.settings(:components).settings(:course_videos_component).enabled = true
+        course.save!
+      end
+    end
     let!(:tab_stub) do
       stub = create(:course_video_tab)
       allow(stub).to receive(:destroy).and_return(false)


### PR DESCRIPTION
Previously, if controllers do not declare which components they are associated with, users are able to access those controllers' pages via their URL even though the associated component has been disabled.

This PR requires all controller that inherit from `Course::ComponentController` to declare which components they are associated with.

Points Disbursement together with other Experience Points Records endpoints have been grouped under `ExperiencePointsComponent` while the `CoursesComponent` has been renamed to `SettingsComponent`.