### PR TITLE
Forum Response [Part 1]: Allow CRUD from assessment page

### DIFF
--- a/app/controllers/course/assessment/question/forum_responses_controller.rb
+++ b/app/controllers/course/assessment/question/forum_responses_controller.rb
@@ -7,9 +7,6 @@ class Course::Assessment::Question::ForumResponsesController < Course::Assessmen
                               through: :assessment, parent: false, except: [:new, :create]
   before_action :load_question_assessment, only: [:edit, :update]
 
-  def new
-  end
-
   def create
     if @forum_response_question.save
       redirect_to course_assessment_path(current_course, @assessment),

--- a/app/controllers/course/assessment/question/forum_responses_controller.rb
+++ b/app/controllers/course/assessment/question/forum_responses_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::ForumResponsesController < Course::Assessment::Question::Controller
+  build_and_authorize_new_question :forum_response_question,
+                                   class: Course::Assessment::Question::ForumResponse, only: [:new, :create]
+  load_and_authorize_resource :forum_response_question,
+                              class: Course::Assessment::Question::ForumResponse,
+                              through: :assessment, parent: false, except: [:new, :create]
+  before_action :load_question_assessment, only: [:edit, :update]
+
+  # TODO: check why question_type cannot be used as a standalone. currently using @forum_response_question.question_type
+  def new
+  end
+
+  def create
+    if @forum_response_question.save
+      redirect_to course_assessment_path(current_course, @assessment),
+                  success: t('.success')
+    else
+      render 'new'
+    end
+  end
+
+  def edit
+    @forum_response_question.description = helpers.format_html(@forum_response_question.description)
+  end
+
+  def update
+    @question_assessment.skill_ids = forum_response_question_params[:question_assessment][:skill_ids]
+    if @forum_response_question.update(forum_response_question_params.except(:question_assessment))
+      redirect_to course_assessment_path(current_course, @assessment),
+                  success: t('.success')
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    title = @forum_response_question.question_type
+    if @forum_response_question.destroy
+      redirect_to course_assessment_path(current_course, @assessment),
+                  success: t('.success')
+    else
+      error = @forum_response_question.errors.full_messages.to_sentence
+      redirect_to course_assessment_path(current_course, @assessment),
+                  danger: t('.failure', error: error)
+    end
+  end
+
+  private
+
+  def forum_response_question_params
+    permitted_params = [
+      :title, :description, :staff_only_comments, :maximum_grade, :has_text_response, :max_posts,
+      question_assessment: { skill_ids: [] }
+    ]
+    params.require(:question_forum_response).permit(*permitted_params)
+  end
+
+  def load_question_assessment
+    @question_assessment = load_question_assessment_for(@forum_response_question)
+  end
+end

--- a/app/controllers/course/assessment/question/forum_responses_controller.rb
+++ b/app/controllers/course/assessment/question/forum_responses_controller.rb
@@ -7,7 +7,6 @@ class Course::Assessment::Question::ForumResponsesController < Course::Assessmen
                               through: :assessment, parent: false, except: [:new, :create]
   before_action :load_question_assessment, only: [:edit, :update]
 
-  # TODO: check why question_type cannot be used as a standalone. currently using @forum_response_question.question_type
   def new
   end
 
@@ -35,7 +34,6 @@ class Course::Assessment::Question::ForumResponsesController < Course::Assessmen
   end
 
   def destroy
-    title = @forum_response_question.question_type
     if @forum_response_question.destroy
       redirect_to course_assessment_path(current_course, @assessment),
                   success: t('.success')

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -55,6 +55,9 @@ class Course::Assessment < ApplicationRecord
   has_many :voice_response_questions,
            through: :questions, inverse_through: :question, source: :actable,
            source_type: Course::Assessment::Question::VoiceResponse.name
+  has_many :forum_response_questions,
+           through: :questions, inverse_through: :question, source: :actable,
+           source_type: Course::Assessment::Question::ForumResponse.name
   has_many :assessment_conditions, class_name: Course::Condition::Assessment.name,
                                    inverse_of: :assessment, dependent: :destroy
   has_many :question_groups, class_name: Course::Assessment::QuestionGroup.name,

