### PR TITLE
Only enable HardSourceWebpackPlugin when running in Travis.

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,6 +6,7 @@ const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const env = process.env.NODE_ENV || 'development';
 const production = env === 'production';
 const development = env === 'development';
+const travis = process.env.TRAVIS === 'true';
 
 // must match config.webpack.dev_server.port
 const devServerPort = 8080;
@@ -80,7 +81,6 @@ const config = {
     // Do not require all locles in moment
     new webpack.ContextReplacementPlugin(/moment\/locale$/, /^\.\/(en-.*|zh-.*)$/),
     new ManifestPlugin({ fileName: 'manifest.json', publicPath: '/webpack/', writeToFileEmit: true }),
-    new HardSourceWebpackPlugin({ cacheDirectory: path.join(__dirname, 'hard-source-cache/[confighash]') }),
   ],
 
   module: {
@@ -164,6 +164,11 @@ if (development) {
   config.devtool = 'cheap-module-eval-source-map';
 } else {
   console.log(`\nWebpack ${env} build for Rails...`); // eslint-disable-line no-console
+}
+
+// Only enable HardSourceWebpackPlugin in Travis
+if (travis) {
+  config.plugins.push(new HardSourceWebpackPlugin({ cacheDirectory: path.join(__dirname, 'hard-source-cache/[confighash]') }));
 }
 
 module.exports = config;


### PR DESCRIPTION
We only need this to speed up build times on Travis. In the previous config, there were problems when running `webpack-dev-server` that went away with an olde version of the plugin.

This is annoying to troubleshoot, so it's better to only cache for CI and use fresh (but slower) builds for dev and production.

References #2955.