### PR TITLE
Add delayed comment feature

### DIFF
--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -48,7 +48,7 @@ module Course::Discussion::PostsConcern
   private
 
   def post_params
-    params.require(:discussion_post).permit(:title, :text, :parent_id, :delayed)
+    params.require(:discussion_post).permit(:title, :text, :parent_id, :is_delayed)
   end
 
   def set_topic

--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -48,7 +48,7 @@ module Course::Discussion::PostsConcern
   private
 
   def post_params
-    params.require(:discussion_post).permit(:title, :text, :parent_id)
+    params.require(:discussion_post).permit(:title, :text, :parent_id, :delayed)
   end
 
   def set_topic

--- a/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
@@ -23,7 +23,7 @@ class Course::Assessment::Submission::Answer::Programming::AnnotationsController
     end
 
     if result
-      send_created_notification(@post) unless @post.delayed
+      send_created_notification(@post) unless @post.is_delayed
       render_create_response
     else
       head :bad_request

--- a/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
@@ -23,7 +23,7 @@ class Course::Assessment::Submission::Answer::Programming::AnnotationsController
     end
 
     if result
-      send_created_notification(@post)
+      send_created_notification(@post) unless @post.delayed
       render_create_response
     else
       head :bad_request

--- a/app/controllers/course/assessment/submission_question/comments_controller.rb
+++ b/app/controllers/course/assessment/submission_question/comments_controller.rb
@@ -15,7 +15,7 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
     end
 
     if result
-      send_created_notification(@post) unless @post.delayed
+      send_created_notification(@post) unless @post.is_delayed
       render_create_response
     else
       head :bad_request

--- a/app/controllers/course/assessment/submission_question/comments_controller.rb
+++ b/app/controllers/course/assessment/submission_question/comments_controller.rb
@@ -15,7 +15,7 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
     end
 
     if result
-      send_created_notification(@post)
+      send_created_notification(@post) unless @post.delayed
       render_create_response
     else
       head :bad_request

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -62,7 +62,7 @@ module Course::Discussion::TopicsHelper
     @student_unread ||=
       if current_course_user&.student?
         current_course.discussion_topics.globally_displayed.from_user(current_user.id).
-          unread_by(current_user).distinct.count
+          unread_by(current_user).distinct.without_delayed_posts.count
       else
         0
       end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -169,7 +169,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
     unless delayed_posts.empty?
       # Remove 'mark as read' (if any)
       topic.read_marks.where('reader_id = ?', creator.id)&.destroy_all
-      delayed_posts.update_all(delayed: false)
+      delayed_posts.update_all(is_delayed: false)
     end
     true
   end

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -27,8 +27,8 @@ class Course::Discussion::Post < ApplicationRecord
   default_scope { ordered_by_created_at.with_creator }
   scope :ordered_by_created_at, -> { order(created_at: :asc) }
   scope :with_creator, -> { includes(:creator) }
-  scope :exclude_delayed_posts, -> { where(delayed: false) }
-  scope :only_delayed_posts, -> { where(delayed: true) }
+  scope :exclude_delayed_posts, -> { where(is_delayed: false) }
+  scope :only_delayed_posts, -> { where(is_delayed: true) }
 
   # @!method self.with_user_votes(user)
   #   Preloads the given posts with votes from the given user.

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -27,6 +27,8 @@ class Course::Discussion::Post < ApplicationRecord
   default_scope { ordered_by_created_at.with_creator }
   scope :ordered_by_created_at, -> { order(created_at: :asc) }
   scope :with_creator, -> { includes(:creator) }
+  scope :exclude_delayed_posts, -> { where(delayed: false) }
+  scope :only_delayed_posts, -> { where(delayed: true) }
 
   # @!method self.with_user_votes(user)
   #   Preloads the given posts with votes from the given user.

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -33,6 +33,11 @@ class Course::Discussion::Topic < ApplicationRecord
       where(actable_type: global_topic_models.map(&:name)).distinct
   end)
 
+  # Topics of which there is at least 1 normal post
+  scope :without_delayed_posts, (lambda do
+    joins(:posts).where('course_discussion_posts.delayed = ?', false).distinct
+  end)
+
   # Returns the topics from the user(s) specified.
   #
   # @param[Integer|Array<Integer>] user_id, the id(s) of the user(s).

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -35,7 +35,7 @@ class Course::Discussion::Topic < ApplicationRecord
 
   # Topics of which there is at least 1 normal post
   scope :without_delayed_posts, (lambda do
-    joins(:posts).where('course_discussion_posts.delayed = ?', false).distinct
+    joins(:posts).where('course_discussion_posts.is_delayed = ?', false).distinct
   end)
 
   # Returns the topics from the user(s) specified.

--- a/app/notifiers/course/assessment/answer/comment_notifier.rb
+++ b/app/notifiers/course/assessment/answer/comment_notifier.rb
@@ -15,7 +15,7 @@ class Course::Assessment::Answer::CommentNotifier < Notifier::Base
       course_user = category.course.course_users.find_by(user: subscription.user)
       is_disabled_as_phantom = course_user.phantom? && !email_enabled.phantom
       is_disabled_as_regular = !course_user.phantom? && !email_enabled.regular
-      is_disabled_delayed = course_user.student? && post.delayed
+      is_disabled_delayed = course_user.student? && post.is_delayed
       exclude_user = subscription.user == user ||
                      is_disabled_as_phantom ||
                      is_disabled_as_regular ||

--- a/app/notifiers/course/assessment/answer/comment_notifier.rb
+++ b/app/notifiers/course/assessment/answer/comment_notifier.rb
@@ -15,9 +15,11 @@ class Course::Assessment::Answer::CommentNotifier < Notifier::Base
       course_user = category.course.course_users.find_by(user: subscription.user)
       is_disabled_as_phantom = course_user.phantom? && !email_enabled.phantom
       is_disabled_as_regular = !course_user.phantom? && !email_enabled.regular
+      is_disabled_delayed = course_user.student? && post.delayed
       exclude_user = subscription.user == user ||
                      is_disabled_as_phantom ||
                      is_disabled_as_regular ||
