### PR TITLE
Fix unable to update autograded programming question

### DIFF
--- a/app/services/course/assessment/question/programming/language_package_service.rb
+++ b/app/services/course/assessment/question/programming/language_package_service.rb
@@ -24,7 +24,7 @@ class Course::Assessment::Question::Programming::LanguagePackageService
   #
   # @return [Boolean]
   def autograded?
-    @test_params.key?(:autograded)
+    @test_params.key?(:autograded) && (@test_params[:autograded] == true || @test_params[:autograded] == 'true')
   end
 
   # Array of arguments used to create template files for non-autograded programming question.

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -746,23 +746,35 @@ class ProgrammingQuestionForm extends Component {
                 'question',
                 'display_autograded_toggle',
               ]) ? (
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={autograded}
-                      color="primary"
-                      onChange={(e) => {
-                        if (hasAutoGradings) return;
-                        this.handleChange('autograded', e.target.checked);
-                      }}
-                    />
-                  }
-                  disabled={
-                    this.props.data.get('is_loading') || hasAutoGradings
-                  }
-                  label={<b>{autogradedLabel}</b>}
-                  name="question_programming[autograded]"
-                />
+                <>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={autograded}
+                        color="primary"
+                        onChange={(e) => {
+                          if (hasAutoGradings) return;
+                          this.handleChange('autograded', e.target.checked);
+                        }}
+                      />
+                    }
+                    name={ProgrammingQuestionForm.getInputName('autograded')}
+                    disabled={
+                      this.props.data.get('is_loading') || hasAutoGradings
+                    }
+                    label={<b>{autogradedLabel}</b>}
+                  />
+                  <input
+                    type="hidden"
+                    name={ProgrammingQuestionForm.getInputName('autograded')}
+                    id={ProgrammingQuestionForm.getInputId('autograded')}
+                    value={autograded}
+                    style={{ display: 'none' }}
+                    readOnly={
+                      this.props.data.get('is_loading') || hasAutoGradings
+                    }
+                  />
+                </>
               ) : null}
             </div>
             <div className={styles.memoryLimitInput}>


### PR DESCRIPTION
When editing a programming qn thats autograded with existing submissions, the autograded toggle is disabled.
Because of the way the form is written and the new mui component, any disabled field value is not included when the form data is sent to the backend. This results in the backend not knowing that the updated question is of autograded type.

To fix this issue, a separate hidden input is added for toggle to pass the field value of autograded when submitting the form for disabled autograded toggle.