### PR TITLE
Implement other permissions for Course observer role

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -22,7 +22,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   STUDENTS = { my: 'my', phantom: 'phantom' }.freeze
 
   def index
-    authorize!(:manage, @assessment)
+    authorize!(:view_all_submissions, @assessment)
 
     respond_to do |format|
       format.html {}

--- a/app/models/components/course/levels_ability_component.rb
+++ b/app/models/components/course/levels_ability_component.rb
@@ -3,15 +3,22 @@ module Course::LevelsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_staff_manage_levels if user
+    if user
+      allow_staff_read_levels
+      allow_teaching_staff_manage_levels
+    end
 
     super
   end
 
   private
 
-  def allow_staff_manage_levels
-    can :manage, Course::Level, course_staff_hash
+  def allow_staff_read_levels
+    can :read, Course::Level, course_staff_hash
+  end
+
+  def allow_teaching_staff_manage_levels
+    can :manage, Course::Level, course_teaching_staff_hash
     # User cannot delete default level
     cannot :destroy, Course::Level, experience_points_threshold: 0
   end

--- a/app/models/components/course/materials_ability_component.rb
+++ b/app/models/components/course/materials_ability_component.rb
@@ -6,7 +6,8 @@ module Course::MaterialsAbilityComponent
     if user
       allow_students_show_materials
       allow_students_upload_materials
-      allow_staff_manage_materials
+      allow_staff_read_materials
+      allow_teaching_staff_manage_materials
     end
 
     super
@@ -20,6 +21,10 @@ module Course::MaterialsAbilityComponent
 
   def material_course_staff_hash
     { folder: course_staff_hash }
+  end
+
+  def material_course_teaching_staff_hash
+    { folder: course_teaching_staff_hash }
   end
 
   def allow_students_show_materials
@@ -45,11 +50,17 @@ module Course::MaterialsAbilityComponent
     can :manage, Course::Material, creator: user
   end
 
-  def allow_staff_manage_materials
-    can :manage, Course::Material, material_course_staff_hash
+  def allow_staff_read_materials
+    can :read, Course::Material, material_course_staff_hash
+    can [:read, :download], Course::Material::Folder, course_staff_hash
+  end
 
-    can [:read, :upload], Course::Material::Folder, course_staff_hash
-    can :manage, Course::Material::Folder, course_staff_hash.reverse_merge(concrete_folder_hash)
+  def allow_teaching_staff_manage_materials
+    can :manage, Course::Material, material_course_teaching_staff_hash
+
+    can :upload, Course::Material::Folder, course_teaching_staff_hash
+    can :manage, Course::Material::Folder,
+        course_teaching_staff_hash.reverse_merge(concrete_folder_hash)
     # Do not allow admin to edit linked folders
     cannot [:update, :destroy], Course::Material::Folder do |folder|
       folder.owner_id.present?

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -23,17 +23,8 @@ module Course::VideosAbilityComponent
     allow_student_create_and_update_own_video_session
   end
 
-  def define_staff_video_permissions
-    allow_staff_manage_video
-    allow_staff_read_and_update_video_submission
-  end
-
   def video_all_course_users_hash
     { lesson_plan_item: course_all_course_users_hash }
-  end
-
-  def video_all_course_staff_hash
-    { lesson_plan_item: course_staff_hash }
   end
 
   def video_published_all_course_users_hash
@@ -68,19 +59,43 @@ module Course::VideosAbilityComponent
     can :update, Course::Video::Session, submission: video_submission_own_course_user_hash
   end
 
-  def allow_staff_manage_video
-    can :manage, Course::Video, video_all_course_staff_hash
-  end
-
-  def allow_staff_read_and_update_video_submission
-    can [:read, :update], Course::Video::Submission, video: video_all_course_staff_hash
-  end
-
   def allow_student_show_video_topics
     can :read, Course::Video::Topic, video: video_all_course_users_hash
   end
 
   def allow_student_create_video_topics
     can :create, Course::Video::Topic, video: video_all_course_users_hash
