### PR TITLE
Associate Skills with QuestionAssessments instead of Question

### DIFF
--- a/app/controllers/course/assessment/question/controller.rb
+++ b/app/controllers/course/assessment/question/controller.rb
@@ -10,8 +10,12 @@ class Course::Assessment::Question::Controller < Course::Assessment::ComponentCo
   def self.build_and_authorize_new_question(question_name, options)
     before_action only: options[:only], except: options[:except] do
       question = options[:class].new
-      question.question_assessments.build(assessment: @assessment)
-      question.assign_attributes(send("#{question_name}_params")) if action_name != 'new'
+      @question_assessment = question.question_assessments.build(assessment: @assessment)
+      if action_name != 'new'
+        question_params = send("#{question_name}_params")
+        @question_assessment.skill_ids = question_params[:question_assessment].try(:[], :skill_ids)
+        question.assign_attributes(question_params.except(:question_assessment))
+      end
       authorize!(action_name.to_sym, question)
       instance_variable_set("@#{question_name}", question) unless instance_variable_get("@#{question_name}")
     end

--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -5,6 +5,7 @@ class Course::Assessment::Question::MultipleResponsesController < Course::Assess
   load_and_authorize_resource :multiple_response_question,
                               class: Course::Assessment::Question::MultipleResponse,
                               through: :assessment, parent: false, except: [:new, :create]
+  before_action :load_question_assessment, only: [:edit, :update]
 
   def new
     @multiple_response_question.grading_scheme = :any_correct if params[:multiple_choice] == 'true'
@@ -20,12 +21,12 @@ class Course::Assessment::Question::MultipleResponsesController < Course::Assess
     end
   end
 
-  def edit
-    @question_assessment = load_question_assessment_for(@multiple_response_question)
-  end
+  def edit; end
 
   def update
-    if @multiple_response_question.update_attributes(multiple_response_question_params)
+    @question_assessment.skill_ids = multiple_response_question_params[:question_assessment][:skill_ids]
+    if @multiple_response_question.update(multiple_response_question_params.
+                                          except(:question_assessment))
       redirect_to course_assessment_path(current_course, @assessment),
                   success: t('.success')
     else
@@ -49,8 +50,12 @@ class Course::Assessment::Question::MultipleResponsesController < Course::Assess
   def multiple_response_question_params
     params.require(:question_multiple_response).permit(
       :title, :description, :staff_only_comments, :maximum_grade, :grading_scheme,
-      skill_ids: [],
+      question_assessment: { skill_ids: [] },
       options_attributes: [:_destroy, :id, :correct, :option, :explanation, :weight]
     )
+  end
+
+  def load_question_assessment
+    @question_assessment = load_question_assessment_for(@multiple_response_question)
   end
 end

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -34,8 +34,10 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
 
   def update
     result = @programming_question.class.transaction do
-      @programming_question.assign_attributes programming_question_params
-      @programming_question.skills.clear if programming_question_params[:skill_ids].blank?
+      @question_assessment.skill_ids = programming_question_params[:question_assessment].
+                                       try(:[], :skill_ids)
+      @programming_question.assign_attributes(programming_question_params.
+                                              except(:question_assessment))
       process_package
 
       raise ActiveRecord::Rollback unless @programming_question.save
@@ -69,7 +71,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
       :title, :description, :staff_only_comments, :maximum_grade,
       :language_id, :memory_limit, :time_limit, :attempt_limit,
       *attachment_params,
-      skill_ids: []
+      question_assessment: { skill_ids: [] }
     )
   end
 

--- a/app/controllers/course/assessment/question/voice_responses_controller.rb
+++ b/app/controllers/course/assessment/question/voice_responses_controller.rb
@@ -5,6 +5,7 @@ class Course::Assessment::Question::VoiceResponsesController < Course::Assessmen
   load_and_authorize_resource :voice_response_question,
                               class: Course::Assessment::Question::VoiceResponse,
                               through: :assessment, parent: false, except: [:new, :create]
+  before_action :load_question_assessment, only: [:edit, :update]
 
   def create
     if @voice_response_question.save
@@ -19,7 +20,8 @@ class Course::Assessment::Question::VoiceResponsesController < Course::Assessmen
   end
 
   def update
