### PR TITLE
Use hyphen instead of underscore in FactoryBot emails domains.

### DIFF
--- a/spec/factories/user_emails.rb
+++ b/spec/factories/user_emails.rb
@@ -2,7 +2,7 @@
 FactoryBot.define do
   base_time = Time.zone.now.to_i
   sequence :email do |n|
-    "user_#{n}@domain_#{base_time}_name.com"
+    "user_#{n}@domain-#{base_time}-name.com"
   end
 
   factory :user_email, class: User::Email.name do


### PR DESCRIPTION
Underscores are invalid in domain names and fail validation on the login
page.

See https://stackoverflow.com/questions/2049502/what-characters-are-allowed-in-an-email-address

This change will allow developers to login as users when testing with `rake coursemology:seed` data.