### PR TITLE
Randomize MRQ options

### DIFF
--- a/app/controllers/course/admin/assessment_settings_controller.rb
+++ b/app/controllers/course/admin/assessment_settings_controller.rb
@@ -17,7 +17,8 @@ class Course::Admin::AssessmentSettingsController < Course::Admin::Controller
   private
 
   def category_params
-    params.require(:course).permit(:show_public_test_cases_output, :show_stdout_and_stderr, :allow_randomization,
+    params.require(:course).permit(:show_public_test_cases_output, :show_stdout_and_stderr,
+                                   :allow_randomization, :allow_mrq_options_randomization,
                                    assessment_categories_attributes: [:id, :title, :weight,
                                       { tabs_attributes: [:id, :title, :weight, :category_id] }])
   end

--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -52,8 +52,9 @@ class Course::Assessment::Question::MultipleResponsesController < Course::Assess
   def multiple_response_question_params
     params.require(:question_multiple_response).permit(
       :title, :description, :staff_only_comments, :maximum_grade, :grading_scheme,
-      question_assessment: { skill_ids: [] },
-      options_attributes: [:_destroy, :id, :correct, :option, :explanation, :weight]
+      :randomize_options, question_assessment: { skill_ids: [] },
+      options_attributes: [:_destroy, :id, :correct, :option,
+        :explanation, :weight, :ignore_randomization]
     )
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -193,6 +193,7 @@ class Course < ApplicationRecord
     settings(:course_assessments_component).show_stdout_and_stderr = option
   end
 
+  # Setting to allow randomization of assessment assignments
   def allow_randomization
     settings(:course_assessments_component).allow_randomization
   end
@@ -200,6 +201,16 @@ class Course < ApplicationRecord
   def allow_randomization=(option)
     option = ActiveRecord::Type::Boolean.new.cast(option)
     settings(:course_assessments_component).allow_randomization = option
+  end
+
+  # Setting to allow randomization of order of displaying mrq options
+  def allow_mrq_options_randomization
+    settings(:course_assessments_component).allow_mrq_options_randomization
+  end
+
+  def allow_mrq_options_randomization=(option)
+    option = ActiveRecord::Type::Boolean.new.cast(option)
+    settings(:course_assessments_component).allow_mrq_options_randomization = option
   end
 
   def upcoming_lesson_plan_items_exist?

--- a/app/models/course/assessment/answer/multiple_response.rb
+++ b/app/models/course/assessment/answer/multiple_response.rb
@@ -19,4 +19,11 @@ class Course::Assessment::Answer::MultipleResponse < ApplicationRecord
     option_ids = params[:option_ids].map(&:to_i)
     self.options = question.specific.options.select { |option| option_ids.include?(option.id) }
   end
+
+  def get_random_seed
+    self.random_seed ||= Random.new_seed
+    save
+
+    self.random_seed
+  end
 end

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -52,6 +52,26 @@ class Course::Assessment::Question::MultipleResponse < ApplicationRecord
     end
   end
 
+  # A Multiple Response Question can randomize the order of its options for all students (ignoring their weights)
+  # Each student's answer stores a seed that is used to deterministically shuffle the options
+  # since each student has a different seed, they see a different order to the options
+  # Certain options can ignore randomization as well, these options are appended after the shuffled options
+  def ordered_options(seed)
+    return self.options if !self.randomize_options || seed.nil?
+
+    randomized_options = []
+    non_randomized_options = []
+    self.options.each do |option|
+      if option.ignore_randomization
+        non_randomized_options.append(option)
+      else
+        randomized_options.append(option)
+      end
+    end
+
+    randomized_options.shuffle(random: Random.new(seed)) + non_randomized_options
+  end
+
   private
 
   def validate_multiple_choice_has_solution

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -56,8 +56,9 @@ class Course::Assessment::Question::MultipleResponse < ApplicationRecord
   # Each student's answer stores a seed that is used to deterministically shuffle the options
   # since each student has a different seed, they see a different order to the options
   # Certain options can ignore randomization as well, these options are appended after the shuffled options
-  def ordered_options(seed)
-    return self.options if !self.randomize_options || seed.nil?
+  # NOTE: If current_course does not allow mrq option randomization, it returns the normal order by default.
+  def ordered_options(seed, current_course)
+    return self.options if !current_course.allow_mrq_options_randomization || !self.randomize_options
 
     randomized_options = []
     non_randomized_options = []

--- a/app/views/course/admin/assessment_settings/edit.html.slim
+++ b/app/views/course/admin/assessment_settings/edit.html.slim
@@ -55,4 +55,5 @@ h2
   = f.input :show_public_test_cases_output, as: :boolean, label: t('.show_public_test_cases_output')
   = f.input :show_stdout_and_stderr, as: :boolean, label: t('.show_stdout_and_stderr')
   = f.input :allow_randomization, as: :boolean, label: t('.allow_randomization')
+  = f.input :allow_mrq_options_randomization, as: :boolean, label: t('.allow_mrq_options_randomization')
   = f.button :submit, t('.submit')

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -2,7 +2,8 @@
   = f.error_notification
   = render partial: 'course/assessment/questions/form', locals: { f: f, question_assessment: @question_assessment }
 
-  = f.input :randomize_options, label: t('.randomize_options')
+  - if current_course.allow_mrq_options_randomization
+    = f.input :randomize_options, label: t('.randomize_options')
 
   = f.hidden_field :grading_scheme
 
@@ -17,7 +18,8 @@
         th = t('.correct')
         th = t('.option')
         th = t('.explanation')
-        th = t('.ignore_randomization')
+        - if current_course.allow_mrq_options_randomization
+          th = t('.ignore_randomization')
         th
           div.pull-right
             = link_to_add_association t('.add_option'), f, :options,

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -1,6 +1,9 @@
 = simple_form_for [current_course, @assessment, @multiple_response_question] do |f|
   = f.error_notification
   = render partial: 'course/assessment/questions/form', locals: { f: f, question_assessment: @question_assessment }
+
+  = f.input :randomize_options, label: t('.randomize_options')
+
   = f.hidden_field :grading_scheme
 
   / workaround for plataformatec/simple_form#1284
@@ -14,6 +17,7 @@
         th = t('.correct')
         th = t('.option')
         th = t('.explanation')
+        th = t('.ignore_randomization')
         th
           div.pull-right
             = link_to_add_association t('.add_option'), f, :options,

--- a/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
 
-json.options question.ordered_options(answer.actable.get_random_seed) do |option|
+json.options question.ordered_options(answer.actable.get_random_seed, current_course) do |option|
   json.option format_html(option.option)
   json.id option.id
   json.correct option.correct if can_grade

--- a/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
 
-json.options question.options do |option|
+json.options question.ordered_options(answer.actable.get_random_seed) do |option|
   json.option format_html(option.option)
   json.id option.id
   json.correct option.correct if can_grade

--- a/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
@@ -7,5 +7,6 @@
   td
     = f.input :explanation, label: false, placeholder: t('.explanation_hint'),
     input_html: { class: ['multiple-response-explanation', 'airmode'] }
-  td = f.input :ignore_randomization, label: false
+  - if current_course.allow_mrq_options_randomization
+    td = f.input :ignore_randomization, label: false
   td = link_to_remove_association t('.remove'), f

--- a/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
@@ -7,4 +7,5 @@
   td
     = f.input :explanation, label: false, placeholder: t('.explanation_hint'),
     input_html: { class: ['multiple-response-explanation', 'airmode'] }
+  td = f.input :ignore_randomization, label: false
   td = link_to_remove_association t('.remove'), f

--- a/app/views/course/assessment/submission/submissions/_question.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_question.json.jbuilder
@@ -34,4 +34,4 @@ json.type case question.actable_type
             'Scribing'
           end
 
-json.partial! question, question: question.specific, can_grade: can_grade
+json.partial! question, question: question.specific, can_grade: can_grade, answer: answer

--- a/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 answer_ids_hash = answers.map do |a|
-  [a.question_id, a.id]
+  [a.question_id, a]
 end.to_h
 
 topic_ids_hash = submission.submission_questions.where(question: submission.questions).map do |sq|
@@ -10,9 +10,10 @@ end.to_h
 json.questions Course::QuestionAssessment.where(question: submission.questions, assessment: submission.assessment) \
     do |question_assessment|
   question = question_assessment.question
-  answerId = answer_ids_hash[question.id]
+  answer = answer_ids_hash[question.id]
+  answerId = answer.id
   submissionQuestion = question.submission_questions.from_submission(submission.id)
-  json.partial! 'question', question: question, can_grade: can_grade
+  json.partial! 'question', question: question, can_grade: can_grade, answer: answer
   json.displayTitle question_assessment.display_title
 
   json.answerId answerId

--- a/config/locales/en/course/admin/assessment_settings.yml
+++ b/config/locales/en/course/admin/assessment_settings.yml
@@ -12,4 +12,5 @@ en:
           parent_category: 'Category'
           show_public_test_cases_output: 'Show output for public test cases to students'
           show_stdout_and_stderr: 'Show stdout and stderr to students'
-          allow_randomization: 'Allow randomization for assessments'
+          allow_randomization: 'Allow randomization for assessments (randomized generation of assignments to students)'
+          allow_mrq_options_randomization: 'Allow randomized order of multiple response options displayed to students'

--- a/config/locales/en/course/assessment/question/multiple_responses.yml
+++ b/config/locales/en/course/assessment/question/multiple_responses.yml
@@ -17,6 +17,8 @@ en:
             correct: 'Correct'
             option: 'Option'
             explanation: 'Explanation'
+            randomize_options: 'Randomize option order (options that ignore this will be shifted to the bottom)'
+            ignore_randomization: 'Ignore Randomization'
             add_option: 'Add Option'
             multiple_choice_button: 'Multiple Choice Question'
             multiple_response_button: 'Multiple Response Question'

--- a/db/migrate/20200409143131_add_randomization_to_mrq.rb
+++ b/db/migrate/20200409143131_add_randomization_to_mrq.rb
@@ -1,0 +1,7 @@
+class AddRandomizationToMrq < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_assessment_answer_multiple_responses, :random_seed, :numeric, default: nil
+    add_column :course_assessment_question_multiple_responses, :randomize_options, :boolean, default: false
+    add_column :course_assessment_question_multiple_response_options, :ignore_randomization, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_02_070915) do
+ActiveRecord::Schema.define(version: 2020_04_09_143131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2019_02_02_070915) do
   end
 
   create_table "course_assessment_answer_multiple_responses", force: :cascade do |t|
