### PR TITLE
Upgrade to Ruby 3.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.4-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           BUNDLE_APP_CONFIG: ~/repo/.bundle
 
@@ -29,9 +29,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3.2-dependencies-{{ checksum "Gemfile.lock" }}
+            - 3.3-dependencies-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v3.2-dependencies-
+            - 3.3-dependencies-
 
       - run:
           name: install dependencies
@@ -42,7 +42,7 @@ jobs:
           paths:
             - ./vendor/bundle
             - ./.bundle
-          key: v3.2-dependencies-{{ checksum "Gemfile.lock" }}
+          key: 3.3-dependencies-{{ checksum "Gemfile.lock" }}
 
       - restore_cache:
           keys:
@@ -65,7 +65,7 @@ jobs:
   test:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.4-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
@@ -95,9 +95,9 @@ jobs:
 
       - restore_cache:
           keys:
-            - v3.2-dependencies-{{ checksum "Gemfile.lock" }}
+            - 3.3-dependencies-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v3.2-dependencies-
+            - 3.3-dependencies-
 
       - restore_cache:
           keys:
@@ -163,7 +163,7 @@ jobs:
   lint:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.4-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           RAILS_ENV: test
 
@@ -188,7 +188,7 @@ jobs:
   jstest:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.4-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           RAILS_ENV: test
 
@@ -214,7 +214,7 @@ jobs:
   i18n:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:2.7.4-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
@@ -239,9 +239,9 @@ jobs:
 
       - restore_cache:
           keys:
-            - v3.2-dependencies-{{ checksum "Gemfile.lock" }}
+            - 3.3-dependencies-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v3.2-dependencies-
+            - 3.3-dependencies-
 
       # Install bundler version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       # Install bundler version
       - run:
           name: install bundler version
-          command: gem install bundler:1.17.3
+          command: gem install bundler:2.2.22
 
       # Download and cache dependencies
       - restore_cache:
@@ -125,7 +125,7 @@ jobs:
       - run:
           name: install bundler version
           command: |
-            gem install bundler:1.17.3
+            gem install bundler:2.2.22
             bundle install
 
       # Install ghostscript so `identify` in ImageMagick works with PDF files.
@@ -274,7 +274,7 @@ jobs:
       # Install bundler version
       - run:
           name: install bundler version
-          command: gem install bundler:1.17.3
+          command: gem install bundler:2.2.22
 
       # Database setup
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,20 @@ jobs:
           keys:
             - v1.1-yarn-{{ checksum "client/yarn.lock" }}
 
+      - run:
+          name: Swap node versions
+          command: |
+            set +e
+            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+            nvm install v14.16.1
+            nvm alias default 14.16.1
+
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+
       # Build frontend JS
       - run: cd client && yarn install && yarn build:production && cd -
 
@@ -203,6 +217,20 @@ jobs:
       - restore_cache:
           keys:
             - v1-yarn-{{ checksum "client/yarn.lock" }}
+
+      - run:
+          name: Swap node versions
+          command: |
+            set +e
+            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+            nvm install v14.16.1
+            nvm alias default 14.16.1
+
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
 
       # Build frontend JS
       - run:

--- a/.hound.yml
+++ b/.hound.yml
@@ -2,7 +2,7 @@ fail_on_violations: true
 
 rubocop:
   config_file: .rubocop.yml
-  version: 1.5.2
+  version: 1.22.1
 
 jshint:
   config_file: .jshintrc

--- a/.hound.yml
+++ b/.hound.yml
@@ -2,7 +2,7 @@ fail_on_violations: true
 
 rubocop:
   config_file: .rubocop.yml
-  version: 0.91.0
+  version: 1.5.2
 
 jshint:
   config_file: .jshintrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,9 @@ Layout/FirstHashElementIndentation:
 Layout/LineLength:
   Max: 120
 
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 20
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'db/migrate/*'
     - 'vendor/bundle/**/*'
     - 'client/**/*'
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Bundler/OrderedGems:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'font-awesome-rails'
 gem 'html-pipeline'
 gem 'sanitize', '>= 4.6.3'
 gem 'rinku'
-gem 'html-pipeline-rouge_filter'
+gem 'html-pipeline-rouge_filter', git: 'https://github.com/ekowidianto/html-pipeline-rouge_filter.git'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder'
 # Slim as the templating language
@@ -76,6 +76,7 @@ gem 'kaminari'
 gem 'docker-api'
 
 gem 'recaptcha'
+gem 'rexml'
 
 group :development do
   # Spring speeds up development by keeping your application running in the background.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -765,4 +765,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.3
+   2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,15 @@ GIT
       rails (>= 6)
 
 GIT
+  remote: https://github.com/ekowidianto/html-pipeline-rouge_filter.git
+  revision: 4d43afb07930cbf78a8c6a6f9debd5c426ad490c
+  specs:
+    html-pipeline-rouge_filter (1.0.7)
+      activesupport
+      html-pipeline (>= 1.11)
+      rouge (>= 2.0.0, < 4)
+
+GIT
   remote: https://github.com/makqien/rwordnet
   revision: 54a85eed974002cb2cfb858cbcaed8e1069b5cb8
   specs:
