### PR TITLE
Fix docker build error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,7 @@ GEM
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
-      sprockets (> 3.0, < 4.0)
+      sprockets (> 3.0)
       sprockets-rails
       tilt
     selenium-webdriver (3.142.6)


### PR DESCRIPTION
See https://circleci.com/gh/Coursemology/dockerfiles/85

Error message: Downloading sassc-rails-2.1.2 revealed dependencies not in the API or the lockfile (sprockets (> 3.0)).