### PR TITLE
Fix survey submission time and survey edit permission

### DIFF
--- a/app/controllers/course/survey/responses_controller.rb
+++ b/app/controllers/course/survey/responses_controller.rb
@@ -54,6 +54,7 @@ class Course::Survey::ResponsesController < Course::Survey::Controller
       @response.submit
     else
       authorize!(:modify, @response)
+      @response.update_updated_at
     end
 
     if @response.update(response_update_params)

--- a/app/models/components/course/surveys_ability_component.rb
+++ b/app/models/components/course/surveys_ability_component.rb
@@ -22,6 +22,7 @@ module Course::SurveysAbilityComponent
     allow_students_submit_own_response
     allow_students_modify_own_response_to_active_survey
     allow_students_modify_own_response_to_modifiable_submitted_survey
+    disallow_students_modify_own_response_to_modifiable_expired_submitted_survey
     allow_students_modify_own_response_to_respondable_expired_survey
   end
 
@@ -47,6 +48,13 @@ module Course::SurveysAbilityComponent
     survey_published_all_course_users_hash.deep_merge(
       lesson_plan_item: { default_reference_time: { end_at: (Time.min..Time.zone.now) } },
       allow_response_after_end: true
+    )
+  end
+
+  def survey_expired_and_not_respondable
+    survey_published_all_course_users_hash.deep_merge(
+      lesson_plan_item: { default_reference_time: { end_at: (Time.min..Time.zone.now) } },
+      allow_response_after_end: false, allow_modify_after_submit: true
     )
   end
 
@@ -100,6 +108,10 @@ module Course::SurveysAbilityComponent
     can :modify, Course::Survey::Response,
         creator_id: user.id, submitted_at: (Time.min..Time.max),
         survey: survey_open_all_course_users_hash.deep_merge(allow_modify_after_submit: true)
+  end
+
+  def disallow_students_modify_own_response_to_modifiable_expired_submitted_survey
+    cannot :modify, Course::Survey::Response, survey: survey_expired_and_not_respondable
   end
 
   def allow_students_modify_own_response_to_respondable_expired_survey

--- a/app/models/course/survey/response.rb
+++ b/app/models/course/survey/response.rb
@@ -44,6 +44,10 @@ class Course::Survey::Response < ApplicationRecord
     end
   end
 
+  def update_updated_at
+    self.updated_at = Time.zone.now if self.submitted_at
+  end
+
   private
 
   def options_invalid(attributes)

--- a/app/models/course/survey/response.rb
+++ b/app/models/course/survey/response.rb
@@ -45,7 +45,7 @@ class Course::Survey::Response < ApplicationRecord
   end
 
   def update_updated_at
-    self.updated_at = Time.zone.now if self.submitted_at
+    self.updated_at = Time.zone.now if submitted?
   end
 
   private

