### PR TITLE
Add course materials to the condition-conditional framework

### DIFF
--- a/app/helpers/course/condition/conditions_helper.rb
+++ b/app/helpers/course/condition/conditions_helper.rb
@@ -19,6 +19,7 @@ module Course::Condition::ConditionsHelper
       hash[Course::Condition::Achievement.name] = :course_achievements_component
       hash[Course::Condition::Assessment.name] = :course_assessments_component
       hash[Course::Condition::Level.name] = :course_levels_component
+      hash[Course::Condition::Material.name] = :course_materials_component
       hash[Course::Condition::Survey.name] = :course_survey_component
       hash[Course::Condition::Video.name] = :course_videos_component
     end

--- a/app/jobs/course/material/zip_download_job.rb
+++ b/app/jobs/course/material/zip_download_job.rb
@@ -12,8 +12,8 @@ class Course::Material::ZipDownloadJob < ApplicationJob
   # @param [String] filename The name of the zip file. This defaults to the name of the folder. This
   #   is useful when you don't want to use the name of the folder as the zip filename (such as the
   #   root folder).
-  def perform_tracked(folder, materials, filename = folder.name)
-    zip_file = Course::Material::ZipDownloadService.download_and_zip(folder, materials)
+  def perform_tracked(folder, materials, course_user, filename = folder.name)
+    zip_file = Course::Material::ZipDownloadService.download_and_zip(folder, materials, course_user)
     redirect_to SendFile.send_file(zip_file, "#{Pathname.normalize_filename(filename)}.zip")
   end
 end

--- a/app/models/components/course/conditions_ability_component.rb
+++ b/app/models/components/course/conditions_ability_component.rb
@@ -12,10 +12,8 @@ module Course::ConditionsAbilityComponent
 
   def allow_teaching_staff_manage_conditions
     can :manage, Course::Condition, course_id: course.id
-    can :manage, Course::Condition::Achievement, condition: { course_id: course.id }
-    can :manage, Course::Condition::Assessment, condition: { course_id: course.id }
-    can :manage, Course::Condition::Level, condition: { course_id: course.id }
-    can :manage, Course::Condition::Survey, condition: { course_id: course.id }
-    can :manage, Course::Condition::Video, condition: { course_id: course.id }
+    Course::Condition::ALL_CONDITIONS.each do |condition|
+      can :manage, condition[:name].constantize, condition: { course_id: course.id }
+    end
   end
 end

--- a/app/models/course/condition.rb
+++ b/app/models/course/condition.rb
@@ -22,6 +22,7 @@ class Course::Condition < ApplicationRecord
     { name: Course::Condition::Achievement.name, active: true },
     { name: Course::Condition::Assessment.name, active: true },
     { name: Course::Condition::Level.name, active: true },
+    { name: Course::Condition::Material.name, active: false },
     { name: Course::Condition::Survey.name, active: true },
     { name: Course::Condition::Video.name, active: false }
   ].freeze

--- a/app/models/course/condition/material.rb
+++ b/app/models/course/condition/material.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+class Course::Condition::Material < ApplicationRecord
+  acts_as_condition
+  include DuplicationStateTrackingConcern
+
+  validate :validate_material_condition, if: :material_id_changed?
+  validates :material, presence: true
+
+  belongs_to :material, class_name: Course::Material.name, inverse_of: :material_conditions
+
+  default_scope { includes(:material) }
+
+  alias_method :dependent_object, :material
+
+  def title
+    self.class.human_attribute_name('title.complete', material_title: material.name)
+  end
+
+  def satisfied_by?(course_user)
+    Course::Material::Download.exists?(course_user_id: course_user.id, material_id: material.id)
+  end
+
+  # Class that the condition depends on.
+  def self.dependent_class
+    Course::Material.name
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.material = duplicator.duplicate(other.material)
+    self.conditional_type = other.conditional_type
+    self.conditional = duplicator.duplicate(other.conditional)
+
+    case duplicator.mode
+    when :course
+      self.course = duplicator.duplicate(other.course)
+    when :object
+      self.course = duplicator.options[:destination_course]
+    end
+
+    set_duplication_flag
+  end
+
+  private
+
+  def validate_material_condition
+    validate_references_self
+    validate_unique_dependency unless duplicating?
+    validate_acyclic_dependency
+  end
+
+  def validate_references_self
+    return unless material == conditional
+
+    errors.add(:material, :references_self)
+  end
+
+  def validate_unique_dependency
+    return unless required_materials_for(conditional).include?(material)
+
+    errors.add(:material, :unique_dependency)
+  end
+
+  def validate_acyclic_dependency
+    return unless cyclic?
+
+    errors.add(:material, :cyclic_dependency)
+  end
+
+  # Given a conditional object, returns all materials that it requires.
+  #
+  # @param [Object] conditional The object that is declared as acts_as_conditional and for which
+  #   returned materials are required.
+  # @return [Array<Course::Material]
+  def required_materials_for(conditional)
+    # Workaround, pending the squeel bugfix (activerecord-hackery/squeel#390), similar issue as in
+    # Course::Condition::Material.
+    # TODO: use squeel.
+    Course::Material.joins(<<-SQL)
+      INNER JOIN
+        (SELECT cca.material_id
+          FROM course_condition_materials cca INNER JOIN course_conditions cc
+          ON cc.actable_type = 'Course::Condition::Material' AND cc.actable_id = cca.id
+          WHERE cc.conditional_id = #{conditional.id}
+            AND cc.conditional_type = #{ActiveRecord::Base.connection.quote(conditional.class.name)}
+        ) ids
+      ON ids.material_id = course_materials.id
+    SQL
+  end
+end

