### PR TITLE
fix(course search bar): trim trailing and leading whitespaces for search query

### DIFF
--- a/client/app/bundles/course/courses/components/misc/CourseDisplay.tsx
+++ b/client/app/bundles/course/courses/components/misc/CourseDisplay.tsx
@@ -45,7 +45,9 @@ const CourseDisplay: FC<Props> = (props) => {
     } else {
       setShavedCourses(
         courses.filter((course: CourseMiniEntity) =>
-          course.title.toLowerCase().includes(event.target.value.toLowerCase()),
+          course.title
+            .toLowerCase()
+            .includes(event.target.value.trim().toLowerCase()),
         ),
       );
     }


### PR DESCRIPTION
Closes #4657 