--- a/app/services/course/survey/survey_download_service.rb
+++ b/app/services/course/survey/survey_download_service.rb
@@ -43,7 +43,8 @@ class Course::Survey::SurveyDownloadService
 
     def generate_header(questions)
       [
-        I18n.t('course.surveys.survey_download_service.timestamp'),
+        I18n.t('course.surveys.survey_download_service.created_at'),
+        I18n.t('course.surveys.survey_download_service.updated_at'),
         I18n.t('course.surveys.survey_download_service.course_user_id'),
         I18n.t('course.surveys.survey_download_service.name'),
         I18n.t('course.surveys.survey_download_service.role')
@@ -58,6 +59,7 @@ class Course::Survey::SurveyDownloadService
       end
       [
         response.submitted_at,
+        response.submitted_at ? response.updated_at : response.submitted_at,
         response.course_user.id,
         response.course_user.name,
         response.course_user.role,

--- a/app/views/course/survey/responses/_response.json.jbuilder
+++ b/app/views/course/survey/responses/_response.json.jbuilder
@@ -4,7 +4,7 @@ json.survey do
 end
 
 json.response do
-  json.(response, :id, :submitted_at)
+  json.(response, :id, :submitted_at, :updated_at)
   json.creator_name response.creator.name
 
   json.answers answers do |answer|

--- a/app/views/course/survey/responses/index.json.jbuilder
+++ b/app/views/course/survey/responses/index.json.jbuilder
@@ -12,7 +12,7 @@ json.responses @course_students do |student|
 
   json.present !!response
   if response
-    json.(response, :id, :submitted_at)
+    json.(response, :id, :submitted_at, :updated_at)
     json.canUnsubmit can?(:unsubmit, response)
     json.path course_survey_response_path(current_course, @survey, response) if canReadAnswers
   end

--- a/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
@@ -69,6 +69,10 @@ const translations = defineMessages({
     id: 'course.surveys.ResponseIndex.submittedAt',
     defaultMessage: 'Submitted At',
   },
+  updatedAt: {
+    id: 'course.surveys.ResponseIndex.updatedAt',
+    defaultMessage: 'Updated At',
+  },
   phantoms: {
     id: 'course.surveys.ResponseIndex.phantoms',
     defaultMessage: 'Phantom Students',
@@ -134,6 +138,17 @@ class ResponseIndex extends React.Component {
     return submittedAt;
   }
 
+  static renderUpdatedAt(response, survey) {
+    if (!response.submitted_at) {
+      return null;
+    }
+    const updatedAt = formatLongDateTime(response.updated_at);
+    if (survey.end_at && moment(response.updated_at).isAfter(survey.end_at)) {
+      return <div style={styles.red}>{ updatedAt }</div>;
+    }
+    return updatedAt;
+  }
+
   static renderTable(responses, survey) {
     return (
       <Table>
@@ -150,6 +165,9 @@ class ResponseIndex extends React.Component {
             </TableHeaderColumn>
             <TableHeaderColumn>
               <FormattedMessage {...translations.submittedAt} />
+            </TableHeaderColumn>
+            <TableHeaderColumn>
+              <FormattedMessage {...translations.updatedAt} />
             </TableHeaderColumn>
             <TableHeaderColumn />
           </TableRow>
@@ -171,6 +189,9 @@ class ResponseIndex extends React.Component {
                 </TableRowColumn>
                 <TableRowColumn>
                   { ResponseIndex.renderSubmittedAt(response, survey) }
+                </TableRowColumn>
+                <TableRowColumn>
+                  { ResponseIndex.renderUpdatedAt(response, survey) }
                 </TableRowColumn>
                 <TableRowColumn>
                   {

--- a/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
@@ -71,7 +71,7 @@ const translations = defineMessages({
   },
   updatedAt: {
     id: 'course.surveys.ResponseIndex.updatedAt',
-    defaultMessage: 'Updated At',
+    defaultMessage: 'Last Updated At',
   },
   phantoms: {
     id: 'course.surveys.ResponseIndex.phantoms',

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/__snapshots__/index.test.jsx.snap
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/__snapshots__/index.test.jsx.snap
@@ -78,12 +78,12 @@ exports[`<ResponseShow /> shows form and admin buttons if user has permissions a
         striped={false}
       >
         <TableHeaderColumn>
-          Updated At
+          Last Updated At
         </TableHeaderColumn>
         <TableRowColumn
           hoverable={false}
         >
-          01 Jan 2100, 12:00am
+          13 Jan 2100, 12:00am
         </TableRowColumn>
       </TableRow>
     </TableBody>
@@ -114,7 +114,7 @@ exports[`<ResponseShow /> shows form and admin buttons if user has permissions a
         "creator_name": "Staff",
         "id": 2,
         "submitted_at": "2099-12-31T16:00:00.000Z",
-        "updated_at": "2099-12-31T16:00:00.000Z",
+        "updated_at": "2100-01-12T16:00:00.000Z",
       }
     }
   />

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/__snapshots__/index.test.jsx.snap
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/__snapshots__/index.test.jsx.snap
@@ -70,6 +70,22 @@ exports[`<ResponseShow /> shows form and admin buttons if user has permissions a
           01 Jan 2100, 12:00am
         </TableRowColumn>
       </TableRow>
+      <TableRow
+        displayBorder={true}
+        hoverable={false}
+        hovered={false}
+        selectable={false}
+        striped={false}
+      >
+        <TableHeaderColumn>
+          Updated At
+        </TableHeaderColumn>
+        <TableRowColumn
+          hoverable={false}
+        >
+          01 Jan 2100, 12:00am
+        </TableRowColumn>
+      </TableRow>
     </TableBody>
   </Table>
   <Subheader
@@ -98,6 +114,7 @@ exports[`<ResponseShow /> shows form and admin buttons if user has permissions a
         "creator_name": "Staff",
         "id": 2,
         "submitted_at": "2099-12-31T16:00:00.000Z",
+        "updated_at": "2099-12-31T16:00:00.000Z",
       }
     }
   />

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
@@ -31,7 +31,7 @@ describe('<ResponseShow />', () => {
         id: responseId,
         creator_name: 'Staff',
         submitted_at: '2099-12-31T16:00:00.000Z',
-        updated_at: '2099-12-31T16:00:00.000Z',
+        updated_at: '2100-01-12T16:00:00.000Z',
       },
       flags: {
         canModify: true,

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
@@ -31,6 +31,7 @@ describe('<ResponseShow />', () => {
         id: responseId,
         creator_name: 'Staff',
         submitted_at: '2099-12-31T16:00:00.000Z',
+        updated_at: '2099-12-31T16:00:00.000Z',
       },
       flags: {
         canModify: true,

--- a/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
@@ -69,6 +69,15 @@ class ResponseShow extends React.Component {
               }
             </TableRowColumn>
           </TableRow>
+          <TableRow selectable={false}>
+            <TableHeaderColumn>Updated At</TableHeaderColumn>
+            <TableRowColumn>
+              {response.submitted_at
+                ? formatLongDateTime(response.updated_at)
+                : <FormattedMessage {...translations.notSubmitted} />
+              }
+            </TableRowColumn>
+          </TableRow>
         </TableBody>
       </Table>
     );

--- a/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/index.jsx
@@ -70,7 +70,7 @@ class ResponseShow extends React.Component {
             </TableRowColumn>
           </TableRow>
           <TableRow selectable={false}>
-            <TableHeaderColumn>Updated At</TableHeaderColumn>
+            <TableHeaderColumn>Last Updated At</TableHeaderColumn>
             <TableRowColumn>
               {response.submitted_at
                 ? formatLongDateTime(response.updated_at)

--- a/client/app/bundles/course/survey/propTypes.js
+++ b/client/app/bundles/course/survey/propTypes.js
@@ -53,5 +53,6 @@ export const responseShape = PropTypes.shape({
   id: PropTypes.number,
   name: PropTypes.string,
   submitted_at: PropTypes.string,
+  updated_at: PropTypes.string,
   sections: PropTypes.arrayOf(sectionShape),
 });

--- a/config/locales/en/course/survey/surveys.yml
+++ b/config/locales/en/course/survey/surveys.yml
@@ -5,7 +5,7 @@ en:
         respond: 'Respond'
       survey_download_service:
         created_at: 'Create Timestamp'
-        updated_at: 'Update Timestamp'
+        updated_at: 'Last Update Timestamp'
         course_user_id: 'Course User ID'
         name: 'Name'
         role: 'Role'

--- a/config/locales/en/course/survey/surveys.yml
+++ b/config/locales/en/course/survey/surveys.yml
@@ -4,7 +4,8 @@ en:
       todo_survey_button:
         respond: 'Respond'
       survey_download_service:
-        timestamp: 'Timestamp'
+        created_at: 'Create Timestamp'
+        updated_at: 'Update Timestamp'
         course_user_id: 'Course User ID'
         name: 'Name'
         role: 'Role'

--- a/spec/controllers/course/survey/responses_controller_spec.rb
+++ b/spec/controllers/course/survey/responses_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Course::Survey::ResponsesController do
 
           first_response = json_response['responses'].first
           expect(first_response.keys).to contain_exactly(
-            'present', 'course_user', 'canUnsubmit', 'id', 'path', 'submitted_at'
+            'present', 'course_user', 'canUnsubmit', 'id', 'path', 'submitted_at', 'updated_at'
           )
 
           expect(first_response['course_user'].keys).to contain_exactly(

--- a/spec/services/course/survey/survey_download_spec.rb
+++ b/spec/services/course/survey/survey_download_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Course::Survey::SurveyDownloadService do
       context 'header' do
         it 'fifth element onwards is question descriptions in increasing weight' do
           question_descriptions = questions.sort_by(&:weight).map(&:description)
-          expect(subject[0].slice(4..-1)).to eq(question_descriptions)
+          expect(subject[0].slice(5..-1)).to eq(question_descriptions)
         end
       end
 
@@ -88,13 +88,14 @@ RSpec.describe Course::Survey::SurveyDownloadService do
       end
 
       it 'returns an array with four more elements than the no. of questions' do
-        expect(subject.size).to eq(questions.size + 4)
+        expect(subject.size).to eq(questions.size + 5)
       end
 
-      it 'first four elements are timestamp, course user id, name, and role' do
-        expect(subject.slice(0..3)).to eq(
+      it 'first five elements are submit timestamp, update timestamp, course user id, name, and role' do
+        expect(subject.slice(0..4)).to eq(
           [
             response.submitted_at,
+            response.updated_at,
             response.course_user.id,
             response.course_user.name,
             response.course_user.role
@@ -103,7 +104,7 @@ RSpec.describe Course::Survey::SurveyDownloadService do
       end
 
       it 'returns answers that correspond to questions' do
-        expect(subject.slice(4..-1)).to eq(['Q1 Answer', 'Q2 Answer', 'Q3 Answer'])
+        expect(subject.slice(5..-1)).to eq(['Q1 Answer', 'Q2 Answer', 'Q3 Answer'])
       end
     end
 

--- a/spec/services/course/survey/survey_download_spec.rb
+++ b/spec/services/course/survey/survey_download_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Course::Survey::SurveyDownloadService do
       end
 
       context 'header' do
-        it 'fifth element onwards is question descriptions in increasing weight' do
+        it 'sixth element (inclusive) onwards is question descriptions in increasing weight' do
           question_descriptions = questions.sort_by(&:weight).map(&:description)
           expect(subject[0].slice(5..-1)).to eq(question_descriptions)
         end
@@ -87,11 +87,11 @@ RSpec.describe Course::Survey::SurveyDownloadService do
         ]
       end
 
-      it 'returns an array with four more elements than the no. of questions' do
+      it 'returns an array with five more elements than the no. of questions' do
         expect(subject.size).to eq(questions.size + 5)
       end
 
-      it 'first five elements are submit timestamp, update timestamp, course user id, name, and role' do
+      it 'first five elements are submit timestamp, last update timestamp, course user id, name, and role' do
         expect(subject.slice(0..4)).to eq(
           [
             response.submitted_at,


### PR DESCRIPTION
**Problem**
1) Coursemology surveys do not update the submission time for the latest submission.
2) Submitted surveys can be updated even after the survey is expired.

**Solution**

1) An additional information of response update timestamp is added to the frontend views for both response index and specific, and also csv download.

Index Page
![image](https://user-images.githubusercontent.com/42570513/132434903-e7ecd398-0550-4ed0-b4b0-d914e23a53bd.png)

Show Page
![image](https://user-images.githubusercontent.com/42570513/132434982-2b4fbf90-b3de-4d6f-b1d7-49e34f921d2e.png)

CSV
![image](https://user-images.githubusercontent.com/42570513/132435076-17f3d239-3033-4510-9425-560261bbc09c.png)

2) Add cancancan ability to disallow submitted surveys to be updated after it's expired

This PR solves #3879 