### PR TITLE
Add default timeline algorithm in course settings

### DIFF
--- a/app/controllers/course/admin/admin_controller.rb
+++ b/app/controllers/course/admin/admin_controller.rb
@@ -25,7 +25,8 @@ class Course::Admin::AdminController < Course::Admin::Controller
   def course_setting_params # :nodoc:
     params.require(:course).
       permit(:title, :description, :published, :enrollable, :start_at, :end_at, :logo, :gamified,
-             :show_personalized_timeline_features, :time_zone, :advance_start_at_duration_days)
+             :show_personalized_timeline_features, :default_timeline_algorithm,
+             :time_zone, :advance_start_at_duration_days)
   end
 
   def destroy_success # :nodoc:

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -44,8 +44,8 @@ class Course::EnrolRequestsController < Course::ComponentController
 
   def create_course_user
     course_user = CourseUser.new(course_user_params.
-      reverse_merge(course: current_course, user_id: @enrol_request.user_id))
-    course_user.timeline_algorithm = current_course.default_timeline_algorithm
+      reverse_merge(course: current_course, user_id: @enrol_request.user_id,
+                    timeline_algorithm: current_course.default_timeline_algorithm))
 
     CourseUser.transaction do
       raise ActiveRecord::Rollback unless @enrol_request.destroy && course_user.save

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -45,6 +45,7 @@ class Course::EnrolRequestsController < Course::ComponentController
   def create_course_user
     course_user = CourseUser.new(course_user_params.
       reverse_merge(course: current_course, user_id: @enrol_request.user_id))
+    course_user.timeline_algorithm = current_course.default_timeline_algorithm
 
     CourseUser.transaction do
       raise ActiveRecord::Rollback unless @enrol_request.destroy && course_user.save

--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -70,7 +70,7 @@ class Course::UserInvitationsController < Course::ComponentController
       params[:course] = { invitations_attributes: {} } unless params.key?(:course)
 
       params.require(:course).permit(:invitations_file, :registration_key,
-                                     invitations_attributes: [:name, :email, :role, :phantom])
+                                     invitations_attributes: [:name, :email, :role, :phantom, :timeline_algorithm])
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -266,8 +266,7 @@ class Course < ApplicationRecord
     course_users.build(user: creator,
                        role: :owner,
                        creator: creator,
-                       updater: updater,
-                       timeline_algorithm: default_timeline_algorithm)
+                       updater: updater)
   end
 
   def validate_only_one_default_reference_timeline

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -27,6 +27,8 @@ class Course < ApplicationRecord
   validates :instance, presence: true
   validates :conditional_satisfiability_evaluation_time, presence: true
 
+  enum default_timeline_algorithm: CourseUser.timeline_algorithms
+
   has_many :enrol_requests, inverse_of: :course, dependent: :destroy
   has_many :course_users, inverse_of: :course, dependent: :destroy
   has_many :users, through: :course_users
@@ -257,10 +259,15 @@ class Course < ApplicationRecord
     self.start_at ||= Time.zone.now.beginning_of_hour
     self.end_at ||= self.start_at + 1.month
     self.default_reference_timeline ||= reference_timelines.new(default: true)
+    self.default_timeline_algorithm ||= 0 # 'fixed' algorithm
 
     return unless creator && course_users.empty?
 
-    course_users.build(user: creator, role: :owner, creator: creator, updater: updater)
+    course_users.build(user: creator,
+                       role: :owner,
+                       creator: creator,
+                       updater: updater,
+                       timeline_algorithm: default_timeline_algorithm)
   end
 
   def validate_only_one_default_reference_timeline

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -11,6 +11,7 @@ class Course::UserInvitation < ApplicationRecord
   validate :no_existing_unconfirmed_invitation
 
   enum role: CourseUser.roles
+  enum timeline_algorithm: CourseUser.timeline_algorithms
 
   belongs_to :course, inverse_of: :invitations
   belongs_to :confirmer, class_name: User.name, inverse_of: nil, optional: true

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -215,7 +215,6 @@ class CourseUser < ApplicationRecord
   def set_defaults # :nodoc:
     self.name ||= user.name if user
     self.role ||= :student
