### PR TITLE
Remove second parameter for seekToDirectly

### DIFF
--- a/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
+++ b/client/app/bundles/course/video/submission/containers/DiscussionElements/Topic.jsx
@@ -66,7 +66,7 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    onTimeStampClick: timestamp => (() => dispatch(seekToDirectly(timestamp, true))),
+    onTimeStampClick: timestamp => (() => dispatch(seekToDirectly(timestamp))),
   };
 }
 


### PR DESCRIPTION
Previously used in a more general function to specific a force seek. seekToDirectly achieves the same functionality as a more specific function.