### PR TITLE
Add opening time warning on course assessments page

### DIFF
--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -24,7 +24,11 @@ module Course::Assessment::AssessmentsHelper
   def condition_not_satisfied(can_attempt_assessment, assessment, assessment_time)
     (!can_attempt_assessment &&
       !assessment.conditions_satisfied_by?(current_course_user)) ||
-      assessment_time.start_at > Time.zone.now
+      assessment_time.start_at >= Time.zone.now
+  end
+
+  def assessment_not_unlocked(assessment_time)
+    assessment_time.start_at >= Time.zone.now
   end
 
   def show_bonus_attributes?

--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -22,9 +22,9 @@ module Course::Assessment::AssessmentsHelper
   end
 
   def condition_not_satisfied(can_attempt_assessment, assessment, assessment_time)
-    !can_attempt_assessment &&
-      assessment_time.start_at < Time.zone.now &&
-      !assessment.conditions_satisfied_by?(current_course_user)
+    (!can_attempt_assessment &&
+      !assessment.conditions_satisfied_by?(current_course_user)) ||
+      assessment_time.start_at > Time.zone.now
   end
 
   def show_bonus_attributes?

--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -24,7 +24,7 @@ module Course::Assessment::AssessmentsHelper
   def condition_not_satisfied(can_attempt_assessment, assessment, assessment_time)
     (!can_attempt_assessment &&
       !assessment.conditions_satisfied_by?(current_course_user)) ||
-      assessment_time.start_at >= Time.zone.now
+      assessment_not_unlocked(assessment_time)
   end
 
   def assessment_not_unlocked(assessment_time)

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -32,21 +32,18 @@
       - achievement_conditionals.each do |achievement|
         = link_to course_achievement_path(current_course, achievement) do
           = display_achievement_badge(achievement)
-  td.table-start-at
-    - start_at_tooltip_title = nil
+  td.table-start-attd.table-start-at
     - if assessment_not_unlocked(assessment_time)
-      - start_at_tooltip_title = ".assessment_not_unlocked"
+      div.condition-not-satisfied data-toggle='tooltip' title="#{t('.assessment_not_unlocked')}"
+        = render partial: 'course/lesson_plan/items/personal_or_ref_time',
+                 locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
     - elsif condition_not_satisfied(can_attempt_assessment, assessment_with_loaded_timeline, assessment_time)
-      - start_at_tooltip_title = ".condition_not_satisfied"
-
-    - if start_at_tooltip_title
-      div.condition-not-satisfied data-toggle='tooltip' title="#{t(start_at_tooltip_title)}"
+      div.condition-not-satisfied data-toggle='tooltip' title="#{t('.condition_not_satisfied')}"
         = render partial: 'course/lesson_plan/items/personal_or_ref_time',
                  locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
     - else
-        = render partial: 'course/lesson_plan/items/personal_or_ref_time',
-                 locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
-
+      = render partial: 'course/lesson_plan/items/personal_or_ref_time',
+               locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
   - if show_bonus_attributes?
     td.table-bonus-cut-off
       - if assessment_time.bonus_end_at.present? && assessment.time_bonus_exp > 0

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -33,17 +33,20 @@
         = link_to course_achievement_path(current_course, achievement) do
           = display_achievement_badge(achievement)
   td.table-start-at
+    - start_at_tooltip_title = nil
     - if assessment_not_unlocked(assessment_time)
-      div.condition-not-satisfied data-toggle='tooltip' title="#{t('.assessment_not_unlocked')}"
-        = render partial: 'course/lesson_plan/items/personal_or_ref_time',
-                 locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
+      - start_at_tooltip_title = ".assessment_not_unlocked"
     - elsif condition_not_satisfied(can_attempt_assessment, assessment_with_loaded_timeline, assessment_time)
-      div.condition-not-satisfied data-toggle='tooltip' title="#{t('.condition_not_satisfied')}"
+      - start_at_tooltip_title = ".condition_not_satisfied"
+
+    - if start_at_tooltip_title
+      div.condition-not-satisfied data-toggle='tooltip' title="#{t(start_at_tooltip_title)}"
         = render partial: 'course/lesson_plan/items/personal_or_ref_time',
                  locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
     - else
-      = render partial: 'course/lesson_plan/items/personal_or_ref_time',
-               locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
+        = render partial: 'course/lesson_plan/items/personal_or_ref_time',
+                 locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
+
   - if show_bonus_attributes?
     td.table-bonus-cut-off
       - if assessment_time.bonus_end_at.present? && assessment.time_bonus_exp > 0

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -33,7 +33,11 @@
         = link_to course_achievement_path(current_course, achievement) do
           = display_achievement_badge(achievement)
   td.table-start-at
