### PR TITLE
Remove enum maps

### DIFF
--- a/app/models/components/ability_host.rb
+++ b/app/models/components/ability_host.rb
@@ -13,7 +13,7 @@ class AbilityHost
     # @return [Hash] This hash is relative to a Course.
     def course_user_hash(*roles)
       course_users = { user_id: user.id }
-      course_users[:role] = roles.map { |role| CourseUser.roles[role] } unless roles.empty?
+      course_users[:role] = roles unless roles.empty?
 
       { course_users: course_users }
     end
@@ -66,7 +66,7 @@ class AbilityHost
     # @return [Hash] This hash is relative to a Instance.
     def instance_user_hash(*roles)
       instance_users = { user_id: user.id }
-      instance_users[:role] = roles.map { |role| InstanceUser.roles[role] } unless roles.empty?
+      instance_users[:role] = roles unless roles.empty?
 
       { instance_users: instance_users }
     end

--- a/app/models/components/course/groups_ability_component.rb
+++ b/app/models/components/course/groups_ability_component.rb
@@ -27,6 +27,6 @@ module Course::GroupsAbilityComponent
   end
 
   def course_group_manager_hash
-    { group_users: { course_user: { user_id: user.id }, role: Course::GroupUser.roles[:manager] } }
+    { group_users: { course_user: { user_id: user.id }, role: :manager } }
   end
 end

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -50,7 +50,7 @@ class Course::UserInvitation < ApplicationRecord
   #
   # @return [void]
   def set_defaults
-    self.role ||= Course::UserInvitation.roles[:student]
+    self.role ||= :student
     self.phantom ||= false
   end
 

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -103,7 +103,7 @@ class CourseUser < ApplicationRecord
   end)
   scope :managers, -> { where(role: MANAGER_ROLES) }
   scope :instructors, -> { staff }
-  scope :students, -> { where(role: roles[:student]) }
+  scope :students, -> { where(role: :student) }
   scope :phantom, -> { where(phantom: true) }
   scope :without_phantom_users, -> { where(phantom: false) }
   scope :with_course_statistics, -> { all.calculated(:experience_points, :achievement_count) }
@@ -197,7 +197,7 @@ class CourseUser < ApplicationRecord
 
   def set_defaults # :nodoc:
     self.name ||= user.name if user
-    self.role ||= CourseUser.roles[:student]
+    self.role ||= :student
   end
 
   # TODO(#3092): Validation is correct but everyone's reference timeline should be nil

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -136,10 +136,10 @@ module Course::UserInvitationService::ParseInvitationConcern
   # @return [Integer] The enum integer for +Course::UserInvitation.role+ matching the input.
   #                   (+Course::UserInvitation.roles[:student]+) is returned by default.
   def parse_file_role(role)
-    return Course::UserInvitation.roles[:student] if role.blank?
+    return :student if role.blank?
 
     symbol = role.parameterize(separator: '_').to_sym
-    Course::UserInvitation.roles[symbol] || Course::UserInvitation.roles[:student]
+    symbol || :student
   end
 
   # Parses file value for whether an invitation is a phantom or not.

--- a/app/services/course/user_registration_service.rb
+++ b/app/services/course/user_registration_service.rb
@@ -48,7 +48,7 @@ class Course::UserRegistrationService
   # @return [CourseUser] The Course User object which was found or created.
   def find_or_create_course_user!(registration, invitation = nil)
     name = invitation.try(:name) || registration.user.name
-    role = invitation.try(:role) || CourseUser.roles[:student]
+    role = invitation.try(:role) || :student
     phantom = invitation.try(:phantom) || false
 
     registration.course_user =

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Course::Group, type: :model do
       subject { Course::Group.new(course: course, name: 'group') }
 
       # TODO: Remove when using Rails 5.0
-      self::MANAGER_ROLE = Course::GroupUser.roles[:manager]
+      self::MANAGER_ROLE = :manager
 
       context 'when the group creator is a course_user of the course' do
         subject { Course::Group.new(course: course, creator: owner) }

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
     end
     subject { Course::UserInvitationService.new(user, course) }
 
-    let(:existing_roles) { Course::UserInvitation.roles.keys.sample(3) }
+    let(:existing_roles) { Course::UserInvitation.roles.keys.sample(3).map(&:to_sym) }
     let(:existing_users) do
       (1..3).map do
         create(:instance_user).user
@@ -36,10 +36,10 @@ RSpec.describe Course::UserInvitationService, type: :service do
     let(:existing_user_attributes) do
       existing_users.each_with_index.map do |user, id|
         { name: user.name, email: user.email, phantom: false,
-          role: Course::UserInvitation.roles[existing_roles[id]] }
+          role: existing_roles[id] }
       end
     end
-    let(:new_roles) { Course::UserInvitation.roles.keys.sample(3) }
+    let(:new_roles) { Course::UserInvitation.roles.keys.sample(3).map(&:to_sym) }
     let(:new_users) do
       (1..3).map do
         build(:user)
@@ -48,7 +48,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
     let(:new_user_attributes) do
       new_users.each_with_index.map do |user, id|
         { name: user.name, email: user.email, phantom: false,
-          role: Course::UserInvitation.roles[new_roles[id]] }
+          role: new_roles[id] }
       end
     end
     let(:invalid_user_attributes) do
@@ -246,7 +246,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         it 'defaults the role to student' do
           result = subject.send(:parse_from_file, temp_csv_without_role)
           result.each do |attr|
-            expect(attr[:role]).to eq(Course::UserInvitation.roles[:student])
+            expect(attr[:role]).to eq(:student)
           end
         end
       end
@@ -270,7 +270,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
 
         it 'defaults blank role column to student' do
-          expect(subject[0][:role]).to eq(Course::UserInvitation.roles[:student])
+          expect(subject[0][:role]).to eq(:student)
         end
 
         it 'defaults blank phantom to false' do
@@ -278,11 +278,11 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
 
         it 'parses roles correctly anyway' do
-          expect(subject[1][:role]).to eq(Course::UserInvitation.roles[:teaching_assistant])
-          expect(subject[2][:role]).to eq(Course::UserInvitation.roles[:manager])
-          expect(subject[3][:role]).to eq(Course::UserInvitation.roles[:owner])
-          expect(subject[4][:role]).to eq(Course::UserInvitation.roles[:observer])
-          expect(subject[5][:role]).to eq(Course::UserInvitation.roles[:teaching_assistant])
+          expect(subject[1][:role]).to eq(:teaching_assistant)
+          expect(subject[2][:role]).to eq(:manager)
+          expect(subject[3][:role]).to eq(:owner)
+          expect(subject[4][:role]).to eq(:observer)
+          expect(subject[5][:role]).to eq(:teaching_assistant)
         end
 
         it 'parses phantom columns correctly anyway' do

--- a/spec/services/course/user_registration_service_spec.rb
+++ b/spec/services/course/user_registration_service_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Course::UserRegistrationService, type: :service do
 
         context 'when a role is specified' do
           let!(:invitation_with_role) do
-            create(:course_user_invitation, course: course, role: Course::UserInvitation.roles[:teaching_assistant])
+            create(:course_user_invitation, course: course, role: :teaching_assistant)
           end
           let(:registration_with_role) do
             Course::Registration.new(course: course, user: user, code: invitation_with_role.invitation_key.dup)


### PR DESCRIPTION
Remove mapping of rails enum keys to values, since Rails 5 added support for passing enum keys into ActiveRecord queries.

Have manually tested the following:

- Changing role of course users
- Creating course user invitations via UI
- Creating course user invitations from file