### PR TITLE
Fix consolidated opening reminder email duplication

### DIFF
--- a/app/jobs/consolidated_item_email_job.rb
+++ b/app/jobs/consolidated_item_email_job.rb
@@ -7,7 +7,7 @@ class ConsolidatedItemEmailJob < ApplicationJob
     midnight_time_zones = ActiveSupport::TimeZone.all.select { |time| time.now.hour == 0 }.
                           map(&:name)
     ActsAsTenant.without_tenant do
-      courses = Course.where('time_zone in (?) AND end_at >=(?)', midnight_time_zones, Time.now)
+      courses = Course.where(time_zone: midnight_time_zones)
       courses.each do |course|
         Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course)
       end

--- a/app/jobs/consolidated_item_email_job.rb
+++ b/app/jobs/consolidated_item_email_job.rb
@@ -7,7 +7,7 @@ class ConsolidatedItemEmailJob < ApplicationJob
     midnight_time_zones = ActiveSupport::TimeZone.all.select { |time| time.now.hour == 0 }.
                           map(&:name)
     ActsAsTenant.without_tenant do
-      courses = Course.where(time_zone: midnight_time_zones)
+      courses = Course.where('time_zone in (?) AND end_at >=(?)', midnight_time_zones, Time.now)
       courses.each do |course|
         Course::ConsolidatedOpeningReminderNotifier.opening_reminder(course)
       end

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -213,7 +213,7 @@ class Course::Assessment < ApplicationRecord
 
   def include_in_consolidated_email?(event)
     email_enabled = course.email_enabled(:assessments, event, tab.category.id)
-    unless email_enabled # TO REMOVE - Testing for duplicate opening emails #4531
+    unless email_enabled # TO REMOVE - Monitoring for duplicate opening emails #4531
       logger.debug(message: 'Duplicate emails debugging', course: course , assessment_id: id,
                    lesson_plan: lesson_plan_item, tab: tab, category_id: tab&.category&.id)
       return false

--- a/app/models/course/assessment/category.rb
+++ b/app/models/course/assessment/category.rb
@@ -60,6 +60,8 @@ class Course::Assessment::Category < ApplicationRecord
   # @return [Boolean] true if post-duplication processing is successful.
   def after_duplicate_save(duplicator)
     User.with_stamper(duplicator.options[:current_user]) do
+      Course::Settings::Email.build_assessment_email_settings(self)
+      save
       build_initial_tab ? save : true
     end
   end

--- a/app/models/course/settings/email.rb
+++ b/app/models/course/settings/email.rb
@@ -88,11 +88,11 @@ class Course::Settings::Email < ApplicationRecord
 
   def self.build_assessment_email_settings(category)
     default_email_settings = [{ assessments: :opening_reminder },
-      { assessments: :closing_reminder },
-      { assessments: :closing_reminder_summary },
-      { assessments: :grades_released },
-      { assessments: :new_comment },
-      { assessments: :new_submission }]
+                              { assessments: :closing_reminder },
+                              { assessments: :closing_reminder_summary },
+                              { assessments: :grades_released },
+                              { assessments: :new_comment },
+                              { assessments: :new_submission }]
 
     default_email_settings.each do |default_email_setting|
       component = default_email_setting.keys[0]

--- a/app/models/course/settings/email.rb
+++ b/app/models/course/settings/email.rb
@@ -83,12 +83,16 @@ class Course::Settings::Email < ApplicationRecord
   def self.after_assessment_category_initialize(category)
     return if category.persisted? || !category.setting_emails.empty? || !category.course
 
+    build_assessment_email_settings(category)
+  end
+
+  def self.build_assessment_email_settings(category)
     default_email_settings = [{ assessments: :opening_reminder },
-                              { assessments: :closing_reminder },
-                              { assessments: :closing_reminder_summary },
-                              { assessments: :grades_released },
-                              { assessments: :new_comment },
-                              { assessments: :new_submission }]
+      { assessments: :closing_reminder },
+      { assessments: :closing_reminder_summary },
+      { assessments: :grades_released },
+      { assessments: :new_comment },
+      { assessments: :new_submission }]
 
     default_email_settings.each do |default_email_setting|
       component = default_email_setting.keys[0]

--- a/lib/tasks/db/add_missing_email_settings.rake
+++ b/lib/tasks/db/add_missing_email_settings.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+namespace :db do
+    task add_missing_email_settings: :environment do
+      def create_default_email_settings(category_ids)
+        assessment_categories = Course::Assessment::Category.where(id: category_ids)
+        assessment_categories.each do |assessment_cat|
+          default_email_settings = [{ assessments: :opening_reminder },
+                                    { assessments: :closing_reminder },
+                                    { assessments: :closing_reminder_summary },
+                                    { assessments: :grades_released },
+                                    { assessments: :new_comment },
+                                    { assessments: :new_submission }]
+  
+          default_email_settings.each do |default_email_setting|
+            component = default_email_setting.keys[0]
+            setting = default_email_setting[component]
+            assessment_cat.setting_emails.create!(course: assessment_cat.course, component: component, setting: setting)
+          end
+        end
+      end
+  
+      ActsAsTenant.without_tenant do
+        connection = ActiveRecord::Base.connection
+        assessment_categories_with_missing_email_settings = connection.exec_query(<<-SQL)
+          SELECT cac.id FROM course_assessment_categories cac
+          LEFT JOIN course_settings_emails cse
+          ON cac.id = cse.course_assessment_category_id
+          WHERE cse.id IS NULL
+        SQL
+        assessment_category_ids = assessment_categories_with_missing_email_settings.pluck('id')
+        create_default_email_settings(assessment_category_ids)
+      end
+    end
+  end
+  

