### PR TITLE
feat(submissions edit form): add warning popup when navigating away from page with dirty state

### DIFF
--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
+import { Prompt } from 'react-router-dom';
 import { injectIntl, intlShape } from 'react-intl';
 import { Element, scroller } from 'react-scroll';
 import { Tabs, Tab } from 'material-ui/Tabs';
@@ -84,7 +85,24 @@ class SubmissionEditForm extends Component {
           : initialStep;
       scroller.scrollTo(`step${initialStep}`, { offset: -60 });
     }
+
+    window.addEventListener('beforeunload', this.handleUnload);
   }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.handleUnload);
+  }
+
+  handleUnload = (e) => {
+    if (!this.props.pristine) {
+      e.preventDefault();
+      // For Chrome to show warning when navigating away from the page, we need to
+      // indicate the returnValue below.
+      e.returnValue = '';
+      return '';
+    }
+    return null;
+  };
 
   renderQuestionGrading(id) {
     const { attempting, published, graderView } = this.props;
@@ -586,6 +604,19 @@ class SubmissionEditForm extends Component {
     );
   }
 
+  renderNavigateAwayWarning() {
+    const isDirty = !this.props.pristine;
+    return (
+      <Prompt
+        when={isDirty}
+        message={(action) =>
+          // Note: POP refers to back action in a browser.
+          action === 'POP'
+        }
+      />
+    );
+  }
+
   render() {
     const { tabbedView } = this.props;
     return (
@@ -604,10 +635,12 @@ class SubmissionEditForm extends Component {
         {this.renderUnmarkButton()}
         {this.renderPublishButton()}
 
-        {this.state.submitConfirmation && this.renderSubmitDialog()}
-        {this.state.unsubmitConfirmation && this.renderUnsubmitDialog()}
-        {this.state.resetConfirmation && this.renderResetDialog()}
+        {this.renderSubmitDialog()}
+        {this.renderUnsubmitDialog()}
+        {this.renderResetDialog()}
         {this.renderExamDialog()}
+
+        {this.renderNavigateAwayWarning()}
       </Card>
     );
   }

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
+import { Prompt } from 'react-router-dom';
 import { injectIntl, intlShape } from 'react-intl';
 import Hotkeys from 'react-hot-keys';
 import { Card, CardHeader, CardText } from 'material-ui/Card';
@@ -83,6 +84,25 @@ class SubmissionEditStepForm extends Component {
       hoveredToolTip: '',
     };
   }
+
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.handleUnload);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.handleUnload);
+  }
+
+  handleUnload = (e) => {
+    if (!this.props.pristine) {
+      e.preventDefault();
+      // For Chrome to show warning when navigating away from the page, we need to
+      // indicate the returnValue below.
+      e.returnValue = '';
+      return '';
+    }
+    return null;
+  };
 
   handleNext() {
     const { maxStep, stepIndex } = this.state;
@@ -565,6 +585,19 @@ class SubmissionEditStepForm extends Component {
     );
   }
 
