### PR TITLE
Fix submission page student view showing hidden test cases

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/__test__/index.test.js
@@ -1,0 +1,171 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ProviderWrapper from 'lib/components/ProviderWrapper';
+import { VisibleTestCaseView } from 'course/assessment/submission/containers/TestCaseView';
+
+import { workflowStates } from '../../../constants';
+
+const defaultTestCaseViewProps = {
+  submissionState: workflowStates.Published,
+  graderView: false,
+  showPublicTestCasesOutput: false,
+  showStdoutAndStderr: false,
+  showPrivate: false,
+  showEvaluation: false,
+  isAutograding: false,
+  collapsible: false,
+  testCases: {
+    canReadTests: false,
+    public_test: [{
+      identifier: 'public_test_1_identifier',
+      expression: 'public_test_1_expression',
+      expected: 'public_test_1_expected',
+    }],
+    private_test: [{
+      identifier: 'private_test_1_identifier',
+      expression: 'private_test_1_expression',
+      expected: 'private_test_1_expected',
+    }],
+    evaluation_test: [{
+      identifier: 'evaluation_test_1_identifier',
+      expression: 'evaluation_test_1_expression',
+      expected: 'evaluation_test_1_expected',
+    }],
+    stdout: 'stdout',
+    stderr: 'stderr',
+  },
+};
+
+const defaultStaffViewProps = {
+  ...defaultTestCaseViewProps,
+  graderView: true,
+  testCases: {
+    ...defaultTestCaseViewProps.testCases,
+    canReadTests: true,
+  },
+};
+
+describe('TestCaseView', () => {
+  describe('when viewing as staff', () => {
+    it('renders all test cases and standard streams', () => {
+      const testCaseView = mount(
+        <ProviderWrapper>
+          <VisibleTestCaseView {...defaultStaffViewProps} />
+        </ProviderWrapper>
+      );
+
+      expect(testCaseView.find('#publicTestCases').exists()).toBe(true);
+      expect(testCaseView.find('#privateTestCases').exists()).toBe(true);
+      expect(testCaseView.find('#evaluationTestCases').exists()).toBe(true);
+      expect(testCaseView.find('#standardOutput').exists()).toBe(true);
+      expect(testCaseView.find('#standardError').exists()).toBe(true);
+    });
+
+    it('renders staff-only warnings', () => {
+      const testCaseView = mount(
+        <ProviderWrapper>
+          <VisibleTestCaseView {...defaultStaffViewProps} />
+        </ProviderWrapper>
+      );
+
+      expect(testCaseView.find('#privateTestCases').find('i.fa-exclamation-triangle').exists()).toBe(true);
+      expect(testCaseView.find('#evaluationTestCases').find('i.fa-exclamation-triangle').exists()).toBe(true);
+      expect(testCaseView.find('#standardOutput').find('i.fa-exclamation-triangle').exists()).toBe(true);
+      expect(testCaseView.find('#standardError').find('i.fa-exclamation-triangle').exists()).toBe(true);
+    });
+
+    describe('when showEvaluation & showPrivate are true', () => {
+      it('renders staff-only warnings when assessment is not yet published', () => {
+        const testCaseView = mount(
+          <ProviderWrapper>
+            <VisibleTestCaseView
+              {...defaultStaffViewProps}
+              showPrivate
+              showEvaluation
+              submissionState={workflowStates.Attempting}
+            />
+          </ProviderWrapper>
+        );
+
+        expect(testCaseView.find('#privateTestCases').find('i.fa-exclamation-triangle').exists()).toBe(true);
+        expect(testCaseView.find('#evaluationTestCases').find('i.fa-exclamation-triangle').exists()).toBe(true);
+      });
+
+      it('does not render staff-only warnings when assessment is published', () => {
+        const testCaseView = mount(
+          <ProviderWrapper>
+            <VisibleTestCaseView {...defaultStaffViewProps} showPrivate showEvaluation />
+          </ProviderWrapper>
+        );
+
+        expect(testCaseView.find('#privateTestCases').find('i.fa-exclamation-triangle').exists()).toBe(false);
+        expect(testCaseView.find('#evaluationTestCases').find('i.fa-exclamation-triangle').exists()).toBe(false);
+      });
+    });
+
+    describe('when students can see standard streams', () => {
+      it('does not render staff-only warnings', () => {
+        const testCaseView = mount(
+          <ProviderWrapper>
+            <VisibleTestCaseView {...defaultStaffViewProps} showStdoutAndStderr />
+          </ProviderWrapper>
+        );
+
+        expect(testCaseView.find('#standardOutput').find('i.fa-exclamation-triangle').exists()).toBe(false);
+        expect(testCaseView.find('#standardError').find('i.fa-exclamation-triangle').exists()).toBe(false);
+      });
+    });
+  });
+
+  describe('when viewing as student', () => {
+    it('does not show any staff-only warnings', () => {
+      const testCaseView = mount(
+        <ProviderWrapper>
+          <VisibleTestCaseView {...defaultTestCaseViewProps} showPrivate showEvaluation showStdoutAndStderr />
+        </ProviderWrapper>
+      );
+
+      expect(testCaseView.find('i.fa-exclamation-triangle').exists()).toBe(false);
+    });
+
+    it('shows standard streams when the flag is enabled', () => {
+      const testCaseView = mount(
+        <ProviderWrapper>
+          <VisibleTestCaseView {...defaultTestCaseViewProps} showStdoutAndStderr />
+        </ProviderWrapper>
+      );
+
+      expect(testCaseView.find('#standardOutput').exists()).toBe(true);
+      expect(testCaseView.find('#standardError').exists()).toBe(true);
+    });
+
+    describe('when showEvaluation & showPrivate flags are enabled', () => {
+      it('shows private and evaluation tests after assessment is published', () => {
+        const testCaseView = mount(
+          <ProviderWrapper>
+            <VisibleTestCaseView {...defaultTestCaseViewProps} showPrivate showEvaluation />
+          </ProviderWrapper>
+        );
+
+        expect(testCaseView.find('#privateTestCases').exists()).toBe(true);
+        expect(testCaseView.find('#evaluationTestCases').exists()).toBe(true);
+      });
+
+      it('does not show private and evaluation tests before assessment is published', () => {
+        const testCaseView = mount(
+          <ProviderWrapper>
+            <VisibleTestCaseView
+              {...defaultTestCaseViewProps}
+              showPrivate
+              showEvaluation
+              submissionState={workflowStates.Attempting}
+            />
+          </ProviderWrapper>
+        );
+
+        expect(testCaseView.find('#privateTestCases').exists()).toBe(false);
+        expect(testCaseView.find('#evaluationTestCases').exists()).toBe(false);
+      });
+    });
+  });
+});

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -12,8 +12,8 @@ import { Table, TableHeader, TableHeaderColumn, TableBody, TableRow, TableRowCol
 import Paper from 'material-ui/Paper';
 
 import ExpandableText from 'lib/components/ExpandableText';
-import { testCaseShape } from '../propTypes';
-import { workflowStates } from '../constants';
+import { testCaseShape } from '../../propTypes';
+import { workflowStates } from '../../constants';
 
 const styles = {
   testCaseRow: {
@@ -94,7 +94,7 @@ const translations = defineMessages({
   },
 });
 
-class VisibleTestCaseView extends Component {
+export class VisibleTestCaseView extends Component {
   static renderStaffOnlyTestCasesWarning() {
     return (
       <span style={{ display: 'inline-block', marginLeft: 5 }}>
@@ -123,7 +123,7 @@ class VisibleTestCaseView extends Component {
 
   static renderOutputStream(outputStreamType, output, showStaffOnlyWarning) {
     return (
-      <Card>
+      <Card id={outputStreamType}>
         <CardHeader
           showExpandableButton
           title={
@@ -147,7 +147,7 @@ class VisibleTestCaseView extends Component {
     );
   }
 
-  renderTestCases(testCases, title) {
+  renderTestCases(testCases, testCaseType, warn) {
     const { collapsible, testCases: { canReadTests } } = this.props;
     const { showPublicTestCasesOutput } = this.props;
 
@@ -172,8 +172,10 @@ class VisibleTestCaseView extends Component {
       </TableHeaderColumn>
     );
 
+    const title = VisibleTestCaseView.renderTitle(testCaseType, warn);
+
     return (
-      <Card>
+      <Card id={testCaseType}>
         <CardHeader title={title} actAsExpander={collapsible} showExpandableButton={collapsible} style={headerStyle} />
         <CardText expandable={collapsible}>
           <Table selectable={false} style={{}}>
@@ -236,8 +238,11 @@ class VisibleTestCaseView extends Component {
     const attempting = (submissionState === workflowStates.Attempting);
     const published = (submissionState === workflowStates.Published);
     const showOutputStreams = (graderView || showStdoutAndStderr);
-    const showPrivateTest = testCases.canReadTests || (published && showPrivate);
-    const showEvaluationTest = testCases.canReadTests || (published && showEvaluation);
+    const showPrivateTestToStudents = published && showPrivate;
+    const showEvaluationTestToStudents = published && showEvaluation;
+    const showPrivateTest = (graderView && testCases.canReadTests) || showPrivateTestToStudents;
+    const showEvaluationTest = (graderView && testCases.canReadTests) || showEvaluationTestToStudents;
+
     return (
       <div style={styles.testCasesContainer}>
         { !attempting && isAutograding &&
@@ -247,16 +252,13 @@ class VisibleTestCaseView extends Component {
         }
         <h3><FormattedMessage {...translations.testCases} /></h3>
         {this.renderTestCases(
-          testCases.public_test,
-          VisibleTestCaseView.renderTitle('publicTestCases', false)
+          testCases.public_test, 'publicTestCases', false
         )}
         {showPrivateTest && this.renderTestCases(
-          testCases.private_test,
-          VisibleTestCaseView.renderTitle('privateTestCases', testCases.canReadTests)
+          testCases.private_test, 'privateTestCases', !showPrivateTestToStudents
         )}
         {showEvaluationTest && this.renderTestCases(
-          testCases.evaluation_test,
-          VisibleTestCaseView.renderTitle('evaluationTestCases', testCases.canReadTests)
+          testCases.evaluation_test, 'evaluationTestCases', !showEvaluationTestToStudents
         )}
         {(showOutputStreams && !collapsible) && VisibleTestCaseView.renderOutputStream(
           'standardOutput', testCases.stdout, !showStdoutAndStderr


### PR DESCRIPTION
Fixed a bug where private & evaluation test cases were visible to staff even in student view.
Also fixed a bug where the staff-only warnings were shown to staff regardless of whether the students could see the test cases.