### PR TITLE
Add missing nil guard to _personal_or_ref_time

### DIFF
--- a/app/views/course/lesson_plan/items/_personal_or_ref_time.html.slim
+++ b/app/views/course/lesson_plan/items/_personal_or_ref_time.html.slim
@@ -3,7 +3,7 @@
 - if effective_time.is_a? Course::PersonalTime and effective_time.fixed?
   span title=t('course.lesson_plan.items.fixed_desc')
     = fa_icon 'lock'
-=< format_datetime(effective_time[attribute], datetime_format)
+=< format_datetime(effective_time[attribute], datetime_format) if effective_time[attribute]
 - if effective_time[attribute] != reference_time[attribute]
   br
   strike


### PR DESCRIPTION
Fix https://rollbar.com/coursemology/Coursemology2/items/1574/

`undefined method 'zone' for nil:NilClass` error. To reproduce:
Add end date to an assessment. Users with personal time already computed before addition of this end date will encounter this error.