### PR TITLE
Disable evaluator containers from using worker swap

### DIFF
--- a/lib/autoload/coursemology_docker_container.rb
+++ b/lib/autoload/coursemology_docker_container.rb
@@ -40,7 +40,11 @@ class CoursemologyDockerContainer < Docker::Container
                                               image: image) do |payload|
         options = { 'Image' => image }
         options['Cmd'] = argv if argv.present?
-        options['HostConfig'] = { 'memory': CONTAINER_MEMORY_LIMIT, 'LogConfig': LOG_CONFIG }
+        options['HostConfig'] = {
+          'memory': CONTAINER_MEMORY_LIMIT,
+          'memory-swap': CONTAINER_MEMORY_LIMIT,
+          'LogConfig': LOG_CONFIG
+        }
         options['NetworkDisabled'] = true
 
         payload[:container] = super(options)


### PR DESCRIPTION
Evaluations running on worker's swap is significantly slower than expected, which might exceed time limit and appears to students as if their code took too long.

This PR prevents evaluator containers from using swap.
Refer to: https://docs.docker.com/config/containers/resource_constraints/#prevent-a-container-from-using-swap