### PR TITLE
Store query result in variables to reduce N+1

### DIFF
--- a/app/views/course/lesson_plan/items/_personal_or_ref_time.html.slim
+++ b/app/views/course/lesson_plan/items/_personal_or_ref_time.html.slim
@@ -1,9 +1,11 @@
-- if item.time_for(course_user).is_a? Course::PersonalTime and item.time_for(course_user).fixed?
+- effective_time = item.time_for(course_user)
+- reference_time = item.reference_time_for(course_user)
+- if effective_time.is_a? Course::PersonalTime and effective_time.fixed?
   span title=t('course.lesson_plan.items.fixed_desc')
     = fa_icon 'lock'
-=< format_datetime(item.time_for(course_user)[attribute], datetime_format)
-- if item.time_for(course_user)[attribute] != item.reference_time_for(course_user)[attribute]
+=< format_datetime(effective_time[attribute], datetime_format)
+- if effective_time[attribute] != reference_time[attribute]
   br
   strike
     = t('course.lesson_plan.items.ref')
-    = format_datetime(item.reference_time_for(course_user)[attribute], datetime_format)
+    = format_datetime(reference_time[attribute], datetime_format)


### PR DESCRIPTION
Currently, when a student on personalized timeline loads assessment index, many queries are fired for each assessment from _personal_or_ref_time and _assessment_management_buttons:
![image](https://user-images.githubusercontent.com/35135264/65027380-cec19800-d96c-11e9-9c36-aedd9dedffab.png)
On localhost a heavy index such as 1010s' takes around 10s.

This PR stores personal_time and reference_time in a variable to reduce partial load time.
![image](https://user-images.githubusercontent.com/35135264/65027655-527b8480-d96d-11e9-8e7c-c4c0fba9bdf5.png)

It can be seen that partials take longer to load more queries, even if all of them are cached.
1010s assessment index see a 2s reduction after the number of cached queries is reduced.