### PR TITLE
Fix hash content for non-development filenames

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -20,7 +20,7 @@ const config = {
   },
 
   output: {
-    filename: '[name].js',
+    filename: development ? '[name].js' : '[name]-[contenthash].js',
     path: path.join(__dirname, '..', 'public', 'webpack'),
     publicPath: '/webpack/',
   },


### PR DESCRIPTION
As production will end up caching the bundles across builds otherwise.