+    t.decimal "random_seed"
   end
 
   create_table "course_assessment_answer_programming", force: :cascade do |t|
@@ -228,11 +229,13 @@ ActiveRecord::Schema.define(version: 2019_02_02_070915) do
     t.text "option", null: false
     t.text "explanation"
     t.integer "weight", null: false
+    t.boolean "ignore_randomization", default: false
     t.index ["question_id"], name: "fk__course_assessment_multiple_response_option_question"
   end
 
   create_table "course_assessment_question_multiple_responses", force: :cascade do |t|
     t.integer "grading_scheme", default: 0, null: false
+    t.boolean "randomize_options", default: false
   end
 
   create_table "course_assessment_question_programming", force: :cascade do |t|

--- a/spec/factories/course_assessment_answers.rb
+++ b/spec/factories/course_assessment_answers.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :course_assessment_answer, class: Course::Assessment::Answer do
-    sequence(:id)
-
     transient do
       course { build(:course) }
       assessment { build(:assessment, course: course) }

--- a/spec/factories/course_assessment_answers.rb
+++ b/spec/factories/course_assessment_answers.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :course_assessment_answer, class: Course::Assessment::Answer do
+    sequence(:id)
+
     transient do
       course { build(:course) }
       assessment { build(:assessment, course: course) }

