### PR TITLE
Strip null byte from stdout and stderr before save

### DIFF
--- a/app/models/course/assessment/answer/programming_auto_grading.rb
+++ b/app/models/course/assessment/answer/programming_auto_grading.rb
@@ -3,6 +3,8 @@ class Course::Assessment::Answer::ProgrammingAutoGrading < ApplicationRecord
   acts_as :auto_grading, class_name: Course::Assessment::Answer::AutoGrading.name,
                          inverse_of: :actable
 
+  before_save :strip_null_byte
+
   validates :exit_code, numericality: { only_integer: true }, allow_nil: true
 
   has_one :programming_answer, through: :answer,
@@ -12,4 +14,13 @@ class Course::Assessment::Answer::ProgrammingAutoGrading < ApplicationRecord
            class_name: Course::Assessment::Answer::ProgrammingAutoGradingTestResult.name,
            foreign_key: :auto_grading_id, inverse_of: :auto_grading,
            dependent: :destroy
+
+  private
+
+  # Remove null bytes from stdout and stderr to avoid psql error:
+  # ArgumentError Exception: string contains null byte
+  def strip_null_byte
+    self.stdout = stdout.delete("\000") if stdout
+    self.stderr = stderr.delete("\000") if stderr
+  end
 end

--- a/spec/factories/course_assessment_answer_programming_auto_gradings.rb
+++ b/spec/factories/course_assessment_answer_programming_auto_gradings.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
   factory :course_assessment_answer_programming_auto_grading,
           class: Course::Assessment::Answer::ProgrammingAutoGrading,
           parent: :course_assessment_answer_auto_grading do
+
+    trait :with_null_byte do
+      stderr { "Makefile:6: recipe for target 'test' failed\000" }
+      stdout { "\000SyntaxError: invalid syntax" }
+    end
   end
 end

--- a/spec/models/course/assessment/answer/programming_auto_grading_spec.rb
+++ b/spec/models/course/assessment/answer/programming_auto_grading_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGrading do
       class_name(Course::Assessment::Answer::ProgrammingAutoGradingTestResult.name).
       with_foreign_key(:auto_grading_id)
   end
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#strip_null_byte' do
+      let(:auto_grading) do
+        build(:course_assessment_answer_programming_auto_grading, :with_null_byte)
+      end
+      it 'removes all null bytes from stderr and stdout' do
+        expect(auto_grading.save).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/Coursemology/coursemology2/issues/3371

By stripping all null bytes from stdout and stderr before persisting in DB.

Root cause: null bytes in string will cause the following PSQL error
`ArgumentError: string contains null byte`