### PR TITLE
Forum Post Response [Part 2]: Add text answer in submission page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'tzinfo-data', platforms: [:mswin, :mswin64]
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '>= 6.0'
-# gem 'rails-i18n', '~> 6.0.0'
 
 # Use PostgreSQL for the backend
 gem 'pg'
@@ -26,10 +25,8 @@ gem 'activerecord-userstamp', git: 'https://github.com/raymondtangsc/activerecor
 gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
 gem 'calculated_attributes'
-# Baby Squeel as an SQL-like DSL
-# gem 'baby_squeel', '>= 1.2'
 # For multiple table inheritance
-#   TODO: Figure out breaking changes in v2 as polymorpshism is not working correctly.
+# TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
 gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as', branch: 'rails5.2.3'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
@@ -194,8 +191,6 @@ gem 'omniauth-facebook'
 
 # Use cancancan for authorization
 gem 'cancancan'
-# gem 'cancancan-baby_squeel', git: 'https://github.com/Coursemology/cancancan-baby_squeel.git', branch: 'rails5.2.3'
-# gem 'ransack', require: false
 
 # Some helpers for structuring CSS/JavaScript
 # Official version https://github.com/winston/rails_utils/pull/30 is no longer maintained.
@@ -233,9 +228,6 @@ gem 'coursemology-polyglot', git: 'https://github.com/Coursemology/polyglot.git'
 
 # To assist with bulk inserts into database
 gem 'activerecord-import', '>= 0.2.0'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
 
 gem 'record_tag_helper'
 gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
     faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    ffi (1.15.0)
+    ffi (1.15.4)
     filename (0.1.2)
     flamegraph (0.9.5)
     fog-aws (3.8.0)
@@ -480,7 +480,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rinku (2.0.6)
     rollbar (3.1.1)
     rouge (3.26.0)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Coursemology is an open source gamified learning platform that enables educators
 1. Ruby on Rails
 1. PostgreSQL (>= 9.5)
 1. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick) - if PDF processing doesn't work for the import of scribing questions, download Ghostscript)