@@ -270,10 +279,6 @@ GEM
     html-pipeline (2.14.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html-pipeline-rouge_filter (1.0.7)
-      activesupport
-      html-pipeline (>= 1.11)
-      rouge (>= 2.0.0, < 4)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
     i18n (1.8.11)
@@ -485,7 +490,7 @@ GEM
     rexml (3.2.5)
     rinku (2.0.6)
     rollbar (3.1.1)
-    rouge (3.26.0)
+    rouge (3.26.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -688,7 +693,7 @@ DEPENDENCIES
   friendly_id
   high_voltage
   html-pipeline
-  html-pipeline-rouge_filter
+  html-pipeline-rouge_filter!
   http_accept_language
   i18n-js (>= 3.0.0.rc1)
   i18n-tasks
@@ -719,6 +724,7 @@ DEPENDENCIES
   recaptcha
   record_tag_helper
   redis-rails
+  rexml
   rinku
   rollbar (>= 1.5.3)
   rspec-html-matchers

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Coursemology is an open source gamified learning platform that enables educators
 
 ### System Requirements
 
-1. Ruby (>= 2.7)
+1. Ruby (>= 3.0)
 1. Ruby on Rails
 1. PostgreSQL (>= 9.5)
 1. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick) - if PDF processing doesn't work for the import of scribing questions, download Ghostscript)

--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -87,7 +87,7 @@ module Course::LessonPlan::PersonalizationConcern
         if personal_time.start_at > Time.zone.now
           personal_time.start_at =
             round_to_date(
-              personal_point + (reference_time.start_at - reference_point) * learning_rate_ema,
+              personal_point + ((reference_time.start_at - reference_point) * learning_rate_ema),
               course_tz,
               FOMO_DATE_ROUNDING_THRESHOLD
             )
@@ -148,7 +148,7 @@ module Course::LessonPlan::PersonalizationConcern
         end
         if reference_time.end_at.present? && personal_time.end_at > Time.zone.now
           personal_time.end_at = round_to_date(
-            personal_point + (reference_time.end_at - reference_point) * learning_rate_ema,
+            personal_point + ((reference_time.end_at - reference_point) * learning_rate_ema),
             course_tz,
             STRAGGLERS_DATE_ROUNDING_THRESHOLD
           )
@@ -210,10 +210,10 @@ module Course::LessonPlan::PersonalizationConcern
     reference_remaining_time = items.last.start_at - last_submitted_item.reference_time_for(course_user).start_at
     min_personal_remaining_time =
       course_start +
-      min_overall_learning_rate * (course_end - course_start) - last_submitted_item.time_for(course_user).start_at
+      (min_overall_learning_rate * (course_end - course_start)) - last_submitted_item.time_for(course_user).start_at
     max_personal_remaining_time =
       course_start +
-      max_overall_learning_rate * (course_end - course_start) - last_submitted_item.time_for(course_user).start_at
+      (max_overall_learning_rate * (course_end - course_start)) - last_submitted_item.time_for(course_user).start_at
 
     [min_personal_remaining_time / reference_remaining_time, max_personal_remaining_time / reference_remaining_time]
   end
@@ -233,7 +233,7 @@ module Course::LessonPlan::PersonalizationConcern
 
       learning_rate = (submitted_lesson_plan_item_ids[assessment.id] - times.start_at) / (times.end_at - times.start_at)
       learning_rate = [learning_rate, 0].max
-      learning_rate_ema = alpha * learning_rate + (1 - alpha) * learning_rate_ema
+      learning_rate_ema = (alpha * learning_rate) + ((1 - alpha) * learning_rate_ema)
     end
     learning_rate_ema
   end

--- a/app/controllers/course/achievement/achievements_controller.rb
+++ b/app/controllers/course/achievement/achievements_controller.rb
@@ -2,14 +2,14 @@
 class Course::Achievement::AchievementsController < Course::Achievement::Controller
   before_action :authorize_achievement!, only: [:update]
 
-  def index #:nodoc:
+  def index # :nodoc:
     @achievements = @achievements.includes(:conditions)
   end
 
-  def show #:nodoc:
+  def show # :nodoc:
   end
 
-  def create #:nodoc:
+  def create # :nodoc:
     if @achievement.save
       render json: { id: @achievement.id }, status: :ok
     else
@@ -17,10 +17,10 @@ class Course::Achievement::AchievementsController < Course::Achievement::Control
     end
   end
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @achievement.update(achievement_params)
       respond_to do |format|
         format.html do
@@ -37,7 +37,7 @@ class Course::Achievement::AchievementsController < Course::Achievement::Control
     end
   end
 
-  def destroy #:nodoc:
+  def destroy # :nodoc:
     if @achievement.destroy
       redirect_to course_achievements_path(current_course),
                   success: t('.success', title: @achievement.title)
@@ -61,7 +61,7 @@ class Course::Achievement::AchievementsController < Course::Achievement::Control
 
   private
 
-  def achievement_params #:nodoc:
+  def achievement_params # :nodoc:
     @achievement_params ||= begin
       result = params.require(:achievement).
                permit(:title, :description, :weight, :published, :badge, course_user_ids: [])

--- a/app/controllers/course/admin/admin_controller.rb
+++ b/app/controllers/course/admin/admin_controller.rb
@@ -3,7 +3,7 @@ class Course::Admin::AdminController < Course::Admin::Controller
   def index
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if current_course.update(course_setting_params)
       redirect_to course_admin_path(current_course),
                   success: t('.success', title: current_course.title)
@@ -12,7 +12,7 @@ class Course::Admin::AdminController < Course::Admin::Controller
     end
   end
 
-  def destroy #:nodoc:
+  def destroy # :nodoc:
     if current_course.destroy
       destroy_success
     else
@@ -22,19 +22,19 @@ class Course::Admin::AdminController < Course::Admin::Controller
 
   private
 
-  def course_setting_params #:nodoc:
+  def course_setting_params # :nodoc:
     params.require(:course).
       permit(:title, :description, :published, :enrollable, :start_at, :end_at, :logo, :gamified,
              :show_personalized_timeline_features, :time_zone, :advance_start_at_duration_days)
   end
 
-  def destroy_success #:nodoc:
+  def destroy_success # :nodoc:
     redirect_to courses_path,
                 success: t('course.admin.admin.destroy.success',
                            title: current_course.title)
   end
 
-  def destroy_failure #:nodoc:
+  def destroy_failure # :nodoc:
     redirect_to course_admin_path(current_course),
                 danger: t('course.admin.admin.destroy.failure',
                           error: current_course.errors.full_messages.to_sentence)

--- a/app/controllers/course/admin/announcement_settings_controller.rb
+++ b/app/controllers/course/admin/announcement_settings_controller.rb
@@ -2,10 +2,10 @@
 class Course::Admin::AnnouncementSettingsController < Course::Admin::Controller
   add_breadcrumb :edit, :course_admin_announcements_path
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @settings.update(announcement_settings_params) && current_course.save
       redirect_to course_admin_announcements_path(current_course), success: t('.success')
     else
@@ -15,7 +15,7 @@ class Course::Admin::AnnouncementSettingsController < Course::Admin::Controller
 
   private
 
-  def announcement_settings_params #:nodoc:
+  def announcement_settings_params # :nodoc:
     params.require(:settings_announcements_component).permit(:title, :pagination)
   end
 

--- a/app/controllers/course/admin/component_settings_controller.rb
+++ b/app/controllers/course/admin/component_settings_controller.rb
@@ -3,10 +3,10 @@ class Course::Admin::ComponentSettingsController < Course::Admin::Controller
   before_action :load_settings
   add_breadcrumb :edit, :course_admin_components_path
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @settings.update(settings_components_params) && current_course.save!
       redirect_to course_admin_components_path(current_course), success: t('.success')
     else

--- a/app/controllers/course/admin/forum_settings_controller.rb
+++ b/app/controllers/course/admin/forum_settings_controller.rb
@@ -15,7 +15,7 @@ class Course::Admin::ForumSettingsController < Course::Admin::Controller
 
   private
 
-  def forum_settings_params #:nodoc:
+  def forum_settings_params # :nodoc:
     params.require(:settings_forums_component).permit(:title, :pagination)
   end
 

--- a/app/controllers/course/admin/leaderboard_settings_controller.rb
+++ b/app/controllers/course/admin/leaderboard_settings_controller.rb
@@ -2,10 +2,10 @@
 class Course::Admin::LeaderboardSettingsController < Course::Admin::Controller
   add_breadcrumb :edit, :course_admin_leaderboard_path
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @settings.update(leaderboard_settings_params) && current_course.save
       redirect_to course_admin_leaderboard_path(current_course), success: t('.success')
     else
@@ -15,7 +15,7 @@ class Course::Admin::LeaderboardSettingsController < Course::Admin::Controller
 
   private
 
-  def leaderboard_settings_params #:nodoc:
+  def leaderboard_settings_params # :nodoc:
     params.require(:settings_leaderboard_component).
       permit(:title, :display_user_count, :enable_group_leaderboard, :group_leaderboard_title)
   end

--- a/app/controllers/course/admin/material_settings_controller.rb
+++ b/app/controllers/course/admin/material_settings_controller.rb
@@ -15,7 +15,7 @@ class Course::Admin::MaterialSettingsController < Course::Admin::Controller
 
   private
 
-  def material_settings_params #:nodoc:
+  def material_settings_params # :nodoc:
     params.require(:settings_materials_component).permit(:title)
   end
 

--- a/app/controllers/course/admin/sidebar_settings_controller.rb
+++ b/app/controllers/course/admin/sidebar_settings_controller.rb
@@ -3,10 +3,10 @@ class Course::Admin::SidebarSettingsController < Course::Admin::Controller
   before_action :load_settings
   add_breadcrumb :index, :course_admin_sidebar_path
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @settings.update(settings_sidebar_params) && current_course.save
       redirect_to course_admin_sidebar_path(current_course), success: t('.success')
     else
@@ -16,7 +16,7 @@ class Course::Admin::SidebarSettingsController < Course::Admin::Controller
 
   private
 
-  def settings_sidebar_params #:nodoc:
+  def settings_sidebar_params # :nodoc:
     params.require(:settings_sidebar)
   end
 

--- a/app/controllers/course/admin/video_settings_controller.rb
+++ b/app/controllers/course/admin/video_settings_controller.rb
@@ -17,7 +17,7 @@ class Course::Admin::VideoSettingsController < Course::Admin::Controller
 
   private
 
-  def video_settings_params #:nodoc:
+  def video_settings_params # :nodoc:
     params.require(:settings_videos_component).permit(:title)
   end
 

--- a/app/controllers/course/admin/virtual_classroom_settings_controller.rb
+++ b/app/controllers/course/admin/virtual_classroom_settings_controller.rb
@@ -2,9 +2,9 @@
 class Course::Admin::VirtualClassroomSettingsController < Course::Admin::Controller
   add_breadcrumb :edit, :course_admin_virtual_classrooms_path
 
-  def edit; end #:nodoc:
+  def edit; end # :nodoc:
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @settings.update(virtual_classroom_settings_params) && current_course.save
       redirect_to course_admin_virtual_classrooms_path(current_course), success: t('.success')
     else
@@ -14,7 +14,7 @@ class Course::Admin::VirtualClassroomSettingsController < Course::Admin::Control
 
   private
 
-  def virtual_classroom_settings_params #:nodoc:
+  def virtual_classroom_settings_params # :nodoc:
     params.require(:settings_virtual_classrooms_component).permit(
       :title, :pagination, :braincert_whiteboard_api_key, :max_duration, :braincert_server_region,
       :braincert_whiteboard_timezone

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -4,18 +4,18 @@ class Course::AnnouncementsController < Course::ComponentController
   before_action :add_announcement_breadcrumb
   after_action :mark_announcements_as_read, only: :index
 
-  def index #:nodoc:
+  def index # :nodoc:
     @announcements = @announcements.includes(:creator).sorted_by_sticky.sorted_by_date
     @announcements = @announcements.page(page_param).with_read_marks_for(current_user)
   end
 
-  def show #:nodoc:
+  def show # :nodoc:
   end
 
-  def new #:nodoc:
+  def new # :nodoc:
   end
 
-  def create #:nodoc:
+  def create # :nodoc:
     if @announcement.save
       redirect_to course_announcements_path(current_course),
                   success: t('.success', title: @announcement.title)
@@ -24,10 +24,10 @@ class Course::AnnouncementsController < Course::ComponentController
     end
   end
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @announcement.update(announcement_params)
       redirect_to course_announcements_path(current_course),
                   success: t('.success', title: @announcement.title)
@@ -36,7 +36,7 @@ class Course::AnnouncementsController < Course::ComponentController
     end
   end
 
-  def destroy #:nodoc:
+  def destroy # :nodoc:
     if @announcement.destroy
       redirect_to course_announcements_path(current_course),
                   success: t('.success', title: @announcement.title)
@@ -48,7 +48,7 @@ class Course::AnnouncementsController < Course::ComponentController
 
   private
 
-  def announcement_params #:nodoc:
+  def announcement_params # :nodoc:
     params.require(:announcement).permit(:title, :content, :sticky, :start_at, :end_at)
   end
 

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -4,7 +4,7 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   before_action :add_submissions_breadcrumb
   before_action :load_group_managers, only: [:pending]
 
-  def index #:nodoc:
+  def index # :nodoc:
     @submissions = @submissions.from_category(category).confirmed
     @submissions = @submissions.filter_by_params(filter_params) unless filter_params.blank?
   end

--- a/app/controllers/course/conditions_controller.rb
+++ b/app/controllers/course/conditions_controller.rb
@@ -8,7 +8,7 @@ class Course::ConditionsController < Course::ComponentController
   # @return [Symbol] Similar to above.
   def return_to_path
     raise NotImplementedError, 'To be implemented by the condition controllers of a specific'\
-      'conditional.'
+                               'conditional.'
   end
 
   # Set the instance variable `@conditional` that possesses the condition. The conditional id should
@@ -20,7 +20,7 @@ class Course::ConditionsController < Course::ComponentController
   #     @conditional = Course::Achievement.find(params[:achievement_id])
   def set_conditional
     raise NotImplementedError, 'To be implemented by the condition controllers of a specific'\
-      'conditional.'
+                               'conditional.'
   end
 
   def authorize_conditional

--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -15,13 +15,11 @@ class Course::Discussion::TopicsController < Course::ComponentController
 
   # Loads topics pending staff reply for course_staff, and unread topics for students.
   def pending
-    @topics = begin
-      if current_course_user&.student?
-        unread_topics_for_student
-      else
-        all_topics.pending_staff_reply
-      end
-    end
+    @topics = if current_course_user&.student?
+                unread_topics_for_student
+              else
+                all_topics.pending_staff_reply
+              end
   end
 
   def my_students

--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -39,12 +39,12 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
     params.require(:experience_points_record).permit(:points_awarded, :reason)
   end
 
-  def destroy_success #:nodoc:
+  def destroy_success # :nodoc:
     redirect_to course_user_experience_points_records_path(current_course, @course_user),
                 success: t('course.experience_points_records.destroy.success')
   end
 
-  def destroy_failure #:nodoc:
+  def destroy_failure # :nodoc:
     redirect_to course_user_experience_points_records_path(current_course, @course_user),
                 danger: @experience_points_record.errors.full_messages.to_sentence
   end

--- a/app/controllers/course/groups_controller.rb
+++ b/app/controllers/course/groups_controller.rb
@@ -3,19 +3,19 @@ class Course::GroupsController < Course::ComponentController
   load_and_authorize_resource :group, through: :course, class: Course::Group.name
   add_breadcrumb :index, :course_groups_path
 
-  def index #:nodoc:
+  def index # :nodoc:
     @groups = @groups.ordered_by_name.includes(group_users: { course_user: :course })
   end
 
-  def show #:nodoc:
+  def show # :nodoc:
     @group_users = @group.group_users.includes(:course_user)
     @group_managers, @group_users = @group_users.partition(&:manager?)
   end
 
-  def new #:nodoc:
+  def new # :nodoc:
   end
 
-  def create #:nodoc:
+  def create # :nodoc:
     if @group.save
       redirect_to edit_course_group_path(current_course, @group),
                   success: t('.success', name: @group.name)

--- a/app/controllers/course/leaderboards_controller.rb
+++ b/app/controllers/course/leaderboards_controller.rb
@@ -4,11 +4,11 @@ class Course::LeaderboardsController < Course::ComponentController
   before_action :check_component_settings
   before_action :preload_course_levels, only: [:show]
 
-  def show #:nodoc:
+  def show # :nodoc:
     @course_users = @course.course_users.students.without_phantom_users.includes(:user)
   end
 
-  def groups #:nodoc:
+  def groups # :nodoc:
     @groups = @course.groups
   end
 

--- a/app/controllers/course/lesson_plan/events_controller.rb
+++ b/app/controllers/course/lesson_plan/events_controller.rb
@@ -7,7 +7,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
   load_and_authorize_resource :event, class: Course::LessonPlan::Event.name, through: :course,
                                       through_association: :lesson_plan_events, except: [:new, :create]
 
-  def create #:nodoc:
+  def create # :nodoc:
     if @event.save
       render partial: 'event_lesson_plan_item', locals: { item: @event }
     else
@@ -15,7 +15,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
     end
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @event.update(event_params)
       render partial: 'event_lesson_plan_item', locals: { item: @event }
     else
@@ -23,7 +23,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
     end
   end
 
-  def destroy #:nodoc:
+  def destroy # :nodoc:
     if @event.destroy
       head :ok
     else
@@ -33,7 +33,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
 
   private
 
-  def event_params #:nodoc:
+  def event_params # :nodoc:
     params.require(:lesson_plan_event).
       permit(:event_type, :title, :description, :location, :start_at, :end_at, :published)
   end

--- a/app/controllers/course/lesson_plan/milestones_controller.rb
+++ b/app/controllers/course/lesson_plan/milestones_controller.rb
@@ -9,7 +9,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
                               through: :course, through_association: :lesson_plan_milestones,
                               class: Course::LessonPlan::Milestone.name, except: [:new, :create]
 
-  def create #:nodoc:
+  def create # :nodoc:
     if @milestone.save
       render partial: 'milestone', locals: { milestone: @milestone }
     else
@@ -17,7 +17,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
     end
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @milestone.update(milestone_params)
       render partial: 'milestone', locals: { milestone: @milestone }
     else
@@ -25,7 +25,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
     end
   end
 
-  def destroy #:nodoc:
+  def destroy # :nodoc:
     if @milestone.destroy
       head :ok
     else
@@ -35,7 +35,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
 
   private
 
-  def milestone_params #:nodoc:
+  def milestone_params # :nodoc:
     params.require(:lesson_plan_milestone).
       permit(:title, :description, :start_at)
   end

--- a/app/controllers/course/levels_controller.rb
+++ b/app/controllers/course/levels_controller.rb
@@ -3,10 +3,10 @@ class Course::LevelsController < Course::ComponentController
   load_and_authorize_resource :level, through: :course, class: Course::Level.name
   add_breadcrumb :index, :course_levels_path
 
-  def index #:nodoc:
+  def index # :nodoc:
   end
 
-  def create #:nodoc:
+  def create # :nodoc:
     respond_to do |format|
       if current_course.mass_update_levels(params[:levels])
         format.json { render json: current_course.levels, status: :created }

--- a/app/controllers/course/video/submission/sessions_controller.rb
+++ b/app/controllers/course/video/submission/sessions_controller.rb
@@ -28,9 +28,7 @@ class Course::Video::Submission::SessionsController < Course::Video::Submission:
     @video.statistic.update(cached: false) if @video.statistic&.cached
 
     head :no_content
-  rescue ArgumentError => _e
-    head :bad_request
-  rescue ActiveRecord::RecordInvalid => _e
+  rescue ArgumentError, ActiveRecord::RecordInvalid => _e
     head :bad_request
   end
 

--- a/app/controllers/course/video/submission/submissions_controller.rb
+++ b/app/controllers/course/video/submission/submissions_controller.rb
@@ -34,7 +34,7 @@ class Course::Video::Submission::SubmissionsController < Course::Video::Submissi
 
     @topics = @video.topics.includes(posts: :children).order(:timestamp)
     @topics = @topics.reject { |topic| topic.posts.empty? }
-    @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
+    @posts = @topics.map(&:posts).reduce(Course::Discussion::Post.none, :+)
     set_seek_and_scroll
     set_monitoring
   rescue CanCan::AccessDenied

--- a/app/controllers/course/video/topics_controller.rb
+++ b/app/controllers/course/video/topics_controller.rb
@@ -8,7 +8,7 @@ class Course::Video::TopicsController < Course::Video::Controller
   def index
     @topics = @video.topics.includes(posts: :children).order(:timestamp)
     @topics = @topics.reject { |topic| topic.posts.empty? }
-    @posts = @topics.map(&:posts).inject(Course::Discussion::Post.none, :+)
+    @posts = @topics.map(&:posts).reduce(Course::Discussion::Post.none, :+)
   end
 
   def create

--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -3,7 +3,7 @@ class Course::Video::VideosController < Course::Video::Controller
   skip_load_and_authorize_resource :video, only: [:new, :create]
   build_and_authorize_new_lesson_plan_item :video, class: Course::Video, through: :course, only: [:new, :create]
 
-  def index #:nodoc:
+  def index # :nodoc:
     @videos = @videos.
               from_tab(current_tab).
               with_student_submission_count.

--- a/app/controllers/course/virtual_classrooms_controller.rb
+++ b/app/controllers/course/virtual_classrooms_controller.rb
@@ -5,7 +5,7 @@ class Course::VirtualClassroomsController < Course::ComponentController
                               class: Course::VirtualClassroom.name
   before_action :add_virtual_classroom_breadcrumb
 
-  def access_link #:nodoc:
+  def access_link # :nodoc:
     @braincert_api_service = Course::VirtualClassroom::BraincertApiService.new(
       @virtual_classroom, @settings
     )
@@ -16,7 +16,7 @@ class Course::VirtualClassroomsController < Course::ComponentController
     end
   end
 
-  def recorded_videos #:nodoc:
+  def recorded_videos # :nodoc:
     authorize! :manage, @virtual_classroom
     @braincert_api_service = Course::VirtualClassroom::BraincertApiService.new(
       @virtual_classroom, @settings
@@ -28,7 +28,7 @@ class Course::VirtualClassroomsController < Course::ComponentController
     end
   end
 
-  def recorded_video_link #:nodoc:
+  def recorded_video_link # :nodoc:
     authorize! :access_recorded_videos, current_course
     @braincert_api_service = Course::VirtualClassroom::BraincertApiService.new(
       nil, @settings
@@ -40,15 +40,15 @@ class Course::VirtualClassroomsController < Course::ComponentController
     end
   end
 
-  def index #:nodoc:
+  def index # :nodoc:
     @virtual_classrooms = @virtual_classrooms.includes(:creator).sorted_by_date.page(page_param)
   end
 
-  def show; end #:nodoc:
+  def show; end # :nodoc:
 
-  def new; end #:nodoc:
+  def new; end # :nodoc:
 
-  def create #:nodoc:
+  def create # :nodoc:
     if @virtual_classroom.save
       redirect_to course_virtual_classrooms_path(current_course),
                   success: t('.success', title: @virtual_classroom.title)
@@ -57,9 +57,9 @@ class Course::VirtualClassroomsController < Course::ComponentController
     end
   end
 
-  def edit; end #:nodoc:
+  def edit; end # :nodoc:
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @virtual_classroom.update(virtual_classroom_params)
       redirect_to course_virtual_classrooms_path(current_course),
                   success: t('.success', title: @virtual_classroom.title)
@@ -68,7 +68,7 @@ class Course::VirtualClassroomsController < Course::ComponentController
     end
   end
 
-  def destroy #:nodoc:
+  def destroy # :nodoc:
     if @virtual_classroom.destroy
       redirect_to course_virtual_classrooms_path(current_course),
                   success: t('.success', title: @virtual_classroom.title)
@@ -99,7 +99,7 @@ class Course::VirtualClassroomsController < Course::ComponentController
     end
   end
 
-  def virtual_classroom_params #:nodoc:
+  def virtual_classroom_params # :nodoc:
     params.require(:virtual_classroom).permit(:title, :content, :start_at, :duration)
   end
 

--- a/app/controllers/system/admin/instance/components_controller.rb
+++ b/app/controllers/system/admin/instance/components_controller.rb
@@ -3,10 +3,10 @@ class System::Admin::Instance::ComponentsController < System::Admin::Instance::C
   before_action :load_settings
   add_breadcrumb :edit, :admin_instance_components_path
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @settings.update(settings_components_params) && current_tenant.save!
       redirect_to admin_instance_components_path, success: t('.success')
     else

--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -3,15 +3,15 @@ class System::Admin::InstancesController < System::Admin::Controller
   load_and_authorize_resource :instance, class: ::Instance.name
   add_breadcrumb :index, :admin_instances_path
 
-  def index #:nodoc:
+  def index # :nodoc:
     @instances = Instance.order_for_display.page(page_param).
                  calculated(:active_course_count, :course_count, :active_user_count, :user_count)
   end
 
-  def new #:nodoc:
+  def new # :nodoc:
   end
 
-  def create #:nodoc:
+  def create # :nodoc:
     if @instance.save
       redirect_to admin_instances_path, success: t('.success')
     else
@@ -19,10 +19,10 @@ class System::Admin::InstancesController < System::Admin::Controller
     end
   end
 
-  def edit #:nodoc:
+  def edit # :nodoc:
   end
 
-  def update #:nodoc:
+  def update # :nodoc:
     if @instance.update(instance_params)
       redirect_to admin_instances_path, success: t('.success')
     else
@@ -30,7 +30,7 @@ class System::Admin::InstancesController < System::Admin::Controller
     end
   end
 
-  def destroy #:nodoc:
+  def destroy # :nodoc:
     if @instance.destroy
       redirect_to admin_instances_path, success: t('.success', instance: @instance.name)
     else
@@ -41,7 +41,7 @@ class System::Admin::InstancesController < System::Admin::Controller
 
   private
 
-  def instance_params #:nodoc:
+  def instance_params # :nodoc:
     params.require(:instance).permit(:name, :host)
   end
 end

--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -38,9 +38,7 @@ module Course::Assessment::AssessmentsHelper
   end
 
   def show_end_at?
-    @show_end_at ||= begin
-      @assessments.any? { |assessment| assessment.end_at.present? }
-    end
+    @show_end_at ||= @assessments.any? { |assessment| assessment.end_at.present? }
   end
 
   def display_graded_test_types(assessment)

--- a/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
+++ b/app/helpers/course/assessment/submission/submissions_autograded_helper.rb
@@ -19,9 +19,7 @@ module Course::Assessment::Submission::SubmissionsAutogradedHelper
 
   # The step that current user is on.
   def current_step
-    @current_step ||= begin
-      @current_question ? @submission.questions.index(@current_question) + 1 : nil
-    end
+    @current_step ||= @current_question ? @submission.questions.index(@current_question) + 1 : nil
   end
 
   # Highlight current step and grey out un-accessible steps.

--- a/app/helpers/course/leaderboards_helper.rb
+++ b/app/helpers/course/leaderboards_helper.rb
@@ -17,6 +17,6 @@ module Course::LeaderboardsHelper
   def leaderboard_position(course, course_user, display_user_count)
     index = course.course_users.students.without_phantom_users.includes(:user).
             ordered_by_experience_points.take(display_user_count).find_index(course_user)
-    index && index + 1
+    index && (index + 1)
   end
 end

--- a/app/jobs/course/assessment/submission/force_submitting_job.rb
+++ b/app/jobs/course/assessment/submission/force_submitting_job.rb
@@ -75,7 +75,7 @@ class Course::Assessment::Submission::ForceSubmittingJob < ApplicationJob
         submission.draft_points_awarded = 0
       else
         submission.points_awarded = 0
-        submission.publish!(_ = nil, send_email: false)
+        submission.publish!(_ = nil, false)
       end
       submission.save!
     end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -41,7 +41,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
   # Handles the publishing of a submission.
   #
   # This grades all the answers as well.
-  def publish(_ = nil, send_email: true)
+  def publish(_ = nil, send_email = true) # rubocop:disable Style/OptionalBooleanParameter
     publish_answers
 
     self.publisher = User.stamper || User.system

--- a/app/models/concerns/course/video/watch_statistics_concern.rb
+++ b/app/models/concerns/course/video/watch_statistics_concern.rb
@@ -114,8 +114,8 @@ module Course::Video::WatchStatisticsConcern
     if (EVENT_TYPES[:start].include? event.event_type) && event.video_time == video_duration
       0
     elsif (EVENT_TYPES[:end].include? event.event_type) && event.video_time < last_start.video_time
-      [(last_start.video_time + last_start.playback_rate *
-        (event.event_time - last_start.event_time)).to_i, video_duration].min
+      [(last_start.video_time + (last_start.playback_rate *
+        (event.event_time - last_start.event_time))).to_i, video_duration].min
     else
       event.video_time
     end

--- a/app/models/concerns/course_user/staff_concern.rb
+++ b/app/models/concerns/course_user/staff_concern.rb
@@ -77,7 +77,7 @@ module CourseUser::StaffConcern
 
   def sample_variance(array)
     m = mean(array)
-    sum = array.reduce(0) { |acc, elem| acc + (elem - m)**2 }
+    sum = array.reduce(0) { |acc, elem| acc + ((elem - m)**2) }
     sum / array.length.to_f
   end
 end

--- a/app/models/course/assessment/answer/programming_file.rb
+++ b/app/models/course/assessment/answer/programming_file.rb
@@ -16,7 +16,7 @@ class Course::Assessment::Answer::ProgrammingFile < ApplicationRecord
                          dependent: :destroy, foreign_key: :file_id, inverse_of: :file
 
   # Separate the lines by `\r` `\n` or `\r\n`
-  LINE_SEPARATOR = /\r\n|\r|\n/.freeze
+  LINE_SEPARATOR = /\r\n|\r|\n/
   MAX_LINES = ApplicationHTMLFormattersHelper::MAX_CODE_LINES
   MAX_SIZE = ApplicationHTMLFormattersHelper::MAX_CODE_SIZE
 

--- a/app/models/course/forum/topic.rb
+++ b/app/models/course/forum/topic.rb
@@ -102,10 +102,10 @@ class Course::Forum::Topic < ApplicationRecord
   # Update the `resolve` boolean status based on correct answer counts.
   def update_resolve_status
     status = posts.where(answer: true).count > 0
-    if resolved != status
-      update_attribute(:resolved, status)
-    else
+    if resolved == status
       true
+    else
+      update_attribute(:resolved, status)
     end
   end
 

--- a/app/models/course/group.rb
+++ b/app/models/course/group.rb
@@ -39,7 +39,7 @@ class Course::Group < ApplicationRecord
       left_outer_joins(course_user: :experience_points_records).
       where(CourseUser.arel_table[:role].eq(CourseUser.roles[:student])).
       select(Arel.sql('coalesce(sum(course_experience_points_records.points_awarded), 0.0)::float /'\
-            ' GREATEST(count(distinct(course_group_users.course_user_id)), 1.0)'))
+                      ' GREATEST(count(distinct(course_group_users.course_user_id)), 1.0)'))
   end)
 
   # @!attribute [r] average_achievement_count
@@ -50,7 +50,7 @@ class Course::Group < ApplicationRecord
       left_outer_joins(course_user: :course_user_achievements).
       where(CourseUser.arel_table[:role].eq(CourseUser.roles[:student])).
       select(Arel.sql('count(course_user_achievements.id)::float /'\
-            ' GREATEST(count(distinct(course_group_users.course_user_id)), 1.0)'))
+                      ' GREATEST(count(distinct(course_group_users.course_user_id)), 1.0)'))
   end)
 
   # @!attribute [r] last_obtained_achievement

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -137,7 +137,7 @@ class Instance < ApplicationRecord
 
   private
 