-    if @voice_response_question.update_attributes(voice_response_question_params)
+    @question_assessment.skill_ids = voice_response_question_params[:question_assessment][:skill_ids]
+    if @voice_response_question.update(voice_response_question_params.except(:question_assessment))
       redirect_to course_assessment_path(current_course, @assessment),
                   success: t('.success')
     else
@@ -27,9 +29,7 @@ class Course::Assessment::Question::VoiceResponsesController < Course::Assessmen
     end
   end
 
-  def edit
-    @question_assessment = load_question_assessment_for(@voice_response_question)
-  end
+  def edit; end
 
   def destroy
     if @voice_response_question.destroy
@@ -47,7 +47,12 @@ class Course::Assessment::Question::VoiceResponsesController < Course::Assessmen
   def voice_response_question_params
     params.require(:question_voice_response).permit(
       :file, :title, :description,
-      :staff_only_comments, :maximum_grade, skill_ids: []
+      :staff_only_comments, :maximum_grade,
+      question_assessment: { skill_ids: [] }
     )
+  end
+
+  def load_question_assessment
+    @question_assessment = load_question_assessment_for(@voice_response_question)
   end
 end

--- a/app/controllers/course/assessment/questions_controller.rb
+++ b/app/controllers/course/assessment/questions_controller.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 class Course::Assessment::QuestionsController < Course::Assessment::Controller
   load_and_authorize_resource :question, class: Course::Assessment::Question, through: :assessment
-  before_action :load_and_authorize_destination_assessment, only: :duplicate
+  before_action :load_and_authorize_assessments, only: :duplicate
 
+  # The current assumption is that the destination assessment's course is the same as the current
+  # course for this action.
+  # Thus the skills just have to assigned to the new question_assessment, instead of going through
+  # the Duplicator like the usual process for duplicating question_assessments.
   def duplicate
-    if @destination_assessment.questions << duplicated_question
+    if duplicate_question_and_skills
       flash.now[:success] =
         t('.success', destination_name: @destination_assessment.title,
                       destination_link: course_assessment_path(current_course, @destination_assessment))
@@ -15,19 +19,28 @@ class Course::Assessment::QuestionsController < Course::Assessment::Controller
 
   private
 
-  def load_and_authorize_destination_assessment
+  def load_and_authorize_assessments
     @destination_assessment = Course::Assessment.find(params[:destination_assessment_id])
     authorize! :update, @destination_assessment
+
+    @source_assessment = Course::Assessment.find(params[:assessment_id])
   end
 
-  # Duplicates the target question and associates skills, if any.
+  # Duplicates the target question, skills can only be assigned with a question_assessment.
   # It currently assumes that the destination assessment's course is the current course.
   #
   # @return [Course::Assessment::Question] The duplicated question
   def duplicated_question
     duplicator = Duplicator.new({}, current_course: current_course)
-    duplicator.duplicate(@question.specific).tap do |duplicate|
-      duplicate.skills = @question.skills
-    end.acting_as
+    duplicator.duplicate(@question.specific).acting_as
+  end
+
+  def duplicate_question_and_skills
+    destination_question_assessment = duplicated_question.question_assessments.
+                                      build(assessment: @destination_assessment)
+    source_question_assessment = @question.question_assessments.
+                                 select { |qa| qa.assessment == @source_assessment }.first
+    destination_question_assessment.skills = source_question_assessment.skills
+    @destination_assessment.question_assessments << destination_question_assessment
   end
 end

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -7,7 +7,6 @@ class Course::Assessment::Question < ApplicationRecord
                                   dependent: :destroy
   has_many :answers, class_name: Course::Assessment::Answer.name, dependent: :destroy,
                      inverse_of: :question
-  has_and_belongs_to_many :skills
   has_many :submission_questions, class_name: Course::Assessment::SubmissionQuestion.name,
                                   dependent: :destroy, inverse_of: :question
 
@@ -78,12 +77,5 @@ class Course::Assessment::Question < ApplicationRecord
     self.description = other.description
     self.staff_only_comments = other.staff_only_comments
     self.maximum_grade = other.maximum_grade
-  end
-
-  # Associates duplicated skills with the current question
-  def associate_duplicated_skills(duplicator, other)
-    skills << other.skills.
-              select { |skill| duplicator.duplicated?(skill) }.
-              map { |skill| duplicator.duplicate(skill) }
   end
 end

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -38,7 +38,6 @@ class Course::Assessment::Question::MultipleResponse < ApplicationRecord
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
-    associate_duplicated_skills(duplicator, other)
 
     self.options = duplicator.duplicate(other.options)
   end

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -93,7 +93,6 @@ class Course::Assessment::Question::Programming < ApplicationRecord
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
-    associate_duplicated_skills(duplicator, other)
 
     # TODO: check if there are any side effects from this
     self.import_job_id = nil

