### PR TITLE
Ignore duplicate emails for course invitations

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -199,7 +199,8 @@ class Course::UserInvitationsController < Course::ComponentController
   end
 
   # Returns the successful invitation creation message based on file or entry invitation.
-  def create_success_message(new_invitations, existing_invitations, new_course_users, existing_course_users)
+  def create_success_message(new_invitations, existing_invitations, new_course_users,
+                             existing_course_users, _duplicate_users)
     t('.success',
       new_invitations: t('.summary.new_invitations', count: new_invitations),
       already_invited: t('.summary.already_invited', count: existing_invitations),

--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -16,7 +16,8 @@ class Course::UserInvitationsController < Course::ComponentController
   def create
     result = invite
     if result
-      redirect_to course_user_invitations_path(current_course), success: create_success_message(*result)
+      redirect_to course_user_invitations_path(current_course), success: create_success_message(*result),
+                                                                warning: create_warning_message(*result)
     else
       propagate_errors
       render 'new'
@@ -206,6 +207,12 @@ class Course::UserInvitationsController < Course::ComponentController
       already_invited: t('.summary.already_invited', count: existing_invitations),
       new_course_users: t('.summary.new_course_users', count: new_course_users),
       already_enrolled: t('.summary.already_enrolled', count: existing_course_users))
+  end
+
+  # Returns the warning invitation creation message based on file or entry invitation.
+  def create_warning_message(_new_invitations, _existing_invitations, _new_course_users,
+                             _existing_course_users, duplicate_users)
+    t('.summary.duplicate_emails', count: duplicate_users) if invite_by_file? && duplicate_users > 0
   end
 
   # Enables or disables registration codes in the given course.

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -21,6 +21,7 @@ module Course::UserInvitationService::ParseInvitationConcern
   #     the intended +:role+ in the course, as well as
   #     whether the user is a +:phantom:+ or not.
   #   The provided +emails+ are NOT case sensitive.
+  #   The second subarray contains the leftover duplicate users.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def parse_invitations(users)
     result =
@@ -29,7 +30,29 @@ module Course::UserInvitationService::ParseInvitationConcern
       else
         parse_from_form(users)
       end
-    result.each { |user| user[:email] = user[:email].downcase }
+
+    partition_unique_users(result)
+  end
+
+  # Partition users into unique (including first duplicate instance) and duplicate users.
+  #
+  # @param [Array<Hash>] users
+  # @return [
+  #   [Array<Hash>],
+  #   [Array<Hash>]
+  # ]
+  def partition_unique_users(users)
+    users.each { |user| user[:email] = user[:email].downcase }
+    unique_users = {}
+    duplicate_users = []
+    users.each do |user|
+      if unique_users.key?(user[:email])
+        duplicate_users.push(user)
+      else
+        unique_users[user[:email]] = user
+      end
+    end
+    [unique_users.values, duplicate_users]
   end
 
   # Invites the users from the form submission, which reflects the actual model associations.

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -14,8 +14,11 @@ module Course::UserInvitationService::ParseInvitationConcern
   # Invites users to the given course.
   #
   # @param [Array<Hash>|File|TempFile] users Invites the given users.
-  # @return [Array<Hash{Symbol=>String}>]
-  #   A mutable array of users to add. Each hash must have four attributes:
+  # @return [
+  #   [Array<Hash{Symbol=>String}>],
+  #   [Array<Hash>]
+  # ]
+  #   Both subarrays are mutable array of users to add. Each hash must have four attributes:
   #     the +:name+,
   #     the +:email+ of the user to add,
   #     the intended +:role+ in the course, as well as

--- a/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
@@ -93,24 +93,6 @@ module Course::UserInvitationService::ProcessInvitationConcern
       end
     end
 
-    [validate_new_invitation_emails(new_invitations), existing_invitations]
-  end
-
-  # Validate that the new invitation emails are unique.
-  #
-  # The uniqueness constraint of AR does not guarantee the new_records are unique among themselves.
-  # ( i.e Two new records with the same email will raise a {RecordNotUnique} error upon saving. )
-  #
-  # @param [Array<Course::UserInvitation>] invitations An array of invitations.
-  # @return [Array<Course::UserInvitation>] The validated invitations.
-  def validate_new_invitation_emails(invitations)
-    emails = invitations.map(&:email)
-    duplicates = emails.select { |email| emails.count(email) > 1 }
-    return invitations if duplicates.empty?
-
-    invitations.each do |invitation|
-      invitation.errors.add(:email, :taken) if duplicates.include?(invitation.email)
-    end
-    invitations
+    [new_invitations, existing_invitations]
   end
 end

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -23,16 +23,18 @@ class Course::UserInvitationService
   #
   # @param [Array<Hash>|File|TempFile] users Invites the given users.
   # @return [Array<Integer>|nil] An array containing the the size of new_invitations, existing_invitations,
-  #   new_course_users and existing_course_users respectively if success. nil when fail.
+  #   new_course_users and existing_course_users, duplicate_users respectively if success. nil when fail.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def invite(users)
     new_invitations = nil
     existing_invitations = nil
     new_course_users = nil
     existing_course_users = nil
+    duplicate_users = nil
 
     success = Course.transaction do
