### PR TITLE
Regrade programming answers when test cases change

### DIFF
--- a/app/jobs/course/assessment/submission/auto_grading_job.rb
+++ b/app/jobs/course/assessment/submission/auto_grading_job.rb
@@ -9,10 +9,12 @@ class Course::Assessment::Submission::AutoGradingJob < ApplicationJob
   #
   # @param [Course::Assessment::Submission] submission The object to store the grading
   #   results into.
-  def perform_tracked(submission)
+  # @param [Boolean] only_ungraded Whether grading should be done ONLY for
+  #   ungraded_answers, or for all answers regardless of workflow state
+  def perform_tracked(submission, only_ungraded: false)
     instance = Course.unscoped { submission.assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
-      Course::Assessment::Submission::AutoGradingService.grade(submission)
+      Course::Assessment::Submission::AutoGradingService.grade(submission, only_ungraded: only_ungraded)
       redirect_to(edit_course_assessment_submission_path(submission.assessment.course,
                                                          submission.assessment, submission))
     end

--- a/spec/fixtures/course/programming_single_test_suite_report.xml
+++ b/spec/fixtures/course/programming_single_test_suite_report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnitXmlReporter.constructor" errors="0" skipped="1" tests="3" failures="1" time="0.006" timestamp="2013-05-24T10:23:58">
+<testsuite name="JUnitXmlReporter.constructor" errors="0" skipped="0" tests="3" failures="1" time="0.018" timestamp="2013-05-24T10:23:58">
     <properties>
         <property name="java.vendor" value="Sun Microsystems Inc." />
         <property name="compiler.debug" value="on" />
@@ -13,8 +13,6 @@
 TypeError: mosaic() takes 1 positional argument but 4 were given
 ]]>		</error>
     </testcase>
-    <testcase classname="JUnitXmlReporter.constructor" name="test_private_2" time="0">
-        <skipped />
-    </testcase>
-    <testcase classname="JUnitXmlReporter.constructor" name="test_evaluation_3" time="0" />
+    <testcase classname="JUnitXmlReporter.constructor" name="test_private_2" time="0.006" />
+    <testcase classname="JUnitXmlReporter.constructor" name="test_evaluation_3" time="0.006" />
 </testsuite>


### PR DESCRIPTION
Fix https://github.com/Coursemology/coursemology2/issues/3110

Stress testing, i.e. quick succession of test case boolean changes, causes localhost server to hang while answer auto grading jobs is being performed. Need to see if this is a problem on staging.