### PR TITLE
Add booleans to control has/affects personal times

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -86,7 +86,8 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   def assessment_params
     base_params = [:title, :description, :base_exp, :time_bonus_exp, :start_at, :end_at, :tab_id,
                    :bonus_end_at, :published, :autograded, :show_private, :show_evaluation,
-                   :use_public, :use_private, :use_evaluation]
+                   :use_public, :use_private, :use_evaluation, :has_personal_times,
+                   :affects_personal_times]
     if autograded?
       base_params += [:skippable, :allow_partial_submission]
     else

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -3,6 +3,12 @@
     - unless assessment.published?
       span title=draft_message(assessment)
         => fa_icon 'ban'.freeze
+    - if current_course.show_personalized_timeline_features && assessment.has_personal_times?
+      span title=t('.has_personal_times_hint')
+        => fa_icon 'clock-o'.freeze
+    - if current_course.show_personalized_timeline_features && assessment.affects_personal_times?
+      span title=t('.affects_personal_times_hint')
+        => fa_icon 'random'.freeze
     = link_to(format_inline_text(assessment.title),
               course_assessment_path(current_course, assessment))
 

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -3,7 +3,8 @@ json.attributes do
   json.(@assessment, :id, :title, :description, :start_at, :end_at, :bonus_end_at, :base_exp,
     :time_bonus_exp, :published, :autograded, :show_private, :show_evaluation, :skippable,
     :tabbed_view, :view_password, :session_password, :delayed_grade_publication, :tab_id,
-    :use_public, :use_private, :use_evaluation, :allow_partial_submission)
+    :use_public, :use_private, :use_evaluation, :allow_partial_submission, :has_personal_times,
+    :affects_personal_times)
 end
 
 json.tab_attributes do
@@ -14,6 +15,7 @@ end
 
 json.mode_switching @assessment.allow_mode_switching?
 json.gamified current_course.gamified?
+json.show_personalized_timeline_features current_course.show_personalized_timeline_features?
 
 json.folder_attributes do
   json.folder_id @assessment.folder.id

