### PR TITLE
Send emailer for phantom course_user activity

### DIFF
--- a/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
@@ -69,7 +69,7 @@ class Course::Assessment::Submission::Answer::Programming::AnnotationsController
   end
 
   def send_created_notification(post)
-    return unless current_course_user && !current_course_user.phantom?
+    return unless current_course_user
     post.topic.actable.notify(post)
   end
 

--- a/app/controllers/course/assessment/submission_question/comments_controller.rb
+++ b/app/controllers/course/assessment/submission_question/comments_controller.rb
@@ -39,7 +39,9 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
   end
 
   def send_created_notification(post)
-    post.topic.actable.notify(post) if current_course_user && !current_course_user.phantom?
+    return unless current_course_user
+    topic_actable = post.topic.actable
+    topic_actable.notify(post) if topic_actable.respond_to?(:notify)
   end
 
   def last_post_from(submission_question)

--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -72,7 +72,7 @@ class Course::Discussion::PostsController < Course::ComponentController
   end
 
   def send_created_notification(post)
-    return unless current_course_user && !current_course_user.phantom?
+    return unless current_course_user
     topic_actable = post.topic.actable
     topic_actable.notify(post) if topic_actable.respond_to?(:notify)
   end

--- a/app/controllers/course/forum/posts_controller.rb
+++ b/app/controllers/course/forum/posts_controller.rb
@@ -105,8 +105,8 @@ class Course::Forum::PostsController < Course::Forum::ComponentController
   end
 
   def send_created_notification(post)
-    return unless current_course_user && !current_course_user.phantom?
-    Course::Forum::PostNotifier.post_replied(current_user, post)
+    return unless current_user
+    Course::Forum::PostNotifier.post_replied(current_user, current_course_user, post)
   end
 
   def authorize_locked_topic

--- a/app/controllers/course/forum/topics_controller.rb
+++ b/app/controllers/course/forum/topics_controller.rb
@@ -89,7 +89,7 @@ class Course::Forum::TopicsController < Course::Forum::ComponentController
   end
 
   def send_created_notification(topic)
-    return unless current_course_user && !current_course_user.phantom?
-    Course::Forum::TopicNotifier.topic_created(current_user, topic)
+    return unless current_course_user
+    Course::Forum::TopicNotifier.topic_created(current_user, current_course_user, topic)
   end
 end

--- a/app/models/course/assessment/answer/programming_file_annotation.rb
+++ b/app/models/course/assessment/answer/programming_file_annotation.rb
@@ -16,7 +16,7 @@ class Course::Assessment::Answer::ProgrammingFileAnnotation < ApplicationRecord
   end)
 
   def notify(post)
-    Course::Assessment::Answer::CommentNotifier.annotation_replied(post.creator, post)
+    Course::Assessment::Answer::CommentNotifier.annotation_replied(post)
   end
 
   private

--- a/app/models/course/assessment/submission_question.rb
+++ b/app/models/course/assessment/submission_question.rb
@@ -25,7 +25,7 @@ class Course::Assessment::SubmissionQuestion < ApplicationRecord
   end)
 
   def notify(post)
-    Course::Assessment::SubmissionQuestion::CommentNotifier.post_replied(post.creator, post)
+    Course::Assessment::SubmissionQuestion::CommentNotifier.post_replied(post)
   end
 
   def answers

--- a/app/models/course/settings/assessments_component.rb
+++ b/app/models/course/settings/assessments_component.rb
@@ -8,6 +8,7 @@ class Course::Settings::AssessmentsComponent < Course::Settings::Component
         new_submission: { enabled_by_default: true },
         new_phantom_submission: { enabled_by_default: true },
         new_comment: { enabled_by_default: true },
+        new_phantom_comment: { enabled_by_default: true },
         grades_released: { enabled_by_default: true }
       }
     end

--- a/app/models/course/settings/forums_component.rb
+++ b/app/models/course/settings/forums_component.rb
@@ -8,6 +8,7 @@ class Course::Settings::ForumsComponent < Course::Settings::Component
   def self.email_setting_items
     {
       post_replied: { enabled_by_default: true },
+      post_phantom_replied: { enabled_by_default: true },
       topic_created: { enabled_by_default: true }
     }
   end

--- a/app/notifiers/course/assessment/answer/comment_notifier.rb
+++ b/app/notifiers/course/assessment/answer/comment_notifier.rb
@@ -1,20 +1,31 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::CommentNotifier < Notifier::Base
-  # To be called when user adds a post to a programming annotation.
-  def annotation_replied(user, post)
-    return unless email_enabled?(post)
+  # Called when a user adds a post to a programming annotation.
+  #
+  # @param[Course::Discussion::Post] post The post that was created.
+  def annotation_replied(post)
+    return unless email_notification_enabled?(post)
 
