### PR TITLE
Re-write cancancan abilities

### DIFF
--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -54,7 +54,7 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
                   end
 
     @submissions = Course::Assessment::Submission.by_users(student_ids).
-                   ordered_by_submitted_date.accessible_by(current_ability, :view_all_submissions).
+                   ordered_by_submitted_date.accessible_by(current_ability).
                    page(page_param).calculated(:grade).
                    includes(:assessment, :answers,
                             experience_points_record: { course_user: [:course, :groups] })

--- a/app/models/components/course/announcements_ability_component.rb
+++ b/app/models/components/course/announcements_ability_component.rb
@@ -3,10 +3,10 @@ module Course::AnnouncementsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_students_show_announcements
-      allow_staff_read_announcements
-      allow_teaching_staff_manage_announcements
+    if course_user
+      allow_students_show_announcements if course_user.student?
+      allow_staff_read_announcements if course_user.staff?
+      allow_teaching_staff_manage_announcements if course_user.teaching_staff?
     end
 
     super
@@ -15,15 +15,14 @@ module Course::AnnouncementsAbilityComponent
   private
 
   def allow_students_show_announcements
-    can :read, Course::Announcement,
-        course_all_course_users_hash.reverse_merge(already_started_hash)
+    can :read, Course::Announcement, course_id: course.id, **already_started_hash
   end
 
   def allow_staff_read_announcements
-    can :read, Course::Announcement, course_staff_hash
+    can :read, Course::Announcement, course_id: course.id
   end
 
   def allow_teaching_staff_manage_announcements
-    can :manage, Course::Announcement, course_teaching_staff_hash
+    can :manage, Course::Announcement, course_id: course.id
   end
 end

--- a/app/models/components/course/conditions_ability_component.rb
+++ b/app/models/components/course/conditions_ability_component.rb
@@ -3,7 +3,7 @@ module Course::ConditionsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_teaching_staff_manage_conditions if user
+    allow_teaching_staff_manage_conditions if course_user&.teaching_staff?
 
     super
   end
@@ -11,11 +11,11 @@ module Course::ConditionsAbilityComponent
   private
 
   def allow_teaching_staff_manage_conditions
-    can :manage, Course::Condition, course_teaching_staff_hash
-    can :manage, Course::Condition::Achievement, condition: course_teaching_staff_hash
-    can :manage, Course::Condition::Assessment, condition: course_teaching_staff_hash
-    can :manage, Course::Condition::Level, condition: course_teaching_staff_hash
-    can :manage, Course::Condition::Survey, condition: course_teaching_staff_hash
-    can :manage, Course::Condition::Video, condition: course_teaching_staff_hash
+    can :manage, Course::Condition, course_id: course.id
+    can :manage, Course::Condition::Achievement, condition: { course_id: course.id }
+    can :manage, Course::Condition::Assessment, condition: { course_id: course.id }
+    can :manage, Course::Condition::Level, condition: { course_id: course.id }
+    can :manage, Course::Condition::Survey, condition: { course_id: course.id }
+    can :manage, Course::Condition::Video, condition: { course_id: course.id }
   end
 end

--- a/app/models/components/course/course_user_ability_component.rb
+++ b/app/models/components/course/course_user_ability_component.rb
@@ -3,7 +3,7 @@ module Course::CourseUserAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_course_users_show_coursemates if user
+    allow_course_users_show_coursemates if course_user
 
     super
   end
@@ -11,6 +11,6 @@ module Course::CourseUserAbilityComponent
   private
 
   def allow_course_users_show_coursemates
-    can :read, CourseUser, course_all_course_users_hash
+    can :read, CourseUser, course_id: course.id
   end
 end

--- a/app/models/components/course/discussions_ability_component.rb
+++ b/app/models/components/course/discussions_ability_component.rb
@@ -3,13 +3,13 @@ module Course::DiscussionsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
+    if course_user
       allow_course_users_show_topics
       allow_course_users_mark_topics_as_read
       allow_course_teaching_staff_manage_discussion_topics
       allow_course_users_create_posts
       allow_course_users_reply_and_vote_posts
-      allow_course_teaching_staff_manage_posts
+      allow_course_teaching_staff_manage_posts if course_user.teaching_staff?
       allow_course_users_update_delete_own_post
     end
 
@@ -19,11 +19,11 @@ module Course::DiscussionsAbilityComponent
   private
 
   def allow_course_users_show_topics
-    can [:read, :pending], Course::Discussion::Topic, course_all_course_users_hash
+    can [:read, :pending], Course::Discussion::Topic, course_id: course.id
   end
 
   def allow_course_users_mark_topics_as_read
-    can :mark_as_read, Course::Discussion::Topic, course_all_course_users_hash
+    can :mark_as_read, Course::Discussion::Topic, course_id: course.id
   end
 
   def allow_course_teaching_staff_manage_discussion_topics
@@ -35,11 +35,11 @@ module Course::DiscussionsAbilityComponent
   end
 
   def allow_course_users_reply_and_vote_posts
-    can [:reply, :vote], Course::Discussion::Post, topic: course_all_course_users_hash
+    can [:reply, :vote], Course::Discussion::Post, topic: { course_id: course.id }
   end
 
   def allow_course_teaching_staff_manage_posts
-    can :manage, Course::Discussion::Post, topic: course_teaching_staff_hash
+    can :manage, Course::Discussion::Post, topic: { course_id: course.id }
   end
 
   def allow_course_users_update_delete_own_post

--- a/app/models/components/course/forums_ability_component.rb
+++ b/app/models/components/course/forums_ability_component.rb
@@ -20,7 +20,7 @@ module Course::ForumsAbilityComponent
 
   def define_all_forum_permissions
     allow_show_forums
-    allow_show_topics
+    allow_show_topics if course_user.student?
     allow_create_topics
     allow_update_topics
     allow_reply_unlocked_topics

--- a/app/models/components/course/forums_ability_component.rb
+++ b/app/models/components/course/forums_ability_component.rb
@@ -3,16 +3,10 @@ module Course::ForumsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_students_show_forums
-      allow_students_show_topics
-      allow_students_create_topics
-      allow_students_update_topics
-      allow_student_reply_unlocked_topics
-      allow_student_resolve_own_topics
-      allow_staff_show_all_topics
-      allow_teaching_staff_manage_forums
-      allow_teaching_staff_manage_topics
+    if course_user
+      define_all_forum_permissions
+      define_staff_forum_permissions if course_user.staff?
+      define_teaching_staff_forum_permissions if course_user.teaching_staff?
     end
 
     super
@@ -20,56 +14,64 @@ module Course::ForumsAbilityComponent
 
   private
 
-  def topic_all_course_users_hash
-    { forum: course_all_course_users_hash }
+  def topic_course_hash
+    { forum: { course_id: course.id } }
   end
 
-  def topic_course_staff_hash
-    { forum: course_staff_hash }
+  def define_all_forum_permissions
+    allow_show_forums
+    allow_show_topics
+    allow_create_topics
+    allow_update_topics
+    allow_reply_unlocked_topics
+    allow_resolve_own_topics
   end
 
-  def topic_course_teaching_staff_hash
-    { forum: course_teaching_staff_hash }
+  def allow_show_forums
+    can [:read, :mark_as_read, :mark_all_as_read, :next_unread, :all_posts], Course::Forum, course_id: course.id
+    can [:subscribe, :unsubscribe], Course::Forum, course_id: course.id
   end
 
-  def allow_students_show_forums
-    can [:read, :mark_as_read], Course::Forum, course_all_course_users_hash
-    can [:subscribe, :unsubscribe], Course::Forum, course_all_course_users_hash
+  def allow_show_topics
+    can [:read, :subscribe], Course::Forum::Topic, topic_course_hash.reverse_merge(hidden: false)
   end
 
-  def allow_students_show_topics
-    can :read, Course::Forum::Topic, topic_all_course_users_hash.reverse_merge(hidden: false)
-    can :subscribe, Course::Forum::Topic, topic_all_course_users_hash.reverse_merge(hidden: false)
+  def allow_create_topics
+    can :create, Course::Forum::Topic, topic_course_hash
   end
 
-  def allow_students_create_topics
-    can :create, Course::Forum::Topic, topic_all_course_users_hash
+  def allow_update_topics
+    can :update, Course::Forum::Topic, topic_course_hash.reverse_merge(hidden: false, creator: user)
   end
 