--- a/client/app/bundles/course/assessment/assessments-edit.jsx
+++ b/client/app/bundles/course/assessment/assessments-edit.jsx
@@ -22,6 +22,7 @@ $(document).ready(() => {
         <AssessmentEditPage
           modeSwitching={data.mode_switching}
           gamified={data.gamified}
+          showPersonalizedTimelineFeatures={data.show_personalized_timeline_features}
           folderAttributes={data.folder_attributes}
           conditionAttributes={data.condition_attributes}
           initialValues={{

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -105,6 +105,8 @@ class AssessmentForm extends React.Component {
     editing: PropTypes.bool,
     // if the EXP fields should be displayed
     gamified: PropTypes.bool,
+    // If the personalized timeline fields should be displayed
+    show_personalized_timeline_features: PropTypes.bool,
     // If allow to switch between autoraded and manually graded mode.
     modeSwitching: PropTypes.bool,
     folderAttributes: PropTypes.shape({
@@ -283,8 +285,8 @@ class AssessmentForm extends React.Component {
   }
 
   render() {
-    const { handleSubmit, onSubmit, gamified, modeSwitching, submitting, editing, folderAttributes,
-      conditionAttributes, error } = this.props;
+    const { handleSubmit, onSubmit, gamified, showPersonalizedTimelineFeatures, modeSwitching, submitting, editing,
+      folderAttributes, conditionAttributes, error } = this.props;
 
     return (
       <Form onSubmit={handleSubmit(onSubmit)}>
@@ -457,6 +459,38 @@ class AssessmentForm extends React.Component {
         <div style={styles.hint}>
           <FormattedMessage {...translations.showEvaluationHint} />
         </div>
+
+        {
+          showPersonalizedTimelineFeatures
+          && (
+          <>
+            <Field
+              name="has_personal_times"
+              component={Toggle}
+              parse={Boolean}
+              label={<FormattedMessage {...translations.hasPersonalTimes} />}
+              labelPosition="right"
+              style={styles.toggle}
+              disabled={submitting}
+            />
+            <div style={styles.hint}>
+              <FormattedMessage {...translations.hasPersonalTimesHint} />
+            </div>
+            <Field
+              name="affects_personal_times"
+              component={Toggle}
+              parse={Boolean}
+              label={<FormattedMessage {...translations.affectsPersonalTimes} />}
+              labelPosition="right"
+              style={styles.toggle}
+              disabled={submitting}
+            />
+            <div style={styles.hint}>
+              <FormattedMessage {...translations.affectsPersonalTimesHint} />
+            </div>
+          </>
+          )
+        }
 
         {
           folderAttributes

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
@@ -71,6 +71,24 @@ const translations = defineMessages({
     defaultMessage:
       'Show evaluation tests to students after the submission is graded and published (For programming questions)',
   },
+  hasPersonalTimes: {
+    id: 'course.assessment.form.hasPersonalTimes',
+    defaultMessage: 'Has personal times',
+  },
+  hasPersonalTimesHint: {
+    id: 'course.assessment.form.hasPersonalTimesHint',
+    defaultMessage:
+      'Timings for this item will be automatically adjusted for users based on learning rate',
+  },
+  affectsPersonalTimes: {
+    id: 'course.assessment.form.affectsPersonalTimes',
+    defaultMessage: 'Affects personal times',
+  },
+  affectsPersonalTimesHint: {
+    id: 'course.assessment.form.affectsPersonalTimesHint',
+    defaultMessage:
+      'Student\'s submission time for this item will be taken into account when updating personal times for other items',
+  },
   published: {
     id: 'course.assessment.form.published',
     defaultMessage: 'Published',

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/__test__/index.test.js
@@ -97,4 +97,36 @@ describe('<AssessmentEdit />', () => {
     expect(editPage.find('input[name="base_exp"]')).toHaveLength(0);
     expect(editPage.find('input[name="time_bonus_exp"]')).toHaveLength(0);
   });
+
+  it('renders the has/affects personal time fields', () => {
+    const editPage = mount(
+      <ProviderWrapper store={store}>
+        <AssessmentEdit
+          id={id}
+          showPersonalizedTimelineFeatures
+          modeSwitching
+          initialValues={initialValues}
+        />
+      </ProviderWrapper>
+    );
+
+    expect(editPage.find('input[name="has_personal_times"]').length).toBeGreaterThan(0);
+    expect(editPage.find('input[name="affects_personal_times"]').length).toBeGreaterThan(0);
+  });
+
+  it('does not render the has/affects personal time fields', () => {
+    const editPage = mount(
+      <ProviderWrapper store={store}>
+        <AssessmentEdit
+          id={id}
+          showPersonalizedTimelineFeatures={false}
+          modeSwitching
+          initialValues={initialValues}
+        />
+      </ProviderWrapper>
+    );
+
+    expect(editPage.find('input[name="has_personal_times"]')).toHaveLength(0);
+    expect(editPage.find('input[name="affects_personal_times"]')).toHaveLength(0);
+  });
 });

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
@@ -23,6 +23,8 @@ class EditPage extends React.Component {
     intl: intlShape,
     // If the gamification feature is enabled in the course.
     gamified: PropTypes.bool,
+    // If personalized timeline features are shown for the course
+    showPersonalizedTimelineFeatures: PropTypes.bool,
     // If allow to switch between autoraded and manually graded mode.
     modeSwitching: PropTypes.bool,
     // An array of materials of current assessment.
@@ -57,7 +59,7 @@ class EditPage extends React.Component {
   };
 
   render() {
-    const { gamified, modeSwitching, initialValues, folderAttributes,
+    const { gamified, showPersonalizedTimelineFeatures, modeSwitching, initialValues, folderAttributes,
       conditionAttributes, dispatch } = this.props;
 
     return (
@@ -65,6 +67,7 @@ class EditPage extends React.Component {
         <AssessmentForm
           editing
           gamified={gamified}
+          showPersonalizedTimelineFeatures={showPersonalizedTimelineFeatures}
           onSubmit={this.onFormSubmit}
           modeSwitching={modeSwitching}
           folderAttributes={folderAttributes}

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -17,6 +17,11 @@ en:
         assessment:
           attempt: 'Attempt'
           condition_not_satisfied: 'You do not fulfill the requirements of the assessment'
+          has_personal_times_hint: >
+            Has personal times. Timings for this item will be automatically adjusted for users based on learning rate.
+          affects_personal_times_hint: >
+            Affects personal times. Student's submission time for this item will be taken into account when updating
+            personal times for other items.
         show:
           type: 'Assessment Type'
           autograded: 'Autograded Assessment'

--- a/db/migrate/20181219060042_add_booleans_to_course_lesson_plan_item.rb
+++ b/db/migrate/20181219060042_add_booleans_to_course_lesson_plan_item.rb
@@ -1,0 +1,6 @@
+class AddBooleansToCourseLessonPlanItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_lesson_plan_items, :has_personal_times, :boolean, default: false, null: false
+    add_column :course_lesson_plan_items, :affects_personal_times, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_11_133628) do
+ActiveRecord::Schema.define(version: 2018_12_19_060042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -616,6 +616,8 @@ ActiveRecord::Schema.define(version: 2018_12_11_133628) do
     t.datetime "updated_at", null: false
     t.boolean "triggers_recomputation", default: false, null: false
     t.boolean "movable", default: false, null: false
+    t.boolean "has_personal_times", default: false, null: false
+    t.boolean "affects_personal_times", default: false, null: false
     t.index ["actable_type", "actable_id"], name: "index_course_lesson_plan_items_on_actable_type_and_actable_id", unique: true
     t.index ["course_id"], name: "fk__course_lesson_plan_items_course_id"
     t.index ["creator_id"], name: "fk__course_lesson_plan_items_creator_id"

--- a/spec/factories/course_lesson_plan_items.rb
+++ b/spec/factories/course_lesson_plan_items.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
     end_at { nil }
     sequence(:title) { |n| "Example Lesson Plan Item #{n}" }
     published { false }
+    has_personal_times { true }
+    affects_personal_times { true }
 
     trait :with_bonus_end_time do
       bonus_end_at { 2.days.from_now }


### PR DESCRIPTION
Fixes #3247 

Fixed timeline algo does not need to do anything with these booleans. The smarter ones will need to respect these booleans when they are implemented.

**Test Plan**

![image](https://user-images.githubusercontent.com/11096034/50208250-adb32300-03ab-11e9-98cc-188ef131491f.png)

![image](https://user-images.githubusercontent.com/11096034/50207848-aa6b6780-03aa-11e9-9862-88680ca54117.png)