### PR TITLE
fix(activity list): fix activity list in course home page to disable course user link when the course user is no longer registered in the course

### DIFF
--- a/app/views/notifiers/course/achievement_notifier/gained/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/achievement_notifier/gained/course_notifications/_feed.html.slim
@@ -1,9 +1,10 @@
 - activity = notification.activity
 - achievement = activity.object
+- course_user = @course_users_hash[activity.actor_id]
+- user_link_or_name = course_user ? link_to_user(course_user) : activity.actor.name
 
 = div_for(notification) do
   // TODO: Display user image here.
-  - user_link = link_to_user(@course_users_hash[activity.actor_id])
   - achievement_link = link_to achievement.title, course_achievement_path(current_course, achievement)
-  => t('.gained_achievement_html', user: user_link, achievement: achievement_link)
+  => t('.gained_achievement_html', user: user_link_or_name, achievement: achievement_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/assessment_notifier/attempted/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/assessment_notifier/attempted/course_notifications/_feed.html.slim
@@ -1,9 +1,10 @@
 - activity = notification.activity
 - assessment = activity.object
+- course_user = @course_users_hash[activity.actor_id]
+- user_link_or_name = course_user ? link_to_user(course_user) : activity.actor.name
 
 = div_for(notification) do
   // TODO: Display user image here.
-  - user_link = link_to_user(@course_users_hash[activity.actor_id])
   - assessment_link = link_to assessment.title, course_assessment_path(notification.course, assessment)
-  => t('.attempted_assessment_html', user: user_link, assessment: assessment_link)
+  => t('.attempted_assessment_html', user: user_link_or_name, assessment: assessment_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/forum/post_notifier/replied/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/course_notifications/_feed.html.slim
@@ -2,10 +2,11 @@
 - post = activity.object
 - topic = post.topic.actable
 - topic_path = course_forum_topic_path(notification.course, topic.forum, topic, anchor: dom_id(post))
+- course_user = @course_users_hash[activity.actor_id]
+- user_link_or_name = course_user ? link_to_user(course_user) : activity.actor.name
 
 = div_for(notification) do
   // TODO: Display user image here.
-  - user_link = link_to_user(@course_users_hash[activity.actor_id])
   - topic_link = link_to topic.title, topic_path
-  => t('.replied_to_topic_html', user: user_link, topic: topic_link)
+  => t('.replied_to_topic_html', user: user_link_or_name, topic: topic_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/forum/post_notifier/voted/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/voted/course_notifications/_feed.html.slim
@@ -2,10 +2,11 @@
 - post = activity.object
 - topic = post.topic.actable
 - topic_path = course_forum_topic_path(notification.course, topic.forum, topic, anchor: dom_id(post))
+- course_user = @course_users_hash[activity.actor_id]
+- user_link_or_name = course_user ? link_to_user(course_user) : activity.actor.name
 
 = div_for(notification) do
   // TODO: Display user image here.
-  - user_link = link_to_user(@course_users_hash[activity.actor_id])
   - topic_link = link_to topic.title, topic_path
-  => t('.voted_on_topic_html', user: user_link, topic: topic_link)
+  => t('.voted_on_topic_html', user: user_link_or_name, topic: topic_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/forum/topic_notifier/created/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/forum/topic_notifier/created/course_notifications/_feed.html.slim
@@ -1,9 +1,10 @@
 - activity = notification.activity
 - topic = activity.object
+- course_user = @course_users_hash[activity.actor_id]
+- user_link_or_name = course_user ? link_to_user(course_user) : activity.actor.name
 
 = div_for(notification) do
   // TODO: Display user image here.
-  - user_link = link_to_user(@course_users_hash[activity.actor_id])
   - topic_link = link_to topic.title, course_forum_topic_path(notification.course, topic.forum, topic)
-  => t('.created_topic_html', user: user_link, topic: topic_link)
+  => t('.created_topic_html', user: user_link_or_name, topic: topic_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/level_notifier/reached/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/level_notifier/reached/course_notifications/_feed.html.slim
@@ -1,8 +1,9 @@
 - activity = notification.activity
 - level = activity.object
+- course_user = @course_users_hash[activity.actor_id]
+- user_link_or_name = course_user ? link_to_user(course_user) : activity.actor.name
 
 = div_for(notification) do
   // TODO: Display user image here.
-  - user_link = link_to_user(@course_users_hash[activity.actor_id])
-  => t('.reached_level_html', user: user_link, level_number: level.level_number)
+  => t('.reached_level_html', user: user_link_or_name, level_number: level.level_number)
   i.clearfix.timestamp = format_datetime(activity.created_at)

--- a/app/views/notifiers/course/video_notifier/attempted/course_notifications/_feed.html.slim
+++ b/app/views/notifiers/course/video_notifier/attempted/course_notifications/_feed.html.slim
@@ -1,10 +1,11 @@
 - activity = notification.activity
 - video = activity.object
+- course_user = @course_users_hash[activity.actor_id]
+- user_link_or_name = course_user ? link_to_user(course_user) : activity.actor.name
 
 = div_for(notification) do
   // TODO: Display user image here.
-  - user_link = link_to_user(@course_users_hash[activity.actor_id])
   - video_link = link_to(video.title,
                          course_video_path(notification.course, video))
-  => t('.attempted_video_html', user: user_link, video: video_link)
+  => t('.attempted_video_html', user: user_link_or_name, video: video_link)
   i.clearfix.timestamp = format_datetime(activity.created_at)


### PR DESCRIPTION
Fixes #4603 

We are opting for solution 4) Update link_to_user to have a fallback behaviour in case of error (e.g. display the name without a link) as of now.

Will be exploring soft deletion of course user in the future.