### PR TITLE
Disable networking on Docker containers for evaluation.

### DIFF
--- a/lib/autoload/coursemology_docker_container.rb
+++ b/lib/autoload/coursemology_docker_container.rb
@@ -40,7 +40,8 @@ class CoursemologyDockerContainer < Docker::Container
                                               image: image) do |payload|
         options = { 'Image' => image }
         options['Cmd'] = argv if argv.present?
-        options['HostConfig'] = { 'memory' => CONTAINER_MEMORY_LIMIT, 'LogConfig' => LOG_CONFIG }
+        options['HostConfig'] = { 'memory': CONTAINER_MEMORY_LIMIT, 'LogConfig': LOG_CONFIG }
+        options['NetworkDisabled'] = true
 
         payload[:container] = super(options)
       end


### PR DESCRIPTION
Improves security and reduces potential harm from malicious code.

## Testing
1. Start a long running evaluation locally (start an infinite loop on a question with a 30s time limit).
2. Use `docker ps` to get the container name.
3. Use `docker exec -it <container-name> /bin/bash` to get a shell into the container.
4. Try running `ping google.com` and `apt update`. Both commands should fail.