### PR TITLE
Add workflow-activerecord gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'unread'
 gem 'validates_hostname'
 # A Ruby state machine library
 gem 'workflow'
+gem 'workflow-activerecord', '>= 4.1', '< 6.0'
 # Add creator_id and updater_id attributes to models
 gem 'activerecord-userstamp', git: 'https://github.com/lowjoel/activerecord-userstamp'
 # Allow actions to be deferred until after a record is committed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,7 +548,10 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    workflow (1.2.0)
+    workflow (2.0.0)
+    workflow-activerecord (4.1.2)
+      activerecord (>= 3.0, < 6)
+      workflow (~> 2.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.16)
@@ -652,6 +655,7 @@ DEPENDENCIES
   wdm (>= 0.0.3)
   webpacker (<= 3.5.6)
   workflow
+  workflow-activerecord (>= 4.1, < 6.0)
   yard
 
 BUNDLED WITH

--- a/lib/extensions/deferred_workflow_state_persistence/workflow.rb
+++ b/lib/extensions/deferred_workflow_state_persistence/workflow.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+require 'workflow_activerecord'
+
 module Extensions::DeferredWorkflowStatePersistence::Workflow; end
 module Extensions::DeferredWorkflowStatePersistence::Workflow::Adapter; end
 module Extensions::DeferredWorkflowStatePersistence::Workflow::Adapter::DeferredActiveRecord
   extend ActiveSupport::Concern
   included do
-    include Workflow::Adapter::ActiveRecord
+    include WorkflowActiverecord::Adapter::ActiveRecord
     include InstanceMethods
   end
 


### PR DESCRIPTION
Needed after major refactor of workflow gem and release of workflow 2.0.

https://github.com/geekq/workflow#state-persistence-with-activerecord