### PR TITLE
Create a new submission when an assessment file is downloaded

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -48,7 +48,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     end
 
     @submission.session_id = authentication_service.generate_authentication_token
-    success = @assessment.create_new_submission(@submission)
+    success = @assessment.create_new_submission(@submission, current_user)
 
     if success
       authentication_service.save_token_to_session(@submission.session_id)

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -41,24 +41,14 @@ class Course::Assessment::Submission::SubmissionsController < \
   end
 
   def create
-    @submission.session_id = authentication_service.generate_authentication_token
-
-    success = false
-    if @assessment.randomization == 'prepared'
-      Course::Assessment::Submission.transaction do
-        qbas = @assessment.question_bundle_assignments.where(user: current_user).lock!
-        if qbas.empty? # TODO: More thorough validations here
-          @submission.errors.add(:base, :no_bundles_assigned)
-          raise ActiveRecord::Rollback
-        end
-        raise ActiveRecord::Rollback unless @submission.save
-        raise ActiveRecord::Rollback unless qbas.update_all(submission_id: @submission.id)
-
-        success = true
-      end
-    else
-      success = @submission.save
+    existing_submission = @assessment.submissions.find_by(creator: current_user)
+    if existing_submission
+      @submission = existing_submission
+      return redirect_to edit_course_assessment_submission_path(current_course, @assessment, @submission)
     end
+
+    @submission.session_id = authentication_service.generate_authentication_token
+    success = @assessment.create_new_submission(@submission)
 
     if success
       authentication_service.save_token_to_session(@submission.session_id)

--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -4,6 +4,7 @@ class Course::Material::MaterialsController < Course::Material::Controller
 
   def show
     authorize!(:read_owner, @material.folder)
+    create_submission if @folder.owner_type == 'Course::Assessment'
     redirect_to @material.attachment.url(filename: @material.name)
   end
 
@@ -38,5 +39,30 @@ class Course::Material::MaterialsController < Course::Material::Controller
 
   def material_params
     params.require(:material).permit(:name, :description, attachments_params)
+  end
+
+  def create_submission
+    current_course_user = current_course.course_users.find_by(user: current_user)
+    @assessment = @folder.owner
+    existing_submission = @assessment.submissions.find_by(creator: current_user)
+    unless existing_submission
+      @submission = @assessment.submissions.new(course_user: current_course_user)
+      @submission.session_id = authentication_service.generate_authentication_token
+      @assessment.create_new_submission(@submission)
+
+      authentication_service.save_token_to_session(@submission.session_id)
+      log_service.log_submission_access(request) if @assessment.session_password_protected?
+    end
+    success
+  end
+
+  def authentication_service
+    @authentication_service ||=
+      Course::Assessment::SessionAuthenticationService.new(@assessment, session, @submission)
+  end
+
+  def log_service
+    @log_service ||=
+      Course::Assessment::SessionLogService.new(@assessment, session, @submission)
   end
 end

--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -53,6 +53,7 @@ class Course::Material::MaterialsController < Course::Material::Controller
       if success
         authentication_service.save_token_to_session(@submission.session_id)
         log_service.log_submission_access(request) if @assessment.session_password_protected?
+        @submission.create_new_answers
       end
     end
     success

--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -48,10 +48,12 @@ class Course::Material::MaterialsController < Course::Material::Controller
     unless existing_submission
       @submission = @assessment.submissions.new(course_user: current_course_user)
       @submission.session_id = authentication_service.generate_authentication_token
-      @assessment.create_new_submission(@submission)
+      success = @assessment.create_new_submission(@submission, current_user)
 
-      authentication_service.save_token_to_session(@submission.session_id)
-      log_service.log_submission_access(request) if @assessment.session_password_protected?
+      if success
+        authentication_service.save_token_to_session(@submission.session_id)
+        log_service.log_submission_access(request) if @assessment.session_password_protected?
+      end
     end
     success
   end

--- a/app/models/concerns/course/assessment/new_submission_concern.rb
+++ b/app/models/concerns/course/assessment/new_submission_concern.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Course::Assessment::NewSubmissionConcern
+  extend ActiveSupport::Concern
+
+  def create_new_submission(new_submission)
+    success = false
+    if randomization == 'prepared'
+      Course::Assessment::Submission.transaction do
+        qbas = question_bundle_assignments.where(user: current_user).lock!
+        if qbas.empty? # TODO: More thorough validations here
+          new_submission.errors.add(:base, :no_bundles_assigned)
+          raise ActiveRecord::Rollback
+        end
+        raise ActiveRecord::Rollback unless new_submission.save
+        raise ActiveRecord::Rollback unless qbas.update_all(submission_id: new_submission.id)
+
+        success = true
+      end
+    else
+      success = new_submission.save
+    end
+    success
+  end
+end

--- a/app/models/concerns/course/assessment/new_submission_concern.rb
+++ b/app/models/concerns/course/assessment/new_submission_concern.rb
@@ -2,7 +2,7 @@
 module Course::Assessment::NewSubmissionConcern
   extend ActiveSupport::Concern
 
-  def create_new_submission(new_submission)
+  def create_new_submission(new_submission, current_user)
     success = false
     if randomization == 'prepared'
       Course::Assessment::Submission.transaction do

--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -15,4 +15,17 @@ module Course::Assessment::Submission::AnswersConcern
   def from_question(question_id)
     where(question_id: question_id)
   end
