### PR TITLE
Show only a shortlist of todos on home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@
 /log/*.log
 /tmp
 
+# Ignore ruby-version file
+/.ruby-version
+
+# Ignore byebug_history file
+/.byebug_history
+
 # Ignore generated documentation
 /.yardoc/*
 /doc/*

--- a/app/assets/stylesheets/course/courses.scss
+++ b/app/assets/stylesheets/course/courses.scss
@@ -35,6 +35,10 @@
         }
       }
     }
+
+    .see-more {
+      width: 100%;
+    }
   }
 
   &.index {

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -45,9 +45,12 @@ class Course::CoursesController < Course::Controller
 
   def load_todos
     return unless current_course_user&.student?
-    @todos = Course::LessonPlan::Todo.pending_for(current_course_user).
-             includes(:user, item: :course)
+    todos = Course::LessonPlan::Todo.pending_for(current_course_user).
+            includes(:user, item: :course).order(updated_at: :desc)
     # TODO: Fix n+1 query for #can_user_start?
-    @todos = @todos.select(&:can_user_start?)
+    todos = todos.select(&:can_user_start?)
+    @video_todos = todos.select { |td| td.item.actable_type == Course::Video.name }
+    @assessment_todos = todos.select { |td| td.item.actable_type == Course::Assessment.name }
+    @survey_todos = todos.select { |td| td.item.actable_type == Course::Survey.name }
   end
 end

--- a/app/views/course/courses/_latest_todos.slim
+++ b/app/views/course/courses/_latest_todos.slim
@@ -1,0 +1,15 @@
+- if todos && !todos.empty?
+  h2 = t('.pending_task_type', task_type: todo_type)
+  table.table.table-hover.pending-tasks
+    thead
+      tr
+        th = t('.pending_tasks_title')
+        th.text-center = t('.pending_tasks_start_at')
+        th.text-center = t('.pending_tasks_end_at')
+        th
+    tbody
+      = render todos.first(5)
+- if todos.size > 5
+  = link_to t('.more_tasks', unlisted_count: todos.size - 5),
+    see_more_path,
+    class: ['btn', 'btn-info', 'see-more']

--- a/app/views/course/courses/show.html.slim
+++ b/app/views/course/courses/show.html.slim
@@ -21,17 +21,17 @@
         = render partial: @currently_active_announcements,
                  spacer_template: 'announcements/announcement_spacer'
 
-    - if @todos && !@todos.empty?
-      h2 = t('.pending_tasks')
-      table.table.table-hover.pending-tasks
-        thead
-          tr
-            th = t('.pending_tasks_title')
-            th.text-center = t('.pending_tasks_start_at')
-            th.text-center = t('.pending_tasks_end_at')
-            th
-        tbody
-          = render @todos
+    - if @assessment_todos && !@assessment_todos.empty?
+      = render partial: 'latest_todos',
+        locals: { todos: @assessment_todos, todo_type: 'Assessments', see_more_path: course_assessments_path(current_course) }
+
+    - if @video_todos && !@video_todos.empty?
+      = render partial: 'latest_todos',
+        locals: { todos: @video_todos, todo_type: 'Videos', see_more_path: course_videos_path(current_course) }
+
+    - if @survey_todos && !@survey_todos.empty?
+      = render partial: 'latest_todos',
+        locals: { todos: @survey_todos, todo_type: 'Surveys', see_more_path: course_surveys_path(current_course) }
 
     - if @activity_feeds && !@activity_feeds.empty?
       h2 = t('.activities')

--- a/app/views/course/video/videos/_todo_video_button.html.slim
+++ b/app/views/course/video/videos/_todo_video_button.html.slim
@@ -1,3 +1,3 @@
 - video = todo_video_button
-= render partial: 'course/video/videos/video_attempt_button',
-         locals: { video: video }
+= link_to t('.watch'), course_video_submissions_path(current_course, video),
+  class: ['btn', 'btn-info'], method: :post

--- a/config/locales/en/course/courses.yml
+++ b/config/locales/en/course/courses.yml
@@ -21,7 +21,9 @@ en:
         instructors: 'Instructors'
         announcements: 'Announcements'
         activities: 'Latest Activity'
-        pending_tasks: 'Pending Tasks'
+      latest_todos:
+        pending_task_type: 'Pending %{task_type}'
         pending_tasks_title: 'Title'
         pending_tasks_start_at: 'Start At'
         pending_tasks_end_at: 'End At'
+        more_tasks: 'See all (%{unlisted_count} more pending)'

--- a/config/locales/en/course/video/videos.yml
+++ b/config/locales/en/course/video/videos.yml
@@ -27,6 +27,8 @@ en:
         destroy:
           success: '%{title} was deleted.'
           failure: 'Could not delete video: %{error}'
+        todo_video_button:
+          watch: 'Watch'
         video_attempt_button:
           watch: 'Watch'
           rewatch: 'Re-Watch'
@@ -34,6 +36,6 @@ en:
           url_placeholder: >
             Please provide a valid youtube URL,
             eg. https://www.youtube.com/watch?v=dQw4w9WgXcQ
-          url_change_warning:  >
+          url_change_warning: >
             Warning: Changing url for this video would cause all its submissions and
             sessions data to be destroyed.

--- a/spec/features/course/homepage_spec.rb
+++ b/spec/features/course/homepage_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature 'Course: Homepage' do
         # Reload page to load other todos
         visit course_path(course)
         within find(content_tag_selector(video_todo)) do
-          expect(page).to have_text(I18n.t('course.video.videos.video_attempt_button.watch'))
+          expect(page).to have_text(I18n.t('course.video.videos.todo_video_button.watch'))
         end
 
         within find(content_tag_selector(survey_todo)) do


### PR DESCRIPTION
This PR reduces TTFB on home page when users log in by showing last 5 todos created of each type: videos, assessments, surveys
![image](https://user-images.githubusercontent.com/35135264/64520513-ebd0e800-d328-11e9-9e0c-cc30f7b203a1.png)

The long TTFB comes from N+1 when actables are loaded per todo item in their respective partials, to get their reference and personal times.