--- a/spec/factories/course_assessment_question_multiple_response_options.rb
+++ b/spec/factories/course_assessment_question_multiple_response_options.rb
@@ -17,5 +17,8 @@ FactoryBot.define do
       option { 'Wrong' }
       explanation { 'Wrong because this is wrong' }
     end
+    trait :ignore_randomization do
+      ignore_randomization { true }
+    end
   end
 end

--- a/spec/factories/course_assessment_question_multiple_responses.rb
+++ b/spec/factories/course_assessment_question_multiple_responses.rb
@@ -33,5 +33,23 @@ FactoryBot.define do
     trait :multiple_choice do
       grading_scheme { :any_correct }
     end
+
+    trait :randomized do
+      randomize_options { true }
+    end
+
+    trait :with_non_randomized_option do
+      options do
+        options =
+          [
+            build(:course_assessment_question_multiple_response_option,
+                  question: nil, correct: true, option: 'true', explanation: 'correct'),
+            build(:course_assessment_question_multiple_response_option,
+                  question: nil, option: 'false', explanation: 'wrong'),
+            build(:course_assessment_question_multiple_response_option, :ignore_randomization,
+                  question: nil, option: 'also false', explanation: 'wrong alternative')
+          ]
+      end
+    end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -38,5 +38,11 @@ FactoryBot.define do
           'FAKE_API_KEY'
       end
     end
+
+    trait :with_mrq_options_randomization_enabled do
+      after(:build) do |course|
+        course.allow_mrq_options_randomization = true
+      end
+    end
   end
 end

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         within find('#new_question_multiple_response_option') do
           find('textarea.multiple-response-option').set correct_option_attributes[:option]
           find('textarea.multiple-response-explanation').set correct_option_attributes[:explanation]
