### PR TITLE
Fix non-registered admin could not view forum page for unregistered course

### DIFF
--- a/app/views/course/forum/forums/_subscribe_button.html.slim
+++ b/app/views/course/forum/forums/_subscribe_button.html.slim
@@ -1,9 +1,9 @@
 - course_user = current_course.course_users.find_by(user_id: user.id)
 - email_enabled = current_course.email_enabled(:forums, :new_topic)
-- is_enabled_as_phantom = course_user.phantom? && email_enabled.phantom
-- is_enabled_as_regular = !course_user.phantom? && email_enabled.regular
+- is_enabled_as_phantom = course_user&.phantom? && email_enabled.phantom
+- is_enabled_as_regular = !course_user&.phantom? && email_enabled.regular
 - admin_enable_email = is_enabled_as_phantom || is_enabled_as_regular
-- user_unsubscribed = course_user.email_unsubscriptions.where(course_settings_email_id: email_enabled.id).exists?
+- user_unsubscribed = course_user&.email_unsubscriptions&.where(course_settings_email_id: email_enabled.id)&.exists?
 
 - if !admin_enable_email
   - subscribe_tooltip = t('course.forum.forums.subscribe.admin_disabled')

--- a/app/views/course/forum/topics/_subscribe_button.html.slim
+++ b/app/views/course/forum/topics/_subscribe_button.html.slim
@@ -1,9 +1,9 @@
 - course_user = current_course.course_users.find_by(user_id: current_user.id)
 - email_enabled = current_course.email_enabled(:forums, :post_replied)
-- is_enabled_as_phantom = course_user.phantom? && email_enabled.phantom
-- is_enabled_as_regular = !course_user.phantom? && email_enabled.regular
+- is_enabled_as_phantom = course_user&.phantom? && email_enabled.phantom
+- is_enabled_as_regular = !course_user&.phantom? && email_enabled.regular
 - admin_enable_email = is_enabled_as_phantom || is_enabled_as_regular
-- user_unsubscribed = course_user.email_unsubscriptions.where(course_settings_email_id: email_enabled.id).exists?
+- user_unsubscribed = course_user&.email_unsubscriptions&.where(course_settings_email_id: email_enabled.id)&.exists?
 
 - if !admin_enable_email
   - subscribe_tooltip = t('course.forum.topics.subscribe.admin_disabled')

--- a/app/views/course/forum/topics/_topic.html.slim
+++ b/app/views/course/forum/topics/_topic.html.slim
@@ -2,10 +2,10 @@
 - topic_class.concat(unread_class(topic))
 - course_user = current_course.course_users.find_by(user_id: current_user.id)
 - email_enabled = current_course.email_enabled(:forums, :post_replied)
-- is_enabled_as_phantom = course_user.phantom? && email_enabled.phantom
-- is_enabled_as_regular = !course_user.phantom? && email_enabled.regular
+- is_enabled_as_phantom = course_user&.phantom? && email_enabled.phantom
+- is_enabled_as_regular = !course_user&.phantom? && email_enabled.regular
 - admin_enable_email = is_enabled_as_phantom || is_enabled_as_regular
-- user_unsubscribed = course_user.email_unsubscriptions.where(course_settings_email_id: email_enabled.id).exists?
+- user_unsubscribed = course_user&.email_unsubscriptions&.where(course_settings_email_id: email_enabled.id)&.exists?
 
 = content_tag_for(:tr, topic, class: topic_class) do
   td = fa_icon 'envelope' if topic.unread?(current_user)


### PR DESCRIPTION
When a user with admin role opens the forum page, the user could not view the page as the user is not registered in the course. This PR fixes it.