### PR TITLE
Upgrade to Rails 5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'active_record_upsert'
 gem 'friendly_id'
 
 # Use SCSS for stylesheets
-gem 'sass', '< 3.7' # TODO: remove this line after bootstrap-sass issue is resolved
 gem 'sass-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,7 @@ gem 'bundler', '>= 1.10.3'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 # We need a patched version of rails because stock 5.1.6 has_one associations ignores
 # joins in scope, which we use for Course::LessonPlan::Item.default_reference_time
-gem 'rails', '5.1.6', git: 'https://github.com/Coursemology/rails.git',
-                      branch: 'v5.1.6-fix_association_with_scope_including_joins'
+gem 'rails', '< 5.2.1'
 
 # Use PostgreSQL for the backend
 gem 'pg'
@@ -35,7 +34,7 @@ gem 'calculated_attributes'
 gem 'baby_squeel'
 # For multiple table inheritance
 #   TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
-gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as', branch: 'rails5'
+gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as', branch: 'rails5-2'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Upsert action for Postgres
@@ -44,6 +43,7 @@ gem 'active_record_upsert'
 gem 'friendly_id'
 
 # Use SCSS for stylesheets
+gem 'sass', '< 3.7' # TODO: remove this line after bootstrap-sass issue is resolved
 gem 'sass-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
@@ -211,7 +211,7 @@ gem 'rubyzip', require: 'zip'
 gem 'nokogiri', '>= 1.8.1'
 
 # Polyglot support
-gem 'coursemology-polyglot', git: 'https://github.com/Coursemology/polyglot'
+gem 'coursemology-polyglot'
 
 # To assist with bulk inserts into database
 gem 'activerecord-import', '>= 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,7 +442,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.6.0)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -606,7 +606,6 @@ DEPENDENCIES
   rubyzip
   rwordnet!
   sanitize (>= 4.6.3)
-  sass (< 3.7)
   sass-rails
   settings_on_rails
   should_not

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,79 +1,11 @@
 GIT
   remote: https://github.com/Coursemology/active_record-acts_as
-  revision: 84a2b5f0329870c6c4a72b097b6d7f1344b536e4
-  branch: rails5
+  revision: 1b3e8dc2395ed1799f5aed60e70eb2a1c6ee07ce
+  branch: rails5-2
   specs:
-    active_record-acts_as (2.5.0.3)
-      activerecord (>= 4.2, < 5.2)
-      activesupport (>= 4.2, < 5.2)
-
-GIT
-  remote: https://github.com/Coursemology/polyglot
-  revision: aee1351e1c8e3f42df1b8164473a5ece2dcde980
-  specs:
-    coursemology-polyglot (0.2.9.3)
-      activesupport (>= 4.2, < 6)
-
-GIT
-  remote: https://github.com/Coursemology/rails.git
-  revision: 50223439829b6cb461783a322cdcc2a51515d84c
-  branch: v5.1.6-fix_association_with_scope_including_joins
-  specs:
-    actioncable (5.1.6)
-      actionpack (= 5.1.6)
-      nio4r (~> 2.0)
-      websocket-driver (~> 0.6.1)
-    actionmailer (5.1.6)
-      actionpack (= 5.1.6)
-      actionview (= 5.1.6)
-      activejob (= 5.1.6)
-      mail (~> 2.5, >= 2.5.4)
-      rails-dom-testing (~> 2.0)
-    actionpack (5.1.6)
-      actionview (= 5.1.6)
-      activesupport (= 5.1.6)
-      rack (~> 2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.1.6)
-      activesupport (= 5.1.6)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activejob (5.1.6)
-      activesupport (= 5.1.6)
-      globalid (>= 0.3.6)
-    activemodel (5.1.6)
-      activesupport (= 5.1.6)
-    activerecord (5.1.6)
-      activemodel (= 5.1.6)
-      activesupport (= 5.1.6)
-      arel (~> 8.0)
-    activesupport (5.1.6)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    rails (5.1.6)
-      actioncable (= 5.1.6)
-      actionmailer (= 5.1.6)
-      actionpack (= 5.1.6)
-      actionview (= 5.1.6)
-      activejob (= 5.1.6)
-      activemodel (= 5.1.6)
-      activerecord (= 5.1.6)
-      activesupport (= 5.1.6)
-      bundler (>= 1.3.0)
-      railties (= 5.1.6)
-      sprockets-rails (>= 2.0.0)
-    railties (5.1.6)
-      actionpack (= 5.1.6)
-      activesupport (= 5.1.6)
-      method_source
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
+    active_record-acts_as (3.0.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
 
 GIT
   remote: https://github.com/Coursemology/simple_form-bootstrap
@@ -117,12 +49,53 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (5.2.0)
+      actionpack (= 5.2.0)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailer (5.2.0)
+      actionpack (= 5.2.0)
+      actionview (= 5.2.0)
+      activejob (= 5.2.0)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.2.0)
+      actionview (= 5.2.0)
+      activesupport (= 5.2.0)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.0)
+      activesupport (= 5.2.0)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_record_upsert (0.9.4)
       activerecord (>= 5.0, < 6.0)
       arel (> 7.0, < 10.0)
       pg (>= 0.18, < 2.0)