-    self.timeline_algorithm ||= course.default_timeline_algorithm if course
   end
 
   # TODO(#3092): Validation is correct but everyone's reference timeline should be nil

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -215,6 +215,7 @@ class CourseUser < ApplicationRecord
   def set_defaults # :nodoc:
     self.name ||= user.name if user
     self.role ||= :student
+    self.timeline_algorithm ||= course.default_timeline_algorithm if course
   end
 
   # TODO(#3092): Validation is correct but everyone's reference timeline should be nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,6 +111,7 @@ class User < ApplicationRecord
                          name: invitation.name,
                          role: invitation.role,
                          phantom: invitation.phantom,
+                         timeline_algorithm: invitation.timeline_algorithm,
                          creator: self,
                          updater: self)
     when Instance::UserInvitation::INVITATION_KEY_IDENTIFIER

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,7 +111,8 @@ class User < ApplicationRecord
                          name: invitation.name,
                          role: invitation.role,
                          phantom: invitation.phantom,
-                         timeline_algorithm: invitation.timeline_algorithm,
+                         timeline_algorithm: invitation.timeline_algorithm ||
+                                             invitation.course.default_timeline_algorithm,
                          creator: self,
                          updater: self)
     when Instance::UserInvitation::INVITATION_KEY_IDENTIFIER

--- a/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
@@ -67,6 +67,7 @@ module Course::UserInvitationService::ProcessInvitationConcern
         new_course_users <<
           @current_course.course_users.build(user: user[:user], name: user[:name],
                                              role: user[:role], phantom: user[:phantom],
+                                             timeline_algorithm: @current_course.default_timeline_algorithm,
                                              creator: @current_user, updater: @current_user)
         @current_course.enrol_requests.find_by(user: user[:user].id)&.destroy!
       end

--- a/app/services/course/user_registration_service.rb
+++ b/app/services/course/user_registration_service.rb
@@ -51,10 +51,11 @@ class Course::UserRegistrationService
     name = invitation.try(:name) || registration.user.name
     role = invitation.try(:role) || :student
     phantom = invitation.try(:phantom) || false
+    timeline_algorithm = invitation.try(:timeline_algorithm) || registration.course.default_timeline_algorithm
 
     registration.course_user =
       CourseUser.find_or_create_by!(course: registration.course, user: registration.user,
-                                    name: name, role: role, phantom: phantom)
+                                    name: name, role: role, phantom: phantom, timeline_algorithm: timeline_algorithm)
   end
 
   # Claims a given registration code. The correct type of code is deduced from the code itself and

--- a/app/views/course/admin/admin/index.html.slim
+++ b/app/views/course/admin/admin/index.html.slim
@@ -16,6 +16,14 @@
     = f.input :end_at
     = f.input :gamified, hint: t('.gamified_label')
     = f.input :show_personalized_timeline_features, hint: t('.show_personalized_timeline_features_label')
+
+    div.personalized-timeline-feature style="#{ current_course.show_personalized_timeline_features ? '' : 'display: none' }"
+      = f.input :default_timeline_algorithm, hint: t('.default_timeline_algorithm_label'),
+                as: :select,
+                collection: CourseUser.timeline_algorithms.keys,
+                include_blank: false,
+                label_method: lambda {|k| t("course.users.algorithm.#{k}")}
+
     = f.input :time_zone, hint: t('.time_zone_label')
 
     - max_time = current_course.advance_start_at_duration

--- a/client/app/bundles/course/admin/admin.js
+++ b/client/app/bundles/course/admin/admin.js
@@ -9,4 +9,12 @@ $(() => {
       $('div.advance-start-at-time').hide();
     }
   });
+
+  $('#course_show_personalized_timeline_features').change(function () {
+    if ($(this).is(':checked')) {
+      $('div.personalized-timeline-feature').show();
+    } else {
+      $('div.personalized-timeline-feature').hide();
+    }
+  });
 });

--- a/config/locales/en/course/admin/admin.yml
+++ b/config/locales/en/course/admin/admin.yml
@@ -18,6 +18,9 @@ en:
           show_personalized_timeline_features_label: >
             If enabled, staff will be able to change the timeline algorithm for course users as
             well as manipulate individual course users' personalized timelines.