--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -11,7 +11,7 @@ class Course::Material < ApplicationRecord
   has_many :material_conditions, class_name: Course::Condition::Material.name,
                                  inverse_of: :material, dependent: :destroy
 
-  after_create :set_course_id
+  before_create :set_course_id
   before_save :touch_folder
 
   validate :validate_name_is_unique_among_folders

--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -5,6 +5,9 @@ class Course::Material < ApplicationRecord
 
   belongs_to :folder, inverse_of: :materials, class_name: Course::Material::Folder.name
 
+  has_many :downloads
+  has_many :course_users, through: :downloads
+
   before_save :touch_folder
 
   validate :validate_name_is_unique_among_folders

--- a/app/models/course/material.rb
+++ b/app/models/course/material.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Course::Material < ApplicationRecord
+  acts_as_conditional
   has_one_attachment
   include DuplicationStateTrackingConcern
 
@@ -7,7 +8,10 @@ class Course::Material < ApplicationRecord
 
   has_many :downloads
   has_many :course_users, through: :downloads
+  has_many :material_conditions, class_name: Course::Condition::Material.name,
+                                 inverse_of: :material, dependent: :destroy
 
+  after_create :set_course_id
   before_save :touch_folder
 
   validate :validate_name_is_unique_among_folders
@@ -60,6 +64,7 @@ class Course::Material < ApplicationRecord
                     # remain a child of the root folder.
                     duplicator.options[:destination_course].root_folder
                   end
+    initialize_duplicate_conditions(duplicator, other)
     self.updated_at = other.updated_at
     self.created_at = other.created_at
     set_duplication_flag
@@ -69,7 +74,21 @@ class Course::Material < ApplicationRecord
     self.name = next_valid_name
   end
 
+  def permitted_for!(_course_user)
+  end
+
+  def precluded_for!(_course_user)
+  end
+
+  def satisfiable?
+    true
+  end
+
   private
+
+  def set_course_id
+    self.course_id = folder.course_id
+  end
 
   # TODO: Not threadsafe, consider making all folders as materials
   # Make sure that material won't have the same name with other child folders in the folder
@@ -79,5 +98,13 @@ class Course::Material < ApplicationRecord
 
     conflicts = folder.children.where('name ILIKE ?', name)
     errors.add(:name, :taken) unless conflicts.empty?
+  end
+
+  # Set up conditions that depend on this material and conditions that this material depends on.
+  def initialize_duplicate_conditions(duplicator, other)
+    duplicate_conditions(duplicator, other)
+    material_conditions << other.material_conditions.
+                           select { |condition| duplicator.duplicated?(condition.conditional) }.
+                           map { |condition| duplicator.duplicate(condition) }
   end
 end

--- a/app/models/course/material/download.rb
+++ b/app/models/course/material/download.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class Course::Material::Download < ApplicationRecord
+  belongs_to :course_user
+  belongs_to :material
+
+  validates :course_user, uniqueness: { scope: :material }
+end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -47,6 +47,8 @@ class CourseUser < ApplicationRecord
                          inverse_of: :course_user, dependent: :destroy
   has_many :groups, through: :group_users, class_name: Course::Group.name, source: :group
   has_many :personal_times, class_name: Course::PersonalTime.name, inverse_of: :course_user, dependent: :destroy
