### PR TITLE
Move element ID to outer div

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
+++ b/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
@@ -122,9 +122,9 @@ class SubmissionAnswer extends Component {
   renderMissingAnswerPanel() {
     const { intl } = this.props;
     return (
-      <Card style={{ backgroundColor: yellow100 }}>
+      <Card id="missing-answer" style={{ backgroundColor: yellow100 }}>
         <CardText>
-          <span id="missing-answer">{intl.formatMessage(translations.missingAnswer)}</span>
+          <span>{intl.formatMessage(translations.missingAnswer)}</span>
         </CardText>
       </Card>
     );


### PR DESCRIPTION
Bootstrap-sass upgrade saw specs fail due to capybara unable to find elements in page.
IDs were added to elements to assist specs in https://github.com/Coursemology/coursemology2/commit/0c78bc2515d8e1d22335f7ef64ec45045dd60826
Sometimes deep-nested elements are still not found, even though it is visible in capybara screenshot.

This PR attempts to bring the ID out of nested elements, hopefully we'll no longer see the following spec failure:
`Course: Assessment: Submissions: Manually Graded Assessments with tenant :instance As a Course Staff I can grade the student's work`