### PR TITLE
Refactor personalized timeline

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+module Course::LessonPlan::LearningRateConcern
+  extend ActiveSupport::Concern
+
+  # Returns { lesson_plan_item_id => submitted_time or nil }.
+  # If the lesson plan item is a key in this hash then we consider the item "submitted" regardless of whether we have a
+  # submission time for it.
+  #
+  # @param [CourseUser] course_user The course user to compute the lesson plan items submission time hash for.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] A hash of submitted lesson plan items' ID to their
+  #   submitted time, if relevant/available.
+  def lesson_plan_items_submission_time_hash(course_user)
+    lesson_plan_items_submission_time_hash = {}
+    # Extend this if more lesson plan items to personalize are added in the future.
+    merge_course_assessments(lesson_plan_items_submission_time_hash, course_user)
+    merge_course_videos(lesson_plan_items_submission_time_hash, course_user)
+  end
+
+  # Computes the learning rate exponential moving average for the given course user.
+  #
+  # @param [CourseUser] course_user The course user to compute the learning rate for.
+  # @param [Array<Course::LessonPlan::Item>] items_affecting_personal_times An array of lesson plan items that affect
+  #   personal times, sorted by the start_at for the given user, i.e. via time_for(course_user).start_at.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
+  #   their submitted time, if relevant/available.
+  # @param [Float] alpha Alpha value used in exponential moving average computation.
+  # @return [Float|nil] Learning rate exponential moving average, if computable.
+  def compute_learning_rate_ema(course_user, items_affecting_personal_times, submitted_items, alpha = 0.4) # rubocop:disable Metrics/AbcSize
+    submitted_items_affecting_personal_times = items_affecting_personal_times.
+                                               select { |i| i.id.in? submitted_items.keys }.
+                                               select { |i| i.time_for(course_user).end_at.present? }
+    return nil if submitted_items_affecting_personal_times.empty?
+
+    learning_rate_ema = 1.0
+    # Currently, for the item to affect learning rate, it needs to have an end_at timing.
+    # In the future, we may want to consider other ways of computing how much an item affects learning rate.
+    submitted_items_affecting_personal_times.each do |item|
+      times = item.time_for(course_user)
+      next if times.end_at - times.start_at == 0 || submitted_items[item.id].nil?
+
+      learning_rate = (submitted_items[item.id] - times.start_at) / (times.end_at - times.start_at)
+      learning_rate = [learning_rate, 0].max
+      learning_rate_ema = (alpha * learning_rate) + ((1 - alpha) * learning_rate_ema)
+    end
+    learning_rate_ema
+  end
+
+  # Bounds the learning rate based on a given min and max learning rate.
+  # Min/max overall learning rate refers to how early/late a student is allowed to complete the course.
+  #
+  # E.g. if max_overall_lr = 2 means a student is allowed to complete a 1-month course over 2 months.
+  # However, if the student somehow managed to complete half of the course within the first day, then we can allow him
+  # to continue at lr = 4 and still have the student complete the course over 2 months. This method computes the
+  # effective limits to preserve the overall min/max lr.
+  #
+  # NOTE: It is completely possible for negative results (even -infinity), i.e. student needs to go back in time in
+  # order to have any hope of completing the course within the limits. The algorithm needs to take care of this.
+  #
+  # @param [CourseUser] course_user The course user to compute the learning rate for.
+  # @param [Array<Course::LessonPlan::Item>] items An array of lesson plan items for the course user's course,
+  #   sorted by the start_at for the given user, i.e. via time_for(course_user).start_at.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
+  #   their submitted time, if relevant/available.
+  # @param [Float] min_learning_rate The minimum overall learning rate.
+  # @param [Float] max_learning_rate The maximum overall learning rate.
+  # @return [Array<Float>] An array pair containing [min learning rate, max learning rate].
+  def compute_learning_rate_effective_limits(course_user, items, submitted_items, min_learning_rate, max_learning_rate) # rubocop:disable Metrics/AbcSize
+    course_start = items.first.start_at
+    course_end = items.last.start_at
+    last_submitted_item = items.reverse_each.lazy.
+                          # TODO: Look into whether there's a need to filter on affects_personal_times?
+                          select { |item| item.affects_personal_times? && item.id.in?(submitted_items.keys) }.
+                          first
+    return [min_learning_rate, max_learning_rate] if last_submitted_item.nil?
+
+    reference_remaining_time = items.last.start_at - last_submitted_item.reference_time_for(course_user).start_at
+    min_remaining_time = course_start + (min_learning_rate * (course_end - course_start)) -
+                         last_submitted_item.time_for(course_user).start_at
+    max_remaining_time = course_start + (max_learning_rate * (course_end - course_start)) -
+                         last_submitted_item.time_for(course_user).start_at
+
+    [min_remaining_time / reference_remaining_time, max_remaining_time / reference_remaining_time]
+  end
+
+  private
+
+  # Merges course assessment submissions into the given hash, with the following format:
+  # { lesson_plan_item_id => submitted_time }
+  #
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] hash A hash of submitted lesson plan items' ID to their
+  #   submitted time, if relevant/available.
+  # @param [CourseUser] course_user Course user to retrieve course assessments for.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] Data with course assessment submission data merged in.
+  def merge_course_assessments(hash, course_user)
+    # Assessments - consider submitted only if submitted_at is present
+    hash.merge!(
+      course_user.course.assessments.
+      with_submissions_by(course_user.user).
+      select { |x| x.submissions.present? && x.submissions.first.submitted_at.present? }.
+      map { |x| [x.lesson_plan_item.id, x.submissions.first.submitted_at] }.to_h
+    )
+  end
+
+  # Merges course video submissions into the given hash, with the following format:
+  # { lesson_plan_item_id => nil }
+  #
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] hash A hash of submitted lesson plan items' ID to their
+  #   submitted time, if relevant/available.
+  # @param [CourseUser] course_user Course user to retrieve course videos for.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] Data with course video submission data merged in.
+  def merge_course_videos(hash, course_user)
+    # Videos - consider submitted as long as submission exists
+    hash.merge!(
+      course_user.course.videos.
+      with_submissions_by(course_user.user).
+      select { |x| x.submissions.present? }.
+      map { |x| [x.lesson_plan_item.id, nil] }.to_h
+    )
+  end
+end

--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -2,285 +2,32 @@
 module Course::LessonPlan::PersonalizationConcern
   extend ActiveSupport::Concern
 
