### PR TITLE
Ignore duplicate emails for course invitations

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -16,7 +16,8 @@ class Course::UserInvitationsController < Course::ComponentController
   def create
     result = invite
     if result
-      redirect_to course_user_invitations_path(current_course), success: create_success_message(*result)
+      redirect_to course_user_invitations_path(current_course), success: create_success_message(*result),
+                                                                warning: create_warning_message(*result)
     else
       propagate_errors
       render 'new'
@@ -199,17 +200,23 @@ class Course::UserInvitationsController < Course::ComponentController
   end
 
   # Returns the successful invitation creation message based on file or entry invitation.
-  def create_success_message(new_invitations, existing_invitations, new_course_users, existing_course_users, duplicate_users)
+  def create_success_message(new_invitations, existing_invitations, new_course_users,
+                             existing_course_users, _duplicate_users)
     if invite_by_file?
       t('.file.success',
         new_invitations: t('.file.summary.new_invitations', count: new_invitations),
         already_invited: t('.file.summary.already_invited', count: existing_invitations),
         new_course_users: t('.file.summary.new_course_users', count: new_course_users),
-        already_enrolled: t('.file.summary.already_enrolled', count: existing_course_users),
-        duplicate_emails: t('.file.summary.duplicate_emails', count: duplicate_users))
+        already_enrolled: t('.file.summary.already_enrolled', count: existing_course_users))
     else
       t('.manual_entry.success')
     end
+  end
+
+  # Returns the warning invitation creation message based on file or entry invitation.
+  def create_warning_message(_new_invitations, _existing_invitations, _new_course_users,
+                             _existing_course_users, duplicate_users)
+    t('.file.summary.duplicate_emails', count: duplicate_users) if invite_by_file? && duplicate_users > 0
   end
 
   # Enables or disables registration codes in the given course.

--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -199,13 +199,14 @@ class Course::UserInvitationsController < Course::ComponentController
   end
 
   # Returns the successful invitation creation message based on file or entry invitation.
-  def create_success_message(new_invitations, existing_invitations, new_course_users, existing_course_users)
+  def create_success_message(new_invitations, existing_invitations, new_course_users, existing_course_users, duplicate_users)
     if invite_by_file?
       t('.file.success',
         new_invitations: t('.file.summary.new_invitations', count: new_invitations),
         already_invited: t('.file.summary.already_invited', count: existing_invitations),
         new_course_users: t('.file.summary.new_course_users', count: new_course_users),
-        already_enrolled: t('.file.summary.already_enrolled', count: existing_course_users))
+        already_enrolled: t('.file.summary.already_enrolled', count: existing_course_users),
+        duplicate_emails: t('.file.summary.duplicate_emails', count: duplicate_users))
     else
       t('.manual_entry.success')
     end

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -29,7 +29,9 @@ module Course::UserInvitationService::ParseInvitationConcern
       else
         parse_from_form(users)
       end
-    result.each { |user| user[:email] = user[:email].downcase }
+    users = result.each { |user| user[:email] = user[:email].downcase }
+    emails = users.map { |user| user[:email] }
+    users.partition { |user| emails.count(user[:email]) == 1 }
   end
 
   # Invites the users from the form submission, which reflects the actual model associations.

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -14,13 +14,17 @@ module Course::UserInvitationService::ParseInvitationConcern
   # Invites users to the given course.
   #
   # @param [Array<Hash>|File|TempFile] users Invites the given users.
-  # @return [Array<Hash{Symbol=>String}>]
-  #   A mutable array of users to add. Each hash must have four attributes:
+  # @return [
+  #   [Array<Hash{Symbol=>String}>],
+  #   [Array<Hash>]
+  # ]
+  #   Both subarrays are mutable array of users to add. Each hash must have four attributes:
   #     the +:name+,
   #     the +:email+ of the user to add,
   #     the intended +:role+ in the course, as well as
   #     whether the user is a +:phantom:+ or not.
   #   The provided +emails+ are NOT case sensitive.
+  #   The second subarray contains the users with emails that occur more than once.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def parse_invitations(users)
     result =

--- a/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
@@ -93,24 +93,6 @@ module Course::UserInvitationService::ProcessInvitationConcern
       end
     end
 
-    [validate_new_invitation_emails(new_invitations), existing_invitations]
-  end
-
-  # Validate that the new invitation emails are unique.
-  #
-  # The uniqueness constraint of AR does not guarantee the new_records are unique among themselves.
-  # ( i.e Two new records with the same email will raise a {RecordNotUnique} error upon saving. )
-  #
-  # @param [Array<Course::UserInvitation>] invitations An array of invitations.
-  # @return [Array<Course::UserInvitation>] The validated invitations.
-  def validate_new_invitation_emails(invitations)
-    emails = invitations.map(&:email)
-    duplicates = emails.select { |email| emails.count(email) > 1 }
-    return invitations if duplicates.empty?
-
-    invitations.each do |invitation|
-      invitation.errors.add(:email, :taken) if duplicates.include?(invitation.email)
-    end
-    invitations
+    [new_invitations, existing_invitations]
   end
 end

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -33,7 +33,8 @@ class Course::UserInvitationService
     duplicate_users = nil
 
     success = Course.transaction do
-      new_invitations, existing_invitations, new_course_users, existing_course_users, duplicate_users = invite_users(users)
+      new_invitations, existing_invitations,
+      new_course_users, existing_course_users, duplicate_users = invite_users(users)
       raise ActiveRecord::Rollback unless new_invitations.all?(&:save)
       raise ActiveRecord::Rollback unless new_course_users.all?(&:save)
       true

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -23,7 +23,7 @@ class Course::UserInvitationService
   #
   # @param [Array<Hash>|File|TempFile] users Invites the given users.
   # @return [Array<Integer>|nil] An array containing the the size of new_invitations, existing_invitations,
