### PR TITLE
Refactor assessment submission answers workflow

### DIFF
--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -145,7 +145,6 @@ module Course::Assessment::Submission::WorkflowEventConcern
     end
   end
 
-  
   # When a submission is unsubmitted, every current_answer is copied as and flagged as attempting.
   # The new copied answer is then marked as current_answer which is the answer that can be modified
   # by users. The old current_answer is unmarked as current_answer and is kept as graded past answer.

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -159,6 +159,12 @@ module Course::Assessment::Submission::WorkflowEventConcern
     end
   end
 
+  # When a submission is finalised, we will compare the current answer and the latest non-current answers.
+  # If they are the same, remove the current answer and mark the latest non-current answer as the current answer
+  # to avoid re-grading.
+  # Otherwise, regenerate the current answer to ensure chronological order of all answers and grade it.
+  # For more details, please refer to the PDF page 2 and below here:
+  # https://github.com/Coursemology/coursemology2/files/7606393/Submission.Past.Answers.Issues.pdf
   def finalise_current_answers
     questions.each do |question|
       all_answers = answers.where(question: question)

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -16,7 +16,8 @@ module Course::Assessment::Submission::WorkflowEventConcern
     self.submitted_at = Time.zone.now
     save!
 
-    current_answers.select(&:attempting?).each(&:finalise!)
+    finalise_current_answers
+    answers.reload
 
     assign_zero_experience_points if assessment.questions.empty?
 
@@ -63,7 +64,9 @@ module Course::Assessment::Submission::WorkflowEventConcern
     # Skip the state validation in answers.
     @unsubmitting = true
 
-    unsubmit_current_answers
+    recreate_current_answers
+    answers.reload
+
     self.points_awarded = nil
     self.draft_points_awarded = nil
     self.awarded_at = nil
@@ -139,6 +142,58 @@ module Course::Assessment::Submission::WorkflowEventConcern
     answers_to_unsubmit = only_programming ? current_programming_answers : current_answers
     answers_to_unsubmit.each do |answer|
       answer.unsubmit! unless answer.attempting?
+    end
+  end
+
+  
+  # When a submission is unsubmitted, every current_answer is copied as and flagged as attempting.
+  # The new copied answer is then marked as current_answer which is the answer that can be modified
+  # by users. The old current_answer is unmarked as current_answer and is kept as graded past answer.
+  def recreate_current_answers
+    current_answers.reject(&:attempting?).each do |current_answer|
+      new_answer = current_answer.question.attempt(current_answer.submission, current_answer)
+
+      current_answer.current_answer = false
+      new_answer.current_answer = true
+      current_answer.save!
+      new_answer.save!
+    end
+  end
+
+  def finalise_current_answers
+    questions.each do |question|
+      all_answers = answers.where(question: question)
+      current_answer = all_answers.current_answers.select(&:attempting?).first
+      next if current_answer.nil?
+
+      # For the case when there is no past answer (only 1 attempt per question),
+      # current answer is finalized.
+      if all_answers.non_current_answers.reject(&:attempting?).empty?
+        current_answer.finalise!
+        current_answer.save!
+        # It is mentioned that there could be a race condition creating multiple current_answers
+        # for a given question in load_or_create_answers. Since we always take the first current_answer,
+        # destroy the rest upon submission finalisation.
+        all_answers.current_answers.select(&:attempting?).each(&:destroy)
+      else
+        last_non_current_answer = all_answers.reject(&:current_answer?).reject(&:attempting?).last
+
+        if current_answer.specific.compare_answer(last_non_current_answer.specific)
+          # If the latest non-current answer and the current answer are the same, keep the latest non-current answer
+          # and remove current answer
+          all_answers.current_answers.select(&:attempting?).each(&:destroy)
+          last_non_current_answer.update!(current_answer: true)
+        else
+          # Otherwise, we duplicate the current answer to a new one, and finalise it.
+          # We then remove the previous current answer and mark the copied answer as the current answer.
+          new_answer = question.attempt(current_answer.submission, current_answer)
+          new_answer.finalise!
+          new_answer.save!
+
+          all_answers.current_answers.select(&:attempting?).each(&:destroy)
+          new_answer.update!(current_answer: true)
+        end
+      end
     end
   end
 

--- a/app/models/course/assessment/answer/forum_post_response.rb
+++ b/app/models/course/assessment/answer/forum_post_response.rb
@@ -36,6 +36,8 @@ class Course::Assessment::Answer::ForumPostResponse < ApplicationRecord
   end
 
   def compare_answer(other_answer)
+    return false unless other_answer.is_a?(Course::Assessment::Answer::ForumPostResponse)
+
     same_text = answer_text == other_answer.answer_text
     same_post_packs_length = post_packs.length == other_answer.post_packs.length
 

--- a/app/models/course/assessment/answer/forum_post_response.rb
+++ b/app/models/course/assessment/answer/forum_post_response.rb
@@ -35,6 +35,17 @@ class Course::Assessment::Answer::ForumPostResponse < ApplicationRecord
     end
   end
 
