### PR TITLE
[WIP] Add statistic cache per video

### DIFF
--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -17,6 +17,7 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
     @session.merge_in_events!(update_params[:events])
     # Update video duration using data from frontend VideoPlayer
     @video.update(duration: video_params[:video_duration].round) if @video.duration < video_params[:video_duration]
+    @video.update(workflow_state: 'uncached') if @video.workflow_state == 'cached'
 
     head :no_content
   rescue ArgumentError => _

--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -15,6 +15,8 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
                                   last_video_time: update_params[:last_video_time])
     end
     @session.merge_in_events!(update_params[:events])
+    # Update video duration using data from frontend VideoPlayer
+    @video.update(duration: video_params[:video_duration].round) if @video.duration < video_params[:video_duration]
 
     head :no_content
   rescue ArgumentError => _
@@ -33,5 +35,9 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
     params.require(:session).permit(:last_video_time,
                                     events: [[:sequence_num, :event_type, :video_time,
                                               :playback_rate, :event_time]])
+  end
+
+  def video_params
+    params.permit(:video_duration)
   end
 end

--- a/app/jobs/video_statistic_update_job.rb
+++ b/app/jobs/video_statistic_update_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class VideoStatisticUpdateJob < ApplicationJob
+
+  private
+
+  rescue_from(ActiveJob::DeserializationError) do |_|
+    # Prevent the job from retrying due to deleted records
+  end
+
+  def perform
+    # Compute total watch_freq and average percent_watched (of all associated submissions)
+    # for every uncached Course::Video and save to course_video_statistics table
+    ActsAsTenant.without_tenant do
+      Course::Video.where(workflow_state: 'uncached').includes(:submissions).references(:all).
+        where(id: [198, 201, 244, 256, 261, 262, 252, 260, 1465, 259]).each do |video|
+        video.submissions.map{ |submission| cache_submission(submission, video.duration) }
+        average_coverage = video.submissions.size > 0 ?
+          (video.submissions.map { |submission| submission.statistic.percent_watched }.reduce(:+) / video.submissions.size).round :
+          0
+        video.update(workflow_state: 'cached') if
+          video.build_statistic(watch_freq: video.watch_frequency, percent_watched: average_coverage).upsert
+      end
+    end
+  end
+
+  # Compute watch_freq and percent_watched for Course::Video::Submission if uncached
+  # and save to course_video_statistics table
+  def cache_submission(submission, duration)
+    return unless submission.statistic.nil?
+    frequency_array = submission.watch_frequency
+    coverage = duration > 0 ?
+      coverage = (100 * (frequency_array.count { |x| x > 0 }) / duration).round :
+      0
+    submission.build_statistic(watch_freq: frequency_array, percent_watched: coverage).upsert
+  end
+end

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -20,7 +20,9 @@ class Course::Video < ApplicationRecord
   has_many :discussion_topics, through: :topics, class_name: Course::Discussion::Topic.name
   has_many :posts, through: :discussion_topics, class_name: Course::Discussion::Post.name
   has_many :sessions, through: :submissions
-  has_many :events, through: :sessions
+  has_many :events, through: :sessions, class_name: Course::Video::Event.name
+  has_one :statistic, as: :cacheable, class_name: Course::Video::Statistic.name,
+                      inverse_of: :cacheable, dependent: :destroy, autosave: true
 
   scope :from_course, ->(course) { where(course_id: course) }
 

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Video < ApplicationRecord
+  after_save :init_statistic
+
   acts_as_lesson_plan_item has_todo: true
 
   include Course::ClosingReminderConcern
@@ -122,5 +124,9 @@ class Course::Video < ApplicationRecord
     errors.add(:url, 'cannot be updated for videos with comments or watch data') if url_changed? &&
                                                                                     persisted? &&
                                                                                     url_unchangeble?
+  end
+
+  def init_statistic
+    create_statistic if statistic.nil?
   end
 end

--- a/app/models/course/video/statistic.rb
+++ b/app/models/course/video/statistic.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true.
+class Course::Video::Statistic < ApplicationRecord
+  belongs_to :cacheable, inverse_of: :statistic, polymorphic: true
+end

--- a/app/models/course/video/submission.rb
+++ b/app/models/course/video/submission.rb
@@ -14,7 +14,9 @@ class Course::Video::Submission < ApplicationRecord
   belongs_to :video, inverse_of: :submissions
 
   has_many :sessions, inverse_of: :submission, dependent: :destroy
-  has_many :events, through: :sessions
+  has_many :events, through: :sessions, class_name: Course::Video::Event.name
+  has_one :statistic, as: :cacheable, class_name: Course::Video::Statistic.name,
+                      inverse_of: :cacheable, dependent: :destroy, autosave: true
 
   # @!method self.ordered_by_date
   #   Orders the submissions by date of creation. This defaults to reverse chronological order

