### PR TITLE
Optimize submissions page

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -35,7 +35,7 @@ class Course::Assessment::Submission::SubmissionsController < \
         @assessment = @assessment.calculated(:maximum_grade)
         @submissions = @submissions.calculated(:log_count, :graded_at, :grade)
         @my_students = current_course_user&.my_students || []
-        @course_users = current_course.course_users.order_phantom_user.order_alphabetically.includes(:user)
+        @course_users = current_course.course_users.order_phantom_user.order_alphabetically
       end
     end
   end

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -33,7 +33,7 @@ class Course::Assessment::Submission::SubmissionsController < \
       format.html {}
       format.json do
         @assessment = @assessment.calculated(:maximum_grade)
-        @submissions = @submissions.calculated(:log_count, :graded_at).includes(:answers)
+        @submissions = @submissions.calculated(:log_count, :graded_at, :grade)
         @my_students = current_course_user&.my_students || []
         @course_users = current_course.course_users.order_phantom_user.order_alphabetically.includes(:user)
       end
@@ -69,7 +69,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     respond_to do |format|
       format.html {}
       format.json do
-        calculated_fields = [:graded_at]
+        calculated_fields = [:graded_at, :grade]
         @submission = @submission.calculated(*calculated_fields)
       end
     end

--- a/app/helpers/course/assessment/answer/programming_test_case_helper.rb
+++ b/app/helpers/course/assessment/answer/programming_test_case_helper.rb
@@ -51,7 +51,7 @@ module Course::Assessment::Answer::ProgrammingTestCaseHelper
   # @param [Course::Assessment::Answer::ProgrammingAutoGrading] auto_grading Auto grading object
   # @return [Hash] The hash structure described above
   def get_test_cases_and_results(test_cases_by_type, auto_grading)
-    results_hash = auto_grading ? auto_grading.test_results.group_by(&:test_case) : {}
+    results_hash = auto_grading ? auto_grading.test_results.group_by(&:test_case_id) : {}
     test_cases_by_type.each do |type, test_cases|
       test_cases_by_type[type] =
         test_cases.map { |test_case| [test_case, results_hash[test_case]&.first] }.

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -91,7 +91,7 @@ class Course::Assessment::Submission < ApplicationRecord
   accepts_nested_attributes_for :answers
 
   # @!attribute [r] graded_at