-  def should_validate_host? #:nodoc:
+  def should_validate_host? # :nodoc:
     new_record? || changed_attributes.keys.include?('host')
   end
 end

--- a/app/notifiers/notifier/base.rb
+++ b/app/notifiers/notifier/base.rb
@@ -10,7 +10,7 @@ class Notifier::Base
     # notifiers
     #
     # @api private
-    def method_missing(symbol, *args, **kwargs, &block) # rubocop:disable Style/MissingRespondToMissing, Lint/MissingSuper
+    def method_missing(symbol, *args, **kwargs, &block) # rubocop:disable Style/MissingRespondToMissing
       new.public_send(symbol, *args, **kwargs, &block)
     end
   end

--- a/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/email_invitation_concern.rb
@@ -2,6 +2,7 @@
 
 # This concern deals with the sending of user invitation emails.
 class Course::UserInvitationService; end
+
 module Course::UserInvitationService::EmailInvitationConcern
   extend ActiveSupport::Autoload
 

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -4,6 +4,7 @@ require 'csv'
 # This concern includes methods required to parse the invitations data.
 # This can either be from a form, or a CSV file.
 class Course::UserInvitationService; end
+
 module Course::UserInvitationService::ParseInvitationConcern
   extend ActiveSupport::Autoload
 

