### PR TITLE
fix(java autograder): remove extra super call

### DIFF
--- a/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
@@ -12,7 +12,6 @@ class Course::Assessment::Java::JavaProgrammingTestCaseReport <
     # @param [Nokogiri::XML::Element] suite
     def initialize(suite)
       @suite = suite
-      super
     end
 
     # The name of the test suite.


### PR DESCRIPTION
https://github.com/Coursemology/coursemology2/blob/d27442c3fa676a09655f27582bac19219b2dc38f/lib/autoload/course/assessment/java/java_programming_test_case_report.rb#L15
No need for `super` call since `TestSuite` does not inherit from any parent class.