-1. Node.js (<= 9.6)
+1. Node.js (v14 LTS)
 1. Yarn
 
 Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some front-end components use [React.js](https://facebook.github.io/react/). This [guide](https://gorails.com/setup/) written by the awesome people at GoRails should help you to get started on Ruby on Rails.

--- a/app/models/course/assessment/answer/forum_post_response.rb
+++ b/app/models/course/assessment/answer/forum_post_response.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Course::Assessment::Answer::ForumPostResponse < ApplicationRecord
+  acts_as :answer, class_name: Course::Assessment::Answer.name
+
+  def assign_params(params)
+    acting_as.assign_params(params)
+  end
+end

--- a/app/models/course/assessment/answer/forum_post_response.rb
+++ b/app/models/course/assessment/answer/forum_post_response.rb
@@ -4,5 +4,6 @@ class Course::Assessment::Answer::ForumPostResponse < ApplicationRecord
 
   def assign_params(params)
     acting_as.assign_params(params)
+    self.answer_text = params[:answer_text] if params[:answer_text]
   end
 end

--- a/app/models/course/assessment/question/forum_post_response.rb
+++ b/app/models/course/assessment/question/forum_post_response.rb
@@ -9,6 +9,20 @@ class Course::Assessment::Question::ForumPostResponse < ApplicationRecord
     I18n.t('course.assessment.question.forum_post_responses.question_type')
   end
 
+  def attempt(submission, last_attempt = nil)
+    answer =
+      Course::Assessment::Answer::ForumPostResponse.new(submission: submission, question: question)
+    last_attempt&.answer_options&.each do |answer_option|
+      answer.answer_options.build(option_id: answer_option.option_id)
+    end
+
+    answer.acting_as
+  end
+
+  def initialize_duplicate(_duplicator, other)
+    copy_attributes(other)
+  end
+
   def max_posts_allowed
     10
   end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -67,6 +67,9 @@ class Course::Assessment::Submission < ApplicationRecord
   has_many :scribing_answers,
            through: :answers, inverse_through: :answer, source: :actable,
            source_type: Course::Assessment::Answer::Scribing.name
+  has_many :forum_post_response_answers,
+           through: :answers, inverse_through: :answer, source: :actable,
+           source_type: Course::Assessment::Answer::ForumPostResponse.name
   has_many :question_bundle_assignments, class_name: Course::Assessment::QuestionBundleAssignment.name,
                                          inverse_of: :submission, dependent: :destroy
 

--- a/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
+++ b/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+json.fields do
+  json.questionId answer.question_id
+  json.id answer.acting_as.id
+  json.answer_text answer.answer_text
+end
+
+last_attempt = last_attempt(answer)
+
+json.explanation do
+  json.correct last_attempt&.correct
+  json.explanations []
+end

--- a/app/views/course/assessment/question/forum_post_responses/_forum_post_response.json.jbuilder
+++ b/app/views/course/assessment/question/forum_post_responses/_forum_post_response.json.jbuilder
@@ -1,2 +1,4 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
+json.has_text_response question.has_text_response
+json.max_posts question.max_posts

--- a/app/views/course/assessment/question/forum_post_responses/_forum_post_response.json.jbuilder
+++ b/app/views/course/assessment/question/forum_post_responses/_forum_post_response.json.jbuilder
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+json.autogradable question.auto_gradable?

--- a/app/views/course/assessment/submission/submissions/_question.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_question.json.jbuilder
@@ -32,6 +32,8 @@ json.type case question.actable_type
             'VoiceResponse'
           when Course::Assessment::Question::Scribing.name
             'Scribing'
+          when Course::Assessment::Question::ForumPostResponse.name
+            'ForumPostResponse'
           end
 
 json.partial! question, question: question.specific, can_grade: can_grade, answer: answer

--- a/client/app/bundles/course/assessment/submission/components/Answers.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Answers.jsx
@@ -9,6 +9,7 @@ import MultipleResponseAnswer from './answers/MultipleResponse';
 import TextResponseAnswer from './answers/TextResponse';
 import FileUploadAnswer from './answers/FileUpload';
 import ProgrammingAnswer from './answers/Programming';
+import ForumPostResponseAnswer from './answers/ForumPostResponse';
 
 export default class Answers extends Component {
   static renderMultipleChoice({
@@ -71,5 +72,15 @@ export default class Answers extends Component {
 
   static renderProgramming({ question, readOnly, answerId }) {
     return <ProgrammingAnswer {...{ question, readOnly, answerId }} />;
+  }
+
+  static renderForumPostResponse({ question, readOnly, answerId }) {
+    return (
+      <ForumPostResponseAnswer
+        question={question}
+        readOnly={readOnly}
+        answerId={answerId}
+      />
+    );
   }
 }

--- a/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
+++ b/client/app/bundles/course/assessment/submission/components/SubmissionAnswer.jsx
@@ -72,6 +72,7 @@ class SubmissionAnswer extends Component {
       Programming,
       VoiceResponse,
       Scribing,
+      ForumPostResponse,
     } = questionTypes;
     const { viewHistory } = question;
 
@@ -95,6 +96,8 @@ class SubmissionAnswer extends Component {
         return Answers.renderScribing;
       case VoiceResponse:
         return Answers.renderVoiceResponse;
+      case ForumPostResponse:
+        return Answers.renderForumPostResponse;
       default:
         return this.renderMissingRenderer.bind(this);
     }

--- a/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse.jsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
-import TextResponseAnswer from './TextResponse';
+import {Field} from 'redux-form';
 import RichTextField from 'lib/components/redux-form/RichTextField';
 
-import { questionShape } from '../../propTypes';
+import {questionShape} from '../../propTypes';
 
-function ForumPostResponse({ question, readOnly, answerId, graderView }) {
+function renderForumPostSelector() {
+    // TODO
+}
+
+function renderTextAnswer({readOnly, answerId}) {
     const readOnlyAnswer = (
         <Field
             name={`${answerId}[answer_text]`}
             component={(props) => (
-                <div dangerouslySetInnerHTML={{ __html: props.input.value }} />
+                <div dangerouslySetInnerHTML={{__html: props.input.value}}/>
             )}
         />
     );
@@ -26,8 +29,16 @@ function ForumPostResponse({ question, readOnly, answerId, graderView }) {
 
     return (
         <div>
-            <p>{answerId}</p>
+            {readOnly ? readOnlyAnswer : richtextAnswer}
+        </div>
+    );
+}
 
+function ForumPostResponse({question, readOnly, answerId}) {
+    return (
+        <div>
+            {renderForumPostSelector()}
+            {question.has_text_response && renderTextAnswer({readOnly, answerId})}
         </div>
     );
 }
@@ -36,7 +47,6 @@ ForumPostResponse.propTypes = {
     question: questionShape,
     readOnly: PropTypes.bool,
     answerId: PropTypes.number,
-    graderView: PropTypes.bool,
     input: PropTypes.shape({
         value: PropTypes.string,
     }),

--- a/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+import TextResponseAnswer from './TextResponse';
+import RichTextField from 'lib/components/redux-form/RichTextField';
+
+import { questionShape } from '../../propTypes';
+
+function ForumPostResponse({ question, readOnly, answerId, graderView }) {
+    const readOnlyAnswer = (
+        <Field
+            name={`${answerId}[answer_text]`}
+            component={(props) => (
+                <div dangerouslySetInnerHTML={{ __html: props.input.value }} />
+            )}
+        />
+    );
+
+    const richtextAnswer = (
+        <Field
+            name={`${answerId}[answer_text]`}
+            component={RichTextField}
+            multiLine
+        />
+    );
+
+    return (
+        <div>
+            <p>{answerId}</p>
+
+        </div>
+    );
+}
+
+ForumPostResponse.propTypes = {
+    question: questionShape,
+    readOnly: PropTypes.bool,
+    answerId: PropTypes.number,
+    graderView: PropTypes.bool,
+    input: PropTypes.shape({
+        value: PropTypes.string,
+    }),
+};
+
+export default ForumPostResponse;

--- a/client/app/bundles/course/assessment/submission/constants.js
+++ b/client/app/bundles/course/assessment/submission/constants.js
@@ -11,6 +11,7 @@ export const questionTypes = mirrorCreator([
   'FileUpload',
   'Scribing',
   'VoiceResponse',
+  'ForumPostResponse',
 ]);
 
 export const workflowStates = {

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -217,7 +217,6 @@ class MaterialSummernote extends React.Component {
               lang: i18nLocale,
               followingToolbar: false,
             }}
-            value={this.props.value}
             onChange={this.props.onChange}
             onFocus={() => {
               this.setState({ isFocused: true });
@@ -227,7 +226,9 @@ class MaterialSummernote extends React.Component {
               this.setState({ isFocused: false });
             }}
             onImageUpload={this.onImageUpload}
-          />
+          >
+            <div dangerouslySetInnerHTML={{ __html: this.props.value }} />
+          </ReactSummernote>
         </div>
       </div>
     );


### PR DESCRIPTION
Context: #4060 

The feature to allow forum posts to be submitted in an assessment would be implemented over multiple PRs.

This PR enables text answers to be entered and viewed in submissions.

Part 1: #4102 Allow CRUD from assessment page