### PR TITLE
Fix summer note inlineCodeButton

### DIFF
--- a/app/assets/javascripts/layout.js
+++ b/app/assets/javascripts/layout.js
@@ -4,7 +4,7 @@
 (function($, EVENT_HELPERS) {
   'use strict';
 
-  function inlineCodeButton(context) {
+  function inlineCodeButton() {
     var ui = $.summernote.ui;
 
     var button = ui.button({
@@ -15,14 +15,15 @@
       tooltip: 'Inline Code',
       click: function() {
         var node = $(window.getSelection().getRangeAt(0).commonAncestorContainer);
+        var smrNote = $('.summernote-initialised');
         if(node.parent().is('code')) {
           node.unwrap();
         } else {
-          var range = context.invoke('editor.createRange'), text = range.toString();
+          var range = smrNote.summernote('editor.createRange'), text = range.toString();
           if (text !== '') {
             var newNode = $('<code></code>').eq(0);
             newNode.text(text);
-            context.invoke('editor.insertNode', newNode.get(0));
+            smrNote.summernote('editor.insertNode', newNode.get(0));
           }
         }
       },

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -79,7 +79,7 @@ class MaterialSummernote extends React.Component {
   }
 
   /* eslint class-methods-use-this: "off" */
-  inlineCodeButton(context) {
+  inlineCodeButton() {
     const ui = $.summernote.ui;
 
     const button = ui.button({
@@ -90,15 +90,16 @@ class MaterialSummernote extends React.Component {
       tooltip: this.props.intl.formatMessage(translations.inlineCode),
       click: () => {
         const node = $(window.getSelection().getRangeAt(0).commonAncestorContainer);
+        const smrNote = this.reactSummernote.editor;
         if (node.parent().is('code')) {
           node.unwrap();
         } else {
-          const range = context.invoke('editor.createRange');
+          const range = smrNote.summernote('editor.createRange');
           const text = range.toString();
           if (text !== '') {
             const newNode = $('<code></code>').eq(0);
             newNode.text(text);
-            context.invoke('editor.insertNode', newNode.get(0));
+            smrNote.summernote('editor.insertNode', newNode.get(0));
           }
         }
       },


### PR DESCRIPTION
> passing context to event handler is deprecated as of Summernote ~0.8
https://stackoverflow.com/a/35280482

Fix summernote inlineCodeButton in both jquery and summernote react

Closes https://github.com/Coursemology/coursemology2/issues/3621