### PR TITLE
Fix submission answer display in student view

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -88,8 +88,8 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
 
   def assessment_params
     base_params = [:title, :description, :base_exp, :time_bonus_exp, :start_at, :end_at, :tab_id,
-                   :bonus_end_at, :published, :autograded, :show_private, :show_evaluation,
-                   :use_public, :use_private, :use_evaluation, :has_personal_times,
+                   :bonus_end_at, :published, :autograded, :show_mcq_mrq_solution, :show_private,
+                   :show_evaluation, :use_public, :use_private, :use_evaluation, :has_personal_times,
                    :affects_personal_times]
     if autograded?
       base_params += [:skippable, :allow_partial_submission, :show_mcq_answer]

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 json.attributes do
   json.(@assessment, :id, :title, :description, :start_at, :end_at, :bonus_end_at, :base_exp,
-    :time_bonus_exp, :published, :autograded, :show_private, :show_evaluation, :skippable,
-    :tabbed_view, :view_password, :session_password, :delayed_grade_publication, :tab_id,
+    :time_bonus_exp, :published, :autograded, :show_mcq_mrq_solution, :show_private, :show_evaluation,
+    :skippable, :tabbed_view, :view_password, :session_password, :delayed_grade_publication, :tab_id,
     :use_public, :use_private, :use_evaluation, :allow_partial_submission, :has_personal_times,
     :affects_personal_times, :show_mcq_answer)
   # Pass as boolean since there is only one enum value

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -56,6 +56,9 @@
           tr.show_mcq_answer
             th = t('.show_mcq_answer')
             td = @assessment.show_mcq_answer ? t('.show') : t('.not_show')
+        tr.show_mcq_mrq_solution
+          th = t('.show_mcq_mrq_solution')
+          td = @assessment.show_mcq_mrq_solution ? t('.show') : t('.not_show')
         tr.graded_test_case_types
           th = t('.graded_test_case_types')
           td = format_inline_text(display_graded_test_types(@assessment))

--- a/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
@@ -4,5 +4,5 @@ json.autogradable question.auto_gradable?
 json.options question.ordered_options(answer&.actable.get_random_seed, current_course) do |option|
   json.option format_html(option.option)
   json.id option.id
-  json.correct option.correct if can_grade || @submission.published?
+  json.correct option.correct if can_grade || (@assessment.show_mcq_mrq_solution && @submission.published?)
 end

--- a/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
@@ -4,5 +4,5 @@ json.autogradable question.auto_gradable?
 json.options question.ordered_options(answer&.actable.get_random_seed, current_course) do |option|
   json.option format_html(option.option)
   json.id option.id
-  json.correct option.correct if can_grade
+  json.correct option.correct if can_grade || @submission.published?
 end

--- a/app/views/course/assessment/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/edit.json.jbuilder
@@ -9,6 +9,7 @@ json.assessment do
   json.categoryId @assessment.tab.category_id
   json.tabId @assessment.tab_id
   json.(@assessment, :title, :description, :autograded, :skippable)
+  json.showMcqMrqSolution @assessment.show_mcq_mrq_solution
   json.delayedGradePublication @assessment.delayed_grade_publication
   json.tabbedView @assessment.tabbed_view
   json.showPrivate @assessment.show_private

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -441,6 +441,20 @@ class AssessmentForm extends React.Component {
         }
 
         {this.renderExtraOptions()}
