### PR TITLE
chore(baby squeel): remove remaining baby squeel syntax

### DIFF
--- a/app/models/course/lesson_plan/milestone.rb
+++ b/app/models/course/lesson_plan/milestone.rb
@@ -10,6 +10,7 @@ class Course::LessonPlan::Milestone < ApplicationRecord
   # Used by the with_actable_types scope in Course::LessonPlan::Item.
   # Edit this to remove items for display.
   scope :ids_showable_in_lesson_plan, (lambda do |_|
-    joining { lesson_plan_item }.selecting { lesson_plan_item.id }
+    # joining { lesson_plan_item }.selecting { lesson_plan_item.id }
+    unscoped.joins(:lesson_plan_item).select(Course::LessonPlan::Item.arel_table[:id])
   end)
 end

--- a/app/models/course/lesson_plan/todo.rb
+++ b/app/models/course/lesson_plan/todo.rb
@@ -65,20 +65,6 @@ class Course::LessonPlan::Todo < ApplicationRecord
       result.ids
     end
 
-    # Destroy todos for the associated lesson_plan_item for specified course_users.
-    #   If no course_user is specified, destroy all todos for that lesson_plan_item.
-    #
-    # @param [Course::LessonPlan::Item] item Item's todos to be deleted
-    # @param [Array<CourseUser>] course_users If specified, filter of course_users to delete todos.
-    # @return [Array<Course::LessonPlan::Todo>|nil] The todos that are deleted, or nil if invalid
-    #   params
-    def delete_for(item, course_users = nil)
-      return unless item
-
-      user_ids = course_users ? course_users.select(:user_id) : item.todos.select(:user_id)
-      item.todos.where.has { user_id.in(user_ids) }.destroy_all
-    end
-
     private
 
     # Constructs and returns the column and attribute hash. This is required for


### PR DESCRIPTION
As described.

delete_for function below is not used anywhere in the codebase anymore.