### PR TITLE
chore(circleci test): reduce not output timeout to 10 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
       # Run tests!
       - run:
           name: run
-          no_output_timeout: 30m
+          no_output_timeout: 10m
           command: |
             mkdir /tmp/test-results
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | \


### PR DESCRIPTION
Reduce to 10 minutes as a test now take around 5 minutes to complete