### PR TITLE
Implement the observer role for CourseUser

### DIFF
--- a/app/controllers/components/course/discussion/topics_component.rb
+++ b/app/controllers/components/course/discussion/topics_component.rb
@@ -40,7 +40,7 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
   def sidebar_path
     if staff_with_students?
       my_students_pending_course_topics_path(current_course)
-    elsif current_course_user&.staff? || current_course_user&.student?
+    elsif current_course_user&.teaching_staff? || current_course_user&.student?
       pending_course_topics_path(current_course)
     else
       course_topics_path(current_course)
@@ -50,7 +50,7 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
   def unread_count
     if staff_with_students?
       my_students_unread_count
-    elsif current_course_user&.staff?
+    elsif current_course_user&.teaching_staff?
       all_staff_unread_count
     elsif current_course_user&.student?
       all_student_unread_count

--- a/app/controllers/components/course/groups_component.rb
+++ b/app/controllers/components/course/groups_component.rb
@@ -7,7 +7,7 @@ class Course::GroupsComponent < SimpleDelegator
   end
 
   def sidebar_items
-    return [] unless can_manage_group?
+    return [] unless show_group_sidebar_item?
 
     [
       {
@@ -23,8 +23,8 @@ class Course::GroupsComponent < SimpleDelegator
 
   private
 
-  def can_manage_group?
-    can?(:manage, Course::Group.new(course: current_course)) || !manageable_groups.empty?
+  def show_group_sidebar_item?
+    can?(:read, Course::Group.new(course: current_course)) || !manageable_groups.empty?
   end
 
   def manageable_groups

--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -18,7 +18,7 @@ module Course::Discussion::PostsConcern
   def update_topic_pending_status
     return true if !current_course_user || skip_update_topic_status
 
-    if current_course_user.staff?
+    if current_course_user.teaching_staff?
       @post.topic.unmark_as_pending
     else
       @post.topic.mark_as_pending

--- a/app/controllers/course/groups_controller.rb
+++ b/app/controllers/course/groups_controller.rb
@@ -7,6 +7,11 @@ class Course::GroupsController < Course::ComponentController
     @groups = @groups.ordered_by_name.includes(group_users: { course_user: :course })
   end
 
+  def show #:nodoc:
+    @group_users = @group.group_users.includes(:course_user)
+    @group_managers, @group_users = @group_users.partition(&:manager?)
+  end
+
   def new #:nodoc:
   end
 

--- a/app/models/components/ability_host.rb
+++ b/app/models/components/ability_host.rb
@@ -18,22 +18,39 @@ class AbilityHost
       { course_users: course_users }
     end
 
-    # @return [Hash] The hash is relative to a component which has a +belongs_to+ association with
-    #   a Course.
+    # @return [Hash] Hash relative to a component with a +has_many+ association with CourseUser.
+    def staff_hash
+      course_user_hash(*CourseUser::STAFF_ROLES.to_a)
+    end
+
+    # @return [Hash] Hash relative to a component with a +has_many+ association with CourseUser.
+    def teaching_staff_hash
+      course_user_hash(*CourseUser::TEACHING_STAFF_ROLES.to_a)
+    end
+
+    # @return [Hash] Hash relative to a component with a +has_many+ association with CourseUser.
+    def managers_hash
+      course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
+    end
+
+    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
     def course_course_user_hash(*roles)
       { course: course_user_hash(*roles) }
     end
 
     alias_method :course_all_course_users_hash, :course_course_user_hash
 
-    # @return [Hash] The hash is relative to a component which has a +belongs_to+ association with
-    #   a Course.
+    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
     def course_staff_hash
       course_course_user_hash(*CourseUser::STAFF_ROLES.to_a)
     end
 
-    # @return [Hash] The hash is relative to a component which has a +belongs_to+ association with
-    #   a Course.
+    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
+    def course_teaching_staff_hash
+      course_course_user_hash(*CourseUser::TEACHING_STAFF_ROLES.to_a)
+    end
+
+    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
     def course_managers_hash
       course_course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
     end

--- a/app/models/components/course/achievements_ability_component.rb
+++ b/app/models/components/course/achievements_ability_component.rb
@@ -6,9 +6,10 @@ module Course::AchievementsAbilityComponent
     if course_user
       allow_read_achievements
       allow_user_with_achievement_show_badges
-    end
 
-    allow_manage_achievements if course_user&.staff?
+      allow_read_draft_achievements_and_display_badge if course_user.staff?
+      allow_manage_achievements if course_user.teaching_staff?
+    end
 
     do_not_allow_award_automatically_awarded_achievements
 
@@ -23,6 +24,10 @@ module Course::AchievementsAbilityComponent
 
   def allow_user_with_achievement_show_badges
     can :display_badge, Course::Achievement, course_user_achievements: { course_user_id: course_user.id }
+  end
+
+  def allow_read_draft_achievements_and_display_badge
+    can [:read, :display_badge], Course::Achievement, course_id: course.id
   end
 
   def allow_manage_achievements

--- a/app/models/components/course/announcements_ability_component.rb
+++ b/app/models/components/course/announcements_ability_component.rb
@@ -5,7 +5,8 @@ module Course::AnnouncementsAbilityComponent
   def define_permissions
     if user
       allow_students_show_announcements
-      allow_staff_manage_announcements
+      allow_staff_read_announcements
+      allow_teaching_staff_manage_announcements
     end
 
     super
@@ -18,7 +19,11 @@ module Course::AnnouncementsAbilityComponent
         course_all_course_users_hash.reverse_merge(already_started_hash)
   end
 
-  def allow_staff_manage_announcements
-    can :manage, Course::Announcement, course_staff_hash
+  def allow_staff_read_announcements
+    can :read, Course::Announcement, course_staff_hash
+  end
+
+  def allow_teaching_staff_manage_announcements
+    can :manage, Course::Announcement, course_teaching_staff_hash
   end
 end

--- a/app/models/components/course/conditions_ability_component.rb
+++ b/app/models/components/course/conditions_ability_component.rb
@@ -3,17 +3,17 @@ module Course::ConditionsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_staff_manage_conditions if user
+    allow_teaching_staff_manage_conditions if user
 
     super
   end
 
   private
 
-  def allow_staff_manage_conditions
-    can :manage, Course::Condition, course_staff_hash
-    can :manage, Course::Condition::Achievement, condition: course_staff_hash
-    can :manage, Course::Condition::Assessment, condition: course_staff_hash
-    can :manage, Course::Condition::Level, condition: course_staff_hash
+  def allow_teaching_staff_manage_conditions
+    can :manage, Course::Condition, course_teaching_staff_hash
+    can :manage, Course::Condition::Achievement, condition: course_teaching_staff_hash
+    can :manage, Course::Condition::Assessment, condition: course_teaching_staff_hash
+    can :manage, Course::Condition::Level, condition: course_teaching_staff_hash
   end
 end

--- a/app/models/components/course/course_ability_component.rb
+++ b/app/models/components/course/course_ability_component.rb
@@ -7,8 +7,8 @@ module Course::CourseAbilityComponent
       allow_instructors_create_courses
       allow_unregistered_users_registering_courses
       allow_registered_users_showing_course
-      allow_owners_managing_course
       allow_staff_manage_users
+      allow_owners_managing_course
     end
 
     super
@@ -29,13 +29,14 @@ module Course::CourseAbilityComponent
     can :read, Course, course_user_hash
   end
 
-  def allow_owners_managing_course
-    can :manage, Course, course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
-    can :manage, CourseUser, course_managers_hash
-    can :manage, Course::EnrolRequest, course_managers_hash
+  def allow_staff_manage_users
+    can :show_users, Course, staff_hash
+    can :manage_users, Course, teaching_staff_hash
   end
 
-  def allow_staff_manage_users
-    can [:show_users, :manage_users], Course, course_user_hash(*CourseUser::STAFF_ROLES.to_a)
+  def allow_owners_managing_course
+    can :manage, Course, managers_hash
+    can :manage, CourseUser, course_managers_hash
+    can :manage, Course::EnrolRequest, course_managers_hash
   end
 end

--- a/app/models/components/course/discussions_ability_component.rb
+++ b/app/models/components/course/discussions_ability_component.rb
@@ -6,10 +6,10 @@ module Course::DiscussionsAbilityComponent
     if user
       allow_course_users_show_topics
       allow_course_users_mark_topics_as_read
-      allow_staff_manage_discussion_topics
+      allow_course_teaching_staff_manage_discussion_topics
       allow_course_users_create_posts
       allow_course_users_reply_and_vote_posts
-      allow_course_staff_manage_posts
+      allow_course_teaching_staff_manage_posts
       allow_course_users_update_delete_own_post
     end
 
@@ -26,8 +26,8 @@ module Course::DiscussionsAbilityComponent
     can :mark_as_read, Course::Discussion::Topic, course_all_course_users_hash
   end
 
-  def allow_staff_manage_discussion_topics
-    can :manage, Course::Discussion::Topic, course_staff_hash
+  def allow_course_teaching_staff_manage_discussion_topics
+    can :manage, Course::Discussion::Topic, course_teaching_staff_hash
   end
 
   def allow_course_users_create_posts
@@ -38,8 +38,8 @@ module Course::DiscussionsAbilityComponent
     can [:reply, :vote], Course::Discussion::Post, topic: course_all_course_users_hash
   end
 
-  def allow_course_staff_manage_posts
-    can :manage, Course::Discussion::Post, topic: course_staff_hash
+  def allow_course_teaching_staff_manage_posts
+    can :manage, Course::Discussion::Post, topic: course_teaching_staff_hash
   end
 
   def allow_course_users_update_delete_own_post

--- a/app/models/components/course/duplication_ability_component.rb
+++ b/app/models/components/course/duplication_ability_component.rb
@@ -7,6 +7,7 @@ module Course::DuplicationAbilityComponent
       disallow_superusers_duplicate_via_frontend
       allow_managers_duplicate_to_course
       allow_managers_duplicate_from_course
+      allow_observers_duplicate_from_course
     end
 
     super
@@ -22,10 +23,14 @@ module Course::DuplicationAbilityComponent
   end
 
   def allow_managers_duplicate_to_course
-    can :duplicate_to, Course, course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
+    can :duplicate_to, Course, managers_hash
   end
 
   def allow_managers_duplicate_from_course
-    can :duplicate_from, Course, course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
+    can :duplicate_from, Course, managers_hash
+  end
+
+  def allow_observers_duplicate_from_course
+    can :duplicate_from, Course, course_user_hash(:observer)
   end
 end

--- a/app/models/components/course/experience_points_disbursement_ability_component.rb
+++ b/app/models/components/course/experience_points_disbursement_ability_component.rb
@@ -11,7 +11,7 @@ module Course::ExperiencePointsDisbursementAbilityComponent
   private
 
   def allow_staff_disburse_experience_points
-    can :disburse, Course::ExperiencePoints::Disbursement, course_staff_hash
-    can :disburse, Course::ExperiencePoints::ForumDisbursement, course_staff_hash
+    can :disburse, Course::ExperiencePoints::Disbursement, course_teaching_staff_hash
+    can :disburse, Course::ExperiencePoints::ForumDisbursement, course_teaching_staff_hash
   end
 end

--- a/app/models/components/course/experience_points_records_ability_component.rb
+++ b/app/models/components/course/experience_points_records_ability_component.rb
@@ -3,7 +3,8 @@ module Course::ExperiencePointsRecordsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_manage_experience_points_records if course_user&.staff?
+    allow_manage_experience_points_records if course_user&.teaching_staff?
+    allow_read_course_experience_points_records if course_user&.observer?
     allow_read_own_experience_points_records if user
 
     super
@@ -13,6 +14,10 @@ module Course::ExperiencePointsRecordsAbilityComponent
 
   def allow_manage_experience_points_records
     can :manage, Course::ExperiencePointsRecord, course_user: { course_id: course.id }
+  end
+
+  def allow_read_course_experience_points_records
+    can :read, Course::ExperiencePointsRecord, course_user: { course_id: course.id }
   end
 
   def allow_read_own_experience_points_records

--- a/app/models/components/course/forums_ability_component.rb
+++ b/app/models/components/course/forums_ability_component.rb
@@ -10,8 +10,9 @@ module Course::ForumsAbilityComponent
       allow_students_update_topics
       allow_student_reply_unlocked_topics
       allow_student_resolve_own_topics
-      allow_staff_manage_forums
-      allow_staff_manage_topics
+      allow_staff_show_all_topics
+      allow_teaching_staff_manage_forums
+      allow_teaching_staff_manage_topics
     end
 
     super
@@ -25,6 +26,10 @@ module Course::ForumsAbilityComponent
 
   def topic_course_staff_hash
     { forum: course_staff_hash }
+  end
+
+  def topic_course_teaching_staff_hash
+    { forum: course_teaching_staff_hash }
   end
 
   def allow_students_show_forums
@@ -55,11 +60,16 @@ module Course::ForumsAbilityComponent
     can :toggle_answer, Course::Forum::Topic, creator_id: user.id
   end
 
-  def allow_staff_manage_forums
-    can :manage, Course::Forum, course_staff_hash
+  def allow_staff_show_all_topics
+    can :read, Course::Forum::Topic, topic_course_staff_hash
+    can :subscribe, Course::Forum::Topic, topic_course_staff_hash
   end
 
-  def allow_staff_manage_topics
-    can :manage, Course::Forum::Topic, topic_course_staff_hash
+  def allow_teaching_staff_manage_forums
+    can :manage, Course::Forum, course_teaching_staff_hash
+  end
+
+  def allow_teaching_staff_manage_topics
+    can :manage, Course::Forum::Topic, topic_course_teaching_staff_hash
   end
 end

--- a/app/models/components/course/groups_ability_component.rb
+++ b/app/models/components/course/groups_ability_component.rb
@@ -4,7 +4,8 @@ module Course::GroupsAbilityComponent
 
   def define_permissions
     if user
-      allow_staff_manage_groups
+      allow_staff_read_groups
+      allow_teaching_staff_manage_groups
       allow_group_manager_manage_group
     end
 
@@ -13,8 +14,12 @@ module Course::GroupsAbilityComponent
 
   private
 
-  def allow_staff_manage_groups
-    can :manage, Course::Group, course_staff_hash
+  def allow_staff_read_groups
+    can :read, Course::Group, course_staff_hash
+  end
+
+  def allow_teaching_staff_manage_groups
+    can :manage, Course::Group, course_teaching_staff_hash
   end
 
   def allow_group_manager_manage_group

--- a/app/models/components/course/lesson_plan_ability_component.rb
+++ b/app/models/components/course/lesson_plan_ability_component.rb
@@ -5,7 +5,8 @@ module Course::LessonPlanAbilityComponent
   def define_permissions
     if user
       allow_registered_users_showing_milestones_items
-      allow_course_staff_manage_lesson_plans
+      allow_course_staff_show_items
+      allow_course_teaching_staff_manage_lesson_plans
       allow_own_users_to_ignore_own_todos
     end
 
@@ -20,10 +21,14 @@ module Course::LessonPlanAbilityComponent
     can :read, Course::LessonPlan::Event, lesson_plan_item: course_all_course_users_hash
   end
 
-  def allow_course_staff_manage_lesson_plans
-    can :manage, Course::LessonPlan::Milestone, course_staff_hash
-    can :manage, Course::LessonPlan::Item, course_staff_hash
-    can :manage, Course::LessonPlan::Event, lesson_plan_item: course_staff_hash
+  def allow_course_staff_show_items
+    can :read, Course::LessonPlan::Item, course_staff_hash
+  end
+
+  def allow_course_teaching_staff_manage_lesson_plans
+    can :manage, Course::LessonPlan::Milestone, course_teaching_staff_hash
+    can :manage, Course::LessonPlan::Item, course_teaching_staff_hash
+    can :manage, Course::LessonPlan::Event, lesson_plan_item: course_teaching_staff_hash
   end
 
   def allow_own_users_to_ignore_own_todos

--- a/app/models/components/course/statistics_ability_component.rb
+++ b/app/models/components/course/statistics_ability_component.rb
@@ -11,6 +11,6 @@ module Course::StatisticsAbilityComponent
   private
 
   def allow_staff_read_statistics
-    can :read_statistics, Course, course_user_hash(*CourseUser::STAFF_ROLES.to_a)
+    can :read_statistics, Course, staff_hash
   end
 end

--- a/app/models/components/course/virtual_classrooms_ability_component.rb
+++ b/app/models/components/course/virtual_classrooms_ability_component.rb
@@ -18,7 +18,7 @@ module Course::VirtualClassroomsAbilityComponent
   end
 
   def allow_staff_manage_virtual_classrooms
-    can :manage, Course::VirtualClassroom, course_staff_hash
-    can :access_recorded_videos, Course, course_user_hash(*CourseUser::STAFF_ROLES.to_a)
+    can :manage, Course::VirtualClassroom, course_teaching_staff_hash
+    can :access_recorded_videos, Course, staff_hash
   end
 end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -7,10 +7,13 @@ class CourseUser < ApplicationRecord
   after_initialize :set_defaults, if: :new_record?
   before_validation :set_defaults, if: :new_record?
 
-  enum role: { student: 0, teaching_assistant: 1, manager: 2, owner: 3 }
+  enum role: { student: 0, teaching_assistant: 1, manager: 2, owner: 3, observer: 4 }
 
-  # A set of roles which comprise the staff of a course.
-  STAFF_ROLES = Set[:teaching_assistant, :manager, :owner].freeze
+  # A set of roles which comprise the staff of a course, including the observer.
+  STAFF_ROLES = Set[:teaching_assistant, :manager, :owner, :observer].freeze
+
+  # A set of roles which comprise of the teaching staff of a course.
+  TEACHING_STAFF_ROLES = Set[:teaching_assistant, :manager, :owner].freeze
 
   # A set of roles which comprise the teaching assistants and managers of a course.
   TA_AND_MANAGER_ROLES = Set[:teaching_assistant, :manager].freeze
@@ -65,6 +68,7 @@ class CourseUser < ApplicationRecord
   # Gets the staff associated with the course.
   # TODO: Remove the map when Rails 5 is released.
   scope :staff, -> { where(role: STAFF_ROLES.map { |x| roles[x] }) }
+  scope :teaching_staff, -> { where(role: TEACHING_STAFF_ROLES.map { |x| roles[x] }) }
   scope :teaching_assistant_and_manager, (lambda do
     where(role: TA_AND_MANAGER_ROLES.map { |x| roles[x] })
   end)
@@ -118,11 +122,18 @@ class CourseUser < ApplicationRecord
     MANAGER_ROLES.include?(role.to_sym)
   end
 
-  # Test whether this course_user is a staff (i.e. teaching_assistant, manager or owner)
+  # Test whether this course_user is a staff (i.e. teaching_assistant, manager, owner or observer)
   #
   # @return [Boolean] True if course_user is a staff
   def staff?
     STAFF_ROLES.include?(role.to_sym)
+  end
+
+  # Test whether this course_user is a teaching staff (i.e. teaching_assistant, manager or owner)
+  #
+  # @return [Boolean] True if course_user is a staff
+  def teaching_staff?
+    TEACHING_STAFF_ROLES.include?(role.to_sym)
   end
 
   # Test whether this course_user is a real student (i.e. not phantom and not staff)

--- a/app/views/course/discussion/topics/_tabs.html.slim
+++ b/app/views/course/discussion/topics/_tabs.html.slim
@@ -1,4 +1,4 @@
-- if current_course_user&.staff? || can?(:manage, current_course)
+- if current_course_user&.teaching_staff? || can?(:manage, current_course)
   = tabs do
     = nav_to my_students_pending_course_topics_path(current_course) do
       = t('.my_students_pending')

--- a/app/views/course/groups/_group.html.slim
+++ b/app/views/course/groups/_group.html.slim
@@ -1,5 +1,5 @@
 = content_tag_for(:tr, group) do
-  th = format_inline_text(group.name)
+  th = link_to format_inline_text(group.name), course_group_path(current_course, group)
   td = group.course_users.without_phantom_users.count
   td = group.course_users.phantom.count
   td = group.course_users.count
@@ -9,5 +9,6 @@
         = link_to_course_user(manager) do
           = format_inline_text(manager.name)
   td
-    = edit_button(edit_course_group_path(current_course, group))
-    = delete_button(course_group_path(current_course, group))
+    - if can?(:manage, group)
+      = edit_button(edit_course_group_path(current_course, group))
+      = delete_button(course_group_path(current_course, group))

--- a/app/views/course/groups/show.html.slim
+++ b/app/views/course/groups/show.html.slim
@@ -1,0 +1,24 @@
+- add_breadcrumb @group.name
+= page_header format_inline_text(@group.name) do
+  - if can?(:manage, @group)
+    div.pull-right.btn-group
+      = edit_button(edit_course_group_path(current_course, @group))
+      = delete_button(course_group_path(current_course, @group))
+
+- if @group_managers
+  h3 = t('.managers')
+  table.table.table-bordered
+    tbody
+      - @group_managers.each do |group_manager|
+        tr
+          th = link_to group_manager.course_user.name,
+                       course_user_path(current_course, group_manager.course_user)
+
+- if @group_users
+  h3 = t('.members')
+  table.table.table-bordered
+    tbody
+      - @group_users.each do |group_user|
+        tr
+          th = link_to group_user.course_user.name,
+                       course_user_path(current_course, group_user.course_user)

--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -11,10 +11,11 @@ div
       tr
         td = f.input :id, collection: @student_options,
                           label: false, selected: @student_options.first
-        td = f.input :role, collection: CourseUser::STAFF_ROLES,
+        / TODO: Change to CourseUser::STAFF_ROLES once Observer role is fully implemented.
+        td = f.input :role, collection: CourseUser::TEACHING_STAFF_ROLES,
                             label: false,
                             label_method: lambda { |role_key| t("course.users.role.#{role_key}") },
-                            selected: CourseUser::STAFF_ROLES.first
+                            selected: CourseUser::TEACHING_STAFF_ROLES.first
         td = f.button :submit, t('.upgrade_to_staff')
 
 div.users

--- a/config/locales/en/course/groups.yml
+++ b/config/locales/en/course/groups.yml
@@ -9,6 +9,9 @@ en:
         phantom: 'Phantom'
         total: 'Total'
         managers: 'Managers'
+      show:
+        managers: :'course.groups.index.managers'
+        members: 'Members'
       new:
         header: 'New Group'
       create:

--- a/config/locales/en/course/users.yml
+++ b/config/locales/en/course/users.yml
@@ -5,6 +5,7 @@ en:
       role:
         student: 'Student'
         teaching_assistant: 'Teaching Assistant'
+        observer: 'Observer'
         manager: 'Manager'
         owner: 'Owner'
         phantom: 'Phantom'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,7 +311,7 @@ Rails.application.routes.draw do
       get 'staff' => 'users#staff', as: :users_staff
       patch 'upgrade_to_staff' => 'users#upgrade_to_staff', as: :users_upgrade_to_staff
 
-      resources :groups, except: [:show]
+      resources :groups
 
       namespace :material, path: 'materials' do
         resources :folders, except: [:index, :new, :create] do

--- a/spec/factories/course_users.rb
+++ b/spec/factories/course_users.rb
@@ -29,5 +29,10 @@ FactoryBot.define do
       role :owner
       sequence(:name) { |n| "owner #{n}" }
     end
+
+    factory :course_observer, parent: :course_user do
+      role :observer
+      sequence(:name) { |n| "observer #{n}" }
+    end
   end
 end

--- a/spec/features/course/group_management_spec.rb
+++ b/spec/features/course/group_management_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Courses: Groups' do
         visit course_groups_path(course)
 
         expect do
-          find_link(nil, href: group_delete_path).click
+          find_link(nil, class: 'delete', href: group_delete_path).click
         end.to change { course.groups.count }.by(-1)
 
         expect(page).to have_selector('div',
@@ -105,7 +105,7 @@ RSpec.feature 'Courses: Groups' do
         visit course_groups_path(course)
 
         expect do
-          find_link(nil, href: delete_path).click
+          find_link(nil, class: 'delete', href: delete_path).click
         end.to change { course.groups.count }.by(-1)
 
         expect(page).to have_selector('div', text: I18n.t('course.groups.destroy.success'))

--- a/spec/models/course/achievement_ability_spec.rb
+++ b/spec/models/course/achievement_ability_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Course::Achievement do
       end
     end
 
-    context 'when the user is a Course Staff' do
-      let(:course_user) { create(:course_manager, course: course) }
+    context 'when the user is a Course Teaching Staff' do
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
       let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, achievement) }
@@ -53,6 +53,18 @@ RSpec.describe Course::Achievement do
 
         it { is_expected.not_to be_able_to(:award, achievement) }
       end
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
+
+      it { is_expected.to be_able_to(:read, achievement) }
+      it { is_expected.to be_able_to(:read, draft_achievement) }
+      it { is_expected.to be_able_to(:display_badge, achievement) }
+      it { is_expected.to be_able_to(:display_badge, draft_achievement) }
+      it { is_expected.not_to be_able_to(:manage, achievement) }
+      it { is_expected.not_to be_able_to(:manage, draft_achievement) }
     end
   end
 end

--- a/spec/models/course/announcement_ability_spec.rb
+++ b/spec/models/course/announcement_ability_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Course::Announcement do
       end
     end
 
-    context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+    context 'when the user is a Course Teaching Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       it { is_expected.to be_able_to(:manage, valid_announcement) }
       it { is_expected.to be_able_to(:manage, ended_announcement) }
@@ -35,6 +35,17 @@ RSpec.describe Course::Announcement do
         expect(course.announcements.accessible_by(subject)).
           to contain_exactly(not_started_announcement, valid_announcement, ended_announcement)
       end
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:read, valid_announcement) }
+      it { is_expected.to be_able_to(:read, ended_announcement) }
+      it { is_expected.to be_able_to(:read, not_started_announcement) }
+      it { is_expected.not_to be_able_to(:manage, valid_announcement) }
+      it { is_expected.not_to be_able_to(:manage, ended_announcement) }
+      it { is_expected.not_to be_able_to(:manage, not_started_announcement) }
     end
   end
 end