+    activejob (5.2.0)
+      activesupport (= 5.2.0)
+      globalid (>= 0.3.6)
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activerecord (5.2.0)
+      activemodel (= 5.2.0)
+      activesupport (= 5.2.0)
+      arel (>= 9.0)
     activerecord-import (0.27.0)
       activerecord (>= 3.2)
+    activestorage (5.2.0)
+      actionpack (= 5.2.0)
+      activerecord (= 5.2.0)
+      marcel (~> 0.3.1)
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     acts_as_tenant (0.4.3)
       rails (>= 4.0)
       request_store (>= 1.0.5)
@@ -131,10 +104,10 @@ GEM
     after_commit_action (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-    anbt-sql-formatter (0.0.6)
+    anbt-sql-formatter (0.0.7)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
-    arel (8.0.0)
+    arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.3.1)
       execjs
@@ -193,6 +166,8 @@ GEM
       url
     concurrent-ruby (1.1.3)
     consistency_fail (0.3.7)
+    coursemology-polyglot (0.2.9.3)
+      activesupport (>= 4.2, < 6)
     crass (1.0.4)
     devise (4.5.0)
       bcrypt (~> 3.0)
@@ -228,7 +203,7 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    faraday (0.12.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     filename (0.1.2)
@@ -267,23 +242,23 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    image_optim (0.26.1)
+    image_optim (0.26.3)
       exifr (~> 1.2, >= 1.2.2)
       fspath (~> 3.0)
-      image_size (~> 1.5)
+      image_size (>= 1.5, < 3)
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
     image_optim_rails (0.4.1)
       image_optim (~> 0.24)
       rails
       sprockets
-    image_size (1.5.0)
+    image_size (2.0.0)
     in_threads (1.5.0)
     io-like (0.3.0)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
-    join_dependency (0.1.2)
+    join_dependency (0.1.4)
       activerecord (>= 4.2.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -293,7 +268,7 @@ GEM
       railties (>= 3.2)
       sprockets-rails
     json (2.1.0)
-    jwt (1.5.6)
+    jwt (2.1.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -321,10 +296,13 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    method_source (0.9.0)
-    mime-types (3.1)
+    marcel (0.3.3)
+      mimemagic (~> 0.3.2)
+    method_source (0.9.2)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
+    mimemagic (0.3.2)
     mini_magick (4.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
@@ -338,11 +316,11 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    nokogumbo (2.0.0)
+    nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
-    oauth2 (1.4.0)
-      faraday (>= 0.8, < 0.13)
-      jwt (~> 1.0)
+    oauth2 (1.4.1)
+      faraday (>= 0.8, < 0.16.0)
+      jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
@@ -363,14 +341,27 @@ GEM
     pg (1.1.3)
     polyamorous (1.3.3)
       activerecord (>= 3.0)
-    progress (3.4.0)
+    progress (3.5.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
-    rack-proxy (0.6.4)
+    rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rails (5.2.0)
+      actioncable (= 5.2.0)
+      actionmailer (= 5.2.0)
+      actionpack (= 5.2.0)
+      actionview (= 5.2.0)
+      activejob (= 5.2.0)
+      activemodel (= 5.2.0)
+      activerecord (= 5.2.0)
+      activestorage (= 5.2.0)
+      activesupport (= 5.2.0)
+      bundler (>= 1.3.0)
+      railties (= 5.2.0)
+      sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.2)
       actionpack (~> 5.x, >= 5.0.1)
       actionview (~> 5.x, >= 5.0.1)
@@ -394,6 +385,12 @@ GEM
       rubyzip (~> 1)
     rails_utils (4.0.0)
       rails (>= 3.2)
+    railties (5.2.0)
+      actionpack (= 5.2.0)
+      activesupport (= 5.2.0)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
@@ -412,7 +409,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rinku (2.0.4)
-    rouge (3.1.1)
+    rouge (3.3.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -445,7 +442,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.5.6)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -456,9 +453,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.13.0)
+    selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+      rubyzip (~> 1.2, >= 1.2.2)
     settings_on_rails (0.3.1)
       activerecord (>= 3.1)
     should_not (1.1.0)
@@ -493,7 +490,7 @@ GEM
     temple (0.8.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
     traceroute (0.8.0)
@@ -523,7 +520,7 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.6.5)
+    websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     workflow (1.2.0)
@@ -562,7 +559,7 @@ DEPENDENCIES
   cocoon
   codecov
   consistency_fail
-  coursemology-polyglot!
+  coursemology-polyglot
   devise
   devise-multi_email
   devise_masquerade
@@ -595,7 +592,7 @@ DEPENDENCIES
   parallel_tests
   pg
   puma
-  rails (= 5.1.6)!
+  rails (< 5.2.1)
   rails-controller-testing
   rails-flog
   rails-html-sanitizer (>= 1.0.4)
@@ -609,6 +606,7 @@ DEPENDENCIES
   rubyzip
   rwordnet!
   sanitize (>= 4.6.3)
+  sass (< 3.7)
   sass-rails
   settings_on_rails
   should_not

--- a/app/models/concerns/course/video/interval_query_concern.rb
+++ b/app/models/concerns/course/video/interval_query_concern.rb
@@ -9,8 +9,6 @@ module Course::Video::IntervalQueryConcern
   end
 
   included do
-    private_class_method :type_sym_to_id
-
     START_TYPES = [:play, :seek_end].freeze
     END_TYPES = [:pause, :seek_start, :end].freeze
 

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -16,6 +16,7 @@ class Course::Assessment < ApplicationRecord
   before_validation :propagate_course, if: :new_record?
   before_validation :assign_folder_attributes
   after_commit :grade_with_new_test_cases, on: :update
+  before_save :save_tab, on: :create
 
   validates :autograded, inclusion: { in: [true, false] }
   validates :session_password, length: { maximum: 255 }, allow_nil: true
@@ -254,5 +255,11 @@ class Course::Assessment < ApplicationRecord
       submission.mark!
       submission.publish!
     end
+  end
+
+  # Somehow autosaving more than 1 level of association doesn't work in Rails 5.2
+  def save_tab
+    tab.category.save if tab&.category && !tab.category.persisted?
+    tab.save if tab && !tab.persisted?
   end
 end

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -51,7 +51,7 @@ class Course::Video < ApplicationRecord
   scope :unwatched_by, (lambda do |user|
     where.not(id: Course::Video::Submission.
       by_user(user).
-      pluck('DISTINCT video_id'))
+      pluck(Arel.sql('DISTINCT video_id')))
   end)
 
   # Used by the with_actable_types scope in Course::LessonPlan::Item.

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -69,8 +69,9 @@ class Instance < ApplicationRecord
 
   # Custom ordering. Put default instance first, followed by the others, which are ordered by name.
   # This is for listing all the instances on the index page.
+  # Arel.sql wrapper is required to mark the raw sql string as safe
   scope :order_for_display, (lambda do
-    order("CASE \"id\" WHEN #{DEFAULT_INSTANCE_ID} THEN 0 ELSE 1 END").order_by_name
+    order(Arel.sql("CASE \"id\" WHEN #{DEFAULT_INSTANCE_ID} THEN 0 ELSE 1 END")).order_by_name
   end)
 
   # @!method containing_user

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # Store uploaded files on the local file system in a temporary directory
+  config.active_storage.service = :test
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
-# ApplicationController.renderer.defaults.merge!(
-#   http_host: 'example.org',
-#   https: false
-# )
+# ActiveSupport::Reloader.to_prepare do
+#   ApplicationController.renderer.defaults.merge!(
+#     http_host: 'example.org',
+#     https: false
+#   )
+# end

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.2 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Make Active Record use stable #cache_key alongside new #cache_version method.
+# This is needed for recyclable cache keys.
+# Rails.application.config.active_record.cache_versioning = true
+
+# Use AES-256-GCM authenticated encryption for encrypted cookies.
+# Existing cookies will be converted on read then written with the new scheme.
+# Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+
+# Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
+# instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
+# Rails.application.config.active_support.use_authenticated_message_encryption = true
+
+# Add default protection from forgery to ActionController::Base instead of in
+# ApplicationController.
+# Rails.application.config.action_controller.default_protect_from_forgery = true
+
+# Store boolean values are in sqlite3 databases as 1 and 0 instead of 't' and
+# 'f' after migrating old data.
+# Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
+
+# Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
+# Rails.application.config.active_support.use_sha1_digests = true

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+%w[
+  .ruby-version
+  .rbenv-vars
+  tmp/restart.txt
+  tmp/caching-dev.txt
+].each { |path| Spring.watch(path) }

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,35 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_own_bucket
+
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket
+
+# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   path: your_azure_storage_path
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ amazon, google, microsoft ]

--- a/lib/autoload/active_record/associations/preloader/manual_has_many.rb
+++ b/lib/autoload/active_record/associations/preloader/manual_has_many.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ActiveRecord::Associations::Preloader
-  class ManualHasMany < HasMany
+  class ManualHasMany < Association
     prepend ManualAssociationPreloader
   end
 end

--- a/lib/autoload/active_record/associations/preloader/manual_preloader.rb
+++ b/lib/autoload/active_record/associations/preloader/manual_preloader.rb
@@ -8,16 +8,15 @@ class ActiveRecord::Associations::Preloader
       super
     end
 
-    def preloader_for(reflection, owners, rhs_klass)
+    def preloader_for(reflection, owners)
       preloader_class = super
-      case preloader_class.name
-      when HasMany.name
-        ActiveRecord::Associations::Preloader::ManualHasMany
-      when NullPreloader.name, AlreadyLoaded.name
-        preloader_class
-      else
-        raise NotImplementedError
+      return preloader_class if preloader_class.name == AlreadyLoaded.name
+
+      if reflection.instance_of? ActiveRecord::Reflection::HasManyReflection
+        return ActiveRecord::Associations::Preloader::ManualHasMany
       end
+
+      raise NotImplementedError
     end
   end
 end

--- a/spec/controllers/course/achievement/condition/achievements_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/achievements_controller_spec.rb
@@ -13,14 +13,12 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
     describe '#destroy' do
       let(:other_achievement) { create(:course_achievement, course: course) }
       let(:achievement_condition) do
-        create(:course_condition_achievement,
-               achievement: other_achievement, course: course).tap do |stub|
+        create(:course_condition_achievement, achievement: other_achievement, course: course,
+                                              conditional: achievement).tap do |stub|
           allow(stub).to receive(:destroy).and_return(false)
         end
       end
-      let(:achievement) do
-        create(:course_achievement, course: course, conditions: [achievement_condition])
-      end
+      let(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         delete :destroy, params: { course_id: course, achievement_id: achievement, id: achievement_condition }
@@ -43,15 +41,12 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
     describe '#create' do
       let(:other_achievement) { create(:course_achievement, course: course) }
       let(:achievement_condition) do
-        create(:course_condition_achievement,
-               achievement: other_achievement,
-               course: course).tap do |stub|
+        create(:course_condition_achievement, achievement: other_achievement, course: course,
+                                              conditional: achievement).tap do |stub|
           allow(stub).to receive(:save).and_return(false)
         end
       end
-      let(:achievement) do
-        create(:course_achievement, course: course, conditions: [achievement_condition])
-      end
+      let(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         post :create, params: { course_id: course, achievement_id: achievement }
@@ -72,15 +67,12 @@ RSpec.describe Course::Achievement::Condition::AchievementsController, type: :co
     describe '#update' do
       let(:other_achievement) { create(:course_achievement, course: course) }
       let(:achievement_condition) do
-        create(:course_condition_achievement,
-               achievement: other_achievement,
-               course: course).tap do |stub|
+        create(:course_condition_achievement, achievement: other_achievement, course: course,
+                                              conditional: achievement).tap do |stub|
           allow(stub).to receive(:update_attributes).and_return(false)
         end
       end
-      let(:achievement) do
-        create(:course_achievement, course: course, conditions: [achievement_condition])
-      end
+      let(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         patch :update, params: {

--- a/spec/controllers/course/achievement/condition/assessments_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/assessments_controller_spec.rb
@@ -12,15 +12,11 @@ RSpec.describe Course::Achievement::Condition::AssessmentsController, type: :con
 
     describe '#destroy' do
       let(:assessment_condition) do
-        create(:course_condition_assessment, course: course).tap do |stub|
+        create(:course_condition_assessment, course: course, conditional: achievement).tap do |stub|
           allow(stub).to receive(:destroy).and_return(false)
         end
       end
-      let(:achievement) do
-        create(:course_achievement,
-               course: course,
-               conditions: [assessment_condition])
-      end
+      let(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         delete :destroy, params: {
@@ -46,15 +42,11 @@ RSpec.describe Course::Achievement::Condition::AssessmentsController, type: :con
 
     describe '#create' do
       let(:assessment_condition) do
-        create(:course_condition_assessment, course: course).tap do |stub|
+        create(:course_condition_assessment, course: course, conditional: achievement).tap do |stub|
           allow(stub).to receive(:save).and_return(false)
         end
       end
-      let!(:achievement) do
-        create(:course_achievement,
-               course: course,
-               conditions: [assessment_condition])
-      end
+      let(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         post :create, params: { course_id: course, achievement_id: achievement }
@@ -75,15 +67,12 @@ RSpec.describe Course::Achievement::Condition::AssessmentsController, type: :con
       let(:assessment) { create(:assessment) }
       let(:minimum_grade_percentage) { 50.0 }
       let(:assessment_condition) do
-        create(:course_condition_assessment, course: course, assessment: assessment).tap do |stub|
+        create(:course_condition_assessment, course: course, assessment: assessment,
+                                             conditional: achievement).tap do |stub|
           allow(stub).to receive(:update_attributes).and_return(false)
         end
       end
-      let!(:achievement) do
-        create(:course_achievement,
-               course: course,
-               conditions: [assessment_condition])
-      end
+      let(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         patch :update, params: {

--- a/spec/controllers/course/achievement/condition/levels_controller_spec.rb
+++ b/spec/controllers/course/achievement/condition/levels_controller_spec.rb
@@ -12,15 +12,11 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
 
     describe '#destroy' do
       let(:level_condition) do
-        create(:course_condition_level, course: course).tap do |stub|
+        create(:course_condition_level, course: course, conditional: achievement).tap do |stub|
           allow(stub).to receive(:destroy).and_return(false)
         end
       end
-      let(:achievement) do
-        create(:course_achievement,
-               course: course,
-               conditions: [level_condition])
-      end
+      let(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         delete :destroy, params: {
@@ -46,15 +42,11 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
 
     describe '#create' do
       let(:level_condition) do
-        create(:course_condition_level, course: course).tap do |stub|
+        create(:course_condition_level, course: course, conditional: achievement).tap do |stub|
           allow(stub).to receive(:save).and_return(false)
         end
       end
-      let!(:achievement) do
-        create(:course_achievement,
-               course: course,
-               conditions: [level_condition])
-      end
+      let!(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         post :create, params: { course_id: course, achievement_id: achievement }
@@ -76,15 +68,12 @@ RSpec.describe Course::Achievement::Condition::LevelsController, type: :controll
     describe '#update' do
       let(:min_level) { 7 }
       let(:level_condition) do
-        create(:course_condition_level, course: course, minimum_level: min_level).tap do |stub|
+        create(:course_condition_level, course: course, minimum_level: min_level,
+                                        conditional: achievement).tap do |stub|
           allow(stub).to receive(:update_attributes).and_return(false)
         end
       end
-      let!(:achievement) do
-        create(:course_achievement,
-               course: course,
-               conditions: [level_condition])
-      end
+      let!(:achievement) { create(:course_achievement, course: course) }
 
       subject do
         patch :update, params: {

--- a/spec/controllers/course/courses_controller_spec.rb
+++ b/spec/controllers/course/courses_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Course::CoursesController, type: :controller do
       context 'when there is no user logged in' do
         it 'allows unauthenticated access' do
           get :index
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Course::CoursesController, type: :controller do
         it 'allows access' do
           sign_in(user)
           get :index
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end

--- a/spec/factories/course_achievements.rb
+++ b/spec/factories/course_achievements.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
 
     trait :with_level_condition do
       after(:build) do |achievement|
-        achievement.conditions = [build(:level_condition, course: achievement.course)]
+        achievement.conditions = [build(:level_condition, course: achievement.course, conditional: achievement)]
       end
     end
   end

--- a/spec/factories/course_condition_levels.rb
+++ b/spec/factories/course_condition_levels.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
           class: Course::Condition::Level.name, aliases: [:level_condition] do
     course
     minimum_level { 1 }
-    association :conditional, factory: :course_level
+    association :conditional, factory: :course_achievement
   end
 end

--- a/spec/features/course/achievement_condition_management_spec.rb
+++ b/spec/features/course/achievement_condition_management_spec.rb
@@ -12,19 +12,16 @@ RSpec.feature 'Course: Achievements' do
     context 'As a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
       let(:other_achievement) { create(:course_achievement, course: course) }
-      let(:achievement_condition) do
-        create(:achievement_condition, course: course, achievement: other_achievement)
+      let!(:achievement_condition) do
+        create(:achievement_condition, course: course, achievement: other_achievement,
+                                       conditional: achievement)
       end
       let(:assessment) { create(:assessment, course: course) }
-      let(:assessment_condition) do
-        create(:assessment_condition, course: course, assessment: assessment)
+      let!(:assessment_condition) do
+        create(:assessment_condition, course: course, assessment: assessment, conditional: achievement)
       end
-      let(:level_condition) { create(:level_condition, course: course) }
-      let!(:achievement) do
-        create(:course_achievement,
-               course: course,
-               conditions: [achievement_condition, assessment_condition, level_condition])
-      end
+      let!(:level_condition) { create(:level_condition, course: course, conditional: achievement) }
+      let!(:achievement) { create(:course_achievement, course: course) }
 
       # Achievement condition
       scenario 'I can create, edit and delete an achievement condition', js: true do

--- a/spec/libraries/acts_as_condition_spec.rb
+++ b/spec/libraries/acts_as_condition_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Extension: Acts as Condition', type: :model do
 
         context 'when there are no changes' do
           it 'does not rebuild satisfiability graph' do
-            allow(subject).to receive(:changed?).and_return(false)
+            allow(subject).to receive(:saved_changes?).and_return(false)
             expect(subject).to_not receive(:rebuild_satisfiability_graph)
             subject.run_callbacks(:save)
           end


### PR DESCRIPTION
Upgrade to Rails 5.2 so that we don't have to maintain our own fork of Rails.
Anyway, once Rails 6 is out support for 5.1 will be dropped and it will no longer receive security fixes.

#3135 