-  def allow_students_update_topics
-    can :update, Course::Forum::Topic, topic_all_course_users_hash.reverse_merge(hidden: false,
-                                                                                 creator: user)
+  def allow_reply_unlocked_topics
+    can :reply, Course::Forum::Topic, topic_course_hash.reverse_merge(locked: false)
+    cannot :reply, Course::Forum::Topic, topic_course_hash.reverse_merge(locked: true)
   end
 
-  def allow_student_reply_unlocked_topics
-    can :reply, Course::Forum::Topic, topic_all_course_users_hash.reverse_merge(locked: false)
-    cannot :reply, Course::Forum::Topic, topic_all_course_users_hash.reverse_merge(locked: true)
-  end
-
-  def allow_student_resolve_own_topics
+  def allow_resolve_own_topics
     can :toggle_answer, Course::Forum::Topic, creator_id: user.id
   end
 
+  def define_staff_forum_permissions
+    allow_staff_show_all_topics
+  end
+
   def allow_staff_show_all_topics
-    can :read, Course::Forum::Topic, topic_course_staff_hash
-    can :subscribe, Course::Forum::Topic, topic_course_staff_hash
+    can :read, Course::Forum::Topic, topic_course_hash
+    can :subscribe, Course::Forum::Topic, topic_course_hash
+  end
+
+  def define_teaching_staff_forum_permissions
+    allow_teaching_staff_manage_forums
+    allow_teaching_staff_manage_topics
   end
 
   def allow_teaching_staff_manage_forums
-    can :manage, Course::Forum, course_teaching_staff_hash
+    can :manage, Course::Forum, course_id: course.id
   end
 
   def allow_teaching_staff_manage_topics
-    can :manage, Course::Forum::Topic, topic_course_teaching_staff_hash
+    can :manage, Course::Forum::Topic, topic_course_hash
   end
 end

--- a/app/models/components/course/groups_ability_component.rb
+++ b/app/models/components/course/groups_ability_component.rb
@@ -3,9 +3,9 @@ module Course::GroupsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_staff_read_groups
-      allow_teaching_staff_manage_groups
+    if course_user
+      allow_staff_read_groups if course_user.staff?
+      allow_teaching_staff_manage_groups if course_user.teaching_staff?
       allow_group_manager_manage_group
     end
 
@@ -15,11 +15,11 @@ module Course::GroupsAbilityComponent
   private
 
   def allow_staff_read_groups
-    can :read, Course::Group, course_staff_hash
+    can :read, Course::Group, course_id: course.id
   end
 
   def allow_teaching_staff_manage_groups
-    can :manage, Course::Group, course_teaching_staff_hash
+    can :manage, Course::Group, course_id: course.id
   end
 
   def allow_group_manager_manage_group
@@ -27,6 +27,6 @@ module Course::GroupsAbilityComponent
   end
 
   def course_group_manager_hash
-    { group_users: { course_user: { user_id: user.id }, role: Course::GroupUser.roles[:manager] } }
+    { course_id: course.id, group_users: { course_user_id: course_user.id, role: Course::GroupUser.roles[:manager] } }
   end
 end

--- a/app/models/components/course/lesson_plan_ability_component.rb
+++ b/app/models/components/course/lesson_plan_ability_component.rb
@@ -3,10 +3,10 @@ module Course::LessonPlanAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
+    if course_user
       allow_registered_users_showing_milestones_items
-      allow_course_staff_show_items
-      allow_course_teaching_staff_manage_lesson_plans
+      allow_course_staff_show_items if course_user.staff?
+      allow_course_teaching_staff_manage_lesson_plans if course_user.teaching_staff?
       allow_own_users_to_ignore_own_todos
     end
 
@@ -16,19 +16,19 @@ module Course::LessonPlanAbilityComponent
   private
 
   def allow_registered_users_showing_milestones_items
-    can :read, Course::LessonPlan::Milestone, lesson_plan_item: course_all_course_users_hash
-    can :read, Course::LessonPlan::Item, course_all_course_users_hash.merge(published: true)
-    can :read, Course::LessonPlan::Event, lesson_plan_item: course_all_course_users_hash
+    can :read, Course::LessonPlan::Milestone, lesson_plan_item: { course_id: course.id }
+    can :read, Course::LessonPlan::Item, { course_id: course.id, published: true }
+    can :read, Course::LessonPlan::Event, lesson_plan_item: { course_id: course.id }
   end
 
   def allow_course_staff_show_items
-    can :read, Course::LessonPlan::Item, course_staff_hash
+    can :read, Course::LessonPlan::Item, course_id: course.id
   end
 
   def allow_course_teaching_staff_manage_lesson_plans
-    can :manage, Course::LessonPlan::Milestone, lesson_plan_item: course_teaching_staff_hash
-    can :manage, Course::LessonPlan::Item, course_teaching_staff_hash
-    can :manage, Course::LessonPlan::Event, lesson_plan_item: course_teaching_staff_hash
+    can :manage, Course::LessonPlan::Milestone, lesson_plan_item: { course_id: course.id }
+    can :manage, Course::LessonPlan::Item, course_id: course.id
+    can :manage, Course::LessonPlan::Event, lesson_plan_item: { course_id: course.id }
   end
 
   def allow_own_users_to_ignore_own_todos

--- a/app/models/components/course/levels_ability_component.rb
+++ b/app/models/components/course/levels_ability_component.rb
@@ -3,9 +3,9 @@ module Course::LevelsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_staff_read_levels
-      allow_teaching_staff_manage_levels
+    if course_user
+      allow_staff_read_levels if course_user.staff?
+      allow_teaching_staff_manage_levels if course_user.teaching_staff?
     end
 
     super
@@ -14,11 +14,11 @@ module Course::LevelsAbilityComponent
   private
 
   def allow_staff_read_levels
-    can :read, Course::Level, course_staff_hash
+    can :read, Course::Level, course_id: course.id
   end
 
   def allow_teaching_staff_manage_levels
-    can :manage, Course::Level, course_teaching_staff_hash
+    can :manage, Course::Level, course_id: course.id
     # User cannot delete default level
     cannot :destroy, Course::Level, experience_points_threshold: 0
   end

--- a/app/models/components/course/materials_ability_component.rb
+++ b/app/models/components/course/materials_ability_component.rb
@@ -3,38 +3,31 @@ module Course::MaterialsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_students_show_materials
-      allow_students_upload_materials
-      allow_staff_read_materials
-      allow_teaching_staff_manage_materials
+    if course_user
+      allow_show_materials
+      allow_upload_materials
+      allow_staff_read_materials if course_user.staff?
+      allow_teaching_staff_manage_materials if course_user.teaching_staff?
     end
 
+    disallow_superusers_change_root_and_linked_folders
     super
   end
 
   private
 
-  def material_all_course_users_hash
-    { folder: course_all_course_users_hash }
+  def material_course_hash
+    { folder: { course_id: course.id } }
   end
 
-  def material_course_staff_hash
-    { folder: course_staff_hash }
-  end
-
-  def material_course_teaching_staff_hash
-    { folder: course_teaching_staff_hash }
-  end
-
-  def allow_students_show_materials
+  def allow_show_materials
     valid_materials_hashes.each do |properties|
-      can :read, Course::Material, material_all_course_users_hash.deep_merge(properties)
+      can :read, Course::Material, material_course_hash.deep_merge(properties)
     end
 
     opened_material_hashes.each do |properties|
       can [:read, :download],
-          Course::Material::Folder, course_all_course_users_hash.reverse_merge(properties)
+          Course::Material::Folder, { course_id: course.id }.reverse_merge(properties)
     end
 
     can :read_owner, Course::Material::Folder do |folder|
@@ -43,24 +36,27 @@ module Course::MaterialsAbilityComponent
     end
   end
 
-  def allow_students_upload_materials
+  def allow_upload_materials
     alias_action :new_materials, :upload_materials, to: :upload
-    can :upload, Course::Material::Folder, course_all_course_users_hash.
+    can :upload, Course::Material::Folder, { course_id: course.id }.
       reverse_merge(can_student_upload: true)
     can :manage, Course::Material, creator: user
   end
 
   def allow_staff_read_materials
-    can :read, Course::Material, material_course_staff_hash
-    can [:read, :download], Course::Material::Folder, course_staff_hash
+    can :read, Course::Material, material_course_hash
+    can [:read, :download], Course::Material::Folder, { course_id: course.id }
   end
 
   def allow_teaching_staff_manage_materials
-    can :manage, Course::Material, material_course_teaching_staff_hash
+    can :manage, Course::Material, material_course_hash
 