+  has_many :downloads
+  has_many :materials, through: :downloads
   belongs_to :reference_timeline, class_name: Course::ReferenceTimeline.name, inverse_of: :course_users, optional: true
 
   validate :validate_reference_timeline_belongs_to_course

--- a/app/services/course/material/zip_download_service.rb
+++ b/app/services/course/material/zip_download_service.rb
@@ -6,8 +6,8 @@ class Course::Material::ZipDownloadService
     # @param [Course::Material::Folder] folder The folder containing the materials.
     # @param [Array<Course::Material>] materials The materials to be downloaded.
     # @return [String] The path to the zip file.
-    def download_and_zip(folder, materials)
-      service = new(folder, materials)
+    def download_and_zip(folder, materials, course_user)
+      service = new(folder, materials, course_user)
       service.download_and_zip
     end
   end
@@ -19,10 +19,11 @@ class Course::Material::ZipDownloadService
 
   private
 
-  def initialize(folder, materials)
+  def initialize(folder, materials, course_user)
     @folder = folder
     @materials = Array(materials)
     @base_dir = Dir.mktmpdir('coursemology-download-')
+    @course_user = course_user
   end
 
   # Downloads the materials to the the base directory.
@@ -48,6 +49,7 @@ class Course::Material::ZipDownloadService
 
   # Downloads the material and store it in the given directory.
   def download_material(material, folder, dir)
+    Course::Material::Download.upsert(material_id: material.id, course_user_id: @course_user.id)
     file_path = Pathname.new(dir) + material.path.relative_path_from(folder.path)
     file_path.dirname.mkpath
 

--- a/db/migrate/20220201103010_create_course_material_downloads.rb
+++ b/db/migrate/20220201103010_create_course_material_downloads.rb
@@ -1,0 +1,15 @@
+class CreateCourseMaterialDownloads < ActiveRecord::Migration[6.0]
+  def change
+    create_table :course_material_downloads do |t|
+      t.integer :course_user_id, references: :course_users, null: false,
+                                 index: true, foreign_key: true
+      t.integer :material_id, references: :course_materials, null: false,
+                              index: true, foreign_key: true
+      t.timestamps
+    end
+
+    # Custom index name provided since the default name is too long
+    add_index :course_material_downloads, [:course_user_id, :material_id], unique: true,
+                                          name: :index_downloads_on_course_user_and_materials
+  end
+end

--- a/db/migrate/20220201163053_create_course_condition_materials.rb
+++ b/db/migrate/20220201163053_create_course_condition_materials.rb
@@ -1,0 +1,8 @@
+class CreateCourseConditionMaterials < ActiveRecord::Migration[6.0]
+  def change
+    create_table :course_condition_materials do |t|
+      t.references :material, null: false, foreign_key: { to_table: :course_materials },
+                              index: { name: 'fk__course_condition_materials_material_id' }
+    end
+  end
+end

--- a/db/migrate/20220202035840_add_satisfiability_type_to_materials.rb
+++ b/db/migrate/20220202035840_add_satisfiability_type_to_materials.rb
@@ -1,0 +1,5 @@
+class AddSatisfiabilityTypeToMaterials < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_materials, :satisfiability_type, :integer, default: 0
+  end
+end

