### PR TITLE
[2/2] QuestionBundleAssignment validations

### DIFF
--- a/app/assets/stylesheets/course/assessment/question_bundle_assignments.scss
+++ b/app/assets/stylesheets/course/assessment/question_bundle_assignments.scss
@@ -1,0 +1,14 @@
+.course-assessment-question-bundle-assignments {
+  .validation-desc {
+    margin-top: 5px;
+  }
+
+  .question-group-select {
+    display: inline-block;
+    width: 70%;
+  }
+
+  .question-group-errors {
+    display: inline-block;
+  }
+}

--- a/app/controllers/concerns/course/assessment/question_bundle_assignment_concern.rb
+++ b/app/controllers/concerns/course/assessment/question_bundle_assignment_concern.rb
@@ -2,6 +2,20 @@
 module Course::Assessment::QuestionBundleAssignmentConcern
   extend ActiveSupport::Concern
 
+  # All validations need to present a ValidationResult of this form, which will be consumed by the view.
+  # This struct is loosely inspired by Rails' model validation, but heavily extended.
+  # rubocop:disable Layout/CommentIndentation
+  ValidationResult = Struct.new(
+    :type,              # Hard or soft
+    :pass,              # Whether this should be displayed as a tick or cross on the validation summary
+    :score_penalty,     # For selecting the best randomized outcome
+    :info,              # For displaying additional information. I18n string.
+    :offending_cells,   # For highlighting the cell and displaying the error in a tooltip. I18n string.
+                        # E.g. { (student, group): 'Lift: 1.4' }
+    keyword_init: true
+  )
+  # rubocop:enable Layout/CommentIndentation
+
   # Computations on a large set of QBAs are expensive, and we need a lean in-memory representation of a set of QBAs.
   #
   # An AssignmentSet is a (thin) abstraction over a set of QBAs for an assessment which assumes consistency of the
@@ -10,7 +24,7 @@ module Course::Assessment::QuestionBundleAssignmentConcern
   # Essentially a nested hash of Student -> Group -> Bundle. Group is nil if assigned bundle is extraneous. Everything
   # is identified by an integer ID.
   class AssignmentSet
-    attr_accessor :assignments
+    attr_accessor :assignments, :group_bundles
 
     def initialize(students, group_bundles)
       @assignments = students.map { |x| [x, { nil => [] }] }.to_h
@@ -32,13 +46,19 @@ module Course::Assessment::QuestionBundleAssignmentConcern
   end
 
   class AssignmentRandomizer
-    attr_accessor :assignments, :students, :group_bundles
+    attr_accessor :assignments, :students, :group_bundles, :name_lookup
 
     def initialize(assessment)
       @assessment = assessment
       @students = assessment.course.user_ids
       @group_bundles = assessment.question_group_ids.map { |x| [x, []] }.to_h
       assessment.question_bundles.each { |bundle| @group_bundles[bundle.group_id].append(bundle.id) }
+
+      # Reverse lookup of user_id -> course_user.name or user.name
+      # Retrieve for current course users, users with submissions, and users with bundle assignments
+      @name_lookup = User.where(id: @assessment.question_bundle_assignments.select(:user_id)).
+                     pluck(:id, :name).to_h.
+                     merge(@assessment.course.course_users.pluck(:user_id, :name).to_h)
     end
 
     def load
@@ -76,6 +96,113 @@ module Course::Assessment::QuestionBundleAssignmentConcern
           end
         end
       end
