### PR TITLE
Finish updating Gemfile.lock file from removing schema_plus gems.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,7 +280,6 @@ GEM
     image_size (1.5.0)
     in_threads (1.5.0)
     io-like (0.3.0)
-    its-it (1.3.0)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)


### PR DESCRIPTION
This was missed out after fixing a merge conflict and shows up after running `bundle`.

References #3183 