### PR TITLE
Remove unnecessary bundler lock. Downgrade bundler.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,6 @@ source 'https://rubygems.org'
 # For Windows devs
 gem 'tzinfo-data', platforms: [:mswin, :mswin64]
 
-# Lock down Bundle version as new versions will cause noisy
-# changes in the Gemfile.lock file
-gem 'bundler', '>= 1.10.3'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', git: 'https://github.com/coursemology/rails', branch: '5-2-0-security-patches'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,6 @@ DEPENDENCIES
   bootstrap3-datetimepicker-rails
   bootstrap_tokenfield_rails
   bullet (>= 4.14.9)
-  bundler (>= 1.10.3)
   byebug
   calculated_attributes
   cancancan
@@ -665,4 +664,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
Bundler 2 cannot find the nokogiri gem when starting puma.

Downgrade build agent as well. See if it's necessary to downgrade staging env.

Previously, bundler 1.14 could not find the nokogiri gem as well when starting puma.