### PR TITLE
Show year in personal times editor fields

### DIFF
--- a/app/views/course/personal_times/index.html.slim
+++ b/app/views/course/personal_times/index.html.slim
@@ -57,9 +57,9 @@
                     = t('.create_new_personal_time')
                 - fields_class = "hidden personal-time-#{personal_time.lesson_plan_item_id}"
               td class=fields_class = f.input :fixed, label: false, as: :boolean
-              td class=fields_class = f.input :start_at, label: false, input_html: { format: '%d %b %H:%M' }
-              td class=fields_class = f.input :bonus_end_at, label: false, input_html: { format: '%d %b %H:%M' }
-              td class=fields_class = f.input :end_at, label: false, input_html: { format: '%d %b %H:%M' }
+              td class=fields_class = f.input :start_at, label: false, input_html: { format: '%d %b %y %H:%M' }
+              td class=fields_class = f.input :bonus_end_at, label: false, input_html: { format: '%d %b %y %H:%M' }
+              td class=fields_class = f.input :end_at, label: false, input_html: { format: '%d %b %y %H:%M' }
               td class=fields_class
                 = f.button :submit, id: 'update' do
                   = fa_icon 'save'.freeze


### PR DESCRIPTION
Bootstrap datepicker defaults the year to the current year (2018), which is not what we want.

**Test Plan**

![image](https://user-images.githubusercontent.com/11096034/50385074-b5572c80-0709-11e9-8ff9-79b0259d6f08.png)
