### PR TITLE
Minor fixes and upgrade of html-pipeline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
     hashie (3.5.7)
     high_voltage (3.1.0)
     highline (2.0.0)
-    html-pipeline (2.7.1)
+    html-pipeline (2.8.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     html-pipeline-rouge_filter (1.0.7)

--- a/app/controllers/course/assessment/skill_branches_controller.rb
+++ b/app/controllers/course/assessment/skill_branches_controller.rb
@@ -32,7 +32,7 @@ class Course::Assessment::SkillBranchesController < Course::ComponentController
   def destroy
     if @skill_branch.destroy
       redirect_to course_assessments_skills_path(current_course),
-                  success: t('.success', skill: @skill_branch.title)
+                  success: t('.success', skill_branch: @skill_branch.title)
     else
       redirect_to course_assessments_skills_path(current_course),
                   danger: t('.failure', error: @skill_branch.errors.full_messages.to_sentence)

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -60,7 +60,7 @@ module ApplicationHTMLFormattersHelper
   # SanitizationFilter Custom Options
   # Link: https://github.com/jch/html-pipeline#2-how-do-i-customize-a-whitelist-for-sanitizationfilters
   SANITIZATION_FILTER_WHITELIST = begin
-    list = HTML::Pipeline::SanitizationFilter::WHITELIST
+    list = HTML::Pipeline::SanitizationFilter::WHITELIST.dup
     list[:elements] |= ['span', 'font', 'u']
     list[:attributes][:all] |= ['style']
     list[:attributes]['font'] = ['face']

--- a/app/views/course/statistics/staff.html.slim
+++ b/app/views/course/statistics/staff.html.slim
@@ -1,18 +1,24 @@
 = page_header
-table.table.table-middle-align.table-hover
-  thead
-    tr
-      th.text-center
-        = t('.serial_number')
-      th = t('.name')
-      th.text-center
-        = t('.marked')
-      th.text-center
-        = t('.students')
-      th.text-center
-        = t('.average_time')
-      th.text-center
-        = t('.stddev')
-  tbody
-    - @staffs.each.with_index(1) do |staff, index|
-      = render partial: 'staff_performance', locals: { staff: staff, index: index }
+
+- graded_staff = @staffs.reject { |staff| staff.published_submissions.empty? }
+- if graded_staff.empty?
+  div.alert.alert-info
+    = t('.no_statistics')
+- else
+  table.table.table-middle-align.table-hover
+    thead
+      tr
+        th.text-center
+          = t('.serial_number')
+        th = t('.name')
+        th.text-center
+          = t('.marked')
+        th.text-center
+          = t('.students')
+        th.text-center
+          = t('.average_time')
+        th.text-center
+          = t('.stddev')
+    tbody
+      - graded_staff.each.with_index(1) do |staff, index|
+        = render partial: 'staff_performance', locals: { staff: staff, index: index }

--- a/config/locales/en/course/statistics.yml
+++ b/config/locales/en/course/statistics.yml
@@ -20,3 +20,4 @@ en:
         students: '#Students'
         average_time: 'Average Time Per Assignment'
         stddev: 'Standard Deviation'
+        no_statistics: 'There are no staff statistics as nothing has been graded yet.'


### PR DESCRIPTION
 - Upgrade html-pipeline to 2.8.0 (Blocked previously, see commit message)
 - Fixed translation key for skill deletion
 - Remove staff in statistics who have not graded (#1950)