--- a/spec/models/course/experience_points_record_ability_spec.rb
+++ b/spec/models/course/experience_points_record_ability_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Course::ExperiencePointsRecord do
       end
     end
 
-    context 'when the user is a Course Staff' do
-      let(:course_user) { create(:course_manager, course: course) }
+    context 'when the user is a Course Teaching Staff' do
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
       let(:user) { course_user.user }
       let(:foreign_points_record) { create(:course_experience_points_record) }
 
@@ -66,6 +66,22 @@ RSpec.describe Course::ExperiencePointsRecord do
         it "cannot access the student's experience points history" do
           records = foreign_points_record.course_user.experience_points_records
           expect(records.accessible_by(subject)).to be_empty
+        end
+      end
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
+
+      context 'when record belongs to a student from the same course' do
+        it { is_expected.to be_able_to(:read, points_record) }
+        it { is_expected.not_to be_able_to(:create, points_record) }
+        it { is_expected.not_to be_able_to(:update, points_record) }
+        it { is_expected.not_to be_able_to(:destroy, points_record) }
+        it "can access the student's experience points history" do
+          expect(course_student.experience_points_records.accessible_by(subject)).
+            to contain_exactly(points_record)
         end
       end
     end

--- a/spec/models/course/forum/topic_ability_spec.rb
+++ b/spec/models/course/forum/topic_ability_spec.rb
@@ -43,5 +43,14 @@ RSpec.describe Course::Forum::Topic, type: :model do
       it { is_expected.to be_able_to(:manage, shown_topic) }
       it { is_expected.to be_able_to(:manage, hidden_topic) }
     end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:show, shown_topic) }
