### PR TITLE
Redesign of Course User Badge

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -46,6 +46,7 @@ $course-user-achievement-badge: $picture-medium !default;
 $course-leaderboard-groupuser-picture: $picture-small !default;
 $course-leaderboard-user-picture: $picture-small !default;
 $course-leaderboard-achievement-badge: $picture-thumb !default;
+$course-user-badge-achievement-badge: $picture-thumb !default;
 $course-user-listing-picture: $picture-small !default;
 $course-user-profile-picture: $picture-large !default;
 

--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -1,24 +1,45 @@
 .course-layout {
   @include timestamp;
 
-  #course-user-badge {
-    #course-user-progress {
-      .progress {
-        margin-bottom: 10px;
-        margin-top: 10px;
+  #course-badge-achievement {
+    margin-bottom: 0.5em;
+    margin-left: 0.5em;
 
-        .course-user-experience-points {
-          min-width: 10em;
-        }
-      }
+    .image > img {
+      height: $course-user-badge-achievement-badge;
+      width: $course-user-badge-achievement-badge;
     }
 
-    #course-user-achievements,
-    #course-user-level {
-      h5,
-      p {
-        text-align: center;
-      }
+    .achievement > a:hover {
+      text-decoration: none;
+    }
+
+    .achievement-difference {
+      margin-left: 6px;
+    }
+  }
+
+  #course-badge-level {
+    margin-left: 0.5em;
+
+    .experience-points {
+      font-weight: 300;
+    }
+
+    .level {
+      font-size: 150%;
+      margin-right: 0.5em;
+    }
+
+    .next-level {
+      font-size: 85%;
+      margin-bottom: 1em;
+    }
+
+    .progress {
+      height: 12px;
+      margin-bottom: 3px;
+      margin-top: 6px;
     }
   }
 

--- a/app/helpers/application_widgets_helper.rb
+++ b/app/helpers/application_widgets_helper.rb
@@ -94,14 +94,17 @@ module ApplicationWidgetsHelper
   # original view_context, rather than within the view_context of the progress bar layout.
   #
   # @param [Integer] percentage The percentage to be displayed on the progress bar.
-  # @param [Array<String>] classes An array of classes to apply to the progress bar.
+  # @param [Hash] opts Options to apply on the progress bar. Supports the following:
+  #                    class: css classes of progress bar (defaults to `progress-bar-info`),
+  #                    tooltip_text: text to be included in tooltip,
+  #                    tooltip_placement: 'left', 'top', 'bottom', or 'right'.
   # @yield The HTML text which will be passed to the partial as text to be shown in the bar.
   # @return [String] HTML string to render the progress bar.
-  def display_progress_bar(percentage, classes = ['progress-bar-info'], &block)
+  def display_progress_bar(percentage, opts = {}, &block)
+    opts[:class] = ['progress-bar-info'] unless opts[:class]
     text_in_block = capture(&block) if block_given?
-    render partial: 'layouts/progress_bar', locals: { percentage: percentage,
-                                                      progress_bar_classes: classes,
-                                                      progress_bar_text: text_in_block }
+    render partial: 'layouts/progress_bar',
+           locals: { percentage: percentage, opts: opts, progress_bar_text: text_in_block }
   end
 
   private

--- a/app/models/concerns/course_user/achievements_concern.rb
+++ b/app/models/concerns/course_user/achievements_concern.rb
@@ -4,4 +4,8 @@ module CourseUser::AchievementsConcern
   def ordered_by_date_obtained
     order('course_user_achievements.obtained_at DESC')
   end
+
+  def recently_obtained(num = 3)
+    ordered_by_date_obtained.last(num)
+  end
 end

--- a/app/views/course/user_invitations/index.html.slim
+++ b/app/views/course/user_invitations/index.html.slim
@@ -5,7 +5,7 @@
 
 - accepted_invitations, pending_invitations = @invitations.partition(&:confirmed?)
 - progress = accepted_invitations.size * 100 / [@invitations.length, 1].max
-= display_progress_bar(progress, []) do
+= display_progress_bar(progress) do
   = t('.progress', accepted: accepted_invitations.size, total: @invitations.size)
 
 = simple_format t('.manual_acceptance')

