### PR TITLE
Add a feature to skip grading for mrq question type

### DIFF
--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -76,7 +76,7 @@ class Course::Assessment::Question::MultipleResponsesController < Course::Assess
   def multiple_response_question_params
     params.require(:question_multiple_response).permit(
       :title, :description, :staff_only_comments, :maximum_grade, :grading_scheme,
-      :randomize_options, question_assessment: { skill_ids: [] },
+      :randomize_options, :skip_grading, question_assessment: { skill_ids: [] },
                           options_attributes: [:_destroy, :id, :correct, :option,
                                                :explanation, :weight, :ignore_randomization]
     )

--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -84,6 +84,8 @@ class Course::Assessment::Question::MultipleResponse < ApplicationRecord
   private
 
   def validate_multiple_choice_has_solution
+    return true if skip_grading
+
     errors.add(:options, :no_correct_option) if options.select(&:correct?).empty?
   end
 end

--- a/app/services/course/assessment/answer/multiple_response_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/multiple_response_auto_grading_service.rb
@@ -18,6 +18,8 @@ class Course::Assessment::Answer::MultipleResponseAutoGradingService < \
   def evaluate_answer(answer)
     question = answer.question.actable
 
+    return [true, grade_for(question, true), ['']] if question.skip_grading?
+
     if question.any_correct?
       grade_any_correct(question, answer)
     else

--- a/app/views/course/assessment/question/multiple_responses/_form.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_form.html.slim
@@ -8,6 +8,8 @@
 
   = f.hidden_field :grading_scheme
 
+  = f.input :skip_grading, label: t('.skip_grading')
+
   / workaround for plataformatec/simple_form#1284
   div.has-error
     = f.full_error :options
@@ -21,7 +23,7 @@
       tr
         th.reorder
         th = t('.correct')
-        th = t('.option')
+        th.table-option = t('.option')
         th = t('.explanation')
         - if current_course.allow_mrq_options_randomization
           th = t('.ignore_randomization')

--- a/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
+++ b/app/views/course/assessment/question/multiple_responses/_option_fields.html.slim
@@ -2,7 +2,7 @@
   td.reorder.handle.weight
     span = fa_icon 'reorder'.freeze
     = f.hidden_field :weight
-  td = f.input :correct, label: false
+  td.table-option = f.input :correct, label: false
   td = f.input :option, label: false, input_html: { class: ['multiple-response-option', 'airmode', 'no-color-palette'] }
   td
     = f.input :explanation, label: false, placeholder: t('.explanation_hint'),

--- a/client/app/bundles/course/assessment/question/multiple-responses.js
+++ b/client/app/bundles/course/assessment/question/multiple-responses.js
@@ -26,4 +26,26 @@ $(() => {
       updateWeights();
     },
   });
+
+  function rendeTableOptionColumn() {
+    const element = $('#question_multiple_response_skip_grading');
+    if (element && element[0].checked) {
+      $('.table-option').hide();
+    } else {
+      $('.table-option').show();
+    }
+  }
+
+  $(rendeTableOptionColumn);
+
+  $('.question_multiple_response_skip_grading').on('click', () => {
+    rendeTableOptionColumn();
+  });
+
+  // When add_option button is clicked, hide the correct option after it's rendered
+  $('.add_fields').on('click', () => {
+    setTimeout(() => {
+      rendeTableOptionColumn();
+    }, 10);
+  });
 });

--- a/config/locales/en/course/assessment/question/multiple_responses.yml
+++ b/config/locales/en/course/assessment/question/multiple_responses.yml
@@ -30,6 +30,7 @@ en:
             explanation: 'Explanation'
             randomize_options: 'Randomize option order (options that ignore this will be shifted to the bottom)'
             ignore_randomization: 'Ignore Randomization'
+            skip_grading: 'Always grade as correct, as there is no correct or wrong answer.'
             add_option: 'Add Option'
             multiple_choice_button: 'Multiple Choice Question (MCQ)'
             multiple_response_button: 'Multiple Response Question (MRQ)'