-      new_invitations, existing_invitations, new_course_users, existing_course_users = invite_users(users)
+      new_invitations, existing_invitations,
+      new_course_users, existing_course_users, duplicate_users = invite_users(users)
       raise ActiveRecord::Rollback unless new_invitations.all?(&:save)
       raise ActiveRecord::Rollback unless new_course_users.all?(&:save)
       true
@@ -40,7 +42,7 @@ class Course::UserInvitationService
 
     send_registered_emails(new_course_users) if success
     send_invitation_emails(new_invitations) if success
-    success ? [new_invitations, existing_invitations, new_course_users, existing_course_users].map(&:size) : nil
+    success ? [new_invitations, existing_invitations, new_course_users, existing_course_users, duplicate_users].map(&:size) : nil
   end
 
   # Resends invitation emails to CourseUsers to the given course.
@@ -63,10 +65,11 @@ class Course::UserInvitationService
   #     Array<(Array<Course::UserInvitation>,
   #     Array<Course::UserInvitation>,
   #     Array<CourseUser>,
-  #     Array<CourseUser>)>
+  #     Array<CourseUser>)>,
+  #     Array<Hash>,
   #   ]
   #   A tuple containing the users newly invited, already invited,
-  #     newly registered and already registered respectively.
+  #     newly registered and already registered, and duplicate users respectively.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def invite_users(users)
     users, duplicate_users = parse_invitations(users)

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -69,7 +69,7 @@ class Course::UserInvitationService
   #     newly registered and already registered respectively.
   # @raise [CSV::MalformedCSVError] When the file provided is invalid.
   def invite_users(users)
-    users = parse_invitations(users)
-    process_invitations(users)
+    users, duplicate_users = parse_invitations(users)
+    process_invitations(users) + [duplicate_users]
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -82,6 +82,7 @@ ignore_missing:
 
 # I18n-tasks gives the wrong results for normal (non action) methods in the controller, ignore them here.
   - 'course.user_invitations.create_success_message.*'
+  - 'course.user_invitations.create_warning_message.*'
 
 ## Consider these keys used:
 ignore_unused:

--- a/config/locales/en/course/user_invitations.yml
+++ b/config/locales/en/course/user_invitations.yml
@@ -68,6 +68,7 @@ en:
             other: '%{count} users just enrolled'
           already_enrolled: '%{count} already enrolled'
           already_invited: '%{count} already invited'
+          duplicate_emails: '%{count} duplicate emails ignored.'
       invitation_fields:
         remove: 'Remove'
       resend_invitation:

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -145,19 +145,12 @@ RSpec.describe Course::UserInvitationService, type: :service do
           new_users.push(new_users.last)
         end
 
-        it 'fails' do
-          expect(invite).to be_falsey
+        it 'ignores duplicate users' do
+          expect(invite).to eq([new_user_attributes.size - 2, 0, existing_user_attributes.size, 0])
         end
 
-        it 'does not send any notifications' do
-          expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(0)
-        end
-
-        it 'sets the proper errors' do
-          invite
-          errors = course.invitations.map(&:errors).tap(&:compact!).reject(&:empty?)
-          expect(errors.length).to eq(1)
-          expect(errors.first[:email].all? { |error| error =~ /been taken/ }).to be_truthy
+        it 'does not send any notifications to duplicate users' do
+          expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(new_user_attributes.size - 2 + existing_user_attributes.size)
         end
       end
 

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
 
       context 'when a list of invitation form attributes are provided' do
         it 'registers everyone' do
-          expect(invite).to eq([new_users.size, 0, existing_users.size, 0])
+          expect(invite).to eq([new_users.size, 0, existing_users.size, 0, 0])
           verify_users
         end
 
@@ -103,7 +103,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         it 'accepts a CSV file with a header' do
           expect(subject.invite(temp_csv_from_attributes(user_attributes.map do |attributes|
             OpenStruct.new(attributes)
-          end))).to eq([new_users.size, 0, existing_users.size, 0])
+          end))).to eq([new_users.size, 0, existing_users.size, 0, 0])
 
           verify_users
         end
@@ -129,7 +129,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
 
         it 'succeeds' do
           expect(invite).to eq([new_users.size - users_invited.size, users_invited.size,
-                                existing_users.size - users_in_course.size, users_in_course.size])
+                                existing_users.size - users_in_course.size, users_in_course.size, 0])
         end
 
         with_active_job_queue_adapter(:test) do
@@ -145,12 +145,15 @@ RSpec.describe Course::UserInvitationService, type: :service do
           new_users.push(new_users.last)
         end
 
-        it 'ignores duplicate users' do
-          expect(invite).to eq([new_user_attributes.size - 2, 0, existing_user_attributes.size, 0])
+        it 'processes duplicate users only once' do
+          expect(invite).to eq([new_user_attributes.size - 1, 0, existing_user_attributes.size, 0, 1])
         end
 
-        it 'does not send any notifications to duplicate users' do
-          expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(new_user_attributes.size - 2 + existing_user_attributes.size)
+        with_active_job_queue_adapter(:test) do
+          it 'sends only one invitation to duplicate users' do
+            expect { invite }.to change { ActionMailer::Base.deliveries.count }.
+              by(new_user_attributes.size - 1 + existing_user_attributes.size)
+          end
         end
       end
 


### PR DESCRIPTION
Fixes merge conflicts in #3257 introduced by #3261.

Send one invite for duplicated emails in the invitation CSV. Show the number of duplicates in the CSV.

Fixes #3249.