### PR TITLE
Update exp when a question's Autograder package is updated for an autograded assessment

### DIFF
--- a/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
@@ -26,8 +26,18 @@ class Course::Assessment::Answer::ReducePriorityAutoGradingJob < ApplicationJob
   def perform_tracked(answer, redirect_to_path = nil)
     ActsAsTenant.without_tenant do
       Course::Assessment::Answer::AutoGradingService.grade(answer)
+      if update_exp?(answer.submission)
+        Course::Assessment::Submission::CalculateExpService.update_exp(answer.submission)
+      end
     end
 
     redirect_to redirect_to_path
+  end
+
+  private
+
+  def update_exp?(submission)
+    submission.assessment.autograded? && !submission.attempting? &&
+      !submission.awarded_at.nil? && submission.awarder == User.system
   end
 end

--- a/app/services/course/assessment/submission/calculate_exp_service.rb
+++ b/app/services/course/assessment/submission/calculate_exp_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+class Course::Assessment::Submission::CalculateExpService
+  class << self
+    # Updates the exp for a submission
+    #
+    # @param [Course::Assessment::Submission] submission The answer to be graded.
+    def update_exp(submission)
+      submission.points_awarded = calculate_exp(submission).to_i
+      submission.awarder = User.system
+      submission.awarded_at = Time.zone.now
+      submission.save!
+    end
+
+    # Calculates the exp given a specific submission of an assessment.
+    # Calculating scheme:
+    #   Submit before bonus cutoff: ( base_exp + bonus_exp ) * actual_grade / max_grade
+    #   Submit after bonus cutoff: base_exp * actual_grade / max_grade
+    #   Submit after end_at: 0
+    # @param [Course::Assessment::Submission] submission The submission of which the exp needs to be calculated.
+    def calculate_exp(submission)
+      assessment = submission.assessment
+      end_at = assessment.end_at
+      bonus_end_at = assessment.bonus_end_at
+      total_exp = assessment.base_exp
+
+      return 0 if end_at && submission.submitted_at > end_at
+
+      total_exp += assessment.time_bonus_exp if bonus_end_at && submission.submitted_at <= bonus_end_at
+
+      maximum_grade = submission.questions.sum(:maximum_grade).to_f
+
+      maximum_grade == 0 ? total_exp : submission.grade.to_f / maximum_grade * total_exp
+    end
+  end
+end

--- a/app/services/course/assessment/submission/calculate_exp_service.rb
+++ b/app/services/course/assessment/submission/calculate_exp_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Course::Assessment::Submission::CalculateExpService
   class << self
