### PR TITLE
Fix levels edit text field defocusing after keystroke.

### DIFF
--- a/client/app/bundles/course/level/components/LevelRow.jsx
+++ b/client/app/bundles/course/level/components/LevelRow.jsx
@@ -39,23 +39,24 @@ class LevelRow extends React.Component {
   }
 
   renderInput(levelNumber, experiencePointsThreshold) {
+    const { updateExpThreshold, disabled, sortLevels } = this.props;
     return (
       <TextField
         type="text"
         name={`level_${levelNumber}`}
         onChange={(e, newValue) => {
-          this.props.updateExpThreshold(levelNumber, newValue);
+          updateExpThreshold(levelNumber, newValue);
         }}
-        disabled={this.props.disabled}
+        disabled={disabled}
         errorText={experiencePointsThreshold === 0 ? <FormattedMessage {...translations.zeroThresholdError} /> : ''}
-        onBlur={() => { this.props.sortLevels(); }}
+        onBlur={() => { sortLevels(); }}
         value={experiencePointsThreshold}
       />
     );
   }
 
   render() {
-    const { levelNumber, experiencePointsThreshold } = this.props;
+    const { levelNumber, experiencePointsThreshold, deleteLevel, disabled } = this.props;
     return (
       <TableRow>
         <TableRowColumn style={styles.levelNumber}>{ levelNumber }</TableRowColumn>
@@ -66,8 +67,8 @@ class LevelRow extends React.Component {
             name={`delete_${levelNumber}`}
             backgroundColor={grey300}
             icon={<DeleteIcon />}
-            onClick={this.props.deleteLevel(levelNumber)}
-            disabled={this.props.disabled}
+            onClick={deleteLevel(levelNumber)}
+            disabled={disabled}
             style={{ minWidth: '40px', width: '40px' }}
           />
         </TableHeaderColumn>

--- a/client/app/bundles/course/level/pages/Level/index.jsx
+++ b/client/app/bundles/course/level/pages/Level/index.jsx
@@ -129,19 +129,21 @@ class Level extends React.Component {
   }
 
   handleSaveLevels() {
+    const { dispatch, levels } = this.props;
     return (e) => {
       e.preventDefault();
       if (this.levelsHaveError() === false) {
         const successMessage = <FormattedMessage {...translations.saveSuccess} />;
         const failureMessage = <FormattedMessage {...translations.saveFailure} />;
-        this.props.dispatch(saveLevels(this.props.levels, successMessage, failureMessage));
+        dispatch(saveLevels(levels, successMessage, failureMessage));
       }
     };
   }
 
   renderBody() {
-    const rows = this.props.levels.slice(1).map((experiencePointsThreshold, index) => {
-      const key = `${index}-${experiencePointsThreshold}`;
+    const { levels, isSaving } = this.props;
+    const rows = levels.slice(1).map((experiencePointsThreshold, index) => {
+      const key = `${index}`;
       return (
         <LevelRow
           key={key}
@@ -150,7 +152,7 @@ class Level extends React.Component {
           updateExpThreshold={this.handleUpdateExpThreshold}
           sortLevels={this.handleLevelTextBlur}
           deleteLevel={this.handleDeleteLevel}
-          disabled={this.props.isSaving}
+          disabled={isSaving}
         />
       );
     });
@@ -180,7 +182,7 @@ class Level extends React.Component {
                   id="add-level"
                   icon={<i className="fa fa-plus" />}
                   label={<FormattedMessage {...translations.addNewLevel} />}
-                  disabled={this.props.isSaving}
+                  disabled={isSaving}
                   onClick={this.handleCreateLevel()}
                 />
               </TableRowColumn>
@@ -193,7 +195,7 @@ class Level extends React.Component {
                   style={styles.formButton}
                   type="submit"
                   label={<FormattedMessage {...translations.saveLevels} />}
-                  disabled={this.props.isSaving}
+                  disabled={isSaving}
                   primary
                   onClick={this.handleSaveLevels()}
                 />


### PR DESCRIPTION
Use a simpler key that does not change as the thresholds are being
updated. (http://reactkungfu.com/2015/09/react-js-loses-input-focus-on-typing/)

Use object destructuring when there are multiple calls to this.props in
a function.