### PR TITLE
fix(submission edit submit validation): skip validation for non voice response answer

### DIFF
--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
@@ -203,7 +203,12 @@ class VisibleSubmissionEditIndex extends Component {
      * Therefore we need to manually touch all the fields
      */
     answers.forEach((answer = {}) => {
-      if (questions[answer.questionId].type !== 'VoiceResponse') return;
+      if (
+        answer.questionId in questions &&
+        questions[answer.questionId].type !== 'VoiceResponse'
+      ) {
+        return;
+      }
       const answerId = answer.id;
       Object.keys(answer).forEach((key) => {
         dispatch(touch(formNames.SUBMISSION, `${answerId}.${key}`));

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
@@ -194,7 +194,7 @@ class VisibleSubmissionEditIndex extends Component {
   }
 
   validateSubmit = () => {
-    const { dispatch, form } = this.props;
+    const { dispatch, form, questions } = this.props;
     const answers = Object.values(form.values);
     /**
      * Assume there are syncErrors in the form initially.
@@ -203,6 +203,7 @@ class VisibleSubmissionEditIndex extends Component {
      * Therefore we need to manually touch all the fields
      */
     answers.forEach((answer = {}) => {
+      if (questions[answer.questionId].type !== 'VoiceResponse') return;
       const answerId = answer.id;
       Object.keys(answer).forEach((key) => {
         dispatch(touch(formNames.SUBMISSION, `${answerId}.${key}`));


### PR DESCRIPTION
Related to [#2564](https://github.com/Coursemology/coursemology2/pull/2564)

After clicking submit and confirm in the confirmation dialog when finalizing a submission, there is a short lag before the confirmation dialog disappears. This occurs due to the frontend validation for every answer which needs to be 'touched. Supposedly the validation is only for voice response related answer. For other question types, in order to minimize the delay for the confirmation dialog to disappear, we can skip the validation.