--- a/app/views/layouts/_course_user_badge.html.slim
+++ b/app/views/layouts/_course_user_badge.html.slim
@@ -1,17 +1,32 @@
-div#course-user-badge
-  div.col-xs-12#course-user-progress
-    - progress_bar_classes = { class: ['progress-bar-info', 'progress-bar-striped',
-                                       'course-user-experience-points'] }
-    = display_progress_bar(course_user.level_progress_percentage, progress_bar_classes) do
-      = t('.progress', current: course_user.experience_points,
-                       next: course_user.next_level_threshold)
-  div.col-xs-6#course-user-achievements
-    - unless current_component_host[:course_achievements_component].nil?
-      = link_to course_achievements_path(course_user.course) do
-        h5 = t('.achievements')
-        p = course_user.achievement_count
-  div.col-xs-6#course-user-level
-    - unless current_component_host[:course_levels_component].nil?
-      = link_to_course_user(course_user) do
-        h5 = t('.levels')
-        p = course_user.level_number
+- levels_enabled = !current_component_host[:course_levels_component].nil?
+- achievements_enabled = !current_component_host[:course_achievements_component].nil?
+
+- if levels_enabled
+  - level_number = course_user.level_number
+  - percentage = course_user.level_progress_percentage
+  - experience_points = course_user.experience_points
+  - next_threshold = course_user.next_level_threshold
+  - difference = next_threshold - experience_points
+
+  div.col-xs-12#course-badge-level
+    = link_to_course_user(course_user) do
+      span.level = t('.level', level: level_number)
+      span.experience-points = t('.experience_points', exp: experience_points)
+
+    - progress_bar_options = { class: ['progress-bar-info', 'course-user-experience-points'],
+                               tooltip_text: t('common.percentage', percentage: percentage),
+                               tooltip_placement: 'right' }
+    = display_progress_bar(percentage, progress_bar_options)
+    div.next-level.text-center
+      = t('.next_level', difference: difference)
+
+- if achievements_enabled
+  div.col-xs-12#course-badge-achievement
+    - course_user.achievements.recently_obtained(3).each do |achievement|
+      = content_tag_for(:span, achievement) do
+        = link_to course_achievement_path(current_course, achievement) do
+          = display_achievement_badge(achievement)
+    - if course_user.achievement_count > 3
+      - difference = course_user.achievement_count - 3
+      = link_to t('.achievements', difference: difference),
+                course_achievements_path(current_course), class: ['achievement-difference']

--- a/app/views/layouts/_course_user_badge.html.slim
+++ b/app/views/layouts/_course_user_badge.html.slim
@@ -1,7 +1,7 @@
 div#course-user-badge
   div.col-xs-12#course-user-progress
-    - progress_bar_classes = ['progress-bar-info', 'progress-bar-striped',
-                              'course-user-experience-points']
+    - progress_bar_classes = { class: ['progress-bar-info', 'progress-bar-striped',
+                                       'course-user-experience-points'] }
     = display_progress_bar(course_user.level_progress_percentage, progress_bar_classes) do
       = t('.progress', current: course_user.experience_points,
                        next: course_user.next_level_threshold)

--- a/app/views/layouts/_progress_bar.html.slim
+++ b/app/views/layouts/_progress_bar.html.slim
@@ -1,5 +1,6 @@
 div.progress
-  div.progress-bar [ class=progress_bar_classes role='progressbar' aria-valuenow="#{percentage}"
-                     aria-valuemin='0' aria-valuemax='100' style="width: #{percentage}%" ]
+  div.progress-bar [ class=opts[:class] role='progressbar'  aria-valuenow="#{percentage}"
+                     aria-valuemin='0' aria-valuemax='100' style="width: #{percentage}%"
+                     title=opts[:tooltip_text] data-placement=opts[:tooltip_placement]]
     span.sr-only #{percentage}% Complete
     = progress_bar_text

--- a/app/views/system/admin/courses/_course.html.slim
+++ b/app/views/system/admin/courses/_course.html.slim
@@ -7,7 +7,7 @@
               course_url(course, host: course.instance.host, port: nil)
   td = format_datetime(course.created_at, :date_only_long)
   td.active-level
