### PR TITLE
fix(lesson plan): fix unauthorized header buttons shown in lesson plan page

### DIFF
--- a/client/app/bundles/course/lesson-plan/containers/LessonPlanLayout/index.jsx
+++ b/client/app/bundles/course/lesson-plan/containers/LessonPlanLayout/index.jsx
@@ -99,13 +99,10 @@ class LessonPlanLayout extends Component {
 LessonPlanLayout.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   groups: lessonPlanTypesGroups.isRequired,
-  canManageLessonPlan: PropTypes.bool.isRequired,
-
   dispatch: PropTypes.func.isRequired,
 };
 
 export default connect((state) => ({
   isLoading: state.lessonPlan.isLoading,
   groups: state.lessonPlan.groups,
-  canManageLessonPlan: state.flags.canManageLessonPlan,
 }))(LessonPlanLayout);

--- a/client/app/bundles/course/lesson-plan/pages/LessonPlanEdit/index.jsx
+++ b/client/app/bundles/course/lesson-plan/pages/LessonPlanEdit/index.jsx
@@ -94,7 +94,7 @@ class LessonPlanEdit extends Component {
 
     return (
       <>
-        {this.renderHeader()}
+        {this.props.canManageLessonPlan && this.renderHeader()}
         <div style={styles.page}>
           <table>
             {this.renderTableHeader()}
@@ -109,9 +109,11 @@ class LessonPlanEdit extends Component {
 LessonPlanEdit.propTypes = {
   groups: lessonPlanTypesGroups.isRequired,
   columnsVisible: PropTypes.shape({}).isRequired,
+  canManageLessonPlan: PropTypes.bool.isRequired,
 };
 
 export default connect((state) => ({
   groups: state.lessonPlan.groups,
   columnsVisible: state.flags.editPageColumnsVisible,
+  canManageLessonPlan: state.flags.canManageLessonPlan,
 }))(LessonPlanEdit);

--- a/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/index.jsx
+++ b/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/index.jsx
@@ -88,7 +88,7 @@ class LessonPlanShow extends Component {
   render() {
     return (
       <>
-        {this.renderHeader()}
+        {this.props.canManageLessonPlan && this.renderHeader()}
         {this.props.groups.map((group) => this.renderGroup(group))}
       </>
     );
@@ -99,6 +99,7 @@ LessonPlanShow.propTypes = {
   groups: lessonPlanTypesGroups.isRequired,
   visibility: PropTypes.shape({}).isRequired,
   milestonesExpanded: PropTypes.string,
+  canManageLessonPlan: PropTypes.bool.isRequired,
 };
 
 export const UnconnectedLessonPlanShow = LessonPlanShow;
@@ -106,4 +107,5 @@ export default connect((state) => ({
   groups: state.lessonPlan.groups,
   visibility: state.lessonPlan.visibilityByType,
   milestonesExpanded: state.flags.milestonesExpanded,
+  canManageLessonPlan: state.flags.canManageLessonPlan,
 }))(LessonPlanShow);


### PR DESCRIPTION
Fix buttons (enter and exit edit mode) in lesson plan page header shown for unauthorized users. No backend level change is required as another level of check is done at backend if an authorized user tries to edit the lesson plan.