+  renderNavigateAwayWarning() {
+    const isDirty = !this.props.pristine;
+    return (
+      <Prompt
+        when={isDirty}
+        message={(action) =>
+          // Note: POP refers to back action in a browser.
+          action === 'POP'
+        }
+      />
+    );
+  }
+
   render() {
     return (
       <div style={styles.questionContainer}>
@@ -575,6 +608,8 @@ class SubmissionEditStepForm extends Component {
         {this.renderSubmitDialog()}
         {this.renderUnsubmitDialog()}
         {this.renderResetDialog()}
+
+        {this.renderNavigateAwayWarning()}
       </div>
     );
   }

--- a/client/app/bundles/course/survey/containers/ResponseForm/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/__test__/index.test.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 import storeCreator from 'course/survey/store';
 import ResponseForm, {
   buildInitialValues,
   buildResponsePayload,
 } from '../index';
+
+const courseId = 1;
 
 const responseData = {
   response: {
@@ -111,10 +114,16 @@ describe('<ResponseForm />', () => {
     const mockEndpoint = jest.fn();
     const onSubmit = (data) => mockEndpoint(buildResponsePayload(data));
     const responseForm = mount(
-      <ResponseForm
-        {...{ response, flags, onSubmit }}
-        initialValues={buildInitialValues(survey, response)}
-      />,
+      <MemoryRouter
+        initialEntries={[
+          `/courses/${courseId}/surveys/${survey.id}/responses/${response.id}/edit`,
+        ]}
+      >
+        <ResponseForm
+          {...{ response, flags, onSubmit }}
+          initialValues={buildInitialValues(survey, response)}
+        />
+      </MemoryRouter>,
       buildContextOptions(storeCreator({})),
     );
 

--- a/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { reduxForm, FieldArray, Form, getFormValues } from 'redux-form';
+import { Prompt } from 'react-router-dom';
 import RaisedButton from 'material-ui/RaisedButton';
 import formTranslations from 'lib/translations/form';
 import { formNames } from 'course/survey/constants';
@@ -93,6 +94,25 @@ class ResponseForm extends React.Component {
     );
   }
 
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.handleUnload);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.handleUnload);
+  }
+
+  handleUnload = (e) => {
+    if (!this.props.pristine) {
+      e.preventDefault();
+      // For Chrome to show warning when navigating away from the page, we need to
+      // indicate the returnValue below.
+      e.returnValue = '';
+      return '';
+    }
+    return null;
+  };
+
   renderSaveButton() {
     const {
       pristine,
@@ -147,6 +167,20 @@ class ResponseForm extends React.Component {
     );
   }
 
+  renderNavigateAwayWarning() {
+    const isDirty = !this.props.pristine;
+
+    return (
+      <Prompt
+        when={isDirty}
+        message={(action) =>
+          // Note: POP refers to back action in a browser.
+          action === 'POP'
+        }
+      />
+    );
+  }
+
   render() {
     const {
       handleSubmit,
@@ -165,6 +199,7 @@ class ResponseForm extends React.Component {
         <br />
         {!readOnly && this.renderSaveButton()}
         {!readOnly && this.renderSubmitButton()}
+        {this.renderNavigateAwayWarning()}
       </Form>
     );
   }

--- a/client/app/bundles/course/survey/pages/ResponseEdit/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseEdit/__test__/index.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 import CourseAPI from 'api/course';
 import MockAdapter from 'axios-mock-adapter';
@@ -73,7 +74,9 @@ describe('<ResponseEdit />', () => {
     // Mount response show page and wait for data to load
     window.history.pushState({}, '', responseUrl);
     const responseShow = mount(
-      <InjectedResponseEdit {...{ match: { params: { responseId } } }} />,
+      <MemoryRouter initialEntries={[responseUrl]}>
+        <InjectedResponseEdit {...{ match: { params: { responseId } } }} />
+      </MemoryRouter>,
       buildContextOptions(storeCreator({})),
     );
     await sleep(1);

--- a/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseShow/__test__/index.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 import CourseAPI from 'api/course';
 import storeCreator from 'course/survey/store';
 import ResponseShow, { UnconnectedResponseShow } from '../index';
@@ -9,16 +10,19 @@ describe('<ResponseShow />', () => {
     const surveyId = '1';
     const responseId = '1';
     const spyFetch = jest.spyOn(CourseAPI.survey.responses, 'fetch');
+    const responseUrl = `/courses/${courseId}/surveys/${surveyId}/responses/${responseId}/edit`;
 
     mount(
-      <ResponseShow
-        {...{
-          survey: {},
-          courseId,
-          surveyId,
-          match: { params: { responseId } },
-        }}
-      />,
+      <MemoryRouter initialEntries={[responseUrl]}>
+        <ResponseShow
+          {...{
+            survey: {},
+            courseId,
+            surveyId,
+            match: { params: { responseId } },
+          }}
+        />
+      </MemoryRouter>,
       buildContextOptions(storeCreator({})),
     );
     await sleep(1);


### PR DESCRIPTION
Closes #4329 
Popup will appear when a user clicks refresh, back or close tab/window. Added the same feature for survey submission as well.

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/42570513/150492171-374e1e3d-18d7-4bf7-a182-b911ffc998a4.png">
