### PR TITLE
Ensure user to search has email in user management spec

### DIFF
--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'System: Administration: Users' do
         expect(all('.user').count).to eq(2)
 
         # Search by email
-        random_user = User.order('RANDOM()').first
+        random_user = users_to_search.sample
         fill_in 'search', with: random_user.email
         click_button I18n.t('layouts.search_form.search_button')
 


### PR DESCRIPTION
Random failure occurs when the DELETED or SYSTEM user is selected.