-    can :upload, Course::Material::Folder, course_teaching_staff_hash
+    can :upload, Course::Material::Folder, { course_id: course.id }
     can :manage, Course::Material::Folder,
-        course_teaching_staff_hash.reverse_merge(concrete_folder_hash)
+        { course_id: course.id }.reverse_merge(concrete_folder_hash)
+  end
+
+  def disallow_superusers_change_root_and_linked_folders
     # Do not allow admin to edit linked folders
     cannot [:update, :destroy], Course::Material::Folder do |folder|
       folder.owner_id.present?
@@ -89,7 +85,6 @@ module Course::MaterialsAbilityComponent
     # Add materials with parent assessments that open early due to personalized timeline
     # Dealing with personal times is too complicated to represent as a hash of conditions
     # Instead, we eagerly fetch all the ids we want and return a trivial hash that matches these ids
-    course_user = user && course && course.course_users.find_by(user: user)
     personal_times_opened_folder_hash =
       course_user &&
       {

--- a/app/models/components/course/materials_ability_component.rb
+++ b/app/models/components/course/materials_ability_component.rb
@@ -21,13 +21,15 @@ module Course::MaterialsAbilityComponent
   end
 
   def allow_show_materials
-    valid_materials_hashes.each do |properties|
-      can :read, Course::Material, material_course_hash.deep_merge(properties)
-    end
+    if course_user.student?
+      valid_materials_hashes.each do |properties|
+        can :read, Course::Material, material_course_hash.deep_merge(properties)
+      end
 
-    opened_material_hashes.each do |properties|
-      can [:read, :download],
-          Course::Material::Folder, { course_id: course.id }.reverse_merge(properties)
+      opened_material_hashes.each do |properties|
+        can [:read, :download],
+            Course::Material::Folder, { course_id: course.id }.reverse_merge(properties)
+      end
     end
 
     can :read_owner, Course::Material::Folder do |folder|

--- a/app/models/components/course/statistics_ability_component.rb
+++ b/app/models/components/course/statistics_ability_component.rb
@@ -3,7 +3,7 @@ module Course::StatisticsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_staff_read_statistics if user
+    allow_staff_read_statistics if course_user&.staff?
 
     super
   end
@@ -11,6 +11,6 @@ module Course::StatisticsAbilityComponent
   private
 
   def allow_staff_read_statistics
-    can :read_statistics, Course, staff_hash
+    can :read_statistics, Course, id: course.id
   end
 end

--- a/app/models/components/course/surveys_ability_component.rb
+++ b/app/models/components/course/surveys_ability_component.rb
@@ -3,9 +3,10 @@ module Course::SurveysAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user && !user.administrator?
-      define_student_survey_permissions
-      define_staff_survey_permissions
+    if course_user && !user.administrator?
+      define_all_survey_permissions
+      define_staff_survey_permissions if course_user.staff?
+      define_teaching_staff_survey_permissions if course_user.teaching_staff?
     end
 
     super
@@ -13,21 +14,27 @@ module Course::SurveysAbilityComponent
 
   private
 
-  def define_student_survey_permissions
-    allow_students_show_published_surveys
-    allow_students_show_open_survey_sections
-    allow_students_read_own_response
-    allow_students_update_own_response
-    allow_students_create_response
-    allow_students_submit_own_response
-    allow_students_modify_own_response_to_active_survey
-    allow_students_modify_own_response_to_modifiable_submitted_survey
-    disallow_students_modify_own_response_to_modifiable_expired_submitted_survey
-    allow_students_modify_own_response_to_respondable_expired_survey
+  def survey_course_hash
+    { survey: { lesson_plan_item: { course_id: course.id } } }
+  end
+
+  def define_all_survey_permissions
+    if course_user.student?
+      allow_read_published_surveys
+      allow_read_open_survey_sections
+      allow_read_own_response
+    end
+    allow_update_own_response
+    allow_create_response
+    allow_submit_own_response
+    allow_modify_own_response_to_active_survey
+    allow_modify_own_response_to_modifiable_submitted_survey
+    disallow_modify_own_response_to_modifiable_expired_submitted_survey
+    allow_modify_own_response_to_respondable_expired_survey
   end
 
   def survey_published_all_course_users_hash
-    { lesson_plan_item: course_all_course_users_hash.merge(published: true) }
+    { lesson_plan_item: { course_id: course.id, published: true } }
   end
 
   def survey_open_all_course_users_hash
@@ -58,31 +65,31 @@ module Course::SurveysAbilityComponent
     )
   end
 
-  def allow_students_show_published_surveys
+  def allow_read_published_surveys
     can :read, Course::Survey, survey_published_all_course_users_hash
   end
 
-  def allow_students_show_open_survey_sections
+  def allow_read_open_survey_sections
     can :read, Course::Survey::Section, survey: survey_open_all_course_users_hash
   end
 
-  def allow_students_read_own_response
+  def allow_read_own_response
     can [:read, :read_answers], Course::Survey::Response,
         survey: survey_open_all_course_users_hash, creator_id: user.id
   end
 
-  def allow_students_create_response
+  def allow_create_response
     survey_active_all_course_users_hashes.each do |ability_hash|
       can :create, Course::Survey::Response, survey: ability_hash
     end
     can :create, Course::Survey::Response, survey: survey_expired_but_respondable
   end
 
-  def allow_students_update_own_response
+  def allow_update_own_response
     can :update, Course::Survey::Response, creator_id: user.id
   end
 
-  def allow_students_submit_own_response
+  def allow_submit_own_response
     survey_active_all_course_users_hashes.each do |ability_hash|
       can :submit, Course::Survey::Response,
           creator_id: user.id, submitted_at: nil, survey: ability_hash
@@ -97,24 +104,24 @@ module Course::SurveysAbilityComponent
   # response, the user should be able to `:edit`/`:update` it. Thus, we need a separate
   # `:modify` ability to disambiguate it from the less strict `:edit`/`:update` ability.
 
-  def allow_students_modify_own_response_to_active_survey
+  def allow_modify_own_response_to_active_survey
     survey_active_all_course_users_hashes.each do |ability_hash|
       can :modify, Course::Survey::Response,
           creator_id: user.id, submitted_at: nil, survey: ability_hash
     end
   end
 
-  def allow_students_modify_own_response_to_modifiable_submitted_survey
+  def allow_modify_own_response_to_modifiable_submitted_survey
     can :modify, Course::Survey::Response,
         creator_id: user.id, submitted_at: (Time.min..Time.max),
         survey: survey_open_all_course_users_hash.deep_merge(allow_modify_after_submit: true)
   end
 
-  def disallow_students_modify_own_response_to_modifiable_expired_submitted_survey
+  def disallow_modify_own_response_to_modifiable_expired_submitted_survey
     cannot :modify, Course::Survey::Response, survey: survey_expired_and_not_respondable
   end
 
-  def allow_students_modify_own_response_to_respondable_expired_survey
+  def allow_modify_own_response_to_respondable_expired_survey
     can :modify, Course::Survey::Response, creator_id: user.id, submitted_at: nil,
                                            survey: survey_expired_but_respondable
   end
@@ -123,53 +130,48 @@ module Course::SurveysAbilityComponent
     allow_staff_read_all_surveys
     allow_staff_read_responses
     allow_staff_test_survey
+  end
+
+  def allow_staff_read_all_surveys
+    can :read, Course::Survey, lesson_plan_item: { course_id: course.id }
+    can :read, Course::Survey::Section, survey_course_hash
+  end
+
+  def allow_staff_read_responses
+    can :read, Course::Survey::Response, survey_course_hash
+    can :read_answers, Course::Survey::Response,
+        survey_course_hash.merge(survey: { anonymous: false })
+  end
+
+  def allow_staff_test_survey
+    can :create, Course::Survey::Response, survey_course_hash
+    can [:read_answers, :modify], Course::Survey::Response,
+        survey_course_hash.merge(creator_id: user.id)
+    can :submit, Course::Survey::Response,
+        survey_course_hash.merge(creator_id: user.id, submitted_at: nil)
+  end
+
+  def define_teaching_staff_survey_permissions
     allow_teaching_staff_manage_surveys
     allow_teaching_staff_manage_sections
     allow_teaching_staff_manage_questions
     allow_teaching_staff_unsubmit_responses
   end
 
