### PR TITLE
style(narrow-editor): add scroll to narrow editor

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
@@ -182,41 +182,42 @@ export default function NarrowEditor(props) {
   const { content } = props;
 
   return (
-    <table className="codehilite" style={styles.editor} ref={editorRef}>
-      <tbody>
-        {content.map((line, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <tr key={`${index}-${line}`}>
-            <td
-              style={{
-                width: 50,
-                userSelect: 'none',
-                verticalAlign: 'top',
-              }}
-            >
-              {renderLineNumberColumn(index + 1)}
-            </td>
+    <div style={{ overflow: 'auto' }}>
+      <table className="codehilite" style={styles.editor} ref={editorRef}>
+        <tbody>
+          {content.map((line, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <tr key={`${index}-${line}`}>
+              <td
+                style={{
+                  width: 50,
+                  userSelect: 'none',
+                  verticalAlign: 'top',
+                }}
+              >
+                {renderLineNumberColumn(index + 1)}
+              </td>
 
-            <td
-              style={{
-                display: 'block',
-                overflowX: 'visible',
-                verticalAlign: 'top',
-              }}
-            >
-              <div style={styles.editorLine}>
-                <pre style={{ overflow: 'visible' }}>
-                  <code
-                    dangerouslySetInnerHTML={{ __html: line }}
-                    style={{ whiteSpace: 'inherit' }}
-                  />
-                </pre>
-              </div>
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+              <td
+                style={{
+                  display: 'block',
+                  verticalAlign: 'top',
+                }}
+              >
+                <div style={styles.editorLine}>
+                  <pre style={{ overflow: 'visible' }}>
+                    <code
+                      dangerouslySetInnerHTML={{ __html: line }}
+                      style={{ whiteSpace: 'inherit' }}
+                    />
+                  </pre>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 


### PR DESCRIPTION
fixes #4625

Slightly un-ideal that the scroll also scrolls the line number away, but this is also how the wide editor behaves + only scrolling the code without scrolling the line number seems to be much harder to implement