### PR TITLE
Prevent video URL changes

### DIFF
--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -11,6 +11,8 @@ class Course::Video < ApplicationRecord
   has_many :topics, class_name: Course::Video::Topic.name,
                     dependent: :destroy, foreign_key: :video_id, inverse_of: :video
 
+  validate :url_unchanged
+
   scope :from_course, ->(course) { where(course_id: course) }
 
   scope :from_tab, ->(tab) { where(tab_id: tab) }
@@ -94,5 +96,10 @@ class Course::Video < ApplicationRecord
                else
                  duplicator.options[:target_course].video_tabs.first
                end
+  end
+
+  def url_unchanged
+    errors.add(:url, 'should not be updated for existing videos') if url_changed? &&
+                                                                     persisted?
   end
 end

--- a/app/views/course/video/videos/_form.html.slim
+++ b/app/views/course/video/videos/_form.html.slim
@@ -3,7 +3,9 @@
   = f.input :title
   = f.association :tab, collection: current_course.video_tabs
   = f.input :description, as: :text
-  = f.input :url, placeholder: t('.url_placeholder')
+  = f.input :url,
+            placeholder: t('.url_placeholder'),
+            disabled: @video.persisted?
   = f.input :start_at,
             as: :bootstrap_date_time,
             input_html: { value: f.object.start_at || Date.today }

--- a/spec/models/course/video_spec.rb
+++ b/spec/models/course/video_spec.rb
@@ -99,6 +99,29 @@ RSpec.describe Course::Video, type: :model do
       end
     end
 
+    describe 'validations' do
+      let(:youtube_embedded_url) { "https://www.youtube.com/embed/#{youtube_video_id}" }
+      let(:youtube_video_id) { 'dQw4w9WgXcQ' }
+
+      context 'when video is new' do
+        it 'allows url to be changed' do
+          video = build(:video, course: course)
+          video.url = youtube_embedded_url
+          expect(video.valid?).to be_truthy
+          expect(video.save).to be_truthy
+        end
+      end
+
+      context 'when video exists ' do
+        it 'prevents the url from being changed' do
+          video1.url = youtube_embedded_url
+          expect(video1.valid?).to be_falsey
+          expect(video1.save).to be_falsey
+          expect { video1.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+
     describe 'callbacks' do
       context 'when updating video url' do
         let(:youtube_embedded_url) { "https://www.youtube.com/embed/#{youtube_video_id}" }
@@ -119,9 +142,10 @@ RSpec.describe Course::Video, type: :model do
 
         it 'updates to the youtube embed url' do
           youtube_valid_urls.each do |url|
-            video1.reload.url = url
-            expect(video1.save).to be_truthy
-            expect(video1.reload.url).to eq(youtube_embedded_url)
+            video = build(:video, course: course)
+            video.url = url
+            expect(video.save).to be_truthy
+            expect(video.reload.url).to eq(youtube_embedded_url)
           end
         end
 
@@ -130,9 +154,10 @@ RSpec.describe Course::Video, type: :model do
 
           it ' does not update and returns an error' do
             invalid_urls.each do |url|
-              video1.reload.url = url
-              expect(video1.save).to be_falsey
-              expect { video1.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+              video = build(:video, course: course)
+              video.url = url
+              expect(video.save).to be_falsey
+              expect { video.save! }.to raise_exception(ActiveRecord::RecordInvalid)
             end
           end
         end


### PR DESCRIPTION
Video URL should not be changed once record is persisted, for a number of other
components depend on the underlying video to be the original one.