-  FOMO_LEARNING_RATE_MAX = 1.0
-  FOMO_LEARNING_RATE_MIN = 0.67
-  FOMO_LEARNING_RATE_HARD_MIN = 0.5 # No matter how doomed the student is, refuse to go faster than this
-  FOMO_DATE_ROUNDING_THRESHOLD = 0.8
-
-  STRAGGLERS_LEARNING_RATE_MAX = 2.0
-  STRAGGLERS_LEARNING_RATE_MIN = 1.0
-  STRAGGLERS_LEARNING_RATE_HARD_MIN = 0.8
-  STRAGGLERS_DATE_ROUNDING_THRESHOLD = 0.2
-  STRAGGLERS_FIXES = 1
-
-  # Dispatches the call to the correct personalization algorithm
-  # If the algorithm takes too long (e.g. voodoo AI magic), it is responsible for scheduling an async job
-  def update_personalized_timeline_for(course_user, timeline_algorithm = nil)
-    timeline_algorithm ||= course_user.timeline_algorithm
-    Rails.cache.delete("course/lesson_plan/personalization_concern/#{course_user.id}")
-    send("algorithm_#{timeline_algorithm}", course_user)
-  end
-
-  # Fixed timeline: Follow reference timeline
-  # Delete all personal times that are not fixed or submitted
-  def algorithm_fixed(course_user)
-    submitted_lesson_plan_item_ids = lesson_plan_items_submission_time_hash(course_user)
-    course_user.personal_times.where(fixed: false).
-      where.not(lesson_plan_item_id: submitted_lesson_plan_item_ids.keys).delete_all
-  end
-
-  # Some properties for the following algorithms:
+  # Dispatches the call to the correct personalization algorithm strategy.
+  # If the algorithm takes too long (e.g. voodoo AI magic), it is responsible for scheduling an async job.
+  #
+  # Some properties for the algorithms:
   # - We don't shift personal dates that have already passed. This is to prevent items becoming locked
   #   when students are switched between different algos. There are thus quite a few checks for
   #   > Time.zone.now. The only exception is the backwards-shifting of already-past deadlines, which
   #   allows students to slow down their learning more effectively.
   # - We don't shift closing dates forward when the item has already opened for the student. This is to
   #   prevent students from being shocked that their deadlines have shifted forward suddenly.
+  def update_personalized_timeline_for(course_user, timeline_algorithm = nil)
+    timeline_algorithm ||= course_user.timeline_algorithm
 
-  def algorithm_otot(course_user)
-    learning_rate_ema = retrieve_or_compute_course_user_data(course_user).last
-    return if learning_rate_ema.nil?
+    strategy = case timeline_algorithm
+               when 'otot'
+                 OtotPersonalizationStrategy.new
+               when 'fomo'
+                 FomoPersonalizationStrategy.new
+               when 'stragglers'
+                 StragglersPersonalizationStrategy.new
+               else
+                 # Default to fixed.
+                 FixedPersonalizationStrategy.new
+               end
 