--- a/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
@@ -2,6 +2,7 @@
 
 # This concern deals with the creation of user invitations.
 class Course::UserInvitationService; end
+
 module Course::UserInvitationService::ProcessInvitationConcern
   extend ActiveSupport::Autoload
 

--- a/app/services/concerns/instance/user_invitation_service/email_invitation_concern.rb
+++ b/app/services/concerns/instance/user_invitation_service/email_invitation_concern.rb
@@ -2,6 +2,7 @@
 
 # This concern deals with the sending of user invitation emails.
 class Instance::UserInvitationService; end
+
 module Instance::UserInvitationService::EmailInvitationConcern
   extend ActiveSupport::Autoload
 

--- a/app/services/concerns/instance/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/instance/user_invitation_service/parse_invitation_concern.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # This concern includes methods required to parse the invitations data from a form.
 class Instance::UserInvitationService; end
+
 module Instance::UserInvitationService::ParseInvitationConcern
   extend ActiveSupport::Autoload
 

--- a/app/services/concerns/instance/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/instance/user_invitation_service/process_invitation_concern.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # This concern deals with the creation of user invitations.
 class Instance::UserInvitationService; end
+
 module Instance::UserInvitationService::ProcessInvitationConcern
   extend ActiveSupport::Autoload
 

--- a/app/services/course/assessment/answer/programming_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_auto_grading_service.rb
@@ -156,7 +156,7 @@ class Course::Assessment::Answer::ProgrammingAutoGradingService < \
   # @return [Array<Course::Assessment::Question::ProgrammingTestCase>]
   def build_failed_test_case_records(question, auto_grading)
     messages = {
-      'error': I18n.t('course.assessment.answer.programming_auto_grading.grade.evaluation_failed')
+      error: I18n.t('course.assessment.answer.programming_auto_grading.grade.evaluation_failed')
     }
     remaining_test_cases = question.test_cases - auto_grading.test_results.map(&:test_case)
     remaining_test_cases.map do |test_case|

--- a/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
@@ -29,8 +29,8 @@ class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < 
     keyword_status = find_compre_keyword_in_answer(answer_text_lemma_array, lifted_word_status, hash_keyword_solutions)
 
     answer_text_lemma_status = {
-      'compre_lifted_word': lifted_word_status,
-      'compre_keyword': keyword_status
+      compre_lifted_word: lifted_word_status,
+      compre_keyword: keyword_status
     }
 
     answer_grade, correct_points = grade_for(question, answer_text_lemma_status)
@@ -258,7 +258,7 @@ class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < 
   # @param [Integer] number The positive index number.
   # @return [String] The index in letter format.
   def convert_number_to_letter(number)
-    hash_number_to_letter = Hash[(0..25).zip('a'..'z')]
+    hash_number_to_letter = (0..25).zip('a'..'z').to_h
     output = ''
     while number > 0
       remainder = number % 26

--- a/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/text_response_comprehension_auto_grading_service.rb
@@ -18,7 +18,7 @@ class Course::Assessment::Answer::TextResponseComprehensionAutoGradingService < 
   #   assigned to the grading.
   def evaluate_answer(answer)
     question = answer.question.actable
-    answer_text_array = answer.normalized_answer_text.downcase.gsub(/([^a-z ])/, ' ').split(' ')
+    answer_text_array = answer.normalized_answer_text.downcase.gsub(/([^a-z ])/, ' ').split
     answer_text_lemma_array = []
     answer_text_array.each { |a| answer_text_lemma_array.push(WordNet::Synset.morphy_all(a).first || a) }
 

--- a/app/services/course/assessment/question/programming/language_package_service.rb
+++ b/app/services/course/assessment/question/programming/language_package_service.rb
@@ -98,7 +98,7 @@ class Course::Assessment::Question::Programming::LanguagePackageService
   # @param [String]
   # @return [Boolean]
   def string?(text)
-    text.first == '\'' && text.last == '\'' ||
-      text.first == '"' && text.last == '"'
+    (text.first == '\'' && text.last == '\'') ||
+      (text.first == '"' && text.last == '"')
   end
 end

--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -49,8 +49,8 @@ if attempt.submitted? && !attempt.auto_grading
 end
 
 can_read_tests = can?(:read_tests, submission)
-show_private = can_read_tests || submission.published? && assessment.show_private?
-show_evaluation = can_read_tests || submission.published? && assessment.show_evaluation?
+show_private = can_read_tests || (submission.published? && assessment.show_private?)
+show_evaluation = can_read_tests || (submission.published? && assessment.show_evaluation?)
 
 test_cases_by_type = question.test_cases_by_type
 test_cases_and_results = get_test_cases_and_results(test_cases_by_type, auto_grading)

--- a/app/views/course/assessment/answers/_answer.json.jbuilder
+++ b/app/views/course/assessment/answers/_answer.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.id answer.id
 json.questionId answer.question_id
-json.createdAt answer.created_at
+json.createdAt answer.created_at&.iso8601
 
 specific_answer = answer.specific
 can_grade = can?(:grade, answer.submission)