--- a/db/migrate/20220202073459_add_course_id_to_course_materials.rb
+++ b/db/migrate/20220202073459_add_course_id_to_course_materials.rb
@@ -1,0 +1,6 @@
+class AddCourseIdToCourseMaterials < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_materials, :course_id, :integer
+    execute "update course_materials set course_id = f.course_id from course_material_folders f where course_materials.folder_id = f.id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_26_161011) do
+ActiveRecord::Schema.define(version: 2022_02_02_073459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -483,6 +483,11 @@ ActiveRecord::Schema.define(version: 2021_12_26_161011) do
     t.integer "minimum_level", null: false
   end
 
+  create_table "course_condition_materials", force: :cascade do |t|
+    t.bigint "material_id", null: false
+    t.index ["material_id"], name: "fk__course_condition_materials_material_id"
+  end
+
   create_table "course_condition_surveys", id: :serial, force: :cascade do |t|
     t.bigint "survey_id", null: false
     t.index ["survey_id"], name: "fk__course_condition_surveys_survey_id"
@@ -742,6 +747,16 @@ ActiveRecord::Schema.define(version: 2021_12_26_161011) do
     t.index ["course_id"], name: "fk__course_levels_course_id"
   end
 
+  create_table "course_material_downloads", force: :cascade do |t|
+    t.integer "course_user_id", null: false
+    t.integer "material_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["course_user_id", "material_id"], name: "index_downloads_on_course_user_and_materials", unique: true
+    t.index ["course_user_id"], name: "index_course_material_downloads_on_course_user_id"
+    t.index ["material_id"], name: "index_course_material_downloads_on_material_id"
+  end
+
   create_table "course_material_folders", id: :serial, force: :cascade do |t|
     t.integer "parent_id"
     t.integer "course_id", null: false
@@ -773,6 +788,8 @@ ActiveRecord::Schema.define(version: 2021_12_26_161011) do
     t.integer "updater_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "satisfiability_type", default: 0
+    t.integer "course_id"
     t.index "folder_id, lower((name)::text)", name: "index_course_materials_on_folder_id_and_name", unique: true
     t.index ["creator_id"], name: "fk__course_materials_creator_id"
     t.index ["folder_id"], name: "fk__course_materials_folder_id"
@@ -1336,6 +1353,7 @@ ActiveRecord::Schema.define(version: 2021_12_26_161011) do
   add_foreign_key "course_assessments", "users", column: "updater_id", name: "fk_course_assessments_updater_id"
   add_foreign_key "course_condition_achievements", "course_achievements", column: "achievement_id", name: "fk_course_condition_achievements_achievement_id"
   add_foreign_key "course_condition_assessments", "course_assessments", column: "assessment_id", name: "fk_course_condition_assessments_assessment_id"
+  add_foreign_key "course_condition_materials", "course_materials", column: "material_id", name: "fk_course_condition_materials_material_id"
   add_foreign_key "course_condition_surveys", "course_surveys", column: "survey_id", name: "fk_course_condition_surveys_survey_id"
   add_foreign_key "course_condition_videos", "course_videos", column: "video_id", name: "fk_course_condition_videos_video_id"
   add_foreign_key "course_conditions", "courses", name: "fk_course_conditions_course_id"

--- a/spec/factories/course_condition_materials.rb
+++ b/spec/factories/course_condition_materials.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_condition_material,
+          class: Course::Condition::Material.name, aliases: [:material_condition] do
+    course
+    material
+    association :conditional, factory: :course_material
+  end
+end

--- a/spec/jobs/course/material/zip_download_job_spec.rb
+++ b/spec/jobs/course/material/zip_download_job_spec.rb
@@ -4,16 +4,17 @@ require 'rails_helper'
 RSpec.describe Course::Material::ZipDownloadJob do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
+    let(:course_user) { create(:course_user) }
     let(:folder) { create(:material).folder }
     subject { Course::Material::ZipDownloadJob }
 
     it 'can be queued' do
-      expect { subject.perform_later(folder, []) }.
+      expect { subject.perform_later(folder, [], course_user) }.
         to have_enqueued_job(subject).exactly(:once)
     end
 
     it 'downloads the materials' do
-      download_job = subject.perform_later(folder, folder.materials.to_a)
+      download_job = subject.perform_later(folder, folder.materials.to_a, course_user)
       download_job.perform_now
       expect(download_job.job).to be_completed
       expect(download_job.job.redirect_to).to be_present

--- a/spec/models/course/condition/material_ability_spec.rb
+++ b/spec/models/course/condition/material_ability_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Condition::Material do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    subject { Ability.new(user, course, course_user) }
+    let(:course) { create(:course) }
+    let(:condition) { create(:material_condition, course: course) }
+
+    context 'when the user is a Course Staff' do
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
+
+      it { is_expected.to be_able_to(:manage, condition) }
+    end
+  end
+end

--- a/spec/models/course/condition/material_spec.rb
+++ b/spec/models/course/condition/material_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Condition::Material, type: :model do
+  it { is_expected.to act_as(Course::Condition) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+
+    describe 'validations' do
+      subject do
+        material = create(:material)
+        build(:material_condition, course: course, material: material, conditional: material)
+      end
+
+      context 'when a material is its own condition' do
+        it 'is not valid' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:material]).to include(I18n.t('activerecord.errors.models.' \
+                                                              'course/condition/material.' \
+                                                              'attributes.material.references_self'))
+        end
+      end
+
+      context "when a material is already included in its conditional's conditions" do
+        subject do
+          existing_material_condition = create(:material_condition, course: course)
+          build(:material_condition, course: course, conditional: existing_material_condition.conditional,
+                                     material: existing_material_condition.material)
+        end
+
+        it 'is not valid' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:material]).to include(I18n.t('activerecord.errors.models.' \
+                                                              'course/condition/material.' \
+                                                              'attributes.material.unique_dependency'))
+        end
+      end
+
+      context 'when a material is required by another conditional with the same id' do
+        subject do
+          id = Time.now.to_i
+          material = create(:material, id: id)
+          achievement = create(:achievement, id: id)
+          required_material = create(:material)
+          create(:material_condition, course: course, material: required_material, conditional: achievement)
+          build_stubbed(:material_condition, course: course, material: required_material, conditional: material)
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when a material has the conditional as its own condition' do
+        subject do
+          material1 = create(:material)
+          material2 = create(:material)
+          create(:material_condition, course: course, material: material1, conditional: material2)
+          build(:material_condition, course: course, material: material2, conditional: material1)
+        end
+
+        it 'is not valid' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:material]).to include(I18n.t('activerecord.errors.models.' \
+                                                              'course/condition/material.' \
+                                                              'attributes.material.cyclic_dependency'))
+        end
+      end
+    end
+
+    describe '#title' do
+      let(:material) { create(:material) }
+      subject { create(:course_condition_material, material: material) }
+
+      it 'returns the correct material title' do
+        expect(subject.title).
+          to eq(Course::Condition::Material.human_attribute_name('title.complete', material_title: material.name))
+      end
+    end
+
+    describe '#satisfied_by?' do
+      let(:course_user) { create(:course_student, course: course) }
+      let(:material) { create(:material) }
+
+      context 'when the course user has not downloaded the material' do
+        subject { create(:course_condition_material, material: material) }
+
+        it 'returns false' do
+          expect(subject.satisfied_by?(course_user)).to be_falsey
+        end
+      end
+
+      context 'when the course user has downloaded the material' do
+        subject do
+          Course::Material::Download.create(course_user_id: course_user.id, material_id: material.id)
+          create(:course_condition_material, material: material)
+        end
+
+        it 'returns true' do
+          expect(subject.satisfied_by?(course_user)).to be_truthy
+        end
+      end
+    end
+
+    describe '#dependent_object' do
+      it 'returns the correct dependent material object' do
+        expect(subject.dependent_object).to eq(subject.material)
+      end
+    end
+
+    describe '.dependent_class' do
+      it 'returns Course::Material' do
+        expect(Course::Condition::Material.dependent_class).to eq(Course::Material.name)
+      end
+    end
+  end
+end

