### PR TITLE
fix(questionFlags): Recreate questionFlags upon successful unsubmission

### DIFF
--- a/app/services/course/assessment/submission/statistics_download_service.rb
+++ b/app/services/course/assessment/submission/statistics_download_service.rb
@@ -56,7 +56,7 @@ class Course::Assessment::Submission::StatisticsDownloadService
 
   def download_statistics(csv, submission)
     csv << [submission.course_user.name,
-            submission.course_user.phantom,
+            submission.course_user.phantom?,
             submission.workflow_state,
             submission.grade,
             submission.assessment.maximum_grade,

--- a/client/app/bundles/course/assessment/submission/reducers/questionsFlags.js
+++ b/client/app/bundles/course/assessment/submission/reducers/questionsFlags.js
@@ -3,6 +3,7 @@ import actions from '../constants';
 export default function (state = {}, action) {
   switch (action.type) {
     case actions.FETCH_SUBMISSION_SUCCESS:
+    case actions.UNSUBMIT_SUCCESS:
     case actions.FINALISE_SUCCESS:
       return action.payload.answers.reduce(
         (obj, answer) => ({


### PR DESCRIPTION
closes #3366 

Refer to the issue above. When a question is created after there is an existing submission, there is no answer created to this question created for the submission. As a result, no questionFlags is created as well for this question. When an unsubmission happens, the answer to this question is then newly created. As a result, the questionFlags in the react reducer needs to be re-generated.