### PR TITLE
Disable FB login feature

### DIFF
--- a/app/views/course/users/show.html.slim
+++ b/app/views/course/users/show.html.slim
@@ -5,7 +5,8 @@
 div.row
   div.profile-box.col-xs-12.col-sm-4.col-md-3.col-lg-2
     = display_user_image(@course_user.user)
-    = render partial: 'user/profiles/omniauth_info', locals: { user: @course_user.user }
+    // Note: Facebook login feature is currently disabled.
+    // = render partial: 'user/profiles/omniauth_info', locals: { user: @course_user.user }
 
   div.col-xs-12.col-sm-8.col-md-9.col-lg-10
     h2 = format_inline_text(@course_user.name)

--- a/app/views/user/profiles/edit.html.slim
+++ b/app/views/user/profiles/edit.html.slim
@@ -10,8 +10,9 @@
 
   = f.button :submit, t('.submit')
 
-  hr
-  span
+  // Note: Facebook login feature is currently disabled.
+  // hr
+  // span
     - if current_user.identities.facebook.empty?
       div.facebook
         = link_to user_facebook_omniauth_authorize_path do

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -236,7 +236,14 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :facebook, ENV['OMNIAUTH_FACEBOOK_APP_ID'], ENV['OMNIAUTH_FACEBOOK_APP_SECRET']
+
+  # Facebook login feature has previously been implemented, but in the current state,
+  # it has been decided to remove this feature. However, instead of completely removing
+  # the implementation, this feature is detached/disabled in case in the future, we decide
+  # to re-introduce the feature or to add other platforms login for use in terms of a
+  # wider ecosystem.
+  # Note that related facebook login rspec tests are still kept but disabled.
+  # :facebook, ENV['OMNIAUTH_FACEBOOK_APP_ID'], ENV['OMNIAUTH_FACEBOOK_APP_SECRET']
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 
 RSpec.describe User::OmniauthCallbacksController, type: :controller do
   let!(:instance) { Instance.default }
+  # Note: Facebook login feature is currently disabled.
+  before { skip }
 
   with_tenant(:instance) do
     before { controller.request.env['devise.mapping'] = Devise.mappings[:user] }

--- a/spec/features/user/omniauth_spec.rb
+++ b/spec/features/user/omniauth_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 
 RSpec.feature 'User: Omniauth' do
   let(:instance) { Instance.default }
+  # Note: Facebook login feature is currently disabled.
+  before { skip }
 
   with_tenant(:instance) do
     context 'As a unregistered user' do

--- a/spec/features/user/profile_edit_spec.rb
+++ b/spec/features/user/profile_edit_spec.rb
@@ -32,7 +32,8 @@ RSpec.feature 'User: Profile' do
         expect(user.reload.time_zone).to eq(time_zone)
       end
 
-      scenario 'I can link my account to facebook' do
+      # Note: Facebook login feature is currently disabled.
+      xscenario 'I can link my account to facebook' do
         facebook_link = find_link(nil, href: user_facebook_omniauth_authorize_path)
         expect { facebook_link.click }.to change { user.identities.count }.by(1)
         expect(page).to have_selector('div',

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe User do
       end
     end
 
-    describe '.new_with_session' do
+    # Note: Facebook login feature is currently disabled.
+    xdescribe '.new_with_session' do
       context 'when facebook data is provided' do
         let(:params) { {} }
         let(:facebook_data) { build(:omniauth_facebook) }


### PR DESCRIPTION
## Summary

It has been currently decided to remove the FB login feature. In this PR, however, the login feature is only disabled while leaving the external platform login implementation in place. This is done in order to ease re-implementation should re-introduction of the feature or addition of other platforms login are decided in the future when a larger and wider target users are introduced to the coursemology ecosystem.

### Key Changes

- Remove FB OmniAuth provider.
- Remove FB related view rendering in profile and user pages.
- Disable of FB login related rspec tests.

### Screenshots

#### Sign-in Page
- Before
![image](https://user-images.githubusercontent.com/42570513/133270371-bc6c5502-2902-4b1b-b75b-195642088543.png)

- After
![image](https://user-images.githubusercontent.com/42570513/133270441-a604c06f-cbdc-4421-9a39-498904119c7a.png)

#### Profile Page
- Before
![image](https://user-images.githubusercontent.com/42570513/133270818-d4661669-99f0-4aa8-9ece-defb3d627593.png)

- After
![image](https://user-images.githubusercontent.com/42570513/133270603-4ad643c8-eacc-40f8-ad2c-206e7a4284d1.png)

This PR links to  #4043 