### PR TITLE
Change 'Items' to 'Selected Items' for object duplication.

### DIFF
--- a/client/app/bundles/course/duplication/pages/Duplication/index.jsx
+++ b/client/app/bundles/course/duplication/pages/Duplication/index.jsx
@@ -35,7 +35,7 @@ const translations = defineMessages({
   },
   items: {
     id: 'course.duplication.Duplication.items',
-    defaultMessage: 'Items',
+    defaultMessage: 'Selected Items',
   },
   startAt: {
     id: 'course.duplication.Duplication.startAt',


### PR DESCRIPTION
Users were confused by what the item list was displaying.