-    # Apply the appropriate algo depending on student's leaning rate
-    learning_rate_ema < 1 ? algorithm_fomo(course_user) : algorithm_stragglers(course_user)
-  end
-
-  def algorithm_fomo(course_user)
-    submitted_lesson_plan_item_ids, items, learning_rate_ema = retrieve_or_compute_course_user_data(course_user)
-    Rails.cache.delete("course/lesson_plan/personalization_concern/#{course_user.id}")
-    return if learning_rate_ema.nil?
-
-    # Constrain learning rate
-    effective_min, effective_max = compute_learning_rate_effective_limits(
-      course_user, items, submitted_lesson_plan_item_ids, FOMO_LEARNING_RATE_MIN, FOMO_LEARNING_RATE_MAX
-    )
-    learning_rate_ema = [FOMO_LEARNING_RATE_HARD_MIN, effective_min, [learning_rate_ema, effective_max].min].max
-
-    # Compute personal times for all items
-    course_tz = course_user.course.time_zone
-    reference_point = items.first.reference_time_for(course_user).start_at
-    personal_point = reference_point
-    course_user.transaction do
-      items.each do |item|
-        # Update reference point and personal point
-        if item.affects_personal_times? && item.id.in?(submitted_lesson_plan_item_ids.keys)
-          reference_point = item.reference_time_for(course_user).start_at
-          personal_point = item.time_for(course_user).start_at
-        end
-
-        next if !item.has_personal_times? || item.id.in?(submitted_lesson_plan_item_ids.keys) ||
-                item.personal_time_for(course_user)&.fixed?
-
-        reference_time = item.reference_time_for(course_user)
-        personal_time = item.find_or_create_personal_time_for(course_user)
-
-        # If the user was previously on the stragglers algorithm and just switched over, and has already open
-        # items, we want to keep those items as they are
-        if personal_time.end_at && personal_time.end_at > reference_time.end_at &&
-           personal_time.start_at < Time.zone.now
-          next
-        end
-
-        # Update start_at
-        if personal_time.start_at > Time.zone.now
-          personal_time.start_at =
-            round_to_date(
-              personal_point + ((reference_time.start_at - reference_point) * learning_rate_ema),
-              course_tz,
-              FOMO_DATE_ROUNDING_THRESHOLD
-            )
-        end
-        # Hard limits to make sure we don't fail bounds checks
-        personal_time.start_at = [personal_time.start_at, reference_time.start_at, reference_time.end_at].compact.min
-
-        # Update bonus_end_at
-        if personal_time.bonus_end_at && personal_time.bonus_end_at > Time.zone.now
-          personal_time.bonus_end_at = reference_time.bonus_end_at
-        end
-
-        # Update end_at
-        personal_time.end_at = reference_time.end_at if personal_time.end_at && personal_time.end_at > Time.zone.now
-
-        personal_time.save!
-      end
-    end
-  end
-
-  def algorithm_stragglers(course_user)
-    submitted_lesson_plan_item_ids, items, learning_rate_ema = retrieve_or_compute_course_user_data(course_user)
-    Rails.cache.delete("course/lesson_plan/personalization_concern/#{course_user.id}")
-    return if learning_rate_ema.nil?
-
-    # Constrain learning rate
-    effective_min, effective_max = compute_learning_rate_effective_limits(
-      course_user, items, submitted_lesson_plan_item_ids, STRAGGLERS_LEARNING_RATE_MIN, STRAGGLERS_LEARNING_RATE_MAX
-    )
-    learning_rate_ema = [STRAGGLERS_LEARNING_RATE_HARD_MIN, effective_min, [learning_rate_ema, effective_max].min].max
-
-    # Compute personal times for all items
-    course_tz = course_user.course.time_zone
-    reference_point = items.first.reference_time_for(course_user).end_at
-    personal_point = reference_point
-    course_user.transaction do
-      items.each do |item|
-        # Update reference point and personal point
-        if item.affects_personal_times? && item.id.in?(submitted_lesson_plan_item_ids.keys) &&
-           item.reference_time_for(course_user).end_at.present?
-          reference_point = item.reference_time_for(course_user).end_at
-          personal_point = item.time_for(course_user).end_at
-        end
-
-        next if !item.has_personal_times? || item.id.in?(submitted_lesson_plan_item_ids.keys) ||
-                item.personal_time_for(course_user)&.fixed? || reference_point.nil?
-
-        reference_time = item.reference_time_for(course_user)
-        personal_time = item.find_or_create_personal_time_for(course_user)
-
-        # Update start_at
-        personal_time.start_at = reference_time.start_at if personal_time.start_at > Time.zone.now
-
-        # Update bonus_end_at
-        if personal_time.bonus_end_at && personal_time.bonus_end_at > Time.zone.now
-          personal_time.bonus_end_at = reference_time.bonus_end_at
-        end
-
-        # Update end_at
-        if reference_time.end_at.present?
-          new_end_at = round_to_date(
-            personal_point + ((reference_time.end_at - reference_point) * learning_rate_ema),
-            course_tz,
-            STRAGGLERS_DATE_ROUNDING_THRESHOLD,
-            to_2359: true # rubocop:disable Naming/VariableNumber
-          )
-          # Hard limits to make sure we don't fail bounds checks
-          new_end_at = [new_end_at, reference_time.end_at, reference_time.start_at].compact.max
-
-          # We don't want to shift the end_at forward if the item is already opened or if the deadline
-          # has already passed. Backwards is ok.
-          # Assumption: end_at is >= start_at
-          if new_end_at > personal_time.end_at || personal_time.start_at > Time.zone.now
-            personal_time.end_at = new_end_at
-          end
-        end
-        personal_time.save!
-      end
-    end
-
-    # Fix next few items
-    items.select { |item| item.has_personal_times? && !item.id.in?(submitted_lesson_plan_item_ids.keys) }.
-      slice(0, STRAGGLERS_FIXES).
-      each { |item| item.reload.find_or_create_personal_time_for(course_user).update(fixed: true) }
-  end
-
-  # Returns cached data for the course user, if available, else it does the necessary computations and caches.
-  # Data returned is an array containing:
-  # - The submitted lesson plan item IDs
-  # - The published lesson plan items with reference and personal times, sorted by start_at for user
-  # - Learning rate computed for the user
-  # in the above order.
-  def retrieve_or_compute_course_user_data(course_user)
-    Rails.cache.fetch("course/lesson_plan/personalization_concern/#{course_user.id}", expires_in: 1.hours) do
-      submitted_lesson_plan_item_ids = lesson_plan_items_submission_time_hash(course_user)
-      items = course_user.course.lesson_plan_items.published.
-              with_reference_times_for(course_user).
-              with_personal_times_for(course_user).
-              to_a
-      items = items.sort_by { |x| x.time_for(course_user).start_at }
-      items_affects_personal_times = items.select(&:affects_personal_times?)
-
-      learning_rate_ema = compute_learning_rate_ema(
-        course_user, items_affects_personal_times, submitted_lesson_plan_item_ids
-      )
-      [submitted_lesson_plan_item_ids, items, learning_rate_ema]
-    end
-  end
-
-  # Returns { lesson_plan_item_id => submitted_time or nil }
-  # If the lesson plan item is a key in this hash then we consider the item "submitted" regardless of whether we have a
-  # submission time for it.
-  def lesson_plan_items_submission_time_hash(course_user)
-    lesson_plan_items_submission_time_hash = {}
-
-    # Assessments - consider submitted only if submitted_at is present
-    lesson_plan_items_submission_time_hash.merge!(
-      course_user.course.assessments.
-      with_submissions_by(course_user.user).
-      select { |x| x.submissions.present? && x.submissions.first.submitted_at.present? }.
-      map { |x| [x.lesson_plan_item.id, x.submissions.first.submitted_at] }.to_h
-    )
-
-    # Videos - consider submitted as long as submission exists
-    lesson_plan_items_submission_time_hash.merge!(
-      course_user.course.videos.
-      with_submissions_by(course_user.user).
-      select { |x| x.submissions.present? }.
-      map { |x| [x.lesson_plan_item.id, nil] }.to_h
-    )
-  end
-
-  # Min/max overall learning rate refers to how early/late a student is allowed to complete the course.
-  #
-  # E.g. if max_overall_lr = 2 means a student is allowed to complete a 1-month course over 2 months.
-  # However, if the student somehow managed to complete half of the course within the first day, then we can allow him
-  # to continue at lr = 4 and still have the student complete the course over 2 months. This method computes the
-  # effective limits to preserve the overall min/max lr.
-  #
-  # NOTE: It is completely possible for negative results (even -infinity), i.e. student needs to go back in time in
-  # order to have any hope of completing the course within the limits. The algorithm needs to take care of this.
-  def compute_learning_rate_effective_limits(
-    course_user, items, submitted_lesson_plan_item_ids, min_overall_learning_rate, max_overall_learning_rate
-  )
-    course_start = items.first.start_at
-    course_end = items.last.start_at
-    last_submitted_item =
-      items.reverse_each.lazy.
-      select { |item| item.affects_personal_times? && item.id.in?(submitted_lesson_plan_item_ids.keys) }.first
-    return [min_overall_learning_rate, max_overall_learning_rate] if last_submitted_item.nil?
-
-    reference_remaining_time = items.last.start_at - last_submitted_item.reference_time_for(course_user).start_at
-    min_personal_remaining_time =
-      course_start +
-      (min_overall_learning_rate * (course_end - course_start)) - last_submitted_item.time_for(course_user).start_at
-    max_personal_remaining_time =
-      course_start +
-      (max_overall_learning_rate * (course_end - course_start)) - last_submitted_item.time_for(course_user).start_at
-
-    [min_personal_remaining_time / reference_remaining_time, max_personal_remaining_time / reference_remaining_time]
-  end
-
-  # Exponential Moving Average (EMA) of the learning rate
-  def compute_learning_rate_ema(course_user, course_assessments, submitted_lesson_plan_item_ids, alpha = 0.4)
-    submitted_assessments = course_assessments.
-                            select { |x| x.id.in? submitted_lesson_plan_item_ids.keys }.
-                            select { |x| x.time_for(course_user).end_at.present? }.
-                            sort_by { |x| x.time_for(course_user).start_at }
-    return nil if submitted_assessments.empty?
-
-    learning_rate_ema = 1.0
-    submitted_assessments.each do |assessment|
-      times = assessment.time_for(course_user)
-      next if times.end_at - times.start_at == 0 || submitted_lesson_plan_item_ids[assessment.id].nil?
-
-      learning_rate = (submitted_lesson_plan_item_ids[assessment.id] - times.start_at) / (times.end_at - times.start_at)
-      learning_rate = [learning_rate, 0].max
-      learning_rate_ema = (alpha * learning_rate) + ((1 - alpha) * learning_rate_ema)
-    end
-    learning_rate_ema
-  end
-
-  private
-
-  # Round to "nearest" date in course's timezone, NOT user's timezone.
-  #
-  # @param [Time] datetime The datetime object to round.
-  # @param [String] course_tz The timezone of the course.
-  # @param [Float] threshold How generously we round off. E.g. if `threshold` = 0.8, then a datetime with a time of
-  #                          > 0.8 * 1.day will be snapped to the next day.
-  # @param [Boolean] to_2359 Whether to round off to 2359. This will set the datetime to be 2359 of the date before the
-  #                          rounded date.
-  def round_to_date(datetime, course_tz, threshold = 0.5, to_2359: false)
-    prev_day = datetime.in_time_zone(course_tz).to_date.in_time_zone(course_tz).in_time_zone
-    date = ((datetime - prev_day) < threshold ? prev_day : prev_day + 1.day)
-    to_2359 ? date - 1.minute : date
+    precomputed_data = strategy.precompute_data(course_user)
+    strategy.execute(course_user, precomputed_data)
   end
 end

--- a/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
@@ -2,6 +2,7 @@
 # The BasePersonalizationStrategy declares operations common to all, if not most, personalized timeline algorithms.
 # It also defines the interface to use when calling the algorithm defined by the subclasses.
 class BasePersonalizationStrategy
+  include Course::LessonPlan::LearningRateConcern
   # To override any of these constants, simply define the same constant in the subclass.
   LEARNING_RATE_ALPHA = 0.4
   MIN_LEARNING_RATE = 1.0
@@ -26,7 +27,7 @@ class BasePersonalizationStrategy
   #
   # @param [CourseUser] course_user The course user to compute data for.
   # @return [Hash] Precomputed data to aid execution.