--- a/app/models/course/assessment/question/forum_response.rb
+++ b/app/models/course/assessment/question/forum_response.rb
@@ -2,14 +2,20 @@
 class Course::Assessment::Question::ForumResponse < ApplicationRecord
   acts_as :question, class_name: Course::Assessment::Question.name
 
-  validates :has_text_response, presence: true
-  validates :max_posts, presence: true, numericality: { only_integer: true }, in: (1..max_posts_allowed).to_a
+  validates :max_posts, presence: true, numericality: { only_integer: true }
+  validate :allowable_max_post_count
 
   def question_type
     I18n.t('course.assessment.question.forum_responses.question_type')
   end
 
-  def self.max_posts_allowed
+  def max_posts_allowed
     10
+  end
+
+  def allowable_max_post_count
+    unless (1..max_posts_allowed).include?(max_posts)
+      errors.add(:max_posts, "has to be between 1 and #{max_posts_allowed}")
+    end
   end
 end

--- a/app/models/course/assessment/question/forum_response.rb
+++ b/app/models/course/assessment/question/forum_response.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::ForumResponse < ApplicationRecord
+  acts_as :question, class_name: Course::Assessment::Question.name
+
+  validates :has_text_response, presence: true
+  validates :max_posts, presence: true, numericality: { only_integer: true }, in: (1..max_posts_allowed).to_a
+
+  def question_type
+    I18n.t('course.assessment.question.forum_responses.question_type')
+  end
+
+  def self.max_posts_allowed
+    10
+  end
+end

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -129,6 +129,10 @@
             /             new_course_assessment_question_text_response_path(current_course, @assessment,
             /                                                               { comprehension: true }),
             /             role: 'menuitem')
+            li role='presentation'
+              = link_to(t('.new_question.forum_response'),
+                      new_course_assessment_question_forum_response_path(current_course, @assessment),
+                      role: 'menuitem')
 
     h3 = t('.questions')
     br

--- a/app/views/course/assessment/question/forum_responses/_form.html.slim
+++ b/app/views/course/assessment/question/forum_responses/_form.html.slim
@@ -1,0 +1,13 @@
+= simple_form_for [current_course, @assessment, @forum_response_question] do |f|
+  = f.error_notification
+  = render partial: 'course/assessment/questions/form', locals: { f: f, question_assessment: @question_assessment }
+
+  = f.input :max_posts, collection: (1..@forum_response_question.max_posts_allowed).to_a, label: t('.max_posts')
+  = f.input :has_text_response, label: t('.has_text_response')
+
+  - name = t('.forum_response_button')
+  - if f.object.persisted?
+    - button_text = t('helpers.buttons.update', model: name)
+  - else
+    - button_text = t('helpers.buttons.create', model: name)
+  = f.button :submit, button_text

--- a/app/views/course/assessment/question/forum_responses/edit.html.slim
+++ b/app/views/course/assessment/question/forum_responses/edit.html.slim
@@ -1,0 +1,3 @@
+- add_breadcrumb format_inline_text(@question_assessment.display_title)
+= page_header format_inline_text(@question_assessment.display_title)
+= render partial: 'form'

--- a/app/views/course/assessment/question/forum_responses/new.html.slim
+++ b/app/views/course/assessment/question/forum_responses/new.html.slim
@@ -1,0 +1,3 @@
+- add_breadcrumb :new
+= page_header t('.header')
+= render partial: 'form'

--- a/config/locales/en/breadcrumbs.yml
+++ b/config/locales/en/breadcrumbs.yml
@@ -105,6 +105,8 @@ en:
             new: :'course.assessment.question.programming.new.header'
           scribing:
             new: :'course.assessment.question.scribing.new.header'
+          forum_responses:
+            new: :'course.assessment.question.forum_responses.new.header'
         skills:
           new: :'course.assessment.skills.new.header'
           index: :'course.assessment.skills.index.header'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -58,6 +58,7 @@ en:
             scribing: 'Scribing'
             # TODO: Uncomment the line below when TextResponseComprehension is ready
             # comprehension: 'Comprehension'
