### PR TITLE
Fix some minor personalized timeline issues

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -145,7 +145,7 @@ module Course::LessonPlan::PersonalizationConcern
             personal_point + ((reference_time.end_at - reference_point) * learning_rate_ema),
             course_tz,
             STRAGGLERS_DATE_ROUNDING_THRESHOLD,
-            to_2359: true
+            to_2359: true # rubocop:disable Naming/VariableNumber
           )
           # Hard limits to make sure we don't fail bounds checks
           new_end_at = [new_end_at, reference_time.end_at, reference_time.start_at].compact.max

--- a/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
+++ b/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
@@ -71,8 +71,7 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
 
         submit_assessment(assessment)
         dummy_controller.send(:update_personalized_timeline_for, course_user)
-        new_end_at = yet_to_open_assessment.reload.lesson_plan_item.personal_time_for(course_user).end_at
-
+        new_end_at = yet_to_open_assessment.lesson_plan_item.personal_time_for(course_user).end_at
         expect(new_end_at).to be < original_end_at
       end
 
@@ -83,9 +82,17 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
 
         submit_assessment(assessment)
         dummy_controller.send(:update_personalized_timeline_for, course_user)
-        new_end_at = already_open_assessment.reload.lesson_plan_item.personal_time_for(course_user).end_at
+        new_end_at = already_open_assessment.lesson_plan_item.personal_time_for(course_user).end_at
 
         expect(new_end_at).to eq(original_end_at)
+      end
+
+      it 'rounds off to 2359' do
+        submit_assessment(overdue_assessment)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        end_at = assessment.lesson_plan_item.personal_time_for(course_user).end_at
+        course_tz = course.time_zone
+        expect(end_at.in_time_zone(course_tz).strftime('%H:%M')).to eq('23:59')
       end
     end
 

--- a/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
+++ b/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
@@ -11,20 +11,25 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
     let(:dummy_controller) { self.class::DummyController.new }
 
     let!(:course) { create(:course) }
-    let!(:assessment1) do
+    let!(:assessment) do
       create(:course_assessment_assessment, course: course, end_at: 3.days.from_now, published: true)
     end
-    let!(:assessment2) do
-      create(:course_assessment_assessment, course: course, end_at: 3.days.from_now, published: true)
+    let!(:overdue_assessment) do
+      create(:course_assessment_assessment, course: course, start_at: 20.days.ago, end_at: 10.days.ago, published: true)
     end
-    let!(:assessment3) do
-      create(:course_assessment_assessment, course: course, end_at: 3.days.from_now, published: true)
+    let!(:yet_to_open_assessment) do
+      create(:course_assessment_assessment, course: course, start_at: 1.days.from_now, end_at: 10.days.from_now,
+                                            published: true)
+    end
+    let!(:already_open_assessment) do
+      create(:course_assessment_assessment, course: course, start_at: 1.days.ago, end_at: 10.days.from_now,
+                                            published: true)
     end
 
     context 'when course user is on the fixed algorithm' do
       let!(:course_user) { create(:course_user, course: course, timeline_algorithm: 'fixed') }
       let!(:submission1) do
-        create(:course_assessment_submission, assessment: assessment1, creator: course_user.user).tap(&:finalise!)
+        create(:course_assessment_submission, assessment: assessment, creator: course_user.user).tap(&:finalise!)
       end
 
       it 'does not create any personal times' do
@@ -36,7 +41,7 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
     context 'when course user is on the fomo algorithm' do
       let!(:course_user) { create(:course_user, course: course, timeline_algorithm: 'fomo') }
       let!(:submission1) do
-        create(:course_assessment_submission, assessment: assessment1, creator: course_user.user).tap(&:finalise!)
+        create(:course_assessment_submission, assessment: assessment, creator: course_user.user).tap(&:finalise!)
       end
 
       it 'creates personal times' do
@@ -47,20 +52,47 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
 
     context 'when course user is on the stragglers algorithm' do
       let!(:course_user) { create(:course_user, course: course, timeline_algorithm: 'stragglers') }
-      let!(:submission1) do
-        create(:course_assessment_submission, assessment: assessment1, creator: course_user.user).tap(&:finalise!)
+
+      def submit_assessment(assessment)
+        create(:course_assessment_submission, assessment: assessment, creator: course_user.user).
+          tap(&:finalise!)
       end
 
       it 'creates personal times' do
+        submit_assessment(assessment)
         dummy_controller.send(:update_personalized_timeline_for, course_user)
         expect(course_user.personal_times.count).to eq(course.assessments.count - 1)
+      end
+
+      it 'shifts the end_at of non-open items forward' do
+        submit_assessment(overdue_assessment)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        original_end_at = yet_to_open_assessment.lesson_plan_item.personal_time_for(course_user).end_at
+
+        submit_assessment(assessment)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        new_end_at = yet_to_open_assessment.reload.lesson_plan_item.personal_time_for(course_user).end_at
+
+        expect(new_end_at).to be < original_end_at
+      end
+
+      it 'does not shift the end_at of already open items forward' do
+        submit_assessment(overdue_assessment)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        original_end_at = already_open_assessment.lesson_plan_item.personal_time_for(course_user).end_at
+
+        submit_assessment(assessment)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        new_end_at = already_open_assessment.reload.lesson_plan_item.personal_time_for(course_user).end_at
+
+        expect(new_end_at).to eq(original_end_at)
       end
     end
 
     context 'when course user is on the otot algorithm' do
       let!(:course_user) { create(:course_user, course: course, timeline_algorithm: 'otot') }
       let!(:submission1) do
-        create(:course_assessment_submission, assessment: assessment1, creator: course_user.user).tap(&:finalise!)
+        create(:course_assessment_submission, assessment: assessment, creator: course_user.user).tap(&:finalise!)
       end
 
       it 'creates personal times' do


### PR DESCRIPTION
## Summary

Fixes the first two points mentioned in #4203. The other point will be covered in the next phase. The time snap for deadlines is now adjusted to 2359 as well.

Now, the algorithm will not shift the deadlines of already-open items forward, only backwards. It can also now shift already-past deadlines backwards (but never forwards).

The cases covered are:

- Students on Stragglers and remain on Stragglers.
- Students on Stragglers who have just switched to FOMO due to OTOT.

There are, of course, some limitations to these changes. A possible scenario would be when an instructor shortens the time given to an already-open assessment, which would cause all the personal times to shrink (by right). However, that would not happen due to this change in the algorithm. Unfortunately, the instructor will need to manually update the timings for all students.

A fix to this (which will be PRed later) would be to include an optional parameter, such that recomputations will only occur when the instructor initiates the change, and not due to a submission by the student.

## Test Plan

Unfortunately, it's quite difficult to test the algorithm directly as, even when doing black-box testing, the change that actually happens is quite hard to "predict", not that it's not deterministic, but that it depends on the length of the course, constants specified, etc.

Some tests have been added but it's honestly not very ideal to test without further refactoring.