### PR TITLE
fix(submission answers): fix react hook form submission answers component key

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/Answers.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Answers.jsx
@@ -13,12 +13,18 @@ import ForumPostResponseAnswer from './answers/ForumPostResponse';
 
 export default class Answers extends Component {
   static renderFileUpload({ question, readOnly, answerId }) {
-    return <FileUploadAnswer {...{ question, readOnly, answerId }} />;
+    return (
+      <FileUploadAnswer
+        key={`question_${question.id}`}
+        {...{ question, readOnly, answerId }}
+      />
+    );
   }
 
   static renderForumPostResponse({ question, readOnly, answerId }) {
     return (
       <ForumPostResponseAnswer
+        key={`question_${question.id}`}
         question={question}
         readOnly={readOnly}
         answerId={answerId}
@@ -35,6 +41,7 @@ export default class Answers extends Component {
   }) {
     return (
       <MultipleChoiceAnswer
+        key={`question_${question.id}`}
         {...{ question, readOnly, answerId, graderView, showMcqMrqSolution }}
       />
     );
@@ -49,18 +56,25 @@ export default class Answers extends Component {
   }) {
     return (
       <MultipleResponseAnswer
+        key={`question_${question.id}`}
         {...{ question, readOnly, answerId, graderView, showMcqMrqSolution }}
       />
     );
   }
 
   static renderProgramming({ question, readOnly, answerId }) {
-    return <ProgrammingAnswer {...{ question, readOnly, answerId }} />;
+    return (
+      <ProgrammingAnswer
+        key={`question_${question.id}`}
+        {...{ question, readOnly, answerId }}
+      />
+    );
   }
 
   static renderScribing({ question, readOnly, answerId }) {
     return (
       <ScribingView
+        key={`question_${question.id}`}
         scribing={question}
         readOnly={readOnly}
         answerId={answerId}
@@ -70,13 +84,17 @@ export default class Answers extends Component {
 
   static renderTextResponse({ question, readOnly, answerId, graderView }) {
     return (
-      <TextResponseAnswer {...{ question, readOnly, answerId, graderView }} />
+      <TextResponseAnswer
+        key={`question_${question.id}`}
+        {...{ question, readOnly, answerId, graderView }}
+      />
     );
   }
 
   static renderVoiceResponse({ question, readOnly, answerId }) {
     return (
       <VoiceResponseAnswer
+        key={`question_${question.id}`}
         question={question}
         readOnly={readOnly}
         answerId={answerId}

--- a/client/app/bundles/course/assessment/submission/components/Editor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Editor.jsx
@@ -9,7 +9,6 @@ const Editor = (props) => {
   return (
     <Controller
       name={name}
-      key={name}
       control={control}
       render={({ field }) => (
         <AceEditorField

--- a/client/app/bundles/course/assessment/submission/components/FileInput.jsx
+++ b/client/app/bundles/course/assessment/submission/components/FileInput.jsx
@@ -159,7 +159,6 @@ const FileInputField = ({ name, disabled, callback, ...custom }) => {
   return (
     <Controller
       name={name}
-      key={name}
       control={control}
       render={({ field, fieldState }) => (
         <FileInput

--- a/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse/index.jsx
@@ -16,7 +16,6 @@ const ForumPostResponse = (props) => {
     readOnly ? (
       <Controller
         name={`${answerId}.answer_text`}
-        key={`${answerId}.answer_text`}
         control={control}
         render={({ field }) => (
           <div dangerouslySetInnerHTML={{ __html: field.value }} />
@@ -25,7 +24,6 @@ const ForumPostResponse = (props) => {
     ) : (
       <Controller
         name={`${answerId}.answer_text`}
-        key={`${answerId}.answer_text`}
         control={control}
         render={({ field, fieldState }) => (
           <FormRichTextField
@@ -46,7 +44,6 @@ const ForumPostResponse = (props) => {
     <>
       <Controller
         name={`${answerId}.selected_post_packs`}
-        key={`${answerId}.selected_post_packs`}
         control={control}
         render={({ field }) => (
           <ForumPostSelect

--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice.jsx
@@ -16,7 +16,7 @@ const MultipleChoiceOptions = ({
   <>
     {question.options.map((option) => (
       <FormControlLabel
-        checked={option.id === value[0]}
+        checked={value && value.length > 0 && option.id === value[0]}
         control={<Radio style={{ padding: '0 12px' }} />}
         disabled={readOnly}
         key={option.id}
@@ -78,7 +78,6 @@ const MultipleChoice = (props) => {
   return (
     <Controller
       name={`${answerId}.option_ids`}
-      key={`${answerId}.option_ids`}
       control={control}
       render={({ field, fieldState }) => (
         <MemoMultipleChoiceOptions

--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse.jsx
@@ -88,7 +88,6 @@ const MultipleResponse = (props) => {
   return (
     <Controller
       name={`${answerId}.option_ids`}
-      key={`${answerId}.option_ids`}
       control={control}
       render={({ field, fieldState }) => (
         <MemoMultipleResponseOptions

--- a/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
@@ -49,12 +49,14 @@ const Programming = (props) => {
     <div>
       {fileSubmission ? (
         <ProgrammingImportEditor
+          key={question.id}
           questionId={question.id}
           answerId={answerId}
           {...{ readOnly, question }}
         />
       ) : (
         <ProgrammingFiles
+          key={question.id}
           readOnly={readOnly}
           answerId={answerId}
           language={parseLanguages(question.language)}

--- a/client/app/bundles/course/assessment/submission/components/answers/TextResponse.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/TextResponse.jsx
@@ -14,7 +14,6 @@ const TextResponse = (props) => {
   const readOnlyAnswer = (
     <Controller
       name={`${answerId}.answer_text`}
-      key={`${answerId}.answer_text`}
       control={control}
       render={({ field }) => (
         <div dangerouslySetInnerHTML={{ __html: field.value }} />
@@ -25,7 +24,6 @@ const TextResponse = (props) => {
   const richtextAnswer = (
     <Controller
       name={`${answerId}.answer_text`}
-      key={`${answerId}.answer_text`}
       control={control}
       render={({ field, fieldState }) => (
         <FormRichTextField
@@ -46,7 +44,6 @@ const TextResponse = (props) => {
   const plaintextAnswer = (
     <Controller
       name={`${answerId}.answer_text`}
-      key={`${answerId}.answer_text`}
       control={control}
       render={({ field }) => (
         <textarea

--- a/client/app/bundles/course/assessment/submission/containers/ProgrammingImportEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ProgrammingImportEditor.jsx
@@ -154,6 +154,14 @@ const VisibleProgrammingImportEditor = (props) => {
     viewHistory,
   } = props;
   const answers = viewHistory ? historyAnswers : useWatch({ control });
+
+  // When an assessment is submitted/unsubmitted,
+  // the form is somehow not reset yet and the answers for the new answerId
+  // can't be found.
+  if (!answers[answerId]) {
+    return null;
+  }
+
   const files =
     answers[answerId].files_attributes ||
     answers[`${answerId}`].files_attributes;

--- a/client/app/bundles/course/assessment/submission/containers/VoiceResponseAnswer.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/VoiceResponseAnswer.jsx
@@ -230,7 +230,6 @@ class VoiceResponseAnswer extends Component {
       <div>
         <Controller
           name={`${answerId}.file`}
-          key={`${answerId}.file`}
           control={control}
           render={({ field, fieldState }) =>
             this.renderFile({


### PR DESCRIPTION
Move keys for submission answer controllers (hook form) to parent answer components. Instead of using answerId, we should use questionId instead. Otherwise, when a submission is submitted, there could be a change in the answerId which would create a separate component with different key for the same question.

Continuation of #4570 