+          default_timeline_algorithm_label: >
+            Sets the default timeline algorithm for the course. New users enrolled will have this
+            timeline algorithm applied.
           time_zone_label: >
             Sets the time zone for the course. Consolidated email reminders will be sent out
             just after midnight for the time zone indicated here.

--- a/config/locales/en/course/users.yml
+++ b/config/locales/en/course/users.yml
@@ -14,7 +14,9 @@ en:
         invited: 'Invited'
       algorithm:
         fixed: 'Fixed'
-        naive: 'Naive'
+        stragglers: 'Stragglers'
+        otot: 'Otot'
+        fomo: 'Fomo'
       tabs:
         students: :'course.users.students.header'
         staff: :'course.users.staff.header'

--- a/db/migrate/20220519015535_add_default_timeline_algorithm_to_course.rb
+++ b/db/migrate/20220519015535_add_default_timeline_algorithm_to_course.rb
@@ -1,0 +1,5 @@
+class AddDefaultTimelineAlgorithmToCourse < ActiveRecord::Migration[6.0]
+  def change
+    add_column :courses, :default_timeline_algorithm, :integer, default: 0, null: false # 'fixed' algorithm
+  end
+end

--- a/db/migrate/20220519055836_add_timeline_algorithm_to_user_invitation.rb
+++ b/db/migrate/20220519055836_add_timeline_algorithm_to_user_invitation.rb
@@ -1,0 +1,5 @@
+class AddTimelineAlgorithmToUserInvitation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_user_invitations, :timeline_algorithm, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_192851) do
+ActiveRecord::Schema.define(version: 2022_05_19_055836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -979,6 +979,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_192851) do
     t.integer "confirmer_id"
     t.integer "role", default: 0, null: false
     t.boolean "phantom", default: false, null: false
+    t.integer "timeline_algorithm"
     t.index "lower((email)::text)", name: "index_course_user_invitations_on_email"
     t.index ["confirmer_id"], name: "fk__course_user_invitations_confirmer_id"
     t.index ["course_id", "email"], name: "index_course_user_invitations_on_course_id_and_email", unique: true
@@ -1140,6 +1141,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_192851) do
     t.string "time_zone", limit: 255
     t.boolean "show_personalized_timeline_features", default: false, null: false
     t.datetime "conditional_satisfiability_evaluation_time", default: "2021-10-24 10:31:32"
+    t.integer "default_timeline_algorithm", default: 0, null: false
     t.index ["creator_id"], name: "fk__courses_creator_id"
     t.index ["instance_id"], name: "fk__courses_instance_id"
     t.index ["registration_key"], name: "index_courses_on_registration_key", unique: true

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     show_personalized_timeline_features { true }
     published { false }
     enrollable { false }
+    default_timeline_algorithm { 0 }
 
     trait :published do
       published { true }

--- a/spec/features/course/enrol_request_management_spec.rb
+++ b/spec/features/course/enrol_request_management_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Course: EnrolRequests' do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course, default_timeline_algorithm: 'fomo') }
+    let(:user) { create(:course_manager, course: course).user }
+    let!(:enrol_request) { create(:course_enrol_request, course: course) }
+    before { login_as(user, scope: :user) }
+
+    scenario 'Course staff can approve requests', js: true do
+      visit course_enrol_requests_path(course)
+
+      within find(content_tag_selector(enrol_request)) do
+        find('.btn.approve').click
+      end
+
+      wait_for_ajax
+      course_user = course.course_users.find_by(user_id: enrol_request.user.id)
+      expect(course_user).to be_present
+      expect(course_user.timeline_algorithm).to eq('fomo')
+      expect(page).to have_no_content_tag_for(enrol_request)
+      expect(page).to have_text('course.enrol_requests.approve.success')
+
+      visit course_users_students_path(course)
+      expect(page).to have_content_tag_for(course_user)
+    end
+
+    # Allow user to request to enrol again in case she neglects to enter her
+    # invitation code the first time
+    scenario 'Course staff can delete request' do
+      visit course_enrol_requests_path(course)
+      expect(page).to have_field('course_user_name', with: enrol_request.user.name)
+
+      expect do
+        within find(content_tag_selector(enrol_request)) do
+          find_link(nil, href: course_enrol_request_path(course, enrol_request)).click
+        end
+      end.to change(course.enrol_requests, :count).by(-1)
+
+      expect(current_path).to eq(course_enrol_requests_path(course))
+      expect(page).to have_selector('div.alert',
+                                    text: I18n.t('course.enrol_requests.destroy.success'))
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Course, type: :model do
     it { is_expected.to have_many(:setting_emails).dependent(:destroy) }
     it { is_expected.to have_one(:duplication_traceable).dependent(:destroy) }
 
