### PR TITLE
Remove label from course staff management page phantom checkbox

### DIFF
--- a/app/views/course/users/staff.html.slim
+++ b/app/views/course/users/staff.html.slim
@@ -41,7 +41,7 @@ div.users
                                   include_blank: false,
                                   label: false,
                                   label_method: lambda { |role_key| t("course.users.role.#{role_key}") }
-              td = f.input :phantom
+              td = f.input :phantom, label: false
               td
                 = f.button :submit, id: 'update' do
                   = fa_icon 'save'.freeze


### PR DESCRIPTION
On the course staff management tab, there is a bug where clicking on the phantom checkbox label and not the checkbox itself always toggles the first checkbox, no matter which row's checkbox label is being clicked.

![course_staff_management](https://user-images.githubusercontent.com/4056819/40824874-53ed81ae-65a8-11e8-94cb-4cf304d7efc7.gif)

Have removed the labels to avoid this bug and to keep it in sync with the students management tab, where there are no labels for the phantom checkboxes either. This is how the page will look after this PR:

<img width="254" alt="screen shot 2018-06-01 at 2 28 03 pm" src="https://user-images.githubusercontent.com/4056819/40824821-1949137e-65a8-11e8-93a0-c2ff86a09049.png">

Note: to keep the labels and fix the bug, use `inline_label` instead:
```
f.input :phantom, label: false, inline_label: t('course.users.role.phantom')
```