### PR TITLE
[2/3] Overall learning rate limits

### DIFF
--- a/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
+++ b/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
@@ -11,9 +11,15 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
     let(:dummy_controller) { self.class::DummyController.new }
 
     let!(:course) { create(:course) }
-    let!(:assessment1) { create(:course_assessment_assessment, course: course, end_at: 3.days.from_now) }
-    let!(:assessment2) { create(:course_assessment_assessment, course: course, end_at: 3.days.from_now) }
-    let!(:assessment3) { create(:course_assessment_assessment, course: course, end_at: 3.days.from_now) }
+    let!(:assessment1) do
+      create(:course_assessment_assessment, course: course, end_at: 3.days.from_now, published: true)
+    end
+    let!(:assessment2) do
+      create(:course_assessment_assessment, course: course, end_at: 3.days.from_now, published: true)
+    end
+    let!(:assessment3) do
+      create(:course_assessment_assessment, course: course, end_at: 3.days.from_now, published: true)
+    end
 
     context 'when course user is on the fixed algorithm' do
       let!(:course_user) { create(:course_user, course: course, timeline_algorithm: 'fixed') }


### PR DESCRIPTION
Min/max overall learning rate refers to how early/late a student is allowed to complete the course. E.g. if max_overall_lr = 2 means a student is allowed to complete a 1-month course over 2 months. However, if the student somehow managed to complete half of the course within the first day, then we can allow him to continue at lr = 4 and still have the student complete the course over 2 months.

This implements a method to compute the "effective" limits to preserve the overall min/max lr.

**Test Plan**

From diagnostic playground

Student with reasonable rate: M00 and M01 submitted

![image](https://user-images.githubusercontent.com/11096034/50679248-ae9bb400-103d-11e9-82b9-b06632ff36b3.png)

Fast student: M10 start date ~30 Mar~ 1 Feb

![image](https://user-images.githubusercontent.com/11096034/50679238-a6437900-103d-11e9-8f31-63f1f41cb09b.png)

Slow student: M10 start date ~30 Mar~ 1 June

![image](https://user-images.githubusercontent.com/11096034/50679274-cbd08280-103d-11e9-800e-e4d31b99eb06.png)

Incredibly slow student: M10 start date ~30 Mar~ 1 July

![image](https://user-images.githubusercontent.com/11096034/50679313-ee629b80-103d-11e9-8ee3-b40aaf100a08.png)