+
+  def create_new_answers
+    questions_to_attempt ||= assessment.questions
+    new_answers = questions_to_attempt.not_answered(self).attempt(self)
+
+    new_answers.map do |answer|
+      # When there are no existing answers, the first one will be the current_answer.
+      if answer.new_record?
+        answer.current_answer = true
+        answer.save!
+      end
+    end
+  end
 end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -11,6 +11,7 @@ class Course::Assessment < ApplicationRecord
   include Course::Assessment::TodoConcern
   include Course::ClosingReminderConcern
   include DuplicationStateTrackingConcern
+  include Course::Assessment::NewSubmissionConcern
 
   after_initialize :set_defaults, if: :new_record?
   before_validation :propagate_course, if: :new_record?

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -4,6 +4,7 @@ class Course::Assessment::Submission < ApplicationRecord
   include Course::Assessment::Submission::WorkflowEventConcern
   include Course::Assessment::Submission::TodoConcern
   include Course::Assessment::Submission::NotificationConcern
+  include Course::Assessment::Submission::AnswersConcern
 
   acts_as_experience_points_record
 

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -79,6 +79,8 @@
   - if can?(:attempt, @assessment) && @assessment.folder.materials.present?
     - enable_link = !current_component_host[:course_materials_component].nil?
     h3 = t('.files') if enable_link || can?(:manage, @assessment)
+    - if @assessment.submissions.where(creator: current_user).length == 0
+      div = t('.files_note')
     = render partial: 'layouts/materials',
       locals: { folder: @assessment.folder,
                 enable_link: enable_link,

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -47,6 +47,7 @@ en:
           materials_disabled: 'Enable material component in the components tab of course setting
             to gain access to this file.'
           files: 'Files'
+          files_note: 'Note: Downloading the file(s) below will start a new attempt for this assessment.'
           questions: 'Questions'
           new_question:
             multiple_choice: 'Multiple Choice'

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -49,19 +49,35 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
     end
 
     describe '#create' do
-      subject do
-        post :create, params: { course_id: course, assessment_id: assessment }
-      end
+      context 'when an there is already an existing submission for an assessment' do
+        subject do
+          post :create, params: { course_id: course, assessment_id: assessment }
+        end
 
-      context 'when an there is already an existing submission' do
         before do
-          controller.instance_variable_set(:@submission, immutable_submission)
+          controller.instance_variable_set(:@submission, submission)
           subject
         end
 
         it do
           is_expected.
-            to redirect_to(edit_course_assessment_submission_path(course, assessment, immutable_submission))
+            to redirect_to(edit_course_assessment_submission_path(course, assessment, submission))
+        end
+      end
+
+      context 'when a submission of a randomized assesment creation fails' do
+        subject do
+          post :create, params: { course_id: course, assessment_id: randomized_assessment }
+        end
+
+        before do
+          subject
+        end
+
+        it { is_expected.to redirect_to(course_assessments_path(course)) }
+        it 'sets the proper flash message' do
+          expect(flash[:danger]).to eq(I18n.t('course.assessment.submission.submissions.create.'\
+                                              'failure', error: ''))
         end
       end
     end

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -53,16 +53,15 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
         post :create, params: { course_id: course, assessment_id: assessment }
       end
 
-      context 'when create fails' do
+      context 'when an there is already an existing submission' do
         before do
           controller.instance_variable_set(:@submission, immutable_submission)
           subject
         end
 
-        it { is_expected.to redirect_to(course_assessments_path(course)) }
-        it 'sets the proper flash message' do
-          expect(flash[:danger]).to eq(I18n.t('course.assessment.submission.submissions.create.'\
-                                              'failure', error: ''))
+        it do
+          is_expected.
+            to redirect_to(edit_course_assessment_submission_path(course, assessment, immutable_submission))
         end
       end
     end

--- a/spec/controllers/course/material/materials_controller_spec.rb
+++ b/spec/controllers/course/material/materials_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
       it { is_expected.to redirect_to(material.attachment.url) }
 
       context 'when a material is uploaded for an assessment' do
-        let!(:assessment) { create(:assessment, :with_attachments, course: course) }
+        let!(:assessment) { create(:assessment, :with_attachments, course: course, session_password: 'super_secret') }
         let!(:folder_assessment) { assessment.folder }
         let!(:material_assessment) { folder_assessment.materials.first }
 

--- a/spec/controllers/course/material/materials_controller_spec.rb
+++ b/spec/controllers/course/material/materials_controller_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
       it { is_expected.to redirect_to(material.attachment.url) }
 
       context 'when a material is uploaded for an assessment' do
-        let!(:assessment) { create(:assessment, :with_attachments, course: course, session_password: 'super_secret') }
+        let!(:assessment) do
+          create(:assessment, :published, :with_all_question_types, :with_attachments, course: course,
+                                                                                       session_password: 'super_secret')
+        end
         let!(:folder_assessment) { assessment.folder }
         let!(:material_assessment) { folder_assessment.materials.first }
 
@@ -33,6 +36,7 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
         it 'creates a new submission' do
           subject
           expect(assessment.submissions.length).to eq(1)
+          expect(assessment.submissions.first.answers.length).to eq(assessment.questions.length)
           is_expected.to redirect_to(material_assessment.attachment.url)
         end
       end


### PR DESCRIPTION
1. Create a new submission when a file related to an assessment is downloaded
2. Redirect to existing submission, instead of throwing error, when attempting to create a new submission (by clicking attempt button instead of resume) 

The note below is only shown when there is no attempt yet.

![image](https://user-images.githubusercontent.com/42570513/138636714-c6bdb703-6e3d-4481-94a6-f087ef583dd5.png)

Closes #4096 