### PR TITLE
[1/n] Migration + models for multiple reference timelines

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -52,6 +52,10 @@ class Course < ApplicationRecord
   has_many :videos, through: :lesson_plan_items, source: :actable, source_type: Course::Video.name
   has_many :video_tabs, class_name: Course::Video::Tab.name, inverse_of: :course, dependent: :destroy
 
+  has_many :reference_timelines, class_name: Course::ReferenceTimeline.name, inverse_of: :course, dependent: :destroy
+  has_one :default_reference_timeline, -> { where(default: true) },
+          class_name: Course::ReferenceTimeline.name, inverse_of: :course
+
   accepts_nested_attributes_for :invitations, :assessment_categories, :video_tabs
 
   calculated :user_count, (lambda do

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -2,6 +2,10 @@
 class Course::LessonPlan::Item < ApplicationRecord
   include Course::LessonPlan::ItemTodoConcern
 
+  has_many :reference_times,
+           foreign_key: :lesson_plan_item, class_name: Course::ReferenceTime.name, inverse_of: :lesson_plan_item,
+           dependent: :destroy
+
   actable optional: true
   has_many_attachments on: :description
 

--- a/app/models/course/reference_time.rb
+++ b/app/models/course/reference_time.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class Course::ReferenceTime < ApplicationRecord
+  belongs_to :reference_timeline, class_name: Course::ReferenceTimeline.name, inverse_of: :reference_times
+  belongs_to :lesson_plan_item, class_name: Course::LessonPlan::Item.name, inverse_of: :reference_times
+end

--- a/app/models/course/reference_timeline.rb
+++ b/app/models/course/reference_timeline.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Course::ReferenceTimeline < ApplicationRecord
+  belongs_to :course, inverse_of: :reference_timelines
+  has_many :reference_times,
+           class_name: Course::ReferenceTime.name, inverse_of: :reference_timeline, dependent: :destroy
+end

--- a/db/migrate/20180830061522_add_reference_timeline.rb
+++ b/db/migrate/20180830061522_add_reference_timeline.rb
@@ -1,0 +1,30 @@
+class AddReferenceTimeline < ActiveRecord::Migration[5.1]
+  def change
+    # course_lesson_plan_items
+    add_column :course_lesson_plan_items, :triggers_recomputation, :boolean, null: false, default: false
+    add_column :course_lesson_plan_items, :movable, :boolean, null: false, default: false
+
+    # course_reference_timelines
+    create_table :course_reference_timelines do |t|
+      t.references :course, null: false, index: true, foreign_key: { to_table: :courses }
+      t.boolean :default, null: false, default: false
+      t.timestamps
+    end
+
+    # course_reference_times
+    create_table :course_reference_times do |t|
+      t.references :reference_timeline,
+                   null: false, index: true, foreign_key: { to_table: :course_reference_timelines }
+      t.references :lesson_plan_item,
+                   null: false, index: true, foreign_key: { to_table: :course_lesson_plan_items }
+      t.datetime :start_at, null: false
+      t.datetime :bonus_end_at
+      t.datetime :end_at
+      t.timestamps
+    end
+
+    # course_users
+    add_reference :course_users, :reference_timeline,
+                  index: true, foreign_key: { to_table: :course_reference_timelines }
+  end
+end


### PR DESCRIPTION
Implements the LHS of the new schema:
![image](https://user-images.githubusercontent.com/11096034/44983770-fbe31880-afac-11e8-8b56-11aaf37130be.png)

TODOs:
* Create reference timelines for all existing courses and migrate the data over
* Validations on new tables, e.g. make sure that a course must have at least one reference timeline with reference times for all lesson plan items
* Read/write to new tables