### PR TITLE
fix(dialogue layout): fix dialogue layout

### DIFF
--- a/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
@@ -123,7 +123,9 @@ class PopupDialog extends Component {
           open={visible}
           maxWidth="md"
           style={{
-            zIndex: 9999,
+            maxHeight: 1700,
+            position: 'absolute',
+            top: 40,
           }}
         >
           <DialogTitle>

--- a/client/app/lib/components/FormDialogue.jsx
+++ b/client/app/lib/components/FormDialogue.jsx
@@ -88,7 +88,9 @@ class FormDialogue extends Component {
           open={open}
           onClose={this.handleFormClose}
           style={{
-            zIndex: 9999,
+            maxHeight: 1700,
+            position: 'absolute',
+            top: 40,
           }}
         >
           <DialogTitle>{title}</DialogTitle>


### PR DESCRIPTION
When using zindex for dialogue, any other subcomponent dialogues will appear below the main dialogue. Instead of adjusting the zindex, we limit the height of the main dialogue instead. 