+      it { is_expected.to be_able_to(:show, hidden_topic) }
+      it { is_expected.not_to be_able_to(:manage, hidden_topic) }
+      it { is_expected.not_to be_able_to(:manage, shown_topic) }
+    end
   end
 end

--- a/spec/models/course/forum_ability_spec.rb
+++ b/spec/models/course/forum_ability_spec.rb
@@ -14,10 +14,17 @@ RSpec.describe Course::Forum, type: :model do
       it { is_expected.to be_able_to(:show, forum) }
     end
 
-    context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+    context 'when the user is a Course Teaching Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       it { is_expected.to be_able_to(:manage, forum) }
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:read, forum) }
+      it { is_expected.not_to be_able_to(:manage, forum) }
     end
   end
 end

--- a/spec/models/course/group_ability_spec.rb
+++ b/spec/models/course/group_ability_spec.rb
@@ -11,13 +11,20 @@ RSpec.describe Course::Group do
     let!(:group) { create(:course_group, course: course) }
 
     context 'when the user is a Course Staff' do
-      let!(:course_manager) { create(:course_manager, course: course, user: user) }
+      let!(:course_manager) { create(:course_teaching_assistant, course: course, user: user) }
 
       it { is_expected.to be_able_to(:manage, group) }
 
       it 'sees all groups' do
         expect(course.groups.accessible_by(subject)).to contain_exactly(group)
       end
