### PR TITLE
Allow course settings and user management to be disabled at instance level

### DIFF
--- a/app/controllers/components/course/controller_component_host.rb
+++ b/app/controllers/components/course/controller_component_host.rb
@@ -72,9 +72,9 @@ class Course::ControllerComponentHost
         false
       end
 
-      # @return [Boolean] States whether a component can be disabled. Value is true by default.
-      #   Used to hide
-      def can_be_disabled?
+      # @return [Boolean] true if component can be disabled (or enabled) for individual courses.
+      #   Otherwise, the component can only perhaps be disabled instance-wide.
+      def can_be_disabled_for_course?
         true
       end
 

--- a/app/controllers/components/course/settings_component.rb
+++ b/app/controllers/components/course/settings_component.rb
@@ -2,7 +2,8 @@
 class Course::SettingsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
-  def self.can_be_disabled?
+  # Prevent user from locking him/herself out of settings.
+  def self.can_be_disabled_for_course?
     false
   end
 

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -2,7 +2,7 @@
 class Course::UsersComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
 
-  def self.can_be_disabled?
+  def self.can_be_disabled_for_course?
     false
   end
 

--- a/app/models/concerns/course/course_components_concern.rb
+++ b/app/models/concerns/course/course_components_concern.rb
@@ -11,6 +11,6 @@ module Course::CourseComponentsConcern
   end
 
   def disableable_components
-    @disableable_components ||= available_components.select(&:can_be_disabled?)
+    @disableable_components ||= available_components.select(&:can_be_disabled_for_course?)
   end
 end

--- a/app/models/concerns/instance/course_components_concern.rb
+++ b/app/models/concerns/instance/course_components_concern.rb
@@ -7,7 +7,10 @@ module Instance::CourseComponentsConcern
     @available_components ||= Course::ControllerComponentHost.components
   end
 
+  # All components can be disabled at the instance level.
+  # If there is a need, `can_be_disabled_for_instance?` can be implemented for components
+  # to prevent some components from ever being disabled.
   def disableable_components
-    @disableable_components ||= available_components.select(&:can_be_disabled?)
+    available_components
   end
 end

--- a/spec/components/course/controller_component_host_spec.rb
+++ b/spec/components/course/controller_component_host_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
   class self::DummyCoreCourseModule
     include Course::ControllerComponentHost::Component
 
-    def self.can_be_disabled?
+    def self.can_be_disabled_for_course?
       false
     end
 
@@ -196,46 +196,44 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
       end
 
       context 'with preferences' do
-        let(:disableable_component) { default_enabled_components.find(&:can_be_disabled?) }
-        let(:undisableable_component) { default_enabled_components.drop_while(&:can_be_disabled?).first }
+        let(:course_disableable_component) do
+          default_enabled_components.find(&:can_be_disabled_for_course?)
+        end
+        let(:course_undisableable_component) do
+          default_enabled_components.drop_while(&:can_be_disabled_for_course?).first
+        end
 
-        context 'disable a component in course' do
-          before { course.set_component_enabled_boolean(disableable_component.key, false) }
+        context 'when a component is disabled for the course' do
+          before { course.set_component_enabled_boolean(course_disableable_component.key, false) }
 
           it 'does not include the disabled component' do
-            expect(subject).not_to include(disableable_component)
+            expect(subject).not_to include(course_disableable_component)
           end
         end
 
         context 'disable an undisableable component in course' do
-          before { course.send(:unsafe_set_component_enabled_boolean, undisableable_component.key, false) }
+          before do
+            course.send(:unsafe_set_component_enabled_boolean, course_undisableable_component.key, false)
+          end
 
-          it 'includes the disabled component' do
-            expect(subject).to include(undisableable_component)
+          it 'ignores the setting and includes the disabled component' do
+            expect(subject).to include(course_undisableable_component)
           end
         end
 
-        context 'disable a component in instance' do
-          before { instance.set_component_enabled_boolean(disableable_component.key, false) }
+        context 'when a component is disabled for the instance' do
+          before { instance.set_component_enabled_boolean(course_disableable_component.key, false) }
 
           it 'does not include the disabled component' do
-            expect(subject).not_to include(disableable_component)
+            expect(subject).not_to include(course_disableable_component)
           end
         end
 
-        context 'disable an undisableable component in instance' do
-          before { instance.send(:unsafe_set_component_enabled_boolean, undisableable_component.key, false) }
+        context 'when a component is enabled' do
+          before { course.set_component_enabled_boolean(course_disableable_component.key, true) }
 
-          it 'includes the disabled component' do
-            expect(subject).to include(undisableable_component)
-          end
-        end
-
-        context 'enable a component' do
-          before { course.set_component_enabled_boolean(disableable_component.key, true) }
-
-          it 'includes the disabled component' do
-            expect(subject).to include(disableable_component)
+          it 'includes the component' do
+            expect(subject).to include(course_disableable_component)
           end
         end
       end


### PR DESCRIPTION
Depends on #2929 and #2927. Related to moexmen/coursemology-sls#10.

With this PR, all course components will be disableable at the instance level.