--- a/app/views/course/assessment/assessments/_edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/_edit.json.jbuilder
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 json.attributes do
-  json.(@assessment, :id, :title, :description, :start_at, :end_at, :bonus_end_at, :base_exp,
+  json.(@assessment, :id, :title, :description, :base_exp,
         :time_bonus_exp, :published, :autograded, :show_mcq_mrq_solution, :show_private, :show_evaluation,
         :skippable, :tabbed_view, :view_password, :session_password, :delayed_grade_publication, :tab_id,
         :use_public, :use_private, :use_evaluation, :allow_partial_submission, :has_personal_times,
         :affects_personal_times, :show_mcq_answer, :block_student_viewing_after_submitted)
+  json.start_at @assessment.start_at&.iso8601
+  json.end_at @assessment.end_at&.iso8601
+  json.bonus_end_at @assessment.bonus_end_at&.iso8601
   # Pass as boolean since there is only one enum value
   json.randomization @assessment.randomization.present?
 end

--- a/app/views/course/assessment/question/programming/_package_ui.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_package_ui.json.jbuilder
@@ -6,8 +6,8 @@ json.package_ui do
   end
 
   json.test_cases do
-    json.public @programming_question.test_cases.select(&:public_test?)
-    json.private @programming_question.test_cases.select(&:private_test?)
-    json.evaluation @programming_question.test_cases.select(&:evaluation_test?)
+    json.public @programming_question.test_cases.select(&:public_test?).as_json
+    json.private @programming_question.test_cases.select(&:private_test?).as_json
+    json.evaluation @programming_question.test_cases.select(&:evaluation_test?).as_json
   end
 end

--- a/app/views/course/assessment/submission/answer/forum_post_response/posts/_post_packs.json.jbuilder
+++ b/app/views/course/assessment/submission/answer/forum_post_response/posts/_post_packs.json.jbuilder
@@ -26,7 +26,7 @@ json.selected_post_packs selected_posts do |selected_post|
       json.userName 'Deleted User'
       json.avatar image_path('user_silhouette.svg')
     end
-    json.updatedAt selected_post.post_updated_at
+    json.updatedAt selected_post.post_updated_at&.iso8601
     json.isUpdated selected_post.is_post_updated
     json.isDeleted selected_post.is_post_deleted
   end
@@ -47,7 +47,7 @@ json.selected_post_packs selected_posts do |selected_post|
         json.userName 'Deleted User'
         json.avatar image_path('user_silhouette.svg')
       end
-      json.updatedAt selected_post.parent_updated_at
+      json.updatedAt selected_post.parent_updated_at&.iso8601
       json.isUpdated selected_post.is_parent_updated
       json.isDeleted selected_post.is_parent_deleted
     end

--- a/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
@@ -24,14 +24,14 @@ json.submission do
   submitter_course_user = submission.creator.course_users.find_by(course: submission.assessment.course)
   end_at = assessment.time_for(submitter_course_user).end_at
   bonus_end_at = assessment.time_for(submitter_course_user).bonus_end_at
-  json.bonusEndAt bonus_end_at
-  json.dueAt end_at
-  json.attemptedAt submission.created_at
-  json.submittedAt submission.submitted_at
+  json.bonusEndAt bonus_end_at&.iso8601
+  json.dueAt end_at&.iso8601
+  json.attemptedAt submission.created_at&.iso8601
+  json.submittedAt submission.submitted_at&.iso8601
   if ['graded', 'published'].include? apparent_workflow_state
     # Display the published time first, else show the graded time if available.
     # For showing timestamps from delayed grade publication.
-    json.gradedAt submission.published_at || submission.graded_at
+    json.gradedAt submission.published_at&.iso8601 || submission.graded_at&.iso8601
     json.grader display_user(submission.publisher) if apparent_workflow_state == 'published'
     json.grade submission.grade.to_f
   end
@@ -41,7 +41,7 @@ json.submission do
   json.showStdoutAndStderr current_course.show_stdout_and_stderr
 
   json.late end_at && submission.submitted_at &&
-            submission.submitted_at > end_at
+            submission.submitted_at.iso8601 > end_at
 
   json.basePoints assessment.base_exp
   json.bonusPoints assessment.time_bonus_exp

--- a/app/views/course/assessment/submission/submissions/index.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/index.json.jbuilder
@@ -34,8 +34,8 @@ json.submissions @course_users do |course_user|
     json.workflowState submission.workflow_state
     json.grade submission.grade.to_f
     json.pointsAwarded submission.current_points_awarded
-    json.dateSubmitted submission.submitted_at
-    json.dateGraded submission.graded_at
+    json.dateSubmitted submission.submitted_at&.iso8601
+    json.dateGraded submission.graded_at&.iso8601
     json.logCount submission.log_count
   else
     json.workflowState 'unstarted'

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -6,7 +6,7 @@ json.creator do
   json.name post.author_name
   json.avatar creator.profile_photo.medium.url || image_url('user_silhouette.svg')
 end
-json.createdAt post.created_at
+json.createdAt post.created_at&.iso8601
 json.topicId post.topic_id
 json.canUpdate can?(:update, post)
 json.canDestroy can?(:destroy, post)

--- a/app/views/course/forum/forums/all_posts.json.jbuilder
+++ b/app/views/course/forum/forums/all_posts.json.jbuilder
@@ -26,7 +26,7 @@ json.forumTopicPostPacks @forum_topic_posts do |forum, topic_posts|
         else
           json.avatar image_path(post.creator.profile_photo.medium.url)
         end
-        json.updatedAt post.updated_at
+        json.updatedAt post.updated_at&.iso8601
       end
       if post.parent_id
         json.parentPost do
@@ -39,7 +39,7 @@ json.forumTopicPostPacks @forum_topic_posts do |forum, topic_posts|
           else
             json.avatar image_path(post.parent.creator.profile_photo.medium.url)
           end
-          json.updatedAt post.parent.updated_at
+          json.updatedAt post.parent.updated_at&.iso8601
         end
       end
 

--- a/app/views/course/lesson_plan/items/_item.json.jbuilder
+++ b/app/views/course/lesson_plan/items/_item.json.jbuilder
@@ -2,4 +2,8 @@
 # These are the common fields to be displayed for all lesson plan items
 json.id item.acting_as.id
 json.(item, :title, :published)
-json.(item.time_for(current_course_user), :start_at, :bonus_end_at, :end_at)
+
+time_for_current_user = item.time_for(current_course_user)
+json.start_at time_for_current_user.start_at&.iso8601
+json.bonus_end_at time_for_current_user.bonus_end_at&.iso8601
+json.end_at time_for_current_user.end_at&.iso8601

--- a/app/views/course/lesson_plan/milestones/_milestone.json.jbuilder
+++ b/app/views/course/lesson_plan/milestones/_milestone.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 json.(milestone, :id, :title, :description)
-json.(milestone.time_for(current_course_user), :start_at)
+json.start_at milestone.time_for(current_course_user).start_at&.iso8601

--- a/app/views/course/material/_material.json.jbuilder
+++ b/app/views/course/material/_material.json.jbuilder
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
-json.(material, :id, :updated_at)
+json.id material.id
+json.updated_at material.updated_at&.iso8601
 json.name format_inline_text(material.name)
 json.url url_for([current_course, folder, material])

--- a/app/views/course/object_duplications/_course_duplication_data.json.jbuilder
+++ b/app/views/course/object_duplications/_course_duplication_data.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 json.sourceCourse do
-  json.(current_course, :id, :title, :start_at)
+  json.(current_course, :id, :title)
+  json.start_at current_course.start_at&.iso8601
   json.duplicationModesAllowed([].tap do |modes|
     modes << 'COURSE' if current_course.course_duplicable?
     modes << 'OBJECT' if current_course.objects_duplicable?

--- a/app/views/course/survey/responses/_response.json.jbuilder
+++ b/app/views/course/survey/responses/_response.json.jbuilder
@@ -4,7 +4,9 @@ json.survey do
 end
 
 json.response do
-  json.(response, :id, :submitted_at, :updated_at)
+  json.id response.id
+  json.submitted_at response.submitted_at&.iso8601
+  json.updated_at response.updated_at&.iso8601
   json.creator_name response.creator.name
 
   json.answers answers do |answer|

--- a/app/views/course/survey/responses/index.json.jbuilder
+++ b/app/views/course/survey/responses/index.json.jbuilder
@@ -12,7 +12,9 @@ json.responses @course_students do |student|
 
   json.present !!response
   if response
-    json.(response, :id, :submitted_at, :updated_at)
+    json.id response.id
+    json.submitted_at response.submitted_at&.iso8601
+    json.updated_at response.updated_at&.iso8601
     json.canUnsubmit can?(:unsubmit, response)
     json.path course_survey_response_path(current_course, @survey, response) if can_read_answers
   end

--- a/app/views/course/survey/surveys/_survey.json.jbuilder
+++ b/app/views/course/survey/surveys/_survey.json.jbuilder
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 json.(survey, :id, :title, :base_exp, :time_bonus_exp, :published,
-      :start_at, :end_at, :closing_reminded_at,
       :anonymous, :allow_response_after_end, :allow_modify_after_submit)
+json.start_at survey.start_at&.iso8601
+json.end_at survey.end_at&.iso8601
+json.closing_reminded_at survey.closing_reminded_at&.iso8601
 json.description format_html(survey.description)
 
 can_update = can?(:update, survey)
@@ -15,7 +17,8 @@ json.hasStudentResponse survey.has_student_response? if can_update
 current_user_response = survey.responses.find_by(creator: current_user)
 if current_user_response
   json.response do
-    json.(current_user_response, :id, :submitted_at)
+    json.id current_user_response.id
+    json.submitted_at current_user_response.submitted_at&.iso8601
     json.canModify can?(:modify, current_user_response)
     json.canSubmit can?(:submit, current_user_response)
   end

--- a/app/views/course/video/sessions/_session.json.jbuilder
+++ b/app/views/course/video/sessions/_session.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-json.sessionStart session.session_start
-json.sessionEnd session.session_end
+json.sessionStart session.session_start&.iso8601
+json.sessionEnd session.session_end&.iso8601
 json.lastVideoTime session.last_video_time
 
 json.events do

--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -31,7 +31,7 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
     super
   end
 
-  def enqueue(job) #:nodoc:
+  def enqueue(job) # :nodoc:
     ActiveSupport::Notifications.instrument(ENQUEUE_EVENT, job: job, caller: caller) do |payload|
       with_thread_pool { @pending_jobs << job.serialize }
       ensure_threads
@@ -40,7 +40,7 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
     end
   end
 
-  def enqueue_at(job, timestamp) #:nodoc:
+  def enqueue_at(job, timestamp) # :nodoc:
     @future_jobs << { job: job, at: timestamp }
   end
 
@@ -213,8 +213,8 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
 
     def pool_statistics(event)
       "pool size: #{event.payload[:pool_size]}, "\
-      "running jobs: #{event.payload[:running_jobs]}, "\
-      "pending jobs: #{event.payload[:pending_jobs]}"
+        "running jobs: #{event.payload[:running_jobs]}, "\
+        "pending jobs: #{event.payload[:pending_jobs]}"
     end
   end
 

--- a/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
@@ -202,12 +202,12 @@ class Course::Assessment::Java::JavaProgrammingTestCaseReport <
       # prune empty and nil values
       # error_contents and failure_contents are only being stored and not displayed on the interface
       @messages ||= {
-        'error': nil,
-        'error_contents': nil,
-        'hint': hint,
-        'failure': failure_message,
-        'failure_contents': failure_contents,
-        'output': output
+        error: nil,
+        error_contents: nil,
+        hint: hint,
+        failure: failure_message,
+        failure_contents: failure_contents,
+        output: output
       }.reject! { |_, v| v.blank? }
     end
 
@@ -232,9 +232,11 @@ class Course::Assessment::Java::JavaProgrammingTestCaseReport <
   # Parses a test case report.
   #
   # @param [String] report The report XML to parse.
+  # rubocop: disable Lint/MissingSuper
   def initialize(report)
     @report = Nokogiri::XML::Document.parse(report)
   end
+  # rubocop: enable Lint/MissingSuper
 
   # Gets the set of test suites found in this report.
   #

--- a/lib/autoload/course/assessment/programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/programming_test_case_report.rb
@@ -215,12 +215,12 @@ class Course::Assessment::ProgrammingTestCaseReport
       # prune empty and nil values
       # error_contents and failure_contents are only being stored and not displayed on the interface
       @messages ||= {
-        'error': error_message,
-        'error_contents': error_contents,
-        'hint': hint,
-        'failure': failure_message,
-        'failure_contents': failure_contents,
-        'output': output
+        error: error_message,
+        error_contents: error_contents,
+        hint: hint,
+        failure: failure_message,
+        failure_contents: failure_contents,
+        output: output
       }.reject! { |_, v| v.blank? }
     end
 

--- a/lib/autoload/coursemology_docker_container.rb
+++ b/lib/autoload/coursemology_docker_container.rb
@@ -15,10 +15,10 @@ class CoursemologyDockerContainer < Docker::Container
   PRIVATE_REPORT_PATH = File.join(PACKAGE_PATH, 'report-private.xml')
   EVALUATION_REPORT_PATH = File.join(PACKAGE_PATH, 'report-evaluation.xml')
 
-  REPORT_PATHS = { 'report': REPORT_PATH,
-                   'public': PUBLIC_REPORT_PATH,
-                   'private': PRIVATE_REPORT_PATH,
-                   'evaluation': EVALUATION_REPORT_PATH }.freeze
+  REPORT_PATHS = { report: REPORT_PATH,
+                   public: PUBLIC_REPORT_PATH,
+                   private: PRIVATE_REPORT_PATH,
+                   evaluation: EVALUATION_REPORT_PATH }.freeze
 
   # Maximum amount of memory the docker container can use.
   # Enforced by Docker.
@@ -41,9 +41,9 @@ class CoursemologyDockerContainer < Docker::Container
         options = { 'Image' => image }
         options['Cmd'] = argv if argv.present?
         options['HostConfig'] = {
-          'memory': CONTAINER_MEMORY_LIMIT,
+          memory: CONTAINER_MEMORY_LIMIT,
           'memory-swap': CONTAINER_MEMORY_LIMIT,
-          'LogConfig': LOG_CONFIG
+          LogConfig: LOG_CONFIG
         }
         options['NetworkDisabled'] = true
 

--- a/lib/autoload/duplicator.rb
+++ b/lib/autoload/duplicator.rb
@@ -87,13 +87,13 @@ class Duplicator
     return nil unless source_object
 
     @duplicated_objects.fetch(source_object) do |key|
-      if !@exclusion_set.include?(key)
+      if @exclusion_set.include?(key)
+        @duplicated_objects[source_object] = nil
+      else
         source_object.dup.tap do |duplicate|
           @duplicated_objects[key] = duplicate
           duplicate.initialize_duplicate(self, key)
         end
-      else
-        @duplicated_objects[source_object] = nil
       end
     end
   end

--- a/lib/autoload/notifier/base/activity_wrapper.rb
+++ b/lib/autoload/notifier/base/activity_wrapper.rb
@@ -21,7 +21,7 @@ class Notifier::Base::ActivityWrapper < SimpleDelegator
     super.tap { |_| send_pending_email }
   end
 
-  def initialize(notifier, activity) #:nodoc:
+  def initialize(notifier, activity) # :nodoc:
     super(activity)
     @notifier = notifier
   end

--- a/lib/autoload/preformatted_text_line_numbers_filter.rb
+++ b/lib/autoload/preformatted_text_line_numbers_filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class PreformattedTextLineNumbersFilter < HTML::Pipeline::Filter
   # The regex for splitting input by newlines.
-  NEWLINE_REGEX = /\r\n|\r|\n/.freeze
+  NEWLINE_REGEX = /\r\n|\r|\n/
 
   # Adds a line number before the code block.
   # Takes a :line_start option which specifies the start line number, default is 1.

--- a/lib/autoload/preformatted_text_line_split_filter.rb
+++ b/lib/autoload/preformatted_text_line_split_filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class PreformattedTextLineSplitFilter < HTML::Pipeline::Filter
   # The regex for splitting input by newlines.
-  NEWLINE_REGEX = /\r\n|\r|\n/.freeze
+  NEWLINE_REGEX = /\r\n|\r|\n/
 
   # Adds a line number before the code block.
   # Takes a :line_start option which specifies the start line number, default is 1.

--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 module Extensions
-  EXTENSIONS_PATH = "#{__dir__}/extensions"
+  EXTENSIONS_PATH = "#{__dir__}/extensions".freeze
 
   class << self
     # Loads all extensions defined in this directory.
     #
     # @return [void]
     def load_all
-      Dir["#{EXTENSIONS_PATH}/*.rb"].sort.each do |ext|
+      Dir["#{EXTENSIONS_PATH}/*.rb"].each do |ext|
         require ext
         load(const_get(module_name(File.basename(ext, '.*'))))
       end
@@ -81,7 +81,7 @@ module Extensions
       class_to_extend = expected_module_name.constantize
       if expected_module_name != class_to_extend.name
         warn "Class does not match: expected #{module_name(path)}, got #{class_to_extend}. Maybe "\
-          "#{module_name(path)} has not been defined?"
+             "#{module_name(path)} has not been defined?"
       end
 
       module_to_include = "#{module_.name}::#{class_to_extend}".constantize

--- a/lib/extensions/attachable/active_record/base.rb
+++ b/lib/extensions/attachable/active_record/base.rb
@@ -222,7 +222,7 @@ module Extensions::Attachable::ActiveRecord::Base
     end
 
     # Regex for filtering Attachment IDs from URLs.
-    ATTACHMENT_ID_REGEX = /\/attachments\/([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})$/.freeze
+    ATTACHMENT_ID_REGEX = /\/attachments\/([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})$/
 
     # Parse attachment_reference uuid from the given url.
     #

--- a/lib/extensions/deferred_workflow_state_persistence/workflow.rb
+++ b/lib/extensions/deferred_workflow_state_persistence/workflow.rb
@@ -2,7 +2,9 @@
 require 'workflow-activerecord'
 
 module Extensions::DeferredWorkflowStatePersistence::Workflow; end
+
 module Extensions::DeferredWorkflowStatePersistence::Workflow::Adapter; end
+
 module Extensions::DeferredWorkflowStatePersistence::Workflow::Adapter::DeferredActiveRecord
   extend ActiveSupport::Concern
   included do

--- a/spec/components/course/controller_component_host_spec.rb
+++ b/spec/components/course/controller_component_host_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
     describe 'Components' do
       subject do
         component_host.components.find do |component|
-          component.class == self.class::DummyCourseModule
+          component.instance_of?(self.class::DummyCourseModule)
         end
       end
 
@@ -95,7 +95,7 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
         context 'when the settings interface class is not defined' do
           subject do
             component_host.components.find do |component|
-              component.class == self.class::DummyGamifiedCourseModule
+              component.instance_of?(self.class::DummyGamifiedCourseModule)
             end
           end
 
@@ -115,7 +115,7 @@ RSpec.describe Course::ControllerComponentHost, type: :controller do
         context 'when the settings interface class is not defined' do
           subject do
             component_host.components.find do |component|
-              component.class == self.class::DummyGamifiedCourseModule
+              component.instance_of?(self.class::DummyGamifiedCourseModule)
             end
           end
 

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
           expect(response.status).to eq(200)
         end
 
-        context 'when other users are subscribed to notifications' do
+        context 'when other users are subscribed to notifications', type: :mailer do
           let(:annotation) do
             create(:course_assessment_answer_programming_file_annotation, file: file, line: 1)
           end

--- a/spec/controllers/course/assessment/submission/answer/programming/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/programming_controller_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::ProgrammingC
     let!(:course) { create(:course, creator: user) }
     let(:assessment) { create(:assessment, :published, :with_programming_file_submission_question, course: course) }
     let(:submission) { create(:submission, :attempting, assessment: assessment, creator: user) }
-    let(:submission_2) { create(:submission, :attempting, assessment: assessment, creator: user) }
+    let(:submission2) { create(:submission, :attempting, assessment: assessment, creator: user) }
     let(:answer) { submission.answers.first }
-    let(:answer_2) { submission_2.answers.first }
+    let(:answer2) { submission2.answers.first }
     before { sign_in(user) }
 
     describe '#create_programming_files' do
@@ -44,16 +44,16 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::ProgrammingC
     describe '#delete_programming_file' do
       subject do
         post :destroy_programming_file, as: :json, params: {
-          course_id: course, assessment_id: assessment.id, submission_id: submission_2.id,
-          answer_id: answer_2.id, answer: {
-            id: answer_2.id,
-            file_id: answer_2.specific.files.first.id
+          course_id: course, assessment_id: assessment.id, submission_id: submission2.id,
+          answer_id: answer2.id, answer: {
+            id: answer2.id,
+            file_id: answer2.specific.files.first.id
           }
         }
       end
 
       context 'when deleting existing programming files' do
-        it { expect { subject }.to change { answer_2.specific.files.count }.by(-1) }
+        it { expect { subject }.to change { answer2.specific.files.count }.by(-1) }
       end
     end
   end

--- a/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
           expect { subject }.to change(Course::Discussion::Post, :count).by(1)
         end
 
-        context 'when other users are subscribed to notifications' do
+        context 'when other users are subscribed to notifications', type: :mailer do
           let!(:subscriber) do
             user = create(:course_manager, course: course).user
             submission_question.acting_as.subscriptions.create!(user: user)

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Course::UsersController, type: :controller do
           expect(flash[:success]).to eq(I18n.t('course.users.update.success'))
         end
 
-        it 'does not send a notification email to the user' do
+        it 'does not send a notification email to the user', type: :mailer do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
 

--- a/spec/controllers/user/emails_controller_spec.rb
+++ b/spec/controllers/user/emails_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe User::EmailsController, type: :controller do
       end
     end
 
-    describe '#send_confirmation' do
+    describe '#send_confirmation', type: :mailer do
       let!(:email) { create(:user_email, email_traits, user: user, primary: false) }
       subject { post :send_confirmation, params: { id: email } }
 

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe User::OmniauthCallbacksController, type: :controller do
   let!(:instance) { Instance.default }
-  # Note: Facebook login feature is currently disabled.
+  # NOTE: Facebook login feature is currently disabled.
   before { skip }
 
   with_tenant(:instance) do

--- a/spec/factories/course_assessment_answer_programming_auto_grading_test_results.rb
+++ b/spec/factories/course_assessment_answer_programming_auto_grading_test_results.rb
@@ -7,24 +7,24 @@ FactoryBot.define do
 
     trait :failed do
       passed { false }
-      messages { { 'failure': 'simulated failure message' } }
+      messages { { failure: 'simulated failure message' } }
     end
 
     trait :errored do
       passed { false }
-      messages { { 'error': 'simulated error message' } }
+      messages { { error: 'simulated error message' } }
     end
 
     trait :output do
-      messages { { 'output': 'simulated test function output' } }
+      messages { { output: 'simulated test function output' } }
     end
 
     trait :failed_with_output do
       passed { false }
       messages do
         {
-          'failure': 'simulated failure message',
-          'output': 'simulated failed output'
+          failure: 'simulated failure message',
+          output: 'simulated failed output'
         }
       end
     end

--- a/spec/factories/course_assessment_question_programming.rb
+++ b/spec/factories/course_assessment_question_programming.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     imported_attachment do
       if template_package
         file = File.new(File.join(Rails.root, 'spec/fixtures/course/'\
-                          'programming_question_template.zip'), 'rb')
+                                              'programming_question_template.zip'), 'rb')
         AttachmentReference.new(file: file)
       end
     end

--- a/spec/factories/course_assessment_submission_logs.rb
+++ b/spec/factories/course_assessment_submission_logs.rb
@@ -9,10 +9,10 @@ FactoryBot.define do
     submission { build(:submission, assessment: assessment, course: course) }
     request do
       {
-        'HTTP_X_FORWARDED_FOR': '192.168.123.45',
-        'HTTP_USER_AGENT': 'Internet Explorer',
-        'USER_SESSION_ID': SecureRandom.hex(8),
-        'SUBMISSION_SESSION_ID': SecureRandom.hex(8)
+        HTTP_X_FORWARDED_FOR: '192.168.123.45',
+        HTTP_USER_AGENT: 'Internet Explorer',
+        USER_SESSION_ID: SecureRandom.hex(8),
+        SUBMISSION_SESSION_ID: SecureRandom.hex(8)
       }.to_json
     end
   end

--- a/spec/factories/course_assessment_submissions.rb
+++ b/spec/factories/course_assessment_submissions.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
       submitted
       after(:build) do |submission, evaluator|
         submission.answers.each do |answer|
-          answer.grade = Random::DEFAULT.rand(answer.question.maximum_grade)
+          answer.grade = Random.new.rand(answer.question.maximum_grade)
           answer.grader = evaluator.grader
         end
 

--- a/spec/factories/course_virtual_classrooms.rb
+++ b/spec/factories/course_virtual_classrooms.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     trait :ended do
       start_at { 1.week.ago }
-      end_at { (24 * 7 + 1).hours.ago }
+      end_at { ((24 * 7) + 1).hours.ago }
     end
   end
 end

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
     let(:submission) do
       create(:submission, *submission_traits, assessment: assessment, creator: user)
     end
-    let(:submission_2) do
-      create(:submission, *submission_traits_2, assessment: assessment_2, creator: user)
+    let(:submission2) do
+      create(:submission, *submission_traits2, assessment: assessment_2, creator: user)
     end
     let(:submission_traits) { nil }
-    let(:submission_traits_2) { nil }
+    let(:submission_traits2) { nil }
 
     before { login_as(user, scope: :user) }
 
@@ -96,7 +96,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
     context 'As Course Staff' do
       let(:user) { create(:course_teaching_assistant, course: course).user }
       let(:submission_traits) { :submitted }
-      let(:submission_traits_2) { :attempting }
+      let(:submission_traits2) { :attempting }
 
       pending 'I can view the test cases' do
         # View test cases for submitted submission
@@ -109,9 +109,9 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
         end
 
         # View test cases for attempting submission
-        visit edit_course_assessment_submission_path(course, assessment_2, submission_2)
+        visit edit_course_assessment_submission_path(course, assessment_2, submission2)
 
-        within find(content_tag_selector(submission_2.answers.first)) do
+        within find(content_tag_selector(submission2.answers.first)) do
           assessment_2.questions.first.actable.test_cases.each do |solution|
             expect(page).to have_content_tag_for(solution)
           end

--- a/spec/features/course/assessment/answer/programming_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_answer_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe 'Course: Assessments: Submissions: Programming Answers' do
   with_tenant(:instance) do
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, :published_with_programming_question, course: course) }
-    let(:assessment_2) { create(:assessment, :published_with_programming_question, course: course) }
+    let(:assessment2) { create(:assessment, :published_with_programming_question, course: course) }
     let(:submission) do
       create(:submission, *submission_traits, assessment: assessment, creator: user)
     end
     let(:submission2) do
