### PR TITLE
Revert "Disable evaluator containers from using worker swap"

### DIFF
--- a/lib/autoload/coursemology_docker_container.rb
+++ b/lib/autoload/coursemology_docker_container.rb
@@ -40,11 +40,7 @@ class CoursemologyDockerContainer < Docker::Container
                                               image: image) do |payload|
         options = { 'Image' => image }
         options['Cmd'] = argv if argv.present?
-        options['HostConfig'] = {
-          'memory': CONTAINER_MEMORY_LIMIT,
-          'memory-swap': CONTAINER_MEMORY_LIMIT,
-          'LogConfig': LOG_CONFIG
-        }
+        options['HostConfig'] = { 'memory': CONTAINER_MEMORY_LIMIT, 'LogConfig': LOG_CONFIG }
         options['NetworkDisabled'] = true
 
         payload[:container] = super(options)


### PR DESCRIPTION
Reverts Coursemology/coursemology2#3640

c_cpp package evaluator uses the same container config, yet they need to use swap.

Occasional answer evaluation failures were no longer observed after more memory is added to worker servers.