### PR TITLE
Reset question_bundle_assignments when a submission is deleted

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -174,7 +174,7 @@ class Course::Assessment::Submission::SubmissionsController < \
     if success
       head :ok
     else
-      logger.error("failed to unsubmit submission: #{submission.errors.inspect}")
+      logger.error("Failed to unsubmit submission: #{submission.errors.inspect}")
       render json: { errors: submission.errors }, status: :bad_request
     end
   end
@@ -196,10 +196,10 @@ class Course::Assessment::Submission::SubmissionsController < \
   def delete
     @submission = @assessment.submissions.find(params[:submission_id])
     authorize!(:delete_submission, @submission)
+
     success = @submission.transaction do
       reset_question_bundle_assignments if @assessment.randomization == 'prepared'
-      @submission.destroy!
-      true
+      @submission.destroy
     end
     if success
       head :ok

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -194,11 +194,11 @@ class Course::Assessment::Submission::SubmissionsController < \
   end
 
   def delete
-    submission = @assessment.submissions.find(params[:submission_id])
-    authorize!(:delete_submission, submission)
-    success = submission.transaction do
-      submission.destroy!
-
+    @submission = @assessment.submissions.find(params[:submission_id])
+    authorize!(:delete_submission, @submission)
+    success = @submission.transaction do
+      reset_question_bundle_assignments if @assessment.randomization == 'prepared'
+      @submission.destroy!
       true
     end
     if success
@@ -207,6 +207,11 @@ class Course::Assessment::Submission::SubmissionsController < \
       logger.error("Failed to delete submission: #{submission.errors.inspect}")
       render json: { errors: submission.errors }, status: :bad_request
     end
+  end
+
+  def reset_question_bundle_assignments
+    qbas = @assessment.question_bundle_assignments.where(submission: @submission).lock!
+    raise ActiveRecord::Rollback unless qbas.update_all(submission_id: nil)
   end
 
   def delete_all

--- a/app/jobs/course/assessment/submission/deleting_job.rb
+++ b/app/jobs/course/assessment/submission/deleting_job.rb
@@ -9,7 +9,7 @@ class Course::Assessment::Submission::DeletingJob < ApplicationJob
     instance = Course.unscoped { assessment.course.instance }
     ActsAsTenant.with_tenant(instance) do
       submissions = assessment.submissions.find(submission_ids)
-      delete_submission(submissions, deleter)
+      delete_submission(assessment, submissions, deleter)
     end
 
     redirect_to course_assessment_submissions_path(assessment.course, assessment)
@@ -19,15 +19,27 @@ class Course::Assessment::Submission::DeletingJob < ApplicationJob
 
   # Delete all submissions for a given assessment.
   #
-  # @param [Course::Submissions] submissions Submissions that are to be deleted.
+  # @param [Course::Assessment] assessment Assessment of which its submissions to be deleted
+  # @param [Course::Assessment::Submissions] submissions Submissions that are to be deleted.
   # @param [User] deleter The user object who would be deleting the submission.
-  def delete_submission(submissions, deleter)
+  def delete_submission(assessment, submissions, deleter)
     User.with_stamper(deleter) do
       Course::Assessment::Submission.transaction do
+        reset_question_bundle_assignments(assessment, submissions) if assessment.randomization == 'prepared'
         submissions.each do |submission|
           submission.destroy!
         end
       end
     end
+  end
+
+  # Remove submission ids from question bundle assignments that are related to the deleted submissions.
+  #
+  # @param [Course::Assessment] assessment Assessment of which its submissions to be deleted
+  # @param [Course::Assessment::Submissions] submissions Submissions that are to be deleted.
+  def reset_question_bundle_assignments(assessment, submissions)
+    submission_ids = submissions.pluck(:id)
+    qbas = assessment.question_bundle_assignments.where('submission_id in (?)', submission_ids).lock!
+    raise ActiveRecord::Rollback unless qbas.update_all(submission_id: nil)
   end
 end


### PR DESCRIPTION
When a submission is deleted, the submission_id in the question_bundle_assignments should be removed as the submission does no longer exist and so that the qbas can be used when the user re-attempt the deleted submission.