### PR TITLE
Try node upgrade in CI instead of deactivating tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,17 @@ jobs:
       # Checkout submodules
       - run: git submodule update --init --recursive
 
+      # Update Node.js to version 14 LTS
+      - run:
+          name: 'Update Node.js and npm'
+          command: |
+            curl -sSL "https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v14.17.6-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+
+      - run:
+          name: Check current version of node
+          command: node -v
+
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -79,6 +90,17 @@ jobs:
       # Checkout submodules
       - run: git submodule update --init --recursive
 
+      # Update Node.js to version 14 LTS
+      - run:
+          name: 'Update Node.js and npm'
+          command: |
+            curl -sSL "https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v14.17.6-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+
+      - run:
+          name: Check current version of node
+          command: node -v
+
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "Gemfile.lock" }}
@@ -100,7 +122,7 @@ jobs:
           command: |
             bundle exec rake db:setup
           environment:
-            DATABASE_URL: "postgres://ubuntu@localhost:5432/coursemology_test"
+            DATABASE_URL: 'postgres://ubuntu@localhost:5432/coursemology_test'
 
       # run tests!
       - run:
@@ -118,7 +140,7 @@ jobs:
               --format progress \
               $TEST_FILES
           environment:
-            DATABASE_URL: "postgres://ubuntu@localhost:5432/coursemology_test"
+            DATABASE_URL: 'postgres://ubuntu@localhost:5432/coursemology_test'
 
       # collect reports
       - store_test_results:
@@ -141,6 +163,17 @@ jobs:
 
       # Checkout submodules
       - run: git submodule update --init --recursive
+
+      # Update Node.js to version 14 LTS
+      - run:
+          name: 'Update Node.js and npm'
+          command: |
+            curl -sSL "https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v14.17.6-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+
+      - run:
+          name: Check current version of node
+          command: node -v
 
       - restore_cache:
           keys:
@@ -166,6 +199,17 @@ jobs:
 
       # Checkout submodules
       - run: git submodule update --init --recursive
+
+      # Update Node.js to version 14 LTS
+      - run:
+          name: 'Update Node.js and npm'
+          command: |
+            curl -sSL "https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v14.17.6-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+
+      - run:
+          name: Check current version of node
+          command: node -v
 
       - restore_cache:
           keys:
@@ -204,6 +248,17 @@ jobs:
       # Checkout submodules
       - run: git submodule update --init --recursive
 
+      # Update Node.js to version 14 LTS
+      - run:
+          name: 'Update Node.js and npm'
+          command: |
+            curl -sSL "https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v14.17.6-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+
+      - run:
+          name: Check current version of node
+          command: node -v
+
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "Gemfile.lock" }}
@@ -216,7 +271,7 @@ jobs:
           command: |
             bundle exec rake db:setup
           environment:
-            DATABASE_URL: "postgres://ubuntu@localhost:5432/coursemology_test"
+            DATABASE_URL: 'postgres://ubuntu@localhost:5432/coursemology_test'
 
       # run i18n checks!
       - run:
@@ -226,7 +281,7 @@ jobs:
             bundle exec i18n-tasks missing
             bundle exec rake factory_bot:lint
           environment:
-            DATABASE_URL: "postgres://ubuntu@localhost:5432/coursemology_test"
+            DATABASE_URL: 'postgres://ubuntu@localhost:5432/coursemology_test'
 workflows:
   version: 2
   build_and_test_and_lint:

--- a/spec/features/course/virtual_classroom/virtual_classroom_access_link_spec.rb
+++ b/spec/features/course/virtual_classroom/virtual_classroom_access_link_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Course: VirtualClassrooms', js: true do
     context 'As a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
 
-      pending 'Can generate link for active virtual_classroom' do
+      scenario 'Can generate link for active virtual_classroom' do
         visit course_virtual_classrooms_path(course)
         valid_virtual_classroom_eid = virtual_classroom_eid valid_virtual_classroom
         expect(page).not_to have_selector(virtual_classroom_eid(ended_virtual_classroom))
@@ -42,7 +42,7 @@ RSpec.feature 'Course: VirtualClassrooms', js: true do
         expect(valid_virtual_classroom.instructor_classroom_link).to be_truthy
       end
 
-      pending 'I can fetch recorded videos if they exist' do
+      scenario 'I can fetch recorded videos if they exist' do
         visit course_virtual_classrooms_path(course)
         page.find("#lec-#{course.id}-#{ended_virtual_classroom.id}-list").click
         wait_for_ajax
@@ -53,7 +53,7 @@ RSpec.feature 'Course: VirtualClassrooms', js: true do
     context 'As a Student' do
       let(:user) { create(:course_student, course: course).user }
 
-      pending 'Can generate link for active virtual_classroom' do
+      scenario 'Can generate link for active virtual_classroom' do
         visit course_virtual_classrooms_path(course)
         valid_virtual_classroom_eid = virtual_classroom_eid valid_virtual_classroom
         # W/O instructor_classroom_link, learner cannot generate link


### PR DESCRIPTION
I was thinking about why these virtual classroom tests can pass locally but always fail on CI, and it occurred to me that the key difference between my machine and the CI images is the node version.

Here's an attempt at upgrading Node in the CI pipelines. Let's see whether this works.