### PR TITLE
Fix conditional editing views

### DIFF
--- a/app/models/course/condition.rb
+++ b/app/models/course/condition.rb
@@ -19,11 +19,11 @@ class Course::Condition < ApplicationRecord
   delegate :satisfied_by?, to: :actable
 
   ALL_CONDITIONS = [
-    {name: Course::Condition::Achievement.name, active: true},
-    {name: Course::Condition::Assessment.name, active: true},
-    {name: Course::Condition::Level.name, active: true},
-    {name: Course::Condition::Survey.name, active: true},
-    {name: Course::Condition::Video.name, active: false}
+    { name: Course::Condition::Achievement.name, active: true },
+    { name: Course::Condition::Assessment.name, active: true },
+    { name: Course::Condition::Level.name, active: true },
+    { name: Course::Condition::Survey.name, active: true },
+    { name: Course::Condition::Video.name, active: false }
   ].freeze
 
   class << self

--- a/app/models/course/condition.rb
+++ b/app/models/course/condition.rb
@@ -19,11 +19,11 @@ class Course::Condition < ApplicationRecord
   delegate :satisfied_by?, to: :actable
 
   ALL_CONDITIONS = [
-    Course::Condition::Achievement.name,
-    Course::Condition::Assessment.name,
-    Course::Condition::Level.name,
-    Course::Condition::Survey.name,
-    Course::Condition::Video.name
+    {name: Course::Condition::Achievement.name, active: true},
+    {name: Course::Condition::Assessment.name, active: true},
+    {name: Course::Condition::Level.name, active: true},
+    {name: Course::Condition::Survey.name, active: true},
+    {name: Course::Condition::Video.name, active: false},
   ].freeze
 
   class << self
@@ -76,9 +76,9 @@ class Course::Condition < ApplicationRecord
     def dependent_class_to_condition_class_mapping
       mappings = Hash.new { |h, k| h[k] = [] }
 
-      Course::Condition::ALL_CONDITIONS.map do |condition_name|
-        dependent_class = condition_name.constantize.dependent_class
-        mappings[dependent_class] << condition_name unless dependent_class.nil?
+      Course::Condition::ALL_CONDITIONS.map do |condition|
+        dependent_class = condition[:name].constantize.dependent_class
+        mappings[dependent_class] << condition[:name] unless dependent_class.nil?
       end
 
       mappings

--- a/app/models/course/condition.rb
+++ b/app/models/course/condition.rb
@@ -23,7 +23,7 @@ class Course::Condition < ApplicationRecord
     {name: Course::Condition::Assessment.name, active: true},
     {name: Course::Condition::Level.name, active: true},
     {name: Course::Condition::Survey.name, active: true},
-    {name: Course::Condition::Video.name, active: false},
+    {name: Course::Condition::Video.name, active: false}
   ].freeze
 
   class << self

--- a/app/views/course/condition/_conditions.html.slim
+++ b/app/views/course/condition/_conditions.html.slim
@@ -8,8 +8,8 @@ div.dropdown.pull-right
     span.caret
   ul.dropdown-menu.dropdown-menu-right aria-labelledby="new-condition-dropdown-btn"
     - Course::Condition::ALL_CONDITIONS.each do |condition|
-      - if component_enabled?(condition)
-        - condition_name = condition.constantize.model_name
+      - if component_enabled?(condition[:name]) && condition[:active]
+        - condition_name = condition[:name].constantize.model_name
         li = link_to condition_name.human,
                      [:new, current_course, conditional, condition_name.singular_route_key.to_sym]
 

--- a/app/views/course/condition/_conditions.json.jbuilder
+++ b/app/views/course/condition/_conditions.json.jbuilder
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 json.condition_attributes do
   json.new_condition_urls Course::Condition::ALL_CONDITIONS do |condition|
-    next unless component_enabled?(condition)
+    next unless component_enabled?(condition[:name]) && condition[:active]
 
-    condition_model = condition.constantize.model_name
+    condition_model = condition[:name].constantize.model_name
     json.name condition_model.human
     json.url url_for([:new, current_course, conditional, condition_model.singular_route_key.to_sym])
   end


### PR DESCRIPTION
Currently, the editing views for conditionals are broken due to coupling with condition model names. `Course::Condition::Video.name` appears in the `ALL_CONDITIONS` list of the condition model but views for creating video conditions have not been added yet (see #4244). The conditions list view assumes that views are defined for all condition types and breaks as a result.

This PR changes `ALL_CONDITIONS` from a list of condition names to a list of hashes, each containing a name and an `active` flag. This decouples the conditions list view from the condition model names themselves and allows it to only display condition types which have the `active` flag set to `true`.