### PR TITLE
Make Course::LessonPlan::Milestone act as Course::LessonPlan::Item

### DIFF
--- a/app/controllers/course/lesson_plan/items_controller.rb
+++ b/app/controllers/course/lesson_plan/items_controller.rb
@@ -36,7 +36,7 @@ class Course::LessonPlan::ItemsController < Course::LessonPlan::Controller
              order(start_at: :asc).includes(:actable).to_a.
              select { |item| can?(:show, item.actable) }
 
-    @milestones = current_course.lesson_plan_milestones.order(start_at: :asc)
+    @milestones = current_course.lesson_plan_milestones.ordered_by_date
 
     @folder_loader = Course::Material::PreloadService.new(current_course)
 

--- a/app/models/components/course/lesson_plan_ability_component.rb
+++ b/app/models/components/course/lesson_plan_ability_component.rb
@@ -16,7 +16,7 @@ module Course::LessonPlanAbilityComponent
   private
 
   def allow_registered_users_showing_milestones_items
-    can :read, Course::LessonPlan::Milestone, course_all_course_users_hash
+    can :read, Course::LessonPlan::Milestone, lesson_plan_item: course_all_course_users_hash
     can :read, Course::LessonPlan::Item, course_all_course_users_hash.merge(published: true)
     can :read, Course::LessonPlan::Event, lesson_plan_item: course_all_course_users_hash
   end
@@ -26,7 +26,7 @@ module Course::LessonPlanAbilityComponent
   end
 
   def allow_course_teaching_staff_manage_lesson_plans
-    can :manage, Course::LessonPlan::Milestone, course_teaching_staff_hash
+    can :manage, Course::LessonPlan::Milestone, lesson_plan_item: course_teaching_staff_hash
     can :manage, Course::LessonPlan::Item, course_teaching_staff_hash
     can :manage, Course::LessonPlan::Event, lesson_plan_item: course_teaching_staff_hash
   end

--- a/app/models/concerns/course/lesson_plan_concern.rb
+++ b/app/models/concerns/course/lesson_plan_concern.rb
@@ -11,8 +11,9 @@ module Course::LessonPlanConcern
   # @return [Hash{Course::LessonPlan::Milestone,nil=>Array<Course::LessonPlanItem>}]
   #   The items grouped by key, with a nil key indicating items not belonging to any milestone.
   def grouped_lesson_plan_items_with_milestones
-    milestones = lesson_plan_milestones.order(start_at: :asc).to_a
-    items = lesson_plan_items.order(start_at: :asc).includes(:actable).to_a
+    milestones = lesson_plan_milestones.ordered_by_date.to_a
+    items = lesson_plan_items.where.not(id: lesson_plan_items.where(actable_type: Course::LessonPlan::Milestone.name)).
+            order(start_at: :asc).includes(:actable).to_a
 
     group_lesson_plan_items_with_milestones(milestones, items)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -40,8 +40,8 @@ class Course < ApplicationRecord
   end
   has_many :groups, dependent: :destroy, class_name: Course::Group.name
   has_many :lesson_plan_items, class_name: Course::LessonPlan::Item.name, dependent: :destroy
-  has_many :lesson_plan_milestones, class_name: Course::LessonPlan::Milestone.name,
-                                    dependent: :destroy
+  has_many :lesson_plan_milestones, through: :lesson_plan_items,
+                                    source: :actable, source_type: Course::LessonPlan::Milestone.name
   has_many :lesson_plan_events, through: :lesson_plan_items,
                                 source: :actable, source_type: Course::LessonPlan::Event.name
   # Achievements must be declared after material_folders or duplication will fail.

--- a/app/models/course/lesson_plan/milestone.rb
+++ b/app/models/course/lesson_plan/milestone.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 class Course::LessonPlan::Milestone < ApplicationRecord
-  belongs_to :course, inverse_of: :lesson_plan_milestones
+  acts_as_lesson_plan_item has_todo: false
 
-  def initialize_duplicate(duplicator, _other)
-    self.start_at = duplicator.time_shift(start_at)
+  def initialize_duplicate(duplicator, other)
+    copy_attributes(other, duplicator)
     self.course = duplicator.options[:destination_course]
   end
+
+  # Used by the with_actable_types scope in Course::LessonPlan::Item.
+  # Edit this to remove items for display.
+  scope :ids_showable_in_lesson_plan, (lambda do |_|
+    joining { lesson_plan_item }.selecting { lesson_plan_item.id }
+  end)
 end

--- a/app/models/course/settings/lesson_plan_items.rb
+++ b/app/models/course/settings/lesson_plan_items.rb
@@ -86,6 +86,8 @@ class Course::Settings::LessonPlanItems < Course::Settings::PanComponent
       [actable_name, nil] if settings_interfaces_hash['course_videos_component'].showable_in_lesson_plan?
     when Course::LessonPlan::Event.name
       [actable_name, nil]
+    when Course::LessonPlan::Milestone.name
+      [actable_name, nil]
     end
   end
 end