+    end
+
+    context 'when the user is a Course Observer' do
+      let!(:course_observer) { create(:course_observer, course: course, user: user) }
+
+      it { is_expected.to be_able_to(:read, group) }
+      it { is_expected.not_to be_able_to(:manage, group) }
     end
 
     context 'when the user is a Group Manager' do

--- a/spec/models/course/lesson_plan/lesson_plan_item_ability_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_ability_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe Course::LessonPlan::Item do
   with_tenant(:instance) do
     subject { Ability.new(user) }
     let(:course) { create(:course) }
+    let(:unpublished_item) { create(:course_lesson_plan_item, course: course) }
     let(:lesson_plan_item) { create(:course_lesson_plan_item, course: course, published: true) }
 
-    context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+    context 'when the user is a Course Teaching Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       it { is_expected.to be_able_to(:manage, lesson_plan_item) }
+      it { is_expected.to be_able_to(:show, unpublished_item) }
 
       it 'allows him to see all lesson plan items' do
         expect(course.lesson_plan_items.accessible_by(subject)).
@@ -20,10 +22,18 @@ RSpec.describe Course::LessonPlan::Item do
       end
     end
 
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:show, lesson_plan_item) }
+      it { is_expected.to be_able_to(:show, unpublished_item) }
+    end
+
     context 'when the user is a Course Student' do
       let(:user) { create(:course_student, course: course).user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_item) }
