### PR TITLE
Personal times abilities

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -70,10 +70,9 @@ module Course::Assessment::AssessmentAbility
 
   def allow_students_attempt_assessment
     can :attempt, Course::Assessment do |assessment|
-      assessment.published? && assessment.self_directed_started? &&
-        assessment.conditions_satisfied_by?(
-          user.course_users.find_by(course: assessment.course)
-        )
+      course_user = user.course_users.find_by(course: assessment.course)
+      assessment.published? && assessment.self_directed_started?(course_user) &&
+        assessment.conditions_satisfied_by?(course_user)
     end
   end
 

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -209,9 +209,10 @@ class Course::LessonPlan::Item < ApplicationRecord
   # Test if the lesson plan item has started for self directed learning.
   #
   # @return [Boolean]
-  def self_directed_started?
+  def self_directed_started?(course_user = nil)
     if course&.advance_start_at_duration
-      start_at.blank? || start_at - course.advance_start_at_duration < Time.zone.now
+      time_for(course_user).start_at.blank? ||
+        time_for(course_user).start_at - course.advance_start_at_duration < Time.zone.now
     else
       started?
     end

--- a/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
@@ -18,7 +18,8 @@ json.submission do
   json.workflowState apparent_workflow_state
   json.submitter display_course_user(submission.course_user)
 
-  json.dueAt assessment.time_for(submission.creator.course_users.find_by(course: submission.assessment.course)).end_at
+  end_at = assessment.time_for(submission.creator.course_users.find_by(course: submission.assessment.course)).end_at
+  json.dueAt end_at
   json.attemptedAt submission.created_at
   json.submittedAt submission.submitted_at
   if ['graded', 'published'].include? apparent_workflow_state
@@ -33,8 +34,8 @@ json.submission do
   json.showPublicTestCasesOutput current_course.show_public_test_cases_output
   json.showStdoutAndStderr current_course.show_stdout_and_stderr
 
-  json.late assessment.end_at && submission.submitted_at &&
-    submission.submitted_at > assessment.end_at
+  json.late end_at && submission.submitted_at &&
+    submission.submitted_at > end_at
 
   if current_course.gamified?
     json.basePoints assessment.base_exp


### PR DESCRIPTION
Fixes minor issues from manually clicking around when masquerading as a student.

1. Allow assessment attempt based on personal times
1. Show late message based on personal times

**Test Plan**

Masquerade as Serene Koh on CS1010X.

![image](https://user-images.githubusercontent.com/11096034/50579512-70a56100-0e80-11e9-8d1b-b860366ccb6b.png)
