### PR TITLE
Enable Randomized Assessments

### DIFF
--- a/app/assets/stylesheets/course/assessment/assessments.scss
+++ b/app/assets/stylesheets/course/assessment/assessments.scss
@@ -32,6 +32,10 @@
       }
     }
 
+    .question-bundle-buttons {
+      margin-right: 10px;
+    }
+
     #sortable-questions {
       .card {
         box-shadow: 0 1px 3px $course-assessment-question-card-shadow;

--- a/app/controllers/course/admin/assessment_settings_controller.rb
+++ b/app/controllers/course/admin/assessment_settings_controller.rb
@@ -17,7 +17,7 @@ class Course::Admin::AssessmentSettingsController < Course::Admin::Controller
   private
 
   def category_params
-    params.require(:course).permit(:show_public_test_cases_output, :show_stdout_and_stderr,
+    params.require(:course).permit(:show_public_test_cases_output, :show_stdout_and_stderr, :allow_randomization,
                                    assessment_categories_attributes: [:id, :title, :weight,
                                       { tabs_attributes: [:id, :title, :weight, :category_id] }])
   end

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -15,6 +15,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def create
+    @assessment.update_randomization(randomization_params)
     if @assessment.save
       render json: { id: @assessment.id }, status: :ok
     else
@@ -28,6 +29,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
 
   def update
     @assessment.update_mode(autograded_params)
+    @assessment.update_randomization(randomization_params)
     if @assessment.update(assessment_params)
       head :ok
     else
@@ -99,6 +101,10 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
 
   def autograded_params
     params.require(:assessment).permit(:autograded)
+  end
+
+  def randomization_params
+    params.require(:assessment).permit(:randomization)
   end
 
   # Infer the autograded state from @assessment or params.

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -193,6 +193,15 @@ class Course < ApplicationRecord
     settings(:course_assessments_component).show_stdout_and_stderr = option
   end
 
+  def allow_randomization
+    settings(:course_assessments_component).allow_randomization
+  end
+
+  def allow_randomization=(option)
+    option = ActiveRecord::Type::Boolean.new.cast(option)
+    settings(:course_assessments_component).allow_randomization = option
+  end
+
   def upcoming_lesson_plan_items_exist?
     opening_items = lesson_plan_items.published.eager_load(:personal_times, :reference_times).preload(:actable)
     opening_items.select { |item| item.actable.include_in_consolidated_email?(:opening) }.any? do |item|

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -142,6 +142,13 @@ class Course::Assessment < ApplicationRecord
     end
   end
 
+  # Update assessment randomization from params
+  #
+  # @param [Hash] Params with randomization boolean from user
+  def update_randomization(params)
+    self.randomization = params[:randomization] ? :prepared : nil
+  end
+
   # Whether the assessment allows mode switching.
   # Allow mode switching if:
   # - The assessment don't have any submissions.

--- a/app/views/course/admin/assessment_settings/edit.html.slim
+++ b/app/views/course/admin/assessment_settings/edit.html.slim
@@ -54,4 +54,5 @@ h2
 
   = f.input :show_public_test_cases_output, as: :boolean, label: t('.show_public_test_cases_output')
   = f.input :show_stdout_and_stderr, as: :boolean, label: t('.show_stdout_and_stderr')
+  = f.input :allow_randomization, as: :boolean, label: t('.allow_randomization')
   = f.button :submit, t('.submit')

--- a/app/views/course/assessment/assessments/_assessment_question_bundle_buttons.html.slim
+++ b/app/views/course/assessment/assessments/_assessment_question_bundle_buttons.html.slim
@@ -1,0 +1,16 @@
+div.btn-group.question-bundle-buttons
+  = link_to(t('.question_groups'),
+            course_assessment_question_groups_path(current_course, assessment),
+            class: ['btn', 'btn-default'])
+  
+  = link_to(t('.question_bundles'),
+            course_assessment_question_bundles_path(current_course, assessment),
+            class: ['btn', 'btn-default'])
+  
+  = link_to(t('.question_bundle_questions'),
+            course_assessment_question_bundle_questions_path(current_course, assessment),
+            class: ['btn', 'btn-default'])
+  
+  = link_to(t('.question_bundle_assignments'),
+            course_assessment_question_bundle_assignments_path(current_course, assessment),
+            class: ['btn', 'btn-default'])

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -5,6 +5,8 @@ json.attributes do
     :tabbed_view, :view_password, :session_password, :delayed_grade_publication, :tab_id,
     :use_public, :use_private, :use_evaluation, :allow_partial_submission, :has_personal_times,
     :affects_personal_times)
+  # Pass as boolean since there is only one enum value
+  json.randomization @assessment.randomization.present?
 end
 
 json.tab_attributes do
@@ -16,6 +18,7 @@ end
 json.mode_switching @assessment.allow_mode_switching?
 json.gamified current_course.gamified?
 json.show_personalized_timeline_features current_course.show_personalized_timeline_features?
+json.randomization_allowed current_course.allow_randomization
 
 json.folder_attributes do
   json.folder_id @assessment.folder.id

--- a/app/views/course/assessment/assessments/index.html.slim
+++ b/app/views/course/assessment/assessments/index.html.slim
@@ -1,7 +1,8 @@
 = page_header format_inline_text(@category.title) do
   - if can?(:create, Course::Assessment.new(tab: @tab))
     div.pull-right
-      div.new-btn data="#{{ gamified: current_course.gamified?, tab_id: @tab.id, category_id: @category.id }.to_json}"
+      div.new-btn data="#{{ gamified: current_course.gamified?, tab_id: @tab.id, category_id: @category.id,
+        randomization_allowed: current_course.allow_randomization }.to_json}"
 
 = display_assessment_tabs
 

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -1,5 +1,8 @@
 - add_breadcrumb format_inline_text(@assessment.title)
 = page_header format_inline_text(@assessment.title) do
