### PR TITLE
Navigation to personalized timelines page

### DIFF
--- a/app/views/course/users/_tabs.html.slim
+++ b/app/views/course/users/_tabs.html.slim
@@ -1,14 +1,16 @@
 = tabs do
-  = nav_to(t('.students'), course_users_students_path(current_course))
-  = nav_to(t('.staff'), course_users_staff_path(current_course))
-  = nav_to(course_enrol_requests_path(current_course)) do
-    = t('.requests')
-    - requests_count = current_course.enrol_requests.count
-    =< badge(requests_count) if requests_count > 0
+  - if can?(:manage, CourseUser.new(course: current_course))
+    = nav_to(t('.students'), course_users_students_path(current_course))
+    = nav_to(t('.staff'), course_users_staff_path(current_course))
+  - if can?(:manage, Course::EnrolRequest.new(course: current_course))
+    = nav_to(course_enrol_requests_path(current_course)) do
+      = t('.requests')
+      - requests_count = current_course.enrol_requests.count
+      =< badge(requests_count) if requests_count > 0
   = nav_to(t('.invite'), invite_course_users_path(current_course), class: 'dropdown')
   = nav_to(course_user_invitations_path(current_course)) do
     = t('.invitations')
     - invitations_count = current_course.invitations.unconfirmed.count
     =< badge(invitations_count) if invitations_count > 0
-  - if current_course.show_personalized_timeline_features?
+  - if current_course.show_personalized_timeline_features? && can?(:manage_personal_times, current_course)
     = nav_to(t('.personal_times'), personal_times_course_users_path(current_course))

--- a/spec/features/course/staff_management_spec.rb
+++ b/spec/features/course/staff_management_spec.rb
@@ -24,10 +24,10 @@ RSpec.feature 'Courses: Staff Management' do
       let(:user) { create(:user) }
       let!(:course_staff) { create(:course_teaching_assistant, course: course, user: user) }
 
-      scenario 'I cannot view the Users Management Sidebar item' do
+      scenario 'I can view the Users Management Sidebar item' do
         visit course_path(course)
 
-        expect(page).not_to have_selector('li', text: 'layouts.course_users.title')
+        expect(page).to have_selector('li', text: 'layouts.course_users.title')
       end
 
       scenario 'I cannot access the staff list' do


### PR DESCRIPTION
"Manage Users" links to personal_times directly if user is not a manager.

**Test Plan**

Manager:

![image](https://user-images.githubusercontent.com/11096034/50675404-fcf28800-1028-11e9-9570-dd5335694e58.png)

Teaching staff:

![image](https://user-images.githubusercontent.com/11096034/50675409-0380ff80-1029-11e9-89f4-845366fa7f76.png)