-      create(:submission, *submission_traits2, assessment: assessment_2, creator: user)
+      create(:submission, *submission_traits2, assessment: assessment2, creator: user)
     end
     let(:submission_traits) { nil }
     let(:submission_traits2) { nil }

--- a/spec/features/course/assessment/answer/programming_file_submission_answer_spec.rb
+++ b/spec/features/course/assessment/answer/programming_file_submission_answer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming File Submission An
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, :published, :with_programming_file_submission_question, course: course) }
     let(:submission) { create(:submission, :attempting, assessment: assessment, creator: user) }
-    let(:submission_2) { create(:submission, :attempting, assessment: assessment, creator: user) }
+    let(:submission2) { create(:submission, :attempting, assessment: assessment, creator: user) }
 
     before { login_as(user, scope: :user) }
 
@@ -17,7 +17,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming File Submission An
       let(:file_path) do
         File.join(Rails.root, 'spec/fixtures/files/template_file')
       end
-      let(:file_path_2) do
+      let(:file_path2) do
         File.join(Rails.root, 'spec/fixtures/files/template_file_2')
       end
 
@@ -46,7 +46,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming File Submission An
 
         # Stage the same file again and attempt to upload
         # (Need to set to another file first before setting again to the first file)
-        file_input.set(file_path_2)
+        file_input.set(file_path2)
         file_input.set(file_path)
         click_button('Upload Files')
 
@@ -57,7 +57,7 @@ RSpec.describe 'Course: Assessments: Submissions: Programming File Submission An
       end
 
       scenario 'I can delete existing programming files', js: true do
-        visit edit_course_assessment_submission_path(course, assessment, submission_2)
+        visit edit_course_assessment_submission_path(course, assessment, submission2)
 
         file_view = find('strong', text: 'Uploaded Files:').find(:xpath, '..')
 

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
       end
 
       pending 'I can view tabbed assessments and tabs for assessments with more than 1 question,'\
-               'and view tabs directly through a URL',
+              'and view tabs directly through a URL',
               js: true do
         assessment_tabbed_single_question
         visit course_assessments_path(course)

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management' do
         options.each_with_index do |option, i|
           click_link I18n.t('course.assessment.question.multiple_responses.form.add_option')
           within all('.edit_question_multiple_response '\
-            'tr.question_multiple_response_option')[i] do
+                     'tr.question_multiple_response_option')[i] do
             # A custom css selector, :last is added here because +fill_in_rails_summernote+ doesn't
             # acknowledge the scope defined by capabara.
             # This works only if +click_link+ is executed before each option.

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management' do
           link = I18n.t('course.assessment.question.text_responses.form.add_solution')
           find('a.add_fields', text: link).click
           within all('.edit_question_text_response '\
-            'tr.question_text_response_solution')[i] do
+                     'tr.question_text_response_solution')[i] do
             # A custom css selector, :last is added here because +fill_in_rails_summernote+ doesn't
             # acknowledge the scope defined by capabara.
             # This works only if +click_link+ is executed before each option.

--- a/spec/features/course/assessment/submission/manually_graded_spec.rb
+++ b/spec/features/course/assessment/submission/manually_graded_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe 'Course: Assessment: Submissions: Manually Graded Assessments', j
         expect(page.all('td', text: '1 / 2').count).to eq(2)
 
         # Check that bonus point is added to suggected exp award
-        exp = submission.assessment.base_exp / submission.assessment.maximum_grade +
+        exp = (submission.assessment.base_exp / submission.assessment.maximum_grade) +
               submission.assessment.time_bonus_exp
         expect(first('input.exp').value.to_i).to eq(exp)
 

--- a/spec/features/course/registration_spec.rb
+++ b/spec/features/course/registration_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Courses: Registration' do
     context 'when the course allows enrol requests' do
       let(:course) { create(:course, :enrollable) }
 
