### PR TITLE
Skip staff video when calculating stat

### DIFF
--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -6,6 +6,7 @@ class Course::Video::VideosController < Course::Video::Controller
   def index #:nodoc:
     @videos = @videos.
               from_tab(current_tab).
+              with_student_submission_count.
               ordered_by_date_and_title.
               with_submissions_by(current_user)
 

--- a/app/jobs/video_statistic_update_job.rb
+++ b/app/jobs/video_statistic_update_job.rb
@@ -11,7 +11,6 @@ class VideoStatisticUpdateJob < ApplicationJob
   def perform
     ActsAsTenant.without_tenant do
       Course::Video.select { |vid| vid.statistic.nil? || !vid.statistic.cached }.each do |video|
-        video.create_submission_statistics
         video.build_statistic(watch_freq: video.watch_frequency,
                               percent_watched: video.calculate_percent_watched,
                               cached: true).upsert

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -104,17 +104,12 @@ class Course::Video < ApplicationRecord
     sessions.exists? || posts.exists?
   end
 
-  def create_submission_statistics
-    submissions.select { |submission| submission.statistic.nil? }.map(&:update_statistic)
-  end
-
   def calculate_percent_watched
-    if submissions.blank?
+    submission_statistics = Course::Video::Submission::Statistic.where(submission: submissions)
+    if submission_statistics.blank?
       0
     else
-      submissions_count = submissions.size
-      (submissions.map { |submission| submission.statistic.percent_watched }.
-        sum / submissions_count).round
+      (submission_statistics.map(&:percent_watched).sum / submission_statistics.size).round
     end
   end
 

--- a/app/models/course/video.rb
+++ b/app/models/course/video.rb
@@ -26,9 +26,22 @@ class Course::Video < ApplicationRecord
   has_one :statistic, class_name: Course::Video::Statistic.name, dependent: :destroy,
                       foreign_key: :video_id, inverse_of: :video, autosave: true
 
+  # @!attribute [r] student_submission_count
+  #   Returns the total number of video submissions by students in this course.
+  #   Only submissions by students have sessions and statistic.
+  calculated :student_submission_count, (lambda do
+    Course::Video::Submission::Statistic.
+      select('count(*)').
+      joins(:submission).
+      where('course_video_submission_statistics.submission_id = course_video_submissions.id').
+      where('course_video_submissions.video_id = course_videos.id')
+  end)
+
   scope :from_course, ->(course) { where(course_id: course) }
 
   scope :from_tab, ->(tab) { where(tab_id: tab) }
+
+  scope :with_student_submission_count, -> { all.calculated(:student_submission_count) }
 
   # TODO: Refactor this together with assessments.
   # @!method self.ordered_by_date_and_title

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -88,7 +88,7 @@ class CourseUser < ApplicationRecord
   end)
 
   # @!attribute [r] video_submission_count
-  #   Returns the total number of achievements obtained by CourseUser in this course
+  #   Returns the total number of video submissions by CourseUser in this course
   calculated :video_submission_count, (lambda do
     Course::Video::Submission.select('count(*)').
       joins(video: :tab).

--- a/app/views/course/video/videos/_video.html.slim
+++ b/app/views/course/video/videos/_video.html.slim
@@ -1,5 +1,5 @@
 - statistic = video.statistic
-- submissions_count = video.submissions.count
+- submissions_count = video.student_submission_count
 
 = content_tag_for(:tr, video, class: time_period_class(video) + draft_class(video))
   th

--- a/spec/models/course/video/submission_spec.rb
+++ b/spec/models/course/video/submission_spec.rb
@@ -84,8 +84,7 @@ RSpec.describe Course::Video::Submission do
       let!(:session2) { create(:video_session, :with_events_paused, submission: submission1) }
 
       it 'updates the statistic with correct watch_freq and percent_watched' do
-        expect(submission1.statistic.watch_freq).to eq([])
-        expect(submission1.statistic.percent_watched).to eq(0)
+        expect(submission1.statistic).to be_nil
 
         submission1.update_statistic
 


### PR DESCRIPTION
Fixes https://github.com/Coursemology/coursemology2/issues/3310

After this fix is deployed, need to :

- [ ] Go into rails console to delete course_video_submission_statistics for submissions without any session data:

```
Course::Video::Submission.all.includes([:sessions, :statistic]).references(:all).each do |submission|
  submission.statistic.destroy if submission.sessions.blank? && submission.statistic.exists?
end
```

- [ ] Go to psql console to switch all videos to uncached, so that daily job will update all videos again:

```
UPDATE course_video_statistics SET cached = 'f';
```