### PR TITLE
[1/n] Videos have personal times

### DIFF
--- a/app/controllers/course/personal_times_controller.rb
+++ b/app/controllers/course/personal_times_controller.rb
@@ -8,8 +8,8 @@ class Course::PersonalTimesController < Course::ComponentController
     if params[:user_id].present?
       @course_user = CourseUser.find_by(course: @course, id: params[:user_id])
 
-      # Only show for assessments
-      @items = @course.lesson_plan_items.where(actable_type: Course::Assessment.name).
+      # Only show for assessments and videos
+      @items = @course.lesson_plan_items.where(actable_type: [Course::Assessment.name, Course::Video.name]).
                ordered_by_date_and_title.
                with_reference_times_for(@course_user).
                with_personal_times_for(@course_user)

--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -45,7 +45,7 @@ class Course::Video::VideosController < Course::Video::Controller
   private
 
   def video_params
-    params.require(:video).permit(:title, :tab_id, :description, :start_at, :url, :published)
+    params.require(:video).permit(:title, :tab_id, :description, :start_at, :url, :published, :has_personal_times)
   end
 
   def current_tab

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -41,7 +41,8 @@ module Course::VideosAbilityComponent
 
   def allow_student_attempt_video
     can :attempt, Course::Video do |video|
-      video.published? && video.self_directed_started?
+      course_user = user.course_users.find_by(course: video.course)
+      video.published? && video.self_directed_started?(course_user)
     end
   end
 

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -3,12 +3,7 @@
     - unless assessment.published?
       span title=draft_message(assessment)
         => fa_icon 'ban'.freeze
-    - if current_course.show_personalized_timeline_features && assessment.has_personal_times?
-      span title=t('.has_personal_times_hint')
-        => fa_icon 'clock-o'.freeze
-    - if current_course.show_personalized_timeline_features && assessment.affects_personal_times?
-      span title=t('.affects_personal_times_hint')
-        => fa_icon 'random'.freeze
+    = render partial: 'course/lesson_plan/items/personal_time_boolean_icons', locals: { item: assessment }
     = link_to(format_inline_text(assessment.title),
               course_assessment_path(current_course, assessment))
 

--- a/app/views/course/lesson_plan/items/_personal_time_boolean_icons.slim
+++ b/app/views/course/lesson_plan/items/_personal_time_boolean_icons.slim
@@ -1,0 +1,6 @@
+- if current_course.show_personalized_timeline_features && item.has_personal_times?
+  span title=t('.has_personal_times_hint')
+    => fa_icon 'clock-o'.freeze
+- if current_course.show_personalized_timeline_features && item.affects_personal_times?
+  span title=t('.affects_personal_times_hint')
+    => fa_icon 'random'.freeze

--- a/app/views/course/video/videos/_form.html.slim
+++ b/app/views/course/video/videos/_form.html.slim
@@ -15,4 +15,7 @@
             input_html: { value: f.object.start_at || Date.today }
   = f.input :published, as: :boolean
 
+  / Videos cannot affect personal times because we have no clean measure of when they "complete" the video
+  = f.input :has_personal_times, as: :boolean if current_course.show_personalized_timeline_features?
+
   = f.button :submit

--- a/app/views/course/video/videos/_video.html.slim
+++ b/app/views/course/video/videos/_video.html.slim
@@ -5,6 +5,7 @@
     - unless video.published?
       span title=draft_message(video)
         => fa_icon 'ban'.freeze
+    = render partial: 'course/lesson_plan/items/personal_time_boolean_icons', locals: { item: video }
     = link_to(format_inline_text(video.title),
       course_video_path(current_course, video))
   td.table-start-at

--- a/app/views/course/video/videos/_video.html.slim
+++ b/app/views/course/video/videos/_video.html.slim
@@ -9,7 +9,8 @@
     = link_to(format_inline_text(video.title),
       course_video_path(current_course, video))
   td.table-start-at
-    = format_datetime(video.start_at, :short)
+    = render partial: 'course/lesson_plan/items/personal_or_ref_time',
+             locals: {item: video, course_user: current_course_user, attribute: :start_at, datetime_format: :short}
   td.table-buttons
     div.btn-group.attempt
       = render partial: 'video_attempt_button', locals: { video: video }

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -17,11 +17,6 @@ en:
         assessment:
           attempt: 'Attempt'
           condition_not_satisfied: 'You do not fulfill the requirements of the assessment'
-          has_personal_times_hint: >
-            Has personal times. Timings for this item will be automatically adjusted for users based on learning rate.
-          affects_personal_times_hint: >
-            Affects personal times. Student's submission time for this item will be taken into account when updating
-            personal times for other items.
         show:
           type: 'Assessment Type'
           autograded: 'Autograded Assessment'

--- a/config/locales/en/course/lesson_plan/items.yml
+++ b/config/locales/en/course/lesson_plan/items.yml
@@ -8,6 +8,12 @@ en:
         ref: 'Ref: '
         fixed_desc: >
           The personalized timeline for this item has been fixed. It will no longer be automatically modified.
+        personal_time_boolean_icons:
+          has_personal_times_hint: >
+            Has personal times. Timings for this item will be automatically adjusted for users based on learning rate.
+          affects_personal_times_hint: >
+            Affects personal times. Student's submission time for this item will be taken into account when updating
+            personal times for other items.
   activerecord:
     attributes:
       course/lesson_plan/item:


### PR DESCRIPTION
Videos need to have personal times too because otherwise students will not be able to do the missions early even if they are fast.

Right now, videos have opening times but not closing times (only enforced by the UI). We also do not have a clean measure for when a student has "completed" watching a video -- we only know when the student started watching the video. Hence, we will NOT allow videos to affect personal times (even if the boolean somehow gets set to true, the algorithms will ignore it since there is no closing time).

TODO: A video that has opened for a student may suddenly close on a subsequent recomputation. Nothing really _breaks_ but algorithms need to be refactored to check for videos that have been attempted and leave alone those that have already been attempted.

**Test Plan**

Set a student's algorithm to OTOT and recompute (the button is there now 😄).

![image](https://user-images.githubusercontent.com/11096034/50954099-6fafa780-14f0-11e9-876e-72a5d62e2d28.png)

![image](https://user-images.githubusercontent.com/11096034/50953935-d97b8180-14ef-11e9-8189-a43cfa9292c3.png)

![image](https://user-images.githubusercontent.com/11096034/50954064-54dd3300-14f0-11e9-837d-1514e0e64f9f.png)