-    # Updates the exp for a submission
-    #
+    # Updates the exp for an autograded submission that will be awarded by the system
+    # and the awarding time is the current time.
     # @param [Course::Assessment::Submission] submission The answer to be graded.
     def update_exp(submission)
       submission.points_awarded = calculate_exp(submission).to_i

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
@@ -161,9 +161,10 @@ export default defineMessages({
   submitConfirmation: {
     id: 'course.assessment.question.programming.programmingQuestionForm.submitConfirmation',
     defaultMessage:
-      'There are existing submissions for this question.\
-      Updating this question will re-grade submitted answers to this question and\
-      only system-generated exp points for the submissions will be re-calculated.\
-      Are you sure you wish continue?',
+      'There are existing submissions for this autograded question.\
+      Updating this question will re-grade all submitted answers to this question and\
+      only system-issued EXP for the submissions will be re-calculated.\
+      Note that manually-issued EXP will not be updated.\
+      Are you sure you wish to continue?',
   },
 });

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
@@ -158,4 +158,12 @@ export default defineMessages({
     id: 'course.assessment.question.programming.programmingQuestionForm.timeLimitRangeValidationError',
     defaultMessage: 'Time limit must be within 1 to 30.',
   },
+  submitConfirmation: {
+    id: 'course.assessment.question.programming.programmingQuestionForm.submitConfirmation',
+    defaultMessage:
+      'There are existing submissions for this question.\
+      Updating this question will re-grade submitted answers to this question and\
+      only system-generated exp points for the submissions will be re-calculated.\
+      Are you sure you wish continue?',
+  },
 });

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -22,7 +22,7 @@ import OnlineEditor, {
 import UploadedPackageView from '../../components/UploadedPackageView';
 import styles from './ProgrammingQuestionForm.scss';
 import translations from './ProgrammingQuestionForm.intl';
-import ConfirmationDialog from '../../../../../../../lib/components/ConfirmationDialog';
+import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 
 const propTypes = {
   data: PropTypes.instanceOf(Immutable.Map).isRequired,

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -14,6 +14,7 @@ import { Tabs, Tab } from 'material-ui/Tabs';
 import { red500 } from 'material-ui/styles/colors';
 import MaterialSummernote from 'lib/components/MaterialSummernote';
 import ChipInput from 'material-ui-chip-input';
+import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 
 import BuildLog from '../../components/BuildLog';
 import OnlineEditor, {
@@ -22,7 +23,6 @@ import OnlineEditor, {
 import UploadedPackageView from '../../components/UploadedPackageView';
 import styles from './ProgrammingQuestionForm.scss';
 import translations from './ProgrammingQuestionForm.intl';
-import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 
 const propTypes = {
   data: PropTypes.instanceOf(Immutable.Map).isRequired,

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -22,6 +22,7 @@ import OnlineEditor, {
 import UploadedPackageView from '../../components/UploadedPackageView';
 import styles from './ProgrammingQuestionForm.scss';
 import translations from './ProgrammingQuestionForm.intl';
+import ConfirmationDialog from '../../../../../../../lib/components/ConfirmationDialog';
 
 const propTypes = {
   data: PropTypes.instanceOf(Immutable.Map).isRequired,
@@ -121,6 +122,11 @@ class ProgrammingQuestionForm extends React.Component {
     return value === null ? '' : value;
   }
 
+  constructor(props) {
+    super(props);
+    this.state = { confirmationOpen: false };
+  }
+
   componentDidMount() {
     this.summernoteEditors = $(
       '#programming-question-form .note-editor .note-editable',
@@ -173,6 +179,22 @@ class ProgrammingQuestionForm extends React.Component {
     e.preventDefault();
     if (!this.validationCheck()) return;
 
+    const autograded = this.props.data.getIn(['question', 'autograded']);
+    const hasSubmissions = this.props.data.getIn([
+      'question',
+      'has_submissions',
+    ]);
+
+    if (autograded && hasSubmissions) {
+      this.setState((prevState) => ({
+        confirmationOpen: !prevState.confirmationOpen,
+      }));
+    } else {
+      this.handleSubmit();
+    }
+  };
+
+  handleSubmit = () => {
     const url = this.props.data.getIn(['form_data', 'path']);
     const method = this.props.data.getIn(['form_data', 'method']);
 
@@ -793,6 +815,19 @@ class ProgrammingQuestionForm extends React.Component {
               ) : null
             }
           />
+          {this.state.confirmationOpen && (
+            <ConfirmationDialog
+              message={this.props.intl.formatMessage(
+                translations.submitConfirmation,
+              )}
+              open={this.state.confirmationOpen}
+              onCancel={() => this.setState({ confirmationOpen: false })}
+              onConfirm={() => {
+                this.handleSubmit();
+                this.setState({ confirmationOpen: false });
+              }}
+            />
+          )}
         </form>
       </div>
     );

--- a/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
@@ -7,15 +7,13 @@ RSpec.describe Course::Assessment::Answer::AutoGradingJob do
     subject { Course::Assessment::Answer::AutoGradingJob }
     let(:course) { create(:course) }
     let(:student_user) { create(:course_student, course: course).user }
+    let(:assessment_traits) { [] }
     let(:assessment) do
-      create(:assessment, :published_with_mrq_question, course: course)
+      create(:assessment, :published_with_mrq_question, *assessment_traits, course: course)
     end
     let(:question) { assessment.questions.first }
-    let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
-    let(:answer) do
-      create(:course_assessment_answer_multiple_response, :submitted,
-             assessment: assessment, submission: submission, question: question).answer
-    end
+    let(:submission) { create(:submission, :published, assessment: assessment, creator: student_user) }
+    let(:answer) { submission.answers.first }
     let!(:auto_grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
 
     it 'can be queued' do
@@ -23,9 +21,37 @@ RSpec.describe Course::Assessment::Answer::AutoGradingJob do
         have_enqueued_job(subject).exactly(:once).on_queue('highest')
     end
 
-    it 'evaluates answers' do
-      subject.perform_now(answer)
-      expect(answer).to be_evaluated
+    context 'when the assessment is non-autograded' do
+      it 'evaluates answers and does not update the exp' do
+        initial_points = submission.points_awarded
+
+        subject.perform_now(answer)
+        expect(answer).to be_graded
+        expect(submission.points_awarded).to eq(initial_points)
+      end
+    end
+
+    context 'when the assessment is autograded' do
+      before do
+        question = answer.question.actable
+        correct_options = question.options.select(&:correct)
+        correct_options.each { |option| answer.actable.options << option }
+        answer.save!
+        submission.update!(awarder: User.system)
+      end
+
+      let(:assessment_traits) { [:autograded] }
+
+      it 'evaluates answers and updates the exp' do
+        initial_points = submission.points_awarded
+
+        subject.perform_now(answer)
+        expect(answer).to be_graded
+        expect(answer.grade).to eq(question.maximum_grade)
+        correct_exp = assessment.base_exp + assessment.time_bonus_exp
+        expect(submission.points_awarded).to eq(correct_exp)
+        expect(submission.points_awarded).not_to eq(initial_points)
+      end
     end
   end
 end

--- a/spec/jobs/course/assessment/answer/reduce_priority_auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/reduce_priority_auto_grading_job_spec.rb
@@ -9,14 +9,11 @@ RSpec.describe Course::Assessment::Answer::ReducePriorityAutoGradingJob do
     let(:course) { create(:course) }
     let(:student_user) { create(:course_student, course: course).user }
     let(:assessment) do
-      create(:assessment, :published_with_mrq_question, course: course)
+      create(:assessment, :published_with_mrq_question, :autograded, course: course)
     end
     let(:question) { assessment.questions.first }
-    let(:submission) { create(:submission, assessment: assessment, creator: student_user) }
-    let(:answer) do
-      create(:course_assessment_answer_multiple_response, :submitted,
-             assessment: assessment, submission: submission, question: question).answer
-    end
+    let(:submission) { create(:submission, :published, assessment: assessment, creator: student_user) }
+    let(:answer) { submission.answers.first }
     let!(:auto_grading) { create(:course_assessment_answer_auto_grading, answer: answer) }
 
     it 'can be queued' do
@@ -24,9 +21,41 @@ RSpec.describe Course::Assessment::Answer::ReducePriorityAutoGradingJob do
         have_enqueued_job(subject).exactly(:once).on_queue('medium_high')
     end
 
-    it 'evaluates answers' do
-      subject.perform_now(answer)
-      expect(answer).to be_evaluated
+    context 'when the initial wrong answer is re-evaluated' do
+      before do
+        submission.update!(awarder: User.system)
+      end
+
+      it 'evaluates answers and updates the exp' do
+        initial_points = submission.points_awarded
+
+        subject.perform_now(answer)
+        expect(answer).to be_graded
+        expect(answer.grade).to eq(0)
+        expect(submission.points_awarded).to eq(0)
+        expect(submission.points_awarded).not_to eq(initial_points)
+      end
+    end
+
+    context 'when the initial wrong answer is changed to correct one and re-evaluated' do
+      before do
+        question = answer.question.actable
+        correct_options = question.options.select(&:correct)
+        correct_options.each { |option| answer.actable.options << option }
+        answer.save!
+        submission.update!(awarder: User.system)
+      end
+
+      it 'evaluates answers and updates the exp' do
+        initial_points = submission.points_awarded
+
+        subject.perform_now(answer)
+        expect(answer).to be_graded
+        expect(answer.grade).to eq(question.maximum_grade)
+        correct_exp = assessment.base_exp + assessment.time_bonus_exp
+        expect(submission.points_awarded).to eq(correct_exp)
+        expect(submission.points_awarded).not_to eq(initial_points)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #4204 

## **Summary**
Backend:
- If the EXP record for the associated assessment is awarded by the system (as opposed to a manual award by a tutor), then the EXP record should be recomputed based on the percentage of test cases passed.
- If the EXP record is manually awarded (overriden/updated) by an actual user (as opposed to an automatic system action), then the EXP record should remain unchanged.

Frontend:
- A confirmation dialog pops up when updating autograder packages of auto-graded assessments with existing submissions.

## **Test Plan**

Run the modified tests:

```shell
rspec spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
rspec spec/jobs/course/assessment/answer/reduce_priority_auto_grading_job_spec.rb
```

Check that the React frontend looks good:

The confirmation dialog will only appear for autograded assessment with existing submission.

![image](https://user-images.githubusercontent.com/42570513/145820019-c2275f7a-44ea-44c9-a97b-ac06b757dede.png)

