### PR TITLE
[1/2] Use form-attribute to target form within table

### DIFF
--- a/app/views/course/assessment/question_bundle_assignments/index.html.slim
+++ b/app/views/course/assessment/question_bundle_assignments/index.html.slim
@@ -24,12 +24,14 @@ table.table.table-hover
   tbody
     - @assignment_set.assignments.each do |user_id, assignment|
       tr
-        = simple_form_for :assignment_set do |f|
+        = simple_form_for :assignment_set, html: { id: "asg_set_#{user_id}" },
+                                           defaults: { input_html: { form: "asg_set_#{user_id}" } } do |f|
           = f.hidden_field :user_id, value: user_id
           td = @name_lookup[user_id]
           = f.simple_fields_for :bundles do |g|
             - @question_group_lookup.each do |question_group_id, question_group|
-              td = g.input_field "group_#{question_group_id}".to_sym,
+              td
+                = g.input "group_#{question_group_id}".to_sym,
                       collection: @assignment_randomizer.group_bundles[question_group_id],
                       label_method: lambda { |qbid| @question_bundle_lookup[qbid] },
                       selected: assignment[question_group_id],


### PR DESCRIPTION
Fixes the workaround in #3404 

**Test Plan**
* Selectpickers are now correctly validated for "required" on form submission
* Select field is no longer ignored on form submission (params are correctly sent in POST)

![image](https://user-images.githubusercontent.com/11096034/54023469-ff5f9280-41cf-11e9-8a19-894584c5290e.png)

#autoretry