### PR TITLE
Explicitly install bundler on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ env:
     - GROUP="misc"
 
 before_install:
+  - gem update --system
+  - gem install bundler
   - nvm install 8
   - node --version
   - npm list -g yarn --depth=0 || npm install -g yarn


### PR DESCRIPTION
Bundler update introduced a Ruby 3 dependency which caused it to break
on environments without it available.

These 2 commands in the `before_install` section were added on advice from Travis support.