### PR TITLE
Video submission heatmap

### DIFF
--- a/app/models/concerns/course/video/watch_statistics_concern.rb
+++ b/app/models/concerns/course/video/watch_statistics_concern.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+module Course::Video::WatchStatisticsConcern
+  extend ActiveSupport::Concern
+
+  # Computes the watch frequency given the scope of events.
+  #
+  # Watch frequency is a list denoting the number of times a certain point in the video has been
+  # covered. In other words, each video time's frequency is the number of intervals (as computed
+  # from events) that the time is present in.
+  #
+  # This method computes frequency for video times from 0 to the last interval end, not the
+  # entire duration of the video.
+  #
+  # @return [[Integer]] The watch frequency, with the indices matching up to video time in seconds.
+  def watch_frequency
+    starts, ends = start_times, end_times
+    start_index, end_index = 0, 0
+    frequencies = []
+    active_intervals = 0
+    (0..end_times.last).each do |video_time|
+      start_advance = elements_till(starts, start_index) { |time| time <= video_time }
+      end_advance = elements_till(ends, end_index) { |time| time < video_time }
+
+      active_intervals += start_advance - end_advance
+      start_index += start_advance
+      end_index += end_advance
+
+      frequencies << active_intervals
+    end
+    frequencies
+  end
+
+  private
+
+  # The scope for events to compute statistics with.
+  #
+  # Implementations must return a database query scope, not an array, since the return value will
+  # be converted to SQL.
+  #
+  # @return [ActiveRecord::Relation[Course::Video::Events]] The events to analyze.
+  def relevant_events_scope
+    raise NotImplementedError
+  end
+
+  # Counts the elements of a stack until a condition is fulfilled.
+  #
+  # @param [[Integer]] stack The stack to count.
+  # @param [Integer] start_index The index to start counting from.
+  # @param [&block] Elements from the stack will be yield to check for the termination condition
+  # @return [Integer] The number of elements counted.
+  def elements_till(stack, start_index)
+    advance_count = 0
+    advance_count += 1 while (start_index + advance_count) < stack.size &&
+                             (yield stack[start_index + advance_count])
+    advance_count
+  end
+
+  # The video times for the interval starts.
+  #
+  # @return [Integer] The start times.
+  def start_times
+    relevant_events_scope.
+      interval_starts.
+      unscope(:order).
+      order(:video_time).
+      pluck(:video_time)
+  end
+
+  # The video times for the interval ends.
+  #
+  # If no explicit end to an interval is recorded in an event, the last_video_time from the
+  # session is taken as the interval end.
+  #
+  # @return [Integer] The end times.
+  def end_times
+    interval_end_query = relevant_events_scope.
+                         interval_ends.
+                         select('course_video_events.video_time AS end_time').
+                         to_sql
+    implict_end_query = relevant_events_scope.
+                        unclosed_starts.
+                        joins(:session).
+                        select('course_video_sessions.last_video_time AS end_time').
+                        to_sql
+
+    ActiveRecord::Base.connection.
+      exec_query("(#{implict_end_query}) UNION ALL (#{interval_end_query}) ORDER BY end_time").
+      rows.
+      map { |row| row[0] }
+  end
+end

--- a/app/models/course/video/event.rb
+++ b/app/models/course/video/event.rb
@@ -17,9 +17,72 @@ class Course::Video::Event < ApplicationRecord
   scope :start_events, -> { where(event_type: type_sym_to_id(START_TYPES)) }
   scope :end_events, -> { where(event_type: type_sym_to_id(END_TYPES)) }
 
-  private
+  # @!method self.interval_starts
+  #   Returns events that are considered to be an start of a watch interval.
+  #
+  #   An event can be considered an interval start if it is an start_event, and that it is the first
+  #   start_event since the start of a session, or since an earlier end_event.
+  scope :interval_starts, lambda {
+    start_events.
+      where('NOT EXISTS ('\
+              'SELECT 1 FROM course_video_events AS prev_start '\
+              'WHERE prev_start.event_type IN (:start_types) '\
+                'AND prev_start.session_id = course_video_events.session_id '\
+                'AND prev_start.sequence_num < course_video_events.sequence_num '\
+                'AND NOT EXISTS ('\
+                  'SELECT 1 FROM course_video_events AS middle_end '\
+                  'WHERE middle_end.event_type IN (:end_types) '\
+                    'AND middle_end.session_id = course_video_events.session_id '\
+                    'AND middle_end.sequence_num > prev_start.sequence_num '\
+                    'AND middle_end.sequence_num < course_video_events.sequence_num'\
+                ')'\
+            ')',
+            start_types: type_sym_to_id(START_TYPES),
+            end_types: type_sym_to_id(END_TYPES))
+  }
 