-      scenario 'Users can create and cancel enrol requests' do
+      scenario 'Users can create and cancel enrol requests', type: :mailer do
         visit course_path(course)
 
         expect(page).to have_text(course.description)

--- a/spec/features/course/video/video_viewing_and_attempting_spec.rb
+++ b/spec/features/course/video/video_viewing_and_attempting_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Course: Videos: Viewing' do
           expect(current_path).
             to eq(edit_course_video_submission_path(course, published_video, submission))
 
-          expect(page).to have_tag('div', with: { 'id': 'video-component' })
+          expect(page).to have_tag('div', with: { id: 'video-component' })
         end
 
         # Button is updated when submission exists
@@ -45,7 +45,7 @@ RSpec.describe 'Course: Videos: Viewing' do
           find('.btn.btn-info').click
         end
 
-        expect(page).to have_tag('div', with: { 'id': 'video-component' })
+        expect(page).to have_tag('div', with: { id: 'video-component' })
         data = JSON.parse(page.find('#video-component')['data'])
 
         expect(data['video']['videoUrl']).to eq(published_video.url)

--- a/spec/features/instance_user_role_requests_management_spec.rb
+++ b/spec/features/instance_user_role_requests_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Instance::UserRoleRequests' do
     before { login_as(user, scope: :user) }
 
     context 'As a normal instance user' do
-      scenario 'I can create a new role request' do
+      scenario 'I can create a new role request', type: :mailer do
         visit courses_path
         click_link I18n.t('course.courses.index.new_role_request')
 

--- a/spec/features/system/admin/instance_management_spec.rb
+++ b/spec/features/system/admin/instance_management_spec.rb
@@ -56,8 +56,8 @@ RSpec.feature 'System: Administration: Instances' do
 
         instances.each do |instance|
           # Get the page number each instance is on.
-          page_number = Instance.order_for_display.map(&:id).index(instance.id) /
-                        Instance.page.default_per_page + 1
+          page_number = (Instance.order_for_display.map(&:id).index(instance.id) /
+                        Instance.page.default_per_page) + 1
           visit admin_instances_path(page: page_number)
           expect(page).to have_content_tag_for(instance)
           expect(page).
@@ -67,8 +67,8 @@ RSpec.feature 'System: Administration: Instances' do
 
       scenario 'I can destroy an instance' do
         instance = create(:instance)
-        page_number = Instance.order_for_display.map(&:id).index(instance.id) /
-                      Instance.page.default_per_page + 1
+        page_number = (Instance.order_for_display.map(&:id).index(instance.id) /
+                      Instance.page.default_per_page) + 1
         visit admin_instances_path(page: page_number)
 
         within find(content_tag_selector(instance)) do

--- a/spec/features/system/admin/masquerades_spec.rb
+++ b/spec/features/system/admin/masquerades_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require 'rails_helper'
-include DeviseMasquerade::Controllers::UrlHelpers
 
 RSpec.feature 'System: Administration: Masquerade' do
+  include DeviseMasquerade::Controllers::UrlHelpers
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do

--- a/spec/features/user/omniauth_spec.rb
+++ b/spec/features/user/omniauth_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.feature 'User: Omniauth' do
   let(:instance) { Instance.default }
-  # Note: Facebook login feature is currently disabled.
+  # NOTE: Facebook login feature is currently disabled.
   before { skip }
 
   with_tenant(:instance) do

--- a/spec/features/user/profile_edit_spec.rb
+++ b/spec/features/user/profile_edit_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'User: Profile' do
         expect(user.reload.time_zone).to eq(time_zone)
       end
 
-      # Note: Facebook login feature is currently disabled.
+      # NOTE: Facebook login feature is currently disabled.
       xscenario 'I can link my account to facebook' do
         facebook_link = find_link(nil, href: user_facebook_omniauth_authorize_path)
         expect { facebook_link.click }.to change { user.identities.count }.by(1)

--- a/spec/libraries/course/assessment/programming_test_case_report_spec.rb
+++ b/spec/libraries/course/assessment/programming_test_case_report_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
   context 'when given a report with test case meta information' do
     let(:report_path) do
       File.join(Rails.root, 'spec/fixtures/course/'\
-                'programming_single_test_suite_report_meta.xml')
+                            'programming_single_test_suite_report_meta.xml')
     end
 
     let(:report_xml) { File.read(report_path) }
@@ -219,7 +219,7 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
   context 'when given a report with meta information attached to test case tags' do
     let(:report_path) do
       File.join(Rails.root, 'spec/fixtures/course/'\
-                'programming_single_test_suite_report_test_case_meta.xml')
+                            'programming_single_test_suite_report_test_case_meta.xml')
     end
 
     let(:report_xml) { File.read(report_path) }
@@ -291,7 +291,7 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
   context 'when given a report with various kinds of output data' do
     let(:report_path) do
       File.join(Rails.root, 'spec/fixtures/course/'\
-                'programming_messages_test_report.xml')
+                            'programming_messages_test_report.xml')
     end
 
     let(:report_xml) { File.read(report_path) }
@@ -314,9 +314,9 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
 
         describe '#messages' do
           it 'returns the output and failure message in a hash' do
-            expect(subject.messages).to eq('output': '-1',
-                                           'failure': 'AssertionError: -1 != 6188 : Wrong answer',
-                                           'failure_contents': 'Some failure traceback')
+            expect(subject.messages).to eq(output: '-1',
+                                           failure: 'AssertionError: -1 != 6188 : Wrong answer',
+                                           failure_contents: 'Some failure traceback')
           end
         end
       end
@@ -399,7 +399,7 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
   context 'when given a report with test cases with errors' do
     let(:report_path) do
       File.join(Rails.root, 'spec/fixtures/course/'\
-                'programming_single_test_suite_report.xml')
+                            'programming_single_test_suite_report.xml')
     end
 
     let(:report_xml) { File.read(report_path) }

--- a/spec/libraries/has_one_many_attachments_spec.rb
+++ b/spec/libraries/has_one_many_attachments_spec.rb
@@ -280,6 +280,7 @@ RSpec.describe 'Extension: Acts as Attachable' do
       include ApplicationFormattersHelper
       include Rails.application.routes.url_helpers
     end
+
     class self::SampleFormBuilder < ActionView::Helpers::FormBuilder; end
 
     let(:attachment) { create(:attachment_reference) }

--- a/spec/libraries/manual_eager_load_spec.rb
+++ b/spec/libraries/manual_eager_load_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe 'Extension: Manual Eager Load', type: :model do
     has_many :referenced_items, inverse_of: :source_item
     has_one :singular_item, inverse_of: :source_item
   end
+
   class self::ReferencedItem < ApplicationRecord
     belongs_to :source_item, inverse_of: :referenced_items
   end
+
   class self::SingularItem < ApplicationRecord
     self.table_name = 'referenced_items'
     belongs_to :source_item, inverse_of: :referenced_items

--- a/spec/libraries/materials_spec.rb
+++ b/spec/libraries/materials_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe 'Extension: Materials' do
 
   describe 'form_builder helper' do
     class self::AssessmentView < ActionView::Base; end
+
     class self::FormBuilder < ActionView::Helpers::FormBuilder; end
 
     let(:template) { self.class::AssessmentView.new(ActionView::LookupContext.new(Rails.root.join('app', 'views'))) }

--- a/spec/models/course/announcement_spec.rb
+++ b/spec/models/course/announcement_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Course::Announcement, type: :model do
         it 'is invalid' do
           expect(subject).to be_invalid
           expect(subject.errors[:start_at]).to include(I18n.t('activerecord.errors.models.' \
-            'course/announcement.attributes.start_at.cannot_be_after_end_at'))
+                                                              'course/announcement.attributes.' \
+                                                              'start_at.cannot_be_after_end_at'))
         end
       end
     end

--- a/spec/models/course/assessment/answer_spec.rb
+++ b/spec/models/course/assessment/answer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Course::Assessment::Answer do
           expect(subject.valid?).to be(false)
           expect(subject.errors[:question]).to include(
             I18n.t('activerecord.errors.models.course/assessment/answer.attributes.question'\
-              '.consistent_assessment')
+                   '.consistent_assessment')
           )
         end
       end

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Course::Assessment do
 
     def get_text_response_answer_for(submission)
       submission.answers.latest_answers.select do |ans|
-        ans.specific.class == Course::Assessment::Answer::TextResponse
+        ans.specific.instance_of?(Course::Assessment::Answer::TextResponse)
       end.first.specific
     end
 

--- a/spec/models/course/assessment/question/text_response_comprehension_group_spec.rb
+++ b/spec/models/course/assessment/question/text_response_comprehension_group_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe Course::Assessment::Question::TextResponseComprehensionGroup, typ
 
           expect(subject.valid?).to be(false)
           expect(subject.errors[:maximum_group_grade]).to include(I18n.t('activerecord.errors.models.' \
-              'course/assessment/question/text_response_comprehension_group.attributes.' \
-              'maximum_group_grade.invalid_group_grade'))
+                                                                         'course/assessment/question/' \
+                                                                         'text_response_comprehension_group.' \
+                                                                         'attributes.maximum_group_grade.' \
+                                                                         'invalid_group_grade'))
         end
       end
     end

--- a/spec/models/course/assessment/question/text_response_comprehension_point_spec.rb
+++ b/spec/models/course/assessment/question/text_response_comprehension_point_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe Course::Assessment::Question::TextResponseComprehensionPoint, typ
 
           expect(subject.valid?).to be(false)
           expect(subject.errors[:point_grade]).to include(I18n.t('activerecord.errors.models.' \
-              'course/assessment/question/text_response_comprehension_point.attributes.' \
-              'point_grade.invalid_point_grade'))
+                                                                 'course/assessment/question/' \
+                                                                 'text_response_comprehension_point.attributes.' \
+                                                                 'point_grade.invalid_point_grade'))
         end
       end
 
@@ -47,8 +48,10 @@ RSpec.describe Course::Assessment::Question::TextResponseComprehensionPoint, typ
         it 'validates at most one compre_lifted_word solution' do
           expect(subject.valid?).to be(false)
           expect(subject.errors[:solutions]).to include(I18n.t('activerecord.errors.models.' \
-              'course/assessment/question/text_response_comprehension_point.attributes.' \
-              'solutions.more_than_one_compre_lifted_word_solution'))
+                                                               'course/assessment/question/' \
+                                                               'text_response_comprehension_point.' \
+                                                               'attributes.solutions.' \
+                                                               'more_than_one_compre_lifted_word_solution'))
         end
       end
     end

--- a/spec/models/course/assessment/question/text_response_solution_spec.rb
+++ b/spec/models/course/assessment/question/text_response_solution_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe Course::Assessment::Question::TextResponseSolution, type: :model 
 
           expect(subject.valid?).to be(false)
           expect(subject.errors[:grade]).to include(I18n.t('activerecord.errors.models.' \
-            'course/assessment/question/text_response_solution.attributes.grade.invalid_grade'))
+                                                           'course/assessment/question/text_response_solution.' \
+                                                           'attributes.grade.invalid_grade'))
         end
       end
     end

--- a/spec/models/course/assessment/question/text_response_spec.rb
+++ b/spec/models/course/assessment/question/text_response_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
 
           expect(subject.valid?).to be(false)
           expect(subject.errors[:maximum_grade]).to include(
-            I18n.t('activerecord.errors.models.course/assessment/question/text_response.attributes'\
-              '.maximum_grade.invalid_grade')
+            I18n.t('activerecord.errors.models.course/assessment/question/text_response.attributes.' \
+                   'maximum_grade.invalid_grade')
           )
         end
       end

--- a/spec/models/course/condition/achievement_spec.rb
+++ b/spec/models/course/condition/achievement_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Course::Condition::Achievement, type: :model do
         it 'is not valid' do
           expect(subject).to_not be_valid
           expect(subject.errors[:achievement]).to include(I18n.t('activerecord.errors.models.' \
-            'course/condition/achievement.attributes.achievement.references_self'))
+                                                                 'course/condition/achievement.' \
+                                                                 'attributes.achievement.references_self'))
         end
       end
 
@@ -34,7 +35,8 @@ RSpec.describe Course::Condition::Achievement, type: :model do
         it 'is not valid' do
           expect(subject).to_not be_valid
           expect(subject.errors[:achievement]).to include(I18n.t('activerecord.errors.models.' \
-            'course/condition/achievement.attributes.achievement.unique_dependency'))
+                                                                 'course/condition/achievement.' \
+                                                                 'attributes.achievement.unique_dependency'))
         end
       end
 