+    it { is_expected.to define_enum_for(:default_timeline_algorithm) }
+
     it { is_expected.to validate_presence_of(:title) }
 
     it { should delegate_method(:staff).to(:course_users) }

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CourseUser, type: :model do
   it { is_expected.to belong_to(:user).inverse_of(:course_users) }
   it { is_expected.to belong_to(:course).inverse_of(:course_users) }
   it { is_expected.to define_enum_for(:role) }
+  it { is_expected.to define_enum_for(:timeline_algorithm) }
   it do
     is_expected.to have_many(:experience_points_records).
       inverse_of(:course_user).

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -362,6 +362,7 @@ RSpec.describe Course::UserInvitationService, type: :service do
           existing_users.each do |user|
             found_user = course.course_users.find { |course_user| course_user.user == user }
             expect(found_user).not_to be_nil
+            expect(found_user.timeline_algorithm).to eq('fixed') # default value
           end
         end
 
@@ -384,6 +385,48 @@ RSpec.describe Course::UserInvitationService, type: :service do
             existing_users.each do |user|
               found_user = course.course_users.find { |course_user| course_user.user == user }
               expect(found_user).not_to be_nil
+            end
+          end
+        end
+
+        context 'when users already exist in the current instance and \
+          default course timeline setting is fomo' do
+          before do
+            course.update!(default_timeline_algorithm: 'fomo')
+          end
+          it 'sets the timeline algorithm for the users to fomo' do
+            subject.send(:invite_users, temp_csv_from_attributes(existing_users, existing_roles))
+            existing_users.each do |user|
+              found_user = course.course_users.find { |course_user| course_user.user == user }
+              expect(found_user.timeline_algorithm).to eq('fomo')
+            end
+          end
+        end
+
+        context 'when users already exist in the current instance and \
+          default course timeline setting is stragglers' do
+          before do
+            course.update!(default_timeline_algorithm: 'stragglers')
+          end
+          it 'sets the timeline algorithm for the users to stragglers' do
+            subject.send(:invite_users, temp_csv_from_attributes(existing_users, existing_roles))
+            existing_users.each do |user|
+              found_user = course.course_users.find { |course_user| course_user.user == user }
+              expect(found_user.timeline_algorithm).to eq('stragglers')
+            end
+          end
+        end
+
+        context 'when users already exist in the current instance and \
+          default course timeline setting is otot' do
+          before do
+            course.update!(default_timeline_algorithm: 'otot')
+          end
+          it 'sets the timeline algorithm for the users to otot' do
+            subject.send(:invite_users, temp_csv_from_attributes(existing_users, existing_roles))
+            existing_users.each do |user|
+              found_user = course.course_users.find { |course_user| course_user.user == user }
+              expect(found_user.timeline_algorithm).to eq('otot')
             end
           end
         end

--- a/spec/services/course/user_registration_service_spec.rb
+++ b/spec/services/course/user_registration_service_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Course::UserRegistrationService, type: :service do
             expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('fomo')
           end
         end
-        
+
         context 'when timeline algorithm is not specified and \
         default course timeline setting is stragglers' do
           before do
@@ -224,7 +224,7 @@ RSpec.describe Course::UserRegistrationService, type: :service do
             expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('stragglers')
           end
         end
-        
+
         context 'when timeline algorithm is not specified and \
         default course timeline setting is otot' do
           before do

--- a/spec/services/course/user_registration_service_spec.rb
+++ b/spec/services/course/user_registration_service_spec.rb
@@ -74,6 +74,59 @@ RSpec.describe Course::UserRegistrationService, type: :service do
             expect(subject.send(:claim_course_registration_code, registration)).to be_truthy
           end.to change { course.course_users.reload.count }.by(1)
         end