--- a/spec/models/course/condition_spec.rb
+++ b/spec/models/course/condition_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Course::Condition, type: :model do
             to receive(:dependent_class).and_return(Course::Achievement.name)
           allow(Course::Condition::Assessment).
             to receive(:dependent_class).and_return(Course::Achievement.name)
+          allow(Course::Condition::Material).
+            to receive(:dependent_class).and_return(Course::Achievement.name)
           allow(Course::Condition::Survey).
             to receive(:dependent_class).and_return(Course::Achievement.name)
           allow(Course::Condition::Video).
@@ -54,6 +56,7 @@ RSpec.describe Course::Condition, type: :model do
           actual_mapping = Course::Condition.send(:dependent_class_to_condition_class_mapping)
           expected_mapping = { Course::Achievement.name => [Course::Condition::Achievement.name,
                                                             Course::Condition::Assessment.name,
+                                                            Course::Condition::Material.name,
                                                             Course::Condition::Survey.name,
                                                             Course::Condition::Video.name] }
           expect(actual_mapping).to eq(expected_mapping)

--- a/spec/models/course/material_spec.rb
+++ b/spec/models/course/material_spec.rb
@@ -53,5 +53,14 @@ RSpec.describe Course::Material, type: :model do
         expect(material.send(:next_valid_name)).to eq("#{common_name} (1)")
       end
     end
+
+    describe '#satisfiable?' do
+      let(:folder) { create(:folder) }
+      let!(:material) { create(:material, folder: folder) }
+
+      it 'is satisfiable' do
+        expect(material.satisfiable?).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR makes course materials act as both conditions and conditionals.

Most of the updated files are in accordance with the developer guide here (for adding new types to the condition-conditional framework):
https://docs.google.com/document/d/1hGfaVMBhKryqoENgPFxfNbLk6eezL-3giCtBcjUx55o/edit?usp=sharing

A new `Course::Material::Download` association class was created to keep track of user downloads of course materials.

The zip downloading job and service were updated to accept `course_user` as a param to update the downloads table.

The `course_id` field was introduced to `Course::Material` (which acts as a conditional) due to the way that the condition-conditional framework currently finds conditionals for a course, which is to make database queries using that field for all conditional types.