-  def type_sym_to_id(symbols)
+  # @!method self.interval_ends
+  #   Returns events that are considered to be an end of a watch interval.
+  #
+  #   An event can be considered an interval end if it is an end_event, and that it is the first
+  #   end_event since a previous interval start.
+  scope :interval_ends, lambda {
+    end_events.
+      where('EXISTS ('\
+              'SELECT 1 FROM course_video_events AS prev_start '\
+              'WHERE prev_start.event_type IN (:start_types) '\
+                'AND prev_start.session_id = course_video_events.session_id '\
+                'AND prev_start.sequence_num < course_video_events.sequence_num '\
+                'AND NOT EXISTS ('\
+                  'SELECT 1 FROM course_video_events AS middle_end '\
+                  'WHERE middle_end.event_type IN (:end_types) '\
+                    'AND middle_end.session_id = course_video_events.session_id '\
+                    'AND middle_end.sequence_num > prev_start.sequence_num '\
+                    'AND middle_end.sequence_num < course_video_events.sequence_num'\
+                ')'\
+            ')',
+            start_types: type_sym_to_id(START_TYPES),
+            end_types: type_sym_to_id(END_TYPES))
+  }
+
+  # @!method self.unclosed_starts
+  #   Returns start_events that do not have an end_events after it in a session.
+  #
+  #   These intervals end at the end of the session.
+  scope :unclosed_starts, lambda {
+    interval_starts.
+      where('NOT EXISTS ('\
+              'SELECT 1 FROM course_video_events AS last_end '\
+              'WHERE last_end.event_type IN (:end_types) '\
+                'AND last_end.session_id = course_video_events.session_id '\
+                'AND last_end.sequence_num > course_video_events.sequence_num'\
+            ')',
+            end_types: type_sym_to_id(END_TYPES))
+  }
+
+  def self.type_sym_to_id(symbols)
     symbols.map { |sym| Course::Video::Event.event_types[sym] }
   end
+
+  private_class_method :type_sym_to_id
 end

--- a/app/models/course/video/event.rb
+++ b/app/models/course/video/event.rb
@@ -10,4 +10,16 @@ class Course::Video::Event < ApplicationRecord
   validates :video_time, numericality: { greater_than_or_equal_to: 0 }
 
   enum event_type: [:play, :pause, :speed_change, :seek_start, :seek_end, :buffer, :end]
+
+  START_TYPES = [:play, :seek_end].freeze
+  END_TYPES = [:pause, :seek_start, :end].freeze
+
+  scope :start_events, -> { where(event_type: type_sym_to_id(START_TYPES)) }
+  scope :end_events, -> { where(event_type: type_sym_to_id(END_TYPES)) }
+
+  private
+
+  def type_sym_to_id(symbols)
+    symbols.map { |sym| Course::Video::Event.event_types[sym] }
+  end
 end

--- a/app/models/course/video/submission.rb
+++ b/app/models/course/video/submission.rb
@@ -2,6 +2,7 @@
 class Course::Video::Submission < ApplicationRecord
   include Course::Video::Submission::TodoConcern
   include Course::Video::Submission::NotificationConcern
+  include Course::Video::WatchStatisticsConcern
 
   acts_as_experience_points_record
 
@@ -11,6 +12,7 @@ class Course::Video::Submission < ApplicationRecord
   belongs_to :video, inverse_of: :submissions
 
   has_many :sessions, inverse_of: :submission, dependent: :destroy
+  has_many :events, through: :sessions
 
   # @!method self.ordered_by_date
   #   Orders the submissions by date of creation. This defaults to reverse chronological order
@@ -30,6 +32,12 @@ class Course::Video::Submission < ApplicationRecord
   end
 
   private
+
+  # Returns a scope for all events in this submission.
+  # Used for WatchStatisticsConcern
+  def relevant_events_scope
+    events
+  end
 
   # Validate that the submission creator is the same user as the course_user in the associated
   # experience_points_record.

