### PR TITLE
Fix bug with personalized timeline algorithm

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -75,7 +75,9 @@ module Course::LessonPlan::PersonalizationConcern
 
         # If the user was previously on the stragglers algorithm and just switched over, and has already open
         # items, we want to keep those items as they are
-        next if personal_time.end_at > reference_time.end_at && personal_time.start_at < Time.zone.now
+        if personal_time.end_at && personal_time.end_at > reference_time.end_at && personal_time.start_at < Time.zone.now
+          next
+        end
 
         # Update start_at
         if personal_time.start_at > Time.zone.now

--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -75,7 +75,8 @@ module Course::LessonPlan::PersonalizationConcern
 
         # If the user was previously on the stragglers algorithm and just switched over, and has already open
         # items, we want to keep those items as they are
-        if personal_time.end_at && personal_time.end_at > reference_time.end_at && personal_time.start_at < Time.zone.now
+        if personal_time.end_at && personal_time.end_at > reference_time.end_at &&
+           personal_time.start_at < Time.zone.now
           next
         end
 

--- a/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
+++ b/spec/controllers/concerns/course/lesson_plan/personalization_concern_spec.rb
@@ -107,5 +107,34 @@ RSpec.describe Course::LessonPlan::PersonalizationConcern do
         expect(course_user.personal_times.count).to eq(course.assessments.count - 1)
       end
     end
+
+    context 'when there are lesson plan items without end times' do
+      let!(:no_end_time_assessment) do
+        create(:course_assessment_assessment, course: course, start_at: 1.days.ago, published: true)
+      end
+
+      it 'still works for fixed algorithm' do
+        course_user = create(:course_user, course: course, timeline_algorithm: 'fixed')
+        create(:course_assessment_submission, assessment: assessment, creator: course_user.user).tap(&:finalise!)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        expect(course_user.personal_times.count).to eq(0)
+      end
+
+      it 'still works for fomo timeline' do
+        course_user = create(:course_user, course: course, timeline_algorithm: 'fomo')
+        create(:course_assessment_submission, assessment: assessment, creator: course_user.user).tap(&:finalise!)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        expect(course_user.personal_times.count).to eq(course.assessments.count - 1)
+      end
+
+      it 'still works for stragglers timeline' do
+        course_user = create(:course_user, course: course, timeline_algorithm: 'stragglers')
+        create(:course_assessment_submission, assessment: assessment, creator: course_user.user).tap(&:finalise!)
+        dummy_controller.send(:update_personalized_timeline_for, course_user)
+        expect(course_user.personal_times.count).to eq(course.assessments.count - 1)
+      end
+
+      # No test for OTOT since as of right now, OTOT is composed of stragglers and fomo
+    end
   end
 end


### PR DESCRIPTION
### Summary

Things broke because the FOMO algorithm failed to check for the presence of ending time before comparing.

### Test Plan

Run the updated test. It should all pass.

To check that it won't pass without the fix, checkout to the second last commit and run the test again - it should fail for FOMO.