### PR TITLE
Make a separate fetch to get popup notification data

### DIFF
--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -22,18 +22,6 @@ class Course::Controller < ApplicationController
     end
   end
 
-  # Fetches the first unread popup `UserNotification` for the current course and returns JSON data
-  # for the frontend to display it.
-  #
-  # @return [String] JSON data for the next notification, if there is one.
-  # @return [nil] if there are no unread notifications, or no +current_course_user+.
-  def next_popup_notification
-    return unless current_course_user
-    notification = UserNotification.next_unread_popup_for(current_course_user)
-    notification && render_to_string("#{helpers.notification_view_path(notification)}.json",
-                                     locals: { notification: notification })
-  end
-
   # Gets the current course.
   # @return [Course] The current course that the user is browsing.
   def current_course

--- a/app/controllers/course/user_notifications_controller.rb
+++ b/app/controllers/course/user_notifications_controller.rb
@@ -1,9 +1,27 @@
 # frozen_string_literal: true
 class Course::UserNotificationsController < Course::Controller
-  load_and_authorize_resource :user_notification, class: UserNotification.name
+  load_and_authorize_resource :user_notification, class: UserNotification.name, only: :mark_as_read
+
+  def fetch
+    render json: next_popup_notification, status: :ok
+  end
 
   def mark_as_read
     @user_notification.mark_as_read! for: current_user
     render json: next_popup_notification, status: :ok
+  end
+
+  private
+
+  # Fetches the first unread popup `UserNotification` for the current course and returns JSON data
+  # for the frontend to display it.
+  #
+  # @return [String] JSON data for the next notification, if there is one.
+  # @return [nil] if there are no unread notifications, or no +current_course_user+.
+  def next_popup_notification
+    return unless current_course_user
+    notification = UserNotification.next_unread_popup_for(current_course_user)
+    notification && render_to_string("#{helpers.notification_view_path(notification)}.json",
+                                     locals: { notification: notification })
   end
 end

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -25,4 +25,5 @@
     div.col-lg-10.col-md-9.col-sm-8 class=page_class
       = yield
 
-    #popup-notifier data=controller.next_popup_notification
+    - if current_course_user && UserNotification.next_unread_popup_for(current_course_user).present?
+      #popup-notifier

