### PR TITLE
Show vanilla date if ref and personal times are the same

### DIFF
--- a/app/views/course/lesson_plan/items/_personal_or_ref_time.html.slim
+++ b/app/views/course/lesson_plan/items/_personal_or_ref_time.html.slim
@@ -2,7 +2,7 @@
   span title=t('course.lesson_plan.items.fixed_desc')
     = fa_icon 'lock'
 =< format_datetime(item.time_for(course_user)[attribute], datetime_format)
-- if item.time_for(course_user).is_a? Course::PersonalTime
+- if item.time_for(course_user)[attribute] != item.reference_time_for(course_user)[attribute]
   br
   strike
     = t('course.lesson_plan.items.ref')


### PR DESCRIPTION
**To be merged a month later, i.e. 21 Feb 2019, as agreed with Ben.**

Fixes #3336.

**Test Plan**

Mission view:
![image](https://user-images.githubusercontent.com/11096034/51514523-17ab6600-1e4b-11e9-93cd-b4e5dcdc372c.png)

Underlying personalized timeline view:
![image](https://user-images.githubusercontent.com/11096034/51514505-05312c80-1e4b-11e9-95c2-d03e5b3a365b.png)
