### PR TITLE
Change video constant placeHolderDuration

### DIFF
--- a/client/app/bundles/course/video/submission/__test__/store.test.js
+++ b/client/app/bundles/course/video/submission/__test__/store.test.js
@@ -1,6 +1,6 @@
 import { playerStates } from 'lib/constants/videoConstants';
 import store from '../store';
-import { changePlayerState, updatePlayerProgress } from '../actions/video';
+import { changePlayerState, updatePlayerProgress, updatePlayerDuration } from '../actions/video';
 
 const videoStateObject = {
   videoUrl: 'https://www.youtube.com/watch?v=sTSA_sWGM44',
@@ -77,6 +77,7 @@ describe('persistor', () => {
       it('persists the state to localStorage', async () => {
         const spy = jest.spyOn(localStorage, 'setItem');
 
+        createdStore.store.dispatch(updatePlayerDuration(295));
         createdStore.store.dispatch(changePlayerState(playerStates.PLAYING));
         createdStore.store.dispatch(updatePlayerProgress(13));
         createdStore.persistor.flush();
@@ -85,6 +86,7 @@ describe('persistor', () => {
         const persistedState = JSON.parse(localStorage['persist:videoWatchSessionStore:user-1']);
         expect(persistedState).toHaveProperty('video');
         const videoState = JSON.parse(persistedState.video);
+        expect(videoState.duration).toBe(295);
         expect(videoState.playerProgress).toBe(13);
         expect(videoState.playerState).toBe(playerStates.PLAYING);
         expect(videoState.sessionSequenceNum).toBe(1);

--- a/client/app/bundles/course/video/submission/actions/__test__/video.test.js
+++ b/client/app/bundles/course/video/submission/actions/__test__/video.test.js
@@ -94,7 +94,7 @@ describe('endSession', () => {
       const spyUpdate = jest.spyOn(CourseAPI.video.sessions, 'update');
       createdStore.dispatch(endSession());
 
-      expect(spyUpdate).toHaveBeenCalledWith(32, 0, [], 600, false, true);
+      expect(spyUpdate).toHaveBeenCalledWith(32, 0, [], 0, false, true);
     });
   });
 });

--- a/client/app/lib/constants/videoConstants.js
+++ b/client/app/lib/constants/videoConstants.js
@@ -13,7 +13,7 @@ export const youtubeOpts = {
 export const videoDefaults = {
   volume: 0.8,
   availablePlaybackRates: [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 2.5],
-  placeHolderDuration: 600,
+  placeHolderDuration: 0,
   progressUpdateFrequencyMs: 500,
 };
 

--- a/config/locales/en/course/video/videos.yml
+++ b/config/locales/en/course/video/videos.yml
@@ -8,7 +8,7 @@ en:
           title: 'Title'
           start_at: 'Start At'
           percent_watched: 'Average % Watched'
-          submissions_count: 'Submissions Count'
+          submissions_count: 'Watch Count'
         video:
           progress: '%{progress} %'
           submissions_count: '%{submissions_count} / %{students_count}'


### PR DESCRIPTION
Fixes https://github.com/Coursemology/coursemology2/issues/3324

Proposal to fix wrong data:
------

A while after this PR is merged and deployed, allowing reasonable time to assume that all users have closed their browser tabs with old client bundle, please help ssh in and rectify data (likely at some unearthly hour).

Things to do:
1. Get impacted video ids from psql console, note this down somewhere:
`select id from course_videos where duration = 600;`
2. Edit the video duration to most correct number, something like in the following SQL statement, with a little modification:
coursemology2/db/migrate/20181204070041_add_duration_to_course_videos.rb
3. Recompute all impacted video submission statistics from Rails console:
```
Course::Video.where(id:**insert array of impacted video ids here**).each do |vid|
  vid.submissions.map { |sub| sub.statistic.percent_watched }
  vid.build_statistic(watch_freq: vid.watch_frequency,
                      percent_watched: vid.calculate_percent_watched,
                      cached: true).upsert
end
```