-  def precompute_data(course_user)
+  def precompute_data(course_user) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     submitted_items = lesson_plan_items_submission_time_hash(course_user)
     items = course_user.course.lesson_plan_items.published.
             with_reference_times_for(course_user).
@@ -35,10 +36,12 @@ class BasePersonalizationStrategy
     items = items.sort_by { |x| x.time_for(course_user).start_at }
     items_affecting_personal_times = items.select(&:affects_personal_times?)
     learning_rate_ema = compute_learning_rate_ema(
-      course_user, items_affecting_personal_times, submitted_items
+      course_user, items_affecting_personal_times, submitted_items, self.class::LEARNING_RATE_ALPHA
     )
     unless learning_rate_ema.nil?
-      effective_min, effective_max = compute_learning_rate_effective_limits(course_user, items, submitted_items)
+      effective_min, effective_max = compute_learning_rate_effective_limits(course_user, items, submitted_items,
+                                                                            self.class::MIN_LEARNING_RATE,
+                                                                            self.class::MAX_LEARNING_RATE)
       learning_rate_ema = [self.class::HARD_MIN_LEARNING_RATE, effective_min,
                            [learning_rate_ema, effective_max].min].max
     end
@@ -57,85 +60,6 @@ class BasePersonalizationStrategy
 
   protected
 
-  # Returns { lesson_plan_item_id => submitted_time or nil }.
-  # If the lesson plan item is a key in this hash then we consider the item "submitted" regardless of whether we have a
-  # submission time for it.
-  #
-  # @param [CourseUser] course_user The course user to compute the lesson plan items submission time hash for.
-  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] A hash of submitted lesson plan items' ID to their
-  #   submitted time, if relevant/available.
-  def lesson_plan_items_submission_time_hash(course_user)
-    lesson_plan_items_submission_time_hash = {}
-    # Extend this if more lesson plan items to personalize are added in the future.
-    merge_course_assessments(lesson_plan_items_submission_time_hash, course_user)
-    merge_course_videos(lesson_plan_items_submission_time_hash, course_user)
-  end
-
-  # Computes the learning rate exponential moving average for the given course user.
-  #
-  # @param [CourseUser] course_user The course user to compute the learning rate for.
-  # @param [Array<Course::LessonPlan::Item>] items_affecting_personal_times An array of lesson plan items that affect
-  #   personal times, sorted by the start_at for the given user, i.e. via time_for(course_user).start_at.
-  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
-  #   their submitted time, if relevant/available.
-  # @return [Float|nil] Learning rate exponential moving average, if computable.
-  def compute_learning_rate_ema(course_user, items_affecting_personal_times, submitted_items) # rubocop:disable Metrics/AbcSize
-    submitted_items_affecting_personal_times = items_affecting_personal_times.
-                                               select { |i| i.id.in? submitted_items.keys }.
-                                               select { |i| i.time_for(course_user).end_at.present? }
-    return nil if submitted_items_affecting_personal_times.empty?
-
-    learning_rate_ema = 1.0
-    # Currently, for the item to affect learning rate, it needs to have an end_at timing.
-    # In the future, we may want to consider other ways of computing how much an item affects learning rate.
-    submitted_items_affecting_personal_times.each do |item|
-      times = item.time_for(course_user)
-      next if times.end_at - times.start_at == 0 || submitted_items[item.id].nil?
-
-      learning_rate = (submitted_items[item.id] - times.start_at) / (times.end_at - times.start_at)
-      learning_rate = [learning_rate, 0].max
-      learning_rate_ema = (self.class::LEARNING_RATE_ALPHA * learning_rate) +
-                          ((1 - self.class::LEARNING_RATE_ALPHA) * learning_rate_ema)
-    end
-    learning_rate_ema
-  end
-
-  # Bounds the learning rate based on a given min and max learning rate.
-  # Min/max overall learning rate refers to how early/late a student is allowed to complete the course.
-  #
-  # E.g. if max_overall_lr = 2 means a student is allowed to complete a 1-month course over 2 months.
-  # However, if the student somehow managed to complete half of the course within the first day, then we can allow him
-  # to continue at lr = 4 and still have the student complete the course over 2 months. This method computes the
-  # effective limits to preserve the overall min/max lr.
-  #
-  # NOTE: It is completely possible for negative results (even -infinity), i.e. student needs to go back in time in
-  # order to have any hope of completing the course within the limits. The algorithm needs to take care of this.
-  #
-  # @param [CourseUser] course_user The course user to compute the learning rate for.
-  # @param [Array<Course::LessonPlan::Item>] items An array of lesson plan items for the course user's course,
-  #   sorted by the start_at for the given user, i.e. via time_for(course_user).start_at.
-  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
-  #   their submitted time, if relevant/available.
-  # @return [Array<Float>] An array pair containing [min learning rate, max learning rate].
-  def compute_learning_rate_effective_limits(course_user, items, submitted_items) # rubocop:disable Metrics/AbcSize
-    byebug
-    course_start = items.first.start_at
-    course_end = items.last.start_at
-    last_submitted_item = items.reverse_each.lazy.
-                          # TODO: Look into whether there's a need to filter on affects_personal_times?
-                          select { |item| item.affects_personal_times? && item.id.in?(submitted_items.keys) }.
-                          first
-    return [self.class::MIN_LEARNING_RATE, self.class::MAX_LEARNING_RATE] if last_submitted_item.nil?
-
-    reference_remaining_time = items.last.start_at - last_submitted_item.reference_time_for(course_user).start_at
-    min_remaining_time = course_start + (self.class::MIN_LEARNING_RATE * (course_end - course_start)) -
-                         last_submitted_item.time_for(course_user).start_at
-    max_remaining_time = course_start + (self.class::MAX_LEARNING_RATE * (course_end - course_start)) -
-                         last_submitted_item.time_for(course_user).start_at
-
-    [min_remaining_time / reference_remaining_time, max_remaining_time / reference_remaining_time]
-  end
-
   # Round to "nearest" date in course's timezone, NOT user's timezone.
   #
   # @param [ActiveSupport::TimeWithZone] datetime The datetime object to round.
@@ -146,41 +70,5 @@ class BasePersonalizationStrategy
     prev_day = datetime.in_time_zone(course_tz).to_date.in_time_zone(course_tz).in_time_zone
     date = ((datetime - prev_day) < self.class::DATE_ROUNDING_THRESHOLD ? prev_day : prev_day + 1.day)
     to_2359 ? date - 1.minute : date
-  end
-
-  private
-
-  # Merges course assessment submissions into the given hash, with the following format:
-  # { lesson_plan_item_id => submitted_time }
-  #
-  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] hash A hash of submitted lesson plan items' ID to their
-  #   submitted time, if relevant/available.
-  # @param [CourseUser] course_user Course user to retrieve course assessments for.
-  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] Data with course assessment submission data merged in.
-  def merge_course_assessments(hash, course_user)
-    # Assessments - consider submitted only if submitted_at is present
-    hash.merge!(
-      course_user.course.assessments.
-      with_submissions_by(course_user.user).
-      select { |x| x.submissions.present? && x.submissions.first.submitted_at.present? }.
-      map { |x| [x.lesson_plan_item.id, x.submissions.first.submitted_at] }.to_h
-    )
-  end
-
-  # Merges course video submissions into the given hash, with the following format:
-  # { lesson_plan_item_id => nil }
-  #
-  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] hash A hash of submitted lesson plan items' ID to their
-  #   submitted time, if relevant/available.
-  # @param [CourseUser] course_user Course user to retrieve course videos for.
-  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] Data with course video submission data merged in.
-  def merge_course_videos(hash, course_user)
-    # Videos - consider submitted as long as submission exists
-    hash.merge!(
-      course_user.course.videos.
-      with_submissions_by(course_user.user).
-      select { |x| x.submissions.present? }.
-      map { |x| [x.lesson_plan_item.id, nil] }.to_h
-    )
   end
 end