--- a/client/app/api/course/UserNotifications.js
+++ b/client/app/api/course/UserNotifications.js
@@ -1,6 +1,10 @@
 import BaseCourseAPI from './Base';
 
 export default class UserNotificationsAPI extends BaseCourseAPI {
+  fetch() {
+    return this.getClient().get(`${this._getUrlPrefix()}/fetch`);
+  }
+
   markAsRead(userNotificationId) {
     return this.getClient().post(`${this._getUrlPrefix()}/${userNotificationId}/mark_as_read`);
   }

--- a/client/app/bundles/course/user-notification/actions.js
+++ b/client/app/bundles/course/user-notification/actions.js
@@ -2,6 +2,22 @@
 import courseAPI from 'api/course';
 import actionTypes from './constants';
 
+export function fetchNotification() {
+  return (dispatch) => {
+    dispatch({ type: actionTypes.FETCH_NOTIFICATION_REQUEST });
+    return courseAPI.userNotifications.fetch()
+      .then((response) => {
+        dispatch({
+          type: actionTypes.FETCH_NOTIFICATION_SUCCESS,
+          nextNotification: response.data,
+        });
+      })
+      .catch(() => {
+        dispatch({ type: actionTypes.FETCH_NOTIFICATION_FAILURE });
+      });
+  };
+}
+
 export function markAsRead(userNotificationId) {
   return (dispatch) => {
     dispatch({ type: actionTypes.MARK_AS_READ_REQUEST });

--- a/client/app/bundles/course/user-notification/constants.js
+++ b/client/app/bundles/course/user-notification/constants.js
@@ -1,6 +1,9 @@
 import mirrorCreator from 'mirror-creator';
 
 const actionTypes = mirrorCreator([
+  'FETCH_NOTIFICATION_REQUEST',
+  'FETCH_NOTIFICATION_SUCCESS',
+  'FETCH_NOTIFICATION_FAILURE',
   'MARK_AS_READ_REQUEST',
   'MARK_AS_READ_SUCCESS',
   'MARK_AS_READ_FAILURE',

--- a/client/app/bundles/course/user-notification/containers/PopupNotifier/index.jsx
+++ b/client/app/bundles/course/user-notification/containers/PopupNotifier/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AchievementGainedPopup from 'course/user-notification/components/AchievementGainedPopup';
 import LevelReachedPopup from 'course/user-notification/components/LevelReachedPopup';
-import { markAsRead } from 'course/user-notification/actions';
+import { fetchNotification, markAsRead } from 'course/user-notification/actions';
 
 class PopupNotifier extends React.Component {
   static propTypes = {
@@ -16,6 +16,10 @@ class PopupNotifier extends React.Component {
     achievementGained: AchievementGainedPopup,
     levelReached: LevelReachedPopup,
   };
+
+  componentDidMount() {
+    this.props.dispatch(fetchNotification());
+  }
 
   render() {
     const { dispatch, notification, open } = this.props;

--- a/client/app/bundles/course/user-notification/reducers/index.js
+++ b/client/app/bundles/course/user-notification/reducers/index.js
@@ -2,7 +2,7 @@ import actionTypes from '../constants';
 
 const initialState = {
   popupNotification: {},
-  popupOpen: true,
+  popupOpen: false,
 };
 
 export default function (state = initialState, action) {
@@ -10,6 +10,7 @@ export default function (state = initialState, action) {
     case actionTypes.MARK_AS_READ_REQUEST: {
       return { ...state, popupOpen: false };
     }
+    case actionTypes.FETCH_NOTIFICATION_SUCCESS:
     case actionTypes.MARK_AS_READ_SUCCESS: {
       return {
         popupNotification: action.nextNotification,

--- a/client/app/bundles/course/user-notification/store.js
+++ b/client/app/bundles/course/user-notification/store.js
@@ -2,8 +2,7 @@ import { compose, createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import rootReducer from './reducers';
 
-export default ({ popupNotification }) => {
-  const initialStates = { popupNotification, popupOpen: true };
+export default (initialStates) => {
   const storeCreator = (process.env.NODE_ENV === 'development') ?
     // eslint-disable-next-line global-require
     compose(applyMiddleware(thunkMiddleware, require('redux-logger').logger))(createStore) :

--- a/client/app/lib/initializers/popup-notifier.jsx
+++ b/client/app/lib/initializers/popup-notifier.jsx
@@ -10,10 +10,7 @@ $(document).ready(() => {
   const mountNode = document.getElementById('popup-notifier');
 
   if (mountNode) {
-    const dataAttr = mountNode.getAttribute('data');
-    const data = JSON.parse(dataAttr);
-    if (data === null) { return; }
-    const store = storeCreator({ popupNotification: data });
+    const store = storeCreator({});
 
     render(
       <ProviderWrapper {...{ store }}>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -368,6 +368,7 @@ Rails.application.routes.draw do
       end
 
       resources :user_notifications do
+        get 'fetch', on: :collection
         post 'mark_as_read', on: :member
       end
     end

--- a/spec/controllers/course/controller_spec.rb
+++ b/spec/controllers/course/controller_spec.rb
@@ -92,49 +92,5 @@ RSpec.describe Course::Controller, type: :controller do
         end
       end
     end
-
-    describe '#next_popup_notification' do
-      render_views
-      let(:student) { create(:course_student, course: course) }
-      let(:user) { student.user }
-
-      subject { JSON.parse(controller.next_popup_notification) }
-
-      context "when the next notification is 'level_reached'" do
-        before do
-          create(:course_level, course: course, experience_points_threshold: 10)
-          course.reload
-          build(:course_experience_points_record, course_user: student, points_awarded: 20, awarder: admin).tap(&:save)
-          get :show, params: { id: course.id }
-        end
-
-        context 'when leaderboard is enabled' do
-          before { get :show, params: { id: course.id } }
-
-          it 'returns the appropriate fields' do
-            expect(subject['notificationType']).to eq('levelReached')
-            expect(subject['levelNumber']).to eq(1)
-            expect(subject['leaderboardEnabled']).to eq(true)
-            expect(subject['leaderboardPosition']).to eq(1)
-          end
-        end
-
-        context 'when leaderboard is disabled' do
-          before do
-            course.settings(:components, :course_leaderboard_component).enabled = false
-            course.save
-            controller.instance_variable_set(:@course, nil)
-            get :show, params: { id: course.id }
-          end
-
-          it 'returns the appropriate fields' do
-            expect(subject['notificationType']).to eq('levelReached')
-            expect(subject['levelNumber']).to eq(1)
-            expect(subject['leaderboardEnabled']).to eq(false)
-            expect(subject['leaderboardPosition']).to eq(nil)
-          end
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Fixes #2936.

Instead of embedding the data for the first popup notification on course pages, pay the cost of an additional request and defer the fetching of the data for the first popup notification.