-    = display_progress_bar(active_level, 'progress-bar-success')
+    = display_progress_bar(active_level, class: ['progress-bar-success'])
     = "#{course.active_user_count} / #{course.user_count}"
   td
     = link_to format_inline_text(course.instance.name),

--- a/app/views/system/admin/instance/courses/_course.html.slim
+++ b/app/views/system/admin/instance/courses/_course.html.slim
@@ -6,7 +6,7 @@
     = link_to format_inline_text(course.title), course_path(course)
   td = format_datetime(course.created_at, :date_only_long)
   td.active-level
-    = display_progress_bar(active_level, 'progress-bar-success')
+    = display_progress_bar(active_level, class: ['progress-bar-success'])
     = "#{course.active_user_count} / #{course.user_count}"
   td
     ul.list-unstyled

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -15,6 +15,7 @@ en:
     created_at: 'Created At'
     truthy: 'Yes'
     falsey: 'No'
+    percentage: '%{percentage}%'
   helpers:
     submit:
       condition_level:

--- a/config/locales/en/course/levels.yml
+++ b/config/locales/en/course/levels.yml
@@ -4,6 +4,3 @@ en:
       sidebar_title: :'course.levels.index.header'
       index:
         header: 'Levels'
-        level: 'Level'
-      new:
-        header: 'New Level'

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -47,8 +47,9 @@ en:
     search_form:
       search_button: :'common.search'
     course_user_badge:
-      achievements: :'course.achievement.achievements.index.header'
-      levels: :'course.levels.index.level'
-      progress: '%{current} / %{next} EXP'
+      achievements: '+ %{difference} More'
+      level: 'Level %{level}'
+      experience_points: '%{exp} EXP'
+      next_level: '%{difference} EXP to Next Level'
     code_formatter:
       size_too_big: 'The file is too big and cannot be displayed.'

--- a/spec/helpers/application_widgets_helper_spec.rb
+++ b/spec/helpers/application_widgets_helper_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe ApplicationWidgetsHelper, type: :helper do
     describe '#display_progress_bar' do
       let(:default_class) { 'progress-bar-info' }
       subject { helper.send(:display_progress_bar, 50) }
+
       it 'returns a progress bar' do
         expect(subject).to have_tag('div.progress-bar', with: { role: 'progressbar' })
       end
@@ -211,10 +212,14 @@ RSpec.describe ApplicationWidgetsHelper, type: :helper do
         expect(subject).to include(default_class)
       end
 
-      context 'when classes are specified' do
+      context 'when opts are specified' do
+        let(:tooltip_title) { 'Foo' }
+        let(:opts) { { class: ['progress-bar-striped'], title: tooltip_title } }
+        subject { helper.send(:display_progress_bar, 50, opts) }
+
         it 'is reflected in the progress bar' do
-          expect(helper.send(:display_progress_bar, 50, ['progress-bar-striped'])).
-            to have_tag('div.progress-bar.progress-bar-striped')
+          expect(subject).to have_tag('div.progress-bar.progress-bar-striped')
+          expect(subject).to have_tag('div.progress-bar', title: tooltip_title)
         end
       end
 

--- a/spec/helpers/application_widgets_helper_spec.rb
+++ b/spec/helpers/application_widgets_helper_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe ApplicationWidgetsHelper, type: :helper do
 
     describe '#display_progress_bar' do
       let(:default_class) { 'progress-bar-info' }
-      subject { helper.send(:display_progress_bar, 50) }
+      subject { helper.display_progress_bar(50) }
 
       it 'returns a progress bar' do
         expect(subject).to have_tag('div.progress-bar', with: { role: 'progressbar' })
@@ -215,7 +215,7 @@ RSpec.describe ApplicationWidgetsHelper, type: :helper do
       context 'when opts are specified' do
         let(:tooltip_title) { 'Foo' }
         let(:opts) { { class: ['progress-bar-striped'], title: tooltip_title } }
-        subject { helper.send(:display_progress_bar, 50, opts) }
+        subject { helper.display_progress_bar(50, opts) }
 
         it 'is reflected in the progress bar' do
           expect(subject).to have_tag('div.progress-bar.progress-bar-striped')