-    activity = create_activity(actor: user, object: post, event: :annotated)
+    activity = create_activity(actor: post.creator, object: post, event: :annotated)
+
     post.topic.subscriptions.includes(:user).each do |subscription|
-      activity.notify(subscription.user, :email) unless subscription.user == user
+      activity.notify(subscription.user, :email) unless subscription.user == post.creator
     end
     activity.save!
   end
 
   private
 
-  def email_enabled?(post)
+  def email_notification_enabled?(post)
+    course_user = CourseUser.find_by(user: post.creator, course: post.topic.course)
     category = post.topic.actable.file.answer.submission.assessment.tab.category
-    Course::Settings::AssessmentsComponent.email_enabled?(category, :new_comment)
+
+    response = settings_with_key(category, :new_comment)
+    response &&= settings_with_key(category, :new_phantom_comment) if course_user&.phantom?
+    response
+  end
+
+  def settings_with_key(category, key)
+    Course::Settings::AssessmentsComponent.email_enabled?(category, key)
   end
 end

--- a/app/notifiers/course/forum/post_notifier.rb
+++ b/app/notifiers/course/forum/post_notifier.rb
@@ -1,15 +1,36 @@
 # frozen_string_literal: true
 class Course::Forum::PostNotifier < Notifier::Base
-  # To be called when user replied a forum post.
-  def post_replied(user, post)
-    course = post.topic.actable.forum.course
+  # Called when a user replies to a forum post.
+  #
+  # @param[User] User who replied to the forum post
+  # @param[CourseUser] course_user The course_user who replied to the forum post.
+  #   This can be +nil+ in exceptional cases where the administrator posts to a forum.
+  # @param[Course::Discussion::Post] post The post that was created.
+  def post_replied(user, course_user, post)
+    course = post.topic.course
     activity = create_activity(actor: user, object: post, event: :replied)
-    activity.notify(course, :feed)
-    if Course::Settings::ForumsComponent.email_enabled?(course, :post_replied)
+    activity.notify(course, :feed) if course_user && !course_user.phantom?
+
+    if email_notification_enabled?(course_user)
       post.topic.subscriptions.includes(:user).each do |subscription|
         activity.notify(subscription.user, :email) unless subscription.user == user
       end
     end
+
     activity.save!
+  end
+
+  private
+
+  def email_notification_enabled?(course_user)
+    course = course_user.course
+
+    response = settings_with_key(course, :post_replied)
+    response &&= settings_with_key(course, :post_phantom_replied) if course_user&.phantom?
+    response
+  end
+
+  def settings_with_key(course, key)
+    Course::Settings::ForumsComponent.email_enabled?(course, key)
   end
 end

--- a/app/notifiers/course/forum/topic_notifier.rb
+++ b/app/notifiers/course/forum/topic_notifier.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 class Course::Forum::TopicNotifier < Notifier::Base
   # To be called when user created a new forum topic.
-  def topic_created(user, topic)
+  def topic_created(user, course_user, topic)
     course = topic.forum.course
     activity = create_activity(actor: user, object: topic, event: :created)
-    activity.notify(course, :feed)
+    activity.notify(course, :feed) unless course_user.phantom?
+
     if Course::Settings::ForumsComponent.email_enabled?(course, :topic_created)
       topic.forum.subscriptions.includes(:user).each do |subscription|
         activity.notify(subscription.user, :email) unless subscription.user == user

--- a/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
@@ -2,12 +2,14 @@
 - annotation = post.topic.actable
 - answer = annotation.file.answer
 - question = answer.question
+- course_user = answer.submission.course_user
 - assessment = answer.submission.assessment
 - question_assessment = assessment.question_assessments.find_by!(question: question)
 - course = assessment.course
 - host = course.instance.host
 
 - message.subject = t('.subject', course: course.title, topic: "#{assessment.title}: #{question_assessment.display_title}")
