### PR TITLE
Fix assessment todo button

### DIFF
--- a/app/views/course/assessment/assessments/_todo_assessment_button.html.slim
+++ b/app/views/course/assessment/assessments/_todo_assessment_button.html.slim
@@ -1,12 +1,9 @@
 - assessment = todo_assessment_button
 - if todo.not_started?
-  - if assessment.session_password_protected?
-    = link_to t('.attempt'), new_course_assessment_session_path(current_course, assessment),
-              class: ['btn', 'btn-info']
-  - elsif cannot?(:access, assessment) && can?(:attempt, assessment)
+  - if cannot?(:access, assessment) && can?(:attempt, assessment)
     = link_to t('.enter_password'), course_assessment_path(current_course, assessment),
               class: ['btn', 'btn-info']
-  - else
+  - elsif can?(:attempt, assessment)
     = link_to t('.attempt'), course_assessment_submissions_path(current_course, assessment),
               class: ['btn','btn-info'], method: :post
 - elsif todo.in_progress?


### PR DESCRIPTION
To behave the same as assessment management buttons.

Steps to reproduce:
1. Create password-protected assessment;
2. Leave assessment password blank, i.e. students should not be prompted to enter password on first attempt/session;
3. Set submission password; i.e. subsequent attempts to edit the submission would require a password;
4. As a student, click attempt for this password-protected assessment from home page. It asks for password on first attempt. Clicking attempt from assessments index works as expected.

This PR changes `_todo_assessment_button` to have the same behavior as `_assessment_management_buttons`.