--- a/db/migrate/20180829123352_change_milestones_to_acts_as_lesson_plan_item.rb
+++ b/db/migrate/20180829123352_change_milestones_to_acts_as_lesson_plan_item.rb
@@ -1,0 +1,29 @@
+class ChangeMilestonesToActsAsLessonPlanItem < ActiveRecord::Migration[5.1]
+  def up
+    execute <<-SQL
+      INSERT INTO course_lesson_plan_items (
+        actable_id, actable_type, course_id, title, description, start_at, base_exp,
+        time_bonus_exp, creator_id, updater_id, created_at, updated_at
+      ) (
+        SELECT
+          id, 'Course::LessonPlan::Milestone', course_id, title, description, start_at,
+          0, 0, creator_id, updater_id, created_at, updated_at
+        FROM course_lesson_plan_milestones
+      )
+    SQL
+
+    remove_column :course_lesson_plan_milestones, :course_id
+    remove_column :course_lesson_plan_milestones, :title
+    remove_column :course_lesson_plan_milestones, :description
+    remove_column :course_lesson_plan_milestones, :start_at
+    remove_column :course_lesson_plan_milestones, :creator_id
+    remove_column :course_lesson_plan_milestones, :updater_id
+    remove_column :course_lesson_plan_milestones, :created_at
+    remove_column :course_lesson_plan_milestones, :updated_at
+
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180703023011) do
+ActiveRecord::Schema.define(version: 20180829123352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -525,14 +525,6 @@ ActiveRecord::Schema.define(version: 20180703023011) do
   end
 
   create_table "course_lesson_plan_milestones", force: :cascade do |t|
-    t.integer  "course_id",   :index=>{:name=>"fk__course_lesson_plan_milestones_course_id", :order=>{:course_id=>:asc}}
-    t.string   "title",       :limit=>255, :null=>false
-    t.text     "description"
-    t.datetime "start_at",    :null=>false
-    t.integer  "creator_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_creator_id", :order=>{:creator_id=>:asc}}
-    t.integer  "updater_id",  :null=>false, :index=>{:name=>"fk__course_lesson_plan_milestones_updater_id", :order=>{:updater_id=>:asc}}
-    t.datetime "created_at",  :null=>false
-    t.datetime "updated_at",  :null=>false
   end
 
   create_table "course_lesson_plan_todos", force: :cascade do |t|
@@ -1015,9 +1007,6 @@ ActiveRecord::Schema.define(version: 20180703023011) do
   add_foreign_key "course_lesson_plan_items", "courses", name: "fk_course_lesson_plan_items_course_id"
   add_foreign_key "course_lesson_plan_items", "users", column: "creator_id", name: "fk_course_lesson_plan_items_creator_id"
   add_foreign_key "course_lesson_plan_items", "users", column: "updater_id", name: "fk_course_lesson_plan_items_updater_id"
-  add_foreign_key "course_lesson_plan_milestones", "courses", name: "fk_course_lesson_plan_milestones_course_id"
-  add_foreign_key "course_lesson_plan_milestones", "users", column: "creator_id", name: "fk_course_lesson_plan_milestones_creator_id"
-  add_foreign_key "course_lesson_plan_milestones", "users", column: "updater_id", name: "fk_course_lesson_plan_milestones_updater_id"
   add_foreign_key "course_lesson_plan_todos", "course_lesson_plan_items", column: "item_id", name: "fk_course_lesson_plan_todos_item_id"
   add_foreign_key "course_lesson_plan_todos", "users", column: "creator_id", name: "fk_course_lesson_plan_todos_creator_id"
   add_foreign_key "course_lesson_plan_todos", "users", column: "updater_id", name: "fk_course_lesson_plan_todos_updater_id"

--- a/spec/factories/course_lesson_plan_milestones.rb
+++ b/spec/factories/course_lesson_plan_milestones.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
-  factory :course_lesson_plan_milestone, class: Course::LessonPlan::Milestone.name do
-    course
+  factory :course_lesson_plan_milestone, class: Course::LessonPlan::Milestone.name,
+                                         parent: :course_lesson_plan_item do
     sequence(:title) { |n| "Example Milestone #{n}" }
     description { 'Coolest description.' }
     start_at { 1.day.from_now }

--- a/spec/models/course/lesson_plan/lesson_plan_milestone_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_milestone_spec.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-require 'rails_helper'
-
-RSpec.describe Course::LessonPlan::Milestone, type: :model do
-  it { is_expected.to belong_to(:course).inverse_of(:lesson_plan_milestones) }
-end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Course, type: :model do
     it { is_expected.to have_many(:discussion_topics) }
     it { is_expected.to have_many(:forums).dependent(:destroy) }
     it { is_expected.to have_many(:lesson_plan_items).dependent(:destroy) }
-    it { is_expected.to have_many(:lesson_plan_milestones).dependent(:destroy) }
+    it { is_expected.to have_many(:lesson_plan_events).through(:lesson_plan_items) }
+    it { is_expected.to have_many(:lesson_plan_milestones).through(:lesson_plan_items) }
     it { is_expected.to have_many(:material_folders).dependent(:destroy) }
     it { is_expected.to have_many(:surveys).through(:lesson_plan_items) }
     it { is_expected.to have_many(:videos).through(:lesson_plan_items) }


### PR DESCRIPTION
As title.

No need to special case milestones when looking up items in items_controller because milestones are filtered out by `with_actable_types`.

**Test Plan**

`bundle exec rake db:migrate`

Migrated rows:
![image](https://user-images.githubusercontent.com/11096034/44794087-4eea5380-abda-11e8-8e0a-271b21d8fdf4.png)

Old rows with columns removed:
![image](https://user-images.githubusercontent.com/11096034/44794156-75a88a00-abda-11e8-9f62-7c6e454ce087.png)

Lesson plan page looks correct (http://dev1.louietyj.me:3000/courses/1346/lesson_plan):
![image](https://user-images.githubusercontent.com/11096034/44793952-05016d80-abda-11e8-9ece-a69613dbddbc.png)
