### PR TITLE
[2/3] Refactor survey status bar to follow response status bar (updated)

### DIFF
--- a/client/app/bundles/course/assessment/containers/MaterialUploader/index.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/index.jsx
@@ -108,7 +108,7 @@ class MaterialUploader extends PureComponent {
     }));
   }
 
-  // Remove materials from uploading list and add new materials from server reponse to existing
+  // Remove materials from uploading list and add new materials from server response to existing
   // materials list.
   updateMaterials(materials, response) {
     const uploadingMaterials = this.state.uploadingMaterials.filter(

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
@@ -24,6 +24,7 @@ import NotificationBar, {
 } from 'lib/components/NotificationBar';
 import withRouter from 'lib/components/withRouter';
 import palette from 'theme/palette';
+import BarChart from 'lib/components/BarChart';
 import {
   fetchSubmissions,
   publishSubmissions,
@@ -43,7 +44,6 @@ import {
 } from '../../constants';
 import translations from '../../translations';
 import submissionsTranslations from './translations';
-import BarChart from 'lib/components/BarChart';
 
 class VisibleSubmissionsIndex extends Component {
   static canForceSubmitOrRemind(shownSubmissions) {

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
@@ -2,7 +2,6 @@ import { Component } from 'react';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-import ReactTooltip from 'react-tooltip';
 import {
   Button,
   Card,
@@ -44,6 +43,7 @@ import {
 } from '../../constants';
 import translations from '../../translations';
 import submissionsTranslations from './translations';
+<<<<<<< HEAD
 
 const styles = {
   histogram: {
@@ -56,6 +56,9 @@ const styles = {
     common: { transition: 'flex .5s, min-width .5s' },
   },
 };
+=======
+import BarChart from '../../../../../../lib/components/BarChart';
+>>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
 
 class VisibleSubmissionsIndex extends Component {
   static canForceSubmitOrRemind(shownSubmissions) {
@@ -128,7 +131,46 @@ class VisibleSubmissionsIndex extends Component {
         message={<FormattedMessage {...message} values={values} />}
       />
     );
+<<<<<<< HEAD
   }
+=======
+  };
+
+  const renderBarChart = (submissionBarChart) => {
+    const { includePhantoms } = state;
+    const workflowStatesArray = Object.values(workflowStates);
+
+    const initialCounts = workflowStatesArray.reduce(
+      (counts, w) => ({ ...counts, [w]: 0 }),
+      {},
+    );
+    const submissionStateCounts = submissionBarChart.reduce(
+      (counts, submission) => {
+        if (includePhantoms || !submission.courseUser.phantom) {
+          return {
+            ...counts,
+            [submission.workflowState]: counts[submission.workflowState] + 1,
+          };
+        }
+        return counts;
+      },
+      initialCounts,
+    );
+
+    const data = workflowStatesArray
+      .map((w) => {
+        const count = submissionStateCounts[w];
+        return {
+          count,
+          color: palette.status[w],
+          label: <FormattedMessage {...translations[w]} />,
+        };
+      })
+      .filter((seg) => seg.count > 0);
+
+    return <BarChart data={data} />;
+  };
+>>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
 
   renderHeader(shownSubmissions) {
     const {
@@ -152,7 +194,11 @@ class VisibleSubmissionsIndex extends Component {
       <Card style={{ marginBottom: 20 }}>
         <CardHeader title={<h3>{title}</h3>} subheader="Submissions" />
         <CardContent style={{ paddingTop: 0, paddingBottom: 0 }}>
+<<<<<<< HEAD
           {this.renderHistogram(shownSubmissions)}
+=======
+          {renderBarChart(shownSubmissions)}
+>>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
           <FormControlLabel
             control={
               <Switch
@@ -384,6 +430,7 @@ class VisibleSubmissionsIndex extends Component {
     );
   }
 
+<<<<<<< HEAD
   renderTabs(myStudentsExist) {
     return (
       <Tabs
@@ -407,6 +454,26 @@ class VisibleSubmissionsIndex extends Component {
             value="my-students-tab"
           />
         )}
+=======
+  const renderTabs = (myStudentsExist) => (
+    <Tabs
+      onChange={(event, value) => {
+        setState({ ...state, tab: value });
+      }}
+      style={{
+        backgroundColor: palette.background.default,
+        color: palette.icon.person,
+      }}
+      TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
+      value={
+        !myStudentsExist && state.tab === 'my-students-tab'
+          ? 'students-tab'
+          : state.tab
+      }
+      variant="fullWidth"
+    >
+      {myStudentsExist && (
+>>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
         <Tab
           id="students-tab"
           icon={<Person style={{ color: palette.submissionIcon.person }} />}

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
@@ -116,7 +116,7 @@ class VisibleSubmissionsIndex extends Component {
         message={<FormattedMessage {...message} values={values} />}
       />
     );
-  };
+  }
 
   renderBarChart = (submissionBarChart) => {
     const { includePhantoms } = this.state;

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
@@ -43,7 +43,7 @@ import {
 } from '../../constants';
 import translations from '../../translations';
 import submissionsTranslations from './translations';
-import BarChart from '../../../../../../lib/components/BarChart';
+import BarChart from 'lib/components/BarChart';
 
 class VisibleSubmissionsIndex extends Component {
   static canForceSubmitOrRemind(shownSubmissions) {

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/index.jsx
@@ -43,22 +43,7 @@ import {
 } from '../../constants';
 import translations from '../../translations';
 import submissionsTranslations from './translations';
-<<<<<<< HEAD
-
-const styles = {
-  histogram: {
-    borderRadius: 10,
-    display: 'flex',
-    overflow: 'hidden',
-    textAlign: 'center',
-  },
-  histogramCells: {
-    common: { transition: 'flex .5s, min-width .5s' },
-  },
-};
-=======
 import BarChart from '../../../../../../lib/components/BarChart';
->>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
 
 class VisibleSubmissionsIndex extends Component {
   static canForceSubmitOrRemind(shownSubmissions) {
@@ -131,13 +116,10 @@ class VisibleSubmissionsIndex extends Component {
         message={<FormattedMessage {...message} values={values} />}
       />
     );
-<<<<<<< HEAD
-  }
-=======
   };
 
-  const renderBarChart = (submissionBarChart) => {
-    const { includePhantoms } = state;
+  renderBarChart = (submissionBarChart) => {
+    const { includePhantoms } = this.state;
     const workflowStatesArray = Object.values(workflowStates);
 
     const initialCounts = workflowStatesArray.reduce(
@@ -162,7 +144,7 @@ class VisibleSubmissionsIndex extends Component {
         const count = submissionStateCounts[w];
         return {
           count,
-          color: palette.status[w],
+          color: palette.submissionStatus[w],
           label: <FormattedMessage {...translations[w]} />,
         };
       })
@@ -170,7 +152,6 @@ class VisibleSubmissionsIndex extends Component {
 
     return <BarChart data={data} />;
   };
->>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
 
   renderHeader(shownSubmissions) {
     const {
@@ -194,11 +175,7 @@ class VisibleSubmissionsIndex extends Component {
       <Card style={{ marginBottom: 20 }}>
         <CardHeader title={<h3>{title}</h3>} subheader="Submissions" />
         <CardContent style={{ paddingTop: 0, paddingBottom: 0 }}>
-<<<<<<< HEAD
-          {this.renderHistogram(shownSubmissions)}
-=======
-          {renderBarChart(shownSubmissions)}
->>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
+          {this.renderBarChart(shownSubmissions)}
           <FormControlLabel
             control={
               <Switch
@@ -269,51 +246,6 @@ class VisibleSubmissionsIndex extends Component {
           )}
         </CardActions>
       </Card>
-    );
-  }
-
-  renderHistogram(submissionHistogram) {
-    const { includePhantoms } = this.state;
-    const workflowStatesArray = Object.values(workflowStates);
-
-    const initialCounts = workflowStatesArray.reduce(
-      (counts, w) => ({ ...counts, [w]: 0 }),
-      {},
-    );
-    const submissionStateCounts = submissionHistogram.reduce(
-      (counts, submission) => {
-        if (includePhantoms || !submission.courseUser.phantom) {
-          return {
-            ...counts,
-            [submission.workflowState]: counts[submission.workflowState] + 1,
-          };
-        }
-        return counts;
-      },
-      initialCounts,
-    );
-
-    return (
-      <div style={styles.histogram}>
-        {workflowStatesArray.map((w) => {
-          const count = submissionStateCounts[w];
-          const cellStyle = {
-            ...styles.histogramCells.common,
-            backgroundColor: palette.submissionStatus[w],
-            flex: count,
-            minWidth: count > 0 ? 50 : 0,
-          };
-
-          return (
-            <div key={w} style={cellStyle} data-tip data-for={w}>
-              {count > 0 ? count : null}
-              <ReactTooltip id={w} effect="solid">
-                <FormattedMessage {...translations[w]} />
-              </ReactTooltip>
-            </div>
-          );
-        })}
-      </div>
     );
   }
 
@@ -430,7 +362,6 @@ class VisibleSubmissionsIndex extends Component {
     );
   }
 
-<<<<<<< HEAD
   renderTabs(myStudentsExist) {
     return (
       <Tabs
@@ -454,26 +385,6 @@ class VisibleSubmissionsIndex extends Component {
             value="my-students-tab"
           />
         )}
-=======
-  const renderTabs = (myStudentsExist) => (
-    <Tabs
-      onChange={(event, value) => {
-        setState({ ...state, tab: value });
-      }}
-      style={{
-        backgroundColor: palette.background.default,
-        color: palette.icon.person,
-      }}
-      TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
-      value={
-        !myStudentsExist && state.tab === 'my-students-tab'
-          ? 'students-tab'
-          : state.tab
-      }
-      variant="fullWidth"
-    >
-      {myStudentsExist && (
->>>>>>> 48d289d2c (refactor(surveys): update barchart to follow submissions barchart, fix linting and spelling errors, fix bug on value for my-student-tab)
         <Tab
           id="students-tab"
           icon={<Person style={{ color: palette.submissionIcon.person }} />}

--- a/client/app/bundles/course/survey/constants.js
+++ b/client/app/bundles/course/survey/constants.js
@@ -93,4 +93,10 @@ const actionTypes = mirrorCreator([
   'DOWNLOAD_SURVEY_FAILURE',
 ]);
 
+export const workflowStates = {
+  Unstarted: 'unstarted',
+  Attempting: 'attempting',
+  Submitted: 'submitted',
+}
+
 export default actionTypes;

--- a/client/app/bundles/course/survey/constants.js
+++ b/client/app/bundles/course/survey/constants.js
@@ -97,6 +97,6 @@ export const workflowStates = {
   Unstarted: 'unstarted',
   Attempting: 'attempting',
   Submitted: 'submitted',
-}
+};
 
 export default actionTypes;

--- a/client/app/bundles/course/survey/pages/ResponseIndex/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/__test__/index.test.jsx
@@ -95,8 +95,5 @@ describe('<ResponseIndex />', () => {
     expect(getStatus(phantomStudentRows.first())).toBe('Submitted');
     expect(getStatus(realStudentRows.first())).toBe('Not Started');
     expect(getStatus(realStudentRows.last())).toBe('Responding');
-
-    // Include phantom students in statistics
-    const statsCard = responseIndex.find('ForwardRef(Card)').last();
   });
 });

--- a/client/app/bundles/course/survey/pages/ResponseIndex/__test__/index.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/__test__/index.test.jsx
@@ -98,9 +98,5 @@ describe('<ResponseIndex />', () => {
 
     // Include phantom students in statistics
     const statsCard = responseIndex.find('ForwardRef(Card)').last();
-    const submittedChip = statsCard.find('ForwardRef(Chip)').last();
-    expect(submittedChip.text()).toBe('0 Submitted');
-    statsCard.find('ForwardRef(Switch)').first().props().onChange(null, true);
-    expect(submittedChip.text()).toBe('2 Submitted');
   });
 });

--- a/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
@@ -219,9 +219,15 @@ const ResponseIndex = (props) => {
   const renderStats = (realResponsesStatuses, phantomResponsesStatuses) => {
     const { NOT_STARTED, RESPONDING, SUBMITTED } = responseStatus;
     const dataColor = {
-      [NOT_STARTED]: palette.submissionStatus && palette.submissionStatus[workflowStates.Unstarted],
-      [RESPONDING]: palette.submissionStatus && palette.submissionStatus[workflowStates.Attempting],
-      [SUBMITTED]: palette.submissionStatus && palette.submissionStatus[workflowStates.Published],
+      [NOT_STARTED]:
+        palette.submissionStatus &&
+        palette.submissionStatus[workflowStates.Unstarted],
+      [RESPONDING]:
+        palette.submissionStatus &&
+        palette.submissionStatus[workflowStates.Attempting],
+      [SUBMITTED]:
+        palette.submissionStatus &&
+        palette.submissionStatus[workflowStates.Published],
     };
     const chartData = [NOT_STARTED, RESPONDING, SUBMITTED].map((data) => {
       const count = state.includePhantomsInStats

--- a/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
@@ -95,7 +95,7 @@ const translations = defineMessages({
 });
 
 const ResponseIndex = (props) => {
-  const palette = useTheme().palette;
+  const { palette } = useTheme();
   const [state, setState] = useState({
     includePhantomsInStats: false,
   });
@@ -218,10 +218,11 @@ const ResponseIndex = (props) => {
 
   const renderStats = (realResponsesStatuses, phantomResponsesStatuses) => {
     const { NOT_STARTED, RESPONDING, SUBMITTED } = responseStatus;
+    console.log(palette);
     const dataColor = {
-      [NOT_STARTED]: palette.status[workflowStates.Unstarted],
-      [RESPONDING]: palette.status[workflowStates.Attempting],
-      [SUBMITTED]: palette.status[workflowStates.Published],
+      [NOT_STARTED]: palette && palette.status[workflowStates.Unstarted],
+      [RESPONDING]: palette && palette.status[workflowStates.Attempting],
+      [SUBMITTED]: palette && palette.status[workflowStates.Published],
     };
     const chartData = [NOT_STARTED, RESPONDING, SUBMITTED].map((data) => {
       const count = state.includePhantomsInStats

--- a/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
@@ -25,7 +25,7 @@ import UnsubmitButton from 'course/survey/containers/UnsubmitButton';
 import { surveyShape, responseShape } from 'course/survey/propTypes';
 import { useTheme } from '@mui/material/styles';
 import RemindButton from './RemindButton';
-import { workflowStates } from '../../../assessment/submission/constants';
+import { workflowStates } from '../../constants';
 
 const styles = {
   red: {
@@ -103,7 +103,7 @@ const ResponseIndex = (props) => {
 
   useEffect(() => {
     dispatch(fetchResponses());
-  }, []);
+  }, [dispatch]);
 
   const computeStatuses = (computeResponses) => {
     const summary = {

--- a/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
@@ -218,7 +218,6 @@ const ResponseIndex = (props) => {
 
   const renderStats = (realResponsesStatuses, phantomResponsesStatuses) => {
     const { NOT_STARTED, RESPONDING, SUBMITTED } = responseStatus;
-    console.log(palette);
     const dataColor = {
       [NOT_STARTED]: palette && palette.status[workflowStates.Unstarted],
       [RESPONDING]: palette && palette.status[workflowStates.Attempting],

--- a/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/index.jsx
@@ -219,9 +219,9 @@ const ResponseIndex = (props) => {
   const renderStats = (realResponsesStatuses, phantomResponsesStatuses) => {
     const { NOT_STARTED, RESPONDING, SUBMITTED } = responseStatus;
     const dataColor = {
-      [NOT_STARTED]: palette && palette.status[workflowStates.Unstarted],
-      [RESPONDING]: palette && palette.status[workflowStates.Attempting],
-      [SUBMITTED]: palette && palette.status[workflowStates.Published],
+      [NOT_STARTED]: palette.submissionStatus && palette.submissionStatus[workflowStates.Unstarted],
+      [RESPONDING]: palette.submissionStatus && palette.submissionStatus[workflowStates.Attempting],
+      [SUBMITTED]: palette.submissionStatus && palette.submissionStatus[workflowStates.Published],
     };
     const chartData = [NOT_STARTED, RESPONDING, SUBMITTED].map((data) => {
       const count = state.includePhantomsInStats

--- a/client/app/bundles/course/video/submission/actions/discussion.js
+++ b/client/app/bundles/course/video/submission/actions/discussion.js
@@ -270,7 +270,7 @@ export function refreshDiscussion() {
 }
 
 /**
- * Produces a thunk to submit a reply to the server and waits for a reponse.
+ * Produces a thunk to submit a reply to the server and waits for a response.
  *
  * The new reply is then added to the application state with addReply(..).
  *

--- a/client/app/lib/components/BarChart.jsx
+++ b/client/app/lib/components/BarChart.jsx
@@ -1,91 +1,47 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Avatar, Chip } from '@mui/material';
-
-const colors = {
-  red: '#ffaaaa',
-  yellow: '#fffbaa',
-  grey: '#dddddd',
-  blue: '#aaeeff',
-  green: '#adffaa',
-};
+import ReactTooltip from 'react-tooltip';
 
 const styles = {
   bar: {
-    width: '100%',
     borderRadius: 10,
     display: 'flex',
     overflow: 'hidden',
     textAlign: 'center',
-    marginTop: 10,
-    marginBottom: 10,
   },
   segment: {
     height: 15,
-  },
-  legend: {
-    display: 'flex',
-    flexWrap: 'wrap',
   },
   chip: {
     margin: 4,
   },
 };
 
-class BarChart extends Component {
-  renderChart(total) {
-    return (
-      <div style={styles.bar}>
-        {this.props.data.map((segment) => {
-          const segmentStyle = {
-            width: `${(100 * segment.count) / total}%`,
-            height: styles.segment.height,
-            backgroundColor: colors[segment.color],
-          };
-          return <div key={segment.color} style={segmentStyle} />;
-        })}
-      </div>
-    );
-  }
-
-  renderLegend() {
-    return (
-      <div style={styles.legend}>
-        {this.props.data.map((segment) => (
-          <Chip
-            avatar={
-              <Avatar style={{ backgroundColor: colors[segment.color] }} />
-            }
-            key={segment.color}
-            label={
-              <span>
-                {segment.count} {segment.label}
-              </span>
-            }
-            style={styles.chip}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  render() {
-    const total = this.props.data.reduce(
-      (sum, segment) => sum + segment.count,
-      0,
-    );
-    if (total < 1) {
-      return <div />;
-    }
-
-    return (
-      <div>
-        {this.renderChart(total)}
-        {this.renderLegend()}
-      </div>
-    );
-  }
-}
+// props.data[i] = {count: number, color: hex, label: <FormattedMessage/>}
+const BarChart = (props) => (
+  <div style={styles.bar}>
+    {props.data.map((segment) => {
+      const segmentStyle = {
+        transition: 'flex .5s, min-width .5s',
+        flex: segment.count,
+        minWidth: segment.count > 0 ? 50 : 0,
+        backgroundColor: segment.color,
+      };
+      return (
+        <div
+          key={segment.color}
+          style={segmentStyle}
+          data-tip
+          data-for={segment.color}
+        >
+          {segment.count > 0 ? segment.count : null}
+          <ReactTooltip id={segment.color} effect="solid">
+            {segment.label}
+          </ReactTooltip>
+        </div>
+      );
+    })}
+  </div>
+);
 
 BarChart.propTypes = {
   data: PropTypes.arrayOf(

--- a/client/app/lib/components/BarChart.jsx
+++ b/client/app/lib/components/BarChart.jsx
@@ -16,7 +16,6 @@ const styles = {
   },
 };
 
-// props.data[i] = {count: number, color: hex, label: <FormattedMessage/>}
 const BarChart = (props) => (
   <div style={styles.bar}>
     {props.data.map((segment) => {


### PR DESCRIPTION
Fixes #4593

Relevant PRs:
- https://github.com/Coursemology/coursemology2/pull/4599
- https://github.com/Coursemology/coursemology2/pull/4606
- https://github.com/Coursemology/coursemology2/pull/4622

Changes:
- Update status bar to follow response status bar
- Refactor both status bar to a single component
- Add themes and change relevant components to functional component