### PR TITLE
Improve video watch frequency calculation

### DIFF
--- a/app/models/concerns/course/video/interval_query_concern.rb
+++ b/app/models/concerns/course/video/interval_query_concern.rb
@@ -77,5 +77,16 @@ module Course::Video::IntervalQueryConcern
             ')',
               end_types: type_sym_to_id(END_TYPES))
     }
+
+    # @!method self.all_start_and_end_events
+    #   Returns all events of start-types or end_types,
+    #   sorted first by session then by sequence number inside the same session
+    scope :all_start_and_end_events, lambda {
+      where(event_type: type_sym_to_id(START_TYPES + END_TYPES)).
+        unscope(:order).
+        order(:session_id, :sequence_num).
+        includes(:session).
+        references(:session)
+    }
   end
 end

--- a/app/models/concerns/course/video/interval_query_concern.rb
+++ b/app/models/concerns/course/video/interval_query_concern.rb
@@ -15,69 +15,6 @@ module Course::Video::IntervalQueryConcern
     scope :start_events, -> { where(event_type: type_sym_to_id(START_TYPES)) }
     scope :end_events, -> { where(event_type: type_sym_to_id(END_TYPES)) }
 
-    # @!method self.interval_starts
-    #   Returns events that are considered to be an start of a watch interval.
-    #
-    #   An event can be considered an interval start if it is an start_event, and that it is the first
-    #   start_event since the start of a session, or since an earlier end_event.
-    scope :interval_starts, lambda {
-      start_events.
-        where('NOT EXISTS ('\
-              'SELECT 1 FROM course_video_events AS prev_start '\
-              'WHERE prev_start.event_type IN (:start_types) '\
-                'AND prev_start.session_id = course_video_events.session_id '\
-                'AND prev_start.sequence_num < course_video_events.sequence_num '\
-                'AND NOT EXISTS ('\
-                  'SELECT 1 FROM course_video_events AS middle_end '\
-                  'WHERE middle_end.event_type IN (:end_types) '\
-                    'AND middle_end.session_id = course_video_events.session_id '\
-                    'AND middle_end.sequence_num > prev_start.sequence_num '\
-                    'AND middle_end.sequence_num < course_video_events.sequence_num'\
-                ')'\
-            ')',
-              start_types: type_sym_to_id(START_TYPES),
-              end_types: type_sym_to_id(END_TYPES))
-    }
-
-    # @!method self.interval_ends
-    #   Returns events that are considered to be an end of a watch interval.
-    #
-    #   An event can be considered an interval end if it is an end_event, and that it is the first
-    #   end_event since a previous interval start.
-    scope :interval_ends, lambda {
-      end_events.
-        where('EXISTS ('\
-              'SELECT 1 FROM course_video_events AS prev_start '\
-              'WHERE prev_start.event_type IN (:start_types) '\
-                'AND prev_start.session_id = course_video_events.session_id '\
-                'AND prev_start.sequence_num < course_video_events.sequence_num '\
-                'AND NOT EXISTS ('\
-                  'SELECT 1 FROM course_video_events AS middle_end '\
-                  'WHERE middle_end.event_type IN (:end_types) '\
-                    'AND middle_end.session_id = course_video_events.session_id '\
-                    'AND middle_end.sequence_num > prev_start.sequence_num '\
-                    'AND middle_end.sequence_num < course_video_events.sequence_num'\
-                ')'\
-            ')',
-              start_types: type_sym_to_id(START_TYPES),
-              end_types: type_sym_to_id(END_TYPES))
-    }
-
-    # @!method self.unclosed_starts
-    #   Returns start_events that do not have an end_events after it in a session.
-    #
-    #   These intervals end at the end of the session.
-    scope :unclosed_starts, lambda {
-      interval_starts.
-        where('NOT EXISTS ('\
-              'SELECT 1 FROM course_video_events AS last_end '\
-              'WHERE last_end.event_type IN (:end_types) '\
-                'AND last_end.session_id = course_video_events.session_id '\
-                'AND last_end.sequence_num > course_video_events.sequence_num'\
-            ')',
-              end_types: type_sym_to_id(END_TYPES))
-    }
-
     # @!method self.all_start_and_end_events
     #   Returns all events of start-types or end_types,
     #   sorted first by session then by sequence number inside the same session

--- a/app/models/concerns/course/video/watch_statistics_concern.rb
+++ b/app/models/concerns/course/video/watch_statistics_concern.rb
@@ -56,40 +56,6 @@ module Course::Video::WatchStatisticsConcern
     advance_count
   end
 
