### PR TITLE
Update mimemagic version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,9 @@ GEM
     mime-types (3.3)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
The current version of `mimemagic` is no longer present on https://rubygems.org due to licensing issues.

See details at https://github.com/mimemagicrb/mimemagic/issues/98.

Bumping the version to any version greater than 0.3.7 resolves this.