-  def survey_staff_hash
-    { survey: { lesson_plan_item: course_staff_hash } }
-  end
-
-  def survey_teaching_staff_hash
-    { survey: { lesson_plan_item: course_teaching_staff_hash } }
-  end
-
-  def allow_staff_read_all_surveys
-    can :read, Course::Survey, lesson_plan_item: course_staff_hash
-    can :read, Course::Survey::Section, survey_staff_hash
-  end
-
-  def allow_staff_read_responses
-    can :read, Course::Survey::Response, survey_staff_hash
-    can :read_answers, Course::Survey::Response,
-        survey_staff_hash.merge(survey: { anonymous: false })
-  end
-
-  def allow_staff_test_survey
-    can :create, Course::Survey::Response, survey_staff_hash
-    can [:read_answers, :modify], Course::Survey::Response,
-        survey_staff_hash.merge(creator_id: user.id)
-    can :submit, Course::Survey::Response,
-        survey_staff_hash.merge(creator_id: user.id, submitted_at: nil)
-  end
-
   def allow_teaching_staff_manage_surveys
-    can :manage, Course::Survey, lesson_plan_item: course_teaching_staff_hash
+    can :manage, Course::Survey, lesson_plan_item: { course_id: course.id }
   end
 
   def allow_teaching_staff_manage_sections
-    can :manage, Course::Survey::Section, survey_teaching_staff_hash
+    can :manage, Course::Survey::Section, survey_course_hash
   end
 
   def allow_teaching_staff_manage_questions
-    can :manage, Course::Survey::Question, section: survey_teaching_staff_hash
+    can :manage, Course::Survey::Question, section: survey_course_hash
   end
 
   def allow_teaching_staff_unsubmit_responses
     can :unsubmit, Course::Survey::Response,
-        survey_teaching_staff_hash.merge(submitted_at: (Time.min..Time.max))
+        survey_course_hash.merge(submitted_at: (Time.min..Time.max))
   end
 end

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -3,9 +3,11 @@ module Course::VideosAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      define_student_video_permissions
-      define_staff_video_permissions
+    if course_user
+      define_all_video_permissions
+      define_staff_video_permissions if course_user.staff?
+      define_teaching_staff_video_permissions if course_user.teaching_staff?
+      define_managers_video_permissions if course_user.manager_or_owner?
     end
 
     super
@@ -13,96 +15,98 @@ module Course::VideosAbilityComponent
 
   private
 
-  def define_student_video_permissions
-    allow_student_show_video
-    allow_student_attempt_video
-    allow_student_create_and_read_video_submission
-    allow_student_update_own_video_submission
-    allow_student_show_video_topics
-    allow_student_create_video_topics
-    allow_student_create_and_update_own_video_session
+  def define_all_video_permissions
+    allow_show_video
+    allow_attempt_video
+    allow_create_and_read_video_submission
+    allow_update_own_video_submission
+    allow_show_video_topics
+    allow_create_video_topics
+    allow_create_and_update_own_video_session
   end
 
-  def video_all_course_users_hash
-    { lesson_plan_item: course_all_course_users_hash }
+  def lesson_plan_course_hash
+    { lesson_plan_item: { course_id: course.id } }
   end
 
-  def video_published_all_course_users_hash
-    { lesson_plan_item: { published: true } }.deep_merge(video_all_course_users_hash)
+  def video_course_hash
+    { video: lesson_plan_course_hash }
+  end
+
+  def video_published_course_hash
+    { lesson_plan_item: { published: true, course_id: course.id } }
   end
 
   def video_submission_own_course_user_hash
     { experience_points_record: { course_user: { user_id: user.id } } }
   end
 
-  def allow_student_show_video
-    can :read, Course::Video, video_published_all_course_users_hash
+  def allow_show_video
+    can :read, Course::Video, video_published_course_hash if course_user.student?
   end
 
-  def allow_student_attempt_video
+  def allow_attempt_video
     can :attempt, Course::Video do |video|
       course_user = user.course_users.find_by(course: video.course)
       video.published? && video.self_directed_started?(course_user)
     end
   end
 
-  def allow_student_create_and_read_video_submission
+  def allow_create_and_read_video_submission
     can :create, Course::Video::Submission, video_submission_own_course_user_hash
-    can :read, Course::Video::Submission, video_submission_own_course_user_hash
+    can :read, Course::Video::Submission, video_submission_own_course_user_hash if course_user.student?
   end
 
-  def allow_student_update_own_video_submission
+  def allow_update_own_video_submission
     can :update, Course::Video::Submission, video_submission_own_course_user_hash
   end
 
-  def allow_student_create_and_update_own_video_session
+  def allow_create_and_update_own_video_session
     can :create, Course::Video::Session, submission: video_submission_own_course_user_hash
     can :update, Course::Video::Session, submission: video_submission_own_course_user_hash
   end
 
-  def allow_student_show_video_topics
-    can :read, Course::Video::Topic, video: video_all_course_users_hash
+  def allow_show_video_topics
+    can :read, Course::Video::Topic, video_course_hash
   end
 
-  def allow_student_create_video_topics
-    can :create, Course::Video::Topic, video: video_all_course_users_hash
+  def allow_create_video_topics
+    can :create, Course::Video::Topic, video_course_hash
   end
 
   def define_staff_video_permissions
     allow_staff_read_and_attempt_all_video
     allow_staff_read_and_analzye_all_video_submission
-    allow_course_managers_manage_video_tab
+  end
+
+  def allow_staff_read_and_attempt_all_video
+    can :read, Course::Video, lesson_plan_course_hash
+    can :attempt, Course::Video, lesson_plan_course_hash
+  end
+
+  def allow_staff_read_and_analzye_all_video_submission
+    can :read, Course::Video::Submission, video_course_hash
+    can :analyze, Course::Video::Submission, video_course_hash
+  end
+
+  def define_teaching_staff_video_permissions
     allow_teaching_staff_manage_video
     allow_teaching_staff_update_video_submission
   end
 
-  def video_all_course_staff_hash
-    { lesson_plan_item: course_staff_hash }
-  end
-
-  def video_all_course_teaching_staff_hash
-    { lesson_plan_item: course_teaching_staff_hash }
-  end
-
-  def allow_staff_read_and_attempt_all_video
-    can :read, Course::Video, video_all_course_staff_hash
-    can :attempt, Course::Video, video_all_course_staff_hash
-  end
-
-  def allow_staff_read_and_analzye_all_video_submission
-    can :read, Course::Video::Submission, video: video_all_course_staff_hash
-    can :analyze, Course::Video::Submission, video: video_all_course_staff_hash
-  end
-
   def allow_teaching_staff_manage_video
-    can :manage, Course::Video, video_all_course_teaching_staff_hash
+    can :manage, Course::Video, lesson_plan_course_hash
+  end
+
+  def allow_teaching_staff_update_video_submission
+    can :update, Course::Video::Submission, video_course_hash
+  end
+
+  def define_managers_video_permissions
+    allow_course_managers_manage_video_tab
   end
 
   def allow_course_managers_manage_video_tab
     can :manage, Course::Video::Tab, course_managers_hash
-  end
-
-  def allow_teaching_staff_update_video_submission
-    can :update, Course::Video::Submission, video: video_all_course_teaching_staff_hash
   end
 end

--- a/app/models/components/course/virtual_classrooms_ability_component.rb
+++ b/app/models/components/course/virtual_classrooms_ability_component.rb
@@ -3,9 +3,10 @@ module Course::VirtualClassroomsAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      allow_students_show_virtual_classrooms
-      allow_staff_manage_virtual_classrooms
+    if course_user
+      allow_show_virtual_classrooms
+      allow_staff_access_recorded_videos if course_user.staff?
+      allow_teaching_staff_manage_virtual_classrooms if course_user.teaching_staff?
     end
 
     super
@@ -13,12 +14,15 @@ module Course::VirtualClassroomsAbilityComponent
 
   private
 
-  def allow_students_show_virtual_classrooms
-    can [:read, :access_link], Course::VirtualClassroom, course_all_course_users_hash
+  def allow_show_virtual_classrooms
+    can [:read, :access_link], Course::VirtualClassroom, course_id: course.id
   end
 
-  def allow_staff_manage_virtual_classrooms
-    can :manage, Course::VirtualClassroom, course_teaching_staff_hash
-    can :access_recorded_videos, Course, staff_hash
+  def allow_staff_access_recorded_videos
+    can :access_recorded_videos, Course, id: course.id
+  end
+
+  def allow_teaching_staff_manage_virtual_classrooms
+    can :manage, Course::VirtualClassroom, course_id: course.id
   end
 end

