### PR TITLE
Disable action buttons for assessment files when Materials component setting is disabled

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -217,6 +217,10 @@ class Course < ApplicationRecord
     end
   end
 
+  def materials_component_enabled?
+    settings(:components, :course_materials_component).enabled
+  end
+
   private
 
   # Set default values

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -217,10 +217,6 @@ class Course < ApplicationRecord
     end
   end
 
-  def materials_component_enabled?
-    settings(:components, :course_materials_component).enabled
-  end
-
   private
 
   # Set default values

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -22,7 +22,7 @@ json.randomization_allowed current_course.allow_randomization
 
 json.folder_attributes do
   json.folder_id @assessment.folder.id
-  json.enable_materials_action @assessment.course.settings(:components, :course_materials_component).enabled
+  json.enable_materials_action !current_component_host[:course_materials_component].nil?
   json.materials @assessment.materials.order(:name) do |material|
     json.partial! '/course/material/material.json', material: material, folder: @assessment.folder
   end

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -22,6 +22,7 @@ json.randomization_allowed current_course.allow_randomization
 
 json.folder_attributes do
   json.folder_id @assessment.folder.id
+  json.enable_materials_action @assessment.course.materials_component_enabled?
   json.materials @assessment.materials.order(:name) do |material|
     json.partial! '/course/material/material.json', material: material, folder: @assessment.folder
   end

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -22,7 +22,7 @@ json.randomization_allowed current_course.allow_randomization
 
 json.folder_attributes do
   json.folder_id @assessment.folder.id
-  json.enable_materials_action @assessment.course.materials_component_enabled?
+  json.enable_materials_action @assessment.course.settings(:components, :course_materials_component).enabled
   json.materials @assessment.materials.order(:name) do |material|
     json.partial! '/course/material/material.json', material: material, folder: @assessment.folder
   end

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -77,7 +77,7 @@
     = render partial: @assessment.assessment_conditions.includes(:conditional), suffix: 'condition'
 
   - if can?(:attempt, @assessment) && @assessment.folder.materials.present?