+      it { is_expected.not_to be_able_to(:show, unpublished_item) }
       it { is_expected.not_to be_able_to(:manage, lesson_plan_item) }
 
       it 'allows him to see all lesson plan items' do

--- a/spec/models/course/statistics_ability_spec.rb
+++ b/spec/models/course/statistics_ability_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course, type: :model do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    subject { Ability.new(user) }
+    let(:course) { create(:course) }
+
+    context 'when the user is a Course Student' do
+      let(:user) { create(:course_student, course: course).user }
+
+      it { is_expected.not_to be_able_to(:read_statistics, course) }
+    end
+
+    context 'when the user is a Course Teaching Assistant' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
+
+      it { is_expected.to be_able_to(:read_statistics, course) }
+    end
+
+    context 'when the user is a Course Manager' do
+      let(:user) { create(:course_manager, course: course).user }
+
+      it { is_expected.to be_able_to(:read_statistics, course) }
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:read_statistics, course) }
+    end
+  end
+end

--- a/spec/models/course/virtual_classroom_ability_spec.rb
+++ b/spec/models/course/virtual_classroom_ability_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe Course::VirtualClassroom do
       it { is_expected.to be_able_to(:show, not_started_virtual_classroom) }
       it { is_expected.not_to be_able_to(:manage, valid_virtual_classroom) }
       it { is_expected.not_to be_able_to(:access_recorded_videos, course) }