--- a/lib/tasks/db/add_missing_email_settings.rake
+++ b/lib/tasks/db/add_missing_email_settings.rake
@@ -1,35 +1,34 @@
 # frozen_string_literal: true
 namespace :db do
-    task add_missing_email_settings: :environment do
-      def create_default_email_settings(category_ids)
-        assessment_categories = Course::Assessment::Category.where(id: category_ids)
-        assessment_categories.each do |assessment_cat|
-          default_email_settings = [{ assessments: :opening_reminder },
-                                    { assessments: :closing_reminder },
-                                    { assessments: :closing_reminder_summary },
-                                    { assessments: :grades_released },
-                                    { assessments: :new_comment },
-                                    { assessments: :new_submission }]
-  
-          default_email_settings.each do |default_email_setting|
-            component = default_email_setting.keys[0]
-            setting = default_email_setting[component]
-            assessment_cat.setting_emails.create!(course: assessment_cat.course, component: component, setting: setting)
-          end
+  task add_missing_email_settings: :environment do
+    def create_default_email_settings(category_ids)
+      assessment_categories = Course::Assessment::Category.where(id: category_ids)
+      assessment_categories.each do |assessment_cat|
+        default_email_settings = [{ assessments: :opening_reminder },
+                                  { assessments: :closing_reminder },
+                                  { assessments: :closing_reminder_summary },
+                                  { assessments: :grades_released },
+                                  { assessments: :new_comment },
+                                  { assessments: :new_submission }]
+
+        default_email_settings.each do |default_email_setting|
+          component = default_email_setting.keys[0]
+          setting = default_email_setting[component]
+          assessment_cat.setting_emails.create!(course: assessment_cat.course, component: component, setting: setting)
         end
       end
-  
-      ActsAsTenant.without_tenant do
-        connection = ActiveRecord::Base.connection
-        assessment_categories_with_missing_email_settings = connection.exec_query(<<-SQL)
-          SELECT cac.id FROM course_assessment_categories cac
-          LEFT JOIN course_settings_emails cse
-          ON cac.id = cse.course_assessment_category_id
-          WHERE cse.id IS NULL
-        SQL
-        assessment_category_ids = assessment_categories_with_missing_email_settings.pluck('id')
-        create_default_email_settings(assessment_category_ids)
-      end
+    end
+
+    ActsAsTenant.without_tenant do
+      connection = ActiveRecord::Base.connection
+      assessment_categories_with_missing_email_settings = connection.exec_query(<<-SQL)
+        SELECT cac.id FROM course_assessment_categories cac
+        LEFT JOIN course_settings_emails cse
+        ON cac.id = cse.course_assessment_category_id
+        WHERE cse.id IS NULL
+      SQL
+      assessment_category_ids = assessment_categories_with_missing_email_settings.pluck('id')
+      create_default_email_settings(assessment_category_ids)
     end
   end
-  
+end

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
           it 'creates default assessment email settings for it' do
             expect { duplicate_objects }.to change { destination_course.assessment_categories.count }.by(1)
             new_assessment_email_settings = destination_course.setting_emails.
-                                              where(course_assessment_category_id: destination_course.assessment_categories.second.id)
+                                            where(course_assessment_category_id: destination_course.
+                                              assessment_categories.second.id)
 
             expect(new_assessment_email_settings.length).to eq(6)
           end

--- a/spec/services/course/duplication/object_duplication_service_spec.rb
+++ b/spec/services/course/duplication/object_duplication_service_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe Course::Duplication::ObjectDuplicationService, type: :service do
             default_title = Course::Assessment::Tab.human_attribute_name('title.default')
             expect(duplicate_objects.tabs.first.title).to eq(default_title)
           end
+
+          it 'creates default assessment email settings for it' do
+            expect { duplicate_objects }.to change { destination_course.assessment_categories.count }.by(1)
+            new_assessment_email_settings = destination_course.setting_emails.
+                                              where(course_assessment_category_id: destination_course.assessment_categories.second.id)
+
+            expect(new_assessment_email_settings.length).to eq(6)
+          end
         end
 
         context 'when only a tab is selected' do


### PR DESCRIPTION
Fixes #4531 

### **Problem**
Consolidated opening reminder emails are duplicated 'randomly'.

Upon further investigation, it was found that there is an error when running the job: `E, [2022-05-20T16:24:34.361733 #1] ERROR -- : [ActiveJob] [ConsolidatedItemEmailJob] [2b647bc1-04fc-4e1d-b216-0333c0920b75] Error performing ConsolidatedItemEmailJob (Job ID: 2b647bc1-04fc-4e1d-b216-0333c0920b75) from Sidekiq(default) in 578162.77ms: NoMethodError (undefined method "regular" for nil:NilClass):
/app/coursemology2/app/models/course/assessment.rb:216:in 'include_in_consolidated_email?'
/app/coursemology2/app/models/course.rb:221:in 'block in upcoming_lesson_plan_items_exist?'`.

The job failure caused retries and hence, the duplicated emails.

We suspect that there's missing email settings for certain assessment categories in course_emails_settings table which is proven to be the case. The missing settings occur when an assessment category object is duplicated. Previously, such case did not handle the creation of the duplicated assessment category.

The reason of the duplication randomness is that there's only a few assessment categories that were created by using object duplication method rather than course duplication. As a result, the email duplication only occurred  when these categories were included in the consolidated opening reminder job.

In this PR, we are now handling the case and a test is also added.

### **Note**
To add, we now only run the job for unexpired courses.
Run bundle exec rake db:add_missing_email_settings in staging and production.