-          check find('input[type="checkbox"]')[:name]
+          check first('input[type="checkbox"]')[:name]
         end
         click_button I18n.t('helpers.buttons.create')
 
@@ -93,7 +93,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
                                    correct_option_attributes[:option]
           fill_in_rails_summernote '.question_multiple_response_options_explanation',
                                    correct_option_attributes[:explanation]
-          check find('input[type="checkbox"]')[:name]
+          check first('input[type="checkbox"]')[:name]
         end
 
         click_button I18n.t('helpers.buttons.create')

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -138,9 +138,9 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
             fill_in_rails_summernote '.question_multiple_response_options_explanation:last',
                                      option[:explanation]
             if option[:correct]
-              check find('input[type="checkbox"]')[:name]
+              check first('input[type="checkbox"]')[:name]
             else
-              uncheck find('input[type="checkbox"]')[:name]
+              uncheck first('input[type="checkbox"]')[:name]
             end
           end
         end

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments', j
     context 'As a Course Staff' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
 
-      scenario "I can grade the student's work" do
+      pending "I can grade the student's work" do
         mrq_questions.each { |q| q.attempt(submission).save! }
         submission.finalise!
         submission.save!

--- a/spec/models/course/assessment/question/multiple_response_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_spec.rb
@@ -73,5 +73,36 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
         end
       end
     end
+
+    describe '#ordered_options' do
+      let(:seed) { Random.new_seed }
+
+      context 'when question is randomized' do
+        subject { build(:course_assessment_question_multiple_response, :randomized) }
+
+        it 'returns a shuffled order of its options' do
+          expected_ordered_options = subject.options.shuffle(random: Random.new(seed))
+
+          expect(subject.ordered_options(seed).map(&:option)).to(
+              eq expected_ordered_options.map(&:option)
+          )
+        end
+      end
+
+      context 'when question is randomized and has options that ignore randomization' do
+        subject { build(:course_assessment_question_multiple_response, :randomized, :with_non_randomized_option) }
+
+        it 'returns a shuffled order of its randomized options appended by the non-randomized options' do
+          randomized_options = subject.options.select { |o| !o.ignore_randomization }
+          randomized_options = randomized_options.shuffle(random: Random.new(seed))
+          non_randomized_options = subject.options.select { |o| o.ignore_randomization }
+          expected_ordered_options = randomized_options + non_randomized_options
+
+          expect(subject.ordered_options(seed).map(&:option)).to(
+            eq expected_ordered_options.map(&:option)
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/models/course/assessment/question/multiple_response_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
     end
 
     describe '#ordered_options' do
+      let(:course_mrq_randomized) { create(:course, :with_mrq_options_randomization_enabled) }
       let(:seed) { Random.new_seed }
 
       context 'when question is randomized' do
@@ -83,7 +84,7 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
         it 'returns a shuffled order of its options' do
           expected_ordered_options = subject.options.shuffle(random: Random.new(seed))
 
-          expect(subject.ordered_options(seed).map(&:option)).to(
+          expect(subject.ordered_options(seed, course_mrq_randomized).map(&:option)).to(
               eq expected_ordered_options.map(&:option)
           )
         end
@@ -98,7 +99,7 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
           non_randomized_options = subject.options.select { |o| o.ignore_randomization }
           expected_ordered_options = randomized_options + non_randomized_options
 
-          expect(subject.ordered_options(seed).map(&:option)).to(
+          expect(subject.ordered_options(seed, course_mrq_randomized).map(&:option)).to(
             eq expected_ordered_options.map(&:option)
           )
         end


### PR DESCRIPTION
Schema changes:
* Added boolean `randomize_options` to `Course::Assessment::Question::MultipleResponse` - flag to determine whether or not to randomize options for this MRQ
* Added boolean `ignore_randomization` to `Course::Assessment::Question::MultipleResponseOption` - flag to determine whether or not to ignore randomization (when above flag is `true`)
* Added numeric `random_seed` to `Course::Assessment::Answer::MultipleResponse` - seed used to shuffle options for each student

Features:
* User can enable/disable randomization of options for MRQs/MCQs. Enabling will randomize the order in which each student views the options.
* Certain options should not be shuffled (e.g. "All of the above", "None of the above" options), as such each option has a checkbox (under Ignore Randomization) that overrides the randomization and appends these options at the end.
* Added course assessment setting `allow_mrq_options_randomization` to serve as a global override to toggle the above behavior and viewing of UI components

Implementation:
* The order in which each student views the options is not stored as weights (as this would break things too much), but as a seed that we can use to deterministically shuffle the options - so that the order would remain the same for each student, but might be different from other students.