### PR TITLE
[1/3][Library] Improving User Satisfiability Graph to Support Survey Conditions

### DIFF
--- a/app/models/course/condition.rb
+++ b/app/models/course/condition.rb
@@ -36,7 +36,7 @@ class Course::Condition < ApplicationRecord
         )
 
         conditional_name.constantize.where(course_id: course)
-      end.flatten
+      end.flatten.compact
     end
 
     # Finds all conditionals that depend on the given object.

--- a/lib/autoload/course/conditional/user_satisfiability_graph.rb
+++ b/lib/autoload/course/conditional/user_satisfiability_graph.rb
@@ -73,11 +73,19 @@ class Course::Conditional::UserSatisfiabilityGraph
   def each_child
     lambda do |conditional, &b|
       conditional.specific_conditions.each do |condition|
-        # Append the condition as an outgoing edge for the condition's dependent object
-        @edges.add(condition.dependent_object, condition)
+        dependent_object = condition.dependent_object
+        # We only want conditionals as nodes in this graph. Not all dependent objects are conditionals.
+        next unless conditional_object?(dependent_object)
 
-        b.call(condition.dependent_object) unless condition.dependent_object.nil?
+        # Append the condition as an outgoing edge for the condition's dependent object
+        @edges.add(dependent_object, condition)
+
+        b.call(dependent_object)
       end
     end
+  end
+
+  def conditional_object?(object)
+    object.singleton_class.include?(ActiveRecord::Base::ConditionalInstanceMethods)
   end
 end


### PR DESCRIPTION
Changes for this feature will be pushed as a stack of PRs, i.e. `master <- part-1 <- part-2 <- part-3`. You can find the other two PRs here:

- https://github.com/zhuhanming/coursemology2/pull/1
- https://github.com/zhuhanming/coursemology2/pull/2

The next PR will be rebased onto upstream master once this PR is merged.

## Summary

This summary covers the context for all 3 PRs, so it's a bit on the longer side.

### Context

We want to add a new type of condition - surveys, so that achievements can be given when students complete surveys.

Currently, Coursemology uses a condition-conditional framework.

- Conditionals are objects that can possess conditions, i.e. they will be "unlocked" upon having all their conditions met. There are two conditionals as of right now - achievements and assessments.
- Conditions are objects that represent some requirement to meet. This need not necessarily be an "object" like an assessment or achievement - it can be a level requirement as well, which has no `dependent_object`.

Thus, by adding a new survey condition, we can also make surveys a condition for assessments to unlock as well, not just for unlocking achievements.

### User Satisfiability Graph

Since the `dependent_object`, i.e. the object that the condition depends on, can also be a conditional, we may end up having cyclic dependencies, where Assessment 1 depends on Achievement 2 and vice versa. It may also be challenging to constantly recompute these requirements and how they link up with one another.

This is where the User Satisfiability Graph comes in - it creates a graph where conditionals are the nodes and conditions are the edges. By running a topo sort on this graph, we can easily identify cycles (since it should be a directed acyclic graph) and also help with computations of whether conditions have been satisfied.

### Problem

The issue at hand is that the existing implementation assumed that all `dependent_object`s are conditionals. This might have been true, but with the introduction of survey conditions, we now have conditions that have surveys as their `dependent_object`s, but these surveys themselves do not have conditions, i.e. they are not conditionals! (As of now, we will not be unnecessarily adding unlock requirements to surveys.)

This breaks the existing implementation since the `each_child` method generates `dependent_object`s as neighbours of a given node, and this results in surveys being produced as nodes when the surveys are not conditionals (and thus should not be nodes).

### Solution

The fix is to simply check if the instance possesses the methods that a conditional should have (`ActiveRecord::Base::ConditionalInstanceMethods`). This also helps to cleanly remove all `nil` values, since `NilClass` does not possess the methods required.

### Other Fixes

Another fix is that compacting of conditionals fetched for a specified course. For some reason, a `nil` value was being returned at the end of the array of conditionals. Not sure if this is development-only - will have to test it again later. Either way, this `compact` fix solves the problem.

## Test Plan

Tested that there is no regression in both the test cases and in existing achievements/assessments unlocking.

```bash
bundle exec rspec
```

https://user-images.githubusercontent.com/45617494/130375021-e1a8cd2f-9407-48e3-b7f8-6b9aaca3cb0d.mov