-    - enable_link = @course.settings(:components, :course_materials_component).enabled
+    - enable_link = !current_component_host[:course_materials_component].nil?
     h3 = t('.files') if enable_link || can?(:manage, @assessment)
     = render partial: 'layouts/materials',
       locals: { folder: @assessment.folder,

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -77,7 +77,7 @@
     = render partial: @assessment.assessment_conditions.includes(:conditional), suffix: 'condition'
 
   - if can?(:attempt, @assessment) && @assessment.folder.materials.present?
-    - enable_link = @course.materials_component_enabled?
+    - enable_link = @course.settings(:components, :course_materials_component).enabled
     h3 = t('.files') if enable_link || can?(:manage, @assessment)
     = render partial: 'layouts/materials',
       locals: { folder: @assessment.folder,

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -77,8 +77,12 @@
     = render partial: @assessment.assessment_conditions.includes(:conditional), suffix: 'condition'
 
   - if can?(:attempt, @assessment) && @assessment.folder.materials.present?
-    h3 = t('.files')
-    = render partial: 'layouts/materials', locals: { folder: @assessment.folder }
+    - enable_link = @course.materials_component_enabled?
+    h3 = t('.files') if enable_link || can?(:manage, @assessment)
+    = render partial: 'layouts/materials',
+      locals: { folder: @assessment.folder,
+                enable_link: enable_link,
+                tooltip_title: t('.materials_disabled') }
 
   - if can?(:observe, @assessment)
     - if can?(:manage, @assessment)

--- a/app/views/layouts/_materials.html.slim
+++ b/app/views/layouts/_materials.html.slim
@@ -1,6 +1,11 @@
 - unless folder.materials.empty?
   - folder.materials.includes(:attachment_references).each do |material|
     div
-      = link_to [current_course, folder, material] do
+      - if enable_link
+        = link_to [current_course, folder, material] do
+          => fa_icon 'file-o'.freeze
+          = format_inline_text(material.name)
+      - elsif can?(:manage, @assessment)
         => fa_icon 'file-o'.freeze
-        = format_inline_text(material.name)
+        span title = tooltip_title data-toggle = 'tooltip' data-placement = 'right'
+          = material.name

--- a/client/app/bundles/course/assessment/assessments-show.js
+++ b/client/app/bundles/course/assessment/assessments-show.js
@@ -35,4 +35,5 @@ function initializeQuestionSorting() {
 
 $(document).ready(() => {
   initializeQuestionSorting();
+  $('[data-toggle="tooltip"]').tooltip();
 });

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -550,6 +550,7 @@ class AssessmentForm extends React.Component {
           <>
             <br />
             <MaterialUploader
+              enableMaterialsAction={folderAttributes.enable_materials_action}
               folderId={folderAttributes.folder_id}
               materials={folderAttributes.materials}
             />
@@ -609,6 +610,8 @@ AssessmentForm.propTypes = {
   modeSwitching: PropTypes.bool,
   folderAttributes: PropTypes.shape({
     folder_id: PropTypes.number,
+    // If any action (upload, delete and download) of the materials
+    enableMaterialsAction: PropTypes.bool,
     // See MaterialFormContainer for detailed PropTypes.
     materials: typeMaterial,
   }),

--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -611,7 +611,7 @@ AssessmentForm.propTypes = {
   folderAttributes: PropTypes.shape({
     folder_id: PropTypes.number,
     // If any action (upload, delete and download) of the materials
-    enableMaterialsAction: PropTypes.bool,
+    enable_materials_action: PropTypes.bool,
     // See MaterialFormContainer for detailed PropTypes.
     materials: typeMaterial,
   }),

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/Material.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/Material.jsx
@@ -75,9 +75,9 @@ class Material extends React.Component {
         style={styles.iconButton}
         disabled={disabled}
       >
-        <DeleteIcon data-tip data-for='delete-file-button' data-tip-disable={!disabled}/>
-        <ReactTooltip id='delete-file-button'>
-          <FormattedMessage {...translations.disableDelete}/>
+        <DeleteIcon data-tip data-for="delete-file-button" data-tip-disable={!disabled} />
+        <ReactTooltip id="delete-file-button">
+          <FormattedMessage {...translations.disableDelete} />
         </ReactTooltip>
       </IconButton>
     );

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/Material.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/Material.jsx
@@ -75,7 +75,11 @@ class Material extends React.Component {
         style={styles.iconButton}
         disabled={disabled}
       >
-        <DeleteIcon data-tip data-for="delete-file-button" data-tip-disable={!disabled} />
+        <DeleteIcon
+          data-tip
+          data-for="delete-file-button"
+          data-tip-disable={!disabled}
+        />
         <ReactTooltip id="delete-file-button">
           <FormattedMessage {...translations.disableDelete} />
         </ReactTooltip>

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/Material.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/Material.jsx
@@ -8,6 +8,7 @@ import CircularProgress from 'material-ui/CircularProgress';
 import Avatar from 'material-ui/Avatar';
 import ActionAssignment from 'material-ui/svg-icons/action/assignment';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
+import ReactTooltip from 'react-tooltip';
 
 const styles = {
   root: {
@@ -38,6 +39,11 @@ const translations = defineMessages({
     id: 'course.material.uploading',
     defaultMessage: 'Uploading',
   },
+  disableDelete: {
+    id: 'course.material.disableDelete',
+    defaultMessage:
+      'This action is unavailable as the Materials Component is disabled in the Admin Settings',
+  },
 });
 
 const propTypes = {
@@ -47,6 +53,7 @@ const propTypes = {
   onMaterialDelete: PropTypes.func,
   deleting: PropTypes.bool,
   uploading: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
 class Material extends React.Component {
@@ -57,13 +64,21 @@ class Material extends React.Component {
   };
 
   renderIcon() {
+    const { disabled } = this.props;
     if (this.props.deleting || this.props.uploading) {
       return <CircularProgress size={24} style={styles.iconButton} />;
     }
 
     return (
-      <IconButton onClick={this.onDelete} style={styles.iconButton}>
-        <DeleteIcon />
+      <IconButton
+        onClick={this.onDelete}
+        style={styles.iconButton}
+        disabled={disabled}
+      >
+        <DeleteIcon data-tip data-for='delete-file-button' data-tip-disable={!disabled}/>
+        <ReactTooltip id='delete-file-button'>
+          <FormattedMessage {...translations.disableDelete}/>
+        </ReactTooltip>
       </IconButton>
     );
   }

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/MaterialList.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/MaterialList.jsx
@@ -6,11 +6,9 @@ import Subheader from 'material-ui/Subheader';
 import FlatButton from 'material-ui/FlatButton';
 import Divider from 'material-ui/Divider';
 import ContentAdd from 'material-ui/svg-icons/content/add';
-import NotificationBar, {
-  notificationShape,
-} from 'lib/components/NotificationBar';
-import Material from './Material';
+import NotificationBar, { notificationShape } from 'lib/components/NotificationBar';
 import ReactTooltip from 'react-tooltip';
+import Material from './Material';
 
 const translations = defineMessages({
   disableNewFile: {
@@ -109,11 +107,12 @@ const MaterialList = (props) => {
             multiple
             style={styles.uploadInput}
             onChange={onFileInputChange}
-            disabled={!enableMaterialsAction}/>
+            disabled={!enableMaterialsAction}
+          />
         </FlatButton>
       </div>
       <ReactTooltip id="add-files-button">
-        <FormattedMessage {...translations.disableNewFile}/>
+        <FormattedMessage {...translations.disableNewFile} />
       </ReactTooltip>
     </>
   );

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/MaterialList.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/MaterialList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, defineMessages } from 'react-intl';
 import { List } from 'material-ui/List';
 import Subheader from 'material-ui/Subheader';
 import FlatButton from 'material-ui/FlatButton';
@@ -10,6 +10,15 @@ import NotificationBar, {
   notificationShape,
 } from 'lib/components/NotificationBar';
 import Material from './Material';
+import ReactTooltip from 'react-tooltip';
+
+const translations = defineMessages({
+  disableNewFile: {
+    id: 'course.material.disableNewFile',
+    defaultMessage:
+      'This action is unavailable as the Materials Component is disabled in the Admin Settings',
+  },
+});
 
 const propTypes = {
   materials: PropTypes.arrayOf(
@@ -31,6 +40,7 @@ const propTypes = {
     }),
   ),
   onFileInputChange: PropTypes.func,
+  enableMaterialsAction: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -54,8 +64,7 @@ const styles = {
 };
 
 const MaterialList = (props) => {
-  const { materials, uploadingMaterials, onMaterialDelete, onFileInputChange } =
-    props;
+  const { materials, uploadingMaterials, onMaterialDelete, onFileInputChange, enableMaterialsAction } = props;
   const header = (
     <FormattedMessage
       id="course.assessment.MaterialList.uploadedFiles"
@@ -71,28 +80,42 @@ const MaterialList = (props) => {
       updatedAt={material.updated_at}
       deleting={material.deleting}
       onMaterialDelete={onMaterialDelete}
+      disabled={!enableMaterialsAction}
     />
   ));
 
-  const uploadingMaterialNodes = uploadingMaterials.map((material) => (
-    <Material key={material.name} name={material.name} uploading />
+  const uploadingMaterialNodes = uploadingMaterials.map(material => (
+    <Material
+      key={material.name}
+      name={material.name}
+      uploading
+      disabled={!enableMaterialsAction}
+    />
   ));
 
   const newFileButton = (
-    <FlatButton
-      fullWidth
-      label="Add Files"
-      icon={<ContentAdd />}
-      containerElement="label"
-      style={styles.newFileButton}
-    >
-      <input
-        type="file"
-        multiple
-        style={styles.uploadInput}
-        onChange={onFileInputChange}
-      />
-    </FlatButton>
+    <>
+      <div data-tip data-for="add-files-button" data-tip-disable={enableMaterialsAction}>
+        <FlatButton
+          fullWidth
+          label="Add Files"
+          icon={<ContentAdd />}
+          containerElement="label"
+          style={styles.newFileButton}
+          disabled={!enableMaterialsAction}
+        >
+          <input
+            type="file"
+            multiple
+            style={styles.uploadInput}
+            onChange={onFileInputChange}
+            disabled={!enableMaterialsAction}/>
+        </FlatButton>
+      </div>
+      <ReactTooltip id="add-files-button">
+        <FormattedMessage {...translations.disableNewFile}/>
+      </ReactTooltip>
+    </>
   );
 
   return (
@@ -107,7 +130,10 @@ const MaterialList = (props) => {
         {newFileButton}
       </List>
       <Divider />
-      <NotificationBar notification={props.notification} />
+      <NotificationBar
+        notification={props.notification}
+        autoHideDuration={5000}
+      />
     </>
   );
 };

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/MaterialList.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/MaterialList.jsx
@@ -6,7 +6,9 @@ import Subheader from 'material-ui/Subheader';
 import FlatButton from 'material-ui/FlatButton';
 import Divider from 'material-ui/Divider';
 import ContentAdd from 'material-ui/svg-icons/content/add';
-import NotificationBar, { notificationShape } from 'lib/components/NotificationBar';
+import NotificationBar, {
+  notificationShape,
+} from 'lib/components/NotificationBar';
 import ReactTooltip from 'react-tooltip';
 import Material from './Material';
 
@@ -62,7 +64,13 @@ const styles = {
 };
 
 const MaterialList = (props) => {
-  const { materials, uploadingMaterials, onMaterialDelete, onFileInputChange, enableMaterialsAction } = props;
+  const {
+    materials,
+    uploadingMaterials,
+    onMaterialDelete,
+    onFileInputChange,
+    enableMaterialsAction,
+  } = props;
   const header = (
     <FormattedMessage
       id="course.assessment.MaterialList.uploadedFiles"
@@ -82,7 +90,7 @@ const MaterialList = (props) => {
     />
   ));
 
-  const uploadingMaterialNodes = uploadingMaterials.map(material => (
+  const uploadingMaterialNodes = uploadingMaterials.map((material) => (
     <Material
       key={material.name}
       name={material.name}
@@ -93,7 +101,11 @@ const MaterialList = (props) => {
 
   const newFileButton = (
     <>
-      <div data-tip data-for="add-files-button" data-tip-disable={enableMaterialsAction}>
+      <div
+        data-tip
+        data-for="add-files-button"
+        data-tip-disable={enableMaterialsAction}
+      >
         <FlatButton
           fullWidth
           label="Add Files"

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/__test__/__snapshots__/index.test.js.snap
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/__test__/__snapshots__/index.test.js.snap
@@ -134,7 +134,7 @@ exports[`<MaterialList /> renders the component with materials 1`] = `
     >
       <FlatButton
         containerElement="label"
-        disabled={false}
+        disabled={true}
         fullWidth={true}
         icon={<ContentAdd />}
         label="Add Files"
@@ -153,6 +153,7 @@ exports[`<MaterialList /> renders the component with materials 1`] = `
         }
       >
         <input
+          disabled={true}
           multiple={true}
           style={
             Object {

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/__test__/__snapshots__/index.test.js.snap
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/__test__/__snapshots__/index.test.js.snap
@@ -54,7 +54,24 @@ exports[`<Material /> renders the material 1`] = `
       tooltipPosition="bottom-center"
       touch={false}
     >
-      <ActionDelete />
+      <ActionDelete
+        data-for="delete-file-button"
+        data-tip={true}
+        data-tip-disable={true}
+      />
+      <ReactTooltip
+        clickable={false}
+        id="delete-file-button"
+        insecure={true}
+        resizeHide={true}
+        wrapper="div"
+      >
+        <FormattedMessage
+          defaultMessage="This action is unavailable as the Materials Component is disabled in the Admin Settings"
+          id="course.material.disableDelete"
+          values={Object {}}
+        />
+      </ReactTooltip>
     </IconButton>
   }
   secondaryText={
@@ -95,6 +112,7 @@ exports[`<MaterialList /> renders the component with materials 1`] = `
     </Subheader>
     <Material
       deleting={false}
+      disabled={true}
       id={1}
       key="1"
       name="Material 1"
@@ -103,52 +121,73 @@ exports[`<MaterialList /> renders the component with materials 1`] = `
     />
     <Material
       deleting={false}
+      disabled={true}
       id={2}
       key="2"
       name="Material 2"
       onMaterialDelete={[MockFunction]}
       updatedAt="2017-01-01T02:00:00.0000000Z"
     />
-    <FlatButton
-      containerElement="label"
-      disabled={false}
-      fullWidth={true}
-      icon={<ContentAdd />}
-      label="Add Files"
-      labelPosition="after"
-      labelStyle={Object {}}
-      onKeyboardFocus={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onTouchStart={[Function]}
-      primary={false}
-      secondary={false}
-      style={
-        Object {
-          "verticalAlign": "middle",
-        }
-      }
+    <div
+      data-for="add-files-button"
+      data-tip={true}
     >
-      <input
-        multiple={true}
+      <FlatButton
+        containerElement="label"
+        disabled={false}
+        fullWidth={true}
+        icon={<ContentAdd />}
+        label="Add Files"
+        labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
+        primary={false}
+        secondary={false}
         style={
           Object {
-            "bottom": 0,
-            "cursor": "pointer",
-            "left": 0,
-            "opacity": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "verticalAlign": "middle",
           }
         }
-        type="file"
+      >
+        <input
+          multiple={true}
+          style={
+            Object {
+              "bottom": 0,
+              "cursor": "pointer",
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          type="file"
+        />
+      </FlatButton>
+    </div>
+    <ReactTooltip
+      clickable={false}
+      id="add-files-button"
+      insecure={true}
+      resizeHide={true}
+      wrapper="div"
+    >
+      <FormattedMessage
+        defaultMessage="This action is unavailable as the Materials Component is disabled in the Admin Settings"
+        id="course.material.disableNewFile"
+        values={Object {}}
       />
-    </FlatButton>
+    </ReactTooltip>
   </List>
   <Divider
     inset={false}
   />
-  <NotificationBar />
+  <NotificationBar
+    autoHideDuration={5000}
+  />
 </Fragment>
 `;

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/index.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/index.jsx
@@ -9,6 +9,7 @@ import translations from './translations.intl';
 const propTypes = {
   folderId: PropTypes.number.isRequired,
   materials: typeMaterial,
+  enableMaterialsAction: PropTypes.bool.isRequired,
 };
 
 class MaterialUploader extends React.Component {
@@ -132,6 +133,7 @@ class MaterialUploader extends React.Component {
         notification={this.state.notification}
         onMaterialDelete={this.onMaterialDelete}
         onFileInputChange={this.onFileInputChange}
+        enableMaterialsAction={this.props.enableMaterialsAction}
       />
     );
   }

--- a/client/app/lib/components/NotificationBar.jsx
+++ b/client/app/lib/components/NotificationBar.jsx
@@ -24,7 +24,7 @@ export default class NotificationBar extends React.Component {
   }
 
   render() {
-    const { notification, ...options } = this.props;
+    const { notification, autoHideDuration = 2000, ...options } = this.props;
     const message = notification && notification.message;
     const errors = notification && notification.errors;
 
@@ -40,7 +40,7 @@ export default class NotificationBar extends React.Component {
       <Snackbar
         open={!!message}
         message={notificationNode}
-        autoHideDuration={2000}
+        autoHideDuration={autoHideDuration}
         {...options}
       />
     );
@@ -52,4 +52,5 @@ NotificationBar.propTypes = {
   // reference compare `===` is used and strings with same value will have the same reference.
   notification: notificationShape,
   // Other options are passed to the original implementation of the SnackBar.
+  autoHideDuration: PropTypes.number,
 };

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -44,6 +44,8 @@ en:
           condition_not_satisfied: >
             You must fulfill the following requirements before you can attempt this assessment:
           finish_to_unlock: 'Finish to Unlock'
+          materials_disabled: 'Enable material component in the components tab of course setting
+            to gain access to this file.'
           files: 'Files'
           questions: 'Questions'
           new_question:

--- a/spec/features/course/assessment_condition_management_spec.rb
+++ b/spec/features/course/assessment_condition_management_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'Course: Assessments' do
         create(:assessment_condition,
                course: course, assessment: other_assessment, conditional: assessment)
       end
+      let(:settings) { Course::Settings::Components.new(course.reload) }
 
       # Assessment condition
 


### PR DESCRIPTION
**Issue**

When the Materials component in the course setting is disabled, users are not able to perform any action (upload, delete and download). Instead they will only get an error.

**Solution**

Instead of allowing users to click and perform these actions on the assessment files, all the buttons are disabled when the Materials component is disabled. Tooltip messages are shown (only for course staffs) in order to inform them on how to enable the actions. For students, the files view are completely removed when the setting is disabled.

Add and delete files
![image](https://user-images.githubusercontent.com/42570513/132819394-4188b5e6-223e-4e89-90d4-317da98ed91b.png)

Download files
![image](https://user-images.githubusercontent.com/42570513/132819477-be6a44ed-beba-4254-ae2c-651583938147.png)

This PR solves #4042 