### PR TITLE
Migration + models for multiple reference timelines

### DIFF
--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -46,7 +46,7 @@ class Course::CoursesController < Course::Controller
   def load_todos
     return unless current_course_user&.student?
     @todos = Course::LessonPlan::Todo.pending_for(current_course_user).
-             includes(:user, item: [:actable, :course])
+             includes(:user, item: :course)
     # TODO: Fix n+1 query for #can_user_start?
     @todos = @todos.select(&:can_user_start?)
   end

--- a/app/controllers/course/lesson_plan/items_controller.rb
+++ b/app/controllers/course/lesson_plan/items_controller.rb
@@ -33,7 +33,7 @@ class Course::LessonPlan::ItemsController < Course::LessonPlan::Controller
 
   def render_json_response
     @items = @items.with_actable_types(@item_settings.actable_hash).
-             order(start_at: :asc).includes(:actable).to_a.
+             includes(:actable).to_a.
              select { |item| can?(:show, item.actable) }
 
     @milestones = current_course.lesson_plan_milestones.ordered_by_date

--- a/app/models/components/course/surveys_ability_component.rb
+++ b/app/models/components/course/surveys_ability_component.rb
@@ -3,7 +3,7 @@ module Course::SurveysAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
+    if user && !user.administrator?
       define_student_survey_permissions
       define_staff_survey_permissions
     end
@@ -30,7 +30,10 @@ module Course::SurveysAbilityComponent
   end
 
   def survey_open_all_course_users_hash
-    survey_published_all_course_users_hash.deep_merge(lesson_plan_item: already_started_hash)
+    # TODO(#3092): Check timings for individual users
+    survey_published_all_course_users_hash.deep_merge(
+      lesson_plan_item: { default_reference_time: already_started_hash }
+    )
   end
 
   def survey_active_all_course_users_hashes
@@ -40,8 +43,9 @@ module Course::SurveysAbilityComponent
   end
 
   def survey_expired_but_respondable
+    # TODO(#3092): Check timings for individual users
     survey_published_all_course_users_hash.deep_merge(
-      lesson_plan_item: { end_at: (Time.min..Time.zone.now) },
+      lesson_plan_item: { default_reference_time: { end_at: (Time.min..Time.zone.now) } },
       allow_response_after_end: true
     )
   end

