### PR TITLE
Backend changes to support multiple submissions

### DIFF
--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -34,7 +34,7 @@ class Course::Assessment::Submission < ApplicationRecord
     end
   end
 
-  validate :validate_consistent_user, :validate_unique_submission, on: :create
+  validate :validate_consistent_user, :validate_unique_attempting_submission, on: :create
   validate :validate_awarded_attributes, if: :published?
   validates :submitted_at, presence: true, unless: :attempting?
   validates :workflow_state, length: { maximum: 255 }, presence: true
@@ -238,11 +238,13 @@ class Course::Assessment::Submission < ApplicationRecord
     errors.add(:experience_points_record, :inconsistent_user)
   end
 
-  # Validate that the submission creator does not have an existing submission for this assessment.
-  def validate_unique_submission
-    existing = Course::Assessment::Submission.find_by(assessment_id: assessment.id,
-                                                      creator_id: creator.id)
-    return unless existing
+  # Validate that the submission creator does not have an existing attempting submission for this
+  # assessment.
+  def validate_unique_attempting_submission
+    existing_attempting = Course::Assessment::Submission.find_by(assessment_id: assessment.id,
+                                                                 creator_id: creator.id,
+                                                                 workflow_state: 'attempting')
+    return unless existing_attempting
     errors.clear
     errors[:base] << I18n.t('activerecord.errors.models.course/assessment/'\
                             'submission.submission_already_exists')

--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -19,7 +19,7 @@ en:
             absent_award_attributes: >
               there is no award attributes for your submission, please try again
               or contact the Coursemology team
-          submission_already_exists: "Looks like you have already created a submission. Try again?"
+          submission_already_exists: "Looks like you are already attempting a submission. Try resuming it?"
         course/assessment/category:
           deletion: 'the last category cannot be deleted'
 

--- a/db/migrate/20190215080346_prevent_duplicate_attempting_submissions.rb
+++ b/db/migrate/20190215080346_prevent_duplicate_attempting_submissions.rb
@@ -1,0 +1,10 @@
+class PreventDuplicateAttemptingSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_index :course_assessment_submissions, [:assessment_id, :creator_id], unique: true,
+              name: 'unique_assessment_id_and_creator_id_when_attempting',
+              where: "workflow_state = 'attempting'"
+
+    # Remove the original index from db/migrate/20160815141617_prevent_duplicate_submissions.rb
+    remove_index :course_assessment_submissions, name: 'unique_assessment_id_and_creator_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_02_070915) do
+ActiveRecord::Schema.define(version: 2019_02_15_080346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -388,7 +388,7 @@ ActiveRecord::Schema.define(version: 2019_02_02_070915) do
     t.integer "publisher_id"
     t.datetime "published_at"
     t.datetime "submitted_at"
-    t.index ["assessment_id", "creator_id"], name: "unique_assessment_id_and_creator_id", unique: true
+    t.index ["assessment_id", "creator_id"], name: "unique_assessment_id_and_creator_id_when_attempting", unique: true, where: "((workflow_state)::text = 'attempting'::text)"
     t.index ["assessment_id"], name: "fk__course_assessment_submissions_assessment_id"
     t.index ["creator_id"], name: "fk__course_assessment_submissions_creator_id"
     t.index ["publisher_id"], name: "fk__course_assessment_submissions_publisher_id"


### PR DESCRIPTION
Use a partial unique index (https://www.postgresql.org/docs/current/indexes-partial.html) instead of an unique index on the submissions table on (assessment_id, creator_id).

Each user can have multiple submissions, but only 1 can be in the attempting state at any 1 time. This will be needed for randomized assessments (#3343, #3352) to be fully implemented.

References #1313, #2033.
