### PR TITLE
chore: bump minimist to 1.2.6

### DIFF
--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6059,7 +6059,7 @@ minimatch@^3.0.4, minimatch@^3.1.2:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
+  version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 


### PR DESCRIPTION
Fixes security issue https://github.com/Coursemology/coursemology2/security/dependabot/54

Reference:
https://github.com/substack/minimist/issues/164