### PR TITLE
Remove height, width, float css from whitelist

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -110,6 +110,12 @@
           ['insert', ['link', 'picture', 'video']],
           ['view', ['fullscreen', 'codeview', 'help']],
         ],
+        popover: {
+          image: [
+            ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
+            ['remove', ['removeMedia']],
+          ],
+        },
         callbacks: {
           onImageUpload: function(files) {
             for (var i = 0; i < files.length; i++) {
@@ -126,7 +132,7 @@
         options = $.extend(true, options, airmodeOptions);
       }
       if ($(this).hasClass('focus')) {
-        options = $.extend(true, options, { focus: true} );
+        options = $.extend(true, options, { focus: true } );
       }
       $(this).summernote(options);
       $(this).addClass('summernote-initialised');

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -212,6 +212,10 @@ class MaterialSummernote extends React.Component {
                   ['table', ['table']],
                   ['insert', ['link', 'picture']],
                 ],
+                image: [
+                  ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
+                  ['remove', ['removeMedia']],
+                ],
               },
               buttons: {
                 inlineCode: this.inlineCodeButton,


### PR DESCRIPTION
Fix #2914 

Since `height` and `width` CSS properties are to be allowed only on `img` tags, they have been removed from the whitelist. Instead, `img` tags now go through a separate sanitization transformer.

Also removed `float` from whitelist for all tags as `float: left` or `float: right` can seriously mess up the page layout, even when used on images. As a result of this, the float buttons in the Summernote image toolbar will no longer work and have been removed.

Example: announcement with image set to `float: left`:
<img width="345" alt="screen shot 2018-06-01 at 5 26 30 pm" src="https://user-images.githubusercontent.com/4056819/40833620-011cc7f0-65c1-11e8-8b8e-0edd3aadb0d3.png">