--- a/app/models/course/assessment/question/scribing.rb
+++ b/app/models/course/assessment/question/scribing.rb
@@ -9,7 +9,6 @@ class Course::Assessment::Question::Scribing < ApplicationRecord
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
-    associate_duplicated_skills(duplicator, other)
 
     self.attachment = duplicator.duplicate(other.attachment)
   end

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -70,7 +70,6 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
-    associate_duplicated_skills(duplicator, other)
 
     if comprehension_question?
       self.groups = duplicator.duplicate(other.groups)

--- a/app/models/course/assessment/question/voice_response.rb
+++ b/app/models/course/assessment/question/voice_response.rb
@@ -12,7 +12,6 @@ class Course::Assessment::Question::VoiceResponse < ApplicationRecord
 
   def initialize_duplicate(duplicator, other)
     copy_attributes(other)
-    associate_duplicated_skills(duplicator, other)
   end
 
   # returns the type of question i.e. Audio response

--- a/app/models/course/assessment/skill.rb
+++ b/app/models/course/assessment/skill.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::Skill < ApplicationRecord
   belongs_to :course, inverse_of: :assessment_skills
   belongs_to :skill_branch, class_name: Course::Assessment::SkillBranch.name, inverse_of: :skills, optional: true
-  has_and_belongs_to_many :questions, class_name: Course::Assessment::Question.name
+  has_and_belongs_to_many :question_assessments, class_name: Course::QuestionAssessment.name
 
   validate :validate_consistent_course
 
@@ -13,9 +13,8 @@ class Course::Assessment::Skill < ApplicationRecord
   def initialize_duplicate(duplicator, other)
     self.course = duplicator.options[:destination_course]
     self.skill_branch = duplicator.duplicated?(other.skill_branch) ? duplicator.duplicate(other.skill_branch) : nil
-    questions << other.questions.map(&:actable).
-                 select { |question| duplicator.duplicated?(question) }.
-                 map { |question| duplicator.duplicate(question).acting_as }
+    question_assessments << other.question_assessments.select { |qa| duplicator.duplicated?(qa) }.
+                            map { |qa| duplicator.duplicate(qa) }
   end
 
   private

--- a/app/models/course/question_assessment.rb
+++ b/app/models/course/question_assessment.rb
@@ -4,6 +4,7 @@ class Course::QuestionAssessment < ApplicationRecord
 
   belongs_to :assessment, inverse_of: :question_assessments, class_name: Course::Assessment.name
   belongs_to :question, inverse_of: :question_assessments, class_name: Course::Assessment::Question.name
+  has_and_belongs_to_many :skills, inverse_of: :question_assessments, class_name: Course::Assessment::Skill.name
 
   default_scope { order(weight: :asc) }
 
@@ -22,6 +23,8 @@ class Course::QuestionAssessment < ApplicationRecord
   def initialize_duplicate(duplicator, other)
     self.weight = other.weight
     self.question = duplicator.duplicate(other.question.actable).acting_as
+    skills << other.skills.select { |skill| duplicator.duplicated?(skill) }.
+              map { |skill| duplicator.duplicate(skill) }
   end
 
   private

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -1,6 +1,6 @@
 = simple_form_for [current_course, @assessment, @multiple_response_question] do |f|
   = f.error_notification
-  = render partial: 'course/assessment/questions/form', locals: { f: f }
+  = render partial: 'course/assessment/questions/form', locals: { f: f, question_assessment: @question_assessment }
   = f.hidden_field :grading_scheme
 
   / workaround for plataformatec/simple_form#1284

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -6,8 +6,8 @@ json.question do
     json.(lang, :id, :name)
     json.editor_mode lang.ace_mode
   end
-  json.skill_ids @programming_question.skills.order('LOWER(title) ASC').as_json(only: [:id, :title])
-  json.skills current_course.assessment_skills.order('LOWER(title) ASC') do |skill|
+  json.skill_ids @question_assessment.skills.order_by_title.as_json(only: [:id, :title])
+  json.skills current_course.assessment_skills.order_by_title do |skill|
     json.(skill, :id, :title)
   end
 