+- message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = assessment.questions.index(question) + 1
 
 = format_html(t('.message',

--- a/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
@@ -1,5 +1,6 @@
 - post = @object
 - submission_question = post.topic.actable
+- course_user = submission_question.submission.course_user
 - assessment = submission_question.submission.assessment
 - question = submission_question.question
 - course = assessment.course
@@ -7,6 +8,7 @@
 - question_assessment = assessment.question_assessments.find_by!(question: question)
 
 - message.subject = t('.subject', course: course.title, topic: "#{assessment.title}: #{question_assessment.display_title}")
+- message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = assessment.questions.index(question) + 1
 
 = format_html(t('.message',

--- a/app/views/notifiers/course/assessment_notifier/submitted/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/submitted/user_notifications/email.html.slim
@@ -1,10 +1,12 @@
 - submission = @object
 - assessment = submission.assessment
 - course = assessment.course
+- course_user = submission.course_user
 - host = course.instance.host
 - submission_url = edit_course_assessment_submission_url(course, assessment, submission, host: host)
 
 - message.subject = t('.subject', course: course.title, assessment: submission.assessment.title)
+- message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 
 = simple_format(t('.message', submission: link_to(:submission, submission_url),
                               user: submission.course_user.name))

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -1,6 +1,7 @@
 - post = @object
 - topic = post.topic.actable
 - course = topic.course
+- course_user = CourseUser.find_by(course: course, user: post.creator)
 - host = course.instance.host
 - unsubscribe_url = subscribe_course_forum_topic_url(course, topic.forum, topic, subscribe: false,
                                                      host: host)
@@ -10,6 +11,7 @@
 - post_author = format_inline_text(post.author_name)
 
 - message.subject = t('.subject', course: course_title, topic: topic_title)
+- message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 
 = format_html(t('.message',
                 topic: link_to(topic_title,

--- a/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
+++ b/client/app/bundles/course/admin/pages/NotificationSettings/translations.intl.js
@@ -59,8 +59,9 @@ export const settingDescriptions = defineMessages({
   },
   new_phantom_submission: {
     id: 'course.admin.NotificationSettings.settingDescriptions.new_phantom_submission',
-    defaultMessage: "Sends 'New Submission' email for phantom students also. If 'New Submission' email\
-      notification is disabled, no emails will be sent even though this setting is enabled.",
+    defaultMessage: "Sends 'New Submission' email for phantom students also. If the 'New\
+     Submission' email notification is disabled, no emails will be sent even though this setting\
+      is enabled.",
   },
   grades_released: {
     id: 'course.admin.NotificationSettings.settingDescriptions.grades_released',
@@ -68,7 +69,14 @@ export const settingDescriptions = defineMessages({
   },
   new_comment: {
     id: 'course.admin.NotificationSettings.settingDescriptions.new_comment',
-    defaultMessage: 'Notify users when comments or programming question annotations are made.',
+    defaultMessage: 'Notify users when comments or programming question annotations are made by\
+      non-phantom student or staff.',
+  },
+  new_phantom_comment: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.new_phantom_comment',
+    defaultMessage: "Notify users when comments or programming question annotations are made by\
+      phantom student or staff. If the 'New Comment' email notification is disabled, no emails\
+      will be sent even though this setting is enabled.",
   },
   new_enrol_request: {
     id: 'course.admin.NotificationSettings.settingDescriptions.new_enrol_request',
@@ -76,7 +84,14 @@ export const settingDescriptions = defineMessages({
   },
   post_replied: {
     id: 'course.admin.NotificationSettings.settingDescriptions.post_replied',
-    defaultMessage: 'Notify users who are subscribed to a forum topic when a replied is made to that topic.',
+    defaultMessage: 'Notify users who are subscribed to a forum topic when a reply by a\
+      non-phantom user is made to that topic.',
+  },
+  post_phantom_replied: {
+    id: 'course.admin.NotificationSettings.settingDescriptions.post_phantom_replied',
+    defaultMessage: "Notify users who are subscribed to a forum topic when a reply by a\
+      phantom user is made to that topic. If the 'Post Replied' email notification is disabled,\
+      no emails will be sent even though this setting is enabled.",
   },
   topic_created: {
     id: 'course.admin.NotificationSettings.settingDescriptions.topic_created',
@@ -119,7 +134,7 @@ export const settingTitles = defineMessages({
   },
   new_phantom_submission: {
     id: 'course.admin.NotificationSettings.settingTitles.new_phantom_submission',
-    defaultMessage: 'New Phantom Submission',
+    defaultMessage: 'New Submission by Phantom User',
   },
   grades_released: {
     id: 'course.admin.NotificationSettings.settingTitles.grades_released',
@@ -129,6 +144,10 @@ export const settingTitles = defineMessages({
     id: 'course.admin.NotificationSettings.settingTitles.new_comment',
     defaultMessage: 'New Comment',
   },
+  new_phantom_comment: {
+    id: 'course.admin.NotificationSettings.settingTitles.new_phantom_comment',
+    defaultMessage: 'New Comment by Phantom User',
+  },
   new_enrol_request: {
     id: 'course.admin.NotificationSettings.settingTitles.new_enrol_request',
     defaultMessage: 'New Enrol Request',
@@ -136,6 +155,10 @@ export const settingTitles = defineMessages({
   post_replied: {
     id: 'course.admin.NotificationSettings.settingTitles.post_replied',
     defaultMessage: 'Post Replied',
+  },
+  post_phantom_replied: {
+    id: 'course.admin.NotificationSettings.settingTitles.post_phantom_replied',
+    defaultMessage: 'Post Replied by Phantom User',
   },
   topic_created: {
     id: 'course.admin.NotificationSettings.settingTitles.topic_created',

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -1,6 +1,7 @@
 en:
   notifiers:
     course:
+      phantom: '(Phantom)'
       achievement_notifier:
         gained:
           course_notifications:

--- a/spec/notifiers/course/assessment/answer/comment_notifier_spec.rb
+++ b/spec/notifiers/course/assessment/answer/comment_notifier_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Answer::CommentNotifier, type: :notifier do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:settings_context) do
+      OpenStruct.new(key: Course::AssessmentsComponent.key, current_course: course)
+    end
+
+    def set_assessment_notification_key(course, category_id, key, value)
+      setting = { 'key' => key, 'enabled' => value, 'options' => { 'category_id' => category_id } }
+      Course::Settings::AssessmentsComponent.new(settings_context).update_email_setting(setting)
+      course.save!
+    end
+
+    describe '#annotation_replied' do
+      let(:user) { create(:user) }
+      let(:course) { create(:course) }
+      let(:course_user) { create(:course_user, course: course, user: user) }
+      let(:other_user) { create(:course_user, course: course).user }
+      let(:assessment) { create(:assessment, :published_with_programming_question, course: course) }
+      let(:category_id) { assessment.tab.category_id }
+      let(:programming_file) do
+        sub = create(:submission, assessment: assessment, course_user: course_user, creator: user)
+        ans = create(:course_assessment_answer_programming, question: assessment.questions.first,
+                                                            file_count: 1, submission: sub)
+        ans.files.first
+      end
+      let(:code_annotation) do
+        create(:course_assessment_answer_programming_file_annotation, :with_post,
+               file: programming_file, course: course)
+      end
+      let(:post) do
+        create(:course_discussion_post, topic: code_annotation.acting_as, creator: other_user)
+      end
+
+      before { code_annotation.acting_as.ensure_subscribed_by(user) }
+      subject { Course::Assessment::Answer::CommentNotifier.annotation_replied(post) }
+
+      it 'sends email notifications' do
+        expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      context 'when "new phantom comment" is disabled and a phantom user posts a comment' do
+        let(:other_user) { create(:course_user, :phantom, course: course).user }
+        before do
+          set_assessment_notification_key(course, category_id, 'new_phantom_comment', false)
+        end
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
+
+      context 'when "new comment" is disabled' do
+        before { set_assessment_notification_key(course, category_id, 'new_comment', false) }
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+
+        context 'when "new phantom comment" is enabled and a phantom user posts a comment' do
+          let(:other_user) { create(:course_user, :phantom, course: course).user }
+          before do
+            set_assessment_notification_key(course, category_id, 'new_phantom_comment', true)
+          end
+
+          it 'does not send email notifications' do
+            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/notifiers/course/assessment/submission_question/comment_notifier_spec.rb
+++ b/spec/notifiers/course/assessment/submission_question/comment_notifier_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::SubmissionQuestion::CommentNotifier, type: :notifier do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:settings_context) do
+      OpenStruct.new(key: Course::AssessmentsComponent.key, current_course: course)
+    end
+
+    def set_assessment_notification_key(course, category_id, key, value)
+      setting = { 'key' => key, 'enabled' => value, 'options' => { 'category_id' => category_id } }
+      Course::Settings::AssessmentsComponent.new(settings_context).update_email_setting(setting)
+      course.save!
+    end
+
+    describe '#post_replied' do
+      let(:user) { create(:user) }
+      let(:course) { create(:course) }
+      let(:course_user) { create(:course_user, course: course, user: user) }
+      let(:other_user) { create(:course_user, course: course).user }
+      let(:assessment) { create(:assessment, :published_with_mcq_question, course: course) }
+      let(:category_id) { assessment.tab.category_id }
+      let(:submission_question) do
+        sub = create(:submission, assessment: assessment, course_user: course_user, creator: user)
+        create(:course_assessment_submission_question,
+               submission: sub, question: assessment.questions.first)
+      end
+      let(:post) do
+        create(:course_discussion_post, topic: submission_question.acting_as, creator: other_user)
+      end
+
+      before { submission_question.acting_as.ensure_subscribed_by(user) }
+      subject { Course::Assessment::SubmissionQuestion::CommentNotifier.post_replied(post) }
+
+      it 'sends email notifications' do
+        expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      context 'when "new phantom comment" is disabled and a phantom user posts a comment' do
+        let(:other_user) { create(:course_user, :phantom, course: course).user }
+        before do
+          set_assessment_notification_key(course, category_id, 'new_phantom_comment', false)
+        end
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
+
+      context 'when "new comment" is disabled' do
+        before { set_assessment_notification_key(course, category_id, 'new_comment', false) }
+
+        it 'does not send email notifications' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+
+        context 'when "new phantom comment" is enabled and a phantom user posts a comment' do
+          let(:other_user) { create(:course_user, :phantom, course: course).user }
+          before do
+            set_assessment_notification_key(course, category_id, 'new_phantom_comment', true)
+          end
+
+          it 'does not send email notifications' do
+            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/notifiers/course/forum/post_notifier_spec.rb
+++ b/spec/notifiers/course/forum/post_notifier_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe Course::Forum::PostNotifier, type: :notifier do
     let(:forum) { create(:forum, course: course) }
     let!(:topic) { create(:forum_topic, forum: forum, course: course) }
     let(:post) { create(:course_discussion_post, topic: topic.acting_as, creator: user) }
+    let(:course_user) { create(:course_user, course: course) }
     let!(:user) do
-      user = create(:course_user, course: course).user
+      user = course_user.user
       topic.subscriptions.create(user: user)
       user
     end
@@ -20,8 +21,15 @@ RSpec.describe Course::Forum::PostNotifier, type: :notifier do
       subscriber
     end
 
+    def set_forum_notification_key(key, value)
+      context = OpenStruct.new(key: Course::ForumsComponent.key, current_course: course)
+      setting = { 'key' => key, 'enabled' => value }
+      Course::Settings::ForumsComponent.new(context).update_email_setting(setting)
+      course.save!
+    end
+
     describe '#post_replied' do
-      subject { Course::Forum::PostNotifier.post_replied(user, post) }
+      subject { Course::Forum::PostNotifier.post_replied(user, course_user, post) }
 
       it 'sends a course notification' do
         expect { subject }.to change(course.notifications, :count).by(1)
@@ -31,16 +39,41 @@ RSpec.describe Course::Forum::PostNotifier, type: :notifier do
         expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
 
-      context 'when email notifications are disabled' do
-        before do
-          context = OpenStruct.new(key: Course::ForumsComponent.key, current_course: course)
-          setting = { 'key' => 'post_replied', 'enabled' => false }
-          Course::Settings::ForumsComponent.new(context).update_email_setting(setting)
-          course.save!
+      context 'when course_user is phantom' do
+        let(:course_user) { create(:course_user, :phantom, course: course) }
+
+        it 'does not send a course notification' do
+          expect { subject }.not_to change(course.notifications, :count)
         end
+
+        it 'sends an email notification' do
+          expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
+
+        context 'when course settings disable notification of phantom course_user posting' do
+          before { set_forum_notification_key('post_phantom_replied', false) }
+
+          it 'does not send an email notification' do
+            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          end
+        end
+      end
+
+      context 'when email notifications are disabled' do
+        before { set_forum_notification_key('post_replied', false) }
 
         it 'does not send an email notifications' do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+
+        context 'when course_user is phantom and post_phantom_reply is enabled' do
+          before { set_forum_notification_key('post_phantom_replied', true) }
+
+          let(:course_user) { create(:course_user, :phantom, course: course) }
+
+          it 'does not send an email notification' do
+            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          end
         end
       end
     end


### PR DESCRIPTION
Currently emails are not sent when phantom `course_users`  reply to certain posts. This PR removes that logic, and sends emails to subscribers of a discussion topic (forum topic, programming annotation, submission answers) even if the post creator is a phantom `course_user`.

A little work is required to move some logic into the notifier as we still do not want phantom activities to appear out the course feed. 

Also, we specify `(Phantom)` in the email subject to allow subscribers to do email filtering if necessary.