### PR TITLE
Fix bug with returning frozen hash

### DIFF
--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -117,7 +117,7 @@ class Course::LessonPlan::Item < ApplicationRecord
   def time_for(course_user)
     personal_time = personal_time_for(course_user)
     reference_time = reference_time_for(course_user)
-    (personal_time || reference_time).freeze
+    (personal_time || reference_time).clone.freeze
   end
 
   def personal_time_for(course_user)


### PR DESCRIPTION
Doesn't affect anything on production since nobody is on the "naive" algorithm.

Freezing the record in-place means that subsequent retrieval of the same record will produce a frozen hash, when we only want to freeze the object instance that is returned.

Before:
```
item.time_for(course_user)   # Freezes in-place
item.personal_time_for(course_user)   # Frozen hash, modifying attributes will throw an error
```

Now:
```
item.time_for(course_user)   # Makes a clone before freezing in-place
item.personal_time_for(course_user)   # Modifiable record
```