### PR TITLE
 Enable non-student role to view students' submissions when finalized submissions are blocked

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -68,8 +68,8 @@ class Course::Assessment::Submission::SubmissionsController < \
 
   def edit
     return if @submission.attempting?
-
-    render 'blocked' if @submission.assessment.block_student_viewing_after_submitted? && current_user.normal?
+    current_course_user = @course.course_users.for_user(current_user).first
+    render 'blocked' if @submission.assessment.block_student_viewing_after_submitted? && current_course_user.student?
 
     respond_to do |format|
       format.html {}

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -68,7 +68,6 @@ class Course::Assessment::Submission::SubmissionsController < \
 
   def edit
     return if @submission.attempting?
-    current_course_user = @course.course_users.for_user(current_user).first
     render 'blocked' if @submission.assessment.block_student_viewing_after_submitted? && current_course_user.student?
 
     respond_to do |format|


### PR DESCRIPTION
### Context
Instructors are not able to view students' submissions when 'Block Students from Viewing Finalized Submissions' setting is toggled on.

This PR solves #4055 and is related to #4027 