+  end
+
+  def define_staff_video_permissions
+    allow_staff_read_and_attempt_all_video
+    allow_staff_read_all_video_submission
+    allow_teaching_staff_manage_video
+    allow_teaching_staff_update_video_submission
+  end
+
+  def video_all_course_staff_hash
+    { lesson_plan_item: course_staff_hash }
+  end
+
+  def video_all_course_teaching_staff_hash
+    { lesson_plan_item: course_teaching_staff_hash }
+  end
+
+  def allow_staff_read_and_attempt_all_video
+    can :read, Course::Video, video_all_course_staff_hash
+    can :attempt, Course::Video, video_all_course_staff_hash
+  end
+
+  def allow_staff_read_all_video_submission
+    can :read, Course::Video::Submission, video: video_all_course_staff_hash
+  end
+
+  def allow_teaching_staff_manage_video
+    can :manage, Course::Video, video_all_course_teaching_staff_hash
+  end
+
+  def allow_teaching_staff_update_video_submission
+    can :update, Course::Video::Submission, video: video_all_course_teaching_staff_hash
   end
 end

--- a/app/models/course/assessment/skill_ability.rb
+++ b/app/models/course/assessment/skill_ability.rb
@@ -2,8 +2,8 @@
 module Course::Assessment::SkillAbility
   def define_permissions
     if user
-      allow_staff_manage_skills
-      allow_staff_manage_skill_branches
+      allow_staff_read_skills_and_skill_branches
+      allow_teaching_staff_manage_skills_and_skill_branches
     end
 
     super
@@ -11,11 +11,13 @@ module Course::Assessment::SkillAbility
 
   private
 
-  def allow_staff_manage_skills
-    can :manage, Course::Assessment::Skill, course_staff_hash
+  def allow_staff_read_skills_and_skill_branches
+    can :read, Course::Assessment::Skill, course_staff_hash
+    can :read, Course::Assessment::SkillBranch, course_staff_hash
   end
 
-  def allow_staff_manage_skill_branches
-    can :manage, Course::Assessment::SkillBranch, course_staff_hash
+  def allow_teaching_staff_manage_skills_and_skill_branches
+    can :manage, Course::Assessment::Skill, course_teaching_staff_hash
+    can :manage, Course::Assessment::SkillBranch, course_teaching_staff_hash
   end
 end

--- a/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
+++ b/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
@@ -24,7 +24,7 @@ div.btn-group
   - else
     = link_to(t('.attempt'), '#', class: ['btn', 'btn-info', 'disabled'])
 
-  - if can?(:manage, assessment)
+  - if can?(:view_all_submissions, assessment)
     = link_to(course_assessment_submissions_path(current_course, assessment),
               class: ['btn', 'btn-default']) do
       span.visible-xs-block = fa_icon 'book'

--- a/app/views/course/levels/index.json.jbuilder
+++ b/app/views/course/levels/index.json.jbuilder
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
 json.levels @levels.pluck(:experience_points_threshold)
+json.canManage can?(:manage, @levels.first)

--- a/client/app/bundles/course/level/components/LevelRow.jsx
+++ b/client/app/bundles/course/level/components/LevelRow.jsx
@@ -26,20 +26,27 @@ const styles = {
     textAlign: 'center',
     verticalAlign: 'middle',
   },
