### PR TITLE
Fix N+1 on lesson plan page

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/acts_as_lesson_plan_item_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/acts_as_lesson_plan_item_concern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Course::LessonPlan::ActsAsLessonPlanItemConcern
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Use method to build new specific lesson_plan_items
+    # Refer to app/controllers/course/assessment/question/controller.rb for motivation
+    def build_and_authorize_new_lesson_plan_item(item_name, options)
+      before_action only: options[:only], except: options[:except] do
+        specific_item = options[:class].new
+        specific_item.lesson_plan_item.course = @course
+        if action_name != 'new'
+          item_params = send("#{item_name}_params")
+          specific_item.assign_attributes(item_params.except(:item))
+        end
+        authorize!(action_name.to_sym, specific_item)
+        instance_variable_set("@#{item_name}", specific_item) unless instance_variable_get("@#{item_name}")
+      end
+    end
+  end
+end

--- a/app/controllers/course/lesson_plan/controller.rb
+++ b/app/controllers/course/lesson_plan/controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::LessonPlan::Controller < Course::ComponentController
+  include Course::LessonPlan::ActsAsLessonPlanItemConcern
+
   add_breadcrumb :index, :course_lesson_plan_path
 
   private

--- a/app/controllers/course/lesson_plan/events_controller.rb
+++ b/app/controllers/course/lesson_plan/events_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
+  include Course::LessonPlan::ActsAsLessonPlanItemConcern
+
+  build_and_authorize_new_lesson_plan_item :event, class: Course::LessonPlan::Event, through: :course,
+                                                   through_association: :lesson_plan_events, only: [:new, :create]
   load_and_authorize_resource :event, class: Course::LessonPlan::Event.name, through: :course,
-                                      through_association: :lesson_plan_events
+                                      through_association: :lesson_plan_events, except: [:new, :create]
 
   def create #:nodoc:
     if @event.save

--- a/app/controllers/course/lesson_plan/milestones_controller.rb
+++ b/app/controllers/course/lesson_plan/milestones_controller.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
+  include Course::LessonPlan::ActsAsLessonPlanItemConcern
+
+  build_and_authorize_new_lesson_plan_item :milestone,
+                                           through: :course, through_association: :lesson_plan_milestones,
+                                           class: Course::LessonPlan::Milestone, only: [:new, :create]
   load_and_authorize_resource :milestone,
                               through: :course, through_association: :lesson_plan_milestones,
-                              class: Course::LessonPlan::Milestone.name
+                              class: Course::LessonPlan::Milestone.name, except: [:new, :create]
 
   def create #:nodoc:
     if @milestone.save

--- a/app/controllers/course/lesson_plan/todos_controller.rb
+++ b/app/controllers/course/lesson_plan/todos_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::LessonPlan::TodosController < Course::LessonPlan::Controller
-  load_and_authorize_resource :todo, class: Course::LessonPlan::Todo.name
+  build_and_authorize_new_lesson_plan_item :todo, class: Course::LessonPlan::Todo, only: [:new, :create]
+  load_and_authorize_resource :todo, class: Course::LessonPlan::Todo.name, except: [:new, :create]
 
   def ignore
     if @todo.update_column(:ignore, true) # rubocop:disable Style/GuardClause:

--- a/app/controllers/course/survey/controller.rb
+++ b/app/controllers/course/survey/controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Survey::Controller < Course::ComponentController
+  include Course::LessonPlan::ActsAsLessonPlanItemConcern
+
   load_and_authorize_resource :survey, through: :course, class: Course::Survey.name
   add_breadcrumb :index, :course_surveys_path
 

--- a/app/controllers/course/survey/surveys_controller.rb
+++ b/app/controllers/course/survey/surveys_controller.rb
@@ -2,6 +2,9 @@
 class Course::Survey::SurveysController < Course::Survey::Controller
   include Course::Survey::ReorderingConcern
 
+  skip_load_and_authorize_resource :survey, only: [:new, :create]
+  build_and_authorize_new_lesson_plan_item :survey, class: Course::Survey, through: :course, only: [:new, :create]
+
   def index
     respond_to do |format|
       format.html

--- a/app/controllers/course/video/controller.rb
+++ b/app/controllers/course/video/controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Video::Controller < Course::ComponentController
+  include Course::LessonPlan::ActsAsLessonPlanItemConcern
+
   load_and_authorize_resource :video, through: :course, class: Course::Video.name
   before_action :add_videos_breadcrumb
 

--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 class Course::Video::VideosController < Course::Video::Controller
+  skip_load_and_authorize_resource :video, only: [:new, :create]
+  build_and_authorize_new_lesson_plan_item :video, class: Course::Video, through: :course, only: [:new, :create]
+
   def index #:nodoc:
     @videos = @videos.
               from_tab(current_tab).

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -15,7 +15,7 @@ class Course::LessonPlan::Item < ApplicationRecord
   validates :default_reference_time, presence: true
   validate :validate_only_one_default_reference_time
 
-  actable optional: true
+  actable optional: true, inverse_of: :lesson_plan_item
   has_many_attachments on: :description
 
   after_initialize :set_default_reference_time, if: :new_record?

--- a/app/models/course/lesson_plan/item.rb
+++ b/app/models/course/lesson_plan/item.rb
@@ -63,7 +63,12 @@ class Course::LessonPlan::Item < ApplicationRecord
   end)
 
   scope :with_personal_times_for, (lambda do |course_user|
-    personal_times = Course::PersonalTime.where(course_user_id: course_user.id, lesson_plan_item_id: all).to_a
+    personal_times =
+      if course_user.nil?
+        []
+      else
+        Course::PersonalTime.where(course_user_id: course_user.id, lesson_plan_item_id: all).to_a
+      end
 
     all.to_a.tap do |result|
       preloader = ActiveRecord::Associations::Preloader::ManualPreloader.new
@@ -71,10 +76,16 @@ class Course::LessonPlan::Item < ApplicationRecord
     end
   end)
 
-  scope :with_reference_times_for, (lambda do |course_user|
-    eager_load(:reference_times).
-      where(course_reference_times: { reference_timeline_id: course_user.reference_timeline_id ||
-            course_user.course.default_reference_timeline.id })
+  # Loads the reference times for `course_user`. If `course_user` is nil, then we load the default reference time for
+  # `course`.
+  scope :with_reference_times_for, (lambda do |course_user, course = nil|
+    # Can't eager-load if we have no idea who we are eager-loading for
+    return if course_user.nil? && course.nil?
+
+    reference_timeline_id = course_user&.reference_timeline_id ||
+                            course_user&.course&.default_reference_timeline&.id ||
+                            course.default_reference_timeline.id
+    eager_load(:reference_times).where(course_reference_times: { reference_timeline_id: reference_timeline_id })
   end)
 
   # @!method self.with_actable_types

--- a/app/views/course/lesson_plan/milestones/_milestone.json.jbuilder
+++ b/app/views/course/lesson_plan/milestones/_milestone.json.jbuilder
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
-json.(milestone, :id, :title, :description, :start_at)
+json.(milestone, :id, :title, :description)
+json.(milestone.time_for(current_course_user), :start_at)


### PR DESCRIPTION
Replaces the hack in #3327 with declaring `inverse_of: :lesson_plan_item`.

**Test Plan**

* View as admin not belonging to course (null course_user)
* View as admin belonging to course (present course_user)