+  def compare_answer(other_answer)
+    same_text = answer_text == other_answer.answer_text
+    same_post_packs_length = post_packs.length == other_answer.post_packs.length
+
+    post_packs = self.post_packs.map { |elem| elem.attributes.except('id', 'answer_id').values.join('_') }
+    other_post_packs = other_answer.post_packs.map { |elem| elem.attributes.except('id', 'answer_id').values.join('_') }
+
+    same_post_packs = Set.new(post_packs) == Set.new(other_post_packs)
+    same_text && same_post_packs_length && same_post_packs
+  end
+
   private
 
   def destroy_previous_selection

--- a/app/models/course/assessment/answer/multiple_response.rb
+++ b/app/models/course/assessment/answer/multiple_response.rb
@@ -28,6 +28,8 @@ class Course::Assessment::Answer::MultipleResponse < ApplicationRecord
   end
 
   def compare_answer(other_answer)
+    return false unless other_answer.is_a?(Course::Assessment::Answer::MultipleResponse)
+
     Set.new(option_ids) == Set.new(other_answer.option_ids)
   end
 end

--- a/app/models/course/assessment/answer/multiple_response.rb
+++ b/app/models/course/assessment/answer/multiple_response.rb
@@ -26,4 +26,8 @@ class Course::Assessment::Answer::MultipleResponse < ApplicationRecord
 
     self.random_seed
   end
+
+  def compare_answer(other_answer)
+    Set.new(option_ids) == Set.new(other_answer.option_ids)
+  end
 end

--- a/app/models/course/assessment/answer/programming.rb
+++ b/app/models/course/assessment/answer/programming.rb
@@ -81,6 +81,8 @@ class Course::Assessment::Answer::Programming < ApplicationRecord
   end
 
   def compare_answer(other_answer)
+    return false unless other_answer.is_a?(Course::Assessment::Answer::Programming)
+
     same_file_length = files.length == other_answer.files.length
     answer_filename_content = files.pluck(:filename, :content).map { |elem| elem.join('_') }
     other_answer_filename_content = other_answer.files.pluck(:filename, :content).map { |elem| elem.join('_') }

--- a/app/models/course/assessment/answer/programming.rb
+++ b/app/models/course/assessment/answer/programming.rb
@@ -79,4 +79,13 @@ class Course::Assessment::Answer::Programming < ApplicationRecord
     file.mark_for_destruction if file.present?
     save
   end
+
+  def compare_answer(other_answer)
+    same_file_length = files.length == other_answer.files.length
+    answer_filename_content = files.pluck(:filename, :content).map { |elem| elem.join('_') }
+    other_answer_filename_content = other_answer.files.pluck(:filename, :content).map { |elem| elem.join('_') }
+
+    same_file = Set.new(answer_filename_content) == Set.new(other_answer_filename_content)
+    same_file_length && same_file
+  end
 end

--- a/app/models/course/assessment/answer/scribing.rb
+++ b/app/models/course/assessment/answer/scribing.rb
@@ -18,4 +18,10 @@ class Course::Assessment::Answer::Scribing < ApplicationRecord
     end
     acting_as
   end
+
+  def compare_answer(other_answer)
+    same_scribbles_length = scribbles.length == other_answer.scribbles.length
+    same_scribbles_content = Set.new(scribbles.pluck(:content)) == Set.new(other_answer.scribbles.pluck(:content))
+    same_scribbles_length && same_scribbles_content
+  end
 end

--- a/app/models/course/assessment/answer/scribing.rb
+++ b/app/models/course/assessment/answer/scribing.rb
@@ -20,6 +20,8 @@ class Course::Assessment::Answer::Scribing < ApplicationRecord
   end
 
   def compare_answer(other_answer)
+    return false unless other_answer.is_a?(Course::Assessment::Answer::Scribing)
+
     same_scribbles_length = scribbles.length == other_answer.scribbles.length
     same_scribbles_content = Set.new(scribbles.pluck(:content)) == Set.new(other_answer.scribbles.pluck(:content))
     same_scribbles_length && same_scribbles_content

--- a/app/models/course/assessment/answer/text_response.rb
+++ b/app/models/course/assessment/answer/text_response.rb
@@ -50,6 +50,8 @@ class Course::Assessment::Answer::TextResponse < ApplicationRecord
   end
 
   def compare_answer(other_answer)
+    return false unless other_answer.is_a?(Course::Assessment::Answer::TextResponse)
+
     same_text = answer_text == other_answer.answer_text
     same_attachment_length = attachments.length == other_answer.attachments.length
     answer_filename_attachment = attachments.pluck(:name, :attachment_id).map { |elem| elem.join('#') }

--- a/app/models/course/assessment/answer/text_response.rb
+++ b/app/models/course/assessment/answer/text_response.rb
@@ -49,6 +49,16 @@ class Course::Assessment::Answer::TextResponse < ApplicationRecord
     self.files = params[:files] if params[:files]
   end
 
