### PR TITLE
Remove preload from video statistic update job

### DIFF
--- a/app/jobs/video_statistic_update_job.rb
+++ b/app/jobs/video_statistic_update_job.rb
@@ -10,9 +10,7 @@ class VideoStatisticUpdateJob < ApplicationJob
   # for every uncached Course::Video and upsert to course_video_statistics table
   def perform
     ActsAsTenant.without_tenant do
-      Course::Video.
-        includes([:statistic, { submissions: [:experience_points_record, :statistic, { sessions: :events }] }]).
-        references(:all).select { |vid| vid.statistic.nil? || !vid.statistic.cached }.each do |video|
+      Course::Video.select { |vid| vid.statistic.nil? || !vid.statistic.cached }.each do |video|
         video.create_submission_statistics
         video.build_statistic(watch_freq: video.watch_frequency,
                               percent_watched: video.calculate_percent_watched,

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -112,8 +112,9 @@ class Course::Video < ApplicationRecord
     if submissions.blank?
       0
     else
+      submissions_count = submissions.size
       (submissions.map { |submission| submission.statistic.percent_watched }.
-        sum / submissions.size).round
+        sum / submissions_count).round
     end
   end
 


### PR DESCRIPTION
Fix https://github.com/Coursemology/coursemology2/issues/3316

Video statistic update job likely failed due to machine's limited memory not able to support the preloaded data.

This PR removes preload in the job to reduce memory usage.

To manually queue Video statistic update job after merge and deploy of this PR.