### PR TITLE
Fix flaky circleci test - survey question option attachment null failure

### DIFF
--- a/spec/factories/course_survey_question_options.rb
+++ b/spec/factories/course_survey_question_options.rb
@@ -11,7 +11,10 @@ FactoryBot.define do
     weight { last_weight ? last_weight + 1 : 0 }
 
     trait :with_attachment do
-      attachment_reference
+      after(:build) do |question_option|
+        attachment = create(:attachment_reference)
+        question_option.attachment_reference = attachment
+      end
     end
   end
 end


### PR DESCRIPTION
For the null attachment flaky tests described in #4040, it could happen as the attachment object is not properly built. We try to fix this by explicitly creating the attachment after the question option is created.

Tested 5 times in CircleCI and so far the flaky tests do not appear anymore altho Codecov gets angsty for bugging it too much:(