### PR TITLE
Optimise new submission creation

### DIFF
--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -17,9 +17,10 @@ module Course::Assessment::Submission::AnswersConcern
   end
 
   def create_new_answers
-    questions_to_attempt ||= assessment.questions.includes(:actable)
+    # Load questions from submission instead of assessment in case of randomized assessment
+    questions_to_attempt ||= questions.includes(:actable)
     new_answers = questions_to_attempt.not_answered(self).attempt(self)
-    bulk_save_new_answers(new_answers)
+    bulk_save_new_answers(new_answers) if new_answers.present?
   end
 
   private

--- a/app/models/concerns/course/assessment/submission/answers_concern.rb
+++ b/app/models/concerns/course/assessment/submission/answers_concern.rb
@@ -17,15 +17,37 @@ module Course::Assessment::Submission::AnswersConcern
   end
 
   def create_new_answers
-    questions_to_attempt ||= assessment.questions
+    questions_to_attempt ||= assessment.questions.includes(:actable)
     new_answers = questions_to_attempt.not_answered(self).attempt(self)
+    bulk_save_new_answers(new_answers)
+  end
 
-    new_answers.map do |answer|
-      # When there are no existing answers, the first one will be the current_answer.
-      if answer.new_record?
-        answer.current_answer = true
-        answer.save!
+  private
+
+  # Insert new answer records (and its actables) in bulk.
+  #
+  # @param [Array<Course::Assessment::Answer>] new_answers Array of new submission answers
+  # @raise [ActiveRecord::RecordInvalid] If the new answers cannot be saved.
+  # @return[Boolean] If new answers were created.
+  def bulk_save_new_answers(new_answers)
+    # When there are no existing answers, the first one will be the current_answer.
+    # We first filter new_record from the new_answers and assign the current answer flag
+    # below.
+    new_answers_record = new_answers.select(&:new_record?)
+    return false unless new_answers_record.present?
+
+    new_answers_record.each do |new_answer_record|
+      new_answer_record.current_answer = true
+    end
+
+    new_answers_actables = new_answers_record.map(&:actable)
+    new_answers_group_by_actables = new_answers_actables.group_by { |actable| actable.class.to_s }
+
+    ActiveRecord::Base.transaction do
+      new_answers_group_by_actables.each_key do |key|
+        key.constantize.import! new_answers_group_by_actables[key], recursive: true
       end
     end
+    true
   end
 end

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -116,7 +116,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   end
 
   def questions_to_attempt
-    @questions_to_attempt ||= @submission.assessment.questions
+    @questions_to_attempt ||= @submission.questions
   end
 
   # Find the questions for this submission without submission_questions.

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -34,8 +34,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   def load_or_create_answers
     return unless @submission.attempting?
 
-    new_answers = questions_to_attempt.includes(:actable).not_answered(@submission).attempt(@submission)
-    new_answers_created = bulk_save_new_answers(new_answers)
+    new_answers_created = @submission.create_new_answers
     @submission.answers.reload if new_answers_created && @submission.answers.loaded?
   end
 
@@ -114,33 +113,6 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
 
   def submit_answer_params
     params.require(:answer).permit([:id] + update_answer_type_params)
-  end
-
-  # Insert new answer records (and its actables) in bulk.
-  #
-  # @param [Array<Course::Assessment::Answer>] new_answers Array of new submission answers
-  # @raise [ActiveRecord::RecordInvalid] If the new answers cannot be saved.
-  # @return[Boolean] If new answers were created.
-  def bulk_save_new_answers(new_answers)
-    # When there are no existing answers, the first one will be the current_answer.
-    # We first filter new_record from the new_answers and assign the current answer flag
-    # below.
-    new_answers_record = new_answers.select(&:new_record?)
-    return false unless new_answers_record.present?
-
-    new_answers_record.each do |new_answer_record|
-      new_answer_record.current_answer = true
-    end
-
-    new_answers_actables = new_answers_record.map(&:actable)
-    new_answers_group_by_actables = new_answers_actables.group_by { |actable| actable.class.to_s }
-
-    ActiveRecord::Base.transaction do
-      new_answers_group_by_actables.each_key do |key|
-        key.constantize.import! new_answers_group_by_actables[key], recursive: true
-      end
-    end
-    true
   end
 
   def questions_to_attempt

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -34,7 +34,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   def load_or_create_answers
     return unless @submission.attempting?
 
-    new_answers = questions_to_attempt.not_answered(@submission).attempt(@submission)
+    new_answers = questions_to_attempt.includes(:actable).not_answered(@submission).attempt(@submission)
     new_answers_created = bulk_save_new_answers(new_answers)
     @submission.answers.reload if new_answers_created && @submission.answers.loaded?
   end


### PR DESCRIPTION
When a user attempts a submission for the first time, submission_questions and answers are created and inserted 1 by 1 to the DB resulting in N+1 issue. To solve this, we now use bulk insert instead.

In addition, a new submission of a randomized assessment would create answers and submission_questions for all questions from the assessment. Now, only assigned questions based on the question bundle assignmenets are used.

Improvement comparisons (create new attempt on courses/1745/assessments/30193):
- Local (before: ~2600ms, after: ~1300ms)
- Staging (before: ~700ms, after: ~ms)
- Production (before: ~1000ms, after: ~ms)

In detail (local):
Before
<img width="559" alt="image" src="https://user-images.githubusercontent.com/42570513/149257705-52f2c211-3a97-40f8-9c67-e511ce8f9cb7.png">

After
![image](https://user-images.githubusercontent.com/42570513/149258425-2d7dff61-7875-4367-9f70-b2745fb86754.png)