### PR TITLE
Remove deprecated codeclimate-test-reporter.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,6 @@ end
 
 group :ci do
   # Code Coverage reporters
-  gem 'codeclimate-test-reporter'
   gem 'codecov', :require => false
   gem 'rspec-retry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,8 +186,6 @@ GEM
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     cocoon (1.2.11)
-    codeclimate-test-reporter (1.0.8)
-      simplecov (<= 0.13)
     codecov (0.1.13)
       json
       simplecov
@@ -588,7 +586,6 @@ DEPENDENCIES
   carrierwave
   chromedriver-helper
   cocoon
-  codeclimate-test-reporter
   codecov
   consistency_fail
   coursemology-polyglot!


### PR DESCRIPTION
Don't merge yet, will need to re-create some of the integrations.