### PR TITLE
Add recaptcha to user registration page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'kaminari'
 # Work with Docker
 gem 'docker-api'
 
+gem 'recaptcha'
+
 group :development do
   # Spring speeds up development by keeping your application running in the background.
   # Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,8 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    recaptcha (5.8.1)
+      json
     record_tag_helper (1.0.1)
       actionview (>= 5)
     redis (4.2.5)
@@ -714,6 +716,7 @@ DEPENDENCIES
   rails-html-sanitizer (>= 1.0.4)
   rails_real_favicon
   rails_utils!
+  recaptcha
   record_tag_helper
   redis-rails
   rinku

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -16,6 +16,12 @@ class User::RegistrationsController < Devise::RegistrationsController
 
   # POST /resource
   def create
+    unless verify_recaptcha
+      build_resource(sign_up_params)
+      flash.now[:alert] = 'There was an error with the reCaptcha below, please try again.'
+      flash.delete :recaptcha_error
+      return render :new
+    end
     User.transaction do
       super
       @invitation.confirm!(confirmer: resource) if @invitation && !@invitation.confirmed? && resource.persisted?

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -18,7 +18,7 @@ class User::RegistrationsController < Devise::RegistrationsController
   def create
     unless verify_recaptcha
       build_resource(sign_up_params)
-      flash.now[:alert] = 'There was an error with the reCaptcha below, please try again.'
+      flash.now[:alert] = t('user.registrations.create.verify_recaptcha_alert')
       flash.delete :recaptcha_error
       return render :new
     end

--- a/app/views/user/registrations/new.html.slim
+++ b/app/views/user/registrations/new.html.slim
@@ -17,6 +17,9 @@
               hint: (t('.password_hint', length: @minimum_password_length) if @validatable)
     = f.input :password_confirmation, required: true
 
+  = recaptcha_tags
+  br
+
   .form-actions
     = f.button :submit, t('.sign_up')
 

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Recaptcha.configure do |config|
+  if Rails.env.production?
+    config.site_key = ENV['GOOGLE_RECAPTCHA_SITE_KEY']
+    config.secret_key = ENV['GOOGLE_RECAPTCHA_SECRET_KEY']
+  else
+    # The following keys are for test and development environments only.
+    # You will always get No CAPTCHA and all verification requests will pass.
+    config.site_key = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+    config.secret_key = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
+  end
+end

--- a/config/locales/en/user/registrations.yml
+++ b/config/locales/en/user/registrations.yml
@@ -17,3 +17,5 @@ en:
         new_password_confirmation: 'Confirm your new password'
         new_password_hint: "Leave blank if you don't want to change it"
         current_password_required_hint: 'We need your current password to confirm your changes'
+      create:
+        verify_recaptcha_alert: There was an error with the reCAPTCHA below, please try again.

--- a/spec/controllers/user/registration_controller_spec.rb
+++ b/spec/controllers/user/registration_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe User::RegistrationsController, type: :controller do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    describe '#create' do
+      subject do
+        valid_user = attributes_for(:user).reverse_merge(email: generate(:email))
+        post :create, params: {
+          user: {
+            name: valid_user[:name],
+            email: valid_user[:email],
+            password: valid_user[:password],
+            password_confirmation: valid_user[:password]
+          }
+        }
+      end
+
+      context 'user registration is successful' do
+        before do
+          @request.env['devise.mapping'] = Devise.mappings[:user]
+        end
+
+        it 'creates a new account' do
+          allow(controller).to receive(:verify_recaptcha).and_return(true)
+          expect { subject }.to change { User.count }.by(1)
+        end
+      end
+
+      context 'recaptcha is not validated' do
+        before do
+          @request.env['devise.mapping'] = Devise.mappings[:user]
+        end
+
+        it 'flashes error message and no new user is registered' do
+          allow(controller).to receive(:verify_recaptcha).and_return(false)
+          expect { subject }.to change { User.count }.by(0)
+          expect(flash[:alert]).to be_present
+          expect(response).to render_template(:new)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## **Context**

There may be bots creating random new accounts through the user registration page which then sends confirmation emails to the registered accounts. The actual email owners then may flag these emails as spam which then increases the spam number warning for our AWS SES email account. 

## **Solution**

Here, we propose to add a captcha to the user registration form to prevent bots from creating random accounts. We are using google recaptcha v2 here.

Before deployment, we need to register coursemology here https://www.google.com/recaptcha/admin/create and add both site_key and secret_key to the config files in the production environment.

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/42570513/143971171-6df7fc79-dbf1-4863-873c-fe3c3f13d436.png">
