### PR TITLE
Prevent incorrect submissions when partial submission disabled

### DIFF
--- a/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
+++ b/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
@@ -7,6 +7,10 @@ json.fields do
                 selected_posts: answer.compute_post_packs
 end
 
+json.answerStatus do
+  json.isLatestAnswer true
+end
+
 last_attempt = last_attempt(answer)
 
 json.explanation do

--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.json.jbuilder
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
+last_attempt = last_attempt(answer)
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id
   json.option_ids answer.options.map(&:id)
 end
 
-last_attempt = last_attempt(answer)
+json.answerStatus do
+  json.isLatestAnswer answer.specific.compare_answer(last_attempt.specific)
+end
 
 json.explanation do
   if last_attempt&.auto_grading&.result

--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -35,6 +35,10 @@ json.fields do
   end
 end
 
+json.answerStatus do
+  json.isLatestAnswer answer.specific.compare_answer(latest_answer.specific)
+end
+
 if attempt.submitted? && (job = attempt&.auto_grading&.job)
   json.autograding do
     json.path job_path(job) if job.submitted?

--- a/app/views/course/assessment/answer/scribing/_scribing.json.jbuilder
+++ b/app/views/course/assessment/answer/scribing/_scribing.json.jbuilder
@@ -15,6 +15,10 @@ json.fields do
   json.id answer.acting_as.id
 end
 
+json.answerStatus do
+  json.isLatestAnswer true
+end
+
 last_attempt = last_attempt(answer)
 
 json.explanation do

--- a/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+last_attempt = last_attempt(answer)
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id
@@ -7,11 +9,13 @@ json.fields do
   json.answer_text answer.answer_text unless question.hide_text
 end
 
+json.answerStatus do
+  json.isLatestAnswer answer.specific.compare_answer(last_attempt.specific)
+end
+
 json.attachments answer.attachments do |attachment|
   json.(attachment, :name, :id)
 end
-
-last_attempt = last_attempt(answer)
 
 json.explanation do
   json.correct last_attempt&.correct

--- a/app/views/course/assessment/answer/voice_responses/_voice_response.json.jbuilder
+++ b/app/views/course/assessment/answer/voice_responses/_voice_response.json.jbuilder
@@ -9,6 +9,10 @@ json.fields do
   end
 end
 
+json.answerStatus do
+  json.isLatestAnswer true
+end
+
 last_attempt = last_attempt(answer)
 
 json.explanation do

--- a/client/app/bundles/course/assessment/submission/actions/__test__/scribing.test.js
+++ b/client/app/bundles/course/assessment/submission/actions/__test__/scribing.test.js
@@ -31,6 +31,9 @@ const mockSubmission = {
         id: answerId,
         questionId: 1,
       },