--- a/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+# The BasePersonalizationStrategy declares operations common to all, if not most, personalized timeline algorithms.
+# It also defines the interface to use when calling the algorithm defined by the subclasses.
+class BasePersonalizationStrategy
+  # To override any of these constants, simply define the same constant in the subclass.
+  LEARNING_RATE_ALPHA = 0.4
+  MIN_LEARNING_RATE = 1.0
+  MAX_LEARNING_RATE = 1.0
+  HARD_MIN_LEARNING_RATE = 1.0
+  # How generously we round off. E.g. if `threshold` = 0.5, then a datetime with a time of > 0.5 * 1.day will be
+  # snapped to the next day.
+  DATE_ROUNDING_THRESHOLD = 0.5
+
+  # Returns precomputed data for the given course user.
+  # The data returned depends on the strategy requirements, and will need to be of the same format
+  # that the execute method accepts.
+  #
+  # By default, the data returned is a hash containing {
+  #   items: Array<Course::LessonPlan::Item>,
+  #   submitted_items: Hash{Integer=>DateTime or nil},
+  #   learning_rate_ema: Float|nil
+  # }
+  # where items is a sorted array of lesson plan items based on the course_user start_at,
+  # submitted_items is a hash of the user's submitted lesson plan items to the submission time (if available),
+  # and learning_rate_ema is a learning rate exponential moving average, bounded based on algorithm specifications.
+  #
+  # @param [CourseUser] course_user The course user to compute data for.
+  # @return [Hash] Precomputed data to aid execution.
+  def precompute_data(course_user)
+    submitted_items = lesson_plan_items_submission_time_hash(course_user)
+    items = course_user.course.lesson_plan_items.published.
+            with_reference_times_for(course_user).
+            with_personal_times_for(course_user).
+            to_a
+    items = items.sort_by { |x| x.time_for(course_user).start_at }
+    items_affecting_personal_times = items.select(&:affects_personal_times?)
+    learning_rate_ema = compute_learning_rate_ema(
+      course_user, items_affecting_personal_times, submitted_items
+    )
+    unless learning_rate_ema.nil?
+      effective_min, effective_max = compute_learning_rate_effective_limits(course_user, items, submitted_items)
+      learning_rate_ema = [self.class::HARD_MIN_LEARNING_RATE, effective_min,
+                           [learning_rate_ema, effective_max].min].max
+    end
+
+    { submitted_items: submitted_items, items: items, learning_rate_ema: learning_rate_ema }
+  end
+
+  # Executes the relevant personalization strategy for the given course user, using the given precomputed
+  # data.
+  #
+  # @param [CourseUser] course_user The course user to execute the strategy on.
+  # @param [Hash|nil] precomputed_data Data to determine strategy execution.
+  def execute(_course_user, _precomputed_data)
+    raise NotImplementedError, 'Subclasses must implmement a execute method.'
+  end
+
+  protected
+
+  # Returns { lesson_plan_item_id => submitted_time or nil }.
+  # If the lesson plan item is a key in this hash then we consider the item "submitted" regardless of whether we have a
+  # submission time for it.
+  #
+  # @param [CourseUser] course_user The course user to compute the lesson plan items submission time hash for.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] A hash of submitted lesson plan items' ID to their
+  #   submitted time, if relevant/available.
+  def lesson_plan_items_submission_time_hash(course_user)
+    lesson_plan_items_submission_time_hash = {}
+    # Extend this if more lesson plan items to personalize are added in the future.
+    merge_course_assessments(lesson_plan_items_submission_time_hash, course_user)
+    merge_course_videos(lesson_plan_items_submission_time_hash, course_user)
+  end
+
+  # Computes the learning rate exponential moving average for the given course user.
+  #
+  # @param [CourseUser] course_user The course user to compute the learning rate for.
+  # @param [Array<Course::LessonPlan::Item>] items_affecting_personal_times An array of lesson plan items that affect
+  #   personal times, sorted by the start_at for the given user, i.e. via time_for(course_user).start_at.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
+  #   their submitted time, if relevant/available.
+  # @return [Float|nil] Learning rate exponential moving average, if computable.
+  def compute_learning_rate_ema(course_user, items_affecting_personal_times, submitted_items) # rubocop:disable Metrics/AbcSize
+    submitted_items_affecting_personal_times = items_affecting_personal_times.
+                                               select { |i| i.id.in? submitted_items.keys }.
+                                               select { |i| i.time_for(course_user).end_at.present? }
+    return nil if submitted_items_affecting_personal_times.empty?
+
+    learning_rate_ema = 1.0
+    # Currently, for the item to affect learning rate, it needs to have an end_at timing.
+    # In the future, we may want to consider other ways of computing how much an item affects learning rate.
+    submitted_items_affecting_personal_times.each do |item|
+      times = item.time_for(course_user)
+      next if times.end_at - times.start_at == 0 || submitted_items[item.id].nil?
+
+      learning_rate = (submitted_items[item.id] - times.start_at) / (times.end_at - times.start_at)
+      learning_rate = [learning_rate, 0].max
+      learning_rate_ema = (self.class::LEARNING_RATE_ALPHA * learning_rate) +
+                          ((1 - self.class::LEARNING_RATE_ALPHA) * learning_rate_ema)
+    end
+    learning_rate_ema
+  end
+
+  # Bounds the learning rate based on a given min and max learning rate.
+  # Min/max overall learning rate refers to how early/late a student is allowed to complete the course.
+  #
+  # E.g. if max_overall_lr = 2 means a student is allowed to complete a 1-month course over 2 months.
+  # However, if the student somehow managed to complete half of the course within the first day, then we can allow him
+  # to continue at lr = 4 and still have the student complete the course over 2 months. This method computes the
+  # effective limits to preserve the overall min/max lr.
+  #
+  # NOTE: It is completely possible for negative results (even -infinity), i.e. student needs to go back in time in
+  # order to have any hope of completing the course within the limits. The algorithm needs to take care of this.
+  #
+  # @param [CourseUser] course_user The course user to compute the learning rate for.
+  # @param [Array<Course::LessonPlan::Item>] items An array of lesson plan items for the course user's course,
+  #   sorted by the start_at for the given user, i.e. via time_for(course_user).start_at.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
+  #   their submitted time, if relevant/available.
+  # @return [Array<Float>] An array pair containing [min learning rate, max learning rate].
+  def compute_learning_rate_effective_limits(course_user, items, submitted_items) # rubocop:disable Metrics/AbcSize
+    byebug
+    course_start = items.first.start_at
+    course_end = items.last.start_at
+    last_submitted_item = items.reverse_each.lazy.
+                          # TODO: Look into whether there's a need to filter on affects_personal_times?
+                          select { |item| item.affects_personal_times? && item.id.in?(submitted_items.keys) }.
+                          first
+    return [self.class::MIN_LEARNING_RATE, self.class::MAX_LEARNING_RATE] if last_submitted_item.nil?
+
+    reference_remaining_time = items.last.start_at - last_submitted_item.reference_time_for(course_user).start_at
+    min_remaining_time = course_start + (self.class::MIN_LEARNING_RATE * (course_end - course_start)) -
+                         last_submitted_item.time_for(course_user).start_at
+    max_remaining_time = course_start + (self.class::MAX_LEARNING_RATE * (course_end - course_start)) -
+                         last_submitted_item.time_for(course_user).start_at
+
+    [min_remaining_time / reference_remaining_time, max_remaining_time / reference_remaining_time]
+  end
+
+  # Round to "nearest" date in course's timezone, NOT user's timezone.
+  #
+  # @param [ActiveSupport::TimeWithZone] datetime The datetime object to round.
+  # @param [String] course_tz The timezone of the course.
+  # @param [Boolean] to_2359 Whether to round off to 2359. This will set the datetime to be 2359 of the date before the
+  #   rounded date.
+  def round_to_date(datetime, course_tz, to_2359: false)
+    prev_day = datetime.in_time_zone(course_tz).to_date.in_time_zone(course_tz).in_time_zone
+    date = ((datetime - prev_day) < self.class::DATE_ROUNDING_THRESHOLD ? prev_day : prev_day + 1.day)
+    to_2359 ? date - 1.minute : date
+  end
+
+  private
+
+  # Merges course assessment submissions into the given hash, with the following format:
+  # { lesson_plan_item_id => submitted_time }
+  #
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] hash A hash of submitted lesson plan items' ID to their
+  #   submitted time, if relevant/available.
+  # @param [CourseUser] course_user Course user to retrieve course assessments for.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] Data with course assessment submission data merged in.
+  def merge_course_assessments(hash, course_user)
+    # Assessments - consider submitted only if submitted_at is present
+    hash.merge!(
+      course_user.course.assessments.
+      with_submissions_by(course_user.user).
+      select { |x| x.submissions.present? && x.submissions.first.submitted_at.present? }.
+      map { |x| [x.lesson_plan_item.id, x.submissions.first.submitted_at] }.to_h
+    )
+  end
+
+  # Merges course video submissions into the given hash, with the following format:
+  # { lesson_plan_item_id => nil }
+  #
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] hash A hash of submitted lesson plan items' ID to their
+  #   submitted time, if relevant/available.
+  # @param [CourseUser] course_user Course user to retrieve course videos for.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] Data with course video submission data merged in.
+  def merge_course_videos(hash, course_user)
+    # Videos - consider submitted as long as submission exists
+    hash.merge!(
+      course_user.course.videos.
+      with_submissions_by(course_user.user).
+      select { |x| x.submissions.present? }.
+      map { |x| [x.lesson_plan_item.id, nil] }.to_h
+    )
+  end
+end

