### PR TITLE
chore(deps): revert some gem upgrades

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'active_record-acts_as', git: 'https://github.com/ekowidianto/active_record-
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Upsert action for Postgres
-gem 'active_record_upsert'
+gem 'active_record_upsert', '0.10.1'
 # Create pretty URLs and work with human-friendly strings
 gem 'friendly_id'
 
@@ -166,7 +166,7 @@ end
 
 group :production do
   # Use fog-aws as CarrierWave's storage provider
-  gem 'fog-aws'
+  gem 'fog-aws', '3.8.0'
   gem 'rack-mini-profiler'
   gem 'flamegraph'
   gem 'stackprof'
@@ -188,7 +188,7 @@ gem 'acts_as_tenant'
 gem 'http_accept_language'
 
 # User authentication
-gem 'devise'
+gem 'devise', '4.7.3'
 gem 'devise_masquerade'
 gem 'devise-multi_email'
 
@@ -245,5 +245,5 @@ gem 'loofah', '>= 2.2.1'
 gem 'rails-html-sanitizer', '>= 1.0.4'
 
 gem 'sprockets', '< 4.0.0'
-gem 'mimemagic', '>= 0.3.7'
+gem 'mimemagic', '0.3.10'
 gem 'ffi', '>= 1.14.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,8 +109,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_record_upsert (0.11.1)
-      activerecord (>= 5.2, < 7.1)
+    active_record_upsert (0.10.1)
+      activerecord (>= 5.0, < 6.2)
       pg (>= 0.18, < 2.0)
     activejob (6.0.4.4)
       activesupport (= 6.0.4.4)
@@ -207,7 +207,7 @@ GEM
     connection_pool (2.2.5)
     consistency_fail (0.3.7)
     crass (1.0.6)
-    devise (4.8.1)
+    devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -234,7 +234,7 @@ GEM
     erubi (1.10.0)
     et-orbi (1.2.4)
       tzinfo
-    excon (0.89.0)
+    excon (0.88.0)
     execjs (2.8.1)
     exifr (1.3.9)
     factory_bot (6.2.0)
@@ -245,12 +245,12 @@ GEM
     ffi (1.15.5)
     filename (0.1.2)
     flamegraph (0.9.5)
-    fog-aws (3.12.0)
+    fog-aws (3.8.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-core (2.2.4)
+    fog-core (2.2.3)
       builder
       excon (~> 0.71)
       formatador (~> 0.2)
@@ -258,13 +258,13 @@ GEM
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-xml (0.1.4)
+    fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
-    formatador (0.3.0)
-    friendly_id (5.4.2)
+    formatador (0.2.5)
+    friendly_id (5.4.1)
       activerecord (>= 4.0.0)
     fspath (3.1.2)
     fugit (1.4.2)
@@ -357,10 +357,10 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
-    mimemagic (0.4.3)
+    mime-types-data (3.2020.1104)
+    mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
     mini_magick (4.11.0)
@@ -585,7 +585,7 @@ GEM
     temple (0.8.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.2.1)
+    thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     traceroute (0.8.1)
@@ -628,14 +628,14 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.27)
       webrick (~> 1.7.0)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   active_record-acts_as!
-  active_record_upsert
+  active_record_upsert (= 0.10.1)
   activerecord-import (>= 0.2.0)
   activerecord-userstamp!
   acts_as_tenant
@@ -659,7 +659,7 @@ DEPENDENCIES
   codecov
   consistency_fail
   coursemology-polyglot!
-  devise
+  devise (= 4.7.3)
   devise-multi_email
   devise_masquerade
   docker-api
@@ -670,7 +670,7 @@ DEPENDENCIES
   ffi (>= 1.14.2)
   filename
   flamegraph
-  fog-aws
+  fog-aws (= 3.8.0)
   font-awesome-rails
   friendly_id
   high_voltage
@@ -689,7 +689,7 @@ DEPENDENCIES
   lograge-sql
   lol_dba
   loofah (>= 2.2.1)
-  mimemagic (>= 0.3.7)
+  mimemagic (= 0.3.10)
   mini_magick
   nokogiri (>= 1.8.1)
   parallel_tests


### PR DESCRIPTION
Downgrade some gems in 0.0.8-rc9 releases:
- active_record_upsert
- fog-aws
- devise
- mimemagic