### PR TITLE
Disable scrolling on number fields

### DIFF
--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -349,6 +349,7 @@ class AssessmentForm extends React.Component {
               component={TextField}
               floatingLabelText={<FormattedMessage {...translations.baseExp} />}
               type="number"
+              onWheel={event => event.currentTarget.blur()}
               style={styles.flexChild}
               disabled={submitting}
             />
@@ -357,6 +358,7 @@ class AssessmentForm extends React.Component {
               component={TextField}
               floatingLabelText={<FormattedMessage {...translations.timeBonusExp} />}
               type="number"
+              onWheel={event => event.currentTarget.blur()}
               style={styles.flexChild}
               disabled={submitting}
             />

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -138,6 +138,7 @@ const SurveyForm = ({
           floatingLabelText={intl.formatMessage(translations.basePoints)}
           component={TextField}
           type="number"
+          onWheel={event => event.currentTarget.blur()}
           {...{ disabled }}
         />
       </div>
@@ -152,6 +153,7 @@ const SurveyForm = ({
           floatingLabelText={intl.formatMessage(translations.bonusPoints)}
           component={TextField}
           type="number"
+          onWheel={event => event.currentTarget.blur()}
           disabled={formValues && !formValues.allow_response_after_end}
         />
         <ReactTooltip id="timeBonusExpTooltip">


### PR DESCRIPTION
Only for number fields imported from redux-form.
Impacted pages: assessment form (new/edit), survey form (new/edit)

Fixes https://github.com/Coursemology/coursemology2/issues/3571.

Solution from https://github.com/mui-org/material-ui/issues/7960.
Tested on Chrome and Firefox.