-
-      it 'sees the started virtual_classrooms' do
-        expect(course.virtual_classrooms.accessible_by(subject)).
-          to contain_exactly(valid_virtual_classroom, ended_virtual_classroom,
-                             not_started_virtual_classroom)
-      end
     end
 
     context 'when the user is a Course Staff' do
@@ -34,12 +28,14 @@ RSpec.describe Course::VirtualClassroom do
       it { is_expected.to be_able_to(:manage, valid_virtual_classroom) }
       it { is_expected.to be_able_to(:manage, ended_virtual_classroom) }
       it { is_expected.to be_able_to(:manage, not_started_virtual_classroom) }
+      it { is_expected.to be_able_to(:access_recorded_videos, course) }
+    end
 
-      it 'sees all virtual_classrooms' do
-        expect(course.virtual_classrooms.accessible_by(subject)).
-          to contain_exactly(not_started_virtual_classroom, valid_virtual_classroom,
-                             ended_virtual_classroom)
-      end
+    context 'when the users is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:access_recorded_videos, course) }
+      it { is_expected.not_to be_able_to(:manage, valid_virtual_classroom) }
     end
   end
 end

--- a/spec/models/course_ability_spec.rb
+++ b/spec/models/course_ability_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Course, type: :model do
       it { is_expected.not_to be_able_to(:show, published_course) }
       it { is_expected.not_to be_able_to(:show, enrollable_course) }
       it { is_expected.not_to be_able_to(:show, closed_course) }
