### PR TITLE
fix(testCaseView): Converted expression output to be expandable texts with word wrap

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/UploadedPackageTestCaseView.jsx
@@ -75,7 +75,7 @@ class UploadedPackageTestCaseView extends React.Component {
             {test.get('identifier')}
           </TableHeaderColumn>
           <TableRowColumn className={styles.testCaseCell}>
-            {test.get('expression')}
+            <ExpandableText text={test.get('expression')} />
           </TableRowColumn>
           <TableRowColumn className={styles.testCaseCell}>
             <ExpandableText text={test.get('expected')} />

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -258,7 +258,9 @@ export class VisibleTestCaseView extends Component {
         style={styles.testCaseRow[testCaseResult]}
       >
         {canReadTests && tableRowColumnFor(testCase.identifier)}
-        {tableRowColumnFor(testCase.expression)}
+        {tableRowColumnFor(
+          <ExpandableText style={outputStyle} text={testCase.expression} />,
+        )}
         {tableRowColumnFor(
           (
             <ExpandableText


### PR DESCRIPTION
Fixes #3752  

Rebase and recreate new commit based on #3753

**question edit page**
Before
![image](https://user-images.githubusercontent.com/42570513/138246146-6f1fc189-b161-4ab6-9208-75353cebe24b.png)

After

![image](https://user-images.githubusercontent.com/42570513/138246506-60a171a3-c2f4-4e5d-abd8-564c8ec78797.png)

**Submission show page**
Before
![image](https://user-images.githubusercontent.com/42570513/138247131-6bc1b1aa-991e-4f63-8bde-5a8ce90ebd4a.png)

After
![image](https://user-images.githubusercontent.com/42570513/138246907-60b698af-ffbf-4b5a-a1f9-216d4752d424.png)
