### PR TITLE
Fix Continue button for scribing answer on autograded assessment

### DIFF
--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.json.jbuilder
@@ -8,7 +8,6 @@ end
 last_attempt = last_attempt(answer)
 
 json.explanation do
-  assessment = answer.submission.assessment
   if last_attempt&.auto_grading&.result
     json.correct last_attempt.correct
     json.explanations last_attempt.auto_grading.result['messages'].map { |e| format_html(e) }

--- a/app/views/course/assessment/answer/scribing/_scribing.json.jbuilder
+++ b/app/views/course/assessment/answer/scribing/_scribing.json.jbuilder
@@ -14,3 +14,10 @@ json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id
 end
+
+last_attempt = last_attempt(answer)
+
+json.explanation do
+  json.correct last_attempt&.correct
+  json.explanations []
+end

--- a/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
@@ -14,7 +14,6 @@ end
 last_attempt = last_attempt(answer)
 
 json.explanation do
-  assessment = answer.submission.assessment
   json.correct last_attempt&.correct
   if last_attempt&.auto_grading&.result
     json.explanations last_attempt.auto_grading.result['messages'].map { |e| format_html(e) }


### PR DESCRIPTION
On an autograded assessment, after submitting an answer to a scribing question, the continue button did not appear. This was because the `explanation` field was missing in the server response, which is used to determine whether the answer is considered correct and the student can move on to the next question.