--- a/app/models/course/assessment/answer/programming_ability.rb
+++ b/app/models/course/assessment/answer/programming_ability.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 module Course::Assessment::Answer::ProgrammingAbility
   def define_permissions
-    if user
-      allow_students_create_programming_files
-      allow_students_destroy_programming_files
-      allow_students_download_programming_files
+    if course_user
+      allow_create_programming_files
+      allow_destroy_programming_files
+      allow_download_programming_files
 
-      allow_staff_download_programming_files if course_user&.staff?
+      allow_staff_download_programming_files if course_user.staff?
     end
 
     super
   end
 
-  def allow_students_create_programming_files
+  def allow_create_programming_files
     can :create_programming_files, Course::Assessment::Answer::Programming do |programming_answer|
       multiple_file_submission?(programming_answer.question) &&
         creator?(programming_answer.submission) &&
@@ -21,7 +21,7 @@ module Course::Assessment::Answer::ProgrammingAbility
     end
   end
 
-  def allow_students_destroy_programming_files
+  def allow_destroy_programming_files
     can :destroy_programming_file, Course::Assessment::Answer::Programming do |programming_answer|
       multiple_file_submission?(programming_answer.question) &&
         creator?(programming_answer.submission) &&
@@ -30,7 +30,7 @@ module Course::Assessment::Answer::ProgrammingAbility
     end
   end
 
-  def allow_students_download_programming_files
+  def allow_download_programming_files
     can :download, Course::Assessment::Answer::ProgrammingFile,
         answer: { submission: { creator_id: user.id } }
   end

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -4,9 +4,11 @@ module Course::Assessment::AssessmentAbility
   include Course::Assessment::Answer::ProgrammingAbility
 
   def define_permissions
-    if user
-      define_student_assessment_permissions
-      define_staff_assessment_permissions
+    if course_user
+      define_all_assessment_permissions
+      define_staff_assessment_permissions if course_user.staff?
+      define_teaching_staff_assessment_permissions if course_user.teaching_staff?
+      define_manager_assessment_permissions if course_user.manager_or_owner?
     end
 
     super
@@ -14,20 +16,8 @@ module Course::Assessment::AssessmentAbility
 
   private
 
-  def assessment_all_course_users_hash
-    { tab: { category: course_all_course_users_hash } }
-  end
-
-  def assessment_published_all_course_users_hash
-    { lesson_plan_item: { published: true } }.reverse_merge(assessment_all_course_users_hash)
-  end
-
-  def assessment_course_staff_hash
-    { tab: { category: course_staff_hash } }
-  end
-
-  def assessment_course_teaching_staff_hash
-    { tab: { category: course_teaching_staff_hash } }
+  def assessment_course_hash
+    { tab: { category: { course_id: course.id } } }
   end
 
   def assessment_submission_attempting_hash(user)
@@ -36,28 +26,29 @@ module Course::Assessment::AssessmentAbility
     end
   end
 
-  def define_student_assessment_permissions
-    allow_students_show_assessments
-    allow_students_access_assessment
-    allow_students_attempt_assessment
-    allow_students_read_material
-    allow_students_create_assessment_submission
-    allow_students_update_own_assessment_submission
-    allow_students_manage_annotations_for_own_assessment_submissions
-    allow_students_read_own_assessment_answers
-    allow_students_read_submission_question
-    allow_student_to_destroy_own_attachments_text_response_question
+  def define_all_assessment_permissions
+    allow_read_assessments
+    allow_access_assessment
+    allow_attempt_assessment
+    allow_read_material
+    allow_read_assessment_submission if course_user.student?
+    allow_create_assessment_submission
+    allow_update_own_assessment_submission
+    allow_manage_annotations_for_own_assessment_submissions
+    allow_read_own_assessment_answers
+    allow_read_submission_question
+    allow_to_destroy_own_attachments_text_response_question
   end
 
-  def allow_students_show_assessments
-    can :read_material, Course::Assessment::Category, course_all_course_users_hash
-    can :read_material, Course::Assessment::Tab, category: course_all_course_users_hash
-    can :read, Course::Assessment, assessment_published_all_course_users_hash
-    can :authenticate, Course::Assessment, assessment_published_all_course_users_hash
+  def allow_read_assessments
+    can :read_material, Course::Assessment::Category, course_id: course.id
+    can :read_material, Course::Assessment::Tab, category: { course_id: course.id }
+    can :read, Course::Assessment, lesson_plan_item: { published: true, course_id: course.id }
+    can :authenticate, Course::Assessment, lesson_plan_item: { published: true, course_id: course.id }
   end
 
   # 'access' refers to the ability to access password-protected assessments.
-  def allow_students_access_assessment
+  def allow_access_assessment
     can :access, Course::Assessment do |assessment|
       if assessment.view_password_protected?
         Course::Assessment::AuthenticationService.new(assessment, session).authenticated? ||
@@ -68,47 +59,49 @@ module Course::Assessment::AssessmentAbility
     end
   end
 
-  def allow_students_attempt_assessment
+  def allow_attempt_assessment
     can :attempt, Course::Assessment do |assessment|
-      course_user = user.course_users.find_by(course: assessment.course)
       assessment.published? && assessment.self_directed_started?(course_user) &&
         assessment.conditions_satisfied_by?(course_user)
     end
   end
 
-  def allow_students_read_material
+  def allow_read_material
     can :read_material, Course::Assessment do |assessment|
       can?(:access, assessment) && can?(:attempt, assessment)
     end
   end
 
-  def allow_students_create_assessment_submission
+  def allow_read_assessment_submission
+    can [:read, :reload_answer, :view_all_submissions], Course::Assessment::Submission,
+        experience_points_record: { course_user: { user_id: user.id } }
+  end
+
+  def allow_create_assessment_submission
     can :create, Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
     can [:update, :submit_answer], Course::Assessment::Submission, assessment_submission_attempting_hash(user)
-    can [:read, :reload_answer, :view_all_submissions], Course::Assessment::Submission,
-        experience_points_record: { course_user: { user_id: user.id } } if course_user&.student?
   end
 
-  def allow_students_update_own_assessment_submission
+  def allow_update_own_assessment_submission
     can :update, Course::Assessment::Answer, submission: assessment_submission_attempting_hash(user)
   end
 
-  def allow_students_manage_annotations_for_own_assessment_submissions
+  def allow_manage_annotations_for_own_assessment_submissions
     can :manage, Course::Assessment::Answer::ProgrammingFileAnnotation,
         file: { answer: { submission: { creator_id: user.id } } }
   end
 
-  def allow_students_read_own_assessment_answers
+  def allow_read_own_assessment_answers
     can :read, Course::Assessment::Answer, submission: { creator_id: user.id }
   end
 
-  def allow_students_read_submission_question
+  def allow_read_submission_question
     can :read, Course::Assessment::SubmissionQuestion, submission: { creator_id: user.id }
   end
 
   # Prevent everyone from destroying their own attachment, unless they are attempting the question.
-  def allow_student_to_destroy_own_attachments_text_response_question
+  def allow_to_destroy_own_attachments_text_response_question
     cannot :destroy_attachment, Course::Assessment::Answer::TextResponse
     can :destroy_attachment, Course::Assessment::Answer::TextResponse,
         submission: assessment_submission_attempting_hash(user)
@@ -119,44 +112,51 @@ module Course::Assessment::AssessmentAbility
     allow_staff_read_assessment_submissions
     allow_staff_read_assessment_tests
     allow_staff_read_submission_questions
-    allow_teaching_staff_manage_assessments
-    allow_teaching_staff_grade_assessment_submissions
-    allow_teaching_staff_manage_assessment_annotations
-    allow_managers_manage_tab_and_categories
-    allow_manager_publish_assessment_submission_grades
-    allow_manager_force_submit_assessment_submissions
-    allow_manager_delete_assessment_submission
+    allow_staff_delete_own_assessment_submission
   end
 
   def allow_staff_read_observe_access_and_attempt_assessment
-    can :read, Course::Assessment, assessment_course_staff_hash
-    can :observe, Course::Assessment, assessment_course_staff_hash
-    can :attempt, Course::Assessment, assessment_course_staff_hash
-    can :access, Course::Assessment, assessment_course_staff_hash
+    can :read, Course::Assessment, assessment_course_hash
+    can :observe, Course::Assessment, assessment_course_hash
+    can :attempt, Course::Assessment, assessment_course_hash
+    can :access, Course::Assessment, assessment_course_hash
   end
 
   def allow_staff_read_assessment_submissions
