### PR TITLE
Update parser gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,8 +136,7 @@ group :development, :test do
 
   # Checks that all translations are used and defined
   gem 'i18n-tasks', require: false
-  # Lock parser version to < 2.5 as it doesn't work with abilities
-  gem 'parser', '< 2.5'
+  gem 'parser'
 
   # Helps to prevent database consistency mistakes
   gem 'consistency_fail', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,7 +619,7 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   parallel_tests
-  parser (< 2.5)
+  parser
   pg
   puma
   rails (~> 5.1.0)


### PR DESCRIPTION
Parser gem was version locked because there were some issues with v2.5.0.0, but there have since been several bug fixes ([Changelog](https://github.com/whitequark/parser/blob/master/CHANGELOG.md))