### PR TITLE
Add workaround for number input & submissions comment field bug

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
@@ -76,6 +76,9 @@ export default class ReadOnlyEditor extends Component {
   }
 
   setExpandedLine(lineNumber) {
+    // workaround for Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1495482
+    document.getSelection().removeAllRanges();
+
     const { expanded } = this.state;
     const newExpanded = expanded.slice(0);
     newExpanded[lineNumber - 1] = true;


### PR DESCRIPTION
Fix #3379 

To reproduce the bug on the assessment submission page:

1. Click on any number input (`input[type=number]`)
2. Do not click on anything else
3. Click on the `+` icon next to the line number of a programming answer.

This PR works by making summernote's `createFromSelection()` return early. [Source code](https://github.com/summernote/summernote/blob/93c893cdaa976dd5ca6355b75165571618657c7c/src/js/base/core/range.js#L675)