### PR TITLE
Fix local rspec not working for pages with React injection

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
 web: bundle exec rails server
 client: cd client && yarn build:development
-test: cd client && yarn build:test

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some fr
    ```sh
    # Start the webpack dev server:
    $ cd client && yarn build:development
+   ```
 
-   # Run this command to compile the assets before running the test suite.
+   Either way, run this command to compile the assets before running the test suite.
+   ```
    $ cd client && yarn build:test
    ```
 

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "TZ=Asia/Singapore yarn run jest --coverage",
     "testci": "TZ=Asia/Singapore yarn run jest --maxWorkers=4 --coverage",
-    "build:test": "export NODE_ENV=test && yarn run build:translations && webpack -w --node-env=none",
+    "build:test": "export NODE_ENV=test && yarn run build:translations && webpack -w --node-env=production",
     "build:production": "export NODE_ENV=production && yarn run build:translations && webpack --node-env=production",
     "build:development": "yarn run build:translations && webpack serve",
     "build:translations": "babel-node scripts/aggregate-translations.js",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -5,7 +5,6 @@ const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 const env = process.env.NODE_ENV || 'development';
 const development = env === 'development';
-const none = env === 'none';
 const travis = process.env.TRAVIS === 'true';
 
 const config = {
@@ -21,7 +20,7 @@ const config = {
   },
 
   output: {
-    filename: development || none ? '[name].js' : '[name]-[contenthash].js',
+    filename: development ? '[name].js' : '[name]-[contenthash].js',
     path: path.join(__dirname, '..', 'public', 'webpack'),
     publicPath: '/webpack/',
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1864,6 +1864,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/prop-types@^15.7.3":
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"


### PR DESCRIPTION
Related to #4504 

This PR is submitted to fix regression from PR 4504. When running rspec, it is looking for bundles with contenthash. Since there is no contenthash in the yarn test build, rspec tests involving react pages fail.

To avoid the issue described in #4504, we remove yarn build test from foreman procfile. In the future, yarn build:test should be run before yarn test.

