### PR TITLE
Add error logging when submission fails

### DIFF
--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
 
         edit_path = edit_course_assessment_question_programming_path(course, assessment, question)
         find_link(nil, href: edit_path).click
-        expect(page).to have_xpath('//form[@id=\'programmming-question-form\']')
+        expect(page).to have_xpath('//form[@id=\'programming-question-form\']')
 
         maximum_grade = 999.9
         # For some reasons we have to clear the old field first then can fill in the value, otherwise
@@ -124,7 +124,7 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
       pending 'I can create a new question and upload the template package', js: true do
         visit new_course_assessment_question_programming_path(course, assessment)
 
-        expect(page).to have_xpath('//form[@id=\'programmming-question-form\']')
+        expect(page).to have_xpath('//form[@id=\'programming-question-form\']')
 
         question_attributes = attributes_for(:course_assessment_question_programming)
         fill_in 'question_programming[maximum_grade]', with: question_attributes[:maximum_grade]


### PR DESCRIPTION
new logging will look like this:
```
failed to update answer #<ActiveModel::Errors:0x00007fd91796c3f8 @base=#<Course::Assessment::Answer id: 14275576, actable_id: 9816978, actable_type: "Course::Assessment::Answer::Programming", submission_id: 1012653, question_id: 194181, workflow_state: "graded", submitted_at: nil, grade: 0.0, correct: false, grader_id: 0, graded_at: "2020-08-23 11:13:53", created_at: "2020-08-20 12:40:22", updated_at: "2020-08-23 11:13:53", current_answer: true>, @messages={:submitted_at=>["can't be blank"]}, @details={:submitted_at=>[{:error=>:blank}]}>
   (0.2ms)
	ROLLBACK
failed to update submission: #<ActiveModel::Errors:0x00007fd923fcf180 @base=#<Course::Assessment::Submission id: 1012653, assessment_id: 38873, workflow_state: "attempting", creator_id: 57123, updater_id: 37695, created_at: "2020-08-20 12:40:21", updated_at: "2020-08-23 11:13:52", publisher_id: nil, published_at: nil, session_id: "4900fb6caa7bf638", submitted_at: nil>, @messages={}, @details={}>
Completed 400 Bad Request in 401ms (Views: 0.1ms | ActiveRecord: 21.7ms)
```