### PR TITLE
Small fixes for submission view PR

### DIFF
--- a/app/assets/javascripts/routes.js
+++ b/app/assets/javascripts/routes.js
@@ -1017,6 +1017,12 @@ var ROUTES = (function() {
 // data_course_object_duplication => /courses/:course_id/object_duplication/data(.:format)
   // function(course_id, options)
   data_course_object_duplication_path: Utils.route([["course_id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"courses",false],[2,[7,"/",false],[2,[3,"course_id",false],[2,[7,"/",false],[2,[6,"object_duplication",false],[2,[7,"/",false],[2,[6,"data",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]]]),
+// delete_all_course_assessment_submissions => /courses/:course_id/assessments/:assessment_id/submissions/delete_all(.:format)
+  // function(course_id, assessment_id, options)
+  delete_all_course_assessment_submissions_path: Utils.route([["course_id",true],["assessment_id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"courses",false],[2,[7,"/",false],[2,[3,"course_id",false],[2,[7,"/",false],[2,[6,"assessments",false],[2,[7,"/",false],[2,[3,"assessment_id",false],[2,[7,"/",false],[2,[6,"submissions",false],[2,[7,"/",false],[2,[6,"delete_all",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]]]]]]]),
+// delete_course_assessment_submissions => /courses/:course_id/assessments/:assessment_id/submissions/delete(.:format)
+  // function(course_id, assessment_id, options)
+  delete_course_assessment_submissions_path: Utils.route([["course_id",true],["assessment_id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"courses",false],[2,[7,"/",false],[2,[3,"course_id",false],[2,[7,"/",false],[2,[6,"assessments",false],[2,[7,"/",false],[2,[3,"assessment_id",false],[2,[7,"/",false],[2,[6,"submissions",false],[2,[7,"/",false],[2,[6,"delete",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]]]]]]]),
 // destroy_user_session => /users/sign_out(.:format)
   // function(options)
   destroy_user_session_path: Utils.route([["format",false]], {}, [2,[7,"/",false],[2,[6,"users",false],[2,[7,"/",false],[2,[6,"sign_out",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]),
@@ -1500,6 +1506,12 @@ var ROUTES = (function() {
 // toggle_registration_course_users => /courses/:course_id/users/toggle_registration(.:format)
   // function(course_id, options)
   toggle_registration_course_users_path: Utils.route([["course_id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"courses",false],[2,[7,"/",false],[2,[3,"course_id",false],[2,[7,"/",false],[2,[6,"users",false],[2,[7,"/",false],[2,[6,"toggle_registration",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]]]),
+// unsubmit_all_course_assessment_submissions => /courses/:course_id/assessments/:assessment_id/submissions/unsubmit_all(.:format)
+  // function(course_id, assessment_id, options)
+  unsubmit_all_course_assessment_submissions_path: Utils.route([["course_id",true],["assessment_id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"courses",false],[2,[7,"/",false],[2,[3,"course_id",false],[2,[7,"/",false],[2,[6,"assessments",false],[2,[7,"/",false],[2,[3,"assessment_id",false],[2,[7,"/",false],[2,[6,"submissions",false],[2,[7,"/",false],[2,[6,"unsubmit_all",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]]]]]]]),
+// unsubmit_course_assessment_submissions => /courses/:course_id/assessments/:assessment_id/submissions/unsubmit(.:format)
+  // function(course_id, assessment_id, options)
+  unsubmit_course_assessment_submissions_path: Utils.route([["course_id",true],["assessment_id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"courses",false],[2,[7,"/",false],[2,[3,"course_id",false],[2,[7,"/",false],[2,[6,"assessments",false],[2,[7,"/",false],[2,[3,"assessment_id",false],[2,[7,"/",false],[2,[6,"submissions",false],[2,[7,"/",false],[2,[6,"unsubmit",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]]]]]]]),
 // unsubmit_course_survey_response => /courses/:course_id/surveys/:survey_id/responses/:id/unsubmit(.:format)
   // function(course_id, survey_id, id, options)
   unsubmit_course_survey_response_path: Utils.route([["course_id",true],["survey_id",true],["id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"courses",false],[2,[7,"/",false],[2,[3,"course_id",false],[2,[7,"/",false],[2,[6,"surveys",false],[2,[7,"/",false],[2,[3,"survey_id",false],[2,[7,"/",false],[2,[6,"responses",false],[2,[7,"/",false],[2,[3,"id",false],[2,[7,"/",false],[2,[6,"unsubmit",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]]]]]]]]]),

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
@@ -31,7 +31,7 @@ const styles = {
     backgroundColor: blue600,
   },
   nameWrapper: {
-    display: 'inline-block',
+    display: 'inline',
     flexWrap: 'nowrap',
     alignItems: 'center',
   },

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
@@ -93,11 +93,14 @@ export default class SubmissionsTableRow extends React.Component {
         <>
           <FontIcon
             data-tip
-            data-for="test"
+            data-for={`phantom-user-${submission.courseUser.id}`}
             className="fa fa-user-secret fa-xs"
             style={styles.phantomIcon}
           />
-          <ReactTooltip id="test" effect="solid">
+          <ReactTooltip
+            id={`phantom-user-${submission.courseUser.id}`}
+            effect="solid"
+          >
             <FormattedMessage {...submissionsTranslations.phantom} />
           </ReactTooltip>
         </>

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
@@ -36,7 +36,8 @@ const styles = {
     alignItems: 'center',
   },
   phantomIcon: {
-    fontSize: '16px',
+    fontSize: '14px',
+    marginRight: '2px',
   },
   unstartedText: {
     color: red600,
@@ -299,16 +300,13 @@ export default class SubmissionsTableRow extends React.Component {
     return (
       <>
         <TableRowColumn style={styles.tableCell}>
-          <span>
-            {SubmissionsTableRow.renderPhantomUserIcon(submission)}
-            &nbsp;
-            <a
-              style={styles.nameWrapper}
-              href={getCourseUserURL(courseId, submission.courseUser.id)}
-            >
-              {submission.courseUser.name}
-            </a>
-          </span>
+          {SubmissionsTableRow.renderPhantomUserIcon(submission)}
+          <a
+            style={styles.nameWrapper}
+            href={getCourseUserURL(courseId, submission.courseUser.id)}
+          >
+            {submission.courseUser.name}
+          </a>
         </TableRowColumn>
         <TableRowColumn style={tableCenterCellStyle}>
           {this.renderSubmissionWorkflowState(submission)}

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
@@ -61,7 +61,11 @@ class VisibleSubmissionsIndex extends React.Component {
     this.state = {
       publishConfirmation: false,
       includePhantoms: false,
-      tab: 'my-students-tab',
+      tab: props.submissions.some(
+        (s) => s.courseUser.isStudent && s.courseUser.myStudent,
+      )
+        ? 'my-students-tab'
+        : 'students-tab',
     };
   }
 
@@ -86,15 +90,17 @@ class VisibleSubmissionsIndex extends React.Component {
       (s) => s.courseUser.isStudent,
     );
     const staffSubmissions = submissions.filter((s) => !s.courseUser.isStudent);
-    let submissionHistogram = studentSubmissions;
-    if (tab === '-tab') {
-      submissionHistogram = staffSubmissions;
-    } else if (tab === 'my-students-tab' && myStudentSubmissions.length > 0) {
-      // Additional length check is needed as the default state.tab is my-students-tab upon page opening
-      // However, if this is empty, it is defaulted to students-tab
-      submissionHistogram = myStudentSubmissions;
-    } else {
-      submissionHistogram = studentSubmissions;
+    let submissionHistogram;
+    switch (tab) {
+      case 'staff-tab':
+        submissionHistogram = staffSubmissions;
+        break;
+      case 'my-students-tab':
+        submissionHistogram = myStudentSubmissions;
+        break;
+      case 'students-tab':
+      default:
+        submissionHistogram = studentSubmissions;
     }
     const initialCounts = workflowStatesArray.reduce(
       (counts, w) => ({ ...counts, [w]: 0 }),

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/translations.js
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/translations.js
@@ -73,7 +73,7 @@ const translations = defineMessages({
   },
   unsubmitAllSubmissions: {
     id: 'course.assessment.submission.unsubmitAllSubmissions',
-    defaultMessage: 'Unsubmit all submission',
+    defaultMessage: 'Unsubmit All Submissions',
   },
   unsubmitSubmission: {
     id: 'course.assessment.submission.unsubmitSubmission',
@@ -88,7 +88,7 @@ const translations = defineMessages({
   },
   deleteAllSubmissions: {
     id: 'course.assessment.submission.deleteAllSubmissions',
-    defaultMessage: 'Delete all submission',
+    defaultMessage: 'Delete All Submissions',
   },
   deleteSubmission: {
     id: 'course.assessment.submission.deleteSubmission',


### PR DESCRIPTION
### Summary

- Fix `id` uniqueness + semantics for phantom tooltip
- Remove unnecessary nesting + shifted the spacing (originally `&nbsp;`) into the icon margin. This prevents spacing from being rendered in front of all the student names, regardless of whether the icon is rendered.
- Fix word-break / line-wrapping for student name next to phantom icon, i.e. we want:
   ```
   [icon] student
   name
   ```
   and not
   ```
   [icon]
   student name
   ```

- Standardise the dropdown menu capitalisation

   <img width="319" alt="Screenshot 2021-10-11 at 3 46 41 PM" src="https://user-images.githubusercontent.com/45617494/136752006-8bb916e0-38b1-47e0-8c55-4b738963d9f9.png">

- Fix a small regression with histogram not updating when staff tab is selected. Also rewrote the state initialisation logic.
- Regenerated js-routes file using `bundle exec rake js:routes`. Might be the solution to the broken CircleCI tests.