+            forum_response: 'Forum Response'
           non_auto_gradable_questions: >
             Some of the questions in this assessment are not auto-gradable.
             The autograder will always award the maximum grade for these questions.

--- a/config/locales/en/course/assessment/question/forum_response.yml
+++ b/config/locales/en/course/assessment/question/forum_response.yml
@@ -1,0 +1,19 @@
+en:
+  course:
+    assessment:
+      question:
+        forum_responses:
+          new:
+            header: 'New Forum Response Question'
+          create:
+            success: 'The forum response question was created.'
+          update:
+            success: 'The forum response question was updated.'
+          destroy:
+            success: 'The forum response question was deleted.'
+            failure: 'Could not delete forum response question: %{error}'
+          form:
+            max_posts: 'Max number of forum posts a student could select'
+            has_text_response: 'Include a text field for students to provide further inputs'
+            forum_response_button: 'Forum Response Question'
+          question_type: Forum Response

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,7 @@ Rails.application.routes.draw do
             resources :programming, only: [:new, :create, :edit, :update, :destroy]
             resources :voice_responses, only: [:new, :create, :edit, :update, :destroy]
             resources :scribing, only: [:show, :new, :create, :edit, :update, :destroy]
+            resources :forum_responses, only: [:new, :create, :edit, :update, :destroy]
           end
           scope module: :submission do
             resources :submissions, only: [:index, :create, :edit, :update] do

