### PR TITLE
Display video statistics per user

### DIFF
--- a/app/assets/stylesheets/course/statistics.scss
+++ b/app/assets/stylesheets/course/statistics.scss
@@ -1,0 +1,3 @@
+.progress {
+  margin: 0;
+}

--- a/app/controllers/course/statistics_controller.rb
+++ b/app/controllers/course/statistics_controller.rb
@@ -6,7 +6,7 @@ class Course::StatisticsController < Course::ComponentController
     preload_levels
     course_users = current_course.course_users.includes(:groups)
     staff = course_users.staff
-    all_students = course_users.students.ordered_by_experience_points
+    all_students = course_users.students.ordered_by_experience_points.with_video_statistics
     @phantom_students, @students = all_students.partition(&:phantom?)
     @service = Course::GroupManagerPreloadService.new(staff)
   end

--- a/app/views/course/statistics/_table.html.slim
+++ b/app/views/course/statistics/_table.html.slim
@@ -12,19 +12,28 @@ table.table.table-hover
     - if current_course.gamified?
       th.text-center
         = t('.experience_points')
+    th.text-center
+      = t('.video_watched', total: current_course.videos.count)
+    th.text-center
+      = t('.percent_watched')
 
   - students.each.with_index(1) do |student, index|
-   = content_tag_for(:tr, student)
-     td.text-center
-       = index
-     td
-       = link_to_user(student)
-     - unless @service.no_group_managers?
-       td
-         = @service.group_managers_of(student).map(&:name).join(', ')
-     td.text-center
-       = student.level_number
-     - if current_course.gamified?
-       td.text-center
-         = link_to student.experience_points,
-                   course_user_experience_points_records_path(current_course, student)
+    = content_tag_for(:tr, student)
+      td.text-center
+        = index
+      td
+        = link_to_user(student)
+      - unless @service.no_group_managers?
+        td
+          = @service.group_managers_of(student).map(&:name).join(', ')
+      td.text-center
+        = student.level_number
+      - if current_course.gamified?
+        td.text-center
+          = link_to student.experience_points,
+                    course_user_experience_points_records_path(current_course, student)
+      td.text-center
+        = student.video_submission_count
+      td.text-center
+        = display_progress_bar(student.video_percent_watched) do
+          = t('.progress', progress: student.video_percent_watched)

--- a/config/locales/en/course/statistics.yml
+++ b/config/locales/en/course/statistics.yml
@@ -12,6 +12,9 @@ en:
         serial_number: :'course.statistics.serial_number'
         tutor: 'Tutor'
         experience_points: 'Experience Points'
+        video_watched: 'Videos Watched (Total: %{total})'
+        percent_watched: 'Average % Watched'
+        progress: '%{progress} %'
       staff:
         header: 'Staff Statistics'
         serial_number: :'course.statistics.serial_number'


### PR DESCRIPTION
Blocked by https://github.com/Coursemology/coursemology2/pull/3260

Create association between course_user and video submission
Preload video submissions and statistics for course users
Display watch statistics per course user