### PR TITLE
fix: clear cache after computing course user data

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -47,6 +47,7 @@ module Course::LessonPlan::PersonalizationConcern
 
   def algorithm_fomo(course_user)
     submitted_lesson_plan_item_ids, items, learning_rate_ema = retrieve_or_compute_course_user_data(course_user)
+    Rails.cache.delete("course/lesson_plan/personalization_concern/#{course_user.id}")
     return if learning_rate_ema.nil?
 
     # Constrain learning rate
@@ -107,6 +108,7 @@ module Course::LessonPlan::PersonalizationConcern
 
   def algorithm_stragglers(course_user)
     submitted_lesson_plan_item_ids, items, learning_rate_ema = retrieve_or_compute_course_user_data(course_user)
+    Rails.cache.delete("course/lesson_plan/personalization_concern/#{course_user.id}")
     return if learning_rate_ema.nil?
 
     # Constrain learning rate


### PR DESCRIPTION
We don't actually need the course user data in the cache after either FOMO or Stragglers is called - only OTOT. This fix clears the cache right after the data is retrieved.