--- a/db/migrate/20211003230453_create_course_assessment_question_forum_responses.rb
+++ b/db/migrate/20211003230453_create_course_assessment_question_forum_responses.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+class CreateCourseAssessmentQuestionForumResponses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :course_assessment_question_forum_responses do |t|
+      t.boolean :has_text_response, null: false
+      t.integer :max_posts, limit: 2, null: false
+    end
+
+    create_table:course_assessment_answer_forum_responses do |t|
+      t.string :answer_text, null: true
+    end
+
+    create_table:course_assessment_answer_forum_posts do |t|
+      t.references :answer,
+                   null: false,
+                   foreign_key: {
+                     to_table: :course_assessment_answer_forum_responses
+                   }
+      t.references :forum_topic,
+                   null: false,
+                   foreign_key: {
+                     to_table: :course_forum_topics
+                   }
+      t.references :post,
+                   null: false,
+                   foreign_key: {
+                     to_table: :course_discussion_posts
+                   }
+      t.string :post_text, null: false
+      t.boolean :is_post_updated, null: false
+      t.boolean :is_post_deleted, null: false
+      t.references :parent_post,
+                   null: false,
+                   foreign_key: {
+                     to_table: :course_discussion_posts
+                   }
+      t.string :parent_post_text, null: false
+      t.boolean :is_parent_post_updated, null: false
+      t.boolean :is_parent_post_deleted, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_14_114834) do
+ActiveRecord::Schema.define(version: 2021_10_03_230453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,27 @@ ActiveRecord::Schema.define(version: 2021_09_14_114834) do
     t.index ["actable_id", "actable_type"], name: "index_course_assessment_answer_auto_gradings_on_actable", unique: true
     t.index ["answer_id"], name: "index_course_assessment_answer_auto_gradings_on_answer_id", unique: true
     t.index ["job_id"], name: "index_course_assessment_answer_auto_gradings_on_job_id", unique: true
+  end
+
+  create_table "course_assessment_answer_forum_posts", force: :cascade do |t|
+    t.bigint "answer_id", null: false
+    t.bigint "forum_topic_id", null: false
+    t.bigint "post_id", null: false
+    t.string "post_text", null: false
+    t.boolean "is_post_updated", null: false
+    t.boolean "is_post_deleted", null: false
+    t.bigint "parent_post_id", null: false
+    t.string "parent_post_text", null: false
+    t.boolean "is_parent_post_updated", null: false
+    t.boolean "is_parent_post_deleted", null: false
+    t.index ["answer_id"], name: "index_course_assessment_answer_forum_posts_on_answer_id"
+    t.index ["forum_topic_id"], name: "index_course_assessment_answer_forum_posts_on_forum_topic_id"
+    t.index ["parent_post_id"], name: "index_course_assessment_answer_forum_posts_on_parent_post_id"
+    t.index ["post_id"], name: "index_course_assessment_answer_forum_posts_on_post_id"
+  end
+
+  create_table "course_assessment_answer_forum_responses", force: :cascade do |t|
+    t.string "answer_text"
   end
 
   create_table "course_assessment_answer_multiple_response_options", id: :serial, force: :cascade do |t|
@@ -218,6 +239,11 @@ ActiveRecord::Schema.define(version: 2021_09_14_114834) do
     t.string "title", null: false
     t.bigint "group_id", null: false
     t.index ["group_id"], name: "index_course_assessment_question_bundles_on_group_id"
+  end
+
+  create_table "course_assessment_question_forum_responses", force: :cascade do |t|
+    t.boolean "has_text_response", null: false
+    t.integer "max_posts", limit: 2, null: false
   end
 
   create_table "course_assessment_question_groups", force: :cascade do |t|
@@ -1214,6 +1240,10 @@ ActiveRecord::Schema.define(version: 2021_09_14_114834) do
   add_foreign_key "course_announcements", "users", column: "updater_id", name: "fk_course_announcements_updater_id"
   add_foreign_key "course_assessment_answer_auto_gradings", "course_assessment_answers", column: "answer_id", name: "fk_course_assessment_answer_auto_gradings_answer_id"
   add_foreign_key "course_assessment_answer_auto_gradings", "jobs", name: "fk_course_assessment_answer_auto_gradings_job_id", on_delete: :nullify
+  add_foreign_key "course_assessment_answer_forum_posts", "course_assessment_answer_forum_responses", column: "answer_id"
+  add_foreign_key "course_assessment_answer_forum_posts", "course_discussion_posts", column: "parent_post_id"
+  add_foreign_key "course_assessment_answer_forum_posts", "course_discussion_posts", column: "post_id"
+  add_foreign_key "course_assessment_answer_forum_posts", "course_forum_topics", column: "forum_topic_id"
   add_foreign_key "course_assessment_answer_multiple_response_options", "course_assessment_answer_multiple_responses", column: "answer_id", name: "fk_course_assessment_answer_multiple_response_options_answer_id"
   add_foreign_key "course_assessment_answer_multiple_response_options", "course_assessment_question_multiple_response_options", column: "option_id", name: "fk_course_assessment_answer_multiple_response_options_option_id"
   add_foreign_key "course_assessment_answer_programming_file_annotations", "course_assessment_answer_programming_files", column: "file_id", name: "fk_course_assessment_answer_ed21459e7a2a5034dcf43a14812cb17d"

--- a/spec/factories/course/assessment/question/forum_responses.rb
+++ b/spec/factories/course/assessment/question/forum_responses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :course_assessment_question_forum_response, class: 'Course::Assessment::Question::ForumResponse' do
+    
+  end
+end

--- a/spec/models/course/assessment/question/forum_response_spec.rb
+++ b/spec/models/course/assessment/question/forum_response_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::ForumResponse, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Context: #4060 

The feature to allow forum posts to be submitted in an assessment would be implemented over multiple PRs. This is the first PR to allow CRUD operations on this question type from the assessment page (instructor view). 

When creating a Forum Response question, the instructor would be able to:
- select the max no. of posts a student could submit. 
  - This limit is set in the `Course::Assessment::Question::ForumResponse` model, and it's currently set as 10.
- choose to include a text response field for students to provide further inputs

![Screenshot 2021-10-04 at 12 37 29](https://user-images.githubusercontent.com/10598963/135795199-84189cac-86db-415f-9ce3-614b844ba3fc.png)

![Screenshot 2021-10-04 at 12 35 15](https://user-images.githubusercontent.com/10598963/135795190-fc3c0e2f-259a-4c6d-9a6d-09c5473beff8.png)