--- a/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class FixedPersonalizationStrategy < BasePersonalizationStrategy
+  # Returns a hash containing lesson plan item ids to submission time.
+  #
+  # @param [CourseUser] course_user The course user to compute data for.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] A hash of submitted lesson plan items' IDs to their submitted
+  #   time, if relevant/available.
+  def precompute_data(course_user)
+    lesson_plan_items_submission_time_hash(course_user)
+  end
+
+  # Deletes all personal times that are not fixed or submitted. This basically causes the course user to follow the
+  # reference timeline moving forward.
+  #
+  # @param [CourseUser] course_user The course user to compute data for.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] precompute_data A hash of submitted lesson plan items' ID to their submitted
+  #   time, if relevant/available.
+  def execute(course_user, precompute_data)
+    course_user.personal_times.where(fixed: false).
+      where.not(lesson_plan_item_id: precompute_data.keys).delete_all
+  end
+end

--- a/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
@@ -3,8 +3,8 @@ class FixedPersonalizationStrategy < BasePersonalizationStrategy
   # Returns a hash containing lesson plan item ids to submission time.
   #
   # @param [CourseUser] course_user The course user to compute data for.
-  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] A hash of submitted lesson plan items' IDs to their submitted
-  #   time, if relevant/available.
+  # @return [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] A hash of submitted lesson plan items' IDs to their
+  #   submitted time, if relevant/available.
   def precompute_data(course_user)
     lesson_plan_items_submission_time_hash(course_user)
   end
@@ -13,8 +13,8 @@ class FixedPersonalizationStrategy < BasePersonalizationStrategy
   # reference timeline moving forward.
   #
   # @param [CourseUser] course_user The course user to compute data for.
-  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] precompute_data A hash of submitted lesson plan items' ID to their submitted
-  #   time, if relevant/available.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] precompute_data A hash of submitted lesson plan items' ID to
+  #   their submitted time, if relevant/available.
   def execute(course_user, precompute_data)
     course_user.personal_times.where(fixed: false).
       where.not(lesson_plan_item_id: precompute_data.keys).delete_all