-    can :view_all_submissions, Course::Assessment, assessment_course_staff_hash
-    can :view_all_submissions, Course::Assessment::Submission if course_user&.staff?
-    can :read, Course::Assessment::Submission, assessment: assessment_course_staff_hash
+    can :view_all_submissions, Course::Assessment, assessment_course_hash
+    can :view_all_submissions, Course::Assessment::Submission
+    can :read, Course::Assessment::Submission, assessment: assessment_course_hash
   end
 
   def allow_staff_read_assessment_tests
-    can :read_tests, Course::Assessment::Submission, assessment: assessment_course_staff_hash
+    can :read_tests, Course::Assessment::Submission, assessment: assessment_course_hash
   end
 
   def allow_staff_read_submission_questions
-    can :read, Course::Assessment::SubmissionQuestion, discussion_topic: course_staff_hash
+    can :read, Course::Assessment::SubmissionQuestion, discussion_topic: { course_id: course.id }
+  end
+
+  def allow_staff_delete_own_assessment_submission
+    can :delete_submission, Course::Assessment::Submission, creator_id: user.id
+  end
+
+  def define_teaching_staff_assessment_permissions
+    allow_teaching_staff_manage_assessments
+    allow_teaching_staff_grade_assessment_submissions
+    allow_teaching_staff_manage_assessment_annotations
+    disallow_teaching_staff_publish_assessment_submission_grades
+    disallow_teaching_staff_force_submit_assessment_submissions
+    disallow_teaching_staff_delete_assessment_submissions
   end
 
   def allow_teaching_staff_manage_assessments
-    can :manage, Course::Assessment, assessment_course_teaching_staff_hash
-    allow_manage_questions if course_user&.teaching_staff?
+    can :manage, Course::Assessment, assessment_course_hash
+    allow_manage_questions
   end
 
   def allow_manage_questions
     question_assessments_current_course =
-      { question_assessments: { assessment: { tab: { category: { course: course } } } } }
+      { question_assessments: { assessment: assessment_course_hash } }
 
     [
       Course::Assessment::Question::ForumPostResponse,
@@ -174,43 +174,60 @@ module Course::Assessment::AssessmentAbility
 
   def allow_teaching_staff_grade_assessment_submissions
     can [:update, :reload_answer, :grade],
-        Course::Assessment::Submission, assessment: assessment_course_teaching_staff_hash
+        Course::Assessment::Submission, assessment: assessment_course_hash
     can :grade, Course::Assessment::Answer,
-        submission: { assessment: assessment_course_teaching_staff_hash }
+        submission: { assessment: assessment_course_hash }
   end
 
   def allow_teaching_staff_manage_assessment_annotations
     can :manage, Course::Assessment::Answer::ProgrammingFileAnnotation,
-        discussion_topic: course_teaching_staff_hash
+        discussion_topic: { course_id: course.id }
   end
 
-  def allow_managers_manage_tab_and_categories
-    can :manage, Course::Assessment::Tab, category: course_managers_hash
-    can :manage, Course::Assessment::Category, course_managers_hash
+  def assessment_course_staff_hash
+    { tab: { category: course_staff_hash } }
+  end
+
+  # Teaching assistants have all assessment abilities except :publish_grades
+  def disallow_teaching_staff_publish_assessment_submission_grades
+    cannot :publish_grades, Course::Assessment, assessment_course_staff_hash
+  end
+
+  # Teaching assistants have all assessment abilities except :force_submit_submission
+  def disallow_teaching_staff_force_submit_assessment_submissions
+    cannot :force_submit_assessment_submission, Course::Assessment, assessment_course_staff_hash
+  end
+
+  # Teaching assistants can only delete his/her own submission
+  def disallow_teaching_staff_delete_assessment_submissions
+    cannot :delete_all_submissions, Course::Assessment, assessment_course_staff_hash
+  end
+
+  def define_manager_assessment_permissions
+    allow_manager_manage_tab_and_categories
+    allow_manager_publish_assessment_submission_grades
+    allow_manager_force_submit_assessment_submissions
+    allow_manager_delete_assessment_submissions
+  end
+
+  def allow_manager_manage_tab_and_categories
+    can :manage, Course::Assessment::Tab, category: { course_id: course.id }
+    can :manage, Course::Assessment::Category, course_id: course.id
   end
 
   # Only managers are allowed to publish assessment submission grades
-  # Teaching assistants have all assessment abilities except :publish_grades
   def allow_manager_publish_assessment_submission_grades
-    cannot :publish_grades, Course::Assessment, assessment_course_staff_hash
-    can :publish_grades, Course::Assessment, course_managers_hash
+    can :publish_grades, Course::Assessment, assessment_course_hash
   end
 
   # Only managers are allowed to force submit assessment submissions
-  # Teaching assistants have all assessment abilities except :force_submit_submission
   def allow_manager_force_submit_assessment_submissions
-    cannot :force_submit_assessment_submission, Course::Assessment, assessment_course_staff_hash
-    can :force_submit_assessment_submission, Course::Assessment, course_managers_hash
+    can :force_submit_assessment_submission, Course::Assessment, assessment_course_hash
   end
 
   # Only managers and above are allowed to delete assessment submissions
-  # Teaching assistants can only delete his/her own submission
-  def allow_manager_delete_assessment_submission
-    cannot :delete_all_submissions, Course::Assessment, assessment_course_staff_hash
-    can :delete_all_submissions, Course::Assessment, course_managers_hash
-
-    can :delete_submission, Course::Assessment::Submission, assessment: course_managers_hash
-    can :delete_submission, Course::Assessment::Submission,
-        { assessment: course_teaching_assistants_hash }.reverse_merge(creator: user)
+  def allow_manager_delete_assessment_submissions
+    can :delete_all_submissions, Course::Assessment, assessment_course_hash
+    can :delete_submission, Course::Assessment::Submission, assessment: assessment_course_hash
   end
 end

--- a/app/models/course/assessment/skill_ability.rb
+++ b/app/models/course/assessment/skill_ability.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module Course::Assessment::SkillAbility
   def define_permissions
-    if user
-      allow_staff_read_skills_and_skill_branches
-      allow_teaching_staff_manage_skills_and_skill_branches
+    if course_user
+      allow_staff_read_skills_and_skill_branches if course_user.staff?
+      allow_teaching_staff_manage_skills_and_skill_branches if course_user.teaching_staff?
     end
 
     super
@@ -12,12 +12,12 @@ module Course::Assessment::SkillAbility
   private
 
   def allow_staff_read_skills_and_skill_branches
-    can :read, Course::Assessment::Skill, course_staff_hash
-    can :read, Course::Assessment::SkillBranch, course_staff_hash
+    can :read, Course::Assessment::Skill, course_id: course.id
+    can :read, Course::Assessment::SkillBranch, course_id: course.id
   end
 
   def allow_teaching_staff_manage_skills_and_skill_branches
-    can :manage, Course::Assessment::Skill, course_teaching_staff_hash
-    can :manage, Course::Assessment::SkillBranch, course_teaching_staff_hash
+    can :manage, Course::Assessment::Skill, course_id: course.id
+    can :manage, Course::Assessment::SkillBranch, course_id: course.id
   end
 end

--- a/app/models/course/assessment/submission_question_ability.rb
+++ b/app/models/course/assessment/submission_question_ability.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module Course::Assessment::SubmissionQuestionAbility
   def define_permissions
-    if user
-      allow_students_view_past_answers_submission_question
-      allow_staff_view_past_answers_submission_questions
+    if course_user
+      allow_students_view_past_answers_submission_question if course_user.student?
+      allow_staff_view_past_answers_submission_questions if course_user.staff?
     end
 
     super
@@ -14,6 +14,6 @@ module Course::Assessment::SubmissionQuestionAbility
   end
 
   def allow_staff_view_past_answers_submission_questions
-    can :past_answers, Course::Assessment::SubmissionQuestion, discussion_topic: course_staff_hash
+    can :past_answers, Course::Assessment::SubmissionQuestion, discussion_topic: { course_id: course.id }
   end
 end

--- a/spec/models/course/announcement_ability_spec.rb
+++ b/spec/models/course/announcement_ability_spec.rb
@@ -4,14 +4,15 @@ require 'rails_helper'
 RSpec.describe Course::Announcement do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let!(:not_started_announcement) { create(:course_announcement, :not_started, course: course) }
     let!(:ended_announcement) { create(:course_announcement, :ended, course: course) }
     let!(:valid_announcement) { create(:course_announcement, course: course) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, valid_announcement) }
       it { is_expected.to be_able_to(:show, ended_announcement) }