+
+        context 'when role is not specified' do
+          it 'associates the user as student' do
+            expect(subject.send(:claim_course_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id)).to be_present
+            expect(course.course_users.find_by(user_id: user.id).role).to eq('student')
+          end
+        end
+
+        context 'when timeline algorithm is not specified and \
+        default course timeline setting is fomo' do
+          before do
+            course.update!(default_timeline_algorithm: 'fomo')
+          end
+          let(:registration) do
+            Course::Registration.new(course: course, user: user)
+          end
+
+          it 'sets the timeline algorithm for the user to fomo' do
+            expect(subject.send(:claim_course_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('fomo')
+          end
+        end
+
+        context 'when timeline algorithm is not specified and \
+        default course timeline setting is stragglers' do
+          before do
+            course.update!(default_timeline_algorithm: 'stragglers')
+          end
+          let(:registration) do
+            Course::Registration.new(course: course, user: user)
+          end
+
+          it 'sets the timeline algorithm for the user to stragglers' do
+            expect(subject.send(:claim_course_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('stragglers')
+          end
+        end
+
+        context 'when timeline algorithm is not specified and \
+        default course timeline setting is otot' do
+          before do
+            course.update!(default_timeline_algorithm: 'otot')
+          end
+          let(:registration) do
+            Course::Registration.new(course: course, user: user)
+          end
+
+          it 'sets the timeline algorithm for the user to otot' do
+            expect(subject.send(:claim_course_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('otot')
+          end
+        end
       end
 
       context 'when the wrong code is given' do
@@ -137,6 +190,54 @@ RSpec.describe Course::UserRegistrationService, type: :service do
           it 'sets phantom to true' do
             expect(subject.send(:claim_registration_code, registration)).to be_truthy
             expect(course.course_users.find_by(user_id: user.id).phantom).to be_truthy
+          end
+        end
+
+        context 'when timeline algorithm is not specified and \
+        default course timeline setting is fomo' do
+          before do
+            course.update!(default_timeline_algorithm: 'fomo')
+          end
+          let!(:invitation) { create(:course_user_invitation, course: course) }
+          let(:registration) do
+            Course::Registration.new(course: course, user: user, code: invitation.invitation_key.dup)
+          end
+
+          it 'sets the timeline algorithm for the user to fomo' do
+            expect(subject.send(:claim_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('fomo')
+          end
+        end
+        
+        context 'when timeline algorithm is not specified and \
+        default course timeline setting is stragglers' do
+          before do
+            course.update!(default_timeline_algorithm: 'stragglers')
+          end
+          let!(:invitation) { create(:course_user_invitation, course: course) }
+          let(:registration) do
+            Course::Registration.new(course: course, user: user, code: invitation.invitation_key.dup)
+          end
+
+          it 'sets the timeline algorithm for the user to stragglers' do
+            expect(subject.send(:claim_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('stragglers')
+          end
+        end
+        
+        context 'when timeline algorithm is not specified and \
+        default course timeline setting is otot' do
+          before do
+            course.update!(default_timeline_algorithm: 'otot')
+          end
+          let!(:invitation) { create(:course_user_invitation, course: course) }
+          let(:registration) do
+            Course::Registration.new(course: course, user: user, code: invitation.invitation_key.dup)
+          end
+
+          it 'sets the timeline algorithm for the user to otot' do
+            expect(subject.send(:claim_registration_code, registration)).to be_truthy
+            expect(course.course_users.find_by(user_id: user.id).timeline_algorithm).to eq('otot')
           end
         end
       end


### PR DESCRIPTION
Fixes #4590

In Course Settings, a default personalized timeline algorithm can be applied. All newly enrolled students to the course will be set to this default timeline algorithm.

## Changes
**Frontend** 
- Add toggle in Course Settings for admin to specify default timeline algorithm of course
![image](https://user-images.githubusercontent.com/9080974/169259378-99f492d0-24b5-412d-87e5-c1b5af9f5960.png)

**Backend**
- `course` has `default_timeline_algorithm` column added (defaults to 0 = 'fixed')
- `course_user_invitations` has `timeline_algorithm` column added for user invitation to specify the PT algorithm at the individual user level during the invite phase, both in file upload and individual invite (future PR)
- Add tests for user invitation, enrolment, and registration to check that timeline algorithm is set correctly against default

## Future work
Allow user invitation to specify the PT algorithm at the individual user level during the invite phase, both in file upload and individual invite