### PR TITLE
Add grades into experience records page

### DIFF
--- a/app/controllers/components/course/experience_points_component.rb
+++ b/app/controllers/components/course/experience_points_component.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 class Course::ExperiencePointsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
-
-  def self.gamified?
-    true
-  end
-
+  
   def self.display_name
     I18n.t('components.experience_points.name')
   end

--- a/app/views/course/experience_points_records/_experience_points_record.html.slim
+++ b/app/views/course/experience_points_records/_experience_points_record.html.slim
@@ -5,28 +5,52 @@
 - row_options_hash = { class: 'experience-points-record' }.tap do |hash|
   - hash.merge!({ 'data-action' => points_record_path, 'data-method' => 'patch' }) if can_update
 
-= content_tag_for(:tr, experience_points_record, row_options_hash)
-  = simple_fields_for experience_points_record do |f|
-    td
-      - updater_course_user = @course_user_preload_service.course_user_for(experience_points_record.updater)
-      = link_to_user(updater_course_user || experience_points_record.updater)
-    td
-      - if !experience_points_record.manually_awarded?
-        = render partial: experience_points_record.specific, suffix: 'experience_points_reason'
-      - elsif can_update
-        = f.input :reason, label: false
-      - else
-        = format_inline_text(experience_points_record.reason)
-    td
-      - if can_update
-        = f.input :points_awarded, label: false
-      - else
-        = experience_points_record.points_awarded
-    td
-      = experience_points_record.updated_at
-    td
-      - if can_update
-        = f.button :submit, id: 'update' do
-          = fa_icon 'save'.freeze
-      - if experience_points_record.manually_awarded? && can?(:destroy, experience_points_record)
-        = delete_button(points_record_path)
+- if @course.gamified
+  = content_tag_for(:tr, experience_points_record, row_options_hash)
+    = simple_fields_for experience_points_record do |f|
+      td
+        - updater_course_user = @course_user_preload_service.course_user_for(experience_points_record.updater)
+        = link_to_user(updater_course_user || experience_points_record.updater)
+      td
+        - if !experience_points_record.manually_awarded?
+          = render partial: experience_points_record.specific, suffix: 'experience_points_reason'
+        - elsif can_update
+          = f.input :reason, label: false
+        - else
+          = format_inline_text(experience_points_record.reason)
+      td 
+        = "#{experience_points_record.specific.grade} / #{experience_points_record.specific.assessment.calculated(:maximum_grade).maximum_grade}"
+      td
+        - if can_update
+          = f.input :points_awarded, label: false
+        - else
+          = experience_points_record.points_awarded
+      td
+        = experience_points_record.updated_at
+      td
+        - if can_update
+          = f.button :submit, id: 'update' do
+            = fa_icon 'save'.freeze
+        - if experience_points_record.manually_awarded? && can?(:destroy, experience_points_record)
+          = delete_button(points_record_path)
+
+- else
+  = content_tag_for(:tr, experience_points_record, row_options_hash)
+    = simple_fields_for experience_points_record do |f|
+      td
+        - updater_course_user = @course_user_preload_service.course_user_for(experience_points_record.updater)
+        = link_to_user(updater_course_user || experience_points_record.updater)
+      td
+        - if !experience_points_record.manually_awarded?
+          = render partial: experience_points_record.specific, suffix: 'experience_points_reason'
+        - elsif can_update
+          = f.input :reason, label: false
+        - else
+          = format_inline_text(experience_points_record.reason)
+      td 
+        = "#{experience_points_record.specific.grade} / #{experience_points_record.specific.assessment.calculated(:maximum_grade).maximum_grade}"
+      td
+        = experience_points_record.updated_at
+
+
+

--- a/app/views/course/experience_points_records/index.html.slim
+++ b/app/views/course/experience_points_records/index.html.slim
@@ -1,14 +1,27 @@
 = page_header t('.header', name: display_course_user(@course_user))
 
-table.table.levels-list.table-hover
-  thead
-    tr
-      th = Course::ExperiencePointsRecord.human_attribute_name(:updater)
-      th = Course::ExperiencePointsRecord.human_attribute_name(:reason)
-      th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
-      th = Course::ExperiencePointsRecord.human_attribute_name(:updated_at)
-      th
-  tbody
-    = render @experience_points_records
+- if @course.gamified
+  table.table.levels-list.table-hover
+    thead
+      tr
+        th = Course::ExperiencePointsRecord.human_attribute_name(:updater)
+        th = Course::ExperiencePointsRecord.human_attribute_name(:reason)
+        th = "Grade"
+        th = Course::ExperiencePointsRecord.human_attribute_name(:points_awarded)
+        th = Course::ExperiencePointsRecord.human_attribute_name(:updated_at)
+        th
+    tbody
+      = render @experience_points_records
+
+- else
+  table.table.levels-list.table-hover
+    thead
+      tr
+        th = Course::ExperiencePointsRecord.human_attribute_name(:updater)
+        th = Course::ExperiencePointsRecord.human_attribute_name(:reason)
+        th = "Grade"
+        th = Course::ExperiencePointsRecord.human_attribute_name(:updated_at)
+    tbody
+      = render @experience_points_records
 
 = paginate @experience_points_records

--- a/app/views/course/statistics/_table.html.slim
+++ b/app/views/course/statistics/_table.html.slim
@@ -9,8 +9,11 @@ table.table.table-hover
     - unless @service.no_group_managers?
       th
         = t('.tutor')
-    th.text-center
-      = Course::Level.model_name.human
+    - if current_course.gamified?
+      th.text-center
+        = Course::Level.model_name.human
+    - if !current_course.gamified?
+      th
     - if current_course.gamified?
       th.text-center
         = t('.experience_points')
@@ -29,8 +32,13 @@ table.table.table-hover
       - unless @service.no_group_managers?
         td
           = @service.group_managers_of(student).map(&:name).join(', ')
-      td.text-center
-        = student.level_number
+      - if !current_course.gamified?
+        td.text-center
+          = link_to course_user_experience_points_records_path(current_course, student), class:"btn btn-primary" do
+              = fa_icon 'table'.freeze
+      - if current_course.gamified?
+        td.text-center
+          = student.level_number
       - if current_course.gamified?
         td.text-center
           = link_to student.experience_points,


### PR DESCRIPTION
Fixes #3756 

This PR adds a grades column to the experience records page:

<img width="1190" alt="Screenshot 2020-03-02 at 9 28 01 AM" src="https://user-images.githubusercontent.com/10579415/75638690-21b3b100-5c68-11ea-9196-54f17977d4ea.png">

The above is when gamification is turned on. 

When gamification is turned off, only the relevant columns will be shown (actually `updated_at `should probably be hidden as well):

<img width="1187" alt="Screenshot 2020-03-02 at 9 29 10 AM" src="https://user-images.githubusercontent.com/10579415/75638722-4c056e80-5c68-11ea-96e4-e16b5de543ed.png">

In order to get to this page (without gamification), there will be a button in the statistics page:

<img width="1200" alt="Screenshot 2020-03-02 at 9 31 02 AM" src="https://user-images.githubusercontent.com/10579415/75638777-8ff87380-5c68-11ea-9ccd-a786bfd6fa89.png">


## Changelog

- Added grade column to view and pulled grades from `@experience_points_record`
- Enabled `Experience Points Record` component even if gamification is turned off
- Modified `Student Statistics` view table to add a button to this page
- Hide certain columns in both `Experience Points Record` and `Student Statistics` when gamification is off