+    end
+
+    def validate(assignment_set)
+      [
+        validate_no_overlapping_questions,
+        validate_no_empty_groups,
+        validate_one_bundle_assigned(assignment_set),
+        validate_no_repeat_bundles(assignment_set)
+      ].reduce(&:merge)
+    end
+
+    private
+
+    def validate_no_overlapping_questions
+      questions = Course::Assessment::Question.
+                  where(id: @assessment.question_bundle_questions.group(:question_id).
+                            having('count(*) > 1').
+                            select(:question_id)).
+                  pluck(:title).
+                  to_sentence
+      {
+        no_overlapping_questions:
+          ValidationResult.new(
+            type: :hard,
+            pass: questions.empty?,
+            info: questions.empty? ? nil : t_scoped('.no_overlapping_questions.fail', questions: questions)
+          )
+      }
+    end
+
+    def validate_no_empty_groups
+      groups = @assessment.question_groups.
+               where.not(id: @assessment.question_bundles.select(:group_id)).
+               pluck(:title).to_sentence
+      {
+        no_empty_groups:
+          ValidationResult.new(
+            type: :hard,
+            pass: groups.empty?,
+            info: groups.empty? ? nil : t_scoped('.no_empty_groups.fail', groups: groups)
+          )
+      }
+    end
+
+    def validate_one_bundle_assigned(assignment_set)
+      student_ids = Set.new
+      offending_cells = {}
+      assignment_set.assignments.each do |student_id, assignment|
+        assignment_set.group_bundles.keys.each do |group_bundle|
+          if assignment[group_bundle].nil?
+            student_ids << student_id
+            offending_cells[[student_id, group_bundle]] = t_scoped('.one_bundle_assigned.missing_bundle')
+          end
+        end
+        if assignment[nil].present?
+          student_ids << student_id
+          offending_cells[[student_id, nil]] = t_scoped('.one_bundle_assigned.unbundled')
+        end
+      end
+      students = student_ids.map { |student_id| @name_lookup[student_id] }.to_sentence
+      {
+        one_bundle_assigned:
+          ValidationResult.new(
+            type: :hard,
+            pass: students.empty?,
+            info: students.empty? ? nil : t_scoped('.one_bundle_assigned.fail', students: students),
+            offending_cells: offending_cells
+          )
+      }
+    end
+
+    def validate_no_repeat_bundles(assignment_set)
+      attempted_questions = {}
+      @assessment.question_bundle_assignments.where.not(submission: nil).pluck(:user_id, :bundle_id).
+        each do |user_id, bundle_id|
+        attempted_questions[user_id] ||= Set.new
+        attempted_questions[user_id] << bundle_id
+      end
+      student_ids = Set.new
+      offending_cells = {}
+      assignment_set.assignments.each do |student_id, assignment|
+        assignment_set.group_bundles.keys.each do |group_bundle|
+          if assignment[group_bundle].present? && assignment[group_bundle].in?(attempted_questions[student_id] || [])
+            student_ids << student_id
+            offending_cells[[student_id, group_bundle]] = t_scoped('.no_repeat_bundles.repeat_bundle')
+          end
+        end
+        if assignment[nil].present? && assignment[nil].any? { |b| b.in?(attempted_questions[student_id] || []) }
+          student_ids << student_id
+          offending_cells[[student_id, nil]] = t_scoped('.no_repeat_bundles.repeat_bundle')
+        end
+      end
+      students = student_ids.map { |student_id| @name_lookup[student_id] }.to_sentence
+      {
+        no_repeat_bundles:
+          ValidationResult.new(
+            type: :hard,
+            pass: students.empty?,
+            info: students.empty? ? nil : t_scoped('.no_repeat_bundles.fail', students: students),
+            offending_cells: offending_cells
+          )
+      }
+    end
+
+    # We can't use the default I18n lazy lookups because this is a concern, so we roll our own.
+    def t_scoped(key, *args, **kwargs)
+      I18n.t("course.assessment.question_bundle_assignments.validations#{key}", *args, **kwargs)
     end
   end
 end

--- a/app/views/course/assessment/question_bundle_assignments/_validation_result.html.slim
+++ b/app/views/course/assessment/question_bundle_assignments/_validation_result.html.slim
@@ -1,0 +1,5 @@
+li.validation-desc
+  = fa_icon (result.pass ? 'check'.freeze : 'times'.freeze), class: 'fa-li'
+  = t("course.assessment.question_bundle_assignments.validations.#{validation_id}.desc")
+- if result.info.present?
+  li = result.info

--- a/app/views/course/assessment/question_bundle_assignments/index.html.slim
+++ b/app/views/course/assessment/question_bundle_assignments/index.html.slim
@@ -24,12 +24,14 @@ table.table.table-hover
   tbody
     - @assignment_set.assignments.each do |user_id, assignment|
       tr
-        = simple_form_for :assignment_set do |f|
+        = simple_form_for :assignment_set, html: { id: "asg_set_#{user_id}" },
+                                           defaults: { input_html: { form: "asg_set_#{user_id}" } } do |f|
           = f.hidden_field :user_id, value: user_id
           td = @name_lookup[user_id]
           = f.simple_fields_for :bundles do |g|
             - @question_group_lookup.each do |question_group_id, question_group|
-              td = g.input_field "group_#{question_group_id}".to_sym,
+              td
+                = g.input "group_#{question_group_id}".to_sym,
                       collection: @assignment_randomizer.group_bundles[question_group_id],
                       label_method: lambda { |qbid| @question_bundle_lookup[qbid] },
                       selected: assignment[question_group_id],

