### PR TITLE
Add new line to comment section to fix alignment issue

### DIFF
--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -15,7 +15,8 @@ module Course::Discussion::TopicsHelper
   # @param [Integer] line_end The one based end line line number.
   # @return [String] A HTML fragment containing the code lines.
   def display_code_lines(file, line_start, line_end)
-    code = file.lines((line_start-2)..(line_end-2)).join("\n")
+    code = file.add_line.lines((line_start - 1)..(line_end - 1)).join("\n")
+
     format_code_block(code, file.answer.question.actable.language, [line_start, 1].max)
   end
 

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -15,6 +15,7 @@ module Course::Discussion::TopicsHelper
   # @param [Integer] line_end The one based end line line number.
   # @return [String] A HTML fragment containing the code lines.
   def display_code_lines(file, line_start, line_end)
+    # Line added to fix alignment issue in ReadOnlyEditor adding one empty line
     code = file.add_line.lines((line_start - 1)..(line_end - 1)).join("\n")
 
     format_code_block(code, file.answer.question.actable.language, [line_start, 1].max)

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -15,7 +15,7 @@ module Course::Discussion::TopicsHelper
   # @param [Integer] line_end The one based end line line number.
   # @return [String] A HTML fragment containing the code lines.
   def display_code_lines(file, line_start, line_end)
-    code = file.lines((line_start - 1)..(line_end - 1)).join("\n")
+    code = file.lines((line_start-2)..(line_end-2)).join("\n")
     format_code_block(code, file.answer.question.actable.language, [line_start, 1].max)
   end
 

--- a/app/models/course/assessment/answer/programming_file.rb
+++ b/app/models/course/assessment/answer/programming_file.rb
@@ -39,6 +39,11 @@ class Course::Assessment::Answer::ProgrammingFile < ApplicationRecord
     end
   end
 
+  def add_line
+    content.insert(0, "\r\n  ")
+    self
+  end
+
   private
 
   # Normalises the filename for use across platforms.

--- a/client/app/bundles/course/assessment/submission/components/answers/Programming/ProgrammingFile.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/Programming/ProgrammingFile.jsx
@@ -72,7 +72,9 @@ class ProgrammingFile extends Component {
       );
     }
 
-    const content = file.highlighted_content.split('\n');
+    console.log(file.highlighted_content);
+
+    const content = file.highlighted_content.split('\n').slice(1, -1);
     return (
       <ReadOnlyEditor answerId={answerId} fileId={file.id} content={content} />
     );

--- a/client/app/bundles/course/assessment/submission/components/answers/Programming/ProgrammingFile.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/Programming/ProgrammingFile.jsx
@@ -72,9 +72,7 @@ class ProgrammingFile extends Component {
       );
     }
 
-    console.log(file.highlighted_content);
-
-    const content = file.highlighted_content.split('\n').slice(1, -1);
+    const content = file.highlighted_content.split('\n');
     return (
       <ReadOnlyEditor answerId={answerId} fileId={file.id} content={content} />
     );

--- a/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
@@ -17,7 +17,7 @@ class ReadOnlyEditorContainer extends Component {
         answerId={answerId}
         fileId={fileId}
         annotations={Object.values(annotations)}
-        content={content}
+        content={content.slice(1, -1)}
       />
     );
   }

--- a/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
@@ -12,6 +12,7 @@ class ReadOnlyEditorContainer extends Component {
 
   render() {
     const { answerId, fileId, annotations, content } = this.props;
+    // content has <div> tags at first and last index, increasing line count
     return (
       <ReadOnlyEditorComponent
         answerId={answerId}

--- a/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
@@ -17,7 +17,7 @@ class ReadOnlyEditorContainer extends Component {
         answerId={answerId}
         fileId={fileId}
         annotations={Object.values(annotations)}
-        content={content.slice(1, -1)}
+        content={content}
       />
     );
   }


### PR DESCRIPTION
Fixes #4530

New line is added to Comment section as follows:
![image](https://user-images.githubusercontent.com/66063943/170444895-58b633c6-b9c3-4289-b0e7-b96a13ca3a19.png)

This is to fix the pre-existing alignment issue which is caused by <div> tags wrapping around the code, resulting in the lines being pushed down by one line:

![image](https://user-images.githubusercontent.com/66063943/170445056-aadf1183-9225-454a-ba85-1329005df85b.png)

This fix is used to prevent shifting of old comments to the wrong lines. Trimming the first and last line would cause the old comments to be at the wrong lines.