### PR TITLE
Change forum topic view_count

### DIFF
--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -50,7 +50,10 @@ class Course::Forum::Topic < ApplicationRecord
   # @!attribute [r] view_count
   #   The number of views in this topic.
   calculated :view_count, (lambda do
-    Course::Forum::Topic::View.where('topic_id = course_forum_topics.id').select("count('*')")
+    Course::Forum::Topic::View.
+      where('topic_id = course_forum_topics.id').
+      where('user_id != course_forum_topics.creator_id').
+      select("count('*')")
   end)
 
   # @!method self.order_by_latest_post


### PR DESCRIPTION
1. Exclude author's own view from forum topic view_count to discourage view farming
2. Display view count to only course admin and not students