### PR TITLE
Persist video component enabling on instance in courses factory.

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,7 +22,9 @@ FactoryBot.define do
 
     trait :with_video_component_enabled do
       after(:build) do |course|
-        course.instance.set_component_enabled_boolean(:course_videos_component, true)
+        # Save instance setting to the database so the video component remains enabled on reload.
+        # Should help stop seemingly random video component spec failures.
+        course.instance.set_component_enabled_boolean!(:course_videos_component, true)
         course.set_component_enabled_boolean(:course_videos_component, true)
       end
     end


### PR DESCRIPTION
There were failures arising from `app/models/concerns/validate_settable_component_keys!` raising an exception that the `course_videos_component` was invalid.

This happened in the video model spec, and then in the component settings controller spec.

Stepping through the component settings controller spec `enables the specified component and disables all other components` revealed that the instance's `disableable_components` function was called multiple times during the test and that the results were inconsistent, possibly because the instance was reloaded without the video component enabling being saved.

Persisting the enabling of the video component on the instance to the database keeps the setting consistent across reloads.