### PR TITLE
Add OTOT algo

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -28,6 +28,24 @@ module Course::LessonPlan::PersonalizationConcern
       where.not(lesson_plan_item_id: submitted_lesson_plan_item_ids.keys).delete_all
   end
 
+  def algorithm_otot(course_user)
+    submitted_lesson_plan_item_ids = lesson_plan_items_submission_time_hash(course_user)
+    items = course_user.course.lesson_plan_items.published.
+            with_reference_times_for(course_user).
+            with_personal_times_for(course_user).
+            to_a
+    items = items.sort_by { |x| x.time_for(course_user).start_at }
+    items_affects_personal_times = items.select(&:affects_personal_times?)
+
+    learning_rate_ema = compute_learning_rate_ema(
+      course_user, items_affects_personal_times, submitted_lesson_plan_item_ids
+    )
+    return if learning_rate_ema.nil?
+
+    # Apply the appropriate algo depending on student's leaning rate
+    learning_rate_ema < 1 ? algorithm_fomo(course_user) : algorithm_stragglers(course_user)
+  end
+
   def algorithm_fomo(course_user)
     course_tz = course_user.course.time_zone
     submitted_lesson_plan_item_ids = lesson_plan_items_submission_time_hash(course_user)
@@ -66,6 +84,7 @@ module Course::LessonPlan::PersonalizationConcern
         # Update personal time
         reference_time = item.reference_time_for(course_user)
         personal_time = item.find_or_create_personal_time_for(course_user)
+        next if (personal_time.start_at, personal_time.bonus_end_at, personal_time.end_at).compact.min < Time.zone.now
         personal_time.start_at =
           round_to_date(
             personal_point + (reference_time.start_at - reference_point) * learning_rate_ema,
@@ -120,6 +139,7 @@ module Course::LessonPlan::PersonalizationConcern
         # Update personal time
         reference_time = item.reference_time_for(course_user)
         personal_time = item.find_or_create_personal_time_for(course_user)
+        next if (personal_time.start_at, personal_time.bonus_end_at, personal_time.end_at).compact.min < Time.zone.now
         personal_time.start_at = reference_time.start_at
         personal_time.bonus_end_at = reference_time.bonus_end_at
         if reference_time.end_at.present?

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -8,7 +8,7 @@ class CourseUser < ApplicationRecord
   before_validation :set_defaults, if: :new_record?
 
   enum role: { student: 0, teaching_assistant: 1, manager: 2, owner: 3, observer: 4 }
-  enum timeline_algorithm: { fixed: 0, fomo: 1, stragglers: 2 }
+  enum timeline_algorithm: { fixed: 0, fomo: 1, stragglers: 2, otot: 3 }
 
   # A set of roles which comprise the staff of a course, including the observer.
   STAFF_ROLES = Set[:teaching_assistant, :manager, :owner, :observer].freeze

--- a/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
+++ b/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
@@ -56,5 +56,17 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
         expect(course_user.personal_times.count).to eq(course.assessments.count - 1)
       end
     end
+
+    context 'when course user is on the otot algorithm' do
+      let!(:course_user) { create(:course_user, course: course, timeline_algorithm: 'otot') }
+      let!(:submission1) do
+        create(:course_assessment_submission, assessment: assessment1, creator: course_user.user).tap(&:finalise!)
+      end
+
+      it 'creates personal times' do
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        expect(course_user.personal_times.count).to eq(course.assessments.count - 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements OTOT algo which applies the appropriate algo (either accelerating or decelerating) depending on the student's learning pace. Specs discussed at https://groups.google.com/d/topic/coursemology/Hu24Fjf-rlE/discussion
Fixes https://github.com/Coursemology/coursemology2/issues/3686

Add checks to prevent past personal times from being moved. Fixes https://github.com/Coursemology/coursemology2/issues/3688