+                     is_disabled_delayed ||
                      course_user.email_unsubscriptions.where(course_settings_email_id: email_enabled.id).exists?
 
       activity.notify(subscription.user, :email) unless exclude_user

--- a/app/notifiers/course/assessment/submission_question/comment_notifier.rb
+++ b/app/notifiers/course/assessment/submission_question/comment_notifier.rb
@@ -15,7 +15,7 @@ class Course::Assessment::SubmissionQuestion::CommentNotifier < Notifier::Base
       course_user = category.course.course_users.find_by(user: subscription.user)
       is_disabled_as_phantom = course_user.phantom? && !email_enabled.phantom
       is_disabled_as_regular = !course_user.phantom? && !email_enabled.regular
-      is_disabled_delayed = course_user.student? && post.delayed
+      is_disabled_delayed = course_user.student? && post.is_delayed
       exclude_user = subscription.user == user ||
                      is_disabled_as_phantom ||
                      is_disabled_as_regular ||

--- a/app/notifiers/course/assessment/submission_question/comment_notifier.rb
+++ b/app/notifiers/course/assessment/submission_question/comment_notifier.rb
@@ -15,9 +15,11 @@ class Course::Assessment::SubmissionQuestion::CommentNotifier < Notifier::Base
       course_user = category.course.course_users.find_by(user: subscription.user)
       is_disabled_as_phantom = course_user.phantom? && !email_enabled.phantom
       is_disabled_as_regular = !course_user.phantom? && !email_enabled.regular
+      is_disabled_delayed = course_user.student? && post.delayed
       exclude_user = subscription.user == user ||
                      is_disabled_as_phantom ||
                      is_disabled_as_regular ||
+                     is_disabled_delayed ||
                      course_user.email_unsubscriptions.where(course_settings_email_id: email_enabled.id).exists?
 
       activity.notify(subscription.user, :email) unless exclude_user

--- a/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
+++ b/app/views/course/assessment/answer/programming_file_annotations/_discussion_topic_programming_file_annotation.html.slim
@@ -6,18 +6,19 @@
 - assessment = submission.assessment
 - question_assessment = assessment.question_assessments.find_by!(question: question)
 
-= div_for(topic, 'data-topic-id' => topic.id) do
-  h3
-    - comment_title = "#{assessment.title}: #{question_assessment.display_title}"
-    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: submission.questions.index(question) + 1)
-  - if can?(:manage, topic)
-    = link_to_toggle_pending(topic)
-  - elsif current_course_user&.student?
-    = link_to_mark_as_read(topic)
+- unless topic.posts.exclude_delayed_posts.empty?
+  = div_for(topic, 'data-topic-id' => topic.id) do
+    h3
+      - comment_title = "#{assessment.title}: #{question_assessment.display_title}"
+      = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: submission.questions.index(question) + 1)
+    - if can?(:manage, topic)
+      = link_to_toggle_pending(topic)
+    - elsif current_course_user&.student?
+      = link_to_mark_as_read(topic)
 
-  h4
-    = t('.by_html', user: link_to_user(submission.creator))
+    h4
+      = t('.by_html', user: link_to_user(submission.creator))
 
-  = display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
-  = display_topic topic, post_partial: 'course/discussion/post',
-                         footer: 'course/discussion/posts/form'
+    = display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
+    = display_topic topic, post_partial: 'course/discussion/post',
+                           footer: 'course/discussion/posts/form'

--- a/app/views/course/assessment/submission/submissions/_topics.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_topics.json.jbuilder
@@ -29,5 +29,5 @@ posts = submission_questions.map(&:discussion_topic).flat_map(&:posts)
 posts += programming_answers.flat_map(&:files).flat_map(&:annotations).map(&:discussion_topic).flat_map(&:posts)
 
 json.posts posts do |post|
-  json.partial! post, post: post if can_grade || !post.delayed
+  json.partial! post, post: post if can_grade || !post.is_delayed
 end

--- a/app/views/course/assessment/submission_questions/_discussion_topic_submission_question.html.slim
+++ b/app/views/course/assessment/submission_questions/_discussion_topic_submission_question.html.slim
@@ -5,17 +5,17 @@
 - assessment = submission.assessment
 - question_assessment = assessment.question_assessments.find_by!(question: question)
 
-= div_for(topic, 'data-topic-id' => topic.id) do
-  h3
-    - comment_title = "#{assessment.title}: #{question_assessment.display_title}"
-    = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: submission.questions.index(question) + 1)
-  - if can?(:manage, topic)
-    = link_to_toggle_pending(topic)
-  - elsif current_course_user&.student?
-    = link_to_mark_as_read(topic)
+- unless topic.posts.exclude_delayed_posts.empty?
+  = div_for(topic, 'data-topic-id' => topic.id) do
+    h3
+      - comment_title = "#{assessment.title}: #{question_assessment.display_title}"
+      = link_to comment_title, edit_course_assessment_submission_path(current_course, assessment, submission, step: submission.questions.index(question) + 1)
+    - if can?(:manage, topic)
+      = link_to_toggle_pending(topic)
+    - elsif current_course_user&.student?
+      = link_to_mark_as_read(topic)
 
-  h4
-    = t('.by_html', user: link_to_user(submission.creator))
-
-  = display_topic submission_question.acting_as, post_partial: 'course/discussion/post',
-                                                 footer: 'course/discussion/posts/form'
+    h4
+      = t('.by_html', user: link_to_user(submission.creator))
+    = display_topic submission_question.acting_as, post_partial: 'course/discussion/post',
+                                                   footer: 'course/discussion/posts/form'

--- a/app/views/course/discussion/_posts.html.slim
+++ b/app/views/course/discussion/_posts.html.slim
@@ -1,6 +1,6 @@
 - post_locals ||= {}
 - posts.each do |post|
-  - unless post.first.delayed
+  - unless post.first.is_delayed
     = render partial: post_partial, object: post.first, locals: post_locals
   - nest_replies = max_depth > 1
   - replies_class = nest_replies ? 'nested' : nil

--- a/app/views/course/discussion/_posts.html.slim
+++ b/app/views/course/discussion/_posts.html.slim
@@ -1,6 +1,7 @@
 - post_locals ||= {}
 - posts.each do |post|
