### PR TITLE
[8/n] Add personalized timeline settings models

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
@@ -5,8 +5,8 @@ class Course::LessonPlan::Strategies::BasePersonalizationStrategy
   include Course::LessonPlan::LearningRateConcern
   # To override any of these constants, simply define the same constant in the subclass.
   LEARNING_RATE_ALPHA = 0.4
-  MIN_LEARNING_RATE = 1.0
-  MAX_LEARNING_RATE = 1.0
+  MIN_OVERALL_LIMIT = 1.0 # The fastest that a student can finish a course
+  MAX_OVERALL_LIMIT = 1.0 # The slowest that a student can finish a course
   HARD_MIN_LEARNING_RATE = 1.0
   # How generously we round off. E.g. if `threshold` = 0.5, then a datetime with a time of > 0.5 * 1.day will be
   # snapped to the next day.
@@ -39,15 +39,20 @@ class Course::LessonPlan::Strategies::BasePersonalizationStrategy
       course_user, items_affecting_personal_times, submitted_items, self.class::LEARNING_RATE_ALPHA
     )
     unless learning_rate_ema.nil?
+      settings = course_user.course.settings_personalized_timeline
       effective_min, effective_max = compute_learning_rate_effective_limits(course_user, items, submitted_items,
-                                                                            self.class::MIN_LEARNING_RATE,
-                                                                            self.class::MAX_LEARNING_RATE)
-      learning_rate_ema = [self.class::HARD_MIN_LEARNING_RATE, effective_min,
-                           [learning_rate_ema, effective_max].min].max
+                                                                            min_overall_limit(settings, learning_rate_ema),
+                                                                            max_overall_limit(settings, learning_rate_ema))
+      bounded_learning_rate_ema = [hard_min_learning_rate(settings, learning_rate_ema), effective_min,
+                                   [learning_rate_ema, effective_max].min].max
+      if settings&.hard_max_learning_rate
+        bounded_learning_rate_ema = [bounded_learning_rate_ema,
+                                     settings.hard_max_learning_rate].min
+      end
     end
 
-    { submitted_items: submitted_items, items: items, learning_rate_ema: learning_rate_ema,
-      effective_min: effective_min, effective_max: effective_max }
+    { submitted_items: submitted_items, items: items, learning_rate_ema: bounded_learning_rate_ema,
+      original_learning_rate_ema: learning_rate_ema, effective_min: effective_min, effective_max: effective_max }
   end
 
   # Executes the relevant personalization strategy for the given course user, using the given precomputed
@@ -62,6 +67,18 @@ class Course::LessonPlan::Strategies::BasePersonalizationStrategy
   end
 
   protected
+
+  def min_overall_limit(settings, _learning_rate_ema)
+    settings&.min_overall_limit || self.class::MIN_OVERALL_LIMIT
+  end
+
+  def max_overall_limit(settings, _learning_rate_ema)
+    settings&.max_overall_limit || self.class::MAX_OVERALL_LIMIT
+  end
+
+  def hard_min_learning_rate(settings, _learning_rate_ema)
+    settings&.hard_min_learning_rate || self.class::HARD_MIN_LEARNING_RATE
+  end
 
   # Round to "nearest" date in course's timezone, NOT user's timezone.
   #

--- a/app/controllers/concerns/course/lesson_plan/strategies/fomo_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/fomo_personalization_strategy.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 class Course::LessonPlan::Strategies::FomoPersonalizationStrategy <
   Course::LessonPlan::Strategies::BasePersonalizationStrategy
-  MIN_LEARNING_RATE = 0.67
-  MAX_LEARNING_RATE = 1.0
-  HARD_MIN_LEARNING_RATE = 0.5
+  MIN_OVERALL_LIMIT = 0.67 # Means that the fastest that a course can be completed is in 0.67 of the course duration
+  MAX_OVERALL_LIMIT = 1.0
+  HARD_MIN_LEARNING_RATE = 0.5 
   DATE_ROUNDING_THRESHOLD = 0.8
 
   # Shifts start_at of relevant lesson plan items and resets the bonus_end_at and end_at

--- a/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/stragglers_personalization_strategy.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class Course::LessonPlan::Strategies::StragglersPersonalizationStrategy <
   Course::LessonPlan::Strategies::BasePersonalizationStrategy
-  MIN_LEARNING_RATE = 1.0
-  MAX_LEARNING_RATE = 2.0
+  MIN_OVERALL_LIMIT = 1.0
+  MAX_OVERALL_LIMIT = 2.0 # Means that the default latest that a course can be completed is 2x the duration
   HARD_MIN_LEARNING_RATE = 0.8
   DATE_ROUNDING_THRESHOLD = 0.2
   STRAGGLERS_FIXES = 1

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course < ApplicationRecord
+class Course < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include Course::LessonPlanConcern
   include Course::SearchConcern
   include Course::DuplicationConcern
