### PR TITLE
Only overwrite the session token after submission is saved successfully

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -36,7 +36,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   end
 
   def create
-    @submission.session_id = authentication_service.generate_authentication_token!
+    @submission.session_id = authentication_service.generate_authentication_token
 
     success = false
     if @assessment.randomization == 'prepared'
@@ -56,6 +56,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     end
 
     if success
+      authentication_service.save_token_to_session(@submission.session_id)
       log_service.log_submission_access(request) if @assessment.session_password_protected?
       redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission,
                                                          new_submission: true)


### PR DESCRIPTION
Now that there's a chance when a user clicks the submission "attempt" button multiple times, his/her session token will be overwrite by the later request and become inconsistent with the token in the submission.  

After this PR, the user side token will only be saved when the submission is updated successfully. 