### PR TITLE
Link items on personal timeline editor to the respective assessment/video

### DIFF
--- a/app/views/course/personal_times/index.html.slim
+++ b/app/views/course/personal_times/index.html.slim
@@ -48,7 +48,8 @@
                             method: :post do |f|
             = f.hidden_field :lesson_plan_item_id, value: personal_time.lesson_plan_item_id
             tr
-              td = item.title
+              td = link_to item.title, \
+                     send("course_#{item.actable_type.demodulize.downcase}_path", id: item.actable_id)
               td = item.reference_time_for(@course_user).start_at.nil? ? nil : \
                      format_datetime(item.reference_time_for(@course_user).start_at, :short)
               td = item.reference_time_for(@course_user).bonus_end_at.nil? ? nil : \


### PR DESCRIPTION
Fixes #3314

**Test Plan**

![image](https://user-images.githubusercontent.com/11096034/51671201-5be16680-2003-11e9-8680-39db40b1c696.png)

Assessments link to assessments, videos link to videos.