### PR TITLE
Makes dropdown menu more visible

### DIFF
--- a/client/app/bundles/course/duplication/components/CourseDropdownMenu.jsx
+++ b/client/app/bundles/course/duplication/components/CourseDropdownMenu.jsx
@@ -15,6 +15,9 @@ const styles = {
   },
   dropDown: {
     width: '100%',
+    boxShadow: '3px 3px 2px 1px rgba(231, 231, 231, 1)',
+    margin: '4px',
+    borderRadius: '4px',
   },
   dropdownRow: {
     display: 'flex',


### PR DESCRIPTION
Fixes: #3195
I prefered to add the shadow, because the dropdown already has a thin bottom border, which i couldn't remove or even edit.

<img width="837" alt="Screen Shot 2019-10-31 at 22 11 36" src="https://user-images.githubusercontent.com/35704671/67995898-a1366280-fc2b-11e9-9078-2df55c9e51ec.png">
