### PR TITLE
Prevent duplication of survey reminder date

### DIFF
--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -48,6 +48,7 @@ class Course::Survey < ApplicationRecord
     self.course = duplicator.options[:destination_course]
     copy_attributes(other, duplicator)
     self.sections = duplicator.duplicate(other.sections)
+    self.closing_reminded_at = nil
     survey_conditions << other.survey_conditions.
                          select { |condition| duplicator.duplicated?(condition.conditional) }.
                          map { |condition| duplicator.duplicate(condition) }

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -486,6 +486,10 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
           expect { duplicate_objects }.to change { destination_course.surveys.count }.by(1)
           expect(duplicate_objects.first.title).to eq(survey.title)
         end
+
+        it 'does not copy over closing_reminded_at' do
+          expect(duplicate_objects.first.closing_reminded_at).to be_nil
+        end
       end
 
       context 'when a video tab is selected' do


### PR DESCRIPTION
Fixes #4582 

Sets reminder date of surveys to be nil upon duplication