### PR TITLE
Remove tags from course description on course index page.

### DIFF
--- a/app/views/course/courses/_course.html.slim
+++ b/app/views/course/courses/_course.html.slim
@@ -8,4 +8,4 @@
       h4 = format_inline_text(course.title)
       - unless course.description.blank?
         div.description
-          = format_html(course.description)
+          = strip_tags(course.description)


### PR DESCRIPTION
Prevents image attachments which might require sign in from appearing
and causing an image download upon sign in.

Fixes #3593 