### PR TITLE
Fix submissions tab page performance

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -7,10 +7,12 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   def index # :nodoc:
     @submissions = @submissions.from_category(category).confirmed
     @submissions = @submissions.filter_by_params(filter_params) unless filter_params.blank?
+    load_assessments
   end
 
   def pending
     @submissions = pending_submissions.from_course(current_course)
+    load_assessments
   end
 
   private
@@ -72,6 +74,15 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   def load_group_managers
     course_staff = current_course.course_users.staff.includes(:groups)
     @service = Course::GroupManagerPreloadService.new(course_staff)
+  end
+
+  # Load assessments hash
+  def load_assessments
+    ids = @submissions.map(&:assessment_id)
+    @assessments = Course::Assessment.where(id: ids).calculated(:maximum_grade)
+    @assessments_hash = @assessments.to_h do |assessment|
+      [assessment.id, assessment]
+    end
   end
 
   def add_submissions_breadcrumb

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -45,9 +45,15 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
 
   # Load student submissions.
   def load_submissions
-    student_ids = @course.course_users.students.pluck(:user_id)
+    student_ids = if current_course_user&.student?
+                    current_user.id
+                  else
+                    @course.course_users.students.pluck(:user_id)
+                  end
+
     @submissions = Course::Assessment::Submission.by_users(student_ids).
-                   ordered_by_submitted_date.accessible_by(current_ability).page(page_param).
+                   ordered_by_submitted_date.accessible_by(current_ability, :view_all_submissions).
+                   page(page_param).calculated(:grade).
                    includes(:assessment, :answers,
                             experience_points_record: { course_user: [:course, :groups] })
   end

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -86,8 +86,8 @@ module Course::Assessment::AssessmentAbility
     can :create, Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
     can [:update, :submit_answer], Course::Assessment::Submission, assessment_submission_attempting_hash(user)
-    can [:read, :reload_answer], Course::Assessment::Submission,
-        experience_points_record: { course_user: { user_id: user.id } }
+    can [:read, :reload_answer, :view_all_submissions], Course::Assessment::Submission,
+        experience_points_record: { course_user: { user_id: user.id } } if course_user&.student?
   end
 
   def allow_students_update_own_assessment_submission
@@ -137,6 +137,7 @@ module Course::Assessment::AssessmentAbility
 
   def allow_staff_read_assessment_submissions
     can :view_all_submissions, Course::Assessment, assessment_course_staff_hash
+    can :view_all_submissions, Course::Assessment::Submission if course_user&.staff?
     can :read, Course::Assessment::Submission, assessment: assessment_course_staff_hash
   end
 

--- a/app/views/course/assessment/submissions/_submission.html.slim
+++ b/app/views/course/assessment/submissions/_submission.html.slim
@@ -1,4 +1,4 @@
-- assessment = submission.assessment
+- assessment = assessments_hash[submission.assessment_id]
 = content_tag_for(:tr, submission) do
   td = link_to_course_user(submission.course_user)
   td = link_to(format_inline_text(assessment.title),

--- a/app/views/course/assessment/submissions/_submissions.html.slim
+++ b/app/views/course/assessment/submissions/_submissions.html.slim
@@ -13,4 +13,4 @@ table.table.table-middle-align.submissions-list.table-hover
       th
       th
   tbody
-    = render partial: 'submission', collection: submissions, locals: { pending: pending }
+    = render partial: 'submission', collection: submissions, locals: { pending: pending, assessments_hash: assessments_hash }

--- a/app/views/course/assessment/submissions/index.html.slim
+++ b/app/views/course/assessment/submissions/index.html.slim
@@ -5,6 +5,6 @@
 - if current_course_user&.staff? || can?(:manage, current_course)
   = render partial: 'filter', locals: { category: @category }
 
-= render partial: 'submissions', locals: { submissions: @submissions, pending: false }
+= render partial: 'submissions', locals: { submissions: @submissions, pending: false, assessments_hash: @assessments_hash }
 
 = paginate @submissions

--- a/app/views/course/assessment/submissions/pending.html.slim
+++ b/app/views/course/assessment/submissions/pending.html.slim
@@ -2,6 +2,6 @@
 = page_header
 = render partial: 'tabs'
 
-= render partial: 'submissions', locals: { submissions: @submissions, pending: true }
+= render partial: 'submissions', locals: { submissions: @submissions, pending: true, assessments_hash: @assessments_hash }
 
 = paginate @submissions

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe Course::Assessment do
       it { is_expected.not_to be_able_to(:force_submit_assessment_submission, published_started_assessment) }
 
       # Course Assessment Submissions
+      it { is_expected.to be_able_to(:view_all_submissions, coursemate_attempting_submission) }
       it { is_expected.to be_able_to(:read, coursemate_attempting_submission) }
       it { is_expected.to be_able_to(:read_tests, coursemate_attempting_submission) }
       it { is_expected.not_to be_able_to(:grade, coursemate_attempting_submission) }
@@ -186,6 +187,7 @@ RSpec.describe Course::Assessment do
       it { is_expected.not_to be_able_to(:force_submit_assessment_submission, published_started_assessment) }
 
       # Course Assessment Submissions
+      it { is_expected.to be_able_to(:view_all_submissions, attempting_submission) }
       it { is_expected.to be_able_to(:read, attempting_submission) }
       it { is_expected.to be_able_to(:grade, attempting_submission) }
       it { is_expected.to be_able_to(:grade, submitted_submission) }


### PR DESCRIPTION
Closes #4276 

This PR only refactors a specific small portion of the cancancan rewrite just to close the issue above. A full scale refactoring will be done in the subsequent PR (#4280).

In addition, some N+1 queries are also optimized (eg preloaded assessment, submission grade).

Improvement comparisons (Staff - /courses/2104/assessments/submissions?category=2568):
- Local (before: ~9000ms, after: ~2250ms)
- Staging (before: ~ms, after: ~ms)
- Production (before: ~ms, after: ~ms)