### PR TITLE
fix(image_uploader): catch error when medium.url not found when  duplicating images

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -58,7 +58,11 @@ class ImageUploader < CarrierWave::Uploader::Base
       begin
         download!(other_uploader.url)
       rescue StandardError => _e
-        download!(other_uploader.medium.url)
+        begin
+          download!(other_uploader.medium.url)
+        rescue StandardError => _e
+          return false
+        end
       end
     end
     true


### PR DESCRIPTION
Temporary patch for the image duplication issue. Replace missing images with default image.