@@ -65,7 +67,9 @@ RSpec.describe Course::Condition::Achievement, type: :model do
         it 'is not valid' do
           expect(subject).to_not be_valid
           expect(subject.errors[:achievement]).to include(I18n.t('activerecord.errors.models.' \
-            'course/condition/achievement.attributes.achievement.cyclic_dependency'))
+                                                                 'course/condition/achievement.' \
+                                                                 'attributes.achievement.' \
+                                                                 'cyclic_dependency'))
         end
       end
     end

--- a/spec/models/course/condition/assessment_spec.rb
+++ b/spec/models/course/condition/assessment_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         it 'is not valid' do
           expect(subject).to_not be_valid
           expect(subject.errors[:assessment]).to include(I18n.t('activerecord.errors.models.' \
-            'course/condition/assessment.attributes.assessment.references_self'))
+                                                                'course/condition/assessment.' \
+                                                                'attributes.assessment.references_self'))
         end
       end
 
@@ -39,7 +40,8 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         it 'is not valid' do
           expect(subject).to_not be_valid
           expect(subject.errors[:assessment]).to include(I18n.t('activerecord.errors.models.' \
-            'course/condition/assessment.attributes.assessment.unique_dependency'))
+                                                                'course/condition/assessment'\
+                                                                '.attributes.assessment.unique_dependency'))
         end
       end
 
@@ -70,7 +72,8 @@ RSpec.describe Course::Condition::Assessment, type: :model do
         it 'is not valid' do
           expect(subject).to_not be_valid
           expect(subject.errors[:assessment]).to include(I18n.t('activerecord.errors.models.' \
-            'course/condition/assessment.attributes.assessment.cyclic_dependency'))
+                                                                'course/condition/assessment.'\
+                                                                'attributes.assessment.cyclic_dependency'))
         end
       end
     end

--- a/spec/models/course/condition/survey_spec.rb
+++ b/spec/models/course/condition/survey_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Course::Condition::Survey, type: :model do
         it 'is not valid' do
           expect(subject).to_not be_valid
           expect(subject.errors[:survey]).to include(I18n.t('activerecord.errors.models.' \
-            'course/condition/survey.attributes.survey.unique_dependency'))
+                                                            'course/condition/survey.' \
+                                                            'attributes.survey.unique_dependency'))
         end
       end
     end

--- a/spec/models/course/group_spec.rb
+++ b/spec/models/course/group_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Course::Group, type: :model do
         end
 
         it 'returns the average experience points' do
-          average_count = 1.0 * group.course_users.map(&:experience_points).inject(:+) /
+          average_count = 1.0 * group.course_users.map(&:experience_points).reduce(:+) /
                           group.course_users.students.count
           expect(subject).to eq(average_count)
         end

--- a/spec/models/course/user_achievement_spec.rb
+++ b/spec/models/course/user_achievement_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Course::UserAchievement, type: :model do
         it 'is not valid' do
           expect(subject).not_to be_valid
           expect(subject.errors[:course_user]).
-            to include(I18n.t('activerecord.errors.models.course/user_achievement.'\
-              'attributes.course_user.not_in_course'))
+            to include(I18n.t('activerecord.errors.models.course/user_achievement.' \
+                              'attributes.course_user.not_in_course'))
         end
       end
     end

--- a/spec/models/generic_announcement_spec.rb
+++ b/spec/models/generic_announcement_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe GenericAnnouncement, type: :model do
         it 'is invalid' do
           expect(subject).to be_invalid
           expect(subject.errors[:start_at]).to include(I18n.t('activerecord.errors.models.' \
-            'generic_announcement.attributes.start_at.cannot_be_after_end_at'))
+                                                              'generic_announcement.attributes.' \
+                                                              'start_at.cannot_be_after_end_at'))
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe User do
       end
     end
 
-    # Note: Facebook login feature is currently disabled.
+    # NOTE: Facebook login feature is currently disabled.
     xdescribe '.new_with_session' do
       context 'when facebook data is provided' do
         let(:params) { {} }

--- a/spec/notifiers/notifier/base_spec.rb
+++ b/spec/notifiers/notifier/base_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Notifier::Base, type: :mailer do
             to change { user.notifications.where(notification_type: 'email').count }.by(1)
         end
 
-        it 'sends an email notification' do
+        it 'sends an email notification', type: :mailer do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
         end
       end
@@ -74,7 +74,7 @@ RSpec.describe Notifier::Base, type: :mailer do
             to change { course.notifications.where(notification_type: 'email').count }.by(1)
         end
 
-        it 'sends an email notification' do
+        it 'sends an email notification', type: :mailer do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(2)
         end
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'active_record/acts_as/matchers'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/services/course/assessment/reminder_service_spec.rb
+++ b/spec/services/course/assessment/reminder_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Course::Assessment::ReminderService do
+RSpec.describe Course::Assessment::ReminderService, type: :mailer do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/services/course/skills_mastery_preload_service_spec.rb
+++ b/spec/services/course/skills_mastery_preload_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Course::SkillsMasteryPreloadService, type: :service do
     let!(:course) { create(:course) }
     let!(:course_user) { create(:course_student, course: course) }
     let!(:skill_branch) { create(:course_assessment_skill_branch, course: course) }
-    let!(:skill_1) { create(:course_assessment_skill, skill_branch: skill_branch, course: course) }
-    let!(:skill_2) { create(:course_assessment_skill, skill_branch: skill_branch, course: course) }
+    let!(:skill1) { create(:course_assessment_skill, skill_branch: skill_branch, course: course) }
+    let!(:skill2) { create(:course_assessment_skill, skill_branch: skill_branch, course: course) }
     let!(:assessment) { create(:assessment, :with_all_question_types, course: course) }
     let!(:published_submission) do
       create(:submission, :published, assessment: assessment, course: course, creator: course_user.user)
@@ -16,7 +16,7 @@ RSpec.describe Course::SkillsMasteryPreloadService, type: :service do
 
     before do
       assessment.question_assessments.each do |question_assessment|
-        question_assessment.skills << skill_1
+        question_assessment.skills << skill1
       end
     end
     subject { Course::SkillsMasteryPreloadService.new(course, course_user) }
@@ -29,8 +29,8 @@ RSpec.describe Course::SkillsMasteryPreloadService, type: :service do
 
     describe '#grade' do
       it "returns the sum of student's grades for questions tagged with a skill" do
-        expect(subject.grade(skill_1)).to eq(published_submission.answers.map(&:grade).sum)
-        expect(subject.grade(skill_2)).to eq(0)
+        expect(subject.grade(skill1)).to eq(published_submission.answers.map(&:grade).sum)
+        expect(subject.grade(skill2)).to eq(0)
       end
     end
 

--- a/spec/services/course/skills_mastery_preload_service_spec.rb
+++ b/spec/services/course/skills_mastery_preload_service_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe Course::SkillsMasteryPreloadService, type: :service do
 
     describe '#percentage_mastery' do
       it "returns student's grade as a percentage of total maximum grade for a skill" do
-        expect(subject.percentage_mastery(skill_1)).to \
+        expect(subject.percentage_mastery(skill1)).to \
           eq((100 * published_submission.answers.map(&:grade).sum / \
             assessment.questions.map(&:maximum_grade).sum).to_f.round)
-        expect(subject.percentage_mastery(skill_2)).to eq(0)
+        expect(subject.percentage_mastery(skill2)).to eq(0)
       end
     end
   end

--- a/spec/services/course/survey/reminder_service_spec.rb
+++ b/spec/services/course/survey/reminder_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Course::Survey::ReminderService do
+RSpec.describe Course::Survey::ReminderService, type: :mailer do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
 
         with_active_job_queue_adapter(:test) do
-          it 'sends an email to everyone' do
+          it 'sends an email to everyone', type: :mailer do
             expect { invite }.to change { ActionMailer::Base.deliveries.count }.
               by(user_form_attributes.length)
           end
@@ -109,7 +109,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
 
         with_active_job_queue_adapter(:test) do
-          it 'sends an email to everyone' do
+          it 'sends an email to everyone', type: :mailer do
             expect do
               subject.invite(temp_csv_from_attributes(user_attributes.map do |attributes|
                 OpenStruct.new(attributes)
@@ -133,7 +133,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
 
         with_active_job_queue_adapter(:test) do
-          it 'does not send notification to the existing users' do
+          it 'does not send notification to the existing users', type: :mailer do
             expect { invite }.to change { ActionMailer::Base.deliveries.count }.
               by(user_attributes.size - users_invited.size - users_in_course.size)
           end
@@ -150,7 +150,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
 
         with_active_job_queue_adapter(:test) do
-          it 'sends only one invitation to duplicate users' do
+          it 'sends only one invitation to duplicate users', type: :mailer do
             expect { invite }.to change { ActionMailer::Base.deliveries.count }.
               by(new_user_attributes.size - 1 + existing_user_attributes.size)
           end
@@ -166,7 +166,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
           expect(invite).to be_falsey
         end
 
-        it 'does not send any notifications' do
+        it 'does not send any notifications', type: :mailer do
           expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
 
@@ -186,7 +186,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
       end
 
       with_active_job_queue_adapter(:test) do
-        it 'sends an email to everyone' do
+        it 'sends an email to everyone', type: :mailer do
           expect do
             subject.resend_invitation(pending_invitations)
           end.to change { ActionMailer::Base.deliveries.count }.by(pending_invitations.count)

--- a/spec/services/instance/user_invitation_service_spec.rb
+++ b/spec/services/instance/user_invitation_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Instance::UserInvitationService, type: :service do
         end
 
         with_active_job_queue_adapter(:test) do
-          it 'sends an email to everyone' do
+          it 'sends an email to everyone', type: :mailer do
             expect { invite }.to change { ActionMailer::Base.deliveries.count }.
               by(user_form_attributes.length)
           end
@@ -109,7 +109,7 @@ RSpec.describe Instance::UserInvitationService, type: :service do
         end
 
         with_active_job_queue_adapter(:test) do
-          it 'does not send notification to the existing users' do
+          it 'does not send notification to the existing users', type: :mailer do
             expect { invite }.to change { ActionMailer::Base.deliveries.count }.
               by(user_attributes.size - users_invited.size - users_in_instance.size)
           end
@@ -126,7 +126,7 @@ RSpec.describe Instance::UserInvitationService, type: :service do
         end
 
         with_active_job_queue_adapter(:test) do
-          it 'sends only one invitation to duplicate users' do
+          it 'sends only one invitation to duplicate users', type: :mailer do
             expect { invite }.to change { ActionMailer::Base.deliveries.count }.
               by(new_user_attributes.size - 1 + existing_user_attributes.size)
           end
@@ -142,7 +142,7 @@ RSpec.describe Instance::UserInvitationService, type: :service do
           expect(invite).to be_falsey
         end
 
-        it 'does not send any notifications' do
+        it 'does not send any notifications', type: :mailer do
           expect { invite }.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
 
@@ -162,7 +162,7 @@ RSpec.describe Instance::UserInvitationService, type: :service do
       end
 
       with_active_job_queue_adapter(:test) do
-        it 'sends an email to everyone' do
+        it 'sends an email to everyone', type: :mailer do
           expect do
             subject.resend_invitation(pending_invitations)
           end.to change { ActionMailer::Base.deliveries.count }.by(pending_invitations.count)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,5 +115,5 @@ RSpec.configure do |config|
   end
 end
 
-Capybara.server = :puma, { Silent: true } # rubocop:disable Style/HashAsLastArrayItem
+Capybara.server = :puma, { Silent: true }
 Capybara.default_max_wait_time = 5

--- a/spec/support/have_content_tag_for_matcher.rb
+++ b/spec/support/have_content_tag_for_matcher.rb
@@ -3,6 +3,7 @@ require 'rspec/expectations'
 require 'action_view/record_identifier'
 
 module ContentTag; end
+
 module ContentTag::TestExampleHelpers; end
 
 module ContentTag::TestExampleHelpers::FeatureHelpers


### PR DESCRIPTION
**References:**
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
https://rubyreferences.github.io/rubychanges/3.0.html

**Main breaking change (Warning in 2.7 and error in 3.0):**
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

**Forked and updated gems:**
html-pipeline-rouge_filter: https://github.com/ekowidianto/html-pipeline-rouge_filter/commit/4d43afb07930cbf78a8c6a6f9debd5c426ad490c

**Note:**
https://stackoverflow.com/questions/66871265/to-json-on-activerecord-object-ruby-3-0