--- a/app/controllers/concerns/course/lesson_plan/strategies/fomo_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/fomo_personalization_strategy.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+class FomoPersonalizationStrategy < BasePersonalizationStrategy
+  MIN_LEARNING_RATE = 0.67
+  MAX_LEARNING_RATE = 1.0
+  HARD_MIN_LEARNING_RATE = 0.5
+  DATE_ROUNDING_THRESHOLD = 0.8
+
+  # Shifts start_at of relevant lesson plan items and resets the bonus_end_at and end_at
+  # of the same items. The amount shifted is based the learning rate precomputed.
+  #
+  # The expected precomputed_data is the default data from precompute_data.
+  #
+  # @param [CourseUser] course_user The user to adjust the personalized timeline for.
+  # @param [Hash] precomputed_data The default data precomputed by precompute_data.
+  def execute(course_user, precomputed_data) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    return if precomputed_data[:learning_rate_ema].nil?
+
+    @course_tz = course_user.course.time_zone
+    reference_point = personal_point = precomputed_data[:items].first.reference_time_for(course_user).start_at
+    course_user.transaction do
+      precomputed_data[:items].each do |item|
+        reference_point, personal_point = update_points(course_user, item, precomputed_data[:submitted_items],
+                                                        reference_point, personal_point)
+        next if should_skip_item(course_user, item, precomputed_data[:submitted_items])
+
+        reference_time = item.reference_time_for(course_user)
+        personal_time = item.find_or_create_personal_time_for(course_user)
+        shift_start_at(personal_time, reference_time, personal_point, reference_point,
+                       precomputed_data[:learning_rate_ema])
+        reset_bonus_end_at(personal_time, reference_time)
+        reset_end_at(personal_time, reference_time)
+        personal_time.save!
+      end
+    end
+  end
+
+  private
+
+  # Checks if the given item should act as the most recent "anchor point" for the following shifts.
+  # If the item should act, returns an array [new_reference_point, new_personal_point] computed with that item.
+  # If the item should not act, then the original reference_point and personal_point will be returned.
+  #
+  # @param [CourseUser] course_user The user to update points for for.
+  # @param [Course::LessonPlan::Item] item The item to reference for the update of points.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
+  #   their submitted time, if relevant/available.
+  # @param [DateTime] reference_point The current reference_point.
+  # @param [DateTime] personal_point The current personal_point.
+  # @return [Array<ActiveSupport::TimeWithZone>] An array containing [new_reference_point, new_personal_point].
+  def update_points(course_user, item, submitted_items, reference_point, personal_point)
+    if item.affects_personal_times? && item.id.in?(submitted_items.keys)
+      return [item.reference_time_for(course_user).start_at, item.time_for(course_user).start_at]
+    end
+
+    [reference_point, personal_point]
+  end
+
+  # Checks if the lesson plan item should be skipped. If skipped, the timings for this item will not be adjusted.
+  # Currently, it checks for the following conditions, for it to NOT be skipped:
+  # - Item has personal times
+  # - Item is not submitted
+  # - Item's personal time isn't fixed
+  # - Item isn't currently open with an adjusted end_at from stragglers algorithm
+  #
+  # @param [CourseUser] course_user The user whose item we are checking.
+  # @param [Course::LessonPlan::Item] item The item that we are checking.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID
+  #   to their submitted time, if relevant/available.
+  # @return [Boolean] Whether the item should be skipped.
+  def should_skip_item(course_user, item, submitted_items)
+    if !item.has_personal_times? || item.id.in?(submitted_items.keys) || item.personal_time_for(course_user)&.fixed?
+      return true
+    end
+
+    # If the user was previously on the stragglers algorithm and just switched over, and has already open
+    # items, we want to keep those items as they are
+    reference_time = item.reference_time_for(course_user)
+    personal_time = item.find_or_create_personal_time_for(course_user)
+    personal_time.end_at && personal_time.end_at > reference_time.end_at && personal_time.start_at < Time.zone.now
+  end
+
+  # Shifts the start_at of the personal_time forward based on the learning rate of the user and the most recent
+  # personal and reference points. This major shift only occurs if the personal_time's current start_at is in the
+  # future.
+  #
+  # In addition, it also handles the case where the reference_time's start_at has shifted forward, as the
+  # start_at of the personal_time will never be later than the start_at of the reference time.
+  #
+  # @param [Course::PersonalTime] personal_time Personal time that we are shifting.
+  # @param [Course::ReferenceTime] reference_time Reference time that we are referring.
+  # @param [ActiveSupport::TimeWithZone] personal_point Personal point from the most recent item.
+  # @param [ActiveSupport::TimeWithZone] reference_point Reference point from the most recent item.
+  # @param [Float] learning_rate_ema Learning rate to use for computing the shift amount.
+  def shift_start_at(personal_time, reference_time, personal_point, reference_point, learning_rate_ema)
+    if personal_time.start_at > Time.zone.now
+      personal_time.start_at =
+        round_to_date(
+          personal_point + ((reference_time.start_at - reference_point) * learning_rate_ema),
+          @course_tz
+        )
+    end
+    # Hard limits to make sure we don't fail bounds checks
+    personal_time.start_at = [personal_time.start_at, reference_time.start_at, reference_time.end_at].compact.min
+  end
+
+  # Resets the bonus_end_at of the personal_time to that of the reference_time if the personal_time has bonus_end_at.
+  # The personal time's current bonus_end_at timing must also be in the future.
+  #
+  # @param [Course::PersonalTime] personal_time Personal time that we are resetting.
+  # @param [Course::ReferenceTime] reference_time Reference time that we are using as reference.
+  def reset_bonus_end_at(personal_time, reference_time)
+    return unless personal_time.bonus_end_at && personal_time.bonus_end_at > Time.zone.now
+
+    personal_time.bonus_end_at = reference_time.bonus_end_at
+  end
+
+  # Resets the end_at of the personal_time to that of the reference_time if the personal_time has end_at.
+  # The personal time's current end_at timing must also be in the future.
+  #
+  # @param [Course::PersonalTime] personal_time Personal time that we are resetting.
+  # @param [Course::ReferenceTime] reference_time Reference time that we are using as reference.
+  def reset_end_at(personal_time, reference_time)
+    return unless personal_time.end_at && personal_time.end_at > Time.zone.now
+
+    personal_time.end_at = reference_time.end_at
+  end
+end

--- a/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class OtotPersonalizationStrategy < BasePersonalizationStrategy
+  # Applies the appropriate algorithm strategy for the student based on the student's learning rate.
+  #
+  # The expected precomputed_data is the default data from precompute_data.
+  #
+  # @param [CourseUser] course_user The user to adjust the personalized timeline for.
+  # @param [Hash] precomputed_data The default data precomputed by precompute_data.
+  def execute(course_user, precomputed_data)
+    return if precomputed_data[:learning_rate_ema].nil?
+
+    # Apply the appropriate algo depending on student's leaning rate
+    new_strategy = if precomputed_data[:learning_rate_ema] < 1
+                     FomoPersonalizationStrategy.new
+                   else
+                     StragglersPersonalizationStrategy.new
+                   end
+    new_strategy.execute(course_user, precomputed_data)
+  end
+end

--- a/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
@@ -22,7 +22,7 @@ class StragglersPersonalizationStrategy < BasePersonalizationStrategy
       precomputed_data[:items].each do |item|
         reference_point, personal_point = update_points(course_user, item, precomputed_data[:submitted_items],
                                                         reference_point, personal_point)
-        next if should_skip_item(course_user, item, precomputed_data[:submitted_items], reference_point)
+        next if cannot_shift_item(course_user, item, precomputed_data[:submitted_items], reference_point)
 
         reference_time = item.reference_time_for(course_user)
         personal_time = item.find_or_create_personal_time_for(course_user)
@@ -59,8 +59,8 @@ class StragglersPersonalizationStrategy < BasePersonalizationStrategy
     [reference_point, personal_point]
   end
 
-  # Checks if the lesson plan item should be skipped. If skipped, the timings for this item will not be adjusted.
-  # Currently, it checks for the following conditions, for it to NOT be skipped:
+  # Checks if the lesson plan item cannot be shifted. If cannot, the timings for this item will not be adjusted.
+  # Currently, it checks for the following conditions, for it to be possible to be shifted:
   # - Item has personal times
   # - Item is not submitted
   # - Item's personal time isn't fixed
@@ -71,8 +71,8 @@ class StragglersPersonalizationStrategy < BasePersonalizationStrategy
   # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID
   #   to their submitted time, if relevant/available.
   # @param [Course::ReferenceTime] reference_time Current reference time to be checked.
-  # @return [Boolean] Whether the item should be skipped.
-  def should_skip_item(course_user, item, submitted_items, reference_point)
+  # @return [Boolean] Whether the item cannot be shifted.
+  def cannot_shift_item(course_user, item, submitted_items, reference_point)
     !item.has_personal_times? || item.id.in?(submitted_items.keys) ||
       item.personal_time_for(course_user)&.fixed? || reference_point.nil?
   end

