### PR TITLE
Redirect on forum unsubscribe link

### DIFF
--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -60,7 +60,13 @@ class Course::Forum::ForumsController < Course::Forum::Controller
     else
       flash.now[:danger] = t('.failure')
     end
-    render 'update_subscribe_button'
+    if request.get?
+      # When forum unsubscribe link is clicked from email
+      redirect_to course_forum_path(current_course, @forum),
+                  success: t('.success', name: @forum.name)
+    else
+      render 'update_subscribe_button'
+    end
   end
 
   def search

--- a/spec/features/course/forum_management_spec.rb
+++ b/spec/features/course/forum_management_spec.rb
@@ -161,6 +161,17 @@ RSpec.feature 'Course: Forum: Management' do
         expect(Course::Forum::Subscription.where(user: user, forum: forum).empty?).to eq(true)
       end
 
+      scenario 'I can click unsubscribe forum link from an email' do
+        forum = create(:forum, course: course)
+        forum.subscriptions.create(user: user)
+        visit unsubscribe_course_forum_path(course, forum)
+        expect(current_path).to eq(course_forum_path(course, forum))
+        expect(page).to have_selector('div.alert.alert-success')
+        expect(page).to have_link(nil, href: subscribe_course_forum_path(course, forum))
+        expect(page).to have_text(I18n.t('course.forum.forums.unsubscribe.success'))
+        expect(Course::Forum::Subscription.where(user: user, forum: forum).empty?).to eq(true)
+      end
+
       scenario 'I can mark all forum topics in the course as read' do
         forum1 = create(:forum, course: course)
         forum2 = create(:forum, course: course)


### PR DESCRIPTION
Fixes https://github.com/Coursemology/coursemology2/issues/3393

Clicking unsubscribe link from email currently generates an error:
![image](https://user-images.githubusercontent.com/35135264/54012478-1e026100-41b1-11e9-89a2-5013a5772437.png)

Upon checking request method and redirect on GET:
![image](https://user-images.githubusercontent.com/35135264/54012504-3f634d00-41b1-11e9-9597-93e090550501.png)