--- a/app/models/concerns/course/duplication_concern.rb
+++ b/app/models/concerns/course/duplication_concern.rb
@@ -15,6 +15,7 @@ module Course::DuplicationConcern
   # List of top-level items that need to be duplicated for the whole course to be considered duplicated.
   def duplication_manifest # rubocop:disable Metrics/MethodLength
     [
+      *reference_timelines,
       *material_folders.concrete,
       *materials.in_concrete_folder,
       *levels,

--- a/app/models/concerns/course/lesson_plan_concern.rb
+++ b/app/models/concerns/course/lesson_plan_concern.rb
@@ -13,7 +13,7 @@ module Course::LessonPlanConcern
   def grouped_lesson_plan_items_with_milestones
     milestones = lesson_plan_milestones.ordered_by_date.to_a
     items = lesson_plan_items.where.not(id: lesson_plan_items.where(actable_type: Course::LessonPlan::Milestone.name)).
-            order(start_at: :asc).includes(:actable).to_a
+            ordered_by_date.to_a
 
     group_lesson_plan_items_with_milestones(milestones, items)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -52,6 +52,12 @@ class Course < ApplicationRecord
   has_many :videos, through: :lesson_plan_items, source: :actable, source_type: Course::Video.name
   has_many :video_tabs, class_name: Course::Video::Tab.name, inverse_of: :course, dependent: :destroy
 
+  has_many :reference_timelines, class_name: Course::ReferenceTimeline.name, inverse_of: :course, dependent: :destroy
+  has_one :default_reference_timeline, -> { where(default: true) },
+          class_name: Course::ReferenceTimeline.name, inverse_of: :course
+  validates :default_reference_timeline, presence: true
+  validate :validate_only_one_default_reference_timeline
+
   accepts_nested_attributes_for :invitations, :assessment_categories, :video_tabs
 
   calculated :user_count, (lambda do
@@ -180,8 +186,15 @@ class Course < ApplicationRecord
   def set_defaults
     self.start_at ||= Time.zone.now.beginning_of_hour
     self.end_at ||= self.start_at + 1.month
+    self.default_reference_timeline ||= reference_timelines.new(default: true)
 
     return unless creator && course_users.empty?
     course_users.build(user: creator, role: :owner, creator: creator, updater: updater)
+  end
+
+  def validate_only_one_default_reference_timeline
+    num_defaults = reference_timelines.where(course_reference_timelines: { default: true }).count
+    return if num_defaults <= 1 # Could be 0 if item is new
+    errors.add(:reference_timelines, :must_have_at_most_one_default)
   end
 end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -69,7 +69,7 @@ class Course::Assessment < ApplicationRecord
   #   Orders the assessments by the starting date and title.
   scope :ordered_by_date_and_title, (lambda do
     select(<<~SQL).
-    course_assessments.*, course_lesson_plan_items.start_at, course_lesson_plan_items.title
+      course_assessments.*, course_reference_times.start_at, course_lesson_plan_items.title
     SQL
     joins(:lesson_plan_item).
     merge(Course::LessonPlan::Item.ordered_by_date_and_title)

--- a/app/models/course/lesson_plan/event.rb
+++ b/app/models/course/lesson_plan/event.rb
@@ -3,8 +3,8 @@ class Course::LessonPlan::Event < ApplicationRecord
   acts_as_lesson_plan_item
 
   def initialize_duplicate(duplicator, other)
-    copy_attributes(other, duplicator)
     self.course = duplicator.options[:destination_course]
+    copy_attributes(other, duplicator)
   end
 
   # Used by the with_actable_types scope in Course::LessonPlan::Item.

--- a/app/models/course/lesson_plan/milestone.rb
+++ b/app/models/course/lesson_plan/milestone.rb
@@ -3,8 +3,8 @@ class Course::LessonPlan::Milestone < ApplicationRecord
   acts_as_lesson_plan_item has_todo: false
 
   def initialize_duplicate(duplicator, other)
-    copy_attributes(other, duplicator)
     self.course = duplicator.options[:destination_course]
+    copy_attributes(other, duplicator)
   end
 
   # Used by the with_actable_types scope in Course::LessonPlan::Item.

--- a/app/models/course/reference_time.rb
+++ b/app/models/course/reference_time.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Course::ReferenceTime < ApplicationRecord
+  belongs_to :reference_timeline, class_name: Course::ReferenceTimeline.name, inverse_of: :reference_times
+  belongs_to :lesson_plan_item, class_name: Course::LessonPlan::Item.name, inverse_of: :reference_times
+
+  def initialize_duplicate(duplicator, other)
+    self.reference_timeline = duplicator.duplicate(other.reference_timeline)
+    self.start_at = duplicator.time_shift(other.start_at)
+    self.bonus_end_at = duplicator.time_shift(other.bonus_end_at) if other.bonus_end_at
+    self.end_at = duplicator.time_shift(other.end_at) if other.end_at
+  end
+end

--- a/app/models/course/reference_timeline.rb
+++ b/app/models/course/reference_timeline.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class Course::ReferenceTimeline < ApplicationRecord
+  belongs_to :course, inverse_of: :reference_timelines
+  has_many :reference_times,
+           class_name: Course::ReferenceTime.name, inverse_of: :reference_timeline, dependent: :destroy
+
+  validates :default, inclusion: [true, false]
+
+  def initialize_duplicate(duplicator, _other)
+    self.course = duplicator.options[:destination_course]
+    self.reference_times = []
+  end
+end

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -35,9 +35,9 @@ class Course::Survey < ApplicationRecord
   end
 
   def initialize_duplicate(duplicator, other)
+    self.course = duplicator.options[:destination_course]
     copy_attributes(other, duplicator)
     self.sections = duplicator.duplicate(other.sections)
-    self.course = duplicator.options[:destination_course]
   end
 
   def include_in_consolidated_email?(event)

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -26,7 +26,7 @@ class Course::Video < ApplicationRecord
   # @!method self.ordered_by_date_and_title
   #   Orders the videos by the starting date and title.
   scope :ordered_by_date_and_title, (lambda do
-    select('course_videos.*, course_lesson_plan_items.start_at, course_lesson_plan_items.title').
+    select('course_videos.*, course_reference_times.start_at, course_lesson_plan_items.title').
       joins(:lesson_plan_item).
       merge(Course::LessonPlan::Item.ordered_by_date_and_title)
   end)
@@ -57,15 +57,16 @@ class Course::Video < ApplicationRecord
   end)
 
   scope :video_after, (lambda do |video|
-    from_tab(video.tab_id).
-      joins(:lesson_plan_item).
-      where('course_lesson_plan_items.start_at > :start_at OR '\
-            '(course_lesson_plan_items.start_at = :start_at AND '\
-            'course_lesson_plan_items.title > :title)',
-            start_at: video.start_at,
-            title: video.title).
-      ordered_by_date_and_title.
-      limit(1)
+    candidates = from_tab(video.tab_id).
+                 joins(lesson_plan_item: :default_reference_time).
+                 where('course_reference_times.start_at > :start_at OR '\
+                       '(course_reference_times.start_at = :start_at AND '\
+                       'course_lesson_plan_items.title > :title)',
+                       start_at: video.start_at,
+                       title: video.title)
+    # Workaround to avoid joining to same table twice
+    candidates = Course::Video.where(id: candidates.to_a)
+    candidates.ordered_by_date_and_title.limit(1)
   end)
 
   def self.use_relative_model_naming?
@@ -81,8 +82,8 @@ class Course::Video < ApplicationRecord
   end
 
   def initialize_duplicate(duplicator, other)
-    copy_attributes(other, duplicator)
     self.course = duplicator.options[:destination_course]
+    copy_attributes(other, duplicator)
     initialize_duplicate_tab(duplicator, other)
   end
 

--- a/config/locales/en/activerecord/course.yml
+++ b/config/locales/en/activerecord/course.yml
@@ -1,0 +1,11 @@
+en:
+  activerecord:
+    attributes:
+      course:
+        reference_timelines: 'Reference timelines'
+    errors:
+      models:
+        course:
+          attributes:
+            reference_timelines:
+              must_have_at_most_one_default: 'must have at most one default'

--- a/config/locales/en/course/lesson_plan/items.yml
+++ b/config/locales/en/course/lesson_plan/items.yml
@@ -5,3 +5,13 @@ en:
         sidebar_title: :'course.lesson_plan.items.index.header'
         index:
           header: 'Lesson Plan'
+  activerecord:
+    attributes:
+      course/lesson_plan/item:
+        reference_times: 'Reference times'
+    errors:
+      models:
+        course/lesson_plan/item:
+          attributes:
+            reference_times:
+              must_have_at_most_one_default: 'must have at most one default'

--- a/db/migrate/20180929061522_add_reference_timeline.rb
+++ b/db/migrate/20180929061522_add_reference_timeline.rb
@@ -1,0 +1,61 @@
+class AddReferenceTimeline < ActiveRecord::Migration[5.1]
+  def up
+    #### Add new tables and columns
+
+    # course_lesson_plan_items
+    add_column :course_lesson_plan_items, :triggers_recomputation, :boolean, null: false, default: false
+    add_column :course_lesson_plan_items, :movable, :boolean, null: false, default: false
+
+    # course_reference_timelines
+    create_table :course_reference_timelines do |t|
+      t.references :course, null: false, index: true, foreign_key: { to_table: :courses }
+      t.boolean :default, null: false, default: false
+      t.timestamps
+    end
+
+    # course_reference_times
+    create_table :course_reference_times do |t|
+      t.references :reference_timeline,
+                   null: false, index: true, foreign_key: { to_table: :course_reference_timelines }
+      t.references :lesson_plan_item,
+                   null: false, index: true, foreign_key: { to_table: :course_lesson_plan_items }
+      t.datetime :start_at, null: false
+      t.datetime :bonus_end_at
+      t.datetime :end_at
+      t.timestamps
+    end
+
+    # course_users
+    add_reference :course_users, :reference_timeline,
+                  index: true, foreign_key: { to_table: :course_reference_timelines }
+
+    #### Data migration
+
+    execute <<-SQL
+      -- Create a reference timeline for each course
+      INSERT INTO course_reference_timelines (course_id, "default", created_at, updated_at)
+      SELECT id, true, NOW()::TIMESTAMP, NOW()::TIMESTAMP FROM courses;
+
+      -- Create a reference time for each lesson plan item
+      INSERT INTO course_reference_times (
+        reference_timeline_id, lesson_plan_item_id, start_at, bonus_end_at, end_at, created_at, updated_at
+      )
+      SELECT
+        course_reference_timelines.id, course_lesson_plan_items.id, start_at, bonus_end_at, end_at,
+        NOW()::TIMESTAMP, NOW()::TIMESTAMP
+      FROM course_lesson_plan_items
+      INNER JOIN course_reference_timelines
+        ON course_lesson_plan_items.course_id = course_reference_timelines.course_id;
+    SQL
+
+    #### Clean up old columns
+
+    remove_column :course_lesson_plan_items, :start_at
+    remove_column :course_lesson_plan_items, :bonus_end_at
+    remove_column :course_lesson_plan_items, :end_at
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/extensions/acts_as_helpers/active_record/base.rb
+++ b/lib/extensions/acts_as_helpers/active_record/base.rb
@@ -24,14 +24,16 @@ module Extensions::ActsAsHelpers::ActiveRecord::Base
     #     1) _todo_#{actable.class.name}_title.html.slim    -> Title and any links if required.
     #     2) _todo_#{actable.class.name}_button.html.slim   -> Action button for todo.
     def acts_as_lesson_plan_item(has_todo: false)
-      acts_as :lesson_plan_item, class_name: Course::LessonPlan::Item.name
+      acts_as :lesson_plan_item, class_name: Course::LessonPlan::Item.name, autosave: true
 
       class << self
         attr_accessor :has_todo
       end
       self.has_todo = has_todo ? true : false
 
-      scope :active, -> { joins(:lesson_plan_item).merge(Course::LessonPlan::Item.currently_active) }
+      scope :active, (lambda do
+        joins(lesson_plan_item: :default_reference_time).merge(Course::ReferenceTime.currently_active)
+      end)
 
       extend LessonPlanItemClassMethods
       include LessonPlanItemInstanceMethods

--- a/spec/services/course/duplication/course_duplication_service_spec.rb
+++ b/spec/services/course/duplication/course_duplication_service_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
       context 'when saving fails' do
         let!(:invalid_event) do
           create(:course_lesson_plan_event, course: course).tap do |event|
-            event.acting_as.update_columns(time_bonus_exp: 1, bonus_end_at: nil)
+            event.acting_as.update_columns(time_bonus_exp: 1)
+            event.acting_as.default_reference_time.update_columns(bonus_end_at: nil)
           end
         end
 
@@ -51,8 +52,8 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
         end
 
         it 'sets the creator of the new course to the current user' do
-          expect(new_course.creator).to be admin
-          expect(new_course.creator).not_to be course.creator
+          expect(new_course.creator).to eq admin
+          expect(new_course.creator).not_to eq course.creator
         end
 
         it 'time shifts the new course' do


### PR DESCRIPTION
Implements the LHS of the new schema:
![image](https://user-images.githubusercontent.com/11096034/44983770-fbe31880-afac-11e8-8b56-11aaf37130be.png)

Application level will pretend that there is only ever one reference timeline for now.