### PR TITLE
Force auto height for Summernote toolbar wrapper.

### DIFF
--- a/client/app/lib/styles/MaterialSummernote.scss
+++ b/client/app/lib/styles/MaterialSummernote.scss
@@ -1236,5 +1236,9 @@
   .note-editor .note-editable {
     padding: 20px 23px;
   }
+
+  .note-toolbar-wrapper {
+    height: auto !important;
+  }
 }
 // scss-lint:enable ImportantRule MergeableSelector QualifyingElement ColorVariable


### PR DESCRIPTION
Fixes #3063. This overrides the `style="height: 45px;"` attribute added on scroll up.

As suggested in https://github.com/summernote/summernote/issues/2688