### PR TITLE
Show updater name in announcement notifier email

### DIFF
--- a/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
+++ b/app/views/notifiers/course/announcement_notifier/new/course_notifications/email.html.slim
@@ -1,6 +1,7 @@
 - announcement = @object
 - course = announcement.course
 - host = course.instance.host
+- creator = format_inline_text(announcement.creator.name)
 
 - message.subject = t('.subject', course: course.title, announcement: announcement.title)
 
@@ -9,4 +10,5 @@
 
 = format_html(t('.message', course: course_link,
                             announcement: announcement_link,
-                            content: announcement.content_to_email))
+                            content: announcement.content_to_email,
+                            creator: creator))

--- a/config/locales/en/notifiers/course/announcement_notifier/new/course_notifications/email.yml
+++ b/config/locales/en/notifiers/course/announcement_notifier/new/course_notifications/email.yml
@@ -7,5 +7,5 @@ en:
             email:
               subject: '%{course} New Announcement: %{announcement}'
               message: >
-                <p>New %{announcement} from course: %{course}</p>
+                <p>%{creator} posted a new %{announcement} from course: %{course}</p>
                 %{content}


### PR DESCRIPTION
Fix https://github.com/Coursemology/coursemology2/issues/3090

To test: change `perform_later` to `perform_now` in https://github.com/Coursemology/coursemology2/blob/c0309a6f6c2917b2fb3811df5723078b28385304/app/models/concerns/course/opening_reminder_concern.rb#L39

![image](https://user-images.githubusercontent.com/35135264/44970045-5e72ef00-af82-11e8-9987-8a7c05bd270f.png)