--- a/app/views/course/video/submission/submissions/show.json.jbuilder
+++ b/app/views/course/video/submission/submissions/show.json.jbuilder
@@ -8,5 +8,5 @@ json.statistics do
       end
     end
   end
-  json.submissionUrl edit_course_video_submission_url(current_course, @video, @submission)
+  json.watchFrequency @submission.watch_frequency
 end

--- a/client/app/bundles/course/video/submission/containers/Charts/HeatMap.jsx
+++ b/client/app/bundles/course/video/submission/containers/Charts/HeatMap.jsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Bar } from 'react-chartjs-2';
+import { injectIntl, intlShape } from 'react-intl';
+import { formatTimestamp } from 'lib/helpers/videoHelpers';
+import { videoDefaults } from 'lib/constants/videoConstants';
+import LoadingIndicator from 'lib/components/LoadingIndicator';
+import { seekToDirectly } from '../../actions/video';
+import translations from '../../translations';
+
+const graphGlobalOptions = {
+  legend: {
+    display: false,
+  },
+  scales: {
+    xAxes: [{
+      scaleLabel: {
+        display: true,
+        labelString: 'Video time',
+        fontSize: 15,
+      },
+      ticks: {
+        suggestedMin: 0,
+      },
+    }],
+    yAxes: [{
+      scaleLabel: {
+        display: true,
+        labelString: 'Watch Frequency',
+        fontSize: 15,
+      },
+      ticks: {
+        suggestedMin: 0,
+        stepSize: 1,
+      },
+    }],
+  },
+};
+
+const barDataOptions = {
+  backgroundColor: 'rgba(75,192,192, 1)',
+  borderColor: 'rgba(75,192,192,1)',
+};
+
+const preferredExpandedBarWidth = 10;
+const expandedChartOffset = 100;
+const fullResWidthThreshold = 16000;
+const minResolution = 0.8;
+const maxWidth = fullResWidthThreshold / minResolution;
+const minWidth = 300;
+const heightOffset = 100;
+const heightScale = 0.85;
+
+const propTypes = {
+  intl: intlShape.isRequired,
+
+  watchFrequency: PropTypes.arrayOf(PropTypes.number).isRequired,
+  videoDuration: PropTypes.number.isRequired,
+  onBarClick: PropTypes.func,
+};
+
+const defaultProps = {
+  onBarClick: () => {},
+};
+
+class HeatMap extends React.Component {
+  mouseOptions = {
+    onClick: (_, elements) => {
+      if (elements.length < 1) {
+        return;
+      }
+      this.props.onBarClick(elements[0]._index); // Index is the video time
+    },
+    hover: {
+      onHover: (event, elements) => {
+        const style = event.target.style;
+        style.cursor = elements.length > 0 ? 'pointer' : 'default';
+      },
+    },
+  };
+
+  calculateWidthAndResolution() {
+    const widthCandidate = (this.props.videoDuration * preferredExpandedBarWidth) + expandedChartOffset;
+
+    if (widthCandidate > maxWidth) {
+      return [maxWidth, minResolution];
+    }
+
+    if (widthCandidate > fullResWidthThreshold) {
+      return [widthCandidate, fullResWidthThreshold / widthCandidate];
+    }
+
+    if (widthCandidate < minWidth) {
+      return [minWidth, 1];
+    }
+
+    return [widthCandidate, 1];
+  }
+
+  render() {
+    if (this.props.videoDuration === videoDefaults.placeHolderDuration) {
+      return <LoadingIndicator />;
+    }
+
+    const data = {
+      labels: Array(this.props.videoDuration).fill(null).map((_, id) => formatTimestamp(id)),
+      datasets: [
+        {
+          ...barDataOptions,
+          data: this.props.watchFrequency,
+        },
+      ],
+    };
+
+    const [width, resolution] = this.calculateWidthAndResolution();
+
+    const options = {
+      maintainAspectRatio: false,
+      devicePixelRatio: resolution,
+      ...graphGlobalOptions,
+      ...this.mouseOptions,
+    };
+
+    return (
+      <div style={{ overflowX: 'scroll' }}>
+        <div style={{ width }}>
+          <Bar data={data} options={options} height={(window.innerHeight - heightOffset) * heightScale} />
+        </div>
+      </div>
+    );
+  }
+}
+
+HeatMap.propTypes = propTypes;
+HeatMap.defaultProps = defaultProps;
+
+function mapStateToProps(state, ownProps) {
+  return {
+    videoDuration: state.video.duration,
+    ...ownProps,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onBarClick: duration => dispatch(seekToDirectly(duration)),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(HeatMap));
+

--- a/client/app/bundles/course/video/submission/containers/Statistics.jsx
+++ b/client/app/bundles/course/video/submission/containers/Statistics.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Tab, Tabs } from 'material-ui/Tabs';
 import { injectIntl, intlShape } from 'react-intl';
 import ProgressGraph from './Charts/ProgressGraph';
