### PR TITLE
fix(programming import editor): show highlighted content for read only editor

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/ProgrammingImportEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ProgrammingImportEditor.jsx
@@ -31,7 +31,7 @@ class VisibleProgrammingImportEditor extends Component {
         {fields.map((answerId, index) => {
           const file = fields.get(index);
           if (readOnly) {
-            const content = file.content.split('\n');
+            const content = file.highlighted_content.split('\n');
             return (
               <ReadOnlyEditor
                 key={answerId}
@@ -73,7 +73,7 @@ class VisibleProgrammingImportEditor extends Component {
     const { displayFileIndex } = this.state;
     const file = answer.files_attributes[displayFileIndex];
     if (file) {
-      const content = file.content.split('\n');
+      const content = file.highlighted_content.split('\n');
       return (
         <ReadOnlyEditor
           key={answer.id}


### PR DESCRIPTION
Fixes #3760 for ProgrammingImportEditor

Use highlighted content to prevent XSS

Before
![image](https://user-images.githubusercontent.com/42570513/149513213-7c20a93c-473a-4020-8b23-b8b461fc3a77.png)

After
![image](https://user-images.githubusercontent.com/42570513/149513063-f7f04311-dd8c-4862-a469-766552cbacc3.png)