+  - if @assessment.randomization.present?
+    = render 'assessment_question_bundle_buttons', assessment: @assessment
+
   = render 'assessment_management_buttons', assessment: @assessment
   - if can?(:manage, @assessment)
     div.btn-group

--- a/client/app/bundles/course/assessment/assessments-edit.jsx
+++ b/client/app/bundles/course/assessment/assessments-edit.jsx
@@ -23,6 +23,7 @@ $(document).ready(() => {
           modeSwitching={data.mode_switching}
           gamified={data.gamified}
           showPersonalizedTimelineFeatures={data.show_personalized_timeline_features}
+          randomizationAllowed={data.randomization_allowed}
           folderAttributes={data.folder_attributes}
           conditionAttributes={data.condition_attributes}
           initialValues={{

--- a/client/app/bundles/course/assessment/assessments-index.jsx
+++ b/client/app/bundles/course/assessment/assessments-index.jsx
@@ -15,6 +15,7 @@ $(document).ready(() => {
       <ProviderWrapper store={store}>
         <AssessmentIndexPage
           gamified={attributes.gamified}
+          randomizationAllowed={attributes.randomization_allowed}
           categoryId={attributes.category_id}
           tabId={attributes.tab_id}
         />

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -98,6 +98,8 @@ class AssessmentForm extends React.Component {
       tab_id: PropTypes.number,
       title: PropTypes.string,
     })),
+    // If randomization is enabled for the assessment
+    randomization: PropTypes.bool,
     error: errorProps,
     // Above are props from redux-form.
 
@@ -108,6 +110,8 @@ class AssessmentForm extends React.Component {
     gamified: PropTypes.bool,
     // If the personalized timeline fields should be displayed
     show_personalized_timeline_features: PropTypes.bool,
+    // If randomization is allowed for assessments in the current course
+    randomizationAllowed: PropTypes.bool,
     // If allow to switch between autoraded and manually graded mode.
     modeSwitching: PropTypes.bool,
     folderAttributes: PropTypes.shape({
@@ -211,6 +215,27 @@ class AssessmentForm extends React.Component {
     );
   }
 
+  renderEnableRandomizationField() {
+    const { submitting } = this.props;
+
+    return (
+      <>
+        <Field
+          name="randomization"
+          component={Toggle}
+          parse={Boolean}
+          label={<FormattedMessage {...translations.enableRandomization} />}
+          labelPosition="right"
+          style={styles.toggle}
+          disabled={submitting}
+        />
+        <div style={styles.hint}>
+          <FormattedMessage {...translations.enableRandomizationHint} />
+        </div>
+      </>
+    );
+  }
+
   renderExtraOptions() {
     const { submitting } = this.props;
     if (this.props.autograded) {
@@ -287,7 +312,7 @@ class AssessmentForm extends React.Component {
 
   render() {
     const { handleSubmit, onSubmit, gamified, showPersonalizedTimelineFeatures, modeSwitching, submitting, editing,
-      folderAttributes, conditionAttributes, error } = this.props;
+      folderAttributes, conditionAttributes, randomizationAllowed, error } = this.props;
 
     return (
       <Form onSubmit={handleSubmit(onSubmit)}>
@@ -462,6 +487,8 @@ class AssessmentForm extends React.Component {
         <div style={styles.hint}>
           <FormattedMessage {...translations.showEvaluationHint} />
         </div>
+
+        {randomizationAllowed && this.renderEnableRandomizationField()}
 
         {
           showPersonalizedTimelineFeatures

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
@@ -174,6 +174,14 @@ const translations = defineMessages({
     id: 'course.assessment.form.tab',
     defaultMessage: 'Tab',
   },
+  enableRandomization: {
+    id: 'course.assessment.form.enable_randomization',
+    defaultMessage: 'Enable Randomization',
+  },
+  enableRandomizationHint: {
+    id: 'course.assessment.form.enable_randomization_hint',
+    defaultMessage: 'Enables randomized assignment of question bundles to students (per question group)',
+  },
 });
 
 export default translations;

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
@@ -25,6 +25,8 @@ class EditPage extends React.Component {
     gamified: PropTypes.bool,
     // If personalized timeline features are shown for the course
     showPersonalizedTimelineFeatures: PropTypes.bool,
+    // If randomization is allowed for assessments in the current course
+    randomizationAllowed: PropTypes.bool,
     // If allow to switch between autoraded and manually graded mode.
     modeSwitching: PropTypes.bool,
     // An array of materials of current assessment.
@@ -59,8 +61,8 @@ class EditPage extends React.Component {
   };
 
   render() {
-    const { gamified, showPersonalizedTimelineFeatures, modeSwitching, initialValues, folderAttributes,
-      conditionAttributes, dispatch } = this.props;
+    const { gamified, showPersonalizedTimelineFeatures, modeSwitching, initialValues, randomizationAllowed,
+      folderAttributes, conditionAttributes, dispatch } = this.props;
 
     return (
       <>
@@ -68,6 +70,7 @@ class EditPage extends React.Component {
           editing
           gamified={gamified}
           showPersonalizedTimelineFeatures={showPersonalizedTimelineFeatures}
+          randomizationAllowed={randomizationAllowed}
           onSubmit={this.onFormSubmit}
           modeSwitching={modeSwitching}
           folderAttributes={folderAttributes}

--- a/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
@@ -32,6 +32,8 @@ class PopupDialog extends React.Component {
     intl: intlShape,
     // If the gamification feature is enabled in the course.
     gamified: PropTypes.bool,
+    // If randomization is allowed for assessments in the current course
+    randomizationAllowed: PropTypes.bool,
     categoryId: PropTypes.number.isRequired,
     tabId: PropTypes.number.isRequired,
     pristine: PropTypes.bool,
@@ -96,6 +98,7 @@ class PopupDialog extends React.Component {
       use_public: false,
       use_private: true,
       use_evaluation: true,
+      randomization: false,
     };
 
     return (
@@ -118,6 +121,7 @@ class PopupDialog extends React.Component {
         >
           <AssessmentForm
             gamified={this.props.gamified}
+            randomizationAllowed={this.props.randomizationAllowed}
             modeSwitching
             onSubmit={this.onFormSubmit}
             initialValues={initialValues}

--- a/config/locales/en/course/admin/assessment_settings.yml
+++ b/config/locales/en/course/admin/assessment_settings.yml
@@ -12,3 +12,4 @@ en:
           parent_category: 'Category'
           show_public_test_cases_output: 'Show output for public test cases to students'
           show_stdout_and_stderr: 'Show stdout and stderr to students'
+          allow_randomization: 'Allow randomization for assessments'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -73,6 +73,11 @@ en:
           view: 'View'
           submissions: 'Submissions'
           enter_password: 'Enter Password'
+        assessment_question_bundle_buttons:
+          question_groups: 'Groups'
+          question_bundles: 'Bundles'
+          question_bundle_questions: 'Bundle Questions'
+          question_bundle_assignments: 'Bundle Assignments'
         todo_assessment_button:
           attempt: :'course.assessment.assessments.assessment_management_buttons.attempt'
           resume: :'course.assessment.assessments.assessment_management_buttons.resume'


### PR DESCRIPTION
* Added course assessment setting to allow randomization of assessments for the course
* Enabled creating randomized assessments (only if the above setting is true)
* Enabled modifying existing assessments to randomized (only if the above setting is true)
* Added links for randomized assessments to its question groups, question bundles, question bundle questions, question bundle assignments.