-  = render partial: post_partial, object: post.first, locals: post_locals
+  - unless post.first.delayed
+    = render partial: post_partial, object: post.first, locals: post_locals
   - nest_replies = max_depth > 1
   - replies_class = nest_replies ? 'nested' : nil
   - replies_max_depth = nest_replies ? max_depth - 1 : max_depth

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -10,4 +10,4 @@ json.createdAt post.created_at
 json.topicId post.topic_id
 json.canUpdate can?(:update, post)
 json.canDestroy can?(:destroy, post)
-json.delayed post.delayed
+json.isDelayed post.is_delayed

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -10,3 +10,4 @@ json.createdAt post.created_at
 json.topicId post.topic_id
 json.canUpdate can?(:update, post)
 json.canDestroy can?(:destroy, post)
+json.delayed post.delayed

--- a/client/app/bundles/course/assessment/submission/actions/annotations.js
+++ b/client/app/bundles/course/assessment/submission/actions/annotations.js
@@ -11,13 +11,20 @@ export function onCreateChange(fileId, line, text) {
   };
 }
 
-export function create(submissionId, answerId, fileId, line, text) {
+export function create(
+  submissionId,
+  answerId,
+  fileId,
+  line,
+  text,
+  delayedComment,
+) {
   const payload = {
     annotation: { line },
-    discussion_post: { text },
+    discussion_post: { text, delayed: delayedComment },
   };
   return (dispatch) => {
-    dispatch({ type: actionTypes.CREATE_ANNOTATION_REQUEST });
+    dispatch({ type: actionTypes.CREATE_ANNOTATION_REQUEST, delayedComment });
 
     return CourseAPI.assessment.submissions
       .createProgrammingAnnotation(submissionId, answerId, fileId, payload)

--- a/client/app/bundles/course/assessment/submission/actions/annotations.js
+++ b/client/app/bundles/course/assessment/submission/actions/annotations.js
@@ -17,14 +17,14 @@ export function create(
   fileId,
   line,
   text,
-  delayedComment,
+  isDelayedComment,
 ) {
   const payload = {
     annotation: { line },
-    discussion_post: { text, delayed: delayedComment },
+    discussion_post: { text, is_delayed: isDelayedComment },
   };
   return (dispatch) => {
-    dispatch({ type: actionTypes.CREATE_ANNOTATION_REQUEST, delayedComment });
+    dispatch({ type: actionTypes.CREATE_ANNOTATION_REQUEST, isDelayedComment });
 
     return CourseAPI.assessment.submissions
       .createProgrammingAnnotation(submissionId, answerId, fileId, payload)

--- a/client/app/bundles/course/assessment/submission/actions/comments.js
+++ b/client/app/bundles/course/assessment/submission/actions/comments.js
@@ -11,12 +11,12 @@ export function onCreateChange(topicId, text) {
   };
 }
 
-export function create(submissionQuestionId, text, delayedComment) {
+export function create(submissionQuestionId, text, isDelayedComment) {
   const payload = {
-    discussion_post: { text, delayed: delayedComment },
+    discussion_post: { text, is_delayed: isDelayedComment },
   };
   return (dispatch) => {
-    dispatch({ type: actionTypes.CREATE_COMMENT_REQUEST, delayedComment });
+    dispatch({ type: actionTypes.CREATE_COMMENT_REQUEST, isDelayedComment });
 
     return CourseAPI.assessment.submissionQuestions
       .createComment(submissionQuestionId, payload)

--- a/client/app/bundles/course/assessment/submission/actions/comments.js
+++ b/client/app/bundles/course/assessment/submission/actions/comments.js
@@ -11,10 +11,12 @@ export function onCreateChange(topicId, text) {
   };
 }
 
-export function create(submissionQuestionId, text) {
-  const payload = { discussion_post: { text } };
+export function create(submissionQuestionId, text, delayedComment) {
+  const payload = {
+    discussion_post: { text, delayed: delayedComment },
+  };
   return (dispatch) => {
-    dispatch({ type: actionTypes.CREATE_COMMENT_REQUEST });
+    dispatch({ type: actionTypes.CREATE_COMMENT_REQUEST, delayedComment });
 
     return CourseAPI.assessment.submissionQuestions
       .createComment(submissionQuestionId, payload)

--- a/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardText } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
-import { red500, lightBlue100, orange100 } from 'material-ui/styles/colors';
+import { red500, grey100, orange100 } from 'material-ui/styles/colors';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import MaterialSummernote from 'lib/components/MaterialSummernote';
 /* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
@@ -30,7 +30,7 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: lightBlue100,
+    backgroundColor: grey100,
   },
   delayedHeader: {
     display: 'flex',

--- a/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
@@ -161,16 +161,16 @@ export default class CommentCard extends Component {
       canUpdate,
       canDestroy,
       id,
-      delayed,
+      isDelayed,
     } = this.props.post;
     return (
       <Card id={CommentCard.postIdentifier(id)} style={styles.card}>
-        <div style={delayed ? styles.delayedHeader : styles.header}>
+        <div style={isDelayed ? styles.delayedHeader : styles.header}>
           <CardHeader
             style={styles.cardHeader}
             title={name}
             subtitle={`${CommentCard.formatDateTime(createdAt)}${
-              delayed ? ' (delayed comment)' : ''
+              isDelayed ? ' (delayed comment)' : ''
             }`}
             titleStyle={{ display: 'inline-block', marginRight: 20 }}
             subtitleStyle={{ display: 'inline-block' }}

--- a/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardText } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
-import { red500, grey100 } from 'material-ui/styles/colors';
+import { red500, lightBlue100, orange100 } from 'material-ui/styles/colors';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import MaterialSummernote from 'lib/components/MaterialSummernote';
 /* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
@@ -30,7 +30,13 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: grey100,
+    backgroundColor: lightBlue100,
+  },
+  delayedHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: orange100,
   },
   cardHeader: {
     padding: 6,
@@ -159,7 +165,7 @@ export default class CommentCard extends Component {
     } = this.props.post;
     return (
       <Card id={CommentCard.postIdentifier(id)} style={styles.card}>
-        <div style={styles.header}>
+        <div style={delayed ? styles.delayedHeader : styles.header}>
           <CardHeader
             style={styles.cardHeader}
             title={name}

--- a/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentCard.jsx
@@ -155,6 +155,7 @@ export default class CommentCard extends Component {
       canUpdate,
       canDestroy,
       id,
+      delayed,
     } = this.props.post;
     return (
       <Card id={CommentCard.postIdentifier(id)} style={styles.card}>
@@ -162,7 +163,9 @@ export default class CommentCard extends Component {
           <CardHeader
             style={styles.cardHeader}
             title={name}
-            subtitle={CommentCard.formatDateTime(createdAt)}
+            subtitle={`${CommentCard.formatDateTime(createdAt)}${
+              delayed ? ' (delayed comment)' : ''
+            }`}
             titleStyle={{ display: 'inline-block', marginRight: 20 }}
             subtitleStyle={{ display: 'inline-block' }}
             avatar={<Avatar src={avatar} size={25} />}

--- a/client/app/bundles/course/assessment/submission/components/CommentField.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentField.jsx
@@ -22,7 +22,7 @@ const translations = defineMessages({
   commentDelayedDescription: {
     id: 'course.assessment.submission.commentField.commentDelayedDescription',
     defaultMessage:
-      'This comment will only be visible to students after this submission is published',
+      'This comment will only be visible to students after this the grades are published',
   },
 });
 

--- a/client/app/bundles/course/assessment/submission/components/CommentField.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentField.jsx
@@ -22,7 +22,7 @@ const translations = defineMessages({
   commentDelayedDescription: {
     id: 'course.assessment.submission.commentField.commentDelayedDescription',
     defaultMessage:
-      'This comment will only be visible to students after this the grades are published',
+      'This comment will only be visible to students after the grades for this submission are published.',
   },
 });
 

--- a/client/app/bundles/course/assessment/submission/components/CommentField.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentField.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import RaisedButton from 'material-ui/RaisedButton';
 import CircularProgress from 'material-ui/CircularProgress';
 import MaterialSummernote from 'lib/components/MaterialSummernote';
+import ReactTooltip from 'react-tooltip';
 
 const translations = defineMessages({
   prompt: {
@@ -14,6 +15,15 @@ const translations = defineMessages({
     id: 'course.assessment.submission.commentField.comment',
     defaultMessage: 'Comment',
   },
+  commentDelayed: {
+    id: 'course.assessment.submission.commentField.commentDelayed',
+    defaultMessage: 'Delayed Comment',
+  },
+  commentDelayedDescription: {
+    id: 'course.assessment.submission.commentField.commentDelayedDescription',
+    defaultMessage:
+      'This comment will only be visible to students after this submission is published',
+  },
 });
 
 export default class CommentField extends Component {
@@ -23,8 +33,8 @@ export default class CommentField extends Component {
   }
 
   onKeyDown(e) {
-    const { createComment, isSubmitting, value } = this.props;
-    if (e.ctrlKey && e.keyCode === 13 && !isSubmitting) {
+    const { createComment, isSubmittingNormalComment, value } = this.props;
+    if (e.ctrlKey && e.keyCode === 13 && !isSubmittingNormalComment) {
       e.preventDefault();
       createComment(value);
     }
@@ -34,17 +44,27 @@ export default class CommentField extends Component {
     const {
       createComment,
       inputId,
-      isSubmitting,
+      isSubmittingNormalComment,
+      isSubmittingDelayedComment,
+      isUpdatingComment,
       value,
       airMode,
       airModeColor,
+      renderDelayedCommentButton,
     } = this.props;
+    const disableCommentButton =
+      value === undefined ||
+      value === '' ||
+      value === '<br>' ||
+      isSubmittingNormalComment ||
+      isSubmittingDelayedComment ||
+      isUpdatingComment;
     return (
       <>
         <MaterialSummernote
           airMode={airMode}
           airModeColor={airModeColor}
-          disabled={isSubmitting}
+          disabled={isSubmittingNormalComment || isSubmittingDelayedComment}
           inputId={inputId}
           label={
             <h4>
@@ -57,11 +77,32 @@ export default class CommentField extends Component {
         />
         <RaisedButton
           primary
+          style={{ marginRight: 10, marginBotton: 10 }}
           label={<FormattedMessage {...translations.comment} />}
           onClick={() => createComment(value)}
-          disabled={value === undefined || value === '' || isSubmitting}
-          icon={isSubmitting ? <CircularProgress size={24} /> : null}
+          disabled={disableCommentButton}
+          icon={
+            isSubmittingNormalComment ? <CircularProgress size={24} /> : null
+          }
         />
+        {renderDelayedCommentButton && (
+          <span data-tip data-for="timeBonusExpTooltip">
+            <RaisedButton
+              primary
+              label={<FormattedMessage {...translations.commentDelayed} />}
+              onClick={() => createComment(value, true)}
+              disabled={disableCommentButton}
+              icon={
+                isSubmittingDelayedComment ? (
+                  <CircularProgress size={24} />
+                ) : null
+              }
+            />
+            <ReactTooltip id="timeBonusExpTooltip">
+              <FormattedMessage {...translations.commentDelayedDescription} />
+            </ReactTooltip>
+          </span>
+        )}
       </>
     );
   }
@@ -69,10 +110,13 @@ export default class CommentField extends Component {
 
 CommentField.propTypes = {
   inputId: PropTypes.string,
-  isSubmitting: PropTypes.bool,
+  isSubmittingNormalComment: PropTypes.bool,
+  isSubmittingDelayedComment: PropTypes.bool,
+  isUpdatingComment: PropTypes.bool,
   value: PropTypes.string,
   airMode: PropTypes.bool,
   airModeColor: PropTypes.bool,
+  renderDelayedCommentButton: PropTypes.bool,
 
   createComment: PropTypes.func,
   handleChange: PropTypes.func,

--- a/client/app/bundles/course/assessment/submission/containers/Annotations.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/Annotations.jsx
@@ -53,7 +53,7 @@ class VisibleAnnotations extends Component {
         <CardText style={{ textAlign: 'left' }}>
           {posts.map(
             (post) =>
-              (graderView || !post.delayed) && (
+              (graderView || !post.isDelayed) && (
                 <CommentCard
                   key={post.id}
                   post={post}
@@ -169,7 +169,7 @@ function mapDispatchToProps(dispatch, ownProps) {
         dispatch(annotationActions.onCreateChange(fileId, lineNumber, comment)),
       handleUpdateChange: (postId, comment) =>
         dispatch(annotationActions.onUpdateChange(postId, comment)),
-      createComment: (comment, delayedComment = false) =>
+      createComment: (comment, isDelayedComment = false) =>
         dispatch(
           annotationActions.create(
             submissionId,
@@ -177,7 +177,7 @@ function mapDispatchToProps(dispatch, ownProps) {
             fileId,
             lineNumber,
             comment,
-            delayedComment,
+            isDelayedComment,
           ),
         ),
       updateComment: () => {},
@@ -189,7 +189,7 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(annotationActions.onCreateChange(fileId, lineNumber, comment)),
     handleUpdateChange: (postId, comment) =>
       dispatch(annotationActions.onUpdateChange(postId, comment)),
-    createComment: (comment, delayedComment = false) =>
+    createComment: (comment, isDelayedComment = false) =>
       dispatch(
         annotationActions.create(
           submissionId,
@@ -197,7 +197,7 @@ function mapDispatchToProps(dispatch, ownProps) {
           fileId,
           lineNumber,
           comment,
-          delayedComment,
+          isDelayedComment,
         ),
       ),
     updateComment: (postId, comment) =>

--- a/client/app/bundles/course/assessment/submission/containers/Annotations.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/Annotations.jsx
@@ -10,6 +10,7 @@ import { postShape, annotationShape } from '../propTypes';
 import CommentCard from '../components/CommentCard';
 import CommentField from '../components/CommentField';
 import * as annotationActions from '../actions/annotations';
+import { workflowStates } from '../constants';
 
 const translations = defineMessages({
   comment: {
@@ -43,29 +44,39 @@ class VisibleAnnotations extends Component {
       handleCreateChange,
       handleUpdateChange,
       airMode,
+      graderView,
+      renderDelayedCommentButton,
     } = this.props;
 
     return (
       <Card style={styles.card}>
         <CardText style={{ textAlign: 'left' }}>
-          {posts.map((post) => (
-            <CommentCard
-              key={post.id}
-              post={post}
-              editValue={commentForms.posts[post.id]}
-              updateComment={(value) => updateComment(post.id, value)}
-              deleteComment={() => deleteComment(post.id)}
-              handleChange={(value) => handleUpdateChange(post.id, value)}
-              airMode={airMode}
-            />
-          ))}
+          {posts.map(
+            (post) =>
+              (graderView || !post.delayed) && (
+                <CommentCard
+                  key={post.id}
+                  post={post}
+                  editValue={commentForms.posts[post.id]}
+                  updateComment={(value) => updateComment(post.id, value)}
+                  deleteComment={() => deleteComment(post.id)}
+                  handleChange={(value) => handleUpdateChange(post.id, value)}
+                  airMode={airMode}
+                />
+              ),
+          )}
           {posts.length === 0 || fieldVisible ? (
             <CommentField
               value={commentForms.annotations[fileId][lineNumber]}
-              isSubmitting={commentForms.isSubmitting}
+              isSubmittingNormalComment={commentForms.isSubmittingNormalComment}
+              isSubmittingDelayedComment={
+                commentForms.isSubmittingDelayedComment
+              }
+              isUpdatingComment={commentForms.isUpdatingComment}
               createComment={createComment}
               handleChange={handleCreateChange}
               airMode={airMode}
+              renderDelayedCommentButton={renderDelayedCommentButton}
             />
           ) : (
             <RaisedButton
@@ -84,7 +95,9 @@ VisibleAnnotations.propTypes = {
   commentForms: PropTypes.shape({
     topics: PropTypes.objectOf(PropTypes.string),
     posts: PropTypes.objectOf(PropTypes.string),
-    isSubmitting: PropTypes.bool,
+    isSubmittingNormalComment: PropTypes.bool,
+    isSubmittingDelayedComment: PropTypes.bool,
+    isUpdatingComment: PropTypes.bool,
     annotations: {},
   }),
   fileId: PropTypes.number.isRequired,
@@ -101,6 +114,8 @@ VisibleAnnotations.propTypes = {
   }),
   annotation: annotationShape,
   answerId: PropTypes.number.isRequired,
+  graderView: PropTypes.bool.isRequired,
+  renderDelayedCommentButton: PropTypes.bool,
   /* eslint-enable react/no-unused-prop-types */
 
   handleCreateChange: PropTypes.func.isRequired,
@@ -116,16 +131,24 @@ VisibleAnnotations.defaultProps = {
 
 function mapStateToProps(state, ownProps) {
   const { annotation } = ownProps;
-
+  const renderDelayedCommentButton =
+    state.submission.graderView &&
+    !state.assessment.autograded &&
+    (state.submission.workflowState === workflowStates.Submitted ||
+      state.submission.workflowState === workflowStates.Graded);
   if (!annotation) {
     return {
       commentForms: state.commentForms,
       posts: [],
+      graderView: state.submission.graderView,
+      renderDelayedCommentButton,
     };
   }
   return {
     commentForms: state.commentForms,
     posts: annotation.postIds.map((postId) => state.posts[postId]),
+    graderView: state.submission.graderView,
+    renderDelayedCommentButton,
   };
 }
 
@@ -146,7 +169,7 @@ function mapDispatchToProps(dispatch, ownProps) {
         dispatch(annotationActions.onCreateChange(fileId, lineNumber, comment)),
       handleUpdateChange: (postId, comment) =>
         dispatch(annotationActions.onUpdateChange(postId, comment)),
-      createComment: (comment) =>
+      createComment: (comment, delayedComment = false) =>
         dispatch(
           annotationActions.create(
             submissionId,
@@ -154,6 +177,7 @@ function mapDispatchToProps(dispatch, ownProps) {
             fileId,
             lineNumber,
             comment,
+            delayedComment,
           ),
         ),
       updateComment: () => {},
@@ -165,7 +189,7 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(annotationActions.onCreateChange(fileId, lineNumber, comment)),
     handleUpdateChange: (postId, comment) =>
       dispatch(annotationActions.onUpdateChange(postId, comment)),
-    createComment: (comment) =>
+    createComment: (comment, delayedComment = false) =>
       dispatch(
         annotationActions.create(
           submissionId,
@@ -173,6 +197,7 @@ function mapDispatchToProps(dispatch, ownProps) {
           fileId,
           lineNumber,
           comment,
+          delayedComment,
         ),
       ),
     updateComment: (postId, comment) =>

--- a/client/app/bundles/course/assessment/submission/containers/Comments.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/Comments.jsx
@@ -37,7 +37,7 @@ class VisibleComments extends Component {
         </h4>
         {posts.map(
           (post) =>
-            (graderView || !post.delayed) && (
+            (graderView || !post.isDelayed) && (
               <CommentCard
                 key={post.id}
                 post={post}
@@ -107,12 +107,12 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(commentActions.onCreateChange(topic.id, comment)),
     handleUpdateChange: (postId, comment) =>
       dispatch(commentActions.onUpdateChange(postId, comment)),
-    createComment: (comment, delayedComment = false) =>
+    createComment: (comment, isDelayedComment = false) =>
       dispatch(
         commentActions.create(
           topic.submissionQuestionId,
           comment,
-          delayedComment,
+          isDelayedComment,
         ),
       ),
     updateComment: (postId, comment) =>

--- a/client/app/bundles/course/assessment/submission/containers/Comments.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/Comments.jsx
@@ -9,6 +9,7 @@ import CommentCard from '../components/CommentCard';
 import CommentField from '../components/CommentField';
 import * as commentActions from '../actions/comments';
 import translations from '../translations';
+import { workflowStates } from '../constants';
 
 class VisibleComments extends Component {
   static newCommentIdentifier(field) {
@@ -25,6 +26,8 @@ class VisibleComments extends Component {
       createComment,
       updateComment,
       deleteComment,
+      graderView,
+      renderDelayedCommentButton,
     } = this.props;
 
     return (
@@ -32,23 +35,29 @@ class VisibleComments extends Component {
         <h4 style={{ color: grey600 }}>
           <FormattedMessage {...translations.comments} />
         </h4>
-        {posts.map((post) => (
-          <CommentCard
-            key={post.id}
-            post={post}
-            editValue={commentForms.posts[post.id]}
-            updateComment={(value) => updateComment(post.id, value)}
-            deleteComment={() => deleteComment(post.id)}
-            handleChange={(value) => handleUpdateChange(post.id, value)}
-          />
-        ))}
+        {posts.map(
+          (post) =>
+            (graderView || !post.delayed) && (
+              <CommentCard
+                key={post.id}
+                post={post}
+                editValue={commentForms.posts[post.id]}
+                updateComment={(value) => updateComment(post.id, value)}
+                deleteComment={() => deleteComment(post.id)}
+                handleChange={(value) => handleUpdateChange(post.id, value)}
+              />
+            ),
+        )}
         <CommentField
           createComment={createComment}
           handleChange={handleCreateChange}
           inputId={VisibleComments.newCommentIdentifier(topic.id)}
-          isSubmitting={commentForms.isSubmitting}
+          isSubmittingNormalComment={commentForms.isSubmittingNormalComment}
+          isSubmittingDelayedComment={commentForms.isSubmittingDelayedComment}
+          isUpdatingComment={commentForms.isUpdatingComment}
           value={commentForms.topics[topic.id]}
           airModeColor={false}
+          renderDelayedCommentButton={renderDelayedCommentButton}
         />
       </div>
     );
@@ -59,10 +68,14 @@ VisibleComments.propTypes = {
   commentForms: PropTypes.shape({
     topics: PropTypes.objectOf(PropTypes.string),
     posts: PropTypes.objectOf(PropTypes.string),
-    isSubmitting: PropTypes.bool,
+    isSubmittingNormalComment: PropTypes.bool,
+    isSubmittingDelayedComment: PropTypes.bool,
+    isUpdatingComment: PropTypes.bool,
   }),
   posts: PropTypes.arrayOf(postShape),
   topic: topicShape,
+  graderView: PropTypes.bool.isRequired,
+  renderDelayedCommentButton: PropTypes.bool,
 
   handleCreateChange: PropTypes.func.isRequired,
   handleUpdateChange: PropTypes.func.isRequired,
@@ -73,9 +86,16 @@ VisibleComments.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const { topic } = ownProps;
+  const renderDelayedCommentButton =
+    state.submission.graderView &&
+    !state.assessment.autograded &&
+    (state.submission.workflowState === workflowStates.Submitted ||
+      state.submission.workflowState === workflowStates.Graded);
   return {
     commentForms: state.commentForms,
     posts: state.topics[topic.id].postIds.map((postId) => state.posts[postId]),
+    graderView: state.submission.graderView,
+    renderDelayedCommentButton,
   };
 }
 
@@ -87,8 +107,14 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(commentActions.onCreateChange(topic.id, comment)),
     handleUpdateChange: (postId, comment) =>
       dispatch(commentActions.onUpdateChange(postId, comment)),
-    createComment: (comment) =>
-      dispatch(commentActions.create(topic.submissionQuestionId, comment)),
+    createComment: (comment, delayedComment = false) =>
+      dispatch(
+        commentActions.create(
+          topic.submissionQuestionId,
+          comment,
+          delayedComment,
+        ),
+      ),
     updateComment: (postId, comment) =>
       dispatch(commentActions.update(topic.id, postId, comment)),
     deleteComment: (postId) =>

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -68,7 +68,7 @@ export const postShape = PropTypes.shape({
   createdAt: PropTypes.string.isRequired,
   canUpdate: PropTypes.bool.isRequired,
   canDestroy: PropTypes.bool.isRequired,
-  delayed: PropTypes.bool.isRequired,
+  isDelayed: PropTypes.bool.isRequired,
 });
 
 export const answerShape = PropTypes.shape({

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -68,6 +68,7 @@ export const postShape = PropTypes.shape({
   createdAt: PropTypes.string.isRequired,
   canUpdate: PropTypes.bool.isRequired,
   canDestroy: PropTypes.bool.isRequired,
+  delayed: PropTypes.bool.isRequired,
 });
 
 export const answerShape = PropTypes.shape({

--- a/client/app/bundles/course/assessment/submission/reducers/commentForms.js
+++ b/client/app/bundles/course/assessment/submission/reducers/commentForms.js
@@ -1,8 +1,9 @@
 import actions from '../constants';
 
 const initialState = {
-  isSubmitting: false,
-  annotations: {},
+  isSubmittingNormalComment: false,
+  isSubmittingDelayedComment: false,
+  annotationsDelayedComment: {},
   topics: {},
   posts: {},
 };
@@ -35,7 +36,8 @@ export default function (state = initialState, action) {
       const { fileId, line } = action.payload;
       return {
         ...state,
-        isSubmitting: false,
+        isSubmittingNormalComment: false,
+        isSubmittingDelayedComment: false,
         annotations: {
           ...state.annotations,
           [fileId]: {
@@ -59,7 +61,8 @@ export default function (state = initialState, action) {
       const { topicId } = action.payload;
       return {
         ...state,
-        isSubmitting: false,
+        isSubmittingNormalComment: false,
+        isSubmittingDelayedComment: false,
         topics: {
           ...state.topics,
           [topicId]: '',
@@ -82,7 +85,7 @@ export default function (state = initialState, action) {
       const { id } = action.payload;
       return {
         ...state,
-        isSubmitting: false,
+        isUpdatingComment: false,
         posts: {
           ...state.posts,
           [id]: action.payload.text,
@@ -103,19 +106,29 @@ export default function (state = initialState, action) {
     }
     case actions.CREATE_ANNOTATION_REQUEST:
     case actions.CREATE_COMMENT_REQUEST:
+      return {
+        ...state,
+        isSubmittingNormalComment: !action.delayedComment,
+        isSubmittingDelayedComment: action.delayedComment,
+      };
     case actions.UPDATE_ANNOTATION_REQUEST:
     case actions.UPDATE_COMMENT_REQUEST:
       return {
         ...state,
-        isSubmitting: true,
+        isUpdatingComment: true,
       };
     case actions.CREATE_ANNOTATION_FAILURE:
     case actions.CREATE_COMMENT_FAILURE:
+      return {
+        ...state,
+        isSubmittingNormalComment: false,
+        isSubmittingDelayedComment: false,
+      };
     case actions.UPDATE_ANNOTATION_FAILURE:
     case actions.UPDATE_COMMENT_FAILURE:
       return {
         ...state,
-        isSubmitting: false,
+        isUpdatingComment: false,
       };
     case actions.AUTOGRADE_SUCCESS: {
       const { latestAnswer } = action.payload;

--- a/client/app/bundles/course/assessment/submission/reducers/commentForms.js
+++ b/client/app/bundles/course/assessment/submission/reducers/commentForms.js
@@ -108,8 +108,8 @@ export default function (state = initialState, action) {
     case actions.CREATE_COMMENT_REQUEST:
       return {
         ...state,
-        isSubmittingNormalComment: !action.delayedComment,
-        isSubmittingDelayedComment: action.delayedComment,
+        isSubmittingNormalComment: !action.isDelayedComment,
+        isSubmittingDelayedComment: action.isDelayedComment,
       };
     case actions.UPDATE_ANNOTATION_REQUEST:
     case actions.UPDATE_COMMENT_REQUEST:

--- a/db/migrate/20211210085034_add_delayed_post_column.rb
+++ b/db/migrate/20211210085034_add_delayed_post_column.rb
@@ -1,0 +1,5 @@
+class AddDelayedPostColumn < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_discussion_posts, :delayed, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20211215055726_rename_delayed_to_is_delayed.rb
+++ b/db/migrate/20211215055726_rename_delayed_to_is_delayed.rb
@@ -1,0 +1,5 @@
+class RenameDelayedToIsDelayed < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :course_discussion_posts, :delayed, :is_delayed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_10_085034) do
+ActiveRecord::Schema.define(version: 2021_12_15_055726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -528,7 +528,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_085034) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "answer", default: false
-    t.boolean "delayed", default: false, null: false
+    t.boolean "is_delayed", default: false, null: false
     t.index ["creator_id"], name: "fk__course_discussion_posts_creator_id"
     t.index ["parent_id"], name: "fk__course_discussion_posts_parent_id"
     t.index ["topic_id"], name: "fk__course_discussion_posts_topic_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_10_015400) do
+ActiveRecord::Schema.define(version: 2021_12_10_085034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -528,6 +528,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_015400) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "answer", default: false
+    t.boolean "delayed", default: false, null: false
     t.index ["creator_id"], name: "fk__course_discussion_posts_creator_id"
     t.index ["parent_id"], name: "fk__course_discussion_posts_parent_id"
     t.index ["topic_id"], name: "fk__course_discussion_posts_topic_id"

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
 
     describe '#create' do
       let(:post_text) { 'test post text' }
+      let(:delayed) { false }
       subject do
         post :create, as: :js, params: {
           course_id: course, assessment_id: assessment,
@@ -29,7 +30,8 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
             answer_id: answer.id
           },
           discussion_post: {
-            text: post_text
+            text: post_text,
+            delayed: delayed
           }
         }
       end
@@ -63,6 +65,13 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
 
           it 'sends email notifications' do
             expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          end
+
+          context 'when the new comment is posted as delayed post' do
+            let!(:delayed) { true }
+            it 'does not send email notifications' do
+              expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+            end
           end
 
           context 'when "New Comment" email notification is disabled' do

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
 
     describe '#create' do
       let(:post_text) { 'test post text' }
-      let(:delayed) { false }
+      let(:is_delayed) { false }
       subject do
         post :create, as: :js, params: {
           course_id: course, assessment_id: assessment,
@@ -31,7 +31,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
           },
           discussion_post: {
             text: post_text,
-            delayed: delayed
+            is_delayed: is_delayed
           }
         }
       end
@@ -68,7 +68,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
           end
 
           context 'when the new comment is posted as delayed post' do
-            let!(:delayed) { true }
+            let!(:is_delayed) { true }
             it 'does not send email notifications' do
               expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end

--- a/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
     before { sign_in(user) }
 
     describe '#create' do
+      let(:delayed) { false }
       subject do
         post :create, as: :js, params: {
           course_id: course, assessment_id: assessment,
           submission_question_id: submission_question,
           discussion_post: {
-            text: comment
+            text: comment,
+            delayed: delayed
           }
         }
       end
@@ -55,6 +57,13 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
 
           it 'sends email notifications' do
             expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          end
+
+          context 'when the new comment is posted as delayed post' do
+            let!(:delayed) { true }
+            it 'does not send email notifications' do
+              expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
+            end
           end
 
           context 'when "New Comment" email notification is disabled' do

--- a/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
     before { sign_in(user) }
 
     describe '#create' do
-      let(:delayed) { false }
+      let(:is_delayed) { false }
       subject do
         post :create, as: :js, params: {
           course_id: course, assessment_id: assessment,
           submission_question_id: submission_question,
           discussion_post: {
             text: comment,
-            delayed: delayed
+            is_delayed: is_delayed
           }
         }
       end
@@ -60,7 +60,7 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
           end
 
           context 'when the new comment is posted as delayed post' do
-            let!(:delayed) { true }
+            let!(:is_delayed) { true }
             it 'does not send email notifications' do
               expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end

--- a/spec/factories/course_discussion_posts.rb
+++ b/spec/factories/course_discussion_posts.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     parent { nil }
     association :topic, factory: :course_discussion_topic
     text { 'This is a test post' }
+    delayed { false }
 
     after(:create) do |post, evaluator|
       Array(evaluator.upvoted_by).each do |user|
@@ -20,6 +21,10 @@ FactoryBot.define do
       Array(evaluator.downvoted_by).each do |user|
         post.cast_vote!(user, -1)
       end
+    end
+
+    trait :delayed do
+      delayed { true }
     end
   end
 end

--- a/spec/factories/course_discussion_posts.rb
+++ b/spec/factories/course_discussion_posts.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     parent { nil }
     association :topic, factory: :course_discussion_topic
     text { 'This is a test post' }
-    delayed { false }
+    is_delayed { false }
 
     after(:create) do |post, evaluator|
       Array(evaluator.upvoted_by).each do |user|
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     trait :delayed do
-      delayed { true }
+      is_delayed { true }
     end
   end
 end

--- a/spec/factories/course_discussion_topics.rb
+++ b/spec/factories/course_discussion_topics.rb
@@ -14,6 +14,19 @@ FactoryBot.define do
       end
     end
 
+    trait :with_delayed_post do
+      after(:build) do |topic|
+        topic.posts = [build(:course_discussion_post, :delayed, topic: topic)]
+      end
+    end
+
+    trait :with_both_normal_and_delayed_post do
+      after(:build) do |topic|
+        topic.posts = [build(:course_discussion_post, :delayed, topic: topic),
+                       build(:course_discussion_post, topic: topic)]
+      end
+    end
+
     trait :pending do
       pending_staff_reply { true }
     end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -457,11 +457,11 @@ RSpec.describe Course::Assessment::Submission do
         end
       end
 
-      it 'sends an email notification' do
+      it 'sends an email notification', type: :mailer do
         expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
 
-      context 'when a user unsubscribes' do
+      context 'when a user unsubscribes', type: :mailer do
         before do
           setting_email = course.
                           setting_emails.
@@ -472,11 +472,11 @@ RSpec.describe Course::Assessment::Submission do
         end
 
         it 'does not send an email notification to the user' do
-          expect { course_student1 }.to change { ActionMailer::Base.deliveries.count }.by(0)
+          expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
       end
 
-      context 'when "submission graded" email setting is disabled for regular students' do
+      context 'when "submission graded" email setting is disabled for regular students', type: :mailer do
         before { set_assessment_email_setting(course, category_id, :grades_released, false, true) }
 
         it 'does not send email notifications to the regular students' do
@@ -484,7 +484,7 @@ RSpec.describe Course::Assessment::Submission do
         end
       end
 
-      context 'when "submission graded" email setting is disabled for phantom students' do
+      context 'when "submission graded" email setting is disabled for phantom students', type: :mailer do
         before { set_assessment_email_setting(course, category_id, :grades_released, true, false) }
 
         it 'does not send email notifications to phantom students' do
@@ -493,7 +493,7 @@ RSpec.describe Course::Assessment::Submission do
         end
       end
 
-      context 'when "submission graded" setting is disabled for everyone' do
+      context 'when "submission graded" setting is disabled for everyone', type: :mailer do
         before { set_assessment_email_setting(course, category_id, :grades_released, false, false) }
 
         it 'does not send email notifications to the users' do

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -452,8 +452,8 @@ RSpec.describe Course::Assessment::Submission do
         end
         it 'is set as not delayed after publication' do
           submission.publish!
-          expect(annotation_post.reload.delayed).to be(false)
-          expect(submission_question_post.reload.delayed).to be(false)
+          expect(annotation_post.reload.is_delayed).to be(false)
+          expect(submission_question_post.reload.is_delayed).to be(false)
         end
       end
 


### PR DESCRIPTION
Fixes #2015 

## Context
When instructors are marking submissions, students are notified and can view new comments or annotations which are supposed to be seen once the submissions are published. To prevent this, delayed comment feature is added here. This feature is only available for non-autograded submissions with either submitted or graded state. When a comment is delayed, there is no notificiation sent to student but if other instructors subscribed to the topic still receive notifications allowing them to communicate. Instructors still can make use of the normal comment feature to seek clarification to students if needed.

## UIUX/Design

### Instructor's View
**Comment**
![image](https://user-images.githubusercontent.com/42570513/145751872-408c7e74-448c-4e87-8266-e58408092c99.png)

**Annotation (Programming answer)**
![image](https://user-images.githubusercontent.com/42570513/145751926-7790c604-f06c-447a-87f7-ec63d0aff0d9.png)

### Student's View (similar to above but without delayed comments)
- Students will not be able to view any of the comments/annotations that are tagged delayed
- In the comments page (courses/x/comments/pending), delayed comments/annotations are not visible
- Once a submission is published, the delayed tag is removed and the comments will be available everywhere (in submission page or comment page).
- There could be a case when an instructor posts both delayed and normal comments. In the case that a student marks the normal comment (or topic to be precise) as read, the same topic of the delayed comment is unmarked as read when the submission is published.
