### PR TITLE
Fix download job not polling

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -39,6 +39,9 @@ class JobsController < ApplicationController
   end
 
   def show_submitted_job
-    response.status = :accepted
+    respond_to do |format|
+      format.html { response.status = :accepted }
+      format.json { render json: { status: :accepted } }
+    end
   end
 end

--- a/client/app/lib/helpers/initializeDownloadLink.js
+++ b/client/app/lib/helpers/initializeDownloadLink.js
@@ -36,7 +36,7 @@ function waitForJob(url, $link) {
             window.location.href = response.redirect_url;
           }
           hideSpinner($link);
-        } else if (response.status === 'submitted') {
+        } else if (response.status === 'accepted') {
           waitForJob(url, $link);
         } else if (response.status === 'errored') {
           hideSpinner($link);


### PR DESCRIPTION
When downloading files with large size, it may take some time for the job to complete. While waiting, the polling ajax waitForJob requested for json response, but the job controller returned html response. As a result, the waitForJob ajax went into the fail callback.

To fix this issue, we specify the format response in the job controller.