@@ -225,13 +225,13 @@ RSpec.describe ApplicationWidgetsHelper, type: :helper do
 
       context 'when a block is given' do
         it 'appends the text within the progress bar' do
-          expect(helper.send(:display_progress_bar, 50) { '30%' }).to include('30%')
+          expect(helper.display_progress_bar(50) { '30%' }).to include('30%')
         end
 
         it 'renders the block in the context of the helper' do
           message = 'foo'
           helper.define_singleton_method(:some_method) { message }
-          expect(helper.send(:display_progress_bar, 50) { helper.some_method }).to include(message)
+          expect(helper.display_progress_bar(50) { helper.some_method }).to include(message)
         end
       end
     end

--- a/spec/helpers/course/controller_helper_spec.rb
+++ b/spec/helpers/course/controller_helper_spec.rb
@@ -109,19 +109,21 @@ RSpec.describe Course::ControllerHelper do
             create(:course_experience_points_record, points_awarded: 140, course_user: user)
           end
 
-          it "shows the course user's experience points" do
-            expect(subject).to include(I18n.t('layouts.course_user_badge.progress'))
+          it "shows the course user's level and experience points" do
+            expect(subject).to include(I18n.t('layouts.course_user_badge.level'))
+            expect(subject).to include(I18n.t('layouts.course_user_badge.experience_points'))
           end
 
-          it "shows the course user's level number" do
-            expect(subject).to include(user.level_number.to_s)
+          it "shows the course user's next level" do
+            expect(subject).to include(I18n.t('layouts.course_user_badge.next_level'))
           end
 
           it 'displays the progress bar with current level progress' do
             expect(helper).to receive(:display_progress_bar).
               with(user.level_progress_percentage,
-                   ['progress-bar-info', 'progress-bar-striped',
-                    'course-user-experience-points'])
+                   class: ['progress-bar-info', 'course-user-experience-points'],
+                   tooltip_text: I18n.t('common.percentage'),
+                   tooltip_placement: 'right')
             subject
           end
         end
@@ -135,12 +137,12 @@ RSpec.describe Course::ControllerHelper do
           end
         end
 
-        context 'when course user has a number of achievements' do
-          before { create_list(:course_user_achievement, 3, course_user: user) }
+        context 'when course user has more than 3 achievements' do
+          before { create_list(:course_user_achievement, 4, course_user: user) }
 
           it "displays the achievement tab with the course user's achievement count" do
             expect(subject).to include(I18n.t('layouts.course_user_badge.achievements'))
-            expect(subject).to include(user.achievement_count.to_s)
+            expect(subject).to include((user.achievement_count - 3).to_s)
           end
         end
       end
@@ -154,7 +156,7 @@ RSpec.describe Course::ControllerHelper do
         end
 
         it 'does not display the level of the course user' do
-          expect(subject).not_to include(I18n.t('layouts.course_user_badge.levels'))
+          expect(subject).not_to include(I18n.t('layouts.course_user_badge.level'))
         end
 
         it 'does not display the achievement tab' do


### PR DESCRIPTION
Context: the original badge provided more confusion that clarity, as the progress bar percentage (exp % progress within that level) does not tally with the exp numbers shown (current exp / exp to next level).

The objective was to try to provide more accurate information concisely without confusing the users. 
——



Took me a few sketches and iterations to simplify it a little, yet show the relevant information. Do let me know if you have better ideas that I can try out?

## New Design
<img width="256" alt="screen shot 2018-05-14 at 4 31 53 pm" src="https://user-images.githubusercontent.com/4353853/39991117-0ddd4060-57a1-11e8-8398-729d57c208d9.png">   <img width="256" alt="screen shot 2018-05-14 at 4 29 54 pm" src="https://user-images.githubusercontent.com/4353853/39991118-0e0e911a-57a1-11e8-8089-9809cd47a3ab.png">

## Current Design
<img width="259" alt="screen shot 2018-05-14 at 6 00 27 pm" src="https://user-images.githubusercontent.com/4353853/39991125-138010ec-57a1-11e8-9459-d4cebae7acac.png">


