### PR TITLE
Fix masquerade not working properly in prod

### DIFF
--- a/app/assets/javascripts/routes.js
+++ b/app/assets/javascripts/routes.js
@@ -1572,9 +1572,9 @@ var ROUTES = (function() {
 // user_emails => /user/emails(.:format)
   // function(options)
   user_emails_path: Utils.route([["format",false]], {}, [2,[7,"/",false],[2,[6,"user",false],[2,[7,"/",false],[2,[6,"emails",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]),
-// user_masquerade_index => /users/masquerade(.:format)
-  // function(options)
-  user_masquerade_index_path: Utils.route([["format",false]], {}, [2,[7,"/",false],[2,[6,"users",false],[2,[7,"/",false],[2,[6,"masquerade",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]),
+// user_masquerade => /users/masquerade/:id(.:format)
+  // function(id, options)
+  user_masquerade_path: Utils.route([["id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"users",false],[2,[7,"/",false],[2,[6,"masquerade",false],[2,[7,"/",false],[2,[3,"id",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]),
 // user_password => /users/password(.:format)
   // function(options)
   user_password_path: Utils.route([["format",false]], {}, [2,[7,"/",false],[2,[6,"users",false],[2,[7,"/",false],[2,[6,"password",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]),


### PR DESCRIPTION
In production, stop masquerading does not appear after masquerading as another user. This does not happen locally and in staging. This happened when https://github.com/Coursemology/dockerfiles/tree/0.0.8-rc8 was deployed 

The diff between 0.0.8-rc8 and rc7 is below and the only item that's changed for masquerading is the js routes. Lets see if this fixes it.
`https://github.com/Coursemology/coursemology2/compare/c9bd69a89cb40b98cb51ef2601697f8381fa7436...f07af4a4b28ef3f387ba648ea43e90402c509fb1#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5`