+      it { is_expected.not_to be_able_to(:show_users, course) }
+      it { is_expected.not_to be_able_to(:manage_users, course) }
     end
 
     context 'when the user is a Course Student' do
@@ -24,6 +26,8 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
+      it { is_expected.not_to be_able_to(:show_users, course) }
+      it { is_expected.not_to be_able_to(:manage_users, course) }
     end
 
     context 'when the user is a Course Teaching Assistant' do
@@ -31,6 +35,8 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
+      it { is_expected.to be_able_to(:show_users, course) }
+      it { is_expected.to be_able_to(:manage_users, course) }
     end
 
     context 'when the user is a Course Manager' do
@@ -38,6 +44,17 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.to be_able_to(:manage, course) }
+      it { is_expected.to be_able_to(:show_users, course) }
+      it { is_expected.to be_able_to(:manage_users, course) }
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:show, course) }
+      it { is_expected.not_to be_able_to(:manage, course) }
+      it { is_expected.to be_able_to(:show_users, course) }
+      it { is_expected.not_to be_able_to(:manage_users, course) }
     end
   end
 end

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe CourseUser, type: :model do
     let(:course) { create(:course, creator: owner, updater: owner) }
     let!(:student) { create(:course_student, course: course) }
     let(:phantom_student) { create(:course_student, :phantom, course: course) }