+  def compare_answer(other_answer)
+    same_text = answer_text == other_answer.answer_text
+    same_attachment_length = attachments.length == other_answer.attachments.length
+    answer_filename_attachment = attachments.pluck(:name, :attachment_id).map { |elem| elem.join('#') }
+    other_answer_filename_content = other_answer.attachments.pluck(:name, :attachment_id).map { |elem| elem.join('#') }
+
+    same_attachment = Set.new(answer_filename_attachment) == Set.new(other_answer_filename_content)
+    same_text && same_attachment_length && same_attachment
+  end
+
   private
 
   def set_default

--- a/app/models/course/assessment/answer/voice_response.rb
+++ b/app/models/course/assessment/answer/voice_response.rb
@@ -9,6 +9,8 @@ class Course::Assessment::Answer::VoiceResponse < ApplicationRecord
   end
 
   def compare_answer(other_answer)
+    return false unless other_answer.is_a?(Course::Assessment::Answer::VoiceResponse)
+
     (attachment&.name == other_answer.attachment&.name) &&
       (attachment&.attachment_id == other_answer.attachment&.attachment_id)
   end

--- a/app/models/course/assessment/answer/voice_response.rb
+++ b/app/models/course/assessment/answer/voice_response.rb
@@ -7,4 +7,9 @@ class Course::Assessment::Answer::VoiceResponse < ApplicationRecord
     acting_as.assign_params(params)
     self.file = params[:file] if params[:file]
   end
+
+  def compare_answer(other_answer)
+    (attachment&.name == other_answer.attachment&.name) &&
+      (attachment&.attachment_id == other_answer.attachment&.attachment_id)
+  end
 end

--- a/app/models/course/assessment/question/forum_post_response.rb
+++ b/app/models/course/assessment/question/forum_post_response.rb
@@ -15,7 +15,7 @@ class Course::Assessment::Question::ForumPostResponse < ApplicationRecord
 
     if last_attempt
       answer.answer_text = last_attempt.answer_text
-      answer.post_packs = Course::Assessment::Answer::ForumPost.where(answer_id: answer.specific.id)
+      answer.post_packs = last_attempt.post_packs.map(&:dup) if last_attempt.post_packs.any?
     end
 
     answer.acting_as

--- a/app/models/course/assessment/question/scribing.rb
+++ b/app/models/course/assessment/question/scribing.rb
@@ -13,9 +13,11 @@ class Course::Assessment::Question::Scribing < ApplicationRecord
     self.attachment = duplicator.duplicate(other.attachment)
   end
 
-  # Scribing is not autogradable, don't need last attempt
-  def attempt(submission, _last_attempt = nil)
+  def attempt(submission, last_attempt = nil)
     answer = Course::Assessment::Answer::Scribing.new(submission: submission, question: question)
+    last_attempt&.scribbles&.each do |scribble|
+      answer.scribbles.build(content: scribble.content)
+    end
     answer.acting_as
   end
 

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -272,10 +272,8 @@ class Course::Assessment::Submission < ApplicationRecord
     return unless saved_change_to_workflow_state?
 
     execute_after_commit do
-      # Grade only ungraded answers when submission state changes from published to submitted.
-      # Otherwise, grade all answers regardless of workflow state.
-      # only_ungraded is true when resubmit_programming event is called.
-      auto_grade!(only_ungraded: changes['workflow_state'] == ['published', 'submitted'])
+      # Grade only ungraded answers regardless of state as we dont want to regrade graded/evaluated answers.
+      auto_grade!(only_ungraded: true)
     end
   end
 

--- a/app/models/course/assessment/submission_question.rb
+++ b/app/models/course/assessment/submission_question.rb
@@ -45,7 +45,8 @@ class Course::Assessment::SubmissionQuestion < ApplicationRecord
 
   # Loads the past answers of a specific question
   def past_answers(answers_to_load)
-    answers.unscope(:order).order(created_at: :desc).non_current_answers.first(answers_to_load)
+    answers.unscope(:order).order(created_at: :desc).
+      where('workflow_state != ?', 'attempting').first(answers_to_load)
   end
 
   private

