### PR TITLE
chore: add logger debug for email duplication and course duplication error

### DIFF
--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -213,7 +213,11 @@ class Course::Assessment < ApplicationRecord
 
   def include_in_consolidated_email?(event)
     email_enabled = course.email_enabled(:assessments, event, tab.category.id)
-    return false unless email_enabled # TO REMOVE - Testing for duplicate opening emails #4531
+    unless email_enabled # TO REMOVE - Testing for duplicate opening emails #4531
+      logger.debug(message: 'Duplicate emails debugging', course: course , assessment_id: id,
+                   lesson_plan: lesson_plan_item, tab: tab, category_id: tab&.category&.id)
+      return false
+    end
     email_enabled.regular || email_enabled.phantom
   end
 


### PR DESCRIPTION
Adding loggers for the following issues that only happen in production:
- Duplicated opening reminder emails (Related to https://github.com/Coursemology/coursemology2/pull/4620 and #4531)
- Course duplication failure