--- a/client/app/api/course/Video/Sessions.js
+++ b/client/app/api/course/Video/Sessions.js
@@ -38,10 +38,11 @@ export default class SessionsAPI extends BaseVideoAPI {
    * @return {Promise} The response from the server
    * success response: 204
    */
-  update(id, lastVideoTime, events = [], isOldSession = false) {
+  update(id, lastVideoTime, events = [], duration = 0, isOldSession = false) {
     return this.getClient().patch(`${this._getUrlPrefix()}/${id}`, {
       session: { last_video_time: lastVideoTime, events },
       is_old_session: isOldSession,
+      video_duration: duration,
     });
   }
 

--- a/client/app/bundles/course/video/submission/actions/__test__/video.test.js
+++ b/client/app/bundles/course/video/submission/actions/__test__/video.test.js
@@ -57,7 +57,7 @@ describe('sendEvents', () => {
     const spyUpdate = jest.spyOn(CourseAPI.video.sessions, 'update');
     createdStore.dispatch(sendEvents());
 
-    expect(spyUpdate).toHaveBeenCalledWith('25', 5, oldSessionsFixtures.get('25').sessionEvents.toArray(), true);
+    expect(spyUpdate).toHaveBeenCalledWith('25', 5, oldSessionsFixtures.get('25').sessionEvents.toArray(), 0, true);
     await sleep(1);
     expect(createdStore.getState().oldSessions.count()).toBe(0);
   });
@@ -94,7 +94,7 @@ describe('endSession', () => {
       const spyUpdate = jest.spyOn(CourseAPI.video.sessions, 'update');
       createdStore.dispatch(endSession());
 
-      expect(spyUpdate).toHaveBeenCalledWith(32, 0, []);
+      expect(spyUpdate).toHaveBeenCalledWith(32, 0, [], 600);
     });
   });
 });

