### PR TITLE
Fix assets precompile needing a database connection.

### DIFF
--- a/app/models/concerns/application_userstamp_concern.rb
+++ b/app/models/concerns/application_userstamp_concern.rb
@@ -15,7 +15,12 @@ module ApplicationUserstampConcern
 
     def add_userstamp_associations(options)
       options.reverse_merge!(inverse_of: false)
-      super(options)
+      # Skip calling `add_userstamp_associations` in the gem during assets precompile.
+      # The env variable RAILS_GROUPS is set to 'assets'.
+      # https://github.com/lowjoel/activerecord-userstamp/blob/master/lib/active_record/userstamp/stampable.rb#L76
+      # calls https://github.com/lowjoel/activerecord-userstamp/blob/master/lib/active_record/userstamp/utilities.rb#L31
+      # which needs a database connection, needlessly complicating the build.
+      super(options) unless ENV['RAILS_GROUPS'] == 'assets'
     end
   end
 end


### PR DESCRIPTION
`rake assets:precompile` would fail without access to a database. This has been traced to https://github.com/lowjoel/activerecord-userstamp/blob/master/lib/active_record/userstamp/utilities.rb#L31 calling `column_names`.

This was previously worked around by giving the build environment access to a database, but this added a lot of complexity to the build. E.g. The Docker builds needed to use `docker-compose` to ensure access to a database container and could not use multistage builds.

This PR attempts to address this by stopping the function from being called during assets precompile, which can be recognised in our build scripts as they pass the environment variable `RAILS_GROUPS=assets`.