### PR TITLE
Auto compute bonus

### DIFF
--- a/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
@@ -18,7 +18,10 @@ json.submission do
   json.workflowState apparent_workflow_state
   json.submitter display_course_user(submission.course_user)
 
-  end_at = assessment.time_for(submission.creator.course_users.find_by(course: submission.assessment.course)).end_at
+  submitter_course_user = submission.creator.course_users.find_by(course: submission.assessment.course)
+  end_at = assessment.time_for(submitter_course_user).end_at
+  bonus_end_at = assessment.time_for(submitter_course_user).bonus_end_at
+  json.bonusEndAt bonus_end_at
   json.dueAt end_at
   json.attemptedAt submission.created_at
   json.submittedAt submission.submitted_at
@@ -39,6 +42,7 @@ json.submission do
 
   if current_course.gamified?
     json.basePoints assessment.base_exp
+    json.bonusPoints assessment.time_bonus_exp
     json.pointsAwarded submission.current_points_awarded
   end
 end

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -100,6 +100,7 @@ class VisibleGradingPanel extends Component {
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <div>
           <input
+            className="exp"
             style={{ width: 50 }}
             type="number"
             min={0}

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -48,16 +48,16 @@ class VisibleGradingPanel extends Component {
   }
 
   handleMultiplierField(value) {
-    const { updateMultiplier } = this.props;
+    const { updateMultiplier, bonusAwarded } = this.props;
     const parsedValue = parseFloat(value);
 
     if (Number.isNaN(parsedValue) || parsedValue < 0) {
-      updateMultiplier(0);
+      updateMultiplier(0, bonusAwarded);
     } else if (parsedValue > 1) {
-      updateMultiplier(1);
+      updateMultiplier(1, bonusAwarded);
     } else {
       const multiplier = parseFloat(parsedValue.toFixed(1));
-      updateMultiplier(multiplier);
+      updateMultiplier(multiplier, bonusAwarded);
     }
   }
 
@@ -89,6 +89,7 @@ class VisibleGradingPanel extends Component {
     const {
       grading: { exp, expMultiplier },
       submission: { basePoints, graderView },
+      bonusAwarded,
     } = this.props;
 
     if (!graderView) {
@@ -97,7 +98,7 @@ class VisibleGradingPanel extends Component {
 
     return (
       <div style={{ display: 'flex', alignItems: 'center' }}>
-        <div style={{ width: 80 }}>
+        <div>
           <input
             style={{ width: 50 }}
             type="number"
@@ -110,7 +111,10 @@ class VisibleGradingPanel extends Component {
             }}
             onWheel={() => this.expInputRef.blur()}
           />
-          {` / ${basePoints}`}
+          {(bonusAwarded > 0)
+            ? ` / (${basePoints} + ${bonusAwarded})`
+            : ` / ${basePoints}`
+          }
         </div>
         <div style={{ marginLeft: 20 }}>
           <FormattedMessage {...translations.multiplier} />
@@ -274,22 +278,30 @@ VisibleGradingPanel.propTypes = {
   submission: submissionShape.isRequired,
   updateExp: PropTypes.func.isRequired,
   updateMultiplier: PropTypes.func.isRequired,
+  bonusAwarded: PropTypes.number,
 };
 
 function mapStateToProps(state) {
+  const { submittedAt, bonusEndAt, bonusPoints } = state.submission;
+  const bonusAwarded = (new Date(submittedAt) < new Date(bonusEndAt)) ? bonusPoints : 0;
   return {
     gamified: state.assessment.gamified,
     grading: state.grading,
     questionIds: state.assessment.questionIds,
     questions: state.questions,
     submission: state.submission,
+    bonusAwarded,
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     updateExp: exp => dispatch({ type: actionTypes.UPDATE_EXP, exp }),
-    updateMultiplier: multiplier => dispatch({ type: actionTypes.UPDATE_MULTIPLIER, multiplier }),
+    updateMultiplier: (multiplier, bonusAwarded) => dispatch({
+      type: actionTypes.UPDATE_MULTIPLIER,
+      multiplier,
+      bonusAwarded,
+    }),
   };
 }
 

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -135,7 +135,7 @@ class VisibleGradingPanel extends Component {
   renderSubmissionTable() {
     const {
       submission: {
-        submitter, workflowState, dueAt, attemptedAt,
+        submitter, workflowState, bonusEndAt, dueAt, attemptedAt,
         submittedAt, grader, gradedAt, graderView,
       },
       gamified, intl,
@@ -162,7 +162,8 @@ class VisibleGradingPanel extends Component {
             {tableRow('status', this.renderSubmissionStatus())}
             {shouldRenderGrading ? tableRow('totalGrade', this.renderTotalGrade()) : null}
             {shouldRenderGrading && gamified ? tableRow('expAwarded', this.renderExperiencePoints()) : null}
-            {tableRow('dueAt', formatDateTime(dueAt))}
+            {bonusEndAt ? tableRow('bonusEndAt', formatDateTime(bonusEndAt)) : null}
+            {dueAt ? tableRow('dueAt', formatDateTime(dueAt)) : null}
             {tableRow('attemptedAt', formatDateTime(attemptedAt))}
             {tableRow('submittedAt', formatDateTime(submittedAt))}
             {shouldRenderGrading ? tableRow('grader', grader) : null}

--- a/client/app/bundles/course/assessment/submission/containers/QuestionGrade.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/QuestionGrade.jsx
@@ -20,19 +20,20 @@ class VisibleQuestionGrade extends Component {
     id: PropTypes.number.isRequired,
     question: questionShape,
     updateGrade: PropTypes.func.isRequired,
+    bonusAwarded: PropTypes.number,
   };
 
   handleGradingField(value) {
-    const { id, question, updateGrade } = this.props;
+    const { id, question, updateGrade, bonusAwarded } = this.props;
     const maxGrade = question.maximumGrade;
     const parsedValue = parseFloat(value);
 
     if (Number.isNaN(parsedValue) || parsedValue < 0) {
-      updateGrade(id, 0);
+      updateGrade(id, 0, bonusAwarded);
     } else if (parsedValue > maxGrade) {
-      updateGrade(id, maxGrade);
+      updateGrade(id, maxGrade, bonusAwarded);
     } else {
-      updateGrade(id, parseFloat(parsedValue.toFixed(1)));
+      updateGrade(id, parseFloat(parsedValue.toFixed(1)), bonusAwarded);
     }
   }
 
@@ -91,15 +92,20 @@ class VisibleQuestionGrade extends Component {
 
 function mapStateToProps(state, ownProps) {
   const { id } = ownProps;
+  const { submittedAt, bonusEndAt, bonusPoints } = state.submission;
+  const bonusAwarded = (new Date(submittedAt) < new Date(bonusEndAt)) ? bonusPoints : 0;
   return {
     question: state.questions[id],
     grading: state.grading.questions[id],
+    bonusAwarded,
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    updateGrade: (id, grade) => dispatch({ type: actionTypes.UPDATE_GRADING, id, grade }),
+    updateGrade: (id, grade, bonusAwarded) => dispatch({
+      type: actionTypes.UPDATE_GRADING, id, grade, bonusAwarded,
+    }),
   };
 }
 

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -109,10 +109,12 @@ export const assessmentShape = PropTypes.shape({
 export const submissionShape = PropTypes.shape({
   attempted_at: PropTypes.string,
   basePoints: PropTypes.number,
+  bonusPoints: PropTypes.number,
   isGrader: PropTypes.bool, // Indicates whether the current user is a grader or not.
   graderView: PropTypes.bool, // Grader can set graderView to false to preview as student.
   showPublicTestCasesOutput: PropTypes.bool,
   canUpdate: PropTypes.bool,
+  bonusEndAt: PropTypes.string,
   dueAt: PropTypes.string,
   grade: PropTypes.number,
   gradedAt: PropTypes.string,

--- a/client/app/bundles/course/assessment/submission/reducers/grading.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading.js
@@ -9,9 +9,9 @@ function sum(array) {
   return array.filter(i => i).reduce((acc, i) => acc + i, 0);
 }
 
-function computeExp(questions, maximumGrade, basePoints, expMultiplier) {
+function computeExp(questions, maximumGrade, basePoints, expMultiplier, bonusAwarded = 0) {
   const totalGrade = sum(Object.values(questions).map(q => q.grade));
-  return Math.round((totalGrade / maximumGrade) * basePoints * expMultiplier);
+  return Math.round((totalGrade / maximumGrade) * basePoints * expMultiplier + bonusAwarded);
 }
 
 export default function (state = initialState, action) {
@@ -37,6 +37,7 @@ export default function (state = initialState, action) {
     }
     case actions.UPDATE_GRADING: {
       const { maximumGrade, basePoints, expMultiplier } = state;
+      const bonusAwarded = action.bonusAwarded;
       const questions = {
         ...state.questions,
         [action.id]: { ...state.questions[action.id], grade: action.grade },
@@ -45,7 +46,7 @@ export default function (state = initialState, action) {
       return {
         ...state,
         questions,
-        exp: computeExp(questions, maximumGrade, basePoints, expMultiplier),
+        exp: computeExp(questions, maximumGrade, basePoints, expMultiplier, bonusAwarded),
       };
     }
     case actions.UPDATE_EXP: {
@@ -56,10 +57,10 @@ export default function (state = initialState, action) {
     }
     case actions.UPDATE_MULTIPLIER: {
       const { questions, maximumGrade, basePoints } = state;
-
+      const bonusAwarded = action.bonusAwarded;
       return {
         ...state,
-        exp: computeExp(questions, maximumGrade, basePoints, action.multiplier),
+        exp: computeExp(questions, maximumGrade, basePoints, action.multiplier, bonusAwarded),
         expMultiplier: action.multiplier,
       };
     }

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -101,6 +101,10 @@ const translations = defineMessages({
     id: 'course.assessment.submission.grader',
     defaultMessage: 'Grader',
   },
+  bonusEndAt: {
+    id: 'course.assessment.submission.bonusEndAt',
+    defaultMessage: 'Bonus End At',
+  },
   dueAt: {
     id: 'course.assessment.submission.dueAt',
     defaultMessage: 'Due At',


### PR DESCRIPTION
Fixes https://github.com/Coursemology/coursemology2/issues/2825

Was: Manual grading panel does not know about assessment's time bonus at all.
Is: Grading panel will execute in sequence:
1. fetch assessment's 'time bonus' and 'bonus due at', 
2. compare 'submitted at' and 'bonus due at', 
3. compute bonus awarded and store in props, 
4. every time user changes a question's grade or multiplier, exp suggestion is recomputed inclusive of bonus awarded

Note: the 'Experience point awarded' displayed depends on whether student submitted in time for bonus.

Screenshot below is of a submission that got awarded 33/60 base exp and 40/40 bonus exp:
![image](https://user-images.githubusercontent.com/35135264/53715630-593d2100-3e8d-11e9-845c-9adf439052d9.png)


