### PR TITLE
Associate video posts through discussion topics to video topics.

### DIFF
--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -10,7 +10,8 @@ class Course::Video < ApplicationRecord
                          inverse_of: :video, dependent: :destroy
   has_many :topics, class_name: Course::Video::Topic.name,
                     dependent: :destroy, foreign_key: :video_id, inverse_of: :video
-  has_many :posts, through: :topics, class_name: Course::Discussion::Post.name
+  has_many :discussion_topics, through: :topics, class_name: Course::Discussion::Topic.name
+  has_many :posts, through: :discussion_topics, class_name: Course::Discussion::Post.name
   has_many :sessions, through: :submissions
 
   validate :url_unchanged

--- a/spec/models/course/video_spec.rb
+++ b/spec/models/course/video_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Course::Video, type: :model do
 
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    let(:course) { create(:course) }
+    let(:course) { create(:course, :with_video_component_enabled) }
     let(:student1) { create(:course_student, course: course) }
     let(:student2) { create(:course_student, course: course) }
     let(:video1) { create(:video, course: course) }


### PR DESCRIPTION
Fixes query generated when discussion posts for videos are retrieved.
Retrieving posts should go through joins on both
course_discussion_topics and course_video_topics.

Fix incorrect association introduced in #2993. This causes the check for whether the video URL is changeable to fail depending on the state of the data in the database.