--- a/app/views/course/assessment/question/scribing/_scribing_question.json.jbuilder
+++ b/app/views/course/assessment/question/scribing/_scribing_question.json.jbuilder
@@ -13,7 +13,7 @@ json.question do
   end
 
   # TODO: Shift skills out into a separate partial.
-  json.skill_ids @scribing_question.skills.order_by_title.pluck(:id)
+  json.skill_ids @question_assessment.skills.order_by_title.pluck(:id)
   json.skills current_course.assessment_skills.order_by_title do |skill|
     json.(skill, :id, :title)
   end

--- a/app/views/course/assessment/question/text_responses/_form.html.slim
+++ b/app/views/course/assessment/question/text_responses/_form.html.slim
@@ -1,6 +1,6 @@
 = simple_form_for [current_course, @assessment, @text_response_question] do |f|
   = f.error_notification
-  = render partial: 'course/assessment/questions/form', locals: { f: f }
+  = render partial: 'course/assessment/questions/form', locals: { f: f, question_assessment: @question_assessment }
   = f.hidden_field :hide_text
   = f.hidden_field :is_comprehension
 

--- a/app/views/course/assessment/question/voice_responses/_form.html.slim
+++ b/app/views/course/assessment/question/voice_responses/_form.html.slim
@@ -1,6 +1,6 @@
 = simple_form_for [current_course, @assessment, @voice_response_question] do |f|
   = f.error_notification
-  = render partial: 'course/assessment/questions/form', locals: { f: f }
+  = render partial: 'course/assessment/questions/form', locals: { f: f, question_assessment: @question_assessment }
   - name = t('.voice_response_button')
   - if f.object.persisted?
     - button_text = t('helpers.buttons.update', model: name)

--- a/app/views/course/assessment/questions/_form.html.slim
+++ b/app/views/course/assessment/questions/_form.html.slim
@@ -2,5 +2,6 @@
 = f.input :description, as: :text
 = f.input :staff_only_comments, as: :text
 = f.input :maximum_grade
-= f.input :skill_ids, as: :token, collection: current_course.assessment_skills,
-  multiple: true, label: t('.skills')
+= f.simple_fields_for question_assessment do |qa_form|
+  = qa_form.input :skill_ids, as: :token, collection: current_course.assessment_skills,
+    multiple: true, label: t('.skills')

--- a/client/app/api/course/Assessment/question/scribing/Scribing.js
+++ b/client/app/api/course/Assessment/question/scribing/Scribing.js
@@ -1,5 +1,6 @@
 import { getCourseId, getAssessmentId, getScribingId } from 'lib/helpers/url-helpers';
 import BaseAPI from '../../../../Base';
