### PR TITLE
chore(webpack): change node env for test build to none

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "TZ=Asia/Singapore yarn run jest --coverage",
     "testci": "TZ=Asia/Singapore yarn run jest --maxWorkers=4 --coverage",
-    "build:test": "export NODE_ENV=test && yarn run build:translations && webpack -w --node-env=production",
+    "build:test": "export NODE_ENV=test && yarn run build:translations && webpack -w --node-env=none",
     "build:production": "export NODE_ENV=production && yarn run build:translations && webpack --node-env=production",
     "build:development": "yarn run build:translations && webpack serve",
     "build:translations": "babel-node scripts/aggregate-translations.js",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -5,6 +5,7 @@ const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 const env = process.env.NODE_ENV || 'development';
 const development = env === 'development';
+const none = env === 'none';
 const travis = process.env.TRAVIS === 'true';
 
 const config = {
@@ -20,7 +21,7 @@ const config = {
   },
 
   output: {
-    filename: development ? '[name].js' : '[name]-[contenthash].js',
+    filename: development || none ? '[name].js' : '[name]-[contenthash].js',
     path: path.join(__dirname, '..', 'public', 'webpack'),
     publicPath: '/webpack/',
   },


### PR DESCRIPTION
Change the nod env for test build to none. (Latest webpack only allows production, development or none)

In Procfile.dev, we are building both dev and test packages. As a result, there are two different webpack files - one with and another without the contenthash. Somehow the webpack filename with contenthash (supposedly only in prod) is requested by the frontend in dev. As a result, when the frontend is asking for the webpack file, the file cant be found and we see jquery errors all over.

![image](https://user-images.githubusercontent.com/42570513/161746090-afe51251-3d94-46f0-9c9f-68fbcc06e304.png)
