### PR TITLE
Update parser gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,7 +136,6 @@ group :development, :test do
 
   # Checks that all translations are used and defined
   gem 'i18n-tasks', require: false
-  gem 'parser'
 
   # Helps to prevent database consistency mistakes
   gem 'consistency_fail', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,8 +339,8 @@ GEM
     parallel (1.12.1)
     parallel_tests (2.21.3)
       parallel
-    parser (2.4.0.2)
-      ast (~> 2.3)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
     pg (1.0.0)
     polyamorous (1.3.3)
       activerecord (>= 3.0)
@@ -619,7 +619,6 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   parallel_tests
-  parser
   pg
   puma
   rails (~> 5.1.0)


### PR DESCRIPTION
Remove from Gemfile as Coursemology doesn't need it directly.
Ran bundle update to get the new version of the parser gem.