+import SubmissionsAPI from '../../Submissions';
 
 export default class ScribingsAPI extends BaseAPI {
   /**
@@ -29,27 +30,15 @@ export default class ScribingsAPI extends BaseAPI {
   }
 
   /**
-   * Helper method to generate FormData
+   * Helper method to generate FormData. Use SubmissionsAPI.appendFormData as it supports
+   * nested objects.
    *
    * @param {object} question object to be converted
    * @return {FormData}
    */
   static generateFormData(question) {
     const formData = new FormData();
-
-    Object.keys(question).forEach((key) => {
-      if (Object.prototype.hasOwnProperty.call(question, key)) {
-        const value = question[key];
-        if (Array.isArray(value)) {
-          value.forEach((val) => {
-            formData.append(`question_scribing[${key}][]`, val);
-          });
-        } else {
-          formData.append(`question_scribing[${key}]`, value);
-        }
-      }
-    });
-
+    SubmissionsAPI.appendFormData(formData, question, 'question_scribing');
     return formData;
   }
 

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -290,7 +290,7 @@ class ProgrammingQuestionForm extends React.Component {
           menuStyle={{ maxHeight: '80vh', overflowY: 'scroll' }}
         />
         <select
-          name={`${ProgrammingQuestionForm.getInputName(field)}[]`}
+          name={`${ProgrammingQuestionForm.getInputName('question_assessment')}[${field}][]`}
           multiple
           value={value.map(opt => opt.id)}
           style={{ display: 'none' }}

--- a/client/app/bundles/course/assessment/question/scribing/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/question/scribing/__test__/index.test.js
@@ -32,7 +32,7 @@ const mockUpdatedFields = {
   question_scribing: {
     description: '',
     maximum_grade: 10,
-    skill_ids: [''],
+    question_assessment: { skill_ids: [''] },
     staff_only_comments: '',
     title: 'Scribing Exercise',
   },

--- a/client/app/bundles/course/assessment/question/scribing/actions/__test__/responses.test.js
+++ b/client/app/bundles/course/assessment/question/scribing/actions/__test__/responses.test.js
@@ -33,7 +33,7 @@ const processedMockFields = {
   question_scribing: {
     title: 'Scribing Exercise',
     maximum_grade: 10,
-    skill_ids: [''],
+    question_assessment: { skill_ids: [''] },
   },
 };
 

--- a/client/app/bundles/course/assessment/question/scribing/actions/scribingQuestionActionCreators.jsx
+++ b/client/app/bundles/course/assessment/question/scribing/actions/scribingQuestionActionCreators.jsx
@@ -59,8 +59,7 @@ function processFields(fields) {
   parsedFields.question_scribing.question_assessment = {};
   if (fields.question_scribing.skill_ids.length < 1) {
     parsedFields.question_scribing.question_assessment.skill_ids = [''];
-  }
-  else {
+  } else {
     parsedFields.question_scribing.question_assessment.skill_ids =
       parsedFields.question_scribing.skill_ids;
   }

--- a/client/app/bundles/course/assessment/question/scribing/actions/scribingQuestionActionCreators.jsx
+++ b/client/app/bundles/course/assessment/question/scribing/actions/scribingQuestionActionCreators.jsx
@@ -54,9 +54,17 @@ function processFields(fields) {
   // Deep clone JSON fields
   const parsedFields = JSON.parse(JSON.stringify(fields));
 
+  // Modify the structure of `parsedFields` so it matches what non React forms
+  // pass to the Rails backend.
+  parsedFields.question_scribing.question_assessment = {};
   if (fields.question_scribing.skill_ids.length < 1) {
-    parsedFields.question_scribing.skill_ids = [''];
+    parsedFields.question_scribing.question_assessment.skill_ids = [''];
   }
+  else {
+    parsedFields.question_scribing.question_assessment.skill_ids =
+      parsedFields.question_scribing.skill_ids;
+  }
+
   if (fields.question_scribing.attachment) {
     parsedFields.question_scribing.file = fields.question_scribing.attachment.file;
   } else {
@@ -64,6 +72,7 @@ function processFields(fields) {
   }
 
   delete parsedFields.question_scribing.attachment;
+  delete parsedFields.question_scribing.skill_ids;
 
   return parsedFields;
 }

--- a/db/migrate/20180703023011_create_course_assessment_skills_question_assessments.rb
+++ b/db/migrate/20180703023011_create_course_assessment_skills_question_assessments.rb
@@ -1,0 +1,29 @@
+class CreateCourseAssessmentSkillsQuestionAssessments < ActiveRecord::Migration[5.1]
+  def up
+    create_table :course_assessment_skills_question_assessments do |t|
+      t.integer :question_assessment_id, references: :course_question_assessments, null: false,
+                index: {name: 'index_course_assessment_skills_question_assessments_on_qa_id'}
+      t.integer :skill_id, references: :course_assessment_skills, null: false, index: true
+    end
+
+    add_index :course_assessment_skills_question_assessments, [:question_assessment_id, :skill_id],
+              unique: true, name: 'index_skills_qn_assessments_on_qa_id_and_skill_id'
+    add_foreign_key :course_assessment_skills_question_assessments, :course_assessment_skills,
+                    column: :skill_id
+    add_foreign_key :course_assessment_skills_question_assessments, :course_question_assessments,
+                    column: :question_assessment_id
+
+    # migrate the question <-> skills data
+    execute <<-SQL
+      INSERT INTO course_assessment_skills_question_assessments(question_assessment_id, skill_id)
+        SELECT cqa.id, skill_id FROM course_assessment_questions_skills caqs INNER JOIN course_question_assessments cqa
+          ON caqs.question_id = cqa.question_id
+    SQL
+
+    drop_table :course_assessment_questions_skills
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180424030829) do
+ActiveRecord::Schema.define(version: 20180703023011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -255,11 +255,6 @@ ActiveRecord::Schema.define(version: 20180424030829) do
     t.datetime "updated_at",          :null=>false
   end
 
-  create_table "course_assessment_questions_skills", force: :cascade do |t|
-    t.integer "question_id", :null=>false, :index=>{:name=>"course_assessment_question_skills_question_index", :order=>{:question_id=>:asc}}
-    t.integer "skill_id",    :null=>false, :index=>{:name=>"course_assessment_question_skills_skill_index", :order=>{:skill_id=>:asc}}
-  end
-
   create_table "course_assessment_skill_branches", force: :cascade do |t|
     t.integer  "course_id",   :null=>false, :index=>{:name=>"fk__course_assessment_skill_branches_course_id", :order=>{:course_id=>:asc}}
     t.string   "title",       :limit=>255, :null=>false
@@ -279,6 +274,13 @@ ActiveRecord::Schema.define(version: 20180424030829) do
     t.integer  "updater_id",      :null=>false, :index=>{:name=>"fk__course_assessment_skills_updater_id", :order=>{:updater_id=>:asc}}
     t.datetime "created_at",      :null=>false
     t.datetime "updated_at",      :null=>false
+  end
+
+  create_table "course_assessment_skills_question_assessments", force: :cascade do |t|
+    t.integer "question_assessment_id", :null=>false, :index=>{:name=>"index_course_assessment_skills_question_assessments_on_qa_id", :order=>{:question_assessment_id=>:asc}}
+    t.integer "skill_id",               :null=>false, :index=>{:name=>"index_course_assessment_skills_question_assessments_on_skill_id", :order=>{:skill_id=>:asc}}
+
+    t.index ["question_assessment_id", "skill_id"], :name=>"index_skills_qn_assessments_on_qa_id_and_skill_id", :unique=>true, :order=>{:question_assessment_id=>:asc, :skill_id=>:asc}
   end
 
   create_table "course_assessment_submission_logs", force: :cascade do |t|
@@ -948,8 +950,6 @@ ActiveRecord::Schema.define(version: 20180424030829) do
   add_foreign_key "course_assessment_question_text_response_solutions", "course_assessment_question_text_responses", column: "question_id", name: "fk_course_assessment_questi_2fbeabfad04f21c2d05c8b2d9100d1c4"
   add_foreign_key "course_assessment_questions", "users", column: "creator_id", name: "fk_course_assessment_questions_creator_id"
   add_foreign_key "course_assessment_questions", "users", column: "updater_id", name: "fk_course_assessment_questions_updater_id"
-  add_foreign_key "course_assessment_questions_skills", "course_assessment_questions", column: "question_id", name: "fk_course_assessment_questions_skills_question_id"
-  add_foreign_key "course_assessment_questions_skills", "course_assessment_skills", column: "skill_id", name: "fk_course_assessment_questions_skills_skill_id"
   add_foreign_key "course_assessment_skill_branches", "courses", name: "fk_course_assessment_skill_branches_course_id"
   add_foreign_key "course_assessment_skill_branches", "users", column: "creator_id", name: "fk_course_assessment_skill_branches_creator_id"
   add_foreign_key "course_assessment_skill_branches", "users", column: "updater_id", name: "fk_course_assessment_skill_branches_updater_id"
@@ -957,6 +957,8 @@ ActiveRecord::Schema.define(version: 20180424030829) do
   add_foreign_key "course_assessment_skills", "courses", name: "fk_course_assessment_skills_course_id"
   add_foreign_key "course_assessment_skills", "users", column: "creator_id", name: "fk_course_assessment_skills_creator_id"
   add_foreign_key "course_assessment_skills", "users", column: "updater_id", name: "fk_course_assessment_skills_updater_id"
+  add_foreign_key "course_assessment_skills_question_assessments", "course_assessment_skills", column: "skill_id"
+  add_foreign_key "course_assessment_skills_question_assessments", "course_question_assessments", column: "question_assessment_id"
   add_foreign_key "course_assessment_submission_logs", "course_assessment_submissions", column: "submission_id", name: "fk_course_assessment_submission_logs_submission_id"
   add_foreign_key "course_assessment_submission_questions", "course_assessment_questions", column: "question_id", name: "fk_course_assessment_submission_questions_question_id"
   add_foreign_key "course_assessment_submission_questions", "course_assessment_submissions", column: "submission_id", name: "fk_course_assessment_submission_questions_submission_id"

--- a/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/multiple_response_controller_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Course::Assessment::Question::MultipleResponsesController do
         question_multiple_response_attributes =
           attributes_for(:course_assessment_question_multiple_response).
           slice(:description, :maximum_grade)
+        question_multiple_response_attributes[:question_assessment] = { skill_ids: [''] }
         patch :update, params: {
           course_id: course, assessment_id: assessment, id: multiple_response,
           question_multiple_response: question_multiple_response_attributes
@@ -77,7 +78,8 @@ RSpec.describe Course::Assessment::Question::MultipleResponsesController do
                       id: multiple_response.options.second.id,
                       weight: multiple_response.options.second.weight
                     }
-                }
+                },
+              question_assessment: { skill_ids: [''] }
             }
           patch :update, params: {
             course_id: course, assessment_id: assessment, id: multiple_response,

--- a/spec/controllers/course/assessment/question/scribing_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/scribing_controller_spec.rb
@@ -11,11 +11,13 @@ RSpec.describe Course::Assessment::Question::ScribingController do
     let(:scribing_question) { nil }
     let(:question_scribing_attributes) do
       attributes_for(:course_assessment_question_scribing).
-        slice(:title, :description, :staff_only_comments, :maximum_grade, :file)
+        slice(:title, :description, :staff_only_comments, :maximum_grade, :file).
+        merge(question_assessment: { skill_ids: [''] })
     end
     let(:question_scribing_update_attributes) do
       attributes_for(:course_assessment_question_scribing).
-        slice(:title, :description, :staff_only_comments, :maximum_grade)
+        slice(:title, :description, :staff_only_comments, :maximum_grade).
+        merge(question_assessment: { skill_ids: [''] })
     end
     let(:immutable_scribing_question) do
       create(:course_assessment_question_scribing, assessment: assessment).tap do |question|

--- a/spec/controllers/course/assessment/question/text_responses_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/text_responses_controller_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Course::Assessment::Question::TextResponsesController do
         question_text_response_attributes =
           attributes_for(:course_assessment_question_text_response).
           slice(:description, :maximum_grade)
+        question_text_response_attributes[:question_assessment] = { skill_ids: [''] }
         patch :update, params: {
           course_id: course, assessment_id: assessment, id: text_response,
           question_text_response: question_text_response_attributes

--- a/spec/features/course/assessment/question/duplication_spec.rb
+++ b/spec/features/course/assessment/question/duplication_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'Course: Assessments: Questions: Duplication Spec' do
     let(:source_assessment) do
       create(:assessment, :with_mcq_question, course: course).tap do |assessment|
         mcq_question = assessment.questions.first
-        mcq_question.skills << build(:course_assessment_skill, course: course)
+        mcq_question.question_assessments.first.skills <<
+          build(:course_assessment_skill, course: course)
       end
     end
     let(:destination_assessment) { create(:assessment, :with_programming_question, course: course) }
@@ -35,7 +36,8 @@ RSpec.describe 'Course: Assessments: Questions: Duplication Spec' do
         original_mcq_question = source_assessment.questions.last
         duplicated_mcq_question = destination_assessment.questions.last
         expect(duplicated_mcq_question.title).to eq(original_mcq_question.title)
-        expect(duplicated_mcq_question.skills.first.id).to eq(original_mcq_question.skills.first.id)
+        expect(duplicated_mcq_question.question_assessments.first.skills.first.id).
+          to eq(original_mcq_question.question_assessments.first.skills.first.id)
       end
     end
   end

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         expect(page).
           to have_selector('div', text: I18n.t('course.assessment.question.multiple_responses.create.success'))
         expect(question_created).not_to be_multiple_choice
-        expect(question_created.skills).to contain_exactly(skill)
+        expect(question_created.question_assessments.first.skills).to contain_exactly(skill)
         expect(question_created.options).to be_present
       end
 

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
                                  question_attributes[:staff_only_comments]
         fill_in 'question_programming[maximum_grade]', with: question_attributes[:maximum_grade]
 
-        page.execute_script("$('select[name=\"question_programming[skill_ids][]\"]').show()")
-        within find_field('question_programming[skill_ids][]') do
+        page.execute_script("$('select[name=\"question_programming[question_assessment][skill_ids][]\"]').show()")
+        within find_field('question_programming[question_assessment][skill_ids][]') do
           select skill.title
         end
 
@@ -49,7 +49,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
           to include(question_attributes[:description])
         expect(question_created.staff_only_comments).
           to include(question_attributes[:staff_only_comments])
-        expect(question_created.skills).to contain_exactly(skill)
+        expect(question_created.question_assessments.first.skills).to contain_exactly(skill)
       end
 
       scenario 'I can upload a template package', js: true do

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
 
         question_created = assessment.questions.first.specific
         expect(page).to have_selector('div', text: I18n.t('course.assessment.question.text_responses.create.success'))
-        expect(question_created.skills).to contain_exactly(skill)
+        expect(question_created.question_assessments.first.skills).to contain_exactly(skill)
         expect(question_created.allow_attachment).to be_truthy
       end
 

--- a/spec/models/course/assessment/question_spec.rb
+++ b/spec/models/course/assessment/question_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Course::Assessment::Question do
   it { is_expected.to be_actable }
   it { is_expected.to have_many(:question_assessments).dependent(:destroy) }
   it { is_expected.to have_many(:answers).dependent(:destroy) }
-  it { is_expected.to have_and_belong_to_many(:skills) }
 
   let(:instance) { Instance.default }
   with_tenant(:instance) do

--- a/spec/models/course/assessment/skill_spec.rb
+++ b/spec/models/course/assessment/skill_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Skill do
   it { is_expected.to belong_to(:course).inverse_of(:assessment_skills) }
   it { is_expected.to belong_to(:skill_branch) }
-  it { is_expected.to have_and_belong_to_many(:questions) }
+  it { is_expected.to have_and_belong_to_many(:question_assessments) }
 
   let(:instance) { Instance.default }
   with_tenant(:instance) do

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -174,22 +174,24 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
           end
         end
 
-        context 'when a skill has an associated question' do
+        context 'when a skill has an associated question_assessment' do
           let(:assessment) { create(:assessment, :with_mcq_question, course: source_course) }
           before do
-            skill.questions << assessment.questions.first
+            skill.question_assessments << assessment.questions.first.question_assessments.first
             skill.save!
           end
 
-          context 'when a skill is duplicated after its associated question' do
+          context 'when a skill is duplicated after its associated question assessment' do
             let(:source_objects) { [assessment, skill] }
 
             it 'associates the duplicates' do
               expect { duplicate_objects }.to change { destination_course.assessment_skills.count }.by(1)
               duplicate_assessment, duplicate_skill = duplicate_objects
-              expect(duplicate_assessment.reload.questions.first.skills.length).to eq(1)
-              expect(duplicate_skill.questions.length).to eq(1)
-              expect(duplicate_skill.questions.first.id).to eq(duplicate_assessment.questions.first.id)
+              expect(duplicate_assessment.reload.questions.first.question_assessments.first.skills.length).
+                to eq(1)
+              expect(duplicate_skill.question_assessments.length).to eq(1)
+              expect(duplicate_skill.question_assessments.first.question.id).
+                to eq(duplicate_assessment.questions.first.id)
             end
           end
 
@@ -199,9 +201,10 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
             it 'associates the duplicates' do
               expect { duplicate_objects }.to change { destination_course.assessment_skills.count }.by(1)
               duplicate_skill, duplicate_assessment = duplicate_objects
-              expect(duplicate_assessment.questions.first.skills.length).to eq(1)
-              expect(duplicate_skill.reload.questions.length).to eq(1)
-              expect(duplicate_skill.questions.first.id).to eq(duplicate_assessment.questions.first.id)
+              expect(duplicate_assessment.question_assessments.first.skills.length).to eq(1)
+              expect(duplicate_skill.reload.question_assessments.length).to eq(1)
+              expect(duplicate_skill.question_assessments.first.question.id).
+                to eq(duplicate_assessment.questions.first.id)
             end
           end
         end


### PR DESCRIPTION
With `QuestionAssessments`, a single question can belong to multiple assessments, even those from different courses. Another course might not have the same Skills, so it no longer makes sense for Skills to be associated with Questions.

This PR:

1. Creates a new association table for skills and question_assessments and migrates the existing data over.
2. Modify the various question type forms so they correctly assign Skills through the QuestionAssessment.
3. Move the Duplication logic so Skills are duplicated through QuestionAssessments.
4. Fix the question cherry picking duplication so Skills are copied from and to QuestionAssessments.

- [x] Check that assessment duplication to a different course with a different Skill structure does NOT duplicate the skills. EDIT: Assessment duplication to a different course does not duplicate the skills at all.