@@ -74,6 +74,8 @@ class Course < ApplicationRecord
 
   has_one :learning_map, dependent: :destroy
   has_many :setting_emails, class_name: Course::Settings::Email.name, inverse_of: :course, dependent: :destroy
+  has_one :settings_personalized_timeline, class_name: Course::Settings::PersonalizedTimeline.name,
+                                           inverse_of: :course, dependent: :destroy
   has_one :duplication_traceable, class_name: DuplicationTraceable::Course.name,
                                   inverse_of: :course, dependent: :destroy
 

--- a/app/models/course/settings/personalized_timeline.rb
+++ b/app/models/course/settings/personalized_timeline.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class Course::Settings::PersonalizedTimeline < ApplicationRecord
+  self.table_name = 'course_settings_personalized_timeline'
+
+  validates :course, presence: true
+  validates :min_overall_limit, numericality: { greater_than: 0, less_than_or_equal: 1 }, allow_nil: true
+  validates :max_overall_limit, numericality: { greater_than_or_equal_to: 1 }, allow_nil: true
+  validates :hard_min_learning_rate, numericality: { greater_than: 0, less_than_or_equal: 1 }, allow_nil: true
+  validates :hard_max_learning_rate, numericality: { greater_than_or_equal_to: 1 }, allow_nil: true
+  validates :assessment_submission_time_weight, numericality: { greater_than_or_equal_to: 0, less_than_or_equal: 1 },
+                                                allow_nil: true
+  validates :assessment_grade_weight, numericality: { greater_than_or_equal_to: 0, less_than_or_equal: 1 },
+                                      allow_nil: true
+  validates :video_watch_percentage_weight, numericality: { greater_than_or_equal_to: 0, less_than_or_equal: 1 },
+                                            allow_nil: true
+
+  belongs_to :course, class_name: Course.name, inverse_of: :setting_personalized_timeline
+
+  def initialize_duplicate(duplicator, _other)
+    self.course = duplicator.options[:destination_course]
+  end
+end

--- a/db/migrate/20220325093906_add_course_settings_personalized_timeline.rb
+++ b/db/migrate/20220325093906_add_course_settings_personalized_timeline.rb
@@ -1,0 +1,15 @@
+class AddCourseSettingsPersonalizedTimeline < ActiveRecord::Migration[6.0]
+  def change
+    create_table :course_settings_personalized_timeline do |t|
+      t.references :course, null: false, foreign_key: { references: :courses }
+      t.float :min_overall_limit # The fastest that a course can be completed
+      t.float :max_overall_limit # The slowest that a course can be completed
+      t.float :hard_min_learning_rate # The fastest learning rate possible
+      t.float :hard_max_learning_rate # The slowest learning rate possible
+      t.float :assessment_submission_time_weight
+      t.float :assessment_grade_weight
+      t.float :video_watch_percentage_weight
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_192851) do
+ActiveRecord::Schema.define(version: 2022_03_25_093906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -865,6 +865,20 @@ ActiveRecord::Schema.define(version: 2022_03_15_192851) do
     t.index ["course_id"], name: "index_course_settings_emails_on_course_id"
   end
 
+  create_table "course_settings_personalized_timeline", force: :cascade do |t|
+    t.bigint "course_id", null: false
+    t.float "min_overall_limit"
+    t.float "max_overall_limit"
+    t.float "hard_min_learning_rate"
+    t.float "hard_max_learning_rate"
+    t.float "assessment_submission_time_weight"
+    t.float "assessment_grade_weight"
+    t.float "video_watch_percentage_weight"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["course_id"], name: "index_course_settings_personalized_timeline_on_course_id"
+  end
+
   create_table "course_survey_answer_options", id: :serial, force: :cascade do |t|
     t.integer "answer_id", null: false
     t.integer "question_option_id", null: false
@@ -1454,6 +1468,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_192851) do
   add_foreign_key "course_reference_times", "course_reference_timelines", column: "reference_timeline_id"
   add_foreign_key "course_settings_emails", "course_assessment_categories"
   add_foreign_key "course_settings_emails", "courses"
+  add_foreign_key "course_settings_personalized_timeline", "courses"
   add_foreign_key "course_survey_answer_options", "course_survey_answers", column: "answer_id", name: "fk_course_survey_answer_options_answer_id"
   add_foreign_key "course_survey_answer_options", "course_survey_question_options", column: "question_option_id", name: "fk_course_survey_answer_options_question_option_id"
   add_foreign_key "course_survey_answers", "course_survey_questions", column: "question_id", name: "fk_course_survey_answers_question_id"


### PR DESCRIPTION
## Summary

Add supporting database table and model for personalized timeline settings.

Configured the existing algorithms to make use of the limits in the settings.

## TODO

- Write tests
- Figure out how to incorporate the different components, e.g. video watch percent, assessment grade, etc. into the instantaneous learning rate computation.