+    let(:observer) { create(:course_observer, course: course) }
     let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
     let(:manager) { create(:course_manager, course: course) }
     let(:course_owner) { course.course_users.find_by!(user: owner) }
@@ -61,6 +62,12 @@ RSpec.describe CourseUser, type: :model do
     describe '.student' do
       it 'returns only student' do
         expect(course.course_users.student).to contain_exactly(student)
+      end
+    end
+
+    describe '.observer' do
+      it 'returns only observer' do
+        expect(course.course_users.observer).to contain_exactly(observer)
       end
     end
 
@@ -155,17 +162,29 @@ RSpec.describe CourseUser, type: :model do
     end
 
     describe '#staff?' do
-      it 'returns true if the role is teaching assistant, manager or owner' do
+      it 'returns true if the role is observer, teaching assistant, manager or owner' do
         expect(student.staff?).to be_falsey
+        expect(observer.staff?).to be_truthy
         expect(teaching_assistant.staff?).to be_truthy
         expect(manager.staff?).to be_truthy
         expect(course_owner.staff?).to be_truthy
       end
     end
 
+    describe '#teaching_staff?' do
+      it 'returns true if the role is teaching assistant, manager or owner' do
+        expect(student.teaching_staff?).to be_falsey
+        expect(observer.teaching_staff?).to be_falsey
+        expect(teaching_assistant.teaching_staff?).to be_truthy
+        expect(manager.teaching_staff?).to be_truthy
+        expect(course_owner.teaching_staff?).to be_truthy
+      end
+    end
+
     describe '#manager_or_owner?' do
       it 'returns true if the role is manager or owner' do
         expect(student.manager_or_owner?).to be_falsey
+        expect(observer.manager_or_owner?).to be_falsey
         expect(teaching_assistant.manager_or_owner?).to be_falsey
         expect(manager.manager_or_owner?).to be_truthy
         expect(course_owner.manager_or_owner?).to be_truthy
@@ -176,6 +195,7 @@ RSpec.describe CourseUser, type: :model do
       it 'returns true if the role is student and not phantom' do
         expect(student.real_student?).to be_truthy
         expect(phantom_student.real_student?).to be_falsey
+        expect(observer.manager_or_owner?).to be_falsey
         expect(teaching_assistant.real_student?).to be_falsey
         expect(manager.real_student?).to be_falsey
         expect(course_owner.real_student?).to be_falsey

--- a/spec/models/duplication_ability_spec.rb
+++ b/spec/models/duplication_ability_spec.rb
@@ -35,5 +35,12 @@ RSpec.describe Course, type: :model do
       it { is_expected.to be_able_to(:duplicate_from, course) }
       it { is_expected.to be_able_to(:duplicate_to, course) }
     end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:duplicate_from, course) }
+      it { is_expected.not_to be_able_to(:duplicate_to, course) }
+    end
   end
 end


### PR DESCRIPTION
First part of #2910. See issue and commit messages for more details. 

Second part will implement the rest of the components, as well as fix user controller and user invitations to allow for the `observer` role.

The current PR only implements the backend logic, and currently there is no way for any user to convert any `CourseUser` into an observer (unless a Database / `rails c` command is used). 