### PR TITLE
Collapse all milestone groups...

### DIFF
--- a/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/index.jsx
+++ b/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/index.jsx
@@ -61,7 +61,7 @@ class LessonPlanShow extends React.Component {
 
     const visibleItems = items.filter(item => visibility[item.itemTypeKey]);
     const initiallyExpanded = {
-      current: currentGroupId ? (id === currentGroupId) : true,
+      current: currentGroupId ? (id === currentGroupId) : false,
       all: true,
       none: false,
     }[milestonesExpanded];


### PR DESCRIPTION
...if none is 'current'.

Fixes https://github.com/Coursemology/coursemology2/issues/3290