### PR TITLE
Remove outdated comment about using custom Rails.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gem 'tzinfo-data', platforms: [:mswin, :mswin64]
 gem 'bundler', '>= 1.10.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-# We need a patched version of rails because stock 5.1.6 has_one associations ignores
-# joins in scope, which we use for Course::LessonPlan::Item.default_reference_time
 gem 'rails', '< 5.2.1'
 
 # Use PostgreSQL for the backend


### PR DESCRIPTION
[ci skip]

We no longer need to use custom Rails thanks to #3191.