### PR TITLE
Fix survey result perf issue

### DIFF
--- a/app/views/course/survey/surveys/results.json.jbuilder
+++ b/app/views/course/survey/surveys/results.json.jbuilder
@@ -23,7 +23,7 @@ json.sections @sections do |section|
       if question.text?
         json.(answer, :text_response)
       else
-        json.(answer, :question_option_ids)
+        json.question_option_ids answer.options.pluck(:question_option_id)
       end
     end
   end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42570513/158213615-959d4c4b-4e43-4f64-937b-bc12761b7599.png)


The following is queried 10k times (n+1)
![image](https://user-images.githubusercontent.com/42570513/158214233-9827f9e2-8e34-4b61-93ad-efaa19c6ded6.png)

Perf issue may occur in frontend as well. To be investigated separately.
