### PR TITLE
Fix bug to reflect phantom for invitations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,7 +98,7 @@ class User < ApplicationRecord
     self.email = invitation.email
     skip_confirmation!
     course_users.build(course: invitation.course, name: invitation.name, role: invitation.role,
-                       creator: self, updater: self)
+                       phantom: invitation.phantom, creator: self, updater: self)
   end
 
   private

--- a/spec/features/user_sign_up_spec.rb
+++ b/spec/features/user_sign_up_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Users: Sign Up' do
 
     context 'As a user invited by course staffs' do
       let(:course) { create(:course) }
-      let(:invitation) { create(:course_user_invitation, course: course) }
+      let(:invitation) { create(:course_user_invitation, :phantom, course: course) }
       let(:invited_email) { invitation.email }
 
       scenario 'I can register for an account' do
@@ -44,10 +44,13 @@ RSpec.feature 'Users: Sign Up' do
         end.to change(course.users, :count).by(1)
 
         email = User::Email.find_by(email: invited_email)
+        user = email.user
+        course_user = CourseUser.where(user: user, course: course).first
         expect(email).to be_primary
         expect(email).to be_confirmed
         expect(invitation.reload).to be_confirmed
         expect(invitation.confirmer).to eq(email.user)
+        expect(course_user).to be_phantom
       end
 
       context 'when the invitation code is confirmed' do


### PR DESCRIPTION
- Currently for course user invitations, phantom status
are not reflected on created course_user records for new
coursemology users.

Fixes #2946.