@@ -25,7 +26,8 @@ RSpec.describe Course::Announcement do
     end
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, valid_announcement) }
       it { is_expected.to be_able_to(:manage, ended_announcement) }
@@ -38,7 +40,8 @@ RSpec.describe Course::Announcement do
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:read, valid_announcement) }
       it { is_expected.to be_able_to(:read, ended_announcement) }

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -153,7 +153,6 @@ RSpec.describe Course::Assessment do
       it { is_expected.not_to be_able_to(:force_submit_assessment_submission, published_started_assessment) }
 
       # Course Assessment Submissions
-      it { is_expected.to be_able_to(:view_all_submissions, coursemate_attempting_submission) }
       it { is_expected.to be_able_to(:read, coursemate_attempting_submission) }
       it { is_expected.to be_able_to(:read_tests, coursemate_attempting_submission) }
       it { is_expected.not_to be_able_to(:grade, coursemate_attempting_submission) }
@@ -187,7 +186,6 @@ RSpec.describe Course::Assessment do
       it { is_expected.not_to be_able_to(:force_submit_assessment_submission, published_started_assessment) }
 
       # Course Assessment Submissions
-      it { is_expected.to be_able_to(:view_all_submissions, attempting_submission) }
       it { is_expected.to be_able_to(:read, attempting_submission) }
       it { is_expected.to be_able_to(:grade, attempting_submission) }
       it { is_expected.to be_able_to(:grade, submitted_submission) }

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Course::Assessment do
       it { is_expected.to be_able_to(:read_tests, coursemate_attempting_submission) }
       it { is_expected.not_to be_able_to(:grade, coursemate_attempting_submission) }
       it { is_expected.not_to be_able_to(:delete_all_submissions, published_started_assessment) }
-      it { is_expected.not_to be_able_to(:delete_submission, attempting_submission) }
+      it { is_expected.to be_able_to(:delete_submission, attempting_submission) }
       it { is_expected.not_to be_able_to(:delete_submission, coursemate_attempting_submission) }
       it { is_expected.to be_able_to(:destroy_attachment, own_attachment) }
       it { is_expected.not_to be_able_to(:destroy_attachment, other_attachment) }

--- a/spec/models/course/assessment/skill_ability_spec.rb
+++ b/spec/models/course/assessment/skill_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Assessment::Skill do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:other_course) { create(:course) }
     let(:skill) { create(:course_assessment_skill, course: course) }
@@ -17,14 +17,16 @@ RSpec.describe Course::Assessment::Skill do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.not_to be_able_to(:show, skill) }
       it { is_expected.not_to be_able_to(:show, skill_branch) }
     end
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, skill) }
       it { is_expected.to be_able_to(:manage, skill_branch) }
@@ -33,7 +35,8 @@ RSpec.describe Course::Assessment::Skill do
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, skill) }
       it { is_expected.to be_able_to(:show, skill_branch) }

--- a/spec/models/course/condition/achievement_ability_spec.rb
+++ b/spec/models/course/condition/achievement_ability_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Achievement do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:condition) { create(:achievement_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end

--- a/spec/models/course/condition/assessment_ability_spec.rb
+++ b/spec/models/course/condition/assessment_ability_spec.rb
@@ -4,18 +4,20 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Assessment do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:condition) { create(:assessment_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       context 'when the assessment is published but has not started' do
         let(:not_started_assessment) do

--- a/spec/models/course/condition/level_ability_spec.rb
+++ b/spec/models/course/condition/level_ability_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Level do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:condition) { create(:level_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end

--- a/spec/models/course/condition/survey_ability_spec.rb
+++ b/spec/models/course/condition/survey_ability_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Survey do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:condition) { create(:survey_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end

--- a/spec/models/course/condition/video_ability_spec.rb
+++ b/spec/models/course/condition/video_ability_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 RSpec.describe Course::Condition::Video do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:condition) { create(:video_condition, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, condition) }
     end

--- a/spec/models/course/forum/topic_ability_spec.rb
+++ b/spec/models/course/forum/topic_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Forum::Topic, type: :model do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject(:ability) { Ability.new(user) }
+    subject(:ability) { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:forum) { create(:forum, course: course) }
     let(:shown_topic) { build_stubbed(:forum_topic, forum: forum) }
@@ -13,7 +13,8 @@ RSpec.describe Course::Forum::Topic, type: :model do
     let(:question_topic) { build_stubbed(:forum_topic, topic_type: :question, forum: forum) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
       let(:my_shown_topic) do
         build_stubbed(:forum_topic, forum: forum, hidden: false, creator: user)
       end
@@ -38,14 +39,16 @@ RSpec.describe Course::Forum::Topic, type: :model do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, shown_topic) }
       it { is_expected.to be_able_to(:manage, hidden_topic) }
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, shown_topic) }
       it { is_expected.to be_able_to(:show, hidden_topic) }

--- a/spec/models/course/forum_ability_spec.rb
+++ b/spec/models/course/forum_ability_spec.rb
@@ -4,24 +4,27 @@ require 'rails_helper'
 RSpec.describe Course::Forum, type: :model do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject(:ability) { Ability.new(user) }
+    subject(:ability) { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:forum) { create(:forum, course: course) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, forum) }
     end
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, forum) }
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:read, forum) }
       it { is_expected.not_to be_able_to(:manage, forum) }

--- a/spec/models/course/group_ability_spec.rb
+++ b/spec/models/course/group_ability_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Course::Group do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:user) { create(:user) }
     let!(:group) { create(:course_group, course: course) }
 
     context 'when the user is a Course Staff' do
-      let!(:course_manager) { create(:course_teaching_assistant, course: course, user: user) }
+      let!(:course_user) { create(:course_teaching_assistant, course: course, user: user) }
 
       it { is_expected.to be_able_to(:manage, group) }
 
@@ -21,7 +21,7 @@ RSpec.describe Course::Group do
     end
 
     context 'when the user is a Course Observer' do
-      let!(:course_observer) { create(:course_observer, course: course, user: user) }
+      let!(:course_user) { create(:course_observer, course: course, user: user) }
 
       it { is_expected.to be_able_to(:read, group) }
       it { is_expected.not_to be_able_to(:manage, group) }

--- a/spec/models/course/lesson_plan/lesson_plan_event_ability_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_event_ability_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe Course::LessonPlan::Event do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:lesson_plan_event) { create(:course_lesson_plan_event, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, lesson_plan_event) }
 
@@ -21,7 +22,8 @@ RSpec.describe Course::LessonPlan::Event do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_event) }
       it { is_expected.not_to be_able_to(:manage, lesson_plan_event) }

--- a/spec/models/course/lesson_plan/lesson_plan_item_ability_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_item_ability_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe Course::LessonPlan::Item do
   let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:unpublished_item) { create(:course_lesson_plan_item, course: course) }
     let(:lesson_plan_item) { create(:course_lesson_plan_item, course: course, published: true) }
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, lesson_plan_item) }
       it { is_expected.to be_able_to(:show, unpublished_item) }
@@ -23,14 +24,16 @@ RSpec.describe Course::LessonPlan::Item do
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_item) }
       it { is_expected.to be_able_to(:show, unpublished_item) }
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_item) }
       it { is_expected.not_to be_able_to(:show, unpublished_item) }

--- a/spec/models/course/lesson_plan/lesson_plan_milestone_ability_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_milestone_ability_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe Course::LessonPlan::Milestone do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:lesson_plan_milestone) { create(:course_lesson_plan_milestone, course: course) }
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, lesson_plan_milestone) }
 
@@ -21,7 +22,8 @@ RSpec.describe Course::LessonPlan::Milestone do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, lesson_plan_milestone) }
       it { is_expected.not_to be_able_to(:manage, lesson_plan_milestone) }