-  # The video times for the interval starts.
-  #
-  # @return [Integer] The start times.
-  def start_times
-    relevant_events_scope.
-      interval_starts.
-      unscope(:order).
-      order(:video_time).
-      pluck(:video_time)
-  end
-
-  # The video times for the interval ends.
-  #
-  # If no explicit end to an interval is recorded in an event, the last_video_time from the
-  # session is taken as the interval end.
-  #
-  # @return [Integer] The end times.
-  def end_times
-    interval_end_query = relevant_events_scope.
-                         interval_ends.
-                         select('course_video_events.video_time AS end_time').
-                         to_sql
-    implict_end_query = relevant_events_scope.
-                        unclosed_starts.
-                        joins(:session).
-                        select('course_video_sessions.last_video_time AS end_time').
-                        to_sql
-
-    ActiveRecord::Base.connection.
-      exec_query("(#{implict_end_query}) UNION ALL (#{interval_end_query}) ORDER BY end_time").
-      rows.
-      map { |row| row[0] }
-  end
-
   # The video times for the interval starts and ends.
   #
   # This method iterates through all relevant start and end events,

--- a/app/models/concerns/course/video/watch_statistics_concern.rb
+++ b/app/models/concerns/course/video/watch_statistics_concern.rb
@@ -13,7 +13,7 @@ module Course::Video::WatchStatisticsConcern
   #
   # @return [[Integer]] The watch frequency, with the indices matching up to video time in seconds.
   def watch_frequency
-    starts, ends = start_times, end_times
+    starts, ends = start_and_end_times.values_at(:start_times, :end_times)
     start_index, end_index = 0, 0
     frequencies = []
     active_intervals = 0

--- a/spec/models/course/video/event_spec.rb
+++ b/spec/models/course/video/event_spec.rb
@@ -62,5 +62,22 @@ RSpec.describe Course::Video::Event, type: :model do
         expect(seq_nums).to eq([19])
       end
     end
+
+    describe '.all_start_and_end_events' do
+      let(:session1) { create(:video_session, :with_events_paused) }
+      let(:session2) { create(:video_session, :with_events_continuous) }
+
+      it 'returns all the start and end events sorted by session and sequennce number' do
+        sorted_events = Course::Video::Event.
+                        where(session_id: [session1.id, session2.id]).
+                        all_start_and_end_events
+        session_id = sorted_events.map(&:session_id)
+        seq_nums = sorted_events.pluck(:sequence_num)
+        video_times = sorted_events.pluck(:video_time)
+        expect(session_id).to eq(Array.new(10, session1.id) + Array.new(8, session2.id))
+        expect(seq_nums).to eq([1, 2, 3, 5, 6, 7, 8, 10, 11, 12, 1, 2, 4, 5, 6, 8, 9, 11])
+        expect(video_times).to eq([0, 20, 20, 39, 39, 70, 70, 10, 10, 25, 0, 5, 30, 30, 50, 19, 20, 24])
+      end
+    end
   end
 end

--- a/spec/models/course/video/event_spec.rb
+++ b/spec/models/course/video/event_spec.rb
@@ -18,51 +18,6 @@ RSpec.describe Course::Video::Event, type: :model do
       end
     end
 
-    describe '.interval_starts' do
-      let(:session1) { create(:video_session, :with_events_paused) }
-      let(:session2) { create(:video_session, :with_events_continuous) }
-
-      it 'returns only the starts of watch intervals' do
-        seq_nums = Course::Video::Event.
-                   unscope(:order).
-                   where(session_id: [session1.id, session2.id]).
-                   interval_starts.
-                   order(:video_time).
-                   pluck(:video_time)
-        expect(seq_nums).to eq([0, 0, 10, 19, 30, 39])
-      end
-    end
-
-    describe '.interval_ends' do
-      let(:session1) { create(:video_session, :with_events_paused) }
-      let(:session2) { create(:video_session, :with_events_continuous) }
-
-      it 'returns only the end of watch intervals' do
-        seq_nums = Course::Video::Event.
-                   unscope(:order).
-                   where(session_id: [session1.id, session2.id]).
-                   interval_ends.
-                   order(:video_time).
-                   pluck(:video_time)
-        expect(seq_nums).to eq([5, 20, 25, 50, 70]) # 37 not included since it's captured in session
-      end
-    end
-
-    describe '.unclosed_starts' do
-      let(:session1) { create(:video_session, :with_events_paused) }
-      let(:session2) { create(:video_session, :with_events_continuous) }
-
-      it 'returns only start events without a matching end event' do
-        seq_nums = Course::Video::Event.
-                   unscope(:order).
-                   where(session_id: [session1.id, session2.id]).
-                   unclosed_starts.
-                   order(:video_time).
-                   pluck(:video_time)
-        expect(seq_nums).to eq([19])
-      end
-    end
-
     describe '.all_start_and_end_events' do
       let(:session1) { create(:video_session, :with_events_paused) }
       let(:session2) { create(:video_session, :with_events_continuous) }


### PR DESCRIPTION
Videos with large amount of watch statistics take much longer to load. Sometimes it does not load at all.

It is suspected that the complicated queries in interval_query_concern.rb are taking too long.
This PR re-implements watch_frequency calculation by:
1. Query all of video's start and end events
2. Use application code to pluck out correct start time and end time, then push to respective arrays
3. Use these arrays in watch frequency calculation