### PR TITLE
Remove N+1 queries in various pages

### DIFF
--- a/app/controllers/course/statistics_controller.rb
+++ b/app/controllers/course/statistics_controller.rb
@@ -12,8 +12,8 @@ class Course::StatisticsController < Course::ComponentController
   end
 
   def staff
-    @staffs = current_course.course_users.teaching_assistant_and_manager.includes(:group_users)
-    @staffs = CourseUser.order_by_average_marking_time(@staffs)
+    @staff = current_course.course_users.teaching_assistant_and_manager.includes(:group_users)
+    @staff = CourseUser.order_by_average_marking_time(@staff)
   end
 
   private

--- a/app/controllers/course/statistics_controller.rb
+++ b/app/controllers/course/statistics_controller.rb
@@ -12,7 +12,7 @@ class Course::StatisticsController < Course::ComponentController
   end
 
   def staff
-    @staffs = current_course.course_users.teaching_assistant_and_manager
+    @staffs = current_course.course_users.teaching_assistant_and_manager.includes(:group_users)
     @staffs = CourseUser.order_by_average_marking_time(@staffs)
   end
 

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -39,9 +39,6 @@ module Course::Discussion::TopicsHelper
       end
   end
 
-  # TODO: Consider adding `creator_id` column to the programming file annotation table.
-  # See https://github.com/Coursemology/coursemology2/issues/2880.
-  #
   # This replaces what the `from_user` scopes in the specific models were doing when getting
   # my_students_unread_count, for better performance.
   def from_user(topic, my_student_ids) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity

--- a/app/views/course/discussion/topics/_tabs.html.slim
+++ b/app/views/course/discussion/topics/_tabs.html.slim
@@ -1,6 +1,6 @@
 - if current_course_user&.teaching_staff? || can?(:manage, current_course)
   = tabs do
-    - my_students_exist = current_course_user&.my_students.any?
+    - my_students_exist = !current_course_user&.my_students&.empty?
     - if my_students_exist
       = nav_to my_students_pending_course_topics_path(current_course) do
         = t('.my_students_pending')

--- a/app/views/course/discussion/topics/_tabs.html.slim
+++ b/app/views/course/discussion/topics/_tabs.html.slim
@@ -1,12 +1,14 @@
 - if current_course_user&.teaching_staff? || can?(:manage, current_course)
   = tabs do
-    = nav_to my_students_pending_course_topics_path(current_course) do
-      = t('.my_students_pending')
-      =< badge(my_students_unread_count) if my_students_unread_count > 0
+    - my_students_exist = current_course_user&.my_students.any?
+    - if my_students_exist
+      = nav_to my_students_pending_course_topics_path(current_course) do
+        = t('.my_students_pending')
+        =< badge(my_students_unread_count) if my_students_unread_count > 0
     = nav_to pending_course_topics_path(current_course) do
       = t('.pending')
       =< badge(all_staff_unread_count) if all_staff_unread_count > 0
-    = nav_to t('.my_students'), my_students_course_topics_path(current_course)
+    = nav_to t('.my_students'), my_students_course_topics_path(current_course) if my_students_exist
     = nav_to t('.all'), course_topics_path(current_course)
 - elsif current_course_user&.student?
   = tabs do

--- a/app/views/course/groups/_group.html.slim
+++ b/app/views/course/groups/_group.html.slim
@@ -2,8 +2,11 @@
   th = link_to format_inline_text(group.name), course_group_path(current_course, group)
   - normal_user_count = group.group_users.count { |group_user| !group_user.course_user.phantom? }
   - all_user_count = group.group_users.size
+  / normal student count in a group
   td = normal_user_count
+  / phantom student count in a group 
   td = all_user_count - normal_user_count
+  / total student count in a group
   td = all_user_count
   td
     - group.group_users.select(&:manager?).map(&:course_user).each do |manager|

--- a/app/views/course/groups/_group.html.slim
+++ b/app/views/course/groups/_group.html.slim
@@ -1,8 +1,10 @@
 = content_tag_for(:tr, group) do
   th = link_to format_inline_text(group.name), course_group_path(current_course, group)
-  td = group.course_users.without_phantom_users.count
-  td = group.course_users.phantom.count
-  td = group.course_users.count
+  - normal_user_count = group.group_users.count { |group_user| !group_user.course_user.phantom? }
+  - all_user_count = group.group_users.size
+  td = normal_user_count
+  td = all_user_count - normal_user_count
+  td = all_user_count
   td
     - group.group_users.select(&:manager?).map(&:course_user).each do |manager|
       div

--- a/app/views/course/statistics/_staff_performance.html.slim
+++ b/app/views/course/statistics/_staff_performance.html.slim
@@ -5,7 +5,7 @@
   td.text-center
     = staff.published_submissions.size
   td.text-center
-    = staff.my_students.count
+    = staff.group_users.count { |group_user| group_user.role == 'normal' }
   td.text-center
     = seconds_to_str(staff.average_marking_time)
   td.text-center

--- a/app/views/course/statistics/_staff_performance.html.slim
+++ b/app/views/course/statistics/_staff_performance.html.slim
@@ -5,6 +5,7 @@
   td.text-center
     = staff.published_submissions.size
   td.text-center
+    / number of students in a group for the staff
     = staff.group_users.count { |group_user| group_user.role == 'normal' }
   td.text-center
     = seconds_to_str(staff.average_marking_time)

--- a/app/views/course/statistics/staff.html.slim
+++ b/app/views/course/statistics/staff.html.slim
@@ -1,6 +1,6 @@
 = page_header
 
-- graded_staff = @staffs.reject { |staff| staff.published_submissions.empty? }
+- graded_staff = @staff.reject { |staff| staff.published_submissions.empty? }
 - if graded_staff.empty?
   div.alert.alert-info
     = t('.no_statistics')

--- a/config/locales/en/course/assessment/submissions.yml
+++ b/config/locales/en/course/assessment/submissions.yml
@@ -13,7 +13,7 @@ en:
           graded_not_published_warning: >
             These grades can't be seen by the student until they are published.
         tabs:
-          my_students_pending: 'My Students'
+          my_students_pending: 'My Students Pending'
           all_pending: 'All Pending Submissions'
         filter:
           student: 'Student'


### PR DESCRIPTION
Optimises loading for the following pages:
1. groups index
2. staff statistics
3. sidebar component (unread count if theres mystudents for a user) -> practically affects every page