### PR TITLE
Show reply chain

### DIFF
--- a/app/controllers/course/forum/posts_controller.rb
+++ b/app/controllers/course/forum/posts_controller.rb
@@ -69,6 +69,15 @@ class Course::Forum::PostsController < Course::Forum::ComponentController
 
   # Render a new post in a separate page
   def reply
+    node = @post
+    @post_chain = [node]
+    # Show up to reply-post + 2 parent posts
+    2.times do
+      break if node.parent.nil?
+      @post_chain << node.parent
+      node = node.parent
+    end
+    @post_chain = @post_chain.reverse
     @reply_post = @post.children.build
   end
 

--- a/app/views/course/forum/posts/_post_chain.slim
+++ b/app/views/course/forum/posts/_post_chain.slim
@@ -1,0 +1,7 @@
+div class='course-forum-topics show'
+  div class='posts'
+    - unless post_chain.empty?
+      - replies_class = post_chain.length > 1 ? 'nested' : nil
+      = render partial: 'post', locals: { post: post_chain.first }
+      div.replies class=replies_class
+        = render partial: 'post_chain', locals: { post_chain: post_chain.slice(1..-1) }

--- a/app/views/course/forum/posts/reply.html.slim
+++ b/app/views/course/forum/posts/reply.html.slim
@@ -1,6 +1,6 @@
 = page_header
 
-= render partial: 'post', locals: { post: @post }
+= render partial: 'post_chain', locals: { post_chain: @post_chain }
 hr
 
 h3 = t('.reply')


### PR DESCRIPTION
Show up to reply-post + 2 parent posts in the chain

Fixes #2859 

**Test Plan**

Temporarily enabled reply button for all posts even if the post is a reply of another post.

http://dev1.louietyj.me:3000/courses/2/forums/forum/topics/some-topic

Original layout
![image](https://user-images.githubusercontent.com/11096034/44254497-8e598d00-a235-11e8-9749-b16c4b844794.png)

Replying to 2.2.1.1: Shown posts in the chain are 2.2, 2.2.1 and 2.2.1.1

![image](https://user-images.githubusercontent.com/11096034/44254592-d2e52880-a235-11e8-8b27-9756e43cdcf4.png)
