### PR TITLE
Fix CircleCI yarn build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-yarn-{{ checksum "client/yarn.lock" }}
+            - v1.1-yarn-{{ checksum "client/yarn.lock" }}
 
       # Build frontend JS
       - run: cd client && yarn install && yarn build:production && cd -
@@ -54,9 +54,13 @@ jobs:
       - save_cache:
           paths:
             - ./client/node_modules
+          key: v1.1-yarn-{{ checksum "client/yarn.lock" }}
+
+      - save_cache:
+          paths:
             - ./client/build
             - ./public/webpack
-          key: v1-yarn-{{ checksum "client/yarn.lock" }}
+          key: v1.1-yarn-build-{{ .Revision }}
 
   test:
     docker:
@@ -97,7 +101,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-yarn-{{ checksum "client/yarn.lock" }}
+            - v1.1-yarn-{{ checksum "client/yarn.lock" }}
+
+      - restore_cache:
+          keys:
+            - v1.1-yarn-build-{{ .Revision }}
 
       # Install bundler version
       - run:

--- a/spec/features/course/assessment/answer/forum_post_response_answer_spec.rb
+++ b/spec/features/course/assessment/answer/forum_post_response_answer_spec.rb
@@ -73,14 +73,10 @@ RSpec.describe 'Course: Assessments: Submissions: Forum Post Response Answers', 
       scenario 'I am informed of the lack of forum posts to select' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
         click_button('Select Forum Post')
-        expect(page).to have_text('You currently do not have any posts. Create one on the forum now!')
+        expect(page).to have_text('You currently do not have any posts. Create one on the forums now!')
       end
 
-      # TODO: The following 3 tests cannot pass on CI as the forum card is not
-      # rendered/selectable for some reason. Need to look into this subsequently.
-      # Likely, the topic card, forum post option, etc. are also not rendered.
-
-      pending 'I am able to see and select my forum posts' do
+      scenario 'I am able to see and select my forum posts' do
         topic = create(:forum_topic, course: course)
         forum_post = create(:course_discussion_post, topic: topic.acting_as, creator: user)
         visit edit_course_assessment_submission_path(course, assessment, submission)
@@ -100,7 +96,7 @@ RSpec.describe 'Course: Assessments: Submissions: Forum Post Response Answers', 
         expect(page).to have_selector('div.selected-forum-post-card', count: 1)
       end
 
-      pending 'I can save my post packs submission' do
+      scenario 'I can save my post packs submission' do
         topic = create(:forum_topic, course: course)
         forum_post = create(:course_discussion_post, topic: topic.acting_as, creator: user)
         visit edit_course_assessment_submission_path(course, assessment, submission)
@@ -120,7 +116,7 @@ RSpec.describe 'Course: Assessments: Submissions: Forum Post Response Answers', 
         expect(submission.current_answers.first.specific.reload.post_packs[0].post_id).to eq(forum_post.id)
       end
 
-      pending 'I cannot update my post packs after finalising' do
+      scenario 'I cannot update my post packs after finalising' do
         topic = create(:forum_topic, course: course)
         create(:course_discussion_post, topic: topic.acting_as, creator: user)
         visit edit_course_assessment_submission_path(course, assessment, submission)

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -113,8 +113,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions' do
         expect(graded_submission.points_awarded).not_to be_nil
       end
 
-      # Works locally but fails in CirlceCI
-      pending 'I can force submit all unsubmitted exams', js: true do
+      scenario 'I can force submit all unsubmitted exams', js: true do
         visit course_assessment_submissions_path(course, assessment)
         find('#students-tab').click
 


### PR DESCRIPTION
Previously, some tests involving interaction with JS frontend failed despite those could pass locally. After further 'investigation', it was found that the each new test job uses cached build which is based on checksum of yarn.lock file. So if there is no change to that file, circleci will keep on using the same older frontend build from the last commit when yarn.lock changes.

In this PR, we will only cache node-module to be used across different commits if there is no change, whereas the build is cached for the specific commit and will not be used in different commit.