### PR TITLE
Fix namespaces for personalized timeline strategies

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/personalization_concern.rb
@@ -17,14 +17,14 @@ module Course::LessonPlan::PersonalizationConcern
 
     strategy = case timeline_algorithm
                when 'otot'
-                 OtotPersonalizationStrategy.new
+                 Course::LessonPlan::Strategies::OtotPersonalizationStrategy.new
                when 'fomo'
-                 FomoPersonalizationStrategy.new
+                 Course::LessonPlan::Strategies::FomoPersonalizationStrategy.new
                when 'stragglers'
-                 StragglersPersonalizationStrategy.new
+                 Course::LessonPlan::Strategies::StragglersPersonalizationStrategy.new
                else
                  # Default to fixed.
-                 FixedPersonalizationStrategy.new
+                 Course::LessonPlan::Strategies::FixedPersonalizationStrategy.new
                end
 
     precomputed_data = strategy.precompute_data(course_user)

--- a/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # The BasePersonalizationStrategy declares operations common to all, if not most, personalized timeline algorithms.
 # It also defines the interface to use when calling the algorithm defined by the subclasses.
-class BasePersonalizationStrategy
+class Course::LessonPlan::Strategies::BasePersonalizationStrategy
   include Course::LessonPlan::LearningRateConcern
   # To override any of these constants, simply define the same constant in the subclass.
   LEARNING_RATE_ALPHA = 0.4

--- a/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-class FixedPersonalizationStrategy < BasePersonalizationStrategy
+class Course::LessonPlan::Strategies::FixedPersonalizationStrategy <
+  Course::LessonPlan::Strategies::BasePersonalizationStrategy
   # Returns a hash containing lesson plan item ids to submission time.
   #
   # @param [CourseUser] course_user The course user to compute data for.

--- a/app/controllers/concerns/course/lesson_plan/strategies/fomo_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/fomo_personalization_strategy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-class FomoPersonalizationStrategy < BasePersonalizationStrategy
+class Course::LessonPlan::Strategies::FomoPersonalizationStrategy <
+  Course::LessonPlan::Strategies::BasePersonalizationStrategy
   MIN_LEARNING_RATE = 0.67
   MAX_LEARNING_RATE = 1.0
   HARD_MIN_LEARNING_RATE = 0.5

--- a/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-class OtotPersonalizationStrategy < BasePersonalizationStrategy
+class Course::LessonPlan::Strategies::OtotPersonalizationStrategy <
+  Course::LessonPlan::Strategies::BasePersonalizationStrategy
   # Applies the appropriate algorithm strategy for the student based on the student's learning rate.
   #
   # The expected precomputed_data is the default data from precompute_data.
@@ -11,9 +12,9 @@ class OtotPersonalizationStrategy < BasePersonalizationStrategy
 
     # Apply the appropriate algo depending on student's leaning rate
     new_strategy = if precomputed_data[:learning_rate_ema] < 1
-                     FomoPersonalizationStrategy.new
+                     Course::LessonPlan::Strategies::FomoPersonalizationStrategy.new
                    else
-                     StragglersPersonalizationStrategy.new
+                     Course::LessonPlan::Strategies::StragglersPersonalizationStrategy.new
                    end
     new_strategy.execute(course_user, precomputed_data)
   end

--- a/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-class StragglersPersonalizationStrategy < BasePersonalizationStrategy
+class Course::LessonPlan::Strategies::StragglersPersonalizationStrategy <
+  Course::LessonPlan::Strategies::BasePersonalizationStrategy
   MIN_LEARNING_RATE = 1.0
   MAX_LEARNING_RATE = 2.0
   HARD_MIN_LEARNING_RATE = 0.8


### PR DESCRIPTION
Otherwise you'd get something like:

```
NameError (uninitialized constant Course::LessonPlan::PersonalizationConcern::FixedPersonalizationStrategy):
```

when you try to submit an assessment.