### PR TITLE
fix(submission answers): fix memo bug for mcq and mrq answers

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice.jsx
@@ -53,7 +53,22 @@ MultipleChoiceOptions.propTypes = {
   }).isRequired,
 };
 
-const MemoMultipleChoiceOptions = memo(MultipleChoiceOptions, propsAreEqual);
+const MemoMultipleChoiceOptions = memo(
+  MultipleChoiceOptions,
+  (prevProps, nextProps) => {
+    const { id: prevId } = prevProps.question;
+    const { id: nextId } = nextProps.question;
+    const { graderView: prevGraderView } = prevProps.readOnly;
+    const { graderView: nextGraderView } = nextProps.readOnly;
+    const isQuestionIdUnchanged = prevId === nextId;
+    const isGraderViewUnchanged = prevGraderView === nextGraderView;
+    return (
+      isQuestionIdUnchanged &&
+      isGraderViewUnchanged &&
+      propsAreEqual(prevProps, nextProps)
+    );
+  },
+);
 
 const MultipleChoice = (props) => {
   const { question, readOnly, showMcqMrqSolution, graderView, answerId } =

--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse.jsx
@@ -65,7 +65,19 @@ MultipleResponseOptions.defaultProps = {
 
 const MemoMultipleResponseOptions = memo(
   MultipleResponseOptions,
-  propsAreEqual,
+  (prevProps, nextProps) => {
+    const { id: prevId } = prevProps.question;
+    const { id: nextId } = nextProps.question;
+    const { graderView: prevGraderView } = prevProps.readOnly;
+    const { graderView: nextGraderView } = nextProps.readOnly;
+    const isQuestionIdUnchanged = prevId === nextId;
+    const isGraderViewUnchanged = prevGraderView === nextGraderView;
+    return (
+      isQuestionIdUnchanged &&
+      isGraderViewUnchanged &&
+      propsAreEqual(prevProps, nextProps)
+    );
+  },
 );
 
 const MultipleResponse = (props) => {


### PR DESCRIPTION
In tabbed / autograded assessments, the options for MCQ/MRQ related questions are not changed when the tab/question is changed (eg MRQ qn 2 to MRQ qn 3). This is caused by the memo function not checking the question number.