### PR TITLE
fix(programming question form): fix data files not being able to be deleted

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/components/OnlineEditor/ExistingPackageFile.jsx
+++ b/client/app/bundles/course/assessment/question/programming/components/OnlineEditor/ExistingPackageFile.jsx
@@ -56,7 +56,8 @@ function ExistingPackageFile(props) {
           type="checkbox"
           hidden
           name={`question_programming[${`${fileType}_to_delete`}][${filename}]`}
-          defaultChecked={toDelete}
+          readOnly
+          checked={toDelete}
         />
       </TableCell>
       <TableCell>{filename}</TableCell>


### PR DESCRIPTION
_to_delete checked value was passed to wrong input props. Instead of defaultChecked, it should be checked and to avoid warning, readOnly prop is added.