### PR TITLE
Pass decoded url to Carrierwave::Downloader

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -47,7 +47,8 @@ class ImageUploader < CarrierWave::Uploader::Base
     when 'CarrierWave::Storage::File'
       cache!(File.new(other_uploader.file.path))
     when 'CarrierWave::Storage::Fog', 'CarrierWave::Storage::AWS'
-      download!(other_uploader.url)
+      # Decode url to prevent double-encoding after carrierwave 2.0 upgrade
+      download!(CGI.unescape(other_uploader.url))
     end
   end
 


### PR DESCRIPTION
Carrierwave::Downloader#process_uri encodes uri again (https://github.com/carrierwaveuploader/carrierwave/blob/c4b6d91bd7ed759bb83a440800c450c79a987dd8/lib/carrierwave/downloader/base.rb#L40-L47), so the url passed in ImageUploader#duplicate_from must be unencoded.