--- a/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+class StragglersPersonalizationStrategy < BasePersonalizationStrategy
+  MIN_LEARNING_RATE = 1.0
+  MAX_LEARNING_RATE = 2.0
+  HARD_MIN_LEARNING_RATE = 0.8
+  DATE_ROUNDING_THRESHOLD = 0.2
+  STRAGGLERS_FIXES = 1
+
+  # Shifts end_at of relevant lesson plan items and resets the bonus_end_at and start_at
+  # of the same items. The amount shifted is based the learning rate precomputed.
+  #
+  # The expected precomputed_data is the default data from precompute_data.
+  #
+  # @param [CourseUser] course_user The user to adjust the personalized timeline for.
+  # @param [Hash] precomputed_data The default data precomputed by precompute_data.
+  def execute(course_user, precomputed_data) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    return if precomputed_data[:learning_rate_ema].nil?
+
+    @course_tz = course_user.course.time_zone
+    reference_point = personal_point = precomputed_data[:items].first.reference_time_for(course_user).end_at
+    course_user.transaction do
+      precomputed_data[:items].each do |item|
+        reference_point, personal_point = update_points(course_user, item, precomputed_data[:submitted_items],
+                                                        reference_point, personal_point)
+        next if should_skip_item(course_user, item, precomputed_data[:submitted_items], reference_point)
+
+        reference_time = item.reference_time_for(course_user)
+        personal_time = item.find_or_create_personal_time_for(course_user)
+        reset_start_at(personal_time, reference_time)
+        reset_bonus_end_at(personal_time, reference_time)
+        shift_end_at(personal_time, reference_time, personal_point, reference_point,
+                     precomputed_data[:learning_rate_ema])
+        personal_time.save!
+      end
+    end
+
+    fix_items(course_user, precomputed_data[:items], precomputed_data[:submitted_items])
+  end
+
+  private
+
+  # Checks if the given item should act as the most recent "anchor point" for the following shifts.
+  # If the item should act, returns an array [new_reference_point, new_personal_point] computed with that item.
+  # If the item should not act, then the original reference_point and personal_point will be returned.
+  #
+  # @param [CourseUser] course_user The user to update points for for.
+  # @param [Course::LessonPlan::Item] item The item to reference for the update of points.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID to
+  #   their submitted time, if relevant/available.
+  # @param [DateTime] reference_point The current reference_point.
+  # @param [DateTime] personal_point The current personal_point.
+  # @return [Array<ActiveSupport::TimeWithZone>] An array containing [new_reference_point, new_personal_point].
+  def update_points(course_user, item, submitted_items, reference_point, personal_point)
+    if item.affects_personal_times? && item.id.in?(submitted_items.keys) &&
+       item.reference_time_for(course_user).end_at.present?
+      return [item.reference_time_for(course_user).end_at, item.time_for(course_user).end_at]
+    end
+
+    [reference_point, personal_point]
+  end
+
+  # Checks if the lesson plan item should be skipped. If skipped, the timings for this item will not be adjusted.
+  # Currently, it checks for the following conditions, for it to NOT be skipped:
+  # - Item has personal times
+  # - Item is not submitted
+  # - Item's personal time isn't fixed
+  # - There is an existing reference_point computed from the most recent submission.
+  #
+  # @param [CourseUser] course_user The user whose item we are checking.
+  # @param [Course::LessonPlan::Item] item The item that we are checking.
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID
+  #   to their submitted time, if relevant/available.
+  # @param [Course::ReferenceTime] reference_time Current reference time to be checked.
+  # @return [Boolean] Whether the item should be skipped.
+  def should_skip_item(course_user, item, submitted_items, reference_point)
+    !item.has_personal_times? || item.id.in?(submitted_items.keys) ||
+      item.personal_time_for(course_user)&.fixed? || reference_point.nil?
+  end
+
+  # Resets the start_at of the personal_time to that of the reference_time.
+  # The personal time's current start_at timing must also be in the future.
+  #
+  # @param [Course::PersonalTime] personal_time Personal time that we are resetting.
+  # @param [Course::ReferenceTime] reference_time Reference time that we are using as reference.
+  def reset_start_at(personal_time, reference_time)
+    return unless personal_time.start_at > Time.zone.now
+
+    personal_time.start_at = reference_time.start_at
+  end
+
+  # Resets the bonus_end_at of the personal_time to that of the reference_time if the personal_time has bonus_end_at.
+  # The personal time's current bonus_end_at timing must also be in the future.
+  #
+  # @param [Course::PersonalTime] personal_time Personal time that we are resetting.
+  # @param [Course::ReferenceTime] reference_time Reference time that we are using as reference.
+  def reset_bonus_end_at(personal_time, reference_time)
+    return unless personal_time.bonus_end_at && personal_time.bonus_end_at > Time.zone.now
+
+    personal_time.bonus_end_at = reference_time.bonus_end_at
+  end
+
+  # Shifts the end_at of the personal_time backward based on the learning rate of the user and the most recent
+  # personal and reference points. This major shift only occurs if the personal_time's current end_at is in the
+  # future.
+  #
+  # In addition, it also handles the case where the reference_time's end_at has shifted backward, as the
+  # end_at of the personal_time will never be earlier than the end_at of the reference time.
+  #
+  # @param [Course::PersonalTime] personal_time Personal time that we are shifting.
+  # @param [Course::ReferenceTime] reference_time Reference time that we are referring.
+  # @param [ActiveSupport::TimeWithZone] personal_point Personal point from the most recent item.
+  # @param [ActiveSupport::TimeWithZone] reference_point Reference point from the most recent item.
+  # @param [Float] learning_rate_ema Learning rate to use for computing the shift amount.
+  def shift_end_at(personal_time, reference_time, personal_point, reference_point, learning_rate_ema)
+    return unless reference_time.end_at.present?
+
+    new_end_at = round_to_date(
+      personal_point + ((reference_time.end_at - reference_point) * learning_rate_ema),
+      @course_tz,
+      to_2359: true # rubocop:disable Naming/VariableNumber
+    )
+    # Hard limits to make sure we don't fail bounds checks
+    new_end_at = [new_end_at, reference_time.end_at, reference_time.start_at].compact.max
+
+    # We don't want to shift the end_at forward if the item is already opened or if the deadline
+    # has already passed. Backwards is ok.
+    # Assumption: end_at is >= start_at
+    return unless new_end_at > personal_time.end_at || personal_time.start_at > Time.zone.now
+
+    personal_time.end_at = new_end_at
+  end
+
+  # Fixes the next few items for the student, such that their deadlines will no longer be automatically modified on
+  # further timeline recomputations.
+  # This guarantee allows students to plan their time accordingly such that they will not be surprised if the deadline
+  # suddenly moves forward, nor will they be able to use this as an excuse to appeal for an extension.
+  #
+  # @param [CourseUser] course_user User to fix items for.
+  # @param [Array<Course::LessonPlan::Item>] items Sorted array of lesson plan items based on the course_user's
+  #   start_at,
+  # @param [Hash{Integer=>ActiveSupport::TimeWithZone|nil}] submitted_items A hash of submitted lesson plan items' ID
+  #   to their submitted time, if relevant/available.
+  def fix_items(course_user, items, submitted_items)
+    items.select { |item| item.has_personal_times? && !item.id.in?(submitted_items.keys) }.
+      slice(0, self.class::STRAGGLERS_FIXES).
+      each { |item| item.reload.find_or_create_personal_time_for(course_user).update(fixed: true) }
+  end
+end

--- a/app/controllers/course/personal_times_controller.rb
+++ b/app/controllers/course/personal_times_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::PersonalTimesController < Course::ComponentController
   include Course::LessonPlan::PersonalizationConcern
+  include Course::LessonPlan::LearningRateConcern
 
   before_action :authorize_personal_times!
 


### PR DESCRIPTION
Refactor existing logic to use a more explicit [strategy pattern](https://refactoring.guru/design-patterns/strategy), with improved abstraction / modularisation of code to make things easier to change and understand.

Also removes the need for Rails cache. Instead, precomputation and execution are separated into two different steps, thus still eliminating repeated work that originally occurred for OTOT.