### PR TITLE
Remove squeel todos as squeel and babysqueel will be removed

### DIFF
--- a/app/models/course/condition/achievement.rb
+++ b/app/models/course/condition/achievement.rb
@@ -76,7 +76,6 @@ class Course::Condition::Achievement < ApplicationRecord
 
     # Workaround, pending the squeel bugfix (activerecord-hackery/squeel#390) that will allow
     # allow the above query to work without #reload
-    # TODO: use squeel
     Course::Achievement.joins(<<-SQL)
       INNER JOIN
         (SELECT cca.achievement_id

--- a/app/models/course/condition/survey.rb
+++ b/app/models/course/condition/survey.rb
@@ -88,7 +88,6 @@ class Course::Condition::Survey < ApplicationRecord
 
     # Workaround, pending the squeel bugfix (activerecord-hackery/squeel#390) that will allow
     # allow the above query to work without #reload
-    # TODO: use squeel
     Course::Survey.joins(<<-SQL)
       INNER JOIN
         (SELECT cca.survey_id

--- a/spec/models/course/condition/achievement_spec.rb
+++ b/spec/models/course/condition/achievement_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe Course::Condition::Achievement, type: :model do
         end
       end
 
-      # TODO: remove this test when Course::Condition::Achievement#required_achievements_for uses
-      # squeel.
       context 'when an achievement is required by another conditional with the same id' do
         subject do
           id = Time.now.to_i

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         end
       end
 
-      # TODO: remove this test when Course::Condition::Assessment#required_assessments_for uses
-      # squeel.
       context 'when an assessment is required by another conditional with the same id' do
         subject do
           id = Time.now.to_i


### PR DESCRIPTION
Squeel has been removed since #2283 and babysqueel will be removed after upgrade to rails 6. We will keep the query methods as it is.

Closes #443 