### PR TITLE
Add unmark as pending link (without login) to comment notification email for instructor

### DIFF
--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -93,4 +93,8 @@ class Course::Discussion::Topic < ApplicationRecord
     self.pending_staff_reply = false
     save
   end
+
+  def create_token_from_record
+    Digest::SHA256.hexdigest(id.to_s + actable_id.to_s + actable_type + course_id.to_s + created_at.utc.to_s)
+  end
 end

--- a/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.html.slim
@@ -9,18 +9,30 @@
 - course = assessment.course
 - host = course.instance.host
 - category_id = assessment.tab.category.id
+- course_user_recipient = course.course_users.find_by(user: @recipient)
 
 - message.subject = t('.subject', course: course.title, topic: "#{assessment.title}: #{question_assessment.display_title}")
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = submission.questions.index(question) + 1
 
-= format_html(t('.message',
-                topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
-                               edit_course_assessment_submission_url(course, assessment,
-                                                                     submission,
-                                                                     step: step, host: host)),
-                               post: post.text_to_email,
-                               post_author: post.author_name))
+- if course_user_recipient.student?
+  = format_html(t('.message',
+                    topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
+                                  edit_course_assessment_submission_url(course, assessment,
+                                                                        submission,
+                                                                        step: step, host: host)),
+                    post: post.text_to_email,
+                    post_author: post.author_name))
+- else
+  = format_html(t('.message_staff',
+                  topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
+                                edit_course_assessment_submission_url(course, assessment,
+                                                                      submission,
+                                                                      step: step, host: host)),
+                  post: post.text_to_email,
+                  post_author: post.author_name,
+                  unmark_as_pending: link_to(t('.unmark_as_pending'),
+                                            unmark_as_pending_course_topic_url(course, post.topic, token: post.topic.create_token_from_record, host: host))))
 
 br
 = render partial: 'layouts/manage_email_subscription',

--- a/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.html.slim
@@ -7,18 +7,30 @@
 - host = course.instance.host
 - question_assessment = assessment.question_assessments.find_by!(question: question)
 - category_id = assessment.tab.category.id
+- course_user_recipient = course.course_users.find_by(user: @recipient)
 
 - message.subject = t('.subject', course: course.title, topic: "#{assessment.title}: #{question_assessment.display_title}")
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user.phantom?
 - step = assessment.questions.index(question) + 1
 
-= format_html(t('.message',
+- if course_user_recipient.student?
+  = format_html(t('.message',
+                  topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
+                                edit_course_assessment_submission_url(course, assessment,
+                                                                      submission_question.submission,
+                                                                      step: step, host: host)),
+                  post: post.text_to_email,
+                  post_author: post.author_name))
+- else
+  = format_html(t('.message_staff',
                 topic: link_to("#{assessment.title}: #{question_assessment.display_title}",
                                edit_course_assessment_submission_url(course, assessment,
                                                                      submission_question.submission,
                                                                      step: step, host: host)),
-                               post: post.text_to_email,
-                               post_author: post.author_name))
+                post: post.text_to_email,
+                post_author: post.author_name,
+                unmark_as_pending: link_to(t('.unmark_as_pending'),
+                                           unmark_as_pending_course_topic_url(course, post.topic, token: post.topic.create_token_from_record, host: host))))
 
 br
 = render partial: 'layouts/manage_email_subscription',

--- a/config/locales/en/course/discussion/topics.yml
+++ b/config/locales/en/course/discussion/topics.yml
@@ -19,4 +19,6 @@ en:
           header: :'course.discussion.topics.index.header'
         mark_as_pending: 'Mark as pending'
         unmark_as_pending: 'Unmark as pending'
+        unmark_as_pending_success: 'The comment has been successfully unmarked as pending'
+        unmark_as_pending_failed: 'Failed to unmark comment as pending'
         mark_as_read: 'Mark as read'

--- a/config/locales/en/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment/answer/comment_notifier/annotated/user_notifications/email.yml
@@ -13,3 +13,9 @@ en:
 
                     <p>You can reply here:</p>
                     %{topic}
+                  message_staff: >
+                    <p>%{post_author} added an annotation, %{post}</p>
+
+                    <p>You can %{unmark_as_pending} or reply here:</p>
+                    %{topic}
+                  unmark_as_pending: 'unmark this comment as pending'

--- a/config/locales/en/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.yml
+++ b/config/locales/en/notifiers/course/assessment/submission_question/comment_notifier/replied/user_notifications/email.yml
@@ -13,3 +13,9 @@ en:
 
                     <p>You can reply here:</p>
                     %{topic}
+                  message_staff: >
+                    <p>%{post_author} added an annotation, %{post}</p>
+
+                    <p>You can %{unmark_as_pending} or reply here:</p>
+                    %{topic}
+                  unmark_as_pending: 'unmark this comment as pending'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,6 +375,7 @@ Rails.application.routes.draw do
           get 'pending', on: :collection
           get 'my_students', on: :collection
           get 'my_students_pending', on: :collection
+          get 'unmark_as_pending', on: :member
           patch 'toggle_pending', on: :member
           patch 'mark_as_read', on: :member
           resources :posts, only: [:create, :update, :destroy]

--- a/spec/controllers/course/discussion/topics_controller_spec.rb
+++ b/spec/controllers/course/discussion/topics_controller_spec.rb
@@ -157,5 +157,33 @@ RSpec.describe Course::Discussion::TopicsController do
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
     end
+
+    describe '#unmark_as_pending' do
+      subject { get :unmark_as_pending, params: { course_id: course, id: pending_topic, token: token } }
+
+      context 'when a user visits the page and the token is valid' do
+        let(:token) { pending_topic.create_token_from_record }
+
+        it { is_expected.to redirect_to(root_path) }
+
+        it 'unmark the comment as pending and shows a success message' do
+          subject
+          expect(pending_topic.reload.pending_staff_reply).to be_falsey
+          expect(flash[:success]).to eq(I18n.t('course.discussion.topics.unmark_as_pending_success'))
+        end
+      end
+
+      context 'when a user visits the page and the token is invalid' do
+        let(:token) { 'woohoo' }
+
+        it { is_expected.to redirect_to(root_path) }
+
+        it 'does not unmark the comment as pending and shows a failed message' do
+          subject
+          expect(pending_topic.reload.pending_staff_reply).to be_truthy
+          expect(flash[:danger]).to eq(I18n.t('course.discussion.topics.unmark_as_pending_failed'))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #3742 

When a user clicks on the link provided in the email notification, the user will be redirected to coursemology home page with the related comment and a success/fail message. There is no need for the user to login. In order to authenticate the GET request, we create a hash from the topic record (id, actable_id, actable_type, course_id, created_at) as the token.