### PR TITLE
Fix null input value warning in grading panel

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -103,7 +103,7 @@ class VisibleGradingPanel extends Component {
             type="number"
             min={0}
             step={1}
-            value={exp}
+            value={exp !== null ? exp : ''}
             onChange={e => this.handleExpField(e.target.value)}
             ref={(ref) => {
               this.expInputRef = ref;


### PR DESCRIPTION
For ungraded submissions, exp is null, triggering warning:
![image](https://user-images.githubusercontent.com/35135264/48329019-bd8b6900-e681-11e8-949c-290d90037259.png)

Assign input value to empty string when exp is null to avoid this warning.