### PR TITLE
fix(Devise): Style pages for 'Forgot Password' and 'Resend Confirmation Instructions'

### DIFF
--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,0 +1,13 @@
+= page_header t('.resend')
+
+= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+  = f.full_error :confirmation_token
+
+  div.form-inputs
+    = f.input :email, required: true, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), input_html: { autocomplete: "email" }
+
+  div.form-actions
+    = f.button :submit, t('.resend')
+
+= render 'devise/shared/links'

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,0 +1,12 @@
+= page_header  t('.title')
+
+= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+
+  div.form-inputs
+    = f.input :email, required: true, autofocus: true, input_html: { autocomplete: "email" }
+
+  div.form-actions
+    = f.button :submit,  t('.button')
+
+= render "devise/shared/links"

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -3,6 +3,8 @@
 en:
   devise:
     confirmations:
+      new:
+        resend: 'Resend confirmation instructions'
       confirmed: 'Your email address has been successfully confirmed.'
       send_instructions: 'You will receive an email with instructions for how to confirm your email address in a few minutes.'
       send_paranoid_instructions: 'If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.'
@@ -27,6 +29,9 @@ en:
       failure: 'Could not authenticate you from %{kind} because "%{reason}".'
       success: 'Successfully authenticated from %{kind} account.'
     passwords:
+      new:
+        title: "Forgot your password?"
+        button: "Send me reset password instructions"
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: 'You will receive an email with instructions on how to reset your password in a few minutes.'
       send_paranoid_instructions: 'If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.'


### PR DESCRIPTION
Generated view files from Devise Gem and styled it as per slim

Closes #4093 