### PR TITLE
Warn user that assessments will be deleted

### DIFF
--- a/app/views/course/admin/assessment_settings/edit.html.slim
+++ b/app/views/course/admin/assessment_settings/edit.html.slim
@@ -32,7 +32,8 @@ h2
                 = new_button(new_course_admin_assessments_category_tab_path(current_course,
                                                                             category))
               - if can?(:destroy, category)
-                = delete_button(course_admin_assessments_category_path(current_course, category))
+                = delete_button(course_admin_assessments_category_path(current_course, category),
+                                {data: {confirm: t('course.admin.assessments.categories.destroy.confirm')}})
 
         - tabs = category.tabs
         = category_form.simple_fields_for :tabs do |tab_form|
@@ -48,8 +49,8 @@ h2
                                                  label: false
             td
               - if can?(:destroy, tab)
-                = delete_button(course_admin_assessments_category_tab_path(current_course,
-                                                                           category, tab))
+                = delete_button(course_admin_assessments_category_tab_path(current_course, category, tab),
+                                {data: {confirm: t('course.admin.assessments.tabs.destroy.confirm')}})
 
   = f.input :show_public_test_cases_output, as: :boolean, label: t('.show_public_test_cases_output')
   = f.input :show_stdout_and_stderr, as: :boolean, label: t('.show_stdout_and_stderr')

--- a/config/locales/en/course/admin/assessment_tabs.yml
+++ b/config/locales/en/course/admin/assessment_tabs.yml
@@ -10,6 +10,6 @@ en:
           destroy:
             success: 'Tab %{title} was deleted.'
             failure: 'Could not delete tab: %{error}'
-            confirm: 'This action will delete all assessments associated with this tab. Are you sure?'
+            confirm: 'Deleting this tab will delete all associated assessments. Are you sure?'
           new:
             header: 'New Assessment Tab'

--- a/config/locales/en/course/admin/assessment_tabs.yml
+++ b/config/locales/en/course/admin/assessment_tabs.yml
@@ -10,5 +10,6 @@ en:
           destroy:
             success: 'Tab %{title} was deleted.'
             failure: 'Could not delete tab: %{error}'
+            confirm: 'This action will delete all assessments associated with this tab. Are you sure?'
           new:
             header: 'New Assessment Tab'

--- a/config/locales/en/course/admin/categories.yml
+++ b/config/locales/en/course/admin/categories.yml
@@ -10,6 +10,6 @@ en:
           destroy:
             success: 'Category %{title} was deleted.'
             failure: 'Could not delete category: %{error}'
-            confirm: 'This action will delete all assessments associated with this category. Are you sure?'
+            confirm: 'Deleting this category will delete all associated assessments. Are you sure?'
           new:
             header: 'New Category'

--- a/config/locales/en/course/admin/categories.yml
+++ b/config/locales/en/course/admin/categories.yml
@@ -10,5 +10,6 @@ en:
           destroy:
             success: 'Category %{title} was deleted.'
             failure: 'Could not delete category: %{error}'
+            confirm: 'This action will delete all assessments associated with this category. Are you sure?'
           new:
             header: 'New Category'


### PR DESCRIPTION
## Why?

Users had a generic "Are you sure?" prompt when choosing to delete a tab/category.

However, such an action will also delete assessments too. I've improved the error messages to make this action more obvious.

Will close https://github.com/Coursemology/coursemology2/issues/3504

#### Before
![image](https://user-images.githubusercontent.com/15990179/66758939-44862a00-ee6d-11e9-8acf-f433e147200a.png)

#### After
![image](https://user-images.githubusercontent.com/15990179/66758904-31735a00-ee6d-11e9-9de9-b3456ac0e56d.png)


![image](https://user-images.githubusercontent.com/15990179/66758861-1ef92080-ee6d-11e9-86c8-e4fa7a9c8382.png)