--- a/app/views/course/assessment/question_bundle_assignments/index.html.slim
+++ b/app/views/course/assessment/question_bundle_assignments/index.html.slim
@@ -9,6 +9,11 @@ h2 = t('.prepared_bundle_assignments')
            recompute_course_assessment_question_bundle_assignments_path(only_unassigned: true),
            method: :post, class: %w(btn btn-primary)
 
+h3 = t('.validations')
+ul.fa-ul
+  - @validation_results.each do |validation_id, result|
+    = render partial: 'validation_result', locals: { validation_id: validation_id, result: result }
+
 - has_unbundled = @assignment_set.assignments.lazy.map { |k, v| v[nil].present? }.any?
 table.table.table-hover
   thead
@@ -31,14 +36,25 @@ table.table.table-hover
           = f.simple_fields_for :bundles do |g|
             - @question_group_lookup.each do |question_group_id, question_group|
               td
-                = g.input "group_#{question_group_id}".to_sym,
-                      collection: @assignment_randomizer.group_bundles[question_group_id],
-                      label_method: lambda { |qbid| @question_bundle_lookup[qbid] },
-                      selected: assignment[question_group_id],
-                      include_blank: true,
-                      label: false
+                div.question-group-select
+                  = g.input "group_#{question_group_id}".to_sym,
+                        collection: @assignment_randomizer.group_bundles[question_group_id],
+                        label_method: lambda { |qbid| @question_bundle_lookup[qbid] },
+                        selected: assignment[question_group_id],
+                        include_blank: true,
+                        label: false
+                - if @aggregated_offending_cells[[user_id, question_group_id]].present?
+                  div.question-group-errors
+                    - @aggregated_offending_cells[[user_id, question_group_id]].each do |error_string|
+                      span title=error_string
+                        = fa_icon 'exclamation-triangle'.freeze
           - if has_unbundled
             td
+              - if @aggregated_offending_cells[[user_id, question_group_id]].present?
+                - @aggregated_offending_cells[[user_id, question_group_id]].each do |error_string|
+                  span title=error_string
+                    = fa_icon 'exclamation-triangle'.freeze
+                br
               ul
                 - assignment[nil].each do |bundle|
                   li = @question_bundle_lookup[bundle]

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -104,6 +104,8 @@ ignore_unused:
 - 'activemodel.errors.*'
 # Used dynamically by the page_header helper
 - '*.*.header'
+# Dynamically constructed using t_scoped
+- 'course.assessment.question_bundle_assignments.validations.*'
 
 # I18n-tasks gives the wrong results for normal (non action) methods in the controller, ignore them here.
 - 'course.user_invitations.create.*'

--- a/config/locales/en/course/assessment/question_bundle_assignments.yml
+++ b/config/locales/en/course/assessment/question_bundle_assignments.yml
@@ -6,6 +6,7 @@ en:
           header: 'Question Bundle Assignments'
           prepared_bundle_assignments: 'Prepared bundle assignments'
           past_bundle_assignments: 'Past bundle assignments'
+          validations: 'Validations'
           rerandomize_all: 'Re-randomize all'
           rerandomize_unassigned: 'Re-randomize unassigned students'
           user: 'User'
@@ -13,3 +14,20 @@ en:
           unbundled: 'Unbundled'
           unbundled_tooltip: >
             These are likely erroneously assigned bundles that don't fit into any existing question groups.
+
+        validations:
+          no_overlapping_questions:
+            desc: 'Question bundles do not have overlapping questions'
+            fail: 'Questions belonging to multiple bundles: %{questions}'
+          no_empty_groups:
+            desc: 'Question groups should contain at least one bundle'
+            fail: 'Groups with no bundle: %{groups}'
+          one_bundle_assigned:
+            desc: 'All students have exactly one bundle assigned per question group'
+            fail: 'Misassigned students: %{students}'
+            missing_bundle: 'Missing bundle'
+            unbundled: 'Unbundled'
+          no_repeat_bundles:
+            desc: 'Students must not be assigned a bundle that was previously attempted'
+            fail: 'Students with repeat bundles: %{students}'
+            repeat_bundle: 'Student has attempted this bundle previously'


### PR DESCRIPTION
As discussed offline, some validations may have complicated information to display to the user such that returning an error hash to be i18nized by the view is too complicated (this was implemented in a separate branch that has been abandoned due to the abstraction becoming more and more leaky). The compromise is for the QBA concern to return i18nized strings directly for consumption by the view.

**Test Plan**

![image](https://user-images.githubusercontent.com/11096034/54023515-1a320700-41d0-11e9-9b88-9131c0db5406.png)

#autoretry