-  #   new_course_users and existing_course_users respectively if success. nil when fail.
+  #   new_course_users and existing_course_users, duplicate_users respectively if success. nil when fail.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def invite(users)
     new_invitations = nil
@@ -65,10 +65,11 @@ class Course::UserInvitationService
   #     Array<(Array<Course::UserInvitation>,
   #     Array<Course::UserInvitation>,
   #     Array<CourseUser>,
-  #     Array<CourseUser>)>
+  #     Array<CourseUser>)>,
+  #     Array<Hash>,
   #   ]
   #   A tuple containing the users newly invited, already invited,
-  #     newly registered and already registered respectively.
+  #     newly registered and already registered, and duplicate users respectively.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def invite_users(users)
     users, duplicate_users = parse_invitations(users)

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -69,7 +69,7 @@ class Course::UserInvitationService
   #     newly registered and already registered respectively.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def invite_users(users)
-    users = parse_invitations(users)
+    users, duplicate_users = parse_invitations(users)
     process_invitations(users)
   end
 end

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -59,7 +59,7 @@ en:
         file:
           success: >
             Successfully invited users from the uploaded file:
-            %{new_invitations}, %{already_invited}, %{new_course_users}, %{already_enrolled}.
+            %{new_invitations}, %{already_invited}, %{new_course_users}, %{already_enrolled}, %{duplicate_emails}.
           summary:
             new_invitations:
               one: '1 new invitation sent'
@@ -69,6 +69,7 @@ en:
               other: '%{count} users just enrolled'
             already_enrolled: '%{count} already enrolled'
             already_invited: '%{count} already invited'
+            duplicate_emails: '%{count} duplicate emails ignored'
         manual_entry:
           success: 'Successfully invited users with the given details.'
       invitation_fields:

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -59,7 +59,7 @@ en:
         file:
           success: >
             Successfully invited users from the uploaded file:
-            %{new_invitations}, %{already_invited}, %{new_course_users}, %{already_enrolled}, %{duplicate_emails}.
+            %{new_invitations}, %{already_invited}, %{new_course_users}, %{already_enrolled}.
           summary:
             new_invitations:
               one: '1 new invitation sent'
@@ -69,7 +69,7 @@ en:
               other: '%{count} users just enrolled'
             already_enrolled: '%{count} already enrolled'
             already_invited: '%{count} already invited'
-            duplicate_emails: '%{count} duplicate emails ignored'
+            duplicate_emails: '%{count} duplicate emails ignored.'
         manual_entry:
           success: 'Successfully invited users with the given details.'
       invitation_fields:

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -145,19 +145,12 @@ RSpec.describe Course::UserInvitationService, type: :service do
           new_users.push(new_users.last)
         end
 
-        it 'fails' do
-          expect(invite).to be_falsey
+        it 'ignore duplicate users' do
+          expect(invite).to eq([new_user_attributes.size - 2, 0, existing_user_attributes.size, 0])
         end
 
-        it 'does not send any notifications' do
-          expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(0)
-        end
-
-        it 'sets the proper errors' do
-          invite
-          errors = course.invitations.map(&:errors).tap(&:compact!).reject(&:empty?)
-          expect(errors.length).to eq(1)
-          expect(errors.first[:email].all? { |error| error =~ /been taken/ }).to be_truthy
+        it 'does not send any notifications to duplicate users' do
+          expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(new_user_attributes.size - 2 + existing_user_attributes.size)
         end
       end
 

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
 
       context 'when a list of invitation form attributes are provided' do
         it 'registers everyone' do
-          expect(invite).to eq([new_users.size, 0, existing_users.size, 0])
+          expect(invite).to eq([new_users.size, 0, existing_users.size, 0, 0])
           verify_users
         end
 
@@ -103,7 +103,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         it 'accepts a CSV file with a header' do
           expect(subject.invite(temp_csv_from_attributes(user_attributes.map do |attributes|
             OpenStruct.new(attributes)
-          end))).to eq([new_users.size, 0, existing_users.size, 0])
+          end))).to eq([new_users.size, 0, existing_users.size, 0, 0])
 
           verify_users
         end
@@ -129,7 +129,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
 
         it 'succeeds' do
           expect(invite).to eq([new_users.size - users_invited.size, users_invited.size,
-                                existing_users.size - users_in_course.size, users_in_course.size])
+                                existing_users.size - users_in_course.size, users_in_course.size, 0])
         end
 
         with_active_job_queue_adapter(:test) do
@@ -146,11 +146,12 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
 
         it 'ignore duplicate users' do
-          expect(invite).to eq([new_user_attributes.size - 2, 0, existing_user_attributes.size, 0])
+          expect(invite).to eq([new_user_attributes.size - 2, 0, existing_user_attributes.size, 0, 2])
         end
 
         it 'does not send any notifications to duplicate users' do
-          expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(new_user_attributes.size - 2 + existing_user_attributes.size)
+          expect { invite }.to change { ActionMailer::Base.deliveries.count }.
+            by(new_user_attributes.size - 2 + existing_user_attributes.size)
         end
       end
 


### PR DESCRIPTION
#3249
The no. of duplicate emails ignored is shown in the success message:

![screen shot 2018-12-19 at 5 06 14 pm](https://user-images.githubusercontent.com/34204380/50210201-7bf08b00-03b0-11e9-9f06-f7ea0e4b5d0e.png)

There may be a better place to partition dups and non-dups emails than in the parsing.