-  #   Gets the time the submission was graded.
+  #   Returns the time the submission was graded.
   #   @return [Time]
   calculated :graded_at, (lambda do
     Course::Assessment::Answer.unscope(:order).
@@ -104,6 +104,15 @@ class Course::Assessment::Submission < ApplicationRecord
   calculated :log_count, (lambda do
     Course::Assessment::Submission::Log.select("count('*')").
       where('course_assessment_submission_logs.submission_id = course_assessment_submissions.id')
+  end)
+
+  # @!attribute [r] grade
+  #   Returns the total grade of the submissions.
+  calculated :grade, (lambda do
+    Course::Assessment::Answer.unscope(:order).
+      where('course_assessment_answers.submission_id = course_assessment_submissions.id
+             AND course_assessment_answers.current_answer = true').
+      select('sum(course_assessment_answers.grade)')
   end)
 
   # @!method self.by_user(user)
@@ -186,11 +195,6 @@ class Course::Assessment::Submission < ApplicationRecord
 
   def unsubmitting?
     !!@unsubmitting
-  end
-
-  # The total grade of the submission
-  def grade
-    current_answers.map { |a| a.grade || 0 }.sum
   end
 
   def questions

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -208,16 +208,21 @@ class Course::Assessment::Submission < ApplicationRecord
   end
 
   # The answers with current_answer flag set to true, filtering out orphaned answers to questions which are no longer
-  # assigned to the submission.
+  # assigned to the submission for randomized assessment.
   #
   # If there are multiple current_answers for a particular question, return the first one.
   # This guards against a race condition creating multiple current_answers for a given
   # question in load_or_create_answers.
   def current_answers
-    # Can't do filtering in AR because `answer` may not be persisted, and AR is dumb.
-    question_ids = questions.pluck(:id)
-    answers.select { |answer| answer.question_id.in? question_ids }.
-      select(&:current_answer?).group_by(&:question_id).map { |pair| pair[1].first }
+    if assessment.randomization.nil?
+      # Filtering by question ids is not needed for non-randomized assessment as it adds more query time.
+      filtered_answers = answers
+    else
+      # Can't do filtering in AR because `answer` may not be persisted, and AR is dumb.
+      question_ids = questions.pluck(:id)
+      filtered_answers = answers.select { |answer| answer.question_id.in? question_ids }
+    end
+    filtered_answers.select(&:current_answer?).group_by(&:question_id).map { |pair| pair[1].first }
   end
 
   # @return [Array<Course::Assessment::Answer>] Current answers to programming questions

--- a/app/services/course/assessment/submission/statistics_download_service.rb
+++ b/app/services/course/assessment/submission/statistics_download_service.rb
@@ -20,8 +20,8 @@ class Course::Assessment::Submission::StatisticsDownloadService
   def generate_csv_report
     submissions = Course::Assessment::Submission.
                   where(id: @submission_ids).
-                  calculated(:log_count, :graded_at).
-                  includes(:course_user, :answers, :publisher)
+                  calculated(:log_count, :graded_at, :grade).
+                  includes(:course_user, :publisher)
     assessment = submissions&.first&.assessment&.calculated(:maximum_grade)
     statistics_file_path = File.join(@base_dir, 'statistics.csv')
     CSV.open(statistics_file_path, 'w') do |csv|
@@ -60,7 +60,7 @@ class Course::Assessment::Submission::StatisticsDownloadService
     csv << [submission.course_user.name,
             submission.course_user.phantom?,
             submission.workflow_state,
-            submission.grade,
+            submission.grade.to_f,
             assessment.maximum_grade,
             csv_exp_points(submission),
             csv_created_at(submission),

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -133,7 +133,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   # @raise [ActiveRecord::RecordInvalid] If the new submission_questions cannot be saved.
   # @return[Boolean] If new submission_questions were created.
   def create_missing_submission_questions
-    questions_with_submission_questions = @submission.submission_questions.map(&:question)
+    questions_with_submission_questions = @submission.submission_questions.includes(:question).map(&:question)
     questions_without_submission_questions = questions_to_attempt - questions_with_submission_questions
     new_submission_questions = []
     questions_without_submission_questions.each do |question|

--- a/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
@@ -8,7 +8,8 @@ topic_ids_hash = submission.submission_questions.where(question: submission.ques
 end.to_h
 
 question_assessments = Course::QuestionAssessment.
-                       where(question: submission.questions, assessment: submission.assessment)
+                       where(question: submission.questions, assessment: submission.assessment).
+                       includes(:question)
 json.questions question_assessments.each_with_index.to_a do |(question_assessment, index)|
   question = question_assessment.question
   answer = answer_ids_hash[question.id]

--- a/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
@@ -3,22 +3,22 @@ answer_ids_hash = answers.map do |a|
   [a.question_id, a]
 end.to_h
 
-topic_ids_hash = submission.submission_questions.where(question: submission.questions).map do |sq|
-  [sq.question_id, sq.discussion_topic.id]
+sq_topic_ids_hash = submission_questions.map do |sq|
+  [sq.question_id, [sq, sq.discussion_topic.id]]
 end.to_h
 
 question_assessments = Course::QuestionAssessment.
-                       where(question: submission.questions, assessment: submission.assessment).
-                       includes(:question)
+                       where(question: submission.questions, assessment: assessment).includes({ question: :actable })
+
 json.questions question_assessments.each_with_index.to_a do |(question_assessment, index)|
   question = question_assessment.question
   answer = answer_ids_hash[question.id]
   answer_id = answer&.id
-  submission_question = question.submission_questions.from_submission(submission.id)
+  submission_question = sq_topic_ids_hash[question.id][0]
   json.partial! 'question', question: question, can_grade: can_grade, answer: answer
   json.displayTitle question_assessment.display_title(index + 1)
 
   json.answerId answer_id
-  json.topicId topic_ids_hash[question.id]
+  json.topicId sq_topic_ids_hash[question.id][1]
   json.submissionQuestionId submission_question.id
 end

--- a/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_submission.json.jbuilder
@@ -3,7 +3,7 @@ json.submission do
   json.id submission.id
   json.canGrade can_grade
   json.canUpdate can_update
-  json.isCreator current_user == submission.creator
+  json.isCreator current_user.id == submission.creator_id
 
   if assessment.autograded? && !assessment.skippable?
     question = submission.questions.next_unanswered(submission)

--- a/app/views/course/assessment/submission/submissions/_topics.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_topics.json.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-json.topics submission.submission_questions.where(question: submission.questions) do |submission_question|
+json.topics submission_questions do |submission_question|
   topic = submission_question.discussion_topic
   json.id topic.id
   json.submissionQuestionId submission_question.id
@@ -7,7 +7,9 @@ json.topics submission.submission_questions.where(question: submission.questions
   json.postIds topic.post_ids
 end
 
-programming_answers = submission.answers.where(question: submission.questions).select do |answer|
+programming_answers = submission.answers.where(question: submission.questions).
+                      includes(actable: { files: { annotations: { discussion_topic: :posts } } }).
+                      select do |answer|
   answer.actable_type == Course::Assessment::Answer::Programming.name
 end.map(&:specific)
 
@@ -21,7 +23,7 @@ json.annotations programming_answers.flat_map(&:files) do |file|
   end
 end
 
-posts = submission.submission_questions.where(question: submission.questions).map(&:discussion_topic).flat_map(&:posts)
+posts = submission_questions.map(&:discussion_topic).flat_map(&:posts)
 posts += programming_answers.flat_map(&:files).flat_map(&:annotations).map(&:discussion_topic).flat_map(&:posts)
 
 json.posts posts do |post|

--- a/app/views/course/assessment/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/edit.json.jbuilder
@@ -26,9 +26,11 @@ json.assessment do
 end
 
 answers = @submission.current_answers
+submission_questions = @submission.submission_questions.
+                       where(question: @submission.questions).includes({ discussion_topic: :posts })
 
 json.partial! 'questions', assessment: @assessment, submission: @submission, can_grade: can_grade,
                            answers: answers
 json.partial! 'answers', submission: @submission, answers: answers
-json.partial! 'topics', submission: @submission, can_grade: can_grade
+json.partial! 'topics', submission: @submission, submission_questions: submission_questions, can_grade: can_grade
 json.partial! 'history', submission: @submission

--- a/app/views/course/assessment/submission/submissions/index.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/index.json.jbuilder
@@ -16,6 +16,7 @@ json.assessment do
 end
 
 my_students_set = Set.new(@my_students.map(&:id))
+current_course_user = current_course.course_users.find_by(user: current_user)
 
 json.submissions @course_users do |course_user|
   json.courseUser do
@@ -24,7 +25,7 @@ json.submissions @course_users do |course_user|
     json.phantom course_user.phantom?
     json.myStudent my_students_set.include?(course_user.id) if course_user.student?
     json.isStudent course_user.student?
-    json.isCurrentUser course_user.user == current_user
+    json.isCurrentUser course_user == current_course_user
   end
 
   submission = submissions_hash[course_user.id]

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -18,7 +18,7 @@
       submission.published? || (submission.graded? && can?(:grade, submission.assessment))
   - if can_see_grades
     td.table-grade
-      = submission.grade.to_s + ' / ' + assessment.maximum_grade.to_s
+      = submission.grade.to_f.to_s + ' / ' + assessment.maximum_grade.to_s
       - if submission.graded?
         span.text-danger title=t('.graded_not_published_warning')
           =< fa_icon 'exclamation-circle'.freeze

--- a/client/app/bundles/course/assessment/submission/components/CommentField.jsx
+++ b/client/app/bundles/course/assessment/submission/components/CommentField.jsx
@@ -31,11 +31,19 @@ export default class CommentField extends Component {
   }
 
   render() {
-    const { createComment, inputId, isSubmitting, value, airMode } = this.props;
+    const {
+      createComment,
+      inputId,
+      isSubmitting,
+      value,
+      airMode,
+      airModeColor,
+    } = this.props;
     return (
       <>
         <MaterialSummernote
           airMode={airMode}
+          airModeColor={airModeColor}
           disabled={isSubmitting}
           inputId={inputId}
           label={
@@ -64,6 +72,7 @@ CommentField.propTypes = {
   isSubmitting: PropTypes.bool,
   value: PropTypes.string,
   airMode: PropTypes.bool,
+  airModeColor: PropTypes.bool,
 
   createComment: PropTypes.func,
   handleChange: PropTypes.func,

--- a/client/app/bundles/course/assessment/submission/containers/Comments.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/Comments.jsx
@@ -48,6 +48,7 @@ class VisibleComments extends Component {
           inputId={VisibleComments.newCommentIdentifier(topic.id)}
           isSubmitting={commentForms.isSubmitting}
           value={commentForms.topics[topic.id]}
+          airModeColor={false}
         />
       </div>
     );

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
@@ -33,10 +33,13 @@ import {
 import SubmissionAnswer from '../../components/SubmissionAnswer';
 import QuestionGrade from '../../containers/QuestionGrade';
 import GradingPanel from '../../containers/GradingPanel';
-import Comments from '../../containers/Comments';
 import { formNames, questionTypes } from '../../constants';
 import translations from '../../translations';
 import submissionFormValidate from './submissionFormValidate';
+
+const Comments = React.lazy(() =>
+  import(/* webpackChunkName: "comment" */ '../../containers/Comments'),
+);
 
 const styles = {
   questionCardContainer: {
@@ -259,7 +262,16 @@ class SubmissionEditForm extends Component {
                 : null}
               {viewHistory ? null : this.renderQuestionGrading(id)}
               {viewHistory ? null : this.renderProgrammingQuestionActions(id)}
-              <Comments topic={topic} />
+              <Suspense
+                fallback={
+                  <>
+                    <br />
+                    <div>{intl.formatMessage(translations.loadingComment)}</div>
+                  </>
+                }
+              >
+                <Comments topic={topic} />
+              </Suspense>
               <hr />
             </Tab>
           );
@@ -270,6 +282,7 @@ class SubmissionEditForm extends Component {
 
   renderQuestions() {
     const {
+      intl,
       attempting,
       questionIds,
       questions,
@@ -309,7 +322,16 @@ class SubmissionEditForm extends Component {
                 : null}
               {viewHistory ? null : this.renderQuestionGrading(id)}
               {viewHistory ? null : this.renderProgrammingQuestionActions(id)}
-              <Comments topic={topic} />
+              <Suspense
+                fallback={
+                  <>
+                    <br />
+                    <div>{intl.formatMessage(translations.loadingComment)}</div>
+                  </>
+                }
+              >
+                <Comments topic={topic} />
+              </Suspense>
               <hr />
             </Element>
           );
@@ -582,9 +604,9 @@ class SubmissionEditForm extends Component {
         {this.renderUnmarkButton()}
         {this.renderPublishButton()}
 
-        {this.renderSubmitDialog()}
-        {this.renderUnsubmitDialog()}
-        {this.renderResetDialog()}
+        {this.state.submitConfirmation && this.renderSubmitDialog()}
+        {this.state.unsubmitConfirmation && this.renderUnsubmitDialog()}
+        {this.state.resetConfirmation && this.renderResetDialog()}
         {this.renderExamDialog()}
       </Card>
     );

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -138,6 +138,10 @@ const translations = defineMessages({
     id: 'course.assessment.submission.questionNumber',
     defaultMessage: 'Q{number}',
   },
+  loadingComment: {
+    id: 'course.assessment.submission.loadingComment',
+    defaultMessage: 'Loading comment field...',
+  },
   comments: {
     id: 'course.assessment.submission.comments',
     defaultMessage: 'Comments',

--- a/client/app/lib/components/MaterialSummernote.jsx
+++ b/client/app/lib/components/MaterialSummernote.jsx
@@ -27,6 +27,7 @@ const propTypes = {
   required: PropTypes.bool,
   value: PropTypes.string,
   airMode: PropTypes.bool,
+  airModeColor: PropTypes.bool,
   intl: intlShape,
 };
 
@@ -201,7 +202,7 @@ class MaterialSummernote extends React.Component {
                   ['style', ['style']],
                   ['font', ['bold', 'underline', 'inlineCode', 'clear']],
                   ['script', ['superscript', 'subscript']],
-                  ['color', ['color']],
+                  ...(this.props.airModeColor ? ['color', ['color']] : []),
                   ['para', ['ul', 'ol', 'paragraph']],
                   ['table', ['table']],
                   ['insert', ['link', 'picture']],
@@ -239,5 +240,8 @@ class MaterialSummernote extends React.Component {
 
 MaterialSummernote.propTypes = propTypes;
 MaterialSummernote.contextTypes = contextTypes;
+MaterialSummernote.defaultProps = {
+  airModeColor: true,
+};
 
 export default injectIntl(MaterialSummernote);

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe Course::Assessment::Submission do
 
       it 'sums the grade of all answers' do
         grade = submission.answers.map(&:grade).compact.sum - earlier_answer.grade
-        expect(submission.grade).to eq(grade)
+        expect(submission.grade.to_f).to eq(grade)
       end
     end
 


### PR DESCRIPTION
**3 main areas for optimization:**
**1. Submission statistics CSV download**
- Backend: N+1 queries

**2. Submissions index** 
- Backend: N+1 queries

**3. Submissions edit**
- Backend: N+1 queries
- Frontend: Initializing multiple instances of summernote in a page is slow (https://github.com/summernote/summernote/issues/3387). For now, we disable the color palette, as it is the main bottleneck, for pages that need to render multiple comment fields in a page (non-autograded submission edit - SubmissionsEditForm). For autograded submission edit page (SubmissionsEditStepForm), the comment field is only initialized once and hence the loading is quite fast.
- Added code-splitting for dynamic rendering of the comment field in the page.

Local
![image](https://user-images.githubusercontent.com/42570513/145947731-3a40e1b3-dbfc-467c-823a-b23d1acddadb.png)

Staging
![image](https://user-images.githubusercontent.com/42570513/145947769-8de71803-9d9b-4805-9746-4c4856acfd4f.png)
