### PR TITLE
Add unmark as pending link to comment notification email for instructor

### DIFF
--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -30,6 +30,17 @@ class Course::Discussion::TopicsController < Course::ComponentController
     @topics = my_students_topics.pending_staff_reply
   end
 
+  def unmark_as_pending
+    if @topic.unmark_as_pending
+      flash.now[:success] = t('course.discussion.topics.unmark_as_pending_success')
+    else
+      flash.now[:danger] = @topic.errors.full_messages.to_sentence
+    end
+    @topics = Course::Discussion::Topic.where(id: @topic.id).page(page_param).per(@settings.pagination)
+
+    render 'index'
+  end
+
   def toggle_pending
     success = if mark_as_pending?
                 @topic.mark_as_pending

--- a/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
@@ -9,18 +9,23 @@
 - course = assessment.course
 - host = course.instance.host
 - category_id = assessment.tab.category.id
+- course_user_recipient = course.course_users.find_by(user: @recipient)
 
 - message.subject = t('.subject', course: course.title, topic: "#{assessment.title}: #{question_assessment.display_title}")
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = submission.questions.index(question) + 1
 
-= format_html(t('.message',
+- message_body = course_user_recipient.student? ? '.message' : '.message_staff'
+
+= format_html(t(message_body,
                 topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
                                edit_course_assessment_submission_url(course, assessment,
                                                                      submission,
                                                                      step: step, host: host)),
-                               post: post.text_to_email,
-                               post_author: post.author_name))
+                post: post.text_to_email,
+                post_author: post.author_name,
+                unmark_as_pending: link_to(t('.unmark_as_pending'),
+                                           unmark_as_pending_course_topic_url(course, post.topic, host: host))))
 
 br
 = render partial: 'layouts/manage_email_subscription',

--- a/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
@@ -15,17 +15,24 @@
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = submission.questions.index(question) + 1
 
-- message_body = course_user_recipient.student? ? '.message' : '.message_staff'
-
-= format_html(t(message_body,
-                topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
-                               edit_course_assessment_submission_url(course, assessment,
-                                                                     submission,
-                                                                     step: step, host: host)),
-                post: post.text_to_email,
-                post_author: post.author_name,
-                unmark_as_pending: link_to(t('.unmark_as_pending'),
-                                           unmark_as_pending_course_topic_url(course, post.topic, host: host))))
+- if course_user_recipient.student?
+  = format_html(t('.message',
+                    topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
+                                  edit_course_assessment_submission_url(course, assessment,
+                                                                        submission,
+                                                                        step: step, host: host)),
+                    post: post.text_to_email,
+                    post_author: post.author_name))
+- else
+  = format_html(t('.message_staff',
+                  topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
+                                edit_course_assessment_submission_url(course, assessment,
+                                                                      submission,
+                                                                      step: step, host: host)),
+                  post: post.text_to_email,
+                  post_author: post.author_name,
+                  unmark_as_pending: link_to(t('.unmark_as_pending'),
+                                            unmark_as_pending_course_topic_url(course, post.topic, host: host))))
 
 br
 = render partial: 'layouts/manage_email_subscription',

--- a/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
@@ -7,18 +7,23 @@
 - host = course.instance.host
 - question_assessment = assessment.question_assessments.find_by!(question: question)
 - category_id = assessment.tab.category.id
+- course_user_recipient = course.course_users.find_by(user: @recipient)
 
 - message.subject = t('.subject', course: course.title, topic: "#{assessment.title}: #{question_assessment.display_title}")
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = assessment.questions.index(question) + 1
 
-= format_html(t('.message',
+- message_body = course_user_recipient.student? ? '.message' : '.message_staff'
+
+= format_html(t(message_body,
                 topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
                                edit_course_assessment_submission_url(course, assessment,
                                                                      submission_question.submission,
                                                                      step: step, host: host)),
-                               post: post.text_to_email,
-                               post_author: post.author_name))
+                post: post.text_to_email,
+                post_author: post.author_name,
+                unmark_as_pending: link_to(t('.unmark_as_pending'),
+                                           unmark_as_pending_course_topic_url(course, post.topic, host: host))))
 
 br
 = render partial: 'layouts/manage_email_subscription',

--- a/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
@@ -13,9 +13,16 @@
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = assessment.questions.index(question) + 1
 
-- message_body = course_user_recipient.student? ? '.message' : '.message_staff'
-
-= format_html(t(message_body,
+- if course_user_recipient.student?
+  = format_html(t('.message',
+                  topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
+                                edit_course_assessment_submission_url(course, assessment,
+                                                                      submission_question.submission,
+                                                                      step: step, host: host)),
+                  post: post.text_to_email,
+                  post_author: post.author_name))
+- else
+  = format_html(t('.message_staff',
                 topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
                                edit_course_assessment_submission_url(course, assessment,
                                                                      submission_question.submission,

--- a/config/locales/en/course/discussion/topics.yml
+++ b/config/locales/en/course/discussion/topics.yml
@@ -19,4 +19,5 @@ en:
           header: :'course.discussion.topics.index.header'
         mark_as_pending: 'Mark as pending'
         unmark_as_pending: 'Unmark as pending'
+        unmark_as_pending_success: 'The comment below has been successfully unmarked as pending.'
         mark_as_read: 'Mark as read'

--- a/config/locales/en/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.yml
@@ -13,3 +13,9 @@ en:
 
                     <p>You can reply here:</p>
                     %{topic}
+                  message_staff: >
+                    <p>%{post_author} added an annotation, %{post}</p>
+
+                    <p>You can %{unmark_as_pending} or reply here:</p>
+                    %{topic}
+                  unmark_as_pending: 'unmark this comment as pending'

--- a/config/locales/en/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.yml
@@ -13,3 +13,9 @@ en:
 
                     <p>You can reply here:</p>
                     %{topic}
+                  message_staff: >
+                    <p>%{post_author} added an annotation, %{post}</p>
+
+                    <p>You can %{unmark_as_pending} or reply here:</p>
+                    %{topic}
+                  unmark_as_pending: 'unmark this comment as pending'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -368,6 +368,7 @@ Rails.application.routes.draw do
           get 'pending', on: :collection
           get 'my_students', on: :collection
           get 'my_students_pending', on: :collection
+          get 'unmark_as_pending', on: :member
           patch 'toggle_pending', on: :member
           patch 'mark_as_read', on: :member
           resources :posts, only: [:create, :update, :destroy]


### PR DESCRIPTION
Closes #3742 

When a user clicks on the link provided in the email notification, the user will be redirected to the comments page with the related comment and a success/fail message.

Test WIP