--- a/client/app/bundles/course/assessment/submission/reducers/scribing.js
+++ b/client/app/bundles/course/assessment/submission/reducers/scribing.js
@@ -33,6 +33,8 @@ function initializeLineStyles() {
 
 export default function (state = {}, action) {
   switch (action.type) {
+    case actions.FINALIZE_SUCCESS:
+    case actions.UNSUBMIT_SUCCESS:
     case actions.FETCH_SUBMISSION_SUCCESS: {
       return {
         ...state,

--- a/spec/factories/course_assessment_answer_programming.rb
+++ b/spec/factories/course_assessment_answer_programming.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
       question_traits { nil }
       file_count { nil }
       file_contents { nil }
+      file_name_contents { nil }
       creator { create(:user) }
     end
 
@@ -26,6 +27,11 @@ FactoryBot.define do
       elsif file_contents
         file_contents.map do |content|
           build(:course_assessment_answer_programming_file, answer: nil, content: content)
+        end
+      elsif file_name_contents
+        file_name_contents.map do |name_content|
+          build(:course_assessment_answer_programming_file, answer: nil, filename: name_content[0],
+                                                            content: name_content[1])
         end
       else
         []

--- a/spec/factories/course_assessment_answer_programming.rb
+++ b/spec/factories/course_assessment_answer_programming.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       question_traits { nil }
       file_count { nil }
       file_contents { nil }
-      file_name_contents { nil }
+      file_name_contents { nil } # [Array<[filename<String>, content<String>]>]
       creator { create(:user) }
     end
 

--- a/spec/factories/course_assessment_answer_scribings.rb
+++ b/spec/factories/course_assessment_answer_scribings.rb
@@ -5,11 +5,22 @@ FactoryBot.define do
           parent: :course_assessment_answer do
     transient do
       question_traits { nil }
+      contents { nil }
     end
 
     question do
       build(:course_assessment_question_scribing, *question_traits,
             assessment: assessment).question
+    end
+
+    scribbles do
+      if contents
+        contents.map do |content|
+          build(:course_assessment_answer_scribing_scribble, answer: nil, content: content)
+        end
+      else
+        []
+      end
     end
   end
 end

--- a/spec/factories/course_assessment_answer_voice_responses.rb
+++ b/spec/factories/course_assessment_answer_voice_responses.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_answer_voice_response,
+          class: Course::Assessment::Answer::VoiceResponse,
+          parent: :course_assessment_answer do
+    transient do
+      question_traits { nil }
+    end
+
+    question do
+      build(:course_assessment_question_voice_response, *question_traits,
+            assessment: assessment).question
+    end
+  end
+end

--- a/spec/factories/course_assessment_question_voice_responses.rb
+++ b/spec/factories/course_assessment_question_voice_responses.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+# rubocop:disable Lint/EmptyBlock
 FactoryBot.define do
   factory :course_assessment_question_voice_response,
           class: Course::Assessment::Question::VoiceResponse,
           parent: :course_assessment_question do
   end
 end
+# rubocop:enable Lint/EmptyBlock

--- a/spec/factories/course_assessment_question_voice_responses.rb
+++ b/spec/factories/course_assessment_question_voice_responses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_question_voice_response,
+          class: Course::Assessment::Question::VoiceResponse,
+          parent: :course_assessment_question do
+  end
+end

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
         expect(page).to have_text('Graded but not published')
         click_button('Publish Grades')
         accept_confirm_dialog
+        wait_for_job
         expect(page).not_to have_text('Graded but not published')
 
         expect(graded_submission.reload).to be_published
@@ -143,6 +144,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
 
         find('.unsubmit-submissions-enabled').click
         accept_confirm_dialog
+        wait_for_job
         expect(page).not_to have_text('Graded but not published')
 
         find('#submission-dropdown-icon').click
@@ -159,6 +161,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
 
         find('.delete-submissions-enabled').click
         accept_confirm_dialog
+        wait_for_job
         expect(page).to have_text('Not Started')
         expect(page).not_to have_text('Attempting')
 

--- a/spec/models/course/assessment/answer/forum_post_response_spec.rb
+++ b/spec/models/course/assessment/answer/forum_post_response_spec.rb
@@ -121,5 +121,55 @@ RSpec.describe Course::Assessment::Answer::ForumPostResponse do
         expect(post_packs[0].is_parent_deleted).to eq(true)
       end
     end
+
+    describe '#compare_answer' do
+      let(:forum) { create(:forum) }
+      let(:topic) { create(:forum_topic, forum: forum) }
+      let(:parent_post1) { create(:course_discussion_post, topic: topic.acting_as) }
+      let(:child_post1) { create(:course_discussion_post, topic: topic.acting_as, parent: parent_post1) }
+      let(:parent_post2) { create(:course_discussion_post, topic: topic.acting_as) }
+      let(:child_post2) { create(:course_discussion_post, topic: topic.acting_as, parent: parent_post2) }
+      let(:answer1) { create(:course_assessment_answer_forum_post_response) }
+      let(:answer1_different_text) do
+        create(:course_assessment_answer_forum_post_response, answer_text: '<div>yyy</div>')
+      end
+      let(:answer1_no_post_pack) { create(:course_assessment_answer_forum_post_response) }
+      let(:answer_with_parent1) { create(:course_assessment_answer_forum_post_response) }
+      let(:answer2) { create(:course_assessment_answer_forum_post_response) }
+      let(:answer_with_parent2) { create(:course_assessment_answer_forum_post_response) }
+      let!(:post_pack1) do
+        create(:course_assessment_answer_forum_post, topic: topic.acting_as, post: parent_post1,
+                                                     answer: answer1.actable)
+      end
+      let!(:post_pack1_different_text) do
+        create(:course_assessment_answer_forum_post, topic: topic.acting_as, post: parent_post1,
+                                                     answer: answer1_different_text.actable)
+      end
+      let!(:post_pack_with_parent1) do
+        create(:course_assessment_answer_forum_post, parent: parent_post1, topic: topic.acting_as, post: child_post1,
+                                                     answer: answer_with_parent1.actable)
+      end
+      let!(:post_pack2) do
+        create(:course_assessment_answer_forum_post, topic: topic.acting_as, post: parent_post2,
+                                                     answer: answer2.actable)
+      end
+      let!(:post_pack_with_parent2) do
+        create(:course_assessment_answer_forum_post, parent: parent_post2, topic: topic.acting_as, post: child_post2,
+                                                     answer: answer_with_parent2.actable)
+      end
+
+      it 'compares if the answers are the same or not' do
+        expect(answer1.compare_answer(answer1)).to be_truthy
+        expect(answer1.compare_answer(answer1_different_text)).to be_falsey
+        expect(answer1.compare_answer(answer1_no_post_pack)).to be_falsey
+        expect(answer1.compare_answer(answer_with_parent1)).to be_falsey
+        expect(answer1.compare_answer(answer2)).to be_falsey
+        expect(answer1.compare_answer(answer_with_parent2)).to be_falsey
+        expect(answer2.compare_answer(answer2)).to be_truthy
+        expect(answer2.compare_answer(answer1)).to be_falsey
+        expect(answer2.compare_answer(answer_with_parent1)).to be_falsey
+        expect(answer2.compare_answer(answer_with_parent2)).to be_falsey
+      end
+    end
   end
 end

--- a/spec/models/course/assessment/answer/multiple_response_spec.rb
+++ b/spec/models/course/assessment/answer/multiple_response_spec.rb
@@ -27,5 +27,27 @@ RSpec.describe Course::Assessment::Answer::MultipleResponse do
         expect(subject).to be_a(Course::Assessment::Answer)
       end
     end
+
+    describe '#compare_answer' do
+      let(:assessment) { create(:assessment, :published_with_mrq_question) }
+      let(:question) { assessment.questions.first }
+      let(:answer1) do
+        create(:course_assessment_answer_multiple_response, :with_all_correct_options,
+               assessment: assessment, question: question)
+      end
+      let(:answer2) do
+        create(:course_assessment_answer_multiple_response, :with_all_wrong_options,
+               assessment: assessment, question: question)
+      end
+      let(:answer3) do
+        create(:course_assessment_answer_multiple_response, :with_all_correct_options,
+               assessment: assessment, question: question)
+      end
+
+      it 'compares if answers are the same or not' do
+        expect(answer1.compare_answer(answer2)).to be_falsey
+        expect(answer1.compare_answer(answer3)).to be_truthy
+      end
+    end
   end
 end

--- a/spec/models/course/assessment/answer/programming_spec.rb
+++ b/spec/models/course/assessment/answer/programming_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Course::Assessment::Answer::Programming do
     describe 'attempting_times_left' do
       subject { answer.attempting_times_left }
 
-      context 'with one exiting attempts' do
+      context 'with one existing attempts' do
         let!(:graded_answer) do
           create(:course_assessment_answer_programming, :graded,
                  submission: submission, question: question.question)
@@ -73,6 +73,53 @@ RSpec.describe Course::Assessment::Answer::Programming do
 
         it 'returns the max attempt limits' do
           expect(subject).to eq(answer.class::MAX_ATTEMPTING_TIMES)
+        end
+      end
+
+      describe '#compare_answer' do
+        let(:answer1) do
+          create(:course_assessment_answer_programming,
+                 question: question,
+                 file_name_contents: [['name1', '123'],
+                                      ['name3', '456']])
+        end
+        let(:answer2) do
+          create(:course_assessment_answer_programming,
+                 question: question,
+                 file_name_contents: [['name1', '456']])
+        end
+        let(:answer3) do
+          create(:course_assessment_answer_programming,
+                 question: question,
+                 file_name_contents: [['name1', '123'],
+                                      ['name2', '456']])
+        end
+        let(:answer4) do
+          create(:course_assessment_answer_programming,
+                 question: question,
+                 file_name_contents: [['name1', '123'],
+                                      ['name2', '123'],
+                                      ['name3', '456']])
+        end
+        let(:answer5) do
+          create(:course_assessment_answer_programming,
+                 question: question,
+                 file_name_contents: [['name3', '456'],
+                                      ['name1', '123']])
+        end
+
+        it 'compares if the answers are the same or not' do
+          expect(answer1.compare_answer(answer1)).to be_truthy
+          expect(answer1.compare_answer(answer2)).to be_falsey
+          expect(answer1.compare_answer(answer3)).to be_falsey
+          expect(answer1.compare_answer(answer4)).to be_falsey
+          expect(answer1.compare_answer(answer5)).to be_truthy
+          expect(answer2.compare_answer(answer3)).to be_falsey
+          expect(answer2.compare_answer(answer4)).to be_falsey
+          expect(answer2.compare_answer(answer5)).to be_falsey
+          expect(answer3.compare_answer(answer4)).to be_falsey
+          expect(answer3.compare_answer(answer5)).to be_falsey
+          expect(answer4.compare_answer(answer5)).to be_falsey
         end
       end
     end

--- a/spec/models/course/assessment/answer/programming_spec.rb
+++ b/spec/models/course/assessment/answer/programming_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Course::Assessment::Answer::Programming do
     describe 'attempting_times_left' do
       subject { answer.attempting_times_left }
 
-      context 'with one existing attempts' do
+      context 'with one existing attempt' do
         let!(:graded_answer) do
           create(:course_assessment_answer_programming, :graded,
                  submission: submission, question: question.question)

--- a/spec/models/course/assessment/answer/scribing_spec.rb
+++ b/spec/models/course/assessment/answer/scribing_spec.rb
@@ -32,5 +32,34 @@ RSpec.describe Course::Assessment::Answer::Scribing, type: :model do
         expect(subject).to be_a(Course::Assessment::Answer)
       end
     end
+
+    describe '#compare_answer' do
+      let(:answer1) do
+        create(:course_assessment_answer_scribing,
+               contents: ['123', '456'])
+      end
+      let(:answer2) do
+        create(:course_assessment_answer_scribing,
+               contents: ['123', '123', '456'])
+      end
+      let(:answer3) do
+        create(:course_assessment_answer_scribing,
+               contents: ['123', '456', '789'])
+      end
+      let(:answer4) do
+        create(:course_assessment_answer_scribing,
+               contents: ['789', '456', '123'])
+      end
+
+      it 'compares if the answers are the same or not' do
+        expect(answer1.compare_answer(answer1)).to be_truthy
+        expect(answer1.compare_answer(answer2)).to be_falsey
+        expect(answer1.compare_answer(answer3)).to be_falsey
+        expect(answer1.compare_answer(answer4)).to be_falsey
+        expect(answer2.compare_answer(answer3)).to be_falsey
+        expect(answer2.compare_answer(answer4)).to be_falsey
+        expect(answer3.compare_answer(answer4)).to be_truthy
+      end
+    end
   end
 end

--- a/spec/models/course/assessment/answer/text_response_spec.rb
+++ b/spec/models/course/assessment/answer/text_response_spec.rb
@@ -55,5 +55,42 @@ RSpec.describe Course::Assessment::Answer::TextResponse, type: :model do
         end
       end
     end
+
+    describe '#compare_answer' do
+      let(:answer1) do
+        create(:course_assessment_answer_text_response, :keyword)
+      end
+      let(:answer2) do
+        create(:course_assessment_answer_text_response, :exact_match)
+      end
+      let(:answer3) do
+        create(:course_assessment_answer_text_response, :exact_match).tap do |answer3|
+          attachment1 = create(:attachment_reference, name: 'att1.txt')
+          attachment1.save!
+          answer3.attachment_references << attachment1
+        end
+      end
+      let(:answer4) do
+        create(:course_assessment_answer_text_response, :exact_match).tap do |answer4|
+          attachment1 = create(:attachment_reference, name: 'att1.txt')
+          attachment1.save!
+          attachment2 = create(:attachment_reference, name: 'att2.txt')
+          attachment2.save!
+          answer4.attachment_references << attachment1
+          answer4.attachment_references << attachment2
+        end
+      end
+
+      it 'compares if the answers are the same or not' do
+        expect(answer1.compare_answer(answer1)).to be_truthy
+        expect(answer1.compare_answer(answer2)).to be_falsey
+        expect(answer1.compare_answer(answer3)).to be_falsey
+        expect(answer1.compare_answer(answer4)).to be_falsey
+        expect(answer2.compare_answer(answer3)).to be_falsey
+        expect(answer2.compare_answer(answer4)).to be_falsey
+        expect(answer3.compare_answer(answer4)).to be_falsey
+        expect(answer4.compare_answer(answer4)).to be_truthy
+      end
+    end
   end
 end

--- a/spec/models/course/assessment/answer/voice_response_spec.rb
+++ b/spec/models/course/assessment/answer/voice_response_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Answer::VoiceResponse, type: :model do
+  it { is_expected.to act_as(Course::Assessment::Answer) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#compare_answer' do
+      let(:answer1) do
+        create(:course_assessment_answer_voice_response)
+      end
+      let(:answer2) do
+        create(:course_assessment_answer_voice_response).tap do |answer2|
+          attachment1 = create(:attachment_reference, name: 'att1.wav')
+          attachment1.save!
+          answer2.attachment_references << attachment1
+        end
+      end
+      let(:answer3) do
+        create(:course_assessment_answer_voice_response).tap do |answer3|
+          attachment1 = create(:attachment_reference, name: 'att2.wav')
+          attachment1.save!
+          answer3.attachment_references << attachment1
+        end
+      end
+
+      it 'compares if the answers are the same or not' do
+        expect(answer1.compare_answer(answer1)).to be_truthy
+        expect(answer1.compare_answer(answer2)).to be_falsey
+        expect(answer1.compare_answer(answer3)).to be_falsey
+        expect(answer2.compare_answer(answer3)).to be_falsey
+        expect(answer3.compare_answer(answer3)).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -523,7 +523,7 @@ RSpec.describe Course::Assessment::Submission do
         end
       end
 
-      context 'when there are delayed annotation and comment' do
+      context 'when there are delayed annotations and comments' do
         let!(:assessment_traits) { [:with_programming_question] }
         let!(:submission1_traits) { :submitted }
         let!(:submission) { submission1 }

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -431,32 +431,6 @@ RSpec.describe Course::Assessment::Submission do
         expect(submission.awarded_at).not_to be_nil
       end
 
-      context 'when there are delayed annotation and comment' do
-        let!(:assessment_traits) { [:with_programming_question] }
-        let!(:submission1_traits) { :submitted }
-        let!(:submission) { submission1 }
-        let!(:answer) { submission.answers.first }
-        let!(:file) { answer.actable.files.first }
-        let!(:annotation) do
-          create(:course_assessment_answer_programming_file_annotation, file: file, line: 1)
-        end
-        let!(:annotation_post) do
-          create(:course_discussion_post, :delayed, topic: annotation.discussion_topic, creator: user)
-        end
-        let!(:submission_question) do
-          create(:course_assessment_submission_question,
-                 submission: submission, question: assessment.questions.first, course: course)
-        end
-        let!(:submission_question_post) do
-          create(:course_discussion_post, :delayed, topic: submission_question.discussion_topic, creator: user)
-        end
-        it 'is set as not delayed after publication' do
-          submission.publish!
-          expect(annotation_post.reload.is_delayed).to be(false)
-          expect(submission_question_post.reload.is_delayed).to be(false)
-        end
-      end
-
       it 'sends an email notification', type: :mailer do
         expect { submission.publish! }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
@@ -546,6 +520,32 @@ RSpec.describe Course::Assessment::Submission do
               expect(subject.points_awarded).to eq(points_awarded)
             end
           end
+        end
+      end
+
+      context 'when there are delayed annotation and comment' do
+        let!(:assessment_traits) { [:with_programming_question] }
+        let!(:submission1_traits) { :submitted }
+        let!(:submission) { submission1 }
+        let!(:answer) { submission.answers.first }
+        let!(:file) { answer.actable.files.first }
+        let!(:annotation) do
+          create(:course_assessment_answer_programming_file_annotation, file: file, line: 1)
+        end
+        let!(:annotation_post) do
+          create(:course_discussion_post, :delayed, topic: annotation.discussion_topic, creator: user)
+        end
+        let!(:submission_question) do
+          create(:course_assessment_submission_question,
+                 submission: submission, question: assessment.questions.first, course: course)
+        end
+        let!(:submission_question_post) do
+          create(:course_discussion_post, :delayed, topic: submission_question.discussion_topic, creator: user)
+        end
+        it 'is set as not delayed after publication' do
+          submission.publish!
+          expect(annotation_post.reload.is_delayed).to be(false)
+          expect(submission_question_post.reload.is_delayed).to be(false)
         end
       end
     end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -601,13 +601,13 @@ RSpec.describe Course::Assessment::Submission do
         end
 
         it 'duplicates all submitted current answers in the submission to attempting' do
-          # In this state, there are 5 current answers and 1 non-current answer
-          expect(subject.answers.length).to eq(6)
+          # In this state, there are 6 current answers and 1 non-current answer
+          expect(subject.answers.length).to eq(7)
 
           unsubmit_and_save_subject
 
-          # In this state, there are 5 current answers and 6 non-current answer
-          expect(subject.answers.length).to eq(11)
+          # In this state, there are 6 current answers and 7 non-current answer
+          expect(subject.answers.length).to eq(13)
           expect(subject.current_answers.all?(&:attempting?)).to be(true)
           expect(earlier_answer.reload).to be_graded
 
@@ -631,8 +631,8 @@ RSpec.describe Course::Assessment::Submission do
           subject.finalise!
           current_answer_ids_after = subject.current_answers.pluck(:id)
 
-          expect(subject.answers.length).to eq(6)
-          expect(subject.current_answers.length).to eq(5)
+          expect(subject.answers.length).to eq(7)
+          expect(subject.current_answers.length).to eq(6)
 
           expect(current_answer_ids_before == current_answer_ids_after).to be_truthy
           expect(current_answer_ids_before == current_answer_ids_intermediate).to be_falsey
@@ -648,7 +648,7 @@ RSpec.describe Course::Assessment::Submission do
           unsubmit_and_save_subject
           current_answer_ids_intermediate = subject.current_answers.pluck(:id)
 
-          # Update the answers of all current_answers
+          # Update/change the answers of all current_answers
           subject.current_answers.each do |current_answer|
             answer = current_answer.specific
             case answer.class.name
@@ -662,14 +662,16 @@ RSpec.describe Course::Assessment::Submission do
               end
             when 'Course::Assessment::Answer::TextResponse'
               answer.update(answer_text: 'updated')
+            when 'Course::Assessment::Answer::ForumPostResponse'
+              answer.update(answer_text: '<div>yyy</div>')
             end
           end
 
           subject.finalise!
           current_answer_ids_after = subject.current_answers.pluck(:id)
 
-          expect(subject.answers.length).to eq(11)
-          expect(subject.current_answers.length).to eq(5)
+          expect(subject.answers.length).to eq(13)
+          expect(subject.current_answers.length).to eq(6)
 
           expect(current_answer_ids_before == current_answer_ids_after).to be_falsey
           expect(current_answer_ids_before == current_answer_ids_intermediate).to be_falsey

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -590,7 +590,7 @@ RSpec.describe Course::Assessment::Submission do
 
       subject { submission1 }
 
-      context 'when the submission is submitted' do
+      context 'when the submission is in submitted state' do
         let(:submission1_traits) { :submitted }
 
         it 'resets the experience points awarded and submitted_at time' do
@@ -600,10 +600,80 @@ RSpec.describe Course::Assessment::Submission do
           expect(subject.submitted_at).to be_nil
         end
 
-        it 'sets all current answers in the submission to attempting' do
+        it 'duplicates all submitted current answers in the submission to attempting' do
+          # In this state, there are 5 current answers and 1 non-current answer
+          expect(subject.answers.length).to eq(6)
+
           unsubmit_and_save_subject
+
+          # In this state, there are 5 current answers and 6 non-current answer
+          expect(subject.answers.length).to eq(11)
           expect(subject.current_answers.all?(&:attempting?)).to be(true)
           expect(earlier_answer.reload).to be_graded
+
+          subject.questions.each do |question|
+            all_answers = subject.answers.where(question: question)
+            current_answer = all_answers.current_answers.select(&:attempting?).first
+            last_non_current_answer = all_answers.reject(&:current_answer?).reject(&:attempting?).last
+            expect(last_non_current_answer).not_to eq('attempting')
+            expect(current_answer.specific.compare_answer(last_non_current_answer.specific)).to be_truthy
+          end
+        end
+      end
+
+      context 'when the submission gets unsubmitted and submitted again without change in answers' do
+        let(:submission1_traits) { :submitted }
+
+        it 'duplicates all submitted current answers in the submission to attempting' do
+          current_answer_ids_before = subject.current_answers.pluck(:id)
+          unsubmit_and_save_subject
+          current_answer_ids_intermediate = subject.current_answers.pluck(:id)
+          subject.finalise!
+          current_answer_ids_after = subject.current_answers.pluck(:id)
+
+          expect(subject.answers.length).to eq(6)
+          expect(subject.current_answers.length).to eq(5)
+
+          expect(current_answer_ids_before == current_answer_ids_after).to be_truthy
+          expect(current_answer_ids_before == current_answer_ids_intermediate).to be_falsey
+          expect(current_answer_ids_after == current_answer_ids_intermediate).to be_falsey
+        end
+      end
+
+      context 'when the submission gets unsubmitted and submitted again with change in answers' do
+        let(:submission1_traits) { :submitted }
+
+        it 'duplicates all submitted current answers in the submission to attempting' do
+          current_answer_ids_before = subject.current_answers.pluck(:id)
+          unsubmit_and_save_subject
+          current_answer_ids_intermediate = subject.current_answers.pluck(:id)
+
+          # Update the answers of all current_answers
+          subject.current_answers.each do |current_answer|
+            answer = current_answer.specific
+            case answer.class.name
+            when 'Course::Assessment::Answer::MultipleResponse'
+              question = answer.question.actable
+              correct_options = question.options.select(&:correct)
+              correct_options.each { |option| answer.options << option }
+            when 'Course::Assessment::Answer::Programming'
+              answer.files.each do |file|
+                file.update(content: 'updated')
+              end
+            when 'Course::Assessment::Answer::TextResponse'
+              answer.update(answer_text: 'updated')
+            end
+          end
+
+          subject.finalise!
+          current_answer_ids_after = subject.current_answers.pluck(:id)
+
+          expect(subject.answers.length).to eq(11)
+          expect(subject.current_answers.length).to eq(5)
+
+          expect(current_answer_ids_before == current_answer_ids_after).to be_falsey
+          expect(current_answer_ids_before == current_answer_ids_intermediate).to be_falsey
+          expect(current_answer_ids_after == current_answer_ids_intermediate).to be_falsey
         end
       end
 


### PR DESCRIPTION
### **Context**

- There are currently issues with the current submission answer workflow.
- Upon submission, there are duplicates of the current answer and latest non-current answer because when a user 'run code/submit' for each question, a new answer is duplicated from the current answer and that duplicated answer is graded while leaving the current answer in attempting state as a 'placeholder' in case of draft answer.
- That said, if the user does not click 'run code/submit' and the user submits the whole submission, the current answer is not duplicated and hence there is inconsistency of the answers to the question as compared to the point above.
- Upon submission, there's not supposed to be any **duplicate answers** and the current system does not check if the latest non-current answer is the duplicate of the current answer.
- And, previously graded answer should be taken as it is and should not be re-graded as it will add more work to the app.

### **Solution**
- In short, upon submission, current answer and latest non-current answer are compared and if they are identical, remove the current answer and mark the latest non-current answer as the current answer. Also, we will avoid re-grading of the graded current answer.
- If they are not identical (as a result of the individual answer not being submitted before the assessment submission), regenerate that current answer (to ensure chronological answer ordering) and grade it.
- When the assessment is unsubmitted, duplicate all current answers to attempting answers (needed as answer placeholder) then mark the duplicated answers as the current answers.

- More info: refer to the pdf below
Reference: [Submission Past Answers Issues.pdf](https://github.com/Coursemology/coursemology2/files/7606393/Submission.Past.Answers.Issues.pdf)
