### PR TITLE
Update simple_form-bootstrap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/Coursemology/simple_form-bootstrap
-  revision: ba048ab714904d9e4fc1407bee33e7b5a1f832b9
+  revision: b2a6f2b53ad599955b8cc288a352a701e52a9693
   specs:
     simple_form-bootstrap (1.6.0)
       actionpack (>= 4.1, < 6)
@@ -188,7 +188,7 @@ GEM
       json
       simplecov
       url
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     consistency_fail (0.3.7)
     coursemology-polyglot (0.2.9.4)
       activesupport (>= 4.2, < 6)
@@ -227,7 +227,7 @@ GEM
       railties (>= 4.2.0)
     faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
+    ffi (1.10.0)
     filename (0.1.2)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
@@ -334,7 +334,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -466,8 +466,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.0)
-      ffi (~> 1.9.6)
+    sassc (2.0.1)
+      ffi (~> 1.9)
       rake
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)

--- a/spec/features/course/assessment/submission/past_answers_spec.rb
+++ b/spec/features/course/assessment/submission/past_answers_spec.rb
@@ -32,10 +32,8 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
             expect(page).to have_selector('div.toggle-history')
             find('div.toggle-history').click
             expect(page).to have_selector('label', text: 'Past Answers')
-            first('button[tabindex="0"]').click if step_number == 2
           end
         end
-        expect(page).to have_selector(%(div[role="menu"]))
       end
     end
 
@@ -49,10 +47,8 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
             expect(page).to have_selector('div.toggle-history')
             find('div.toggle-history').click
             expect(page).to have_selector('label', text: 'Past Answers')
-            first('button[tabindex="0"]').click if step_number == 2
           end
         end
-        expect(page).to have_selector(%(div[role="menu"]))
       end
     end
   end


### PR DESCRIPTION
simple_form-bootstrap was updated to support bootstrap-sass 3.4.1
https://github.com/Coursemology/simple_form-bootstrap/pull/1

This PR updates simple_form-bootstrap SHA and removes some flaky expect statements