+
+        <Field
+          name="show_mcq_mrq_solution"
+          component={Toggle}
+          parse={Boolean}
+          label={<FormattedMessage {...translations.showMcqMrqSolution} />}
+          labelPosition="right"
+          style={styles.toggle}
+          disabled={submitting}
+        />
+        <div style={styles.hint}>
+          <FormattedMessage {...translations.showMcqMrqSolutionHint} />
+        </div>
+
         <div style={styles.conditions}>
           <FormattedMessage {...translations.autogradeTestCasesHint} />
         </div>

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/translations.intl.js
@@ -137,6 +137,14 @@ const translations = defineMessages({
       not be immediately shown to the student. To publish all gradings for this assessment, click \
       on the 'Publish Grades' button on the top right of the submissions listing for this assessment.",
   },
+  showMcqMrqSolution: {
+    id: 'course.assessment.form.showMcqMrqSolution',
+    defaultMessage: 'Show MCQ/MRQ Solution(s)',
+  },
+  showMcqMrqSolutionHint: {
+    id: 'course.assessment.form.showMcqMrqSolutionHint',
+    defaultMessage: 'Show MCQ/MRQ Solution(s) when grades of submissions have been published.',
+  },
   passwordRequired: {
     id: 'course.assessment.form.passwordRequired',
     defaultMessage: 'At least one password is required',

--- a/client/app/bundles/course/assessment/submission/components/Answers.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Answers.jsx
@@ -11,12 +11,12 @@ import FileUploadAnswer from './answers/FileUpload';
 import ProgrammingAnswer from './answers/Programming';
 
 export default class Answers extends Component {
-  static renderMultipleChoice(question, readOnly, answerId) {
-    return <MultipleChoiceAnswer {...{ question, readOnly, answerId }} />;
+  static renderMultipleChoice(question, readOnly, showMcqMrqSolution, answerId, graderView) {
+    return <MultipleChoiceAnswer {...{ question, readOnly, showMcqMrqSolution, answerId, graderView }} />;
   }
 
-  static renderMultipleResponse(question, readOnly, answerId) {
-    return <MultipleResponseAnswer {...{ question, readOnly, answerId }} />;
+  static renderMultipleResponse(question, readOnly, showMcqMrqSolution, answerId, graderView) {
+    return <MultipleResponseAnswer {...{ question, readOnly, showMcqMrqSolution, answerId, graderView }} />;
   }
 
   static renderTextResponse(question, readOnly, answerId, graderView) {

--- a/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
+++ b/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
@@ -57,9 +57,10 @@ class SubmissionAnswer extends Component {
     historyQuestions: PropTypes.objectOf(historyQuestionShape),
     questionsFlags: PropTypes.objectOf(questionFlagsShape),
     readOnly: PropTypes.bool,
+    graderView: PropTypes.bool,
+    showMcqMrqSolution: PropTypes.bool,
     question: questionShape,
     answerId: PropTypes.number,
-    graderView: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -153,8 +154,7 @@ class SubmissionAnswer extends Component {
   }
 
   render() {
-    const { readOnly, question, answerId, graderView } = this.props;
-
+    const { readOnly, showMcqMrqSolution, question, answerId, graderView } = this.props;
     const renderer = this.getRenderer(question);
 
     return (
@@ -165,7 +165,8 @@ class SubmissionAnswer extends Component {
         {this.renderHistoryToggle(question)}
         <div dangerouslySetInnerHTML={{ __html: question.description }} />
         <hr />
-        { answerId ? renderer(question, readOnly, answerId, graderView) : this.renderMissingAnswerPanel() }
+        {answerId
+          ? renderer(question, readOnly, showMcqMrqSolution, answerId, graderView) : this.renderMissingAnswerPanel()}
       </>
     );
   }

--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice.jsx
@@ -6,7 +6,7 @@ import { RadioButton } from 'material-ui/RadioButton';
 
 import { questionShape } from '../../propTypes';
 
-function MultipleChoiceOptions({ readOnly, question, input: { onChange, value } }) {
+function MultipleChoiceOptions({ readOnly, showMcqMrqSolution, graderView, question, input: { onChange, value } }) {
   return (
     <>
       {question.options.map(option => (
@@ -17,7 +17,8 @@ function MultipleChoiceOptions({ readOnly, question, input: { onChange, value } 
           checked={option.id === value}
           label={(
             <div
-              style={option.correct && readOnly ? { backgroundColor: green50 } : null}
+              style={option.correct && readOnly && (showMcqMrqSolution || graderView)
+                ? { backgroundColor: green50 } : null}
               dangerouslySetInnerHTML={{ __html: option.option.trim() }}
             />
           )}
@@ -31,17 +32,19 @@ function MultipleChoiceOptions({ readOnly, question, input: { onChange, value } 
 MultipleChoiceOptions.propTypes = {
   question: questionShape,
   readOnly: PropTypes.bool,
+  showMcqMrqSolution: PropTypes.bool,
+  graderView: PropTypes.bool,
   input: PropTypes.shape({
     onChange: PropTypes.func,
   }).isRequired,
 };
 
-function MultipleChoice({ question, readOnly, answerId }) {
+function MultipleChoice({ question, readOnly, showMcqMrqSolution, graderView, answerId }) {
   return (
     <Field
       name={`${answerId}[option_ids][0]`}
       component={MultipleChoiceOptions}
-      {...{ question, readOnly }}
+      {...{ question, readOnly, showMcqMrqSolution, graderView }}
     />
   );
 }
@@ -49,6 +52,8 @@ function MultipleChoice({ question, readOnly, answerId }) {
 MultipleChoice.propTypes = {
   question: questionShape,
   readOnly: PropTypes.bool,
+  showMcqMrqSolution: PropTypes.bool,
+  graderView: PropTypes.bool,
   answerId: PropTypes.number,
 };
 

--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse.jsx
@@ -6,7 +6,7 @@ import Checkbox from 'material-ui/Checkbox';
 
 import { questionShape } from '../../propTypes';
 
-function MultipleResponseOptions({ readOnly, question, input }) {
+function MultipleResponseOptions({ readOnly, showMcqMrqSolution, graderView, question, input }) {
   return (
     <>
       {question.options.map(option => (
@@ -26,7 +26,8 @@ function MultipleResponseOptions({ readOnly, question, input }) {
           }}
           label={(
             <div
-              style={option.correct && readOnly ? { backgroundColor: green50 } : null}
+              style={option.correct && readOnly && (showMcqMrqSolution || graderView)
+                ? { backgroundColor: green50 } : null}
               dangerouslySetInnerHTML={{ __html: option.option.trim() }}
             />
           )}
@@ -40,6 +41,8 @@ function MultipleResponseOptions({ readOnly, question, input }) {
 MultipleResponseOptions.propTypes = {
   question: questionShape,
   readOnly: PropTypes.bool,
+  showMcqMrqSolution: PropTypes.bool,
+  graderView: PropTypes.bool,
   input: PropTypes.shape({
     onChange: PropTypes.func,
   }).isRequired,
@@ -49,12 +52,12 @@ MultipleResponseOptions.defaultProps = {
   readOnly: false,
 };
 
-function MultipleResponse({ question, readOnly, answerId }) {
+function MultipleResponse({ question, readOnly, showMcqMrqSolution, graderView, answerId }) {
   return (
     <Field
       name={`${answerId}[option_ids]`}
       component={MultipleResponseOptions}
-      {...{ question, readOnly }}
+      {...{ question, readOnly, showMcqMrqSolution, graderView }}
     />
   );
 }
@@ -62,6 +65,8 @@ function MultipleResponse({ question, readOnly, answerId }) {
 MultipleResponse.propTypes = {
   question: questionShape,
   readOnly: PropTypes.bool,
+  showMcqMrqSolution: PropTypes.bool,
+  graderView: PropTypes.bool,
   answerId: PropTypes.number,
 };
 

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -210,8 +210,8 @@ class SubmissionEditForm extends Component {
 
   renderQuestions() {
     const {
-      attempting, questionIds, questions, historyQuestions,
-      topics, graderView, handleToggleViewHistoryMode, questionsFlags,
+      attempting, questionIds, questions, historyQuestions, topics,
+      graderView, showMcqMrqSolution, handleToggleViewHistoryMode, questionsFlags,
     } = this.props;
     return (
       <>
@@ -229,6 +229,7 @@ class SubmissionEditForm extends Component {
                   questionsFlags,
                   historyQuestions,
                   graderView,
+                  showMcqMrqSolution,
                   handleToggleViewHistoryMode,
                 }}
               />
@@ -501,6 +502,8 @@ SubmissionEditForm.propTypes = {
   passwordProtected: PropTypes.bool.isRequired,
   tabbedView: PropTypes.bool.isRequired,
   step: PropTypes.number,
+
+  showMcqMrqSolution: PropTypes.bool.isRequired,
 
   attempting: PropTypes.bool.isRequired,
   submitted: PropTypes.bool.isRequired,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -328,8 +328,8 @@ class SubmissionEditStepForm extends Component {
   renderStepQuestion() {
     const { stepIndex } = this.state;
     const {
-      attempting, questionIds, questions, historyQuestions,
-      topics, graderView, handleToggleViewHistoryMode, questionsFlags,
+      attempting, questionIds, questions, historyQuestions, topics,
+      graderView, showMcqMrqSolution, handleToggleViewHistoryMode, questionsFlags,
     } = this.props;
     const id = questionIds[stepIndex];
     const question = questions[id];
@@ -345,6 +345,7 @@ class SubmissionEditStepForm extends Component {
             questionsFlags,
             historyQuestions,
             graderView,
+            showMcqMrqSolution,
             handleToggleViewHistoryMode,
           }}
         />
@@ -491,6 +492,8 @@ SubmissionEditStepForm.propTypes = {
 
   attempting: PropTypes.bool.isRequired,
   published: PropTypes.bool.isRequired,
+
+  showMcqMrqSolution: PropTypes.bool.isRequired,
 
   explanations: PropTypes.objectOf(explanationShape),
   allConsideredCorrect: PropTypes.bool.isRequired,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -96,10 +96,10 @@ class SubmissionEditStepForm extends Component {
   }
 
   handleStepClick(index) {
-    const { skippable, graderView } = this.props;
+    const { published, skippable, graderView } = this.props;
     const { maxStep } = this.state;
 
-    if (skippable || graderView || index <= maxStep) {
+    if (published || skippable || graderView || index <= maxStep) {
       this.setState({
         stepIndex: index,
       });
@@ -376,7 +376,7 @@ class SubmissionEditStepForm extends Component {
 
   renderStepper() {
     const { maxStep, stepIndex } = this.state;
-    const { skippable, graderView, questionIds = [] } = this.props;
+    const { published, skippable, graderView, questionIds = [] } = this.props;
 
     if (questionIds.length <= 1) {
       return null;
@@ -390,7 +390,7 @@ class SubmissionEditStepForm extends Component {
         style={{ justifyContent: 'center', flexWrap: 'wrap' }}
       >
         {questionIds.map((questionId, index) => {
-          if (skippable || graderView || index <= maxStep) {
+          if (published || skippable || graderView || index <= maxStep) {
             return (
               <Step key={questionId} active={index <= maxStep}>
                 <StepButton

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
@@ -227,7 +227,7 @@ class VisibleSubmissionEditIndex extends Component {
     const {
       assessment: { autograded, delayedGradePublication, tabbedView,
         skippable, questionIds, passwordProtected, categoryId, tabId,
-        allowPartialSubmission, showMcqAnswer },
+        allowPartialSubmission, showMcqAnswer, showMcqMrqSolution },
       submission: { graderView, canUpdate, maxStep, workflowState },
       explanations,
       grading,
@@ -275,6 +275,7 @@ class VisibleSubmissionEditIndex extends Component {
           allConsideredCorrect={this.allConsideredCorrect()}
           allowPartialSubmission={allowPartialSubmission}
           showMcqAnswer={showMcqAnswer}
+          showMcqMrqSolution={showMcqMrqSolution}
           graderView={graderView}
           attempting={workflowState === workflowStates.Attempting}
           submitted={workflowState === workflowStates.Submitted}
@@ -307,6 +308,7 @@ class VisibleSubmissionEditIndex extends Component {
         handleToggleViewHistoryMode={this.handleToggleViewHistoryMode}
         explanations={explanations}
         grading={grading}
+        showMcqMrqSolution={showMcqMrqSolution}
         graderView={graderView}
         canUpdate={canUpdate}
         attempting={workflowState === workflowStates.Attempting}

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -99,6 +99,7 @@ export const assessmentShape = PropTypes.shape({
   delayedGradePublication: PropTypes.bool,
   published: PropTypes.bool,
   skippable: PropTypes.bool,
+  showMcqMrqSolution: PropTypes.bool,
   tabbedView: PropTypes.bool,
   showPrivate: PropTypes.bool,
   showEvaluation: PropTypes.bool,

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -32,6 +32,7 @@ en:
           allow_partial_submission: 'Allow Submission With Incorrect Answers'
           allow: 'Allowed'
           disallow: 'Disallowed'
+          show_mcq_mrq_solution: 'Show MCQ/MRQ Solution(s)'
           graded_test_case_types: 'Graded Test Case Types'
           show_mcq_answer: 'Show MCQ Submit Result'
           show: 'Shown'

--- a/db/migrate/20210817040704_add_show_mcq_mrq_solution_to_course_assessments.rb
+++ b/db/migrate/20210817040704_add_show_mcq_mrq_solution_to_course_assessments.rb
@@ -1,0 +1,5 @@
+class AddShowMcqMrqSolutionToCourseAssessments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_assessments, :show_mcq_mrq_solution, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_074249) do
+ActiveRecord::Schema.define(version: 2021_08_17_040704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -431,6 +431,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_074249) do
     t.boolean "allow_partial_submission", default: false
     t.integer "randomization"
     t.boolean "show_mcq_answer", default: true
+    t.boolean "show_mcq_mrq_solution", default: true
     t.index ["creator_id"], name: "fk__course_assessments_creator_id"
     t.index ["tab_id"], name: "fk__course_assessments_tab_id"
     t.index ["updater_id"], name: "fk__course_assessments_updater_id"


### PR DESCRIPTION
The PR fixes the 2 following items:
1) To show correct answers of a graded/published submission in the student's view.
2) Enable a student to view other questions following a question with an incorrect answer when "allow to skip steps" setting is toggled off.

and adds the following feature:
1) Create a toggle button in assessment setting to show/hide MCQ/MRQ solutions.