### PR TITLE
Upgrade to Ruby 2.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.0-browsers
+      - image: cimg/ruby:2.7.4-browsers
         environment:
           BUNDLE_APP_CONFIG: ~/repo/.bundle
 
@@ -29,9 +29,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3.1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v3.2-dependencies-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v3.1-dependencies-
+            - v3.2-dependencies-
 
       - run:
           name: install dependencies
@@ -42,7 +42,7 @@ jobs:
           paths:
             - ./vendor/bundle
             - ./.bundle
-          key: v3.1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: v3.2-dependencies-{{ checksum "Gemfile.lock" }}
 
       - restore_cache:
           keys:
@@ -61,7 +61,7 @@ jobs:
   test:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.0-browsers
+      - image: cimg/ruby:2.7.4-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
@@ -91,9 +91,9 @@ jobs:
 
       - restore_cache:
           keys:
-            - v3.1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v3.2-dependencies-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v3.1-dependencies-
+            - v3.2-dependencies-
 
       - restore_cache:
           keys:
@@ -147,7 +147,7 @@ jobs:
   lint:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.0-browsers
+      - image: cimg/ruby:2.7.4-browsers
         environment:
           RAILS_ENV: test
 
@@ -172,7 +172,7 @@ jobs:
   jstest:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.0-browsers
+      - image: cimg/ruby:2.7.4-browsers
         environment:
           RAILS_ENV: test
 
@@ -198,7 +198,7 @@ jobs:
   i18n:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.0-browsers
+      - image: cimg/ruby:2.7.4-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
@@ -223,9 +223,9 @@ jobs:
 
       - restore_cache:
           keys:
-            - v3.1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v3.2-dependencies-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v3.1-dependencies-
+            - v3.2-dependencies-
 
       # Install bundler version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.6.8-browsers
+      - image: cimg/ruby:2.7.0-browsers
         environment:
           BUNDLE_APP_CONFIG: ~/repo/.bundle
 
@@ -61,7 +61,7 @@ jobs:
   test:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.6.8-browsers
+      - image: cimg/ruby:2.7.0-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
@@ -147,7 +147,7 @@ jobs:
   lint:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.6.8-browsers
+      - image: cimg/ruby:2.7.0-browsers
         environment:
           RAILS_ENV: test
 
@@ -172,7 +172,7 @@ jobs:
   jstest:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.6.8-browsers
+      - image: cimg/ruby:2.7.0-browsers
         environment:
           RAILS_ENV: test
 
@@ -198,7 +198,7 @@ jobs:
   i18n:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.6.8-browsers
+      - image: cimg/ruby:2.7.0-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,15 @@ jobs:
             bundle install
 
       # Install ghostscript so `identify` in ImageMagick works with PDF files.
-      - run: sudo apt update && sudo apt install imagemagick && sudo apt install ghostscript
+      # Remove pdf security policy for imagemagick (ubuntu 20.04)
+      # https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion
+      - run:
+          name: install ghostscript and imagemagick
+          command: |
+            sudo apt update
+            sudo apt install imagemagick
+            sudo apt install ghostscript
+            sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
 
       - setup_remote_docker
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'db/migrate/*'
     - 'vendor/bundle/**/*'
     - 'client/**/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Bundler/OrderedGems:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -20,14 +20,14 @@ gem 'validates_hostname'
 gem 'workflow'
 gem 'workflow-activerecord', '>= 4.1', '< 6.0'
 # Add creator_id and updater_id attributes to models
-gem 'activerecord-userstamp', git: 'https://github.com/raymondtangsc/activerecord-userstamp'
+gem 'activerecord-userstamp', git: 'https://github.com/ekowidianto/activerecord-userstamp.git'
 # Allow actions to be deferred until after a record is committed.
 gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
 gem 'calculated_attributes'
 # For multiple table inheritance
 # TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
-gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as', branch: 'rails5.2.3'
+gem 'active_record-acts_as', git: 'https://github.com/ekowidianto/active_record-acts_as.git', branch: 'rails5.2.3'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Upsert action for Postgres

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/ekowidianto/active_record-acts_as.git
-  revision: 1ba69ea24c28e7afba7ce452d237d69cf1040069
+  revision: 9e01feb01438ba6736f2d4a8140d9be18464afdc
   branch: rails5.2.3
   specs:
     active_record-acts_as (3.0.1)
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/ekowidianto/activerecord-userstamp.git
-  revision: 9ee6f761b83d9bd335edbdf3591451ce79ffaec2
+  revision: 1170233e314466630e3a545ae3fdee16a0bb4a19
   specs:
     activerecord-userstamp (3.0.5)
       rails (>= 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/Coursemology/active_record-acts_as
-  revision: 6792c5dc16f05a51a2c465c157878e3f4e1ca1a8
-  branch: rails5.2.3
-  specs:
-    active_record-acts_as (3.0.1)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-
-GIT
   remote: https://github.com/Coursemology/polyglot.git
   revision: 291a9e5ebfc3232da58f1eba8fb6c76ec85aa407
   specs:
@@ -22,17 +13,26 @@ GIT
       rails (>= 3.1.0)
 
 GIT
+  remote: https://github.com/ekowidianto/active_record-acts_as.git
+  revision: 1ba69ea24c28e7afba7ce452d237d69cf1040069
+  branch: rails5.2.3
+  specs:
+    active_record-acts_as (3.0.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+
+GIT
+  remote: https://github.com/ekowidianto/activerecord-userstamp.git
+  revision: 9ee6f761b83d9bd335edbdf3591451ce79ffaec2
+  specs:
+    activerecord-userstamp (3.0.5)
+      rails (>= 6)
+
+GIT
   remote: https://github.com/makqien/rwordnet
   revision: 54a85eed974002cb2cfb858cbcaed8e1069b5cb8
   specs:
     rwordnet (2.0.0)
-
-GIT
-  remote: https://github.com/raymondtangsc/activerecord-userstamp
-  revision: 9a182307c3fd254966f5bd94e1b9340ca909a6e5
-  specs:
-    activerecord-userstamp (3.0.5)
-      rails (>= 6)
 
 GIT
   remote: https://github.com/raymondtangsc/rails_utils.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
     docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
-    edge (0.6.0)
+    edge (0.6.1)
       activerecord (>= 5.0.0)
     ejs (1.1.1)
     email_spec (2.2.0)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Coursemology is an open source gamified learning platform that enables educators
 
 ### System Requirements
 
-1. Ruby (>= 2.6.8)
+1. Ruby (>= 2.7)
 1. Ruby on Rails
 1. PostgreSQL (>= 9.5)
 1. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick) - if PDF processing doesn't work for the import of scribing questions, download Ghostscript)

--- a/app/jobs/course/assessment/submission/auto_grading_job.rb
+++ b/app/jobs/course/assessment/submission/auto_grading_job.rb
@@ -11,7 +11,7 @@ class Course::Assessment::Submission::AutoGradingJob < ApplicationJob
   #   results into.
   # @param [Boolean] only_ungraded Whether grading should be done ONLY for
   #   ungraded_answers, or for all answers regardless of workflow state
-  def perform_tracked(submission, only_ungraded = false)
+  def perform_tracked(submission, only_ungraded = false) # rubocop:disable Style/OptionalBooleanParameter
     instance = Course.unscoped { submission.assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
       Course::Assessment::Submission::AutoGradingService.grade(submission, only_ungraded: only_ungraded)

--- a/app/jobs/course/assessment/submission/auto_grading_job.rb
+++ b/app/jobs/course/assessment/submission/auto_grading_job.rb
@@ -11,7 +11,7 @@ class Course::Assessment::Submission::AutoGradingJob < ApplicationJob
   #   results into.
   # @param [Boolean] only_ungraded Whether grading should be done ONLY for
   #   ungraded_answers, or for all answers regardless of workflow state
-  def perform_tracked(submission, only_ungraded: false)
+  def perform_tracked(submission, only_ungraded = false)
     instance = Course.unscoped { submission.assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
       Course::Assessment::Submission::AutoGradingService.grade(submission, only_ungraded: only_ungraded)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -83,7 +83,7 @@ class Attachment < ApplicationRecord
   # @param opt [Hash] The options for opening the stream with.
   # @param block [Proc] The block to receive the stream with.
   def open_with_block(opt, block)
-    Tempfile.create(TEMPORARY_FILE_PREFIX, opt) do |temporary_file|
+    Tempfile.create(TEMPORARY_FILE_PREFIX, **opt) do |temporary_file|
       temporary_file.write(contents)
       temporary_file.seek(0)
 
@@ -96,7 +96,7 @@ class Attachment < ApplicationRecord
   # @param opt [Hash] The options for opening the stream with.
   # @return [Tempfile] The temporary file opened.
   def open_without_block(opt)
-    file = Tempfile.new(TEMPORARY_FILE_PREFIX, Dir.tmpdir, opt)
+    file = Tempfile.new(TEMPORARY_FILE_PREFIX, Dir.tmpdir, **opt)
     file.write(contents)
     file.seek(0)
     file

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -177,7 +177,7 @@ class Course::Assessment::Submission < ApplicationRecord
   #
   # @return [Course::Assessment::Submission::AutoGradingJob] The job instance.
   def auto_grade!(only_ungraded: false)
-    AutoGradingJob.perform_later(self, only_ungraded: only_ungraded)
+    AutoGradingJob.perform_later(self, only_ungraded)
   end
 
   def auto_grade_now!(only_ungraded: false)

--- a/app/notifiers/notifier/base.rb
+++ b/app/notifiers/notifier/base.rb
@@ -10,12 +10,12 @@ class Notifier::Base
     # notifiers
     #
     # @api private
-    def method_missing(symbol, *args, &block)
-      new.public_send(symbol, *args, &block)
+    def method_missing(symbol, *args, **kwargs, &block)
+      new.public_send(symbol, *args, **kwargs, &block)
     end
   end
 
-  def initialize # :nodoc:
+  def initialize
     super
     @pending_emails = []
   end

--- a/app/notifiers/notifier/base.rb
+++ b/app/notifiers/notifier/base.rb
@@ -10,7 +10,7 @@ class Notifier::Base
     # notifiers
     #
     # @api private
-    def method_missing(symbol, *args, **kwargs, &block)
+    def method_missing(symbol, *args, **kwargs, &block) # rubocop:disable Style/MissingRespondToMissing, Lint/MissingSuper
       new.public_send(symbol, *args, **kwargs, &block)
     end
   end

--- a/lib/autoload/send_file.rb
+++ b/lib/autoload/send_file.rb
@@ -13,8 +13,7 @@ module SendFile
     temporary_dir = File.basename(Dir.mktmpdir(nil, public_dir))
     public_file = File.join(public_dir, temporary_dir, public_name)
     FileUtils.cp(file, public_file)
-
-    URI.encode(File.join('/', downloads_dir, temporary_dir, public_name))
+    Addressable::URI.encode(File.join('/', downloads_dir, temporary_dir, public_name))
   end
 
   # Obtains the local path for the given publicly accessible file path.
@@ -22,6 +21,6 @@ module SendFile
   # @param [String] path The URL to the publicly accessible file.
   # @return [String] The absolute file path to the publicly accessible file.
   def self.local_path(path)
-    File.join(Rails.public_path, URI.decode(path))
+    File.join(Rails.public_path, URI.decode_www_form_component(path))
   end
 end

--- a/lib/tasks/coursemology/seed.rake
+++ b/lib/tasks/coursemology/seed.rake
@@ -80,7 +80,7 @@ namespace :coursemology do
           :assessment, :autograded, course: course,
                                     title: 'Published, Autograded with Programming Question'
         )
-        question = FactoryBot.create(
+        FactoryBot.create(
           :course_assessment_question_programming, :auto_gradable,
           template_files: [template_file], test_cases: test_cases, assessment: assessment,
           file: File.new(Rails.root.join('lib/tasks/coursemology/programming_question.zip'))

--- a/spec/libraries/send_file_spec.rb
+++ b/spec/libraries/send_file_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe SendFile do
     subject { SendFile.send_file(file) }
 
     it 'preserves the original file name' do
-      expect(File.basename(URI.decode(subject))).to eq(File.basename(file))
+      expect(File.basename(URI.decode_www_form_component(subject))).to eq(File.basename(file))
     end
 
     it 'copies the file' do
-      public_file = File.join(Rails.public_path, URI.decode(subject))
+      public_file = File.join(Rails.public_path, URI.decode_www_form_component(subject))
       expect(FileUtils.compare_file(public_file, file)).to be_truthy
     end
 
@@ -26,7 +26,7 @@ RSpec.describe SendFile do
       subject { SendFile.send_file(file, file_name) }
 
       it 'uses the custom name' do
-        expect(File.basename(URI.decode(subject))).to eq(file_name)
+        expect(File.basename(URI.decode_www_form_component(subject))).to eq(file_name)
       end
     end
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -86,10 +86,10 @@ end
 
 module Capybara::CustomFinders
   # Supplements find to try for alternative elements.
-  def find(*args)
+  def find(*args, **kwargs)
     super
   rescue Capybara::ElementNotFound
-    result = try_find_ace(*args) || try_find_textarea(*args)
+    result = try_find_ace(*args, **kwargs) || try_find_textarea(*args, **kwargs)
     raise unless result
 
     result
@@ -100,14 +100,14 @@ module Capybara::CustomFinders
   # Tries to find a textarea converted to an Ace editor.
   #
   # We find the hidden node first, then we find the corresponding editor node.
-  def try_find_ace(*args)
+  def try_find_ace(*args, **kwargs)
     options = args.extract_options!.dup
     return nil if options[:visible] == false
 
     options[:visible] = false
     args.push(options)
 
-    textarea = find(*args)
+    textarea = find(*args, **kwargs)
     textarea.find(:xpath, 'following-sibling::*').find(:css, '.ace_text-input', visible: false)
   rescue Capybara::ElementNotFound
     nil
@@ -116,14 +116,14 @@ module Capybara::CustomFinders
   # Tries to find a textarea used by Summernote.
   #
   # We find the hidden node first, then we find the corresponding editor node.
-  def try_find_textarea(*args)
+  def try_find_textarea(*args, **kwargs)
     options = args.extract_options!.dup
     return nil if options[:visible] == false
 
     options[:visible] = false
     args.push(options)
 
-    textarea = find(*args)
+    textarea = find(*args, **kwargs)
     textarea.find(:xpath, 'following-sibling::*').find(:css, '.note-editable')
   rescue Capybara::ElementNotFound
     nil


### PR DESCRIPTION
**References:**
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
https://rubyreferences.github.io/rubychanges/2.7.html

**Main breaking change (Warning in 2.7 and error in 3.0):** 
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

**Forked and updated gems:**
activerecord-userstamp: https://github.com/ekowidianto/activerecord-userstamp/commit/1170233e314466630e3a545ae3fdee16a0bb4a19
active_record-acts_as: https://github.com/ekowidianto/active_record-acts_as/commit/9e01feb01438ba6736f2d4a8140d9be18464afdc

**Note:**
deprecation warnings are turned off by default on 2.7.2 and later. Use RUBYOPT='-W:deprecated' to enable warnings when **testing locally.**