### PR TITLE
Ensures "expression" column can word-wrap

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
@@ -69,7 +69,7 @@ class UploadedPackageTestCaseView extends React.Component {
             { test.get('identifier') }
           </TableHeaderColumn>
           <TableRowColumn className={styles.testCaseCell}>
-            { test.get('expression') }
+            <ExpandableText text={test.get('expression')} />
           </TableRowColumn>
           <TableRowColumn className={styles.testCaseCell}>
             <ExpandableText text={test.get('expected')} />

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -217,7 +217,7 @@ export class VisibleTestCaseView extends Component {
     return (
       <TableRow key={testCase.identifier} style={styles.testCaseRow[testCaseResult]}>
         { canReadTests && tableRowColumnFor(testCase.identifier) }
-        {tableRowColumnFor(testCase.expression)}
+        {tableRowColumnFor(<ExpandableText style={outputStyle} text={testCase.expression} />)}
         {tableRowColumnFor(<ExpandableText style={outputStyle} text={testCase.expected || ''} /> || '')}
         { (canReadTests || showPublicTestCasesOutput)
           && tableRowColumnFor(<ExpandableText style={outputStyle} text={testCase.output || ''} /> || '') }


### PR DESCRIPTION
Fixes #3752 

Simple fix so that expression columns can also word wrap when new lines are added.

<img width="191" alt="Screenshot 2020-02-19 at 12 11 03 AM" src="https://user-images.githubusercontent.com/10579415/74755264-ddaace80-52ad-11ea-84fe-f9eade142e53.png">
