### PR TITLE
Basic UI for question bundle assignments

### DIFF
--- a/app/controllers/concerns/course/assessment/question_bundle_assignment_concern.rb
+++ b/app/controllers/concerns/course/assessment/question_bundle_assignment_concern.rb
@@ -32,6 +32,8 @@ module Course::Assessment::QuestionBundleAssignmentConcern
   end
 
   class AssignmentRandomizer
+    attr_accessor :assignments, :students, :group_bundles
+
     def initialize(assessment)
       @assessment = assessment
       @students = assessment.course.user_ids

--- a/app/controllers/course/assessment/question_bundle_assignments_controller.rb
+++ b/app/controllers/course/assessment/question_bundle_assignments_controller.rb
@@ -1,23 +1,42 @@
 # frozen_string_literal: true
 class Course::Assessment::QuestionBundleAssignmentsController < Course::Assessment::Controller
+  include Course::Assessment::QuestionBundleAssignmentConcern
   load_and_authorize_resource :question_bundle_assignment, class: Course::Assessment::QuestionBundleAssignment,
                                                            through: :assessment
 
   before_action :add_breadcrumbs
 
   def index
-    @question_bundle_assignments = @question_bundle_assignments.order(:user_id, :submission_id, :bundle_id)
-  end
-
-  def new
+    # Reverse lookup of user_id -> course_user.name or user.name
+    # Retrieve for current course users, users with submissions, and users with bundle assignments
+    @name_lookup = User.where(id: @assessment.question_bundle_assignments.select(:user_id)).
+                   select(:id, :name).map { |u| [u.id, u.name] }.to_h.
+                   merge(@course.course_users.select(:user_id, :name).map { |cu| [cu.user_id, cu.name] }.to_h)
+    @question_group_lookup = @assessment.question_groups.select(:id, :title).map { |qg| [qg.id, qg.title] }.to_h
+    @question_bundle_lookup = @assessment.question_bundles.select(:id, :title).map { |qb| [qb.id, qb.title] }.to_h
+    @past_assignments = past_assignments_hash
+    @assignment_randomizer = AssignmentRandomizer.new(@assessment)
+    @assignment_set = @assignment_randomizer.load
   end
 
   def create
-    if @question_bundle_assignment.save
-      redirect_to course_assessment_question_bundle_assignments_path(current_course, @assessment)
-    else
-      render 'new'
+    assignment_set_params = params.require(:assignment_set).permit([:user_id, { bundles: {} }])
+    user = User.find(assignment_set_params[:user_id])
+    bundles = Course::Assessment::QuestionBundle.where(id: assignment_set_params[:bundles].values).
+              joins(:question_group).merge(Course::Assessment::QuestionGroup.where(assessment: @assessment))
+
+    user.transaction do
+      @assessment.question_bundle_assignments.where(submission: nil, user: user).delete_all
+      bundles.each do |bundle|
+        Course::Assessment::QuestionBundleAssignment.create!(
+          user: user,
+          assessment: @assessment,
+          question_bundle: bundle
+        )
+      end
     end
+
+    redirect_to course_assessment_question_bundle_assignments_path(current_course, @assessment)
   end
 
   def edit
@@ -40,15 +59,36 @@ class Course::Assessment::QuestionBundleAssignmentsController < Course::Assessme
     end
   end
 
+  def recompute
+    @assignment_randomizer = AssignmentRandomizer.new(@assessment)
+    @assignment_set = @assignment_randomizer.randomize
+    if params[:only_unassigned] == 'true'
+      current_set = @assignment_randomizer.load
+      @assessment.question_bundle_assignments.distinct.pluck(:user_id).each do |assigned_user_id|
+        @assignment_set.assignments[assigned_user_id] = current_set.assignments[assigned_user_id]
+      end
+    end
+    @assignment_randomizer.save(@assignment_set)
+    redirect_to course_assessment_question_bundle_assignments_path(current_course, @assessment)
+  end
+
   private
+
+  def past_assignments_hash
+    @group_bundles_lookup = @assessment.question_bundles.map { |bundle| [bundle.id, bundle.group_id] }.to_h
+    @assessment.submissions.eager_load(:question_bundle_assignments).map do |submission|
+      hash = { submission_id: submission.id, nil => [] }
+      submission.question_bundle_assignments.each do |qba|
+        group = @group_bundles_lookup[qba.bundle_id]
+        hash[group].nil? ? hash[group] = qba.bundle_id : hash[nil].append(qba.bundle_id)
+      end
+      [submission.creator_id, hash]
+    end.to_h
+  end
 
   def add_breadcrumbs
     add_breadcrumb(@assessment.title, course_assessment_path(current_course, @assessment))
     add_breadcrumb('Question Bundle Assignment',
                    course_assessment_question_bundle_assignments_path(current_course, @assessment))
-  end
-
-  def question_bundle_assignment_params
-    params.require(:question_bundle_assignment).permit(:user_id, :submission_id, :bundle_id)
   end
 end

--- a/app/views/course/assessment/question_bundle_assignments/index.html.slim
+++ b/app/views/course/assessment/question_bundle_assignments/index.html.slim
@@ -1,28 +1,72 @@
-= page_header 'Question Bundle Assignment'
+= page_header
 
-= link_to 'New Question Bundle Assignment',
-          new_course_assessment_question_bundle_assignment_path(current_course, @assessment),
-          class: %w(btn btn-primary)
+h2 = t('.prepared_bundle_assignments')
 
