### PR TITLE
[Obsolete] Fix N+1 on lesson plan page

### DIFF
--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -63,7 +63,12 @@ class Course::LessonPlan::Item < ApplicationRecord
   end)
 
   scope :with_personal_times_for, (lambda do |course_user|
-    personal_times = Course::PersonalTime.where(course_user_id: course_user.id, lesson_plan_item_id: all).to_a
+    personal_times =
+      if course_user.nil?
+        []
+      else
+        Course::PersonalTime.where(course_user_id: course_user.id, lesson_plan_item_id: all).to_a
+      end
 
     all.to_a.tap do |result|
       preloader = ActiveRecord::Associations::Preloader::ManualPreloader.new
@@ -71,10 +76,14 @@ class Course::LessonPlan::Item < ApplicationRecord
     end
   end)
 
-  scope :with_reference_times_for, (lambda do |course_user|
-    eager_load(:reference_times).
-      where(course_reference_times: { reference_timeline_id: course_user.reference_timeline_id ||
-            course_user.course.default_reference_timeline.id })
+  scope :with_reference_times_for, (lambda do |course_user, course = nil|
+    # Can't eager-load if we have no idea who we are eager-loading for
+    return if course_user.nil? && course.nil?
+
+    reference_timeline_id = course_user&.reference_timeline_id ||
+                            course_user&.course&.default_reference_timeline&.id ||
+                            course.default_reference_timeline.id
+    eager_load(:reference_times).where(course_reference_times: { reference_timeline_id: reference_timeline_id })
   end)
 
   # @!method self.with_actable_types

--- a/app/views/course/lesson_plan/milestones/_milestone.json.jbuilder
+++ b/app/views/course/lesson_plan/milestones/_milestone.json.jbuilder
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
-json.(milestone, :id, :title, :description, :start_at)
+json.(milestone, :id, :title, :description)
+json.(milestone.time_for(current_course_user), :start_at)


### PR DESCRIPTION
By hacking around the acts-as gem which happily discards all our painfully eager-loaded associations.
The underlying problem is that `item` and `item.actable.acting_as` are not the same object instance. The hack hence preloads the association for the latter as well.

Pending: Timing tests from a machine stronger than my micro instance

**Test Plan**

* View as admin not belonging to course (null course_user)
* View as admin belonging to course (present course_user)