### PR TITLE
Validate start_at <= end_at

### DIFF
--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -21,8 +21,7 @@ class Course::LessonPlan::Item < ApplicationRecord
   after_initialize :set_default_reference_time, if: :new_record?
   after_initialize :set_default_values, if: :new_record?
 
-  validate :validate_presence_of_bonus_end_at,
-           :validate_start_at_cannot_be_after_end_at
+  validate :validate_presence_of_bonus_end_at
   validates :base_exp, :time_bonus_exp, numericality: { greater_than_or_equal_to: 0 }
   validates :actable_type, length: { maximum: 255 }, allow_nil: true
   validates :title, length: { maximum: 255 }, presence: true
@@ -237,10 +236,5 @@ class Course::LessonPlan::Item < ApplicationRecord
   def validate_presence_of_bonus_end_at
     return unless time_bonus_exp && time_bonus_exp > 0 && bonus_end_at.blank?
     errors.add(:bonus_end_at, :required)
-  end
-
-  def validate_start_at_cannot_be_after_end_at
-    return unless end_at && start_at && start_at > end_at
-    errors.add(:start_at, :cannot_be_after_end_at)
   end
 end

--- a/app/models/course/personal_time.rb
+++ b/app/models/course/personal_time.rb
@@ -6,4 +6,10 @@ class Course::PersonalTime < ApplicationRecord
   validates :start_at, presence: true
   validates :course_user, presence: true, uniqueness: { scope: :lesson_plan_item }
   validates :lesson_plan_item, presence: true
+
+  validate :validate_start_at_cannot_be_after_end_at
+
+  def validate_start_at_cannot_be_after_end_at
+    errors.add(:start_at, :cannot_be_after_end_at) if end_at && start_at && start_at > end_at
+  end
 end

--- a/app/models/course/reference_time.rb
+++ b/app/models/course/reference_time.rb
@@ -7,10 +7,16 @@ class Course::ReferenceTime < ApplicationRecord
   validates :reference_timeline, presence: true, uniqueness: { scope: :lesson_plan_item }
   validates :lesson_plan_item, presence: true
 
+  validate :validate_start_at_cannot_be_after_end_at
+
   def initialize_duplicate(duplicator, other)
     self.reference_timeline = duplicator.duplicate(other.reference_timeline)
     self.start_at = duplicator.time_shift(other.start_at)
     self.bonus_end_at = duplicator.time_shift(other.bonus_end_at) if other.bonus_end_at
     self.end_at = duplicator.time_shift(other.end_at) if other.end_at
+  end
+
+  def validate_start_at_cannot_be_after_end_at
+    errors.add(:start_at, :cannot_be_after_end_at) if end_at && start_at && start_at > end_at
   end
 end

--- a/config/locales/en/activerecord/course/lesson_plan.yml
+++ b/config/locales/en/activerecord/course/lesson_plan.yml
@@ -6,8 +6,6 @@ en:
           attributes:
             bonus_end_at:
               required: 'cannot be blank if time bonus exp is set'
-            start_at:
-              cannot_be_after_end_at: 'cannot be after end at'
     attributes:
       course/lesson_plan/item:
         base_exp: 'Experience Points'

--- a/config/locales/en/activerecord/course/personal_time.yml
+++ b/config/locales/en/activerecord/course/personal_time.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/personal_time:
+          attributes:
+            start_at:
+              cannot_be_after_end_at: 'cannot be after end at'

--- a/config/locales/en/activerecord/course/reference_time.yml
+++ b/config/locales/en/activerecord/course/reference_time.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/reference_time:
+          attributes:
+            start_at:
+              cannot_be_after_end_at: 'cannot be after end at'

--- a/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_spec.rb
@@ -61,28 +61,6 @@ RSpec.describe Course::LessonPlan::Item, type: :model do
           expect(subject.errors[:bonus_end_at]).to be_present
         end
       end
-
-      context 'when start_at is after end_at' do
-        let(:lesson_plan_item) do
-          build(:course_lesson_plan_item, start_at: 1.day.ago, end_at: 3.days.ago)
-        end
-
-        it 'is not valid' do
-          expect(subject).not_to be_valid
-          expect(subject.errors[:start_at]).to be_present
-        end
-      end
-
-      context 'when start_at is before end_at' do
-        let(:lesson_plan_item) do
-          build(:course_lesson_plan_item, start_at: 3.days.ago, end_at: 1.day.ago)
-        end
-
-        it 'is valid' do
-          expect(subject).to be_valid
-          expect(subject.errors[:start_at]).not_to be_present
-        end
-      end
     end
 
     context 'when actable object is declared to have a todo' do

--- a/spec/models/course/personal_time_spec.rb
+++ b/spec/models/course/personal_time_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::PersonalTime, type: :model do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:course_user) { create(:course_user, course: course) }
+    let(:lesson_plan_item) { create(:course_lesson_plan_item, course: course) }
+    let(:personal_time) { course_user.personal_times.new(lesson_plan_item: lesson_plan_item) }
+
+    describe '#validations' do
+      subject { personal_time }
+
+      context 'when end_at is missing' do
+        it 'is valid' do
+          subject.assign_attributes(start_at: 2.days.from_now, end_at: nil)
+          expect(subject).to be_valid
+          expect(subject.errors[:start_at]).not_to be_present
+        end
+      end
+
+      context 'when start_at is before end_at' do
+        it 'is valid' do
+          subject.assign_attributes(start_at: 2.days.from_now, end_at: 3.days.from_now)
+          expect(subject).to be_valid
+          expect(subject.errors[:start_at]).not_to be_present
+        end
+      end
+
+      context 'when start_at is after end_at' do
+        it 'is not valid' do
+          subject.assign_attributes(start_at: 3.days.from_now, end_at: 2.days.from_now)
+          expect(subject).not_to be_valid
+          expect(subject.errors[:start_at]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/reference_time_spec.rb
+++ b/spec/models/course/reference_time_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::ReferenceTime, type: :model do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:lesson_plan_item) { create(:course_lesson_plan_item, course: course) }
+    let(:reference_time) { lesson_plan_item.default_reference_time }
+
+    describe '#validations' do
+      subject { reference_time }
+
+      context 'when end_at is missing' do
+        it 'is valid' do
+          subject.assign_attributes(start_at: 2.days.from_now, end_at: nil)
+          expect(subject).to be_valid
+          expect(subject.errors[:start_at]).not_to be_present
+        end
+      end
+
+      context 'when start_at is before end_at' do
+        it 'is valid' do
+          subject.assign_attributes(start_at: 2.days.from_now, end_at: 3.days.from_now)
+          expect(subject).to be_valid
+          expect(subject.errors[:start_at]).not_to be_present
+        end
+      end
+
+      context 'when start_at is after end_at' do
+        it 'is not valid' do
+          subject.assign_attributes(start_at: 3.days.from_now, end_at: 2.days.from_now)
+          expect(subject).not_to be_valid
+          expect(subject.errors[:start_at]).to be_present
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3277

Turns out the validation for reference time was actually on the Course::LessonPlan::Item model itself (in addition to front-end validation), but regardless this is probably due since in future we will be able to modify reference times directly without going through the lesson plan item.

It seems like there's one existing record in the DB that somehow violates this -- manually fix?

**Test Plan**

![image](https://user-images.githubusercontent.com/11096034/50620671-d145a400-0f3b-11e9-8465-0d47d61f2b1b.png)
