### PR TITLE
Reinstall HardSourceWebpack plugin.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -75,7 +75,7 @@
     "expose-loader": "^0.7.5",
     "fabric": "2.2.2",
     "glob": "^7.1.2",
-    "hard-source-webpack-plugin": "^0.7.0-alpha.0",
+    "hard-source-webpack-plugin": "^0.6.9",
     "history": "^4.6.1",
     "immutable": "^3.8.1",
     "intl": "^1.2.5",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3357,15 +3357,16 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
-hard-source-webpack-plugin@^0.7.0-alpha.0:
-  version "0.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.7.0-alpha.0.tgz#e38751add28fa279413b71f40df522be7271d989"
+hard-source-webpack-plugin@^0.6.9:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.6.9.tgz#b23b3cd3a3c661b6fce2925d928691055f950e7f"
   dependencies:
     lodash "^4.15.0"
     mkdirp "^0.5.1"
     node-object-hash "^1.2.0"
     rimraf "^2.6.2"
     tapable "^1.0.0-beta.5"
+    webpack-core "~0.6.0"
     webpack-sources "^1.0.1"
     write-json-file "^2.3.0"
 
@@ -7083,6 +7084,10 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-list-map@~0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
+
 source-map-resolve@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
@@ -7103,7 +7108,7 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@^0.4.2, source-map@^0.4.4:
+source-map@^0.4.2, source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
@@ -7779,6 +7784,13 @@ webidl-conversions@^3.0.0:
 webidl-conversions@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
+webpack-core@~0.6.0:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
+  dependencies:
+    source-list-map "~0.1.7"
+    source-map "~0.4.1"
 
 webpack-dev-middleware@1.12.2:
   version "1.12.2"


### PR DESCRIPTION
Change version so webpack-dev-server can work. This was done with `yarn remove hard-source-webpack-plugin` followed by `yarn add hard-source-webpack-plugin`.

Possibly related to https://github.com/mzgoddard/hard-source-webpack-plugin/issues/320