### PR TITLE
Fixes to course_user_badge

### DIFF
--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -2,7 +2,7 @@
   @include timestamp;
 
   #course-badge-achievement {
-    margin-bottom: 0.5em;
+    margin-bottom: 1em;
     margin-left: 0.5em;
 
     .image > img {
@@ -83,6 +83,7 @@
     margin: 0.5em;
 
     #user-sidebar {
+      @include text-overflow;
       font-size: 18px;
       font-weight: bold;
     }

--- a/app/assets/stylesheets/mixins/_text_overflow.scss
+++ b/app/assets/stylesheets/mixins/_text_overflow.scss
@@ -1,0 +1,5 @@
+@mixin text-overflow() {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/views/layouts/_course_user_badge.html.slim
+++ b/app/views/layouts/_course_user_badge.html.slim
@@ -18,7 +18,10 @@
                                tooltip_placement: 'right' }
     = display_progress_bar(percentage, progress_bar_options)
     div.next-level.text-center
-      = t('.next_level', difference: difference)
+      - if difference > 0
+        = t('.next_level', difference: difference)
+      - else
+        = t('.max_level')
 
 - if achievements_enabled
   div.col-xs-12#course-badge-achievement

--- a/config/locales/en/layout.yml
+++ b/config/locales/en/layout.yml
@@ -51,5 +51,6 @@ en:
       level: 'Level %{level}'
       experience_points: '%{exp} EXP'
       next_level: '%{difference} EXP to Next Level'
+      max_level: 'Congrats - Highest Level Attained!'
     code_formatter:
       size_too_big: 'The file is too big and cannot be displayed.'

--- a/spec/helpers/course/controller_helper_spec.rb
+++ b/spec/helpers/course/controller_helper_spec.rb
@@ -114,10 +114,6 @@ RSpec.describe Course::ControllerHelper do
             expect(subject).to include(I18n.t('layouts.course_user_badge.experience_points'))
           end
 
-          it "shows the course user's next level" do
-            expect(subject).to include(I18n.t('layouts.course_user_badge.next_level'))
-          end
-
           it 'displays the progress bar with current level progress' do
             expect(helper).to receive(:display_progress_bar).
               with(user.level_progress_percentage,
@@ -125,6 +121,30 @@ RSpec.describe Course::ControllerHelper do
                    tooltip_text: I18n.t('common.percentage'),
                    tooltip_placement: 'right')
             subject
+          end
+
+          context 'when course user is at the max level' do
+            before do
+              create(:course_experience_points_record, points_awarded: 1000, course_user: user)
+            end
+
+            it 'shows the max level message' do
+              # Reload here as course_user#current_level caches and is unable to
+              # reload on updated experience points.
+              course_user = CourseUser.find(user.id)
+              expect(helper.display_course_user_badge(course_user)).
+                to include(I18n.t('layouts.course_user_badge.max_level'))
+            end
+          end
+
+          context 'when course user is not at the max level' do
+            it 'shows the next level message' do
+              # Reload here as course_user#current_level caches and is unable to
+              # reload on updated experience points.
+              course_user = CourseUser.find(user.id)
+              expect(helper.display_course_user_badge(course_user)).
+                to include(I18n.t('layouts.course_user_badge.next_level'))
+            end
           end
         end
       end


### PR DESCRIPTION
These are additional fixes to #2945.

- Increased bottom margin
- Handled text overflow if name is too long
- Handled if course_user is at maximum level

### Previous 
<img width="407" alt="screen shot 2018-05-25 at 3 58 05 pm" src="https://user-images.githubusercontent.com/4353853/40533245-aec6b506-6034-11e8-9d85-8926be22eac6.png">

### New
<img width="414" alt="screen shot 2018-05-25 at 3 58 35 pm" src="https://user-images.githubusercontent.com/4353853/40533251-b3e3c7e0-6034-11e8-9500-224e0e79d315.png">