--- a/spec/models/course/lesson_plan/lesson_plan_todo_ability_spec.rb
+++ b/spec/models/course/lesson_plan/lesson_plan_todo_ability_spec.rb
@@ -5,11 +5,15 @@ RSpec.describe Course::LessonPlan::Item do
   let!(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
-    let(:user) { create(:user) }
-    let(:todo) { create(:course_lesson_plan_todo, user: user) }
-    let(:other_user) { create(:user) }
-    let(:other_todo) { create(:course_lesson_plan_todo, user: other_user) }
+    subject { Ability.new(user, course, course_user) }
+    let(:course) { create(:course) }
+    let(:course_user) { create(:course_student, course: course) }
+    let(:user) { course_user.user }
+    let(:todo) { create(:course_lesson_plan_todo, course: course, user: user) }
+
+    let(:other_course_user) { create(:course_student, course: course) }
+    let(:other_user) { other_course_user.user }
+    let(:other_todo) { create(:course_lesson_plan_todo, course: course, user: other_user) }
 
     context 'when the user is the user of the todo' do
       it { is_expected.to be_able_to(:ignore, todo) }

--- a/spec/models/course/level_ability_spec.rb
+++ b/spec/models/course/level_ability_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe Course::Level do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let!(:level) { create(:course_level, course: course) }
     let!(:default_level) { course.reload.levels.first }
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, level) }
       it { is_expected.not_to be_able_to(:destroy, default_level) }
@@ -22,7 +23,8 @@ RSpec.describe Course::Level do
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:read, level) }
       it { is_expected.not_to be_able_to(:manage, level) }

--- a/spec/models/course/material/folder_ability_spec.rb
+++ b/spec/models/course/material/folder_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Material::Folder, type: :model do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject(:ability) { Ability.new(user) }
+    subject(:ability) { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:root_folder) { course.root_folder }
     let(:valid_folder) { build_stubbed(:folder, course: course) }
@@ -24,7 +24,8 @@ RSpec.describe Course::Material::Folder, type: :model do
              course: course, start_at: 1.day.from_now).folder
     end
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, valid_folder) }
       it { is_expected.not_to be_able_to(:show, not_started_folder) }
@@ -39,7 +40,8 @@ RSpec.describe Course::Material::Folder, type: :model do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, valid_folder) }
       it { is_expected.to be_able_to(:manage, not_started_folder) }
@@ -57,6 +59,7 @@ RSpec.describe Course::Material::Folder, type: :model do
     end
 
     context 'when the user is a System Administrator' do
+      let(:course_user) { nil }
       let(:user) { create(:administrator) }
 
       it { is_expected.not_to be_able_to(:update, started_linked_folder) }

--- a/spec/models/course/material_ability_spec.rb
+++ b/spec/models/course/material_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Material do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject(:ability) { Ability.new(user) }
+    subject(:ability) { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:valid_material) do
       folder = build_stubbed(:folder, course: course)
@@ -30,7 +30,8 @@ RSpec.describe Course::Material do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, valid_material) }
       it { is_expected.not_to be_able_to(:show, not_started_material) }
@@ -46,7 +47,8 @@ RSpec.describe Course::Material do
     end
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, valid_material) }
       it { is_expected.to be_able_to(:manage, not_started_material) }
@@ -56,7 +58,8 @@ RSpec.describe Course::Material do
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, valid_material) }
       it { is_expected.to be_able_to(:show, not_started_material) }

--- a/spec/models/course/statistics_ability_spec.rb
+++ b/spec/models/course/statistics_ability_spec.rb
@@ -5,29 +5,33 @@ RSpec.describe Course, type: :model do
   let(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.not_to be_able_to(:read_statistics, course) }
     end
 
     context 'when the user is a Course Teaching Assistant' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:read_statistics, course) }
     end
 
     context 'when the user is a Course Manager' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:read_statistics, course) }
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:read_statistics, course) }
     end

--- a/spec/models/course/survey/survey_ability_spec.rb
+++ b/spec/models/course/survey/survey_ability_spec.rb
@@ -5,14 +5,15 @@ RSpec.describe Course::LessonPlan::Event do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:student) { create(:course_student, course: course) }
     let(:survey) { create(:survey, *survey_traits, course: course) }
     let(:survey_traits) { [] }
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, survey) }
 
@@ -56,7 +57,8 @@ RSpec.describe Course::LessonPlan::Event do
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.not_to be_able_to(:manage, survey) }
 
@@ -102,6 +104,7 @@ RSpec.describe Course::LessonPlan::Event do
     end
 
     context 'when the user is a Course Student' do
+      let(:course_user) { student }
       let(:user) { student.user }
 
       context 'when the survey is published' do

--- a/spec/models/course/video/video_ability_spec.rb
+++ b/spec/models/course/video/video_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::Video do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let(:course_user) { create(:course_student, course: course) }
     let(:draft_video) { create(:video, course: course) }
@@ -45,7 +45,8 @@ RSpec.describe Course::Video do
     end
 
     context 'when the user is a Course Teaching Staff' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       # Course Video Tabs
       it { is_expected.not_to be_able_to(:create, published_video.tab) }
@@ -65,14 +66,16 @@ RSpec.describe Course::Video do
     end
 
     context 'when the user is a Course Manager' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       # Course Video Tabs
       it { is_expected.to be_able_to(:manage, published_video.tab) }
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       # Course Video Tabs
       it { is_expected.not_to be_able_to(:create, published_video.tab) }

--- a/spec/models/course/virtual_classroom_ability_spec.rb
+++ b/spec/models/course/virtual_classroom_ability_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::VirtualClassroom do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let!(:not_started_virtual_classroom) do
       create(:course_virtual_classroom, :not_started, course: course)
@@ -13,7 +13,8 @@ RSpec.describe Course::VirtualClassroom do
     let!(:valid_virtual_classroom) { create(:course_virtual_classroom, course: course) }
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, valid_virtual_classroom) }
       it { is_expected.to be_able_to(:show, ended_virtual_classroom) }
@@ -23,7 +24,8 @@ RSpec.describe Course::VirtualClassroom do
     end
 
     context 'when the user is a Course Staff' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:manage, valid_virtual_classroom) }
       it { is_expected.to be_able_to(:manage, ended_virtual_classroom) }
@@ -32,7 +34,8 @@ RSpec.describe Course::VirtualClassroom do
     end
 
     context 'when the users is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:access_recorded_videos, course) }
       it { is_expected.not_to be_able_to(:manage, valid_virtual_classroom) }

--- a/spec/models/course_ability_spec.rb
+++ b/spec/models/course_ability_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe Course, type: :model do
   let(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let(:course) { create(:course) }
     let!(:closed_course) { create(:course, published: false, enrollable: false) }
     let!(:published_course) { create(:course, :published) }
     let!(:enrollable_course) { create(:course, :enrollable) }
 
     context 'when the user is a Normal User' do
+      let(:course_user) { nil }
       let(:user) { create(:user) }
 
       it { is_expected.not_to be_able_to(:show, published_course) }
@@ -23,7 +24,8 @@ RSpec.describe Course, type: :model do
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
@@ -33,7 +35,8 @@ RSpec.describe Course, type: :model do
     end
 
     context 'when the user is a Course Teaching Assistant' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.not_to be_able_to(:manage, course) }
@@ -43,7 +46,8 @@ RSpec.describe Course, type: :model do
     end
 
     context 'when the user is a Course Manager' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.to be_able_to(:manage, course) }
@@ -53,7 +57,8 @@ RSpec.describe Course, type: :model do
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:show, course) }
       it { is_expected.not_to be_able_to(:manage, course) }

--- a/spec/models/course_user_ability_spec.rb
+++ b/spec/models/course_user_ability_spec.rb
@@ -4,19 +4,21 @@ require 'rails_helper'
 RSpec.describe Course, type: :model do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
-    subject { Ability.new(user) }
-    let(:course_user) { create(:course_student) }
+    subject { Ability.new(user, course_user.course, course_user) }
+    let(:course_user_mate) { create(:course_student) }
 
     context 'when the user is from the same course' do
-      let(:user) { create(:course_student, course: course_user.course).user }
+      let(:course_user) { create(:course_student, course: course_user_mate.course) }
+      let(:user) { course_user.user }
 
-      it { is_expected.to be_able_to(:read, course_user) }
+      it { is_expected.to be_able_to(:read, course_user_mate) }
     end
 
     context 'when the user is from a different course' do
-      let(:user) { create(:course_student).user }
+      let(:course_user) { create(:course_student) }
+      let(:user) { course_user.user }
 
-      it { is_expected.not_to be_able_to(:read, course_user) }
+      it { is_expected.not_to be_able_to(:read, course_user_mate) }
     end
   end
 end


### PR DESCRIPTION
Closes #2599

This cancancan re-write will improve performance in 2 ways:
1. Remove course_user join table to check for specific role. (Refer to #2590)
2. For multiple :read abilities for the same model, we specify the role thats specific to the ability in order to avoid multiple OR joins for the same ability. (i.e. https://github.com/Coursemology/coursemology2/pull/4280/commits/74f8d6c4714276a278730e17d6b1a79f82d51933)