### PR TITLE
Guard against course_user=nil

### DIFF
--- a/app/notifiers/course/forum/post_notifier.rb
+++ b/app/notifiers/course/forum/post_notifier.rb
@@ -11,7 +11,7 @@ class Course::Forum::PostNotifier < Notifier::Base
     activity = create_activity(actor: user, object: post, event: :replied)
     activity.notify(course, :feed) if course_user && !course_user.phantom?
 
-    if email_notification_enabled?(course_user)
+    if email_notification_enabled?(course_user, course)
       post.topic.subscriptions.includes(:user).each do |subscription|
         activity.notify(subscription.user, :email) unless subscription.user == user
       end
@@ -22,9 +22,7 @@ class Course::Forum::PostNotifier < Notifier::Base
 
   private
 
-  def email_notification_enabled?(course_user)
-    course = course_user.course
-
+  def email_notification_enabled?(course_user, course)
     response = settings_with_key(course, :post_replied)
     response &&= settings_with_key(course, :post_phantom_replied) if course_user&.phantom?
     response

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -11,7 +11,7 @@
 - post_author = format_inline_text(post.author_name)
 
 - message.subject = t('.subject', course: course_title, topic: topic_title)
-- message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
+- message.subject += ' ' + t('notifiers.course.phantom') if course_user&.phantom?
 
 = format_html(t('.message',
                 topic: link_to(topic_title,


### PR DESCRIPTION
Fix https://github.com/Coursemology/coursemology2/issues/3548

This PR adds a guard in post notifier when course_user is nil (system admin posting in a course).