+  threshold: {
+    fontSize: '16px',
+    verticalAlign: 'middle',
+  },
 };
 
 class LevelRow extends React.Component {
   static propTypes = {
-    levelNumber: PropTypes.number.isRequired,
+    canManage: PropTypes.bool.isRequired,
+    deleteLevel: PropTypes.func.isRequired,
     disabled: PropTypes.bool.isRequired,
     experiencePointsThreshold: PropTypes.number.isRequired,
-    updateExpThreshold: PropTypes.func.isRequired,
+    levelNumber: PropTypes.number.isRequired,
     sortLevels: PropTypes.func.isRequired,
-    deleteLevel: PropTypes.func.isRequired,
+    updateExpThreshold: PropTypes.func.isRequired,
   }
 
-  renderInput(levelNumber, experiencePointsThreshold) {
-    const { updateExpThreshold, disabled, sortLevels } = this.props;
+  renderInput() {
+    const {
+      disabled, experiencePointsThreshold, levelNumber, sortLevels, updateExpThreshold,
+    } = this.props;
     return (
       <TextField
         type="text"
@@ -55,22 +62,35 @@ class LevelRow extends React.Component {
     );
   }
 
+  renderDeleteButton() {
+    const { deleteLevel, disabled, levelNumber } = this.props;
+
+    return (
+      <RaisedButton
+        id={`delete_${levelNumber}`}
+        name={`delete_${levelNumber}`}
+        backgroundColor={grey300}
+        icon={<DeleteIcon />}
+        onClick={deleteLevel(levelNumber)}
+        disabled={disabled}
+        style={{ minWidth: '40px', width: '40px' }}
+      />
+    );
+  }
+
   render() {
-    const { levelNumber, experiencePointsThreshold, deleteLevel, disabled } = this.props;
+    const { canManage, experiencePointsThreshold, levelNumber } = this.props;
+
     return (
       <TableRow>
-        <TableRowColumn style={styles.levelNumber}>{ levelNumber }</TableRowColumn>
-        <TableRowColumn>{ this.renderInput(levelNumber, experiencePointsThreshold) }</TableRowColumn>
+        <TableRowColumn style={styles.levelNumber}>
+          { levelNumber }
+        </TableRowColumn>
+        <TableRowColumn style={styles.threshold} >
+          {canManage ? this.renderInput() : experiencePointsThreshold}
+        </TableRowColumn>
         <TableHeaderColumn style={styles.deleteButtonCell}>
-          <RaisedButton
-            id={`delete_${levelNumber}`}
-            name={`delete_${levelNumber}`}
-            backgroundColor={grey300}
-            icon={<DeleteIcon />}
-            onClick={deleteLevel(levelNumber)}
-            disabled={disabled}
-            style={{ minWidth: '40px', width: '40px' }}
-          />
+          {canManage && this.renderDeleteButton()}
         </TableHeaderColumn>
       </TableRow>
     );

--- a/client/app/bundles/course/level/index.jsx
+++ b/client/app/bundles/course/level/index.jsx
@@ -9,7 +9,7 @@ $(document).ready(() => {
   const mountNode = document.getElementById('course-level');
 
   if (mountNode) {
-    const store = storeCreator({ level: {} });
+    const store = storeCreator({});
 
     render(
       <ProviderWrapper store={store}>

--- a/client/app/bundles/course/level/pages/Level/index.jsx
+++ b/client/app/bundles/course/level/pages/Level/index.jsx
@@ -79,11 +79,28 @@ const styles = {
 
 class Level extends React.Component {
   static propTypes = {
+    canManage: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
     isSaving: PropTypes.bool.isRequired,
     levels: PropTypes.arrayOf(PropTypes.number).isRequired,
 
     dispatch: PropTypes.func.isRequired,
+  }
+
+  static renderTableHeader() {
+    return (
+      <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
+        <TableRow>
+          <TableHeaderColumn style={styles.levelHeader} >
+            <FormattedMessage {...translations.levelHeader} />
+          </TableHeaderColumn>
+          <TableHeaderColumn style={styles.thresholdHeader}>
+            <FormattedMessage {...translations.thresholdHeader} />
+          </TableHeaderColumn>
+          <TableHeaderColumn />
+        </TableRow>
+      </TableHeader>
+    );
   }
 
   constructor(props) {
@@ -140,19 +157,55 @@ class Level extends React.Component {
     };
   }
 
+  renderTableFooter() {
+    const { isSaving } = this.props;
+
+    return (
+      <TableFooter adjustForCheckbox={false}>
+        <TableRow>
+          <TableRowColumn />
+          <TableRowColumn colSpan="1" style={styles.addNewLevel}>
+            <FlatButton
+              id="add-level"
+              icon={<i className="fa fa-plus" />}
+              label={<FormattedMessage {...translations.addNewLevel} />}
+              disabled={isSaving}
+              onClick={this.handleCreateLevel()}
+            />
+          </TableRowColumn>
+          <TableRowColumn />
+        </TableRow>
+        <TableRow>
+          <TableRowColumn style={styles.saveLevels}>
+            <RaisedButton
+              id="save-levels"
+              style={styles.formButton}
+              type="submit"
+              label={<FormattedMessage {...translations.saveLevels} />}
+              disabled={isSaving}
+              primary
+              onClick={this.handleSaveLevels()}
+            />
+          </TableRowColumn>
+          <TableRowColumn />
+          <TableRowColumn />
+        </TableRow>
+      </TableFooter>
+    );
+  }
+
   renderBody() {
-    const { levels, isSaving } = this.props;
+    const { canManage, levels, isSaving } = this.props;
     const rows = levels.slice(1).map((experiencePointsThreshold, index) => {
       const key = `${index}`;
       return (
         <LevelRow
-          key={key}
-          levelNumber={index + 1}
-          experiencePointsThreshold={experiencePointsThreshold}
-          updateExpThreshold={this.handleUpdateExpThreshold}
-          sortLevels={this.handleLevelTextBlur}
           deleteLevel={this.handleDeleteLevel}
           disabled={isSaving}
+          levelNumber={index + 1}
+          sortLevels={this.handleLevelTextBlur}
+          updateExpThreshold={this.handleUpdateExpThreshold}
+          {...{ canManage, experiencePointsThreshold, key }}
         />
       );
     });
@@ -160,50 +213,11 @@ class Level extends React.Component {
     return (
       <div style={styles.body}>
         <Table className="table levels-list" fixedHeader={false}>
-          <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
-            <TableRow>
-              <TableHeaderColumn style={styles.levelHeader} >
-                <FormattedMessage {...translations.levelHeader} />
-              </TableHeaderColumn>
-              <TableHeaderColumn style={styles.thresholdHeader}>
-                <FormattedMessage {...translations.thresholdHeader} />
-              </TableHeaderColumn>
-              <TableHeaderColumn />
-            </TableRow>
-          </TableHeader>
+          {Level.renderTableHeader()}
           <TableBody>
             {rows}
           </TableBody>
-          <TableFooter adjustForCheckbox={false}>
-            <TableRow>
-              <TableRowColumn />
-              <TableRowColumn colSpan="1" style={styles.addNewLevel}>
-                <FlatButton
-                  id="add-level"
-                  icon={<i className="fa fa-plus" />}
-                  label={<FormattedMessage {...translations.addNewLevel} />}
-                  disabled={isSaving}
-                  onClick={this.handleCreateLevel()}
-                />
-              </TableRowColumn>
-              <TableRowColumn />
-            </TableRow>
-            <TableRow>
-              <TableRowColumn style={styles.saveLevels}>
-                <RaisedButton
-                  id="save-levels"
-                  style={styles.formButton}
-                  type="submit"
-                  label={<FormattedMessage {...translations.saveLevels} />}
-                  disabled={isSaving}
-                  primary
-                  onClick={this.handleSaveLevels()}
-                />
-              </TableRowColumn>
-              <TableRowColumn />
-              <TableRowColumn />
-            </TableRow>
-          </TableFooter>
+          {canManage && this.renderTableFooter()}
         </Table>
       </div>
     );
@@ -212,7 +226,9 @@ class Level extends React.Component {
   render() {
     return (
       <div>
-        <TitleBar title={<FormattedMessage {...defaultComponentTitles.course_levels_component} />} />
+        <TitleBar
+          title={<FormattedMessage {...defaultComponentTitles.course_levels_component} />}
+        />
         { this.props.isLoading ? <LoadingIndicator /> : this.renderBody() }
       </div>
     );
@@ -220,6 +236,7 @@ class Level extends React.Component {
 }
 
 export default connect(({ levelEdit }) => ({
+  canManage: levelEdit.canManage,
   isLoading: levelEdit.isLoading,
   isSaving: levelEdit.isSaving,
   levels: levelEdit.levels,

--- a/client/app/bundles/course/level/reducers/level.js
+++ b/client/app/bundles/course/level/reducers/level.js
@@ -1,6 +1,7 @@
 import actionTypes from 'course/level/constants';
 
 const initialState = {
+  canManage: false,
   levels: [],
   isLoading: false,
   isSaving: false,

--- a/spec/factories/course_survey_responses.rb
+++ b/spec/factories/course_survey_responses.rb
@@ -9,7 +9,9 @@ FactoryBot.define do
     points_awarded nil
 
     trait :submitted do
-      after(:build, &:submit)
+      after(:build) do |response|
+        response.submit
+      end
 
       transient do
         submitted_time { 1.day.ago }

--- a/spec/models/course/assessment/skill_ability_spec.rb
+++ b/spec/models/course/assessment/skill_ability_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Skill do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    subject { Ability.new(user) }
+    let(:course) { create(:course) }
+    let(:other_course) { create(:course) }
+    let(:skill) { create(:course_assessment_skill, course: course) }
+    let(:skill_branch) do
+      create(:course_assessment_skill_branch, skills: [skill], course: course)
+    end
+    let(:other_skill) { create(:course_assessment_skill, course: other_course) }
+    let(:other_skill_branch) do
+      create(:course_assessment_skill_branch, skills: [other_skill], course: other_course)
+    end
+
+    context 'when the user is a Course Student' do
+      let(:user) { create(:course_student, course: course).user }
+
+      it { is_expected.not_to be_able_to(:show, skill) }
+      it { is_expected.not_to be_able_to(:show, skill_branch) }
+    end
+
+    context 'when the user is a Course Teaching Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
+
+      it { is_expected.to be_able_to(:manage, skill) }
+      it { is_expected.to be_able_to(:manage, skill_branch) }
+      it { is_expected.not_to be_able_to(:show, other_skill) }
+      it { is_expected.not_to be_able_to(:show, other_skill_branch) }
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:show, skill) }
+      it { is_expected.to be_able_to(:show, skill_branch) }
+      it { is_expected.not_to be_able_to(:show, other_skill) }
+      it { is_expected.not_to be_able_to(:show, other_skill_branch) }
+      it { is_expected.not_to be_able_to(:manage, skill) }
+      it { is_expected.not_to be_able_to(:manage, skill_branch) }
+    end
+  end
+end

--- a/spec/models/course/level_ability_spec.rb
+++ b/spec/models/course/level_ability_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Course::Level do
     let!(:level) { create(:course_level, course: course) }
     let!(:default_level) { course.reload.levels.first }
 
-    context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+    context 'when the user is a Course Teaching Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       it { is_expected.to be_able_to(:manage, level) }
       it { is_expected.not_to be_able_to(:destroy, default_level) }
@@ -19,6 +19,14 @@ RSpec.describe Course::Level do
       it 'sees all levels' do
         expect(course.levels.accessible_by(subject)).to contain_exactly(*course.reload.levels)
       end
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:read, level) }
+      it { is_expected.not_to be_able_to(:manage, level) }
+      it { is_expected.not_to be_able_to(:destroy, default_level) }
     end
   end
 end

--- a/spec/models/course/material_ability_spec.rb
+++ b/spec/models/course/material_ability_spec.rb
@@ -45,14 +45,36 @@ RSpec.describe Course::Material do
       it { is_expected.not_to be_able_to(:download, not_started_linked_material.folder) }
     end
 
-    context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+    context 'when the user is a Course Teaching Staff' do
+      let(:user) { create(:course_teaching_assistant, course: course).user }
 
       it { is_expected.to be_able_to(:manage, valid_material) }
       it { is_expected.to be_able_to(:manage, not_started_material) }
       it { is_expected.to be_able_to(:manage, ended_material) }
       it { is_expected.to be_able_to(:manage, not_started_linked_material) }
       it { is_expected.to be_able_to(:show, not_started_linked_material) }
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      it { is_expected.to be_able_to(:show, valid_material) }
+      it { is_expected.to be_able_to(:show, not_started_material) }
+      it { is_expected.to be_able_to(:show, ended_material) }
+      it { is_expected.to be_able_to(:show, started_linked_material) }
+      it { is_expected.to be_able_to(:show, not_started_linked_material) }
+
+      it { is_expected.not_to be_able_to(:manage, valid_material) }
+      it { is_expected.not_to be_able_to(:manage, not_started_material) }
+      it { is_expected.not_to be_able_to(:manage, ended_material) }
+      it { is_expected.not_to be_able_to(:manage, started_linked_material) }
+      it { is_expected.not_to be_able_to(:manage, not_started_linked_material) }
+
+      it { is_expected.to be_able_to(:download, valid_material.folder) }
+      it { is_expected.to be_able_to(:download, not_started_material.folder) }
+      it { is_expected.to be_able_to(:download, ended_material.folder) }
+      it { is_expected.to be_able_to(:download, started_linked_material.folder) }
+      it { is_expected.to be_able_to(:download, not_started_linked_material.folder) }
     end
   end
 end

--- a/spec/models/course/video/video_ability_spec.rb
+++ b/spec/models/course/video/video_ability_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Course::Video do
     let(:published_video) { create(:video, :published, course: course) }
     let(:published_video_not_started) { create(:video, :not_started, :published, course: course) }
     let(:video_submission) do
-      create(:video_submission, video: published_video, creator: course_user.user)
+      create(:video_submission, video: published_video, creator: user)
     end
     let(:other_video_submission) do
       create(:video_submission, course: course, video: published_video)
@@ -38,16 +38,41 @@ RSpec.describe Course::Video do
       it { is_expected.to be_able_to(:update, video_submission) }
     end
 
-    context 'when the user is a Course Staff' do
+    context 'when the user is a Course Teaching Staff' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
 
       # Course Video
       it { is_expected.to be_able_to(:manage, draft_video) }
       it { is_expected.to be_able_to(:manage, published_video) }
+
+      # Course Video Submissions
       it { is_expected.to be_able_to(:update, other_video_submission) }
       it { is_expected.to be_able_to(:read, other_video_submission) }
       it { is_expected.to be_able_to(:update, video_submission) }
       it { is_expected.to be_able_to(:read, video_submission) }
+    end
+
+    context 'when the user is a Course Observer' do
+      let(:user) { create(:course_observer, course: course).user }
+
+      # Course Video
+      it { is_expected.to be_able_to(:read, draft_video) }
+      it { is_expected.to be_able_to(:read, published_video) }
+      it { is_expected.to be_able_to(:read, published_video_not_started) }
+      it { is_expected.to be_able_to(:attempt, draft_video) }
+      it { is_expected.to be_able_to(:attempt, published_video) }
+      it { is_expected.to be_able_to(:attempt, published_video_not_started) }
+      it { is_expected.not_to be_able_to(:manage, draft_video) }
+      it { is_expected.not_to be_able_to(:manage, published_video) }
+      it { is_expected.not_to be_able_to(:manage, published_video_not_started) }
+
+      # Course Video Submissions
+      it { is_expected.to be_able_to(:create, video_submission) }
+      it { is_expected.to be_able_to(:read, video_submission) }
+      it { is_expected.to be_able_to(:update, video_submission) }
+      it { is_expected.not_to be_able_to(:create, other_video_submission) }
+      it { is_expected.to be_able_to(:read, other_video_submission) }
+      it { is_expected.not_to be_able_to(:update, other_video_submission) }
     end
   end
 end


### PR DESCRIPTION
Next steps for #2910. Pushing this up as a PR first as there are quite a few changes. 

The next steps are some to check if front-end work is needed for Surveys and Assessment - from a quick look it seems ok. After this, the options will be set for courses managers to set course observers.