### PR TITLE
Fix correct answers not shown for non-autograded assessment with tabbed view

### DIFF
--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -212,6 +212,8 @@ class SubmissionEditForm extends Component {
       historyQuestions,
       topics,
       step,
+      graderView,
+      showMcqMrqSolution,
       handleToggleViewHistoryMode,
     } = this.props;
 
@@ -247,6 +249,8 @@ class SubmissionEditForm extends Component {
                   question,
                   questionsFlags,
                   historyQuestions,
+                  graderView,
+                  showMcqMrqSolution,
                   handleToggleViewHistoryMode,
                 }}
               />


### PR DESCRIPTION
Green highlight for correct answer was not shown for tabbed question.

**Before**
![image](https://user-images.githubusercontent.com/42570513/140654076-35025c5c-6729-4825-807c-ad7b0bc37015.png)

**After**
![image](https://user-images.githubusercontent.com/42570513/140654030-14e30a97-5b51-4462-a9b0-ceb822845118.png)
