### PR TITLE
Allow students to access workbin if folder owner has opened based on personal times

### DIFF
--- a/app/views/course/material/folders/_folder.slim
+++ b/app/views/course/material/folders/_folder.slim
@@ -1,6 +1,6 @@
 = content_tag_for(:tr, folder)
   td
-    - if folder.effective_start_at > Time.zone.now
+    - if folder.effective_start_at > Time.zone.now && !(current_course_user&.student?)
       span title=t('.unseen_by_students')
         => fa_icon 'ban'.freeze
     = link_to course_material_folder_path(current_course, folder) do


### PR DESCRIPTION
Fixes #3334

**Test Plan**

http://dev1.louietyj.me:3000/courses/1615/materials/folders/31711

Set an unlocked assessment's reference time to April, created a personal time in Jan. Student can access workbin folder and download files (attachment error means it's working).

![image](https://user-images.githubusercontent.com/11096034/51529777-602b4980-1e74-11e9-9cb0-a47f7b25ee18.png)