-    - if condition_not_satisfied(can_attempt_assessment, assessment_with_loaded_timeline, assessment_time)
+    - if assessment_not_unlocked(assessment_time)
+      div.condition-not-satisfied data-toggle='tooltip' title="#{t('.assessment_not_unlocked')}"
+        = render partial: 'course/lesson_plan/items/personal_or_ref_time',
+                 locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
+    - elsif condition_not_satisfied(can_attempt_assessment, assessment_with_loaded_timeline, assessment_time)
       div.condition-not-satisfied data-toggle='tooltip' title="#{t('.condition_not_satisfied')}"
         = render partial: 'course/lesson_plan/items/personal_or_ref_time',
                  locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -71,10 +71,9 @@
     - @assessment.specific_conditions.each do |condition|
       = content_tag_for(:li, condition) do
         = condition.title
-    - if @assessment.start_at > Time.zone.now
-      li = t('.time_not_satisfied',
-             start_at: @assessment.start_at.strftime("%d %b %Y %H:%M"))
-    li = t('.chipo')
+    - if assessment_not_unlocked(@assessment.time_for(current_course_user))
+      li = t('.assessment_not_unlocked',
+             start_at: format_datetime(@assessment.time_for(current_course_user).start_at, :long))
 
   - if @assessment_conditions
     h3 = t('.finish_to_unlock')

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -71,6 +71,9 @@
     - @assessment.specific_conditions.each do |condition|
       = content_tag_for(:li, condition) do
         = condition.title
+    - if @assessment.start_at > Time.zone.now
+      li = t('.time_not_satisfied',
+             start_at: @assessment.start_at)
 
   - if @assessment_conditions
     h3 = t('.finish_to_unlock')

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -73,7 +73,8 @@
         = condition.title
     - if @assessment.start_at > Time.zone.now
       li = t('.time_not_satisfied',
-             start_at: @assessment.start_at)
+             start_at: @assessment.start_at.strftime("%d %b %Y %H:%M"))
+    li = t('.chipo')
 
   - if @assessment_conditions
     h3 = t('.finish_to_unlock')

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -17,7 +17,7 @@ en:
         assessment:
           autograded_assessment: 'Autograded assessment'
           attempt: 'Attempt'
-          condition_not_satisfied: 'You do not fulfill the requirements of the assessment'
+          condition_not_satisfied: 'You do not fulfill the requirements of the assessment, or the assessment is not open yet'
           view_password_set: 'Students need a password to view the assessment'
         show:
           type: 'Assessment Type'
@@ -44,6 +44,7 @@ en:
           requirements: 'Requirements'
           condition_not_satisfied: >
             You must fulfill the following requirements before you can attempt this assessment:
+          time_not_satisfied: 'Wait until %{start_at} for assessment to unlock'
           finish_to_unlock: 'Finish to Unlock'
           materials_disabled: 'Enable material component in the components tab of course setting
             to gain access to this file.'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -17,7 +17,8 @@ en:
         assessment:
           autograded_assessment: 'Autograded assessment'
           attempt: 'Attempt'
-          condition_not_satisfied: 'You do not fulfill the requirements of the assessment, or the assessment is not open yet'
+          condition_not_satisfied: 'You do not fulfill the requirements of the assessment'
+          assessment_not_unlocked: 'The assessment is not unlocked yet'
           view_password_set: 'Students need a password to view the assessment'
         show:
           type: 'Assessment Type'
@@ -44,7 +45,7 @@ en:
           requirements: 'Requirements'
           condition_not_satisfied: >
             You must fulfill the following requirements before you can attempt this assessment:
-          time_not_satisfied: 'Wait until %{start_at} for assessment to unlock'
+          assessment_not_unlocked: 'Wait until %{start_at} for assessment to unlock'
           finish_to_unlock: 'Finish to Unlock'
           materials_disabled: 'Enable material component in the components tab of course setting
             to gain access to this file.'


### PR DESCRIPTION
Closes #4338 

- **Add tooltip which warns user that assessment is not yet open:**
![image](https://user-images.githubusercontent.com/9080974/167532626-ae6a3abc-8cb3-4774-a0ea-9dd8b2002859.png)

- **Assessment opening time is part of the requirements shown on assessments page:**
![image](https://user-images.githubusercontent.com/9080974/167532564-e242fa34-0ebe-49a5-b9d4-3df9d62c282d.png)

- **Assessment opening time can be the only requirement:**
![image](https://user-images.githubusercontent.com/9080974/167532526-d92ff963-fd33-4030-9195-e64a3b4af26a.png)

