### PR TITLE
Remove password input form for locked assessments

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -79,7 +79,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def authenticate
-    if assessment_not_unlocked(@assessment.time_for(current_course_user))
+    if assessment_not_started(@assessment.time_for(current_course_user))
       render json: { success: false }
     elsif authentication_service.authenticate(params.require(:assessment).permit(:password)[:password])
       render json: { success: true }

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Course::Assessment::AssessmentsController < Course::Assessment::Controller
+  include Course::Assessment::AssessmentsHelper
   before_action :load_question_duplication_data, only: [:show, :reorder]
 
   COURSE_USERS = { my_students: 'my_students',
@@ -78,7 +79,9 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def authenticate
-    if authentication_service.authenticate(params.require(:assessment).permit(:password)[:password])
+    if assessment_not_unlocked(@assessment.time_for(current_course_user))
+      render json: { success: false }
+    elsif authentication_service.authenticate(params.require(:assessment).permit(:password)[:password])
       render json: { success: true }
     else
       render json: { success: false }

--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -24,10 +24,10 @@ module Course::Assessment::AssessmentsHelper
   def condition_not_satisfied(can_attempt_assessment, assessment, assessment_time)
     (!can_attempt_assessment &&
       !assessment.conditions_satisfied_by?(current_course_user)) ||
-      assessment_not_unlocked(assessment_time)
+      assessment_not_started(assessment_time)
   end
 
-  def assessment_not_unlocked(assessment_time)
+  def assessment_not_started(assessment_time)
     assessment_time.start_at > Time.zone.now
   end
 

--- a/app/helpers/course/assessment/assessments_helper.rb
+++ b/app/helpers/course/assessment/assessments_helper.rb
@@ -28,7 +28,7 @@ module Course::Assessment::AssessmentsHelper
   end
 
   def assessment_not_unlocked(assessment_time)
-    assessment_time.start_at >= Time.zone.now
+    assessment_time.start_at > Time.zone.now
   end
 
   def show_bonus_attributes?

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -48,6 +48,7 @@ class Course::Survey < ApplicationRecord
     self.course = duplicator.options[:destination_course]
     copy_attributes(other, duplicator)
     self.sections = duplicator.duplicate(other.sections)
+    self.closing_reminded_at = nil
     survey_conditions << other.survey_conditions.
                          select { |condition| duplicator.duplicated?(condition.conditional) }.
                          map { |condition| duplicator.duplicate(condition) }

--- a/app/views/course/assessment/assessments/_assessment.html.slim
+++ b/app/views/course/assessment/assessments/_assessment.html.slim
@@ -33,8 +33,8 @@
         = link_to course_achievement_path(current_course, achievement) do
           = display_achievement_badge(achievement)
   td.table-start-attd.table-start-at
-    - if assessment_not_unlocked(assessment_time)
-      div.condition-not-satisfied data-toggle='tooltip' title="#{t('.assessment_not_unlocked')}"
+    - if assessment_not_started(assessment_time)
+      div.condition-not-satisfied data-toggle='tooltip' title="#{t('.assessment_not_started')}"
         = render partial: 'course/lesson_plan/items/personal_or_ref_time',
                  locals: { item: @items_hash[assessment.id], course_user: current_course_user, attribute: :start_at, datetime_format: :short }
     - elsif condition_not_satisfied(can_attempt_assessment, assessment_with_loaded_timeline, assessment_time)

--- a/app/views/course/assessment/assessments/authenticate.html.slim
+++ b/app/views/course/assessment/assessments/authenticate.html.slim
@@ -2,8 +2,10 @@
   span.fa-stack.fa-5x
     = fa_icon 'circle-thin', class: 'fa-stack-2x'
     = fa_icon 'lock', class: 'fa-stack-1x'
-  p.text-center = t('.message')
-  - if !assessment_not_unlocked(@assessment.time_for(current_course_user))
+  - if assessment_not_unlocked(@assessment.time_for(current_course_user))
+    p.text-center = t('.assessment_not_unlocked')
+  - else
+    p.text-center = t('.message_unlock')
     = simple_form_for :assessment, url: authenticate_course_assessment_path(current_course, @assessment), method: :post do |f|
       = f.input :password, label: false, required: false, placeholder: t('.placeholder')
 

--- a/app/views/course/assessment/assessments/authenticate.html.slim
+++ b/app/views/course/assessment/assessments/authenticate.html.slim
@@ -1,12 +1,12 @@
-- locked = assessment_not_unlocked(@assessment.time_for(current_course_user))
+- not_started = assessment_not_started(@assessment.time_for(current_course_user))
 
 .password-panel.col-lg-4.col-md-5.col-sm-6.col-xs-7.text-center
   span.fa-stack.fa-5x
     = fa_icon 'circle-thin', class: 'fa-stack-2x'
     = fa_icon 'lock', class: 'fa-stack-1x'
 
-  - if locked
-    p.text-center = t('.assessment_not_unlocked',
+  - if not_started
+    p.text-center = t('.message_not_started',
             start_at: format_datetime(@assessment.time_for(current_course_user).start_at, :long))
   - else 
     p.text-center = t('.message_unlock')
@@ -16,8 +16,8 @@
       label: false,
       required: false,
       placeholder: t('.placeholder'),
-      disabled: locked
+      disabled: not_started
 
     = f.submit t('.continue'),
       class: ['btn', 'btn-primary'],
-      disabled: locked
+      disabled: not_started

--- a/app/views/course/assessment/assessments/authenticate.html.slim
+++ b/app/views/course/assessment/assessments/authenticate.html.slim
@@ -3,8 +3,8 @@
     = fa_icon 'circle-thin', class: 'fa-stack-2x'
     = fa_icon 'lock', class: 'fa-stack-1x'
   p.text-center = t('.message')
+  - if !assessment_not_unlocked(@assessment.time_for(current_course_user))
+    = simple_form_for :assessment, url: authenticate_course_assessment_path(current_course, @assessment), method: :post do |f|
+      = f.input :password, label: false, required: false, placeholder: t('.placeholder')
 
-  = simple_form_for :assessment, url: authenticate_course_assessment_path(current_course, @assessment), method: :post do |f|
-    = f.input :password, label: false, required: false, placeholder: t('.placeholder')
-
-    = f.submit t('.continue'), class: ['btn', 'btn-primary']
+      = f.submit t('.continue'), class: ['btn', 'btn-primary']

--- a/app/views/course/assessment/assessments/authenticate.html.slim
+++ b/app/views/course/assessment/assessments/authenticate.html.slim
@@ -1,12 +1,23 @@
+- locked = assessment_not_unlocked(@assessment.time_for(current_course_user))
+
 .password-panel.col-lg-4.col-md-5.col-sm-6.col-xs-7.text-center
   span.fa-stack.fa-5x
     = fa_icon 'circle-thin', class: 'fa-stack-2x'
     = fa_icon 'lock', class: 'fa-stack-1x'
-  - if assessment_not_unlocked(@assessment.time_for(current_course_user))
-    p.text-center = t('.assessment_not_unlocked')
-  - else
-    p.text-center = t('.message_unlock')
-    = simple_form_for :assessment, url: authenticate_course_assessment_path(current_course, @assessment), method: :post do |f|
-      = f.input :password, label: false, required: false, placeholder: t('.placeholder')
 
-      = f.submit t('.continue'), class: ['btn', 'btn-primary']
+  - if locked
+    p.text-center = t('.assessment_not_unlocked',
+            start_at: format_datetime(@assessment.time_for(current_course_user).start_at, :long))
+  - else 
+    p.text-center = t('.message_unlock')
+
+  = simple_form_for :assessment, url: authenticate_course_assessment_path(current_course, @assessment), method: :post do |f|
+    = f.input :password,
+      label: false,
+      required: false,
+      placeholder: t('.placeholder'),
+      disabled: locked
+
+    = f.submit t('.continue'),
+      class: ['btn', 'btn-primary'],
+      disabled: locked

--- a/app/views/course/assessment/assessments/show.html.slim
+++ b/app/views/course/assessment/assessments/show.html.slim
@@ -71,8 +71,8 @@
     - @assessment.specific_conditions.each do |condition|
       = content_tag_for(:li, condition) do
         = condition.title
-    - if assessment_not_unlocked(@assessment.time_for(current_course_user))
-      li = t('.assessment_not_unlocked',
+    - if assessment_not_started(@assessment.time_for(current_course_user))
+      li = t('.assessment_not_started',
              start_at: format_datetime(@assessment.time_for(current_course_user).start_at, :long))
 
   - if @assessment_conditions

--- a/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
@@ -123,8 +123,6 @@ class PopupDialog extends Component {
           open={visible}
           maxWidth="md"
           style={{
-            maxHeight: 1700,
-            position: 'absolute',
             top: 40,
           }}
         >

--- a/client/app/lib/components/FormDialogue.jsx
+++ b/client/app/lib/components/FormDialogue.jsx
@@ -88,8 +88,6 @@ class FormDialogue extends Component {
           open={open}
           onClose={this.handleFormClose}
           style={{
-            maxHeight: 1700,
-            position: 'absolute',
             top: 40,
           }}
         >

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -75,7 +75,8 @@ en:
           failure: 'Could not delete assessment: %{error}'
         authenticate:
           header: 'Input Password'
-          message: 'The assessment is locked.'
+          assessment_not_unlocked: 'The assessment is not unlocked yet.'
+          message_unlock: 'The assessment is locked, please input the password.'
           placeholder: 'Password'
           continue: 'Continue'
         assessment_management_buttons:

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -18,7 +18,7 @@ en:
           autograded_assessment: 'Autograded assessment'
           attempt: 'Attempt'
           condition_not_satisfied: 'You do not fulfill the requirements of the assessment'
-          assessment_not_unlocked: 'The assessment is not unlocked yet'
+          assessment_not_started: 'The assessment is not unlocked yet'
           view_password_set: 'Students need a password to view the assessment'
         show:
           type: 'Assessment Type'
@@ -45,7 +45,7 @@ en:
           requirements: 'Requirements'
           condition_not_satisfied: >
             You must fulfill the following requirements before you can attempt this assessment:
-          assessment_not_unlocked: 'Wait until %{start_at} for assessment to unlock'
+          assessment_not_started: 'Wait until %{start_at} for assessment to unlock'
           finish_to_unlock: 'Finish to Unlock'
           materials_disabled: 'Enable material component in the components tab of course setting
             to gain access to this file.'
@@ -75,7 +75,7 @@ en:
           failure: 'Could not delete assessment: %{error}'
         authenticate:
           header: 'Input Password'
-          assessment_not_unlocked: 'The assessment will be unlocked on %{start_at}.'
+          message_not_started: 'The assessment will be unlocked on %{start_at}.'
           message_unlock: 'The assessment is locked, please input the password.'
           placeholder: 'Password'
           continue: 'Continue'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -75,7 +75,7 @@ en:
           failure: 'Could not delete assessment: %{error}'
         authenticate:
           header: 'Input Password'
-          assessment_not_unlocked: 'The assessment is not unlocked yet.'
+          assessment_not_unlocked: 'The assessment will be unlocked on %{start_at}.'
           message_unlock: 'The assessment is locked, please input the password.'
           placeholder: 'Password'
           continue: 'Continue'

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -75,7 +75,7 @@ en:
           failure: 'Could not delete assessment: %{error}'
         authenticate:
           header: 'Input Password'
-          message: 'The assessment is locked, please input the password.'
+          message: 'The assessment is locked.'
           placeholder: 'Password'
           continue: 'Continue'
         assessment_management_buttons:

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -486,6 +486,10 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
           expect { duplicate_objects }.to change { destination_course.surveys.count }.by(1)
           expect(duplicate_objects.first.title).to eq(survey.title)
         end
+
+        it 'does not copy over closing_reminded_at' do
+          expect(duplicate_objects.first.closing_reminded_at).to be_nil
+        end
       end
 
       context 'when a video tab is selected' do


### PR DESCRIPTION
Solves #4532

When a student accesses a password-protected assessment before the unlock time, the password unlock field is hidden to prevent premature access of the assessment.
![image](https://user-images.githubusercontent.com/9080974/167761943-920886b3-0175-492c-a0a2-9b38148e0419.png)
