### PR TITLE
Fix outdated statistic

### DIFF
--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -17,7 +17,11 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
     @session.merge_in_events!(update_params[:events])
 
     # Update submission's statistic on session close
-    @submission.update_statistic if params[:close_session]
+    if params[:close_session]
+      @submission.update_statistic
+    elsif @submission.statistic&.cached
+      @submission.statistic.update(cached: false)
+    end
 
     # Update video duration using data from frontend VideoPlayer
     @video.update(duration: video_params[:video_duration].round) if @video.duration < video_params[:video_duration]

--- a/app/jobs/video_statistic_update_job.rb
+++ b/app/jobs/video_statistic_update_job.rb
@@ -6,11 +6,16 @@ class VideoStatisticUpdateJob < ApplicationJob
     # Prevent the job from retrying due to deleted records
   end
 
+  # Update video submission statistic for outdated cache.
   # Compute total watch_freq and average percent_watched (of all associated submissions)
-  # for every uncached Course::Video and upsert to course_video_statistics table
+  # for every uncached Course::Video and upsert to course_video_statistics table.
   def perform
     ActsAsTenant.without_tenant do
-      Course::Video.select { |vid| vid.statistic.nil? || !vid.statistic.cached }.each do |video|
+      Course::Video::Submission.includes(:statistic).references(:all).
+        select { |submission| submission.statistic&.cached == false }.
+        map(&:update_statistic)
+      Course::Video.includes(:statistic).references(:all).
+        select { |video| video.statistic.nil? || !video.statistic.cached }.each do |video|
         video.build_statistic(watch_freq: video.watch_frequency,
                               percent_watched: video.calculate_percent_watched,
                               cached: true).upsert

--- a/app/models/course/video/submission.rb
+++ b/app/models/course/video/submission.rb
@@ -43,7 +43,7 @@ class Course::Video::Submission < ApplicationRecord
   def update_statistic
     frequency_array = watch_frequency
     coverage = (100 * (frequency_array.count { |x| x > 0 }) / (video.duration + 1)).round
-    build_statistic(watch_freq: frequency_array, percent_watched: coverage).upsert
+    build_statistic(watch_freq: frequency_array, percent_watched: coverage, cached: true).upsert
   end
 
   private

--- a/app/models/course/video/submission.rb
+++ b/app/models/course/video/submission.rb
@@ -6,6 +6,8 @@ class Course::Video::Submission < ApplicationRecord
 
   acts_as_experience_points_record
 
+  after_save :init_statistic
+
   validate :validate_consistent_user, :validate_unique_submission, on: :create
   validates :creator, presence: true
   validates :updater, presence: true
@@ -67,5 +69,10 @@ class Course::Video::Submission < ApplicationRecord
     errors.clear
     errors[:base] << I18n.t('activerecord.errors.models.course/video/submission.'\
                             'submission_already_exists')
+  end
+
+  # Initialize statistic when submission is created by course student
+  def init_statistic
+    create_statistic if course_user&.role == 'student' && statistic.nil?
   end
 end

--- a/db/migrate/20190129044142_add_cached_to_course_video_submission_statistics.rb
+++ b/db/migrate/20190129044142_add_cached_to_course_video_submission_statistics.rb
@@ -1,0 +1,5 @@
+class AddCachedToCourseVideoSubmissionStatistics < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_video_submission_statistics, :cached, :boolean,
+                default: false, null: false
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_08_042524) do
+ActiveRecord::Schema.define(version: 2019_01_29_044142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -913,6 +913,7 @@ ActiveRecord::Schema.define(version: 2019_01_08_042524) do
     t.integer "submission_id", null: false
     t.integer "watch_freq", default: [], array: true
     t.integer "percent_watched", default: 0, null: false
+    t.boolean "cached", default: false, null: false
     t.index ["submission_id"], name: "index_course_video_submission_statistics_on_submission_id"
   end
 

--- a/spec/controllers/course/admin/videos/tabs_controller_spec.rb
+++ b/spec/controllers/course/admin/videos/tabs_controller_spec.rb
@@ -2,11 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Course::Admin::Videos::TabsController, type: :controller do
-  let(:instance) do
-    Instance.default.tap do |instance|
-      instance.set_component_enabled_boolean!(:course_videos_component, true)
-    end
-  end
+  let!(:instance) { create(:instance, :with_video_component_enabled) }
   with_tenant(:instance) do
     let(:user) { create(:administrator) }
     let!(:course) { create(:course, :with_video_component_enabled, creator: user) }

--- a/spec/models/course/video/submission_spec.rb
+++ b/spec/models/course/video/submission_spec.rb
@@ -84,8 +84,6 @@ RSpec.describe Course::Video::Submission do
       let!(:session2) { create(:video_session, :with_events_paused, submission: submission1) }
 
       it 'updates the statistic with correct watch_freq and percent_watched' do
-        expect(submission1.statistic).to be_nil
-
         submission1.update_statistic
 
         expect(submission1.statistic.watch_freq.size).to eq(71)


### PR DESCRIPTION
Fixes https://github.com/Coursemology/coursemology2/issues/3348

Implement some changes in video statistic module:
1. Statistic record is created for every video submission **by a student**. This is to reflect students who have opened the video, but never pressed play. Video submissions such as these will have associative statistic, even though they do not have any session.
2. Have a flag to keep track of the submission's cache status. For submissions which manage to send back `"close_session" => true` in params, submission statistic will update on the fly. For those that received new session data, but failed to update cache, the cached flag will remain at false, and the submission statistic will be updated by sidekiq cron job overnight.

After this PR is merged, fix existing data with the following commands in rails console:
1. Create statistic object for all video submissions belonging to students:

```
Course::Video::Submission.includes(:statistic).references(:all).select { |submission| submission.statistic.nil? }.
  each do |submission|
  current_course = submission.video.tab.course
  current_course_user = CourseUser.where(course: current_course).where(user: submission.creator).first
  submission.update_statistic if current_course_user&.role == 'student'
end
```

2. Switch all video cache flag to false:

```
Course::Video::Statistic.all.each do |vid_stat|
  vid_stat.update_attribute(:cached, false)
end
```