+      answerStatus: {
+        1: { isLatestAnswer: true },
+      },
       grading: {
         grade: null,
         id: answerId,

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/SavingIndicator.test.js
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/SavingIndicator.test.js
@@ -40,6 +40,9 @@ const mockSubmission = {
         id: answerId,
         questionId: 1,
       },
+      answerStatus: {
+        1: { isLatestAnswer: true },
+      },
       grading: {
         grade: null,
         id: answerId,

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/ScribingToolbar.test.js
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/ScribingToolbar.test.js
@@ -48,6 +48,9 @@ const mockSubmission = {
         id: answerId,
         questionId: 1,
       },
+      answerStatus: {
+        1: { isLatestAnswer: true },
+      },
       grading: {
         grade: null,
         id: answerId,

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/index.test.js
@@ -35,6 +35,9 @@ const mockSubmission = {
         id: answerId,
         questionId: 1,
       },
+      answerStatus: {
+        1: { isLatestAnswer: true },
+      },
       grading: {
         grade: null,
         id: answerId,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -127,6 +127,7 @@ const SubmissionEditForm = (props) => {
     getValues,
     handleSubmit,
     reset,
+    resetField,
     setValue,
     formState: { errors, isDirty },
   } = methods;
@@ -347,7 +348,12 @@ const SubmissionEditForm = (props) => {
                 }
                 id="run-code"
                 onClick={() =>
-                  onSubmitAnswer(answerId, getValues(`${answerId}`), setValue)
+                  onSubmitAnswer(
+                    answerId,
+                    getValues(`${answerId}`),
+                    setValue,
+                    resetField,
+                  )
                 }
                 style={styles.formButton}
               >

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -130,17 +130,6 @@ const SubmissionEditStepForm = (props) => {
     reset(initialValues);
   }, [initialValues]);
 
-  const handleNext = () => {
-    setMaxStep(Math.max(maxStep, stepIndex + 1));
-    setStepIndex(stepIndex + 1);
-  };
-
-  const handleStepClick = (index) => {
-    if (published || skippable || graderView || index <= maxStep) {
-      setStepIndex(index);
-    }
-  };
-
   const isOutdated = (question) => {
     const isBackendOutdated = !answerStatus[question.id].isLatestAnswer;
     const isFrontendDirty = question.answerId in dirtyFields;
@@ -167,6 +156,29 @@ const SubmissionEditStepForm = (props) => {
 
   const shouldRenderContinueButton = () =>
     !isLastQuestion(questionIds, stepIndex);
+
+  const isStepButtonActive = (index) => {
+    if (index === 0) return true;
+
+    const previousQuestion = questionIds[index - 1];
+
+    return (
+      index <= maxStep ||
+      (explanations[previousQuestion] && explanations[previousQuestion].correct)
+    );
+  };
+
+  const handleNext = () => {
+    setMaxStep(Math.max(maxStep, stepIndex + 1));
+    setStepIndex(stepIndex + 1);
+  };
+
+  const handleStepClick = (index) => {
+    if (published || skippable || graderView || isStepButtonActive(index)) {
+      setStepIndex(index);
+      setMaxStep(Math.max(maxStep, stepIndex));
+    }
+  };
 
   const renderAnswerLoadingIndicator = () => {
     const id = questionIds[stepIndex];
@@ -564,9 +576,14 @@ const SubmissionEditStepForm = (props) => {
           } else {
             stepButtonColor = isCurrentQuestion ? blue[800] : lightBlue[400];
           }
-          if (published || skippable || graderView || index <= maxStep) {
+          if (
+            published ||
+            skippable ||
+            graderView ||
+            isStepButtonActive(index)
+          ) {
             return (
-              <Step key={questionId} active={index <= maxStep}>
+              <Step key={questionId}>
                 <StepButton
                   icon={
                     <SvgIcon htmlColor={stepButtonColor}>

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/__test__/index.test.js
@@ -63,6 +63,9 @@ const errorSubmission = {
         questionId: 1,
         file: {},
       },
+      answerStatus: {
+        1: { isLatestAnswer: true },
+      },
       grading: {
         grade: null,
         id: answerId,
@@ -133,6 +136,9 @@ const successSubmission = {
         id: answerId,
         questionId: 1,
         file: { url: 'http://test.org/file.wav', name: 'file.wav' },
+      },
+      answerStatus: {
+        1: { isLatestAnswer: true },
       },
       grading: {
         grade: null,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
@@ -178,12 +178,14 @@ class VisibleSubmissionEditIndex extends Component {
     dispatch(finalise(params.submissionId, data));
   };
 
-  onSubmitAnswer = (answerId, answer, setValue) => {
+  onSubmitAnswer = (answerId, answer, setValue, resetField) => {
     const {
       dispatch,
       match: { params },
     } = this.props;
-    dispatch(submitAnswer(params.submissionId, answerId, answer, setValue));
+    dispatch(
+      submitAnswer(params.submissionId, answerId, answer, setValue, resetField),
+    );
   };
 
   onReevaluateAnswer = (answerId, questionId) => {
@@ -195,15 +197,19 @@ class VisibleSubmissionEditIndex extends Component {
   };
 
   allConsideredCorrect() {
-    const { explanations, questions } = this.props;
+    const { answers, explanations, questions } = this.props;
     if (Object.keys(explanations).length !== Object.keys(questions).length) {
       return false;
     }
 
+    const allUpdated = Object.keys(answers.status).every(
+      (qid) => answers.status[qid] && answers.status[qid].isLatestAnswer,
+    );
+
     const numIncorrect = Object.keys(explanations).filter(
       (qid) => !explanations[qid] || !explanations[qid].correct,
     ).length;
-    return numIncorrect === 0;
+    return numIncorrect === 0 && allUpdated;
   }
 
   renderAssessment() {
@@ -303,6 +309,7 @@ class VisibleSubmissionEditIndex extends Component {
           handleUnsubmit={() => this.handleUnsubmit()}
           handleToggleViewHistoryMode={this.handleToggleViewHistoryMode}
           explanations={explanations}
+          answerStatus={answers.status}
           allConsideredCorrect={this.allConsideredCorrect()}
           allowPartialSubmission={allowPartialSubmission}
           showMcqAnswer={showMcqAnswer}

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -88,6 +88,10 @@ export const answerShape = PropTypes.shape({
   createdAt: PropTypes.string,
 });
 
+export const answerStatusShape = PropTypes.shape({
+  isLatestAnswer: PropTypes.bool,
+});
+
 export const explanationShape = PropTypes.shape({
   correct: PropTypes.bool,
   explanations: PropTypes.arrayOf(PropTypes.string),
@@ -208,7 +212,7 @@ export const forumPostShape = PropTypes.shape({
   id: PropTypes.number,
   text: PropTypes.string,
   updatedAt: PropTypes.string,
-  isUpdated: PropTypes.bool,
+  isLatestAnswer: PropTypes.bool,
   isDeleted: PropTypes.bool,
   userName: PropTypes.string,
   avatar: PropTypes.string,

--- a/client/app/bundles/course/assessment/submission/reducers/answers.js
+++ b/client/app/bundles/course/assessment/submission/reducers/answers.js
@@ -11,8 +11,21 @@ function buildInitialValues(answers) {
   );
 }
 
+function buildAnswerStatus(answers) {
+  return answers.reduce(
+    (obj, answer) => ({
+      ...obj,
+      [answer.fields.questionId]: {
+        isLatestAnswer: answer.answerStatus.isLatestAnswer,
+      },
+    }),
+    {},
+  );
+}
+
 const initialState = {
   initial: {},
+  status: {},
 };
 
 export default function (state = initialState, action) {
@@ -26,18 +39,32 @@ export default function (state = initialState, action) {
     case actions.UNMARK_SUCCESS:
     case actions.PUBLISH_SUCCESS: {
       const initialValues = buildInitialValues(action.payload.answers);
+      const answerStatus = buildAnswerStatus(action.payload.answers);
       return {
         ...state,
         initial: initialValues,
+        status: {
+          ...state.status,
+          ...answerStatus,
+        },
       };
     }
     case actions.IMPORT_FILES_SUCCESS:
-    case actions.REEVALUATE_SUCCESS:
-    case actions.AUTOGRADE_SUCCESS:
-    case actions.RESET_SUCCESS:
     case actions.DELETE_FILE_SUCCESS: {
       return {
         ...state,
+      };
+    }
+    case actions.REEVALUATE_SUCCESS:
+    case actions.AUTOGRADE_SUCCESS:
+    case actions.RESET_SUCCESS: {
+      const answerStatus = buildAnswerStatus([action.payload]);
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          ...answerStatus,
+        },
       };
     }
     default:

--- a/client/app/lib/helpers/react-hook-form-helper.js
+++ b/client/app/lib/helpers/react-hook-form-helper.js
@@ -12,3 +12,54 @@ export function setReactHookFormError(setError, errors) {
     );
   }
 }
+
+/**
+ * Resets nested arrays in fields in react-hook-form
+ * Sets their initialValue to the value in `array`.
+ * This is a workaround solution until the library supports resetting nested arrays
+ *
+ * @param {resetField} resetField a function from react-hook-form that resets field
+ * @param {array} array new value to be reset to
+ * @param {path} path the field name to reset
+ */
+export function resetArrayFields(resetField, array, path = '') {
+  const fieldPath = path === '' ? '' : `${path}.`;
+  array.forEach((obj, index) => {
+    Object.keys(obj).forEach((fieldName) => {
+      resetField(`${fieldPath}${index}.${fieldName}`, {
+        defaultValue: obj[fieldName],
+      });
+    });
+  });
+}
+
+/**
+ * Workaround to reset objects in fields in react-hook-form
+ * Sets their initialValue to the value in `fields`
+ * This is a workaround solution by individually resetting fields of objects,
+ * until the library supports it.
+ * https://github.com/react-hook-form/react-hook-form/issues/7841
+ *
+ * @param {resetField} resetField a function from react-hook-form that resets field
+ * @param {fields} fields new object to be reset to
+ * @param {path} path the field name to reset
+ */
+export function resetObjectFields(resetField, fields, path = '') {
+  const fieldPath = path === '' ? '' : `${path}`;
+  Object.keys(fields).forEach((fieldName) => {
+    if (fieldName === 'files_attributes') {
+      // we specifically target 'files_attributes' since it is a nested array,
+      // and we need to reset this attribute for assessment submissions.
+      // react-hook-form's resetField needs to reset each arrayField individually
+      resetArrayFields(
+        resetField,
+        fields[fieldName],
+        `${fieldPath}.${fieldName}`,
+      );
+    } else {
+      resetField(`${fieldPath}.${fieldName}`, {
+        defaultValue: fields[fieldName],
+      });
+    }
+  });
+}


### PR DESCRIPTION
# Context
**Desired outcome**
When student is doing an assessment with 'disable partial submission', if the student gets all correct, then changes an answer (either by saving draft of new answer or selecting a new answer), the student should not be allowed to finalize submission until all answers are correct again.

This PR prevents incorrect 'dirty' submissions from being finalized. **However, for programming with file upload, uploading/deleting files will not dirty the form. (This matches current behaviour)**. All other question types have been changed.

Resolves #4446 

**Solution**
1. Backend sends an `isLatestAnswer` boolean which checks if the current_answer === last_graded_answer. Whenever we save draft, need to check if the current_answer differs from the last_graded_answer. It was possible for students to save draft on an incorrect answer then submit. This check will prevent that from happening.
2. Frontend needs to reset the `isDirty` attribute of the form every time student makes an answer submission. This means on each submit, the form will be reset to a 'clean' state, and any deviance from this will disable the finalise button. This is done using `resetField` API of react-hook-form. It was possible for students to accidentally change their answer from correct to incorrect before submitting, and this check will prevent that from happening.

![GIF 5-30-2022 11-43-43 AM](https://user-images.githubusercontent.com/9080974/170913655-300e48b7-e63f-4eb2-b7d9-36886d4b5329.gif)

# Using `resetField` API
[`resetField` API](https://react-hook-form.com/api/useform/resetfield) is used to reset the form state of specific fields.

## Problem 1: Cannot reset entire nested object/array
Due to current limitation of the API, it's not possible to simply reset deeply nested objects/arrays. Thus, we have to specifically access the individual field names. This is currently a feature request in react-hook-form, so it can be refactored in future.

As an example, the programming question type has the following nested array json:
```javascript
answers: {
  initial: {
    answerId: {
        questionId: Int,
        id: Int, 
        files_attributes: [ {...} ]
    }
  }
}
```
Calling `resetField` on the `files_attributes` nested array which is created with `useArrayField` in react-hook-form will not allow the form to be dirtied by the `files_attributes` field again. 

Thus, we have to specifically target fields in `files_attributes`, as follows:
⭕: `resetField('id.files_attributes', { defaultValue: [ { filename: newFileName } ] })`
❌: `resetField('id.files_attributes.0.filename', { defaultValue: newFileName })`

## Problem 2: Must call `setValue` before `resetField`
`resetField` is only able to change existing values. For example, `staged: false` to `staged: true`.

However, there are instances where the `staged` attribute is completely removed from the redux store. Thus, we must first call `setValue` to remove `staged` attribute, before resetting form fields, otherwise the form will always be in dirtied state.

# Test plan
**Prerequisites:** Autograded assessment, disable partial submission

**For all question types except programming:**
- After submitting an answer, switching away from that answer will 
    - hide the explanation panel
    - change the current step indicator to blue colour
    - disable finalise submission button
- Switching back to the initial answer will
    - show the explanation panel
    - change the current step indicator to green if initially correct, blue if initially wrong
    - enable finalise submission button
- If entire form has any dirty answer, finalise submission is not allowed 
- Saving draft of changed answer will
    - hide the explanation panel
    - change the current step indicator to blue colour
    - hide finalise submission button
    - User needs to resubmit any blue questions before finalise submission shows

**For programming question type:**
- On initial page load
  - finalise submission button & explanation panel will not show until submission
- On submission
  - explanation panel will show
  - finalise submission button will only show if answer is correct
  - any changes to programming code box:
    - change the current step indicator to blue colour
    - disable finalise submission button
- After submission, on refresh
	- any changes to programming code box will
      - change the current step indicator to blue colour
      - disable finalise submission button
- On reset
    - hide the explanation panel
    - change the current step indicator to blue colour
    - hide finalise submission button

**Programming with file upload:**
- Upload correct file(s) and submit
	- Finalise button will show & enable
- Upload incorrect file(s) and submit
	- Explanation panel will show
	- Finalise button will not show
- Upload file(s) and submit, then modify any file
    - hide the explanation panel
    - change the current step indicator to blue colour
    - hide finalise submission button
- ⚠Upload file(s) and submit. Then add/delete any file
	- Finalise submission button will still be enabled, even though submitted answer might be incorrect! **(No change from current behaviour)**

**All other question types:**
- Since autograder will always mark correct for other question types, student just needs to submit any answer for finalise button to show. Any accidental changes made will still require a resubmit to enable the finalise submission button.
- Test that there is no regression when 'disable partial submission' is enabled