+import HeatMap from './Charts/HeatMap';
 import styles from './Statistics.scss';
 
 const propTypes = {
@@ -19,12 +20,17 @@ const propTypes = {
       videoTime: PropTypes.number,
     })),
   })).isRequired,
+  watchFrequency: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 
 class Statistics extends React.Component {
   render() {
     return (
       <Tabs className={styles.statisticsGraphView}>
+        <Tab label="Frequency Graph">
+          <br />
+          <HeatMap watchFrequency={this.props.watchFrequency} />
+        </Tab>
         <Tab label="Progress Graph">
           <ProgressGraph sessions={this.props.sessions} />
         </Tab>

--- a/client/app/bundles/course/video/submission/containers/Statistics.jsx
+++ b/client/app/bundles/course/video/submission/containers/Statistics.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tab, Tabs } from 'material-ui/Tabs';
-import { injectIntl, intlShape } from 'react-intl';
 import ProgressGraph from './Charts/ProgressGraph';
 import HeatMap from './Charts/HeatMap';
 import styles from './Statistics.scss';
 
 const propTypes = {
-  intl: intlShape.isRequired,
-
   sessions: PropTypes.objectOf(PropTypes.shape({
     sessionStart: PropTypes.string,
     sessionEnd: PropTypes.string,
@@ -41,4 +38,4 @@ class Statistics extends React.Component {
 
 Statistics.propTypes = propTypes;
 
-export default injectIntl(Statistics);
+export default Statistics;

--- a/client/app/bundles/course/video/submission/translations.js
+++ b/client/app/bundles/course/video/submission/translations.js
@@ -45,4 +45,12 @@ export default defineMessages({
     id: 'course.video.submission.session.sessionEndLabel',
     defaultMessage: 'Session End',
   },
+  watchFrequency: {
+    id: 'course.video.submission.watchFrequency',
+    defaultMessage: 'Watched {watchFrequency} times',
+  },
+  barGraphScalingLabel: {
+    id: 'course.video.submission.barGraphScalingLabel',
+    defaultMessage: 'Expand Graph',
+  },
 });

--- a/spec/controllers/course/video/submission/sessions_controller_spec.rb
+++ b/spec/controllers/course/video/submission/sessions_controller_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
     let(:student) { create(:course_student, course: course) }
     let(:video) { create(:video, :published, course: course) }
     let!(:session) do
-      create(:video_session, :with_events, course: course, video: video, student: student,
-                                           last_video_time: 0,
-                                           session_start: Time.zone.now - 5.seconds,
-                                           session_end: Time.zone.now - 5.seconds)
+      create(:video_session, :with_events_paused, course: course, video: video, student: student,
+                                                  last_video_time: 0,
+                                                  session_start: Time.zone.now - 5.seconds,
+                                                  session_end: Time.zone.now - 5.seconds)
     end
 
     before { sign_in(student.user) }
@@ -43,7 +43,7 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
         patch :update, as: :json, params: {
           course_id: course.id, video_id: video.id,
           submission_id: session.submission.id, id: session.id,
-          session: { last_video_time: 6, events: events }
+          session: { last_video_time: 32, events: events }
         }
       end
 
@@ -60,7 +60,7 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
         end
 
         it 'updates the video last time' do
-          expect { subject }.to change { session.reload.last_video_time }.by(6)
+          expect { subject }.to change { session.reload.last_video_time }.by(7)
         end
 
         it 'does not create any events' do
@@ -75,7 +75,7 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
              playback_rate: 1,
              event_type: 'play',
              event_time: Time.zone.now },
-           { sequence_num: 10,
+           { sequence_num: 13,
              video_time: 1234,
              playback_rate: 1,
              event_type: 'seek_start',
@@ -92,7 +92,7 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
         end
 
         it 'updates the video last time' do
-          expect { subject }.to change { session.reload.last_video_time }.by(6)
+          expect { subject }.to change { session.reload.last_video_time }.by(7)
         end
 
         it 'updates existing events' do

--- a/spec/factories/course_video_sessions.rb
+++ b/spec/factories/course_video_sessions.rb
@@ -20,9 +20,67 @@ FactoryBot.define do
 
     last_video_time 0
 
-    trait :with_events do
+    # Series of watch intervals with pauses after each interval
+    # The intervals should be [[0, 20], [39, 70], [10, 25]]
+    trait :with_events_paused do
       after(:build) do |session|
-        session.events = (1..5).map { |n| build(:video_event, sequence_num: n) }
+        session.events << build(:video_event, sequence_num: 1, event_type: 'play',
+                                              video_time: 0)
+        session.events << build(:video_event, sequence_num: 2, event_type: 'pause',
+                                              video_time: 20)
+        session.events << build(:video_event, sequence_num: 3, event_type: 'seek_start',
+                                              video_time: 20)
+        session.events << build(:video_event, sequence_num: 4, event_type: 'buffer',
+                                              video_time: 17)
+        session.events << build(:video_event, sequence_num: 5, event_type: 'seek_end',
+                                              video_time: 39)
+        session.events << build(:video_event, sequence_num: 6, event_type: 'play',
+                                              video_time: 39)
+        session.events << build(:video_event, sequence_num: 7, event_type: 'end',
+                                              video_time: 70)
+        session.events << build(:video_event, sequence_num: 8, event_type: 'seek_start',
+                                              video_time: 70)
+        session.events << build(:video_event, sequence_num: 9, event_type: 'buffer',
+                                              video_time: 67)
+        session.events << build(:video_event, sequence_num: 10, event_type: 'seek_end',
+                                              video_time: 10)
+        session.events << build(:video_event, sequence_num: 11, event_type: 'play',
+                                              video_time: 10)
+        session.events << build(:video_event, sequence_num: 12, event_type: 'pause',
+                                              video_time: 25)
+        session.last_video_time = 25
+      end
+    end
+
+    # Series of watch intervals without pauses after each interval
+    # The intervals should be [[0, 5], [30, 50], [19, 37]]
+    trait :with_events_continuous do
+      after(:build) do |session|
+        session.events << build(:video_event, sequence_num: 1, event_type: 'play',
+                                              video_time: 0)
+        session.events << build(:video_event, sequence_num: 2, event_type: 'seek_start',
+                                              video_time: 5)
+        session.events << build(:video_event, sequence_num: 3, event_type: 'buffer',
+                                              video_time: 17)
+        session.events << build(:video_event, sequence_num: 4, event_type: 'seek_end',
+                                              video_time: 30)
+        session.events << build(:video_event, sequence_num: 5, event_type: 'play',
+                                              video_time: 30)
+        session.events << build(:video_event, sequence_num: 6, event_type: 'seek_start',
+                                              video_time: 50)
+        session.events << build(:video_event, sequence_num: 7, event_type: 'buffer',
+                                              video_time: 18)
+        session.events << build(:video_event, sequence_num: 8, event_type: 'seek_end',
+                                              video_time: 19)
+        session.events << build(:video_event, sequence_num: 9, event_type: 'play',
+                                              video_time: 20)
+        session.events << build(:video_event, sequence_num: 10, event_type: 'buffer',
+                                              video_time: 24)
+        session.events << build(:video_event, sequence_num: 11, event_type: 'play',
+                                              video_time: 24)
+        session.events << build(:video_event, sequence_num: 12, event_type: 'speed_change',
+                                              video_time: 30, playback_rate: 1.5)
+        session.last_video_time = 37
       end
     end
   end

--- a/spec/models/course/video/event_spec.rb
+++ b/spec/models/course/video/event_spec.rb
@@ -17,5 +17,50 @@ RSpec.describe Course::Video::Event, type: :model do
         end
       end
     end
+
+    describe '.interval_starts' do
+      let(:session1) { create(:video_session, :with_events_paused) }
+      let(:session2) { create(:video_session, :with_events_continuous) }
+
+      it 'returns only the starts of watch intervals' do
+        seq_nums = Course::Video::Event.
+                   unscope(:order).
+                   where(session_id: [session1.id, session2.id]).
+                   interval_starts.
+                   order(:video_time).
+                   pluck(:video_time)
+        expect(seq_nums).to eq([0, 0, 10, 19, 30, 39])
+      end
+    end
+
+    describe '.interval_ends' do
+      let(:session1) { create(:video_session, :with_events_paused) }
+      let(:session2) { create(:video_session, :with_events_continuous) }
+
+      it 'returns only the end of watch intervals' do
+        seq_nums = Course::Video::Event.
+                   unscope(:order).
+                   where(session_id: [session1.id, session2.id]).
+                   interval_ends.
+                   order(:video_time).
+                   pluck(:video_time)
+        expect(seq_nums).to eq([5, 20, 25, 50, 70]) # 37 not included since it's captured in session
+      end
+    end
+
+    describe '.unclosed_starts' do
+      let(:session1) { create(:video_session, :with_events_paused) }
+      let(:session2) { create(:video_session, :with_events_continuous) }
+
+      it 'returns only start events without a matching end event' do
+        seq_nums = Course::Video::Event.
+                   unscope(:order).
+                   where(session_id: [session1.id, session2.id]).
+                   unclosed_starts.
+                   order(:video_time).
+                   pluck(:video_time)
+        expect(seq_nums).to eq([19])
+      end
+    end
   end
 end

--- a/spec/models/course/video/session_spec.rb
+++ b/spec/models/course/video/session_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Course::Video::Session do
     end
 
     describe 'events' do
-      let(:session) { create(:video_session, :with_events) }
+      let(:session) { create(:video_session, :with_events_paused) }
 
       it 'returns events in order of sequence number' do
         expect(session.events.pluck(:sequence_num)).to eq((1..session.events.count).to_a)
@@ -39,7 +39,7 @@ RSpec.describe Course::Video::Session do
 
     describe 'with_events_present' do
       let(:submission) { create(:video_submission) }
-      let!(:session1) { create(:video_session, :with_events, submission: submission) }
+      let!(:session1) { create(:video_session, :with_events_paused, submission: submission) }
       let!(:session2) { create(:video_session, submission: submission) }
 
       subject do
@@ -54,7 +54,7 @@ RSpec.describe Course::Video::Session do
 
     describe 'merge_in_events!' do
       subject do
-        create(:video_session, :with_events)
+        create(:video_session, :with_events_paused)
       end
 
       context 'when event already exists' do
@@ -67,7 +67,7 @@ RSpec.describe Course::Video::Session do
         end
 
         it 'overwrites the old event ' do
-          expect(subject.events.count).to eq(5)
+          expect(subject.events.count).to eq(12)
           expect(subject.events.where(sequence_num: 1).count).to eq(1)
 
           old_event = subject.events.find_by(sequence_num: 1)
@@ -87,7 +87,7 @@ RSpec.describe Course::Video::Session do
         end
 
         it `creates a new event` do
-          expect(subject.events.count).to eq(6)
+          expect(subject.events.count).to eq(13)
           expect(subject.events.exists?(sequence_num: 100)).to be_truthy
 
           new_event = subject.events.find_by(sequence_num: 100)

--- a/spec/models/course/video/submission_spec.rb
+++ b/spec/models/course/video/submission_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe Course::Video::Submission do
       end
     end
 
+    describe '.watch_frequency' do
+      let!(:session1) { create(:video_session, :with_events_paused, submission: submission1) }
+      let!(:session2) { create(:video_session, :with_events_continuous, submission: submission1) }
+
+      it 'computes the right watch frequency distribution' do
+        intervals = [[0, 5], [30, 50], [19, 37], [0, 20], [39, 70], [10, 25]]
+        distribution = Array.new(71, 0)
+        intervals.each do |interval|
+          (interval[0]..interval[1]).each do |video_time|
+            distribution[video_time] += 1
+          end
+        end
+
+        expect(submission1.watch_frequency).to eq(distribution)
+      end
+    end
+
     describe 'callbacks from Course::Video::Submission::TodoConcern' do
       before { submission1 }
       subject do


### PR DESCRIPTION
Add a heatmap for video submission so as to analyze which parts of the video are being watched more.

We compute watch intervals by filtering out the events that we consider to start or end an interval.

The heatmap can be represented by a mapping of video time to frequency. Given the sorted start and end events, we can walk down both lists and keep a counter for the currently open intervals to compute the frequency in linear time.