### PR TITLE
fix(course duplication): fix logo not duplicated due to carrierwave upgrade

### DIFF
--- a/app/models/concerns/course/duplication_concern.rb
+++ b/app/models/concerns/course/duplication_concern.rb
@@ -8,7 +8,6 @@ module Course::DuplicationConcern
     self.title = duplicator.options[:new_title]
     self.creator = duplicator.options[:current_user]
     self.registration_key = nil
-    logo.duplicate_from(other.logo) if other.logo_url
     material_folders << duplicator.duplicate(other.root_folder)
   end
 

--- a/app/services/course/duplication/course_duplication_service.rb
+++ b/app/services/course/duplication/course_duplication_service.rb
@@ -56,6 +56,12 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
       raise ActiveRecord::Rollback unless update_course_settings(duplicator, new_course, source_course)
       raise ActiveRecord::Rollback unless update_sidebar_settings(duplicator, new_course, source_course)
 
+      # As per carrierwave v2.1.0, carrierwave image mounter that retains uploaded file as a cache
+      # is reset upon reload (in our case it is new_course.reload).
+      # As a result, logo duplication needs to be done after course reload.
+      # https://github.com/carrierwaveuploader/carrierwave/issues/2482#issuecomment-762966926
+      new_course.logo.duplicate_from(source_course.logo) if source_course.logo_url
+
       new_course
     end
     notify_duplication_complete(duplicated_course)


### PR DESCRIPTION
Fixes #4167 and #3677 

As per carrierwave v2.1.0, carrierwave image mounter that retains uploaded file as a cache is reset upon reload (in our case it is new_course.reload) which then causes course logo to be unduplicated
https://github.com/carrierwaveuploader/carrierwave/issues/2482#issuecomment-762966926