### PR TITLE
Fix randomized assessments

### DIFF
--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -57,8 +57,8 @@ class Course::Assessment::Question::MultipleResponse < ApplicationRecord
   # since each student has a different seed, they see a different order to the options
   # Certain options can ignore randomization as well, these options are appended after the shuffled options
   # NOTE: If current_course does not allow mrq option randomization, it returns the normal order by default.
-  def ordered_options(seed, current_course)
-    return self.options if !current_course.allow_mrq_options_randomization || !self.randomize_options
+  def ordered_options(seed = nil, current_course)
+    return self.options if !current_course.allow_mrq_options_randomization || !self.randomize_options || seed.nil?
 
     randomized_options = []
     non_randomized_options = []

--- a/app/models/course/question_assessment.rb
+++ b/app/models/course/question_assessment.rb
@@ -17,9 +17,10 @@ class Course::QuestionAssessment < ApplicationRecord
   # Prefixes a question number in front of the title
   #
   # @return [string]
-  def display_title
+  def display_title(num = nil)
+    idx = num.present? ? num : assessment.question_assessments.index(self) + 1
     question_number = I18n.t('activerecord.course/assessment/question.question_number',
-                             index: assessment.question_assessments.index(self) + 1)
+                             index: idx)
 
     return question_number if question.title.blank?
     I18n.t('activerecord.course/assessment/question.question_with_title',

--- a/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
+++ b/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
@@ -9,7 +9,7 @@
 = div_for(topic, 'data-topic-id' => topic.id) do
   h3
     - comment_title = "#{assessment.title}: #{question_assessment.display_title}"
-    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: assessment.questions.index(question) +1)
+    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: submission.questions.index(question) + 1)
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
   - elsif current_course_user&.student?

--- a/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
 
-json.options question.ordered_options(answer.actable.get_random_seed, current_course) do |option|
+json.options question.ordered_options(answer&.actable.get_random_seed, current_course) do |option|
   json.option format_html(option.option)
   json.id option.id
   json.correct option.correct if can_grade

--- a/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
@@ -7,14 +7,14 @@ topic_ids_hash = submission.submission_questions.where(question: submission.ques
   [sq.question_id, sq.discussion_topic.id]
 end.to_h
 
-json.questions Course::QuestionAssessment.where(question: submission.questions, assessment: submission.assessment) \
-    do |question_assessment|
+question_assessments = Course::QuestionAssessment.where(question: submission.questions, assessment: submission.assessment)
+json.questions question_assessments.each_with_index.to_a do |(question_assessment, index)|
   question = question_assessment.question
   answer = answer_ids_hash[question.id]
-  answerId = answer.id
+  answerId = answer&.id
   submissionQuestion = question.submission_questions.from_submission(submission.id)
   json.partial! 'question', question: question, can_grade: can_grade, answer: answer
-  json.displayTitle question_assessment.display_title
+  json.displayTitle question_assessment.display_title(index+1)
 
   json.answerId answerId
   json.topicId topic_ids_hash[question.id]

--- a/app/views/course/assessment/submission_questions/_discussion_topic_submission_question.html.slim
+++ b/app/views/course/assessment/submission_questions/_discussion_topic_submission_question.html.slim
@@ -8,7 +8,7 @@
 = div_for(topic, 'data-topic-id' => topic.id) do
   h3
     - comment_title = "#{assessment.title}: #{question_assessment.display_title}"
-    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: assessment.questions.index(question) + 1)
+    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: submission.questions.index(question) + 1)
   - if can?(:manage, topic)
     = link_to_toggle_pending(topic)
   - elsif current_course_user&.student?

--- a/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
@@ -2,20 +2,21 @@
 - annotation = post.topic.actable
 - answer = annotation.file.answer
 - question = answer.question
-- course_user = answer.submission.course_user
-- assessment = answer.submission.assessment
+- submission = answer.submission
+- course_user = submission.course_user
+- assessment = submission.assessment
 - question_assessment = assessment.question_assessments.find_by!(question: question)
 - course = assessment.course
 - host = course.instance.host
 
 - message.subject = t('.subject', course: course.title, topic: "#{assessment.title}: #{question_assessment.display_title}")
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
-- step = assessment.questions.index(question) + 1
+- step = submission.questions.index(question) + 1
 
 = format_html(t('.message',
                 topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
                                edit_course_assessment_submission_url(course, assessment,
-                                                                     answer.submission,
+                                                                     submission,
                                                                      step: step, host: host)),
                                post: post.text_to_email,
                                post_author: post.author_name))


### PR DESCRIPTION
* Display default question number in assessment according to questions assigned to the student (instead of the question number among all questions in the assessment)
* Fixed comment links pointing to the wrong step in the edit assessment links (for randomized assessments)