### PR TITLE
fix(programming question form): fix programming question creation and update error warning

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/actions/programmingQuestionActionCreators.jsx
+++ b/client/app/bundles/course/assessment/question/programming/actions/programmingQuestionActionCreators.jsx
@@ -96,12 +96,12 @@ function fetchImportResult(redirectAssessment, successMessage, failureMessage) {
           import_result: { import_errored: importErrored },
         } = response.data;
 
-        dispatch(setSubmissionMessage(successMessage));
-
         if (importErrored) {
           dispatch(submitFormEndEvaluating(response.data));
           dispatch(submitFormLoading(false));
+          dispatch(setSubmissionMessage(failureMessage));
         } else {
+          dispatch(setSubmissionMessage(successMessage));
           window.location = redirectAssessment;
         }
       })
@@ -130,7 +130,7 @@ function submitFormEvaluate(
       .then((response) => {
         const status = response.data.status;
 
-        if (status === 'submitted') {
+        if (status === 'submitted' || status === 'accepted') {
           dispatch(submitFormStartEvaluating());
 
           setTimeout(() => {


### PR DESCRIPTION
Fixed 2 issues:
1. When a programming question is created or updated, 'accepted' status is first returned from the backend. This should be included in the check to ensure the polling is triggered. Otherwise, it will directly redirect to question index page. We do not want the redirection when there is an error with the question creation/update.
2. Success and failure messages are differentiated when a programming question import is successful / when there is an error.