### PR TITLE
Revert "chore(deps): bump sidekiq from 6.4.2 to 6.5.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -559,7 +559,7 @@ GEM
     should_not (1.1.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.0)
+    sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)


### PR DESCRIPTION
Reverts Coursemology/coursemology2#4644

Due to https://github.com/mperham/sidekiq/issues/5372