--- a/client/app/bundles/course/video/submission/actions/video.js
+++ b/client/app/bundles/course/video/submission/actions/video.js
@@ -188,6 +188,7 @@ function removeOldSessions(sessionIds) {
 function sendCurrentEvents(dispatch, videoState, closeSession = false) {
   const sessionId = videoState.sessionId;
   const events = videoState.sessionEvents;
+  const duration = (events === undefined || events.length === 0) ? 0 : videoState.duration;
 
   if (sessionId === null || (!closeSession && events.isEmpty())) {
     return;
@@ -195,7 +196,7 @@ function sendCurrentEvents(dispatch, videoState, closeSession = false) {
 
   const videoTime = Math.round(videoState.playerProgress);
   CourseAPI.video.sessions
-    .update(sessionId, videoTime, events.toArray())
+    .update(sessionId, videoTime, events.toArray(), duration)
     .then(() => {
       if (!events.isEmpty()) {
         dispatch(removeEvents(events.map(event => event.sequence_num).toSet()), closeSession);
@@ -224,7 +225,7 @@ function sendOldSessions(dispatch, oldSessions) {
       const events = oldVideoState.sessionEvents;
 
       return CourseAPI.video.sessions
-        .update(sessionId, videoTime, events.toArray(), true)
+        .update(sessionId, videoTime, events.toArray(), 0, true)
         .then(() => sessionId)
         .catch(error => (error.response.status === 404 ? sessionId : null));
     })

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-# Sidekiq Cron configuration to invoke ConsolidatedItemEmailJob for opening reminder emails.
+# Sidekiq Cron configuration to invoke ConsolidatedItemEmailJob for opening reminder emails,
+# and VideoStatisticUpdateJob for per video watch_freq cache
 schedule_file = 'config/schedule.yml'
 
 # Use Sidekiq Cron gem (https://github.com/ondrejbartas/sidekiq-cron) to

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -3,3 +3,9 @@ consolidated_item_email_job:
   cron: "5 * * * *"
   class: "ConsolidatedItemEmailJob"
   queue: "default"
+
+# Run the VideoStatisticUpdateJob every day at 5:30 AM
+consolidated_item_email_job:
+  cron: "30 5 * * *"
+  class: "VideoStatisticUpdateJob"
+  queue: "default"

--- a/db/migrate/20181204070041_add_duration_to_course_videos.rb
+++ b/db/migrate/20181204070041_add_duration_to_course_videos.rb
@@ -1,0 +1,38 @@
+class AddDurationToCourseVideos < ActiveRecord::Migration[5.2]
+  def change
+    # Add duration column to course_videos table
+    add_column :course_videos, :duration, :integer, null: false, default: 0
+
+    # Migrate video duration for existing videos:
+    #
+    # Old video's duration is approximated to be equal to maximum event.video_time
+    # or maximum session.last_video_time, whichever higher.
+    #
+    # Old video duration, if wrong, will be updated with real video duration passed from
+    # frontend VideoPlayer when the video is watched again.
+    execute <<-SQL
+      UPDATE course_videos SET duration = max_video_time
+        FROM (SELECT
+          video_id,
+          CASE
+            WHEN session_video_time > event_video_time THEN session_video_time
+            ELSE event_video_time
+          END
+          AS max_video_time
+          FROM (
+            SELECT course_videos.id AS video_id,
+              MAX(video_time) AS event_video_time,
+              MAX(course_video_sessions.last_video_time) AS session_video_time
+              FROM course_video_events
+              JOIN course_video_sessions
+                ON course_video_sessions.id = course_video_events.session_id
+              JOIN course_video_submissions
+                ON course_video_submissions.id = course_video_sessions.submission_id
+              JOIN course_videos
+                ON course_videos.id = course_video_submissions.video_id
+              GROUP BY course_videos.id
+          ) AS all_time) AS max_time
+          WHERE course_videos.id = max_time.video_id
+    SQL
+  end
+end

--- a/db/migrate/20181206042524_create_course_video_statistics.rb
+++ b/db/migrate/20181206042524_create_course_video_statistics.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class CreateCourseVideoStatistics < ActiveRecord::Migration[5.2]
+  def change
+    create_table :course_video_statistics do |t|
+      t.references :cacheable, polymorphic: true, index: { name: 'cacheable_index' }
+      t.string  :cacheable_type
+      t.integer :cacheable_id
+      t.integer :watch_freq, array: true, default: []
+      t.integer :percent_watched, default: 0, null: false
+    end
+    add_column :course_videos, :workflow_state, :string, null: false, default: 'uncached'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_30_061333) do
+ActiveRecord::Schema.define(version: 2018_12_04_070041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -941,6 +941,7 @@ ActiveRecord::Schema.define(version: 2018_11_30_061333) do
     t.integer "updater_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "duration", default: 0, null: false
     t.index ["creator_id"], name: "fk__course_videos_creator_id"
     t.index ["tab_id"], name: "fk__course_videos_tab_id"
     t.index ["updater_id"], name: "fk__course_videos_updater_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_070041) do
+ActiveRecord::Schema.define(version: 2018_12_06_042524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -899,6 +899,14 @@ ActiveRecord::Schema.define(version: 2018_12_04_070041) do
     t.index ["updater_id"], name: "index_course_video_sessions_on_updater_id"
   end
 
+  create_table "course_video_statistics", force: :cascade do |t|
+    t.string "cacheable_type"
+    t.integer "cacheable_id"
+    t.integer "watch_freq", default: [], array: true
+    t.integer "percent_watched", default: 0, null: false
+    t.index ["cacheable_type", "cacheable_id"], name: "cacheable_index"
+  end
+
   create_table "course_video_submissions", force: :cascade do |t|
     t.integer "video_id", null: false
     t.integer "creator_id", null: false
@@ -942,6 +950,7 @@ ActiveRecord::Schema.define(version: 2018_12_04_070041) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "duration", default: 0, null: false
+    t.string "workflow_state", default: "uncached", null: false
     t.index ["creator_id"], name: "fk__course_videos_creator_id"
     t.index ["tab_id"], name: "fk__course_videos_tab_id"
     t.index ["updater_id"], name: "fk__course_videos_updater_id"

--- a/spec/controllers/course/video/submission/sessions_controller_spec.rb
+++ b/spec/controllers/course/video/submission/sessions_controller_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
         patch :update, as: :json, params: {
           course_id: course.id, video_id: video.id,
           submission_id: session.submission.id, id: session.id,
-          session: { last_video_time: 32, events: events }
+          session: { last_video_time: 32, events: events },
+          video_duration: 2456
         }
       end
 
@@ -65,6 +66,10 @@ RSpec.describe Course::Video::Submission::SessionsController, type: :controller 
 
         it 'does not create any events' do
           expect { subject }.to change(Course::Video::Session, :count).by(0)
+        end
+
+        it 'updates the video duration' do
+          expect { subject }.to change { video.reload.duration }.to(2456)
         end
       end
 


### PR DESCRIPTION
Pending https://github.com/Coursemology/coursemology2/pull/3220 and https://github.com/Coursemology/coursemology2/pull/3231.
1. Query all of video's start and end events
2. Use application code to pluck out correct start time and end time, then push to respective arrays
3. Use these arrays in watch frequency calculation

Implement per video cache:
1. Migration to add video workflow_state
2. Migration to add course_video_statistic table: PK id, cacheable_type, cacheable_id, watch_freq
image
3. Create Course::Video:Statistic model, polymorphic relationship with Course::Video (and later Course::Video::Submission)
4. Sidekiq job to calculate watch_frequency for every dirty video and upsert in course_video_statistic table and mark video 'cached' every night
5. Flip video's flag to record to 'uncached' when watched

Not in this PR:
6. Use cached data for frontend rendering
To be submitted separately after this PR has been merged, jobs have been run as scheduled and data consistency is confirmed