--- a/db/migrate/20220701045213_add_skip_grading_to_mrq.rb
+++ b/db/migrate/20220701045213_add_skip_grading_to_mrq.rb
@@ -1,0 +1,5 @@
+class AddSkipGradingToMrq < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_assessment_question_multiple_responses, :skip_grading, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_19_055836) do
+ActiveRecord::Schema.define(version: 2022_07_01_045213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -264,6 +264,7 @@ ActiveRecord::Schema.define(version: 2022_05_19_055836) do
   create_table "course_assessment_question_multiple_responses", id: :serial, force: :cascade do |t|
     t.integer "grading_scheme", default: 0, null: false
     t.boolean "randomize_options", default: false
+    t.boolean "skip_grading", default: false
   end
 
   create_table "course_assessment_question_programming", id: :serial, force: :cascade do |t|

--- a/spec/factories/course_assessment_question_multiple_responses.rb
+++ b/spec/factories/course_assessment_question_multiple_responses.rb
@@ -34,6 +34,10 @@ FactoryBot.define do
       grading_scheme { :any_correct }
     end
 
+    trait :skip_grading do
+      skip_grading { true }
+    end
+
     trait :randomized do
       randomize_options { true }
     end

--- a/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/multiple_response_auto_grading_service_spec.rb
@@ -111,6 +111,98 @@ RSpec.describe Course::Assessment::Answer::MultipleResponseAutoGradingService do
           end
         end
       end
+
+      context 'when the question requires all correct options but grading is skipped' do
+        let(:question_traits) { [:skip_grading] }
+
+        context 'when only the correct answer is selected' do
+          let(:answer_traits) { [:with_all_correct_options] }
+
+          it 'marks the answer correct' do
+            subject.grade(answer)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly('')
+          end
+        end
+
+        context 'when only the wrong answer is selected' do
+          let(:answer_traits) { :with_all_wrong_options }
+
+          it 'marks the answer correct' do
+            subject.grade(answer)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly('')
+          end
+        end
+
+        context 'when the wrong and right answers are selected' do
+          let(:answer_traits) { [:with_all_correct_options, :with_all_wrong_options] }
+
+          it 'marks the answer correct' do
+            subject.grade(answer)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly('')
+          end
+        end
+      end
+
+      context 'when a question requires any correct option but grading is skipped' do
+        let(:question_traits) { [:any_correct, :skip_grading] }
+
+        context 'when only the correct answer is selected' do
+          let(:answer_traits) { :with_all_correct_options }
+
+          it 'marks the answer correct' do
+            subject.grade(answer)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly('')
+          end
+        end
+
+        context 'when only the wrong answer is selected' do
+          let(:answer_traits) { :with_all_wrong_options }
+
+          it 'marks the answer correct' do
+            subject.grade(answer)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly('')
+          end
+        end
+
+        context 'when the wrong and right answers are selected' do
+          let(:answer_traits) { [:with_all_correct_options, :with_all_wrong_options] }
+
+          it 'marks the answer correct' do
+            subject.grade(answer)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly('')
+          end
+        end
+
+        context 'when only one of two right answers is selected' do
+          let(:answer_traits) { :with_one_correct_option }
+
+          it 'marks the answer correct' do
+            subject.grade(answer)
+            expect(answer).to be_correct
+            expect(answer.grade).to eq(question.maximum_grade)
+            expect(grading.result['messages']).
+              to contain_exactly('')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### **Context**

For MCQ/MRQ question types, user would like to have an option to always grade the question as correct when there is no right or wrong answer.

![image](https://user-images.githubusercontent.com/42570513/176834323-34f82e8c-cf95-4ec2-a7a0-2de1fdd82408.png)
![image](https://user-images.githubusercontent.com/42570513/176834338-0d2b74cb-fd7b-48f4-bdfb-d2e512f5e248.png)
