### PR TITLE
fix(programming question form): fix form to not show exp update confirmation when the course is not gamified and the assessment is not autograded

### DIFF
--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -16,6 +16,7 @@ json.question do
   json.has_auto_gradings @programming_question.auto_gradable? && has_submissions
   json.has_submissions has_submissions
   json.display_autograded_toggle display_autograded_toggle?
+  json.course_gamified current_course.gamified?
   json.autograded_assessment @assessment.autograded?
   json.published_assessment @assessment.published?
   json.attempt_limit @programming_question.attempt_limit

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -179,13 +179,17 @@ class ProgrammingQuestionForm extends React.Component {
     e.preventDefault();
     if (!this.validationCheck()) return;
 
-    const autograded = this.props.data.getIn(['question', 'autograded']);
+    const autogradedAssessment = this.props.data.getIn([
+      'question',
+      'autograded_assessment',
+    ]);
     const hasSubmissions = this.props.data.getIn([
       'question',
       'has_submissions',
     ]);
+    const gamified = this.props.data.getIn(['question', 'course_gamified']);
 
-    if (autograded && hasSubmissions) {
+    if (gamified && autogradedAssessment && hasSubmissions) {
       this.setState((prevState) => ({
         confirmationOpen: !prevState.confirmationOpen,
       }));

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -157,6 +157,42 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management' do
         expect(question_created.time_limit).to eq(question_attributes[:time_limit])
         expect(question_created.attempt_limit).to eq(question_attributes[:attempt_limit])
       end
+
+      describe 'When updating a question', js: true do
+        let(:assessment) { create(:assessment, :autograded, course: course) }
+        let!(:question) do
+          create(:course_assessment_question_programming, :auto_gradable, template_package: true,
+                                                                          assessment: assessment)
+        end
+        let(:student_user) { create(:course_student, course: course).user }
+        let(:submission) { create(:submission, :published, assessment: assessment, creator: student_user) }
+        it 'shows confirmation dialog to update all exp when there is a submission' do
+          submission
+          visit edit_course_assessment_question_programming_path(course, assessment, question)
+          page.find('#programming-question-form-submit').click
+          expect(page).to have_selector('button.confirm-btn')
+        end
+
+        it 'does not show the confirmation dialog when the course is not gamified' do
+          course.update!(gamified: false)
+          visit edit_course_assessment_question_programming_path(course, assessment, question)
+          page.find('#programming-question-form-submit').click
+          expect(page).not_to have_selector('button.confirm-btn')
+        end
+
+        it 'does not show the confirmation dialog when there is no submission' do
+          visit edit_course_assessment_question_programming_path(course, assessment, question)
+          page.find('#programming-question-form-submit').click
+          expect(page).not_to have_selector('button.confirm-btn')
+        end
+
+        it 'does not show the confirmation dialog when the assessment is non-autograded' do
+          assessment.update!(autograded: false)
+          visit edit_course_assessment_question_programming_path(course, assessment, question)
+          page.find('#programming-question-form-submit').click
+          expect(page).not_to have_selector('button.confirm-btn')
+        end
+      end
     end
 
     context 'As a Student' do


### PR DESCRIPTION
As described. Related to #4214 