### PR TITLE
Fix scribing question bug in autograded assessment

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/ScribingView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import scribingViewLoader from 'course/assessment/submission/loaders/ScribingViewLoader';
 import ScribingToolbar from './ScribingToolbar';
 import ScribingCanvas from './ScribingCanvas';
-import style from './ScribingView.scss'; // eslint-disable-line no-unused-vars
 import { submissionShape } from '../../propTypes';
 
 const propTypes = {
@@ -29,8 +28,13 @@ export default class ScribingViewComponent extends React.Component {
     const { answerId, submission } = this.props;
     return answerId ? (
       <div style={styles.canvasDiv}>
-        {submission.canUpdate ? <ScribingToolbar {...this.props} /> : null}
-        <ScribingCanvas {...this.props} />
+        {submission.canUpdate ? (
+          <ScribingToolbar
+            key={`ScribingToolbar-${answerId}`}
+            {...this.props}
+          />
+        ) : null}
+        <ScribingCanvas key={`ScribingCanvas-${answerId}`} {...this.props} />
       </div>
     ) : null;
   }


### PR DESCRIPTION
Fixes #3368 

In an autograded assessment, a question is rendered when a tab (or stepper/bubble) is clicked. Currently, since there is no unique identifier of the scribing component, when another scribing question is selected, it does not re-render the other scribing question component. 

Solution: A key is added to the scribing component to differentiate different scribing questions.