### PR TITLE
Allow overflow on test cases

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -264,7 +264,7 @@ export class VisibleTestCaseView extends Component {
         <AccordionSummary expandIcon={<ExpandMoreIcon />} style={headerStyle}>
           {title}
         </AccordionSummary>
-        <AccordionDetails>
+        <AccordionDetails style={{ overflowX: 'auto' }}>
           <Table>
             <TableHead>
               <TableRow>


### PR DESCRIPTION
Fix for #4633 

![GIF 6-6-2022 1-08-20 PM](https://user-images.githubusercontent.com/9080974/172098644-8d9ccd74-f3cb-46ed-94bd-5c9418195049.gif)

Add horizontal scrolling on test cases that require longer horizontal space to display