+= link_to t('.rerandomize_all'),
+          recompute_course_assessment_question_bundle_assignments_path,
+          method: :post, class: %w(btn btn-primary)
+=< link_to t('.rerandomize_unassigned'),
+           recompute_course_assessment_question_bundle_assignments_path(only_unassigned: true),
+           method: :post, class: %w(btn btn-primary)
+
+- has_unbundled = @assignment_set.assignments.lazy.map { |k, v| v[nil].present? }.any?
 table.table.table-hover
   thead
     tr
-      th = 'ID'
-      th = 'User'
-      th = 'Submission'
-      th = 'Question Bundle'
+      th = t('.user')
+      - @question_group_lookup.each do |_, question_group_title|
+        th = question_group_title
+      - if has_unbundled
+        th
+          span title=t('.unbundled_tooltip')
+            = t('.unbundled')
       th
   tbody
-    - @question_bundle_assignments.each do |question_bundle_assignment|
+    - @assignment_set.assignments.each do |user_id, assignment|
       tr
-        td = question_bundle_assignment.id
-        td = question_bundle_assignment.user.name
-        td = question_bundle_assignment.submission
-        td
-          = question_bundle_assignment.question_bundle.title
-          ul
-            - question_bundle_assignment.question_bundle.question_bundle_questions.order(:weight).each do |question_bundle_question|
-              li = question_bundle_question.question.title
-        td
-          = edit_button(edit_course_assessment_question_bundle_assignment_path(current_course, @assessment, question_bundle_assignment))
-          = delete_button(course_assessment_question_bundle_assignment_path(current_course, @assessment, question_bundle_assignment))
+        = simple_form_for :assignment_set do |f|
+          = f.hidden_field :user_id, value: user_id
+          td = @name_lookup[user_id]
+          = f.simple_fields_for :bundles do |g|
+            - @question_group_lookup.each do |question_group_id, question_group|
+              td = g.input_field "group_#{question_group_id}".to_sym,
+                      collection: @assignment_randomizer.group_bundles[question_group_id],
+                      label_method: lambda { |qbid| @question_bundle_lookup[qbid] },
+                      selected: assignment[question_group_id],
+                      include_blank: true,
+                      label: false
+          - if has_unbundled
+            td
+              ul
+                - assignment[nil].each do |bundle|
+                  li = @question_bundle_lookup[bundle]
+          td
+            = f.button :submit, id: 'update' do
+              = fa_icon 'save'.freeze
+
+h2 = t('.past_bundle_assignments')
+
+- past_has_unbundled = @past_assignments.lazy.map {|k, v| v[nil].present?}.any?
+table.table.table-hover
+  thead
+    tr
+      th = t('.user')
+      th = t('.submission_id')
+      - @question_group_lookup.each do |_, question_group_title|
+        th = question_group_title
+      - if has_unbundled
+        th
+          span title=t('.unbundled_tooltip')
+            = t('.unbundled')
+  tbody
+    - @past_assignments.each do |user_id, assignment|
+      tr
+        td = @name_lookup[user_id]
+        td = assignment[:submission_id]
+        - @question_group_lookup.each do |question_group_id, question_group|
+          td = @question_bundle_lookup[assignment[question_group_id]]
+        - if has_unbundled
+          td
+            ul
+              - assignment[nil].each do |bundle|
+                li = @question_bundle_lookup[bundle]

--- a/app/views/course/assessment/question_bundle_assignments/new.html.slim
+++ b/app/views/course/assessment/question_bundle_assignments/new.html.slim
@@ -1,5 +1,0 @@
-- add_breadcrumb 'New Question Bundle Assignment'
-= page_header 'New Question Bundle Assignment'
-
-= simple_form_for @question_bundle_assignment, url: course_assessment_question_bundle_assignments_path(current_course, @assessment) do |f|
-  = render partial: 'form', locals: { f: f }

--- a/config/locales/en/course/assessment/question_bundle_assignments.yml
+++ b/config/locales/en/course/assessment/question_bundle_assignments.yml
@@ -1,0 +1,15 @@
+en:
+  course:
+    assessment:
+      question_bundle_assignments:
+        index:
+          header: 'Question Bundle Assignments'
+          prepared_bundle_assignments: 'Prepared bundle assignments'
+          past_bundle_assignments: 'Past bundle assignments'
+          rerandomize_all: 'Re-randomize all'
+          rerandomize_unassigned: 'Re-randomize unassigned students'
+          user: 'User'
+          submission_id: 'Submission ID'
+          unbundled: 'Unbundled'
+          unbundled_tooltip: >
+            These are likely erroneously assigned bundles that don't fit into any existing question groups.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,7 +250,9 @@ Rails.application.routes.draw do
           resources :question_groups, except: :show
           resources :question_bundles, except: :show
           resources :question_bundle_questions, except: :show
-          resources :question_bundle_assignments, except: :show
+          resources :question_bundle_assignments, except: [:show, :new] do
+            post 'recompute', on: :collection
+          end
         end
         resources :categories, only: [:index]
       end


### PR DESCRIPTION
Todo: I have no idea why `f.input... as: :select` causes the form to ignore the bootstrap select field entirely upon submission, but I need to move on for now. Temporary workaround: `f.input_field` to remove the bootstrap select.

**Test Plan**
* Create 2 groups with 2 bundles respectively.
* Delete some QBAs for a specific user on the console. Index should show an empty user row.
* Create some duplicate QBAs for a specific user on the console. Index should place the duplicates in "unbundled".
* Saving the user row removes the unbundled QBAs.
* First button re-randomizes for all course users.
* Second button only randomizes for course users that have zero QBAs.

![image](https://user-images.githubusercontent.com/11096034/53682958-2896a380-3d36-11e9-86d5-cff073212a0b.png)

![image](https://user-images.githubusercontent.com/11096034/53683003-ae1a5380-3d36-11e9-9703-f05a178a08e8.png)

#autoretry