### PR TITLE
Cleanup style on manage users

### DIFF
--- a/client/app/bundles/course/enrol-requests/components/buttons/PendingEnrolRequestsButtons.tsx
+++ b/client/app/bundles/course/enrol-requests/components/buttons/PendingEnrolRequestsButtons.tsx
@@ -13,6 +13,11 @@ import { approveEnrolRequest, rejectEnrolRequest } from '../../operations';
 interface Props extends WrappedComponentProps {
   enrolRequest: EnrolRequestRowData;
 }
+const styles = {
+  buttonStyle: {
+    padding: '0px 8px',
+  },
+};
 
 const translations = defineMessages({
   approveTooltip: {
@@ -100,6 +105,7 @@ const PendingEnrolRequestsButtons: FC<Props> = (props) => {
         className={`enrol-request-approve-${enrolRequest.id}`}
         disabled={isApproving}
         onClick={onApprove}
+        sx={styles.buttonStyle}
       />
       <DeleteButton
         tooltip={intl.formatMessage(translations.rejectTooltip)}
@@ -111,6 +117,7 @@ const PendingEnrolRequestsButtons: FC<Props> = (props) => {
           name: enrolRequest.name,
           email: enrolRequest.email,
         })}
+        sx={styles.buttonStyle}
       />
     </div>
   );

--- a/client/app/bundles/course/user-invitations/components/buttons/PendingInvitationsButtons.tsx
+++ b/client/app/bundles/course/user-invitations/components/buttons/PendingInvitationsButtons.tsx
@@ -13,6 +13,11 @@ import { resendInvitationEmail, deleteInvitation } from '../../operations';
 interface Props extends WrappedComponentProps {
   invitation: InvitationRowData;
 }
+const styles = {
+  buttonStyle: {
+    padding: '0px 8px',
+  },
+};
 
 const translations = defineMessages({
   resendTooltip: {
@@ -100,6 +105,7 @@ const PendingInvitationsButtons: FC<Props> = (props) => {
         className={`invitation-resend-${invitation.id}`}
         disabled={isResending}
         onClick={onResend}
+        sx={styles.buttonStyle}
       />
       <DeleteButton
         tooltip={intl.formatMessage(translations.deletionTooltip)}
@@ -111,6 +117,7 @@ const PendingInvitationsButtons: FC<Props> = (props) => {
           name: invitation.name,
           email: invitation.email,
         })}
+        sx={styles.buttonStyle}
       />
     </div>
   );

--- a/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
+++ b/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
@@ -14,6 +14,12 @@ interface Props extends WrappedComponentProps {
   user: CourseUserRowData;
 }
 
+const styles = {
+  buttonStyle: {
+    padding: '0px 8px',
+  },
+};
+
 const translations = defineMessages({
   deletionSuccess: {
     id: 'course.user.delete.success',
@@ -81,6 +87,7 @@ const UserManagementButtons: FC<Props> = (props) => {
         className={`user-save-${user.id}`}
         disabled={isSaving}
         onClick={(): Promise<void> => onSave(user)}
+        sx={styles.buttonStyle}
       />
       <DeleteButton
         tooltip="Delete User"
@@ -92,6 +99,7 @@ const UserManagementButtons: FC<Props> = (props) => {
           name: user.name,
           email: user.email,
         })}
+        sx={styles.buttonStyle}
       />
     </div>
   );

--- a/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
+++ b/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
@@ -13,11 +13,13 @@ import {
 import * as yup from 'yup';
 import Add from '@mui/icons-material/Add';
 import { LoadingButton } from '@mui/lab';
-import { Grid, TableCell } from '@mui/material';
+import { Grid, TableCell, Tooltip } from '@mui/material';
+import LockOutlined from '@mui/icons-material/LockOutlined';
+import LockOpenOutlined from '@mui/icons-material/LockOpenOutlined';
 import DeleteButton from 'lib/components/buttons/DeleteButton';
 import SaveButton from 'lib/components/buttons/SaveButton';
 import FormDateTimePickerField from 'lib/components/form/fields/DateTimePickerField';
-import FormToggleField from 'lib/components/form/fields/ToggleField';
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import {
   defineMessages,
   FormattedMessage,
@@ -32,6 +34,12 @@ import { deletePersonalTime, updatePersonalTime } from '../../operations';
 interface Props extends WrappedComponentProps {
   item: PersonalTimeMiniEntity;
 }
+
+const styles = {
+  buttonStyle: {
+    padding: '0px 8px',
+  },
+};
 
 interface IFormInputs {
   fixed: boolean;
@@ -81,6 +89,12 @@ const translations = defineMessages({
   startEndValidationError: {
     id: 'course.users.components.misc.PersonalTimeEditor.error.startEndValidation',
     defaultMessage: 'Must be after start time',
+  },
+  fixedDescription: {
+    id: 'course.users.personalTimes.table.fixed.description',
+    defaultMessage:
+      "A fixed personal time means that the personal time will no longer be automatically modified. If a personal\
+    time is left unfixed, it may be dynamically updated by the algorithm on the user's next submission.",
   },
 });
 
@@ -152,7 +166,7 @@ const PersonalTimeEditor: FC<Props> = (props) => {
     return dispatch(updatePersonalTime(data, +userId!))
       .then(() => {})
       .finally(() => {
-        setIsSaving(false);
+        reset(item);
         if (item.new) {
           toast.success(
             intl.formatMessage(translations.createSuccess, {
@@ -195,15 +209,26 @@ const PersonalTimeEditor: FC<Props> = (props) => {
         </TableCell>
       ) : (
         <>
-          <TableCell>
-            <Controller
-              name="fixed"
-              control={control}
-              render={({ field, fieldState }): JSX.Element => (
-                <FormToggleField field={field} fieldState={fieldState} />
-              )}
-            />
-          </TableCell>
+          <Tooltip
+            title={intl.formatMessage(translations.fixedDescription)}
+            placement="top"
+            arrow
+          >
+            <TableCell>
+              <Controller
+                name="fixed"
+                control={control}
+                render={({ field, fieldState }): JSX.Element => (
+                  <FormCheckboxField
+                    field={field}
+                    fieldState={fieldState}
+                    icon={<LockOpenOutlined />}
+                    checkedIcon={<LockOutlined />}
+                  />
+                )}
+              />
+            </TableCell>
+          </Tooltip>
           <TableCell>
             <Controller
               name="startAt"
@@ -256,6 +281,7 @@ const PersonalTimeEditor: FC<Props> = (props) => {
                 form={`personal-time-form-${item.personalTimeId}`}
                 type="submit"
                 size="small"
+                sx={styles.buttonStyle}
               />
               <DeleteButton
                 tooltip={intl.formatMessage(translations.delete)}
@@ -269,6 +295,7 @@ const PersonalTimeEditor: FC<Props> = (props) => {
                       })
                 }
                 size="small"
+                sx={styles.buttonStyle}
               />
               <form
                 encType="multipart/form-data"

--- a/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
+++ b/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
@@ -115,7 +115,13 @@ const PersonalTimeEditor: FC<Props> = (props) => {
     bonusEndAt: item.personalBonusEndAt,
     endAt: item.personalEndAt,
   };
-  const { control, handleSubmit, setError, reset } = useForm<IFormInputs>({
+  const {
+    control,
+    handleSubmit,
+    setError,
+    reset,
+    formState: { isDirty },
+  } = useForm<IFormInputs>({
     defaultValues: initialValues,
     resolver: yupResolver(validationSchema),
   });
@@ -166,7 +172,8 @@ const PersonalTimeEditor: FC<Props> = (props) => {
     return dispatch(updatePersonalTime(data, +userId!))
       .then(() => {})
       .finally(() => {
-        reset(item);
+        reset(formData);
+        setIsSaving(false);
         if (item.new) {
           toast.success(
             intl.formatMessage(translations.createSuccess, {
@@ -273,16 +280,18 @@ const PersonalTimeEditor: FC<Props> = (props) => {
                   />
                 )}
               />
-              <SaveButton
-                tooltip={intl.formatMessage(translations.update)}
-                disabled={isSaving || isDeleting}
-                onClick={(): UseFormHandleSubmit<IFormInputs> => handleSubmit}
-                className="btn-submit"
-                form={`personal-time-form-${item.personalTimeId}`}
-                type="submit"
-                size="small"
-                sx={styles.buttonStyle}
-              />
+              {isDirty && (
+                <SaveButton
+                  tooltip={intl.formatMessage(translations.update)}
+                  disabled={isSaving || isDeleting}
+                  onClick={(): UseFormHandleSubmit<IFormInputs> => handleSubmit}
+                  className="btn-submit"
+                  form={`personal-time-form-${item.id}-${item.personalTimeId}`}
+                  type="submit"
+                  size="small"
+                  sx={styles.buttonStyle}
+                />
+              )}
               <DeleteButton
                 tooltip={intl.formatMessage(translations.delete)}
                 disabled={isSaving || isDeleting}
@@ -299,7 +308,7 @@ const PersonalTimeEditor: FC<Props> = (props) => {
               />
               <form
                 encType="multipart/form-data"
-                id={`personal-time-form-${item.personalTimeId}`}
+                id={`personal-time-form-${item.id}-${item.personalTimeId}`}
                 noValidate
                 onSubmit={handleSubmit((data) => onSubmit(data, setError))}
               />

--- a/client/app/bundles/course/users/components/tables/PersonalTimesTable.tsx
+++ b/client/app/bundles/course/users/components/tables/PersonalTimesTable.tsx
@@ -7,7 +7,6 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  Tooltip,
 } from '@mui/material';
 import { FC } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
@@ -16,7 +15,6 @@ import tableTranslations from 'lib/components/tables/translations';
 import { getAssessmentURL, getVideoURL } from 'lib/helpers/url-builders';
 import sharedConstants from 'lib/constants/sharedConstants';
 import { getCourseId } from 'lib/helpers/url-helpers';
-import Lock from '@mui/icons-material/Lock';
 import PersonalTimeEditor from '../misc/PersonalTimeEditor';
 
 interface Props extends WrappedComponentProps {
@@ -24,11 +22,9 @@ interface Props extends WrappedComponentProps {
 }
 
 const translations = defineMessages({
-  fixedDescription: {
-    id: 'course.users.personalTimes.table.fixed.description',
-    defaultMessage:
-      "A fixed personal time means that the personal time will no longer be automatically modified. If a personal\
-    time is left unfixed, it may be dynamically updated by the algorithm on the user's next submission.",
+  fixed: {
+    id: 'course.users.personalTimes.table.fixed',
+    defaultMessage: 'Fixed',
   },
 });
 
@@ -103,7 +99,7 @@ const PersonalTimesTable: FC<Props> = (props) => {
                 {intl.formatMessage(tableTranslations.referenceTimeline)}
               </TableCell>
               <TableCell colSpan={4}>
-                {intl.formatMessage(tableTranslations.personalizedTimeline)}e
+                {intl.formatMessage(tableTranslations.personalizedTimeline)}
               </TableCell>
             </TableRow>
             <TableRow>
@@ -119,15 +115,7 @@ const PersonalTimesTable: FC<Props> = (props) => {
               <TableCell>
                 {intl.formatMessage(tableTranslations.endAt)}
               </TableCell>
-              <TableCell align="center">
-                <Tooltip
-                  title={intl.formatMessage(translations.fixedDescription)}
-                  placement="top"
-                  arrow
-                >
-                  <Lock fontSize="small" />
-                </Tooltip>
-              </TableCell>
+              <TableCell>{intl.formatMessage(translations.fixed)}</TableCell>
               <TableCell>
                 {intl.formatMessage(tableTranslations.startAt)}
               </TableCell>

--- a/client/app/bundles/course/users/components/tables/PersonalTimesTable.tsx
+++ b/client/app/bundles/course/users/components/tables/PersonalTimesTable.tsx
@@ -83,7 +83,10 @@ const PersonalTimesTable: FC<Props> = (props) => {
         <TableCell>{item.itemStartAt}</TableCell>
         <TableCell>{item.itemBonusEndAt}</TableCell>
         <TableCell>{item.itemEndAt}</TableCell>
-        <PersonalTimeEditor item={item} />
+        <PersonalTimeEditor
+          key={`personal-time-editor-${item.id}`}
+          item={item}
+        />
       </TableRow>
     );
   };

--- a/client/app/lib/components/form/fields/CheckboxField.jsx
+++ b/client/app/lib/components/form/fields/CheckboxField.jsx
@@ -1,0 +1,80 @@
+import { memo } from 'react';
+import PropTypes from 'prop-types';
+import { Checkbox, FormControlLabel, FormHelperText } from '@mui/material';
+import { formatErrorMessage } from './utils/mapError';
+import propsAreEqual from './utils/propsAreEqual';
+
+const styles = {
+  checkboxContainer: {
+    width: '100%',
+  },
+  checkbox: {
+    margin: '-4px 0px 0px 0px',
+    padding: '2px',
+  },
+  checkboxStyle: {
+    marginLeft: '0px',
+  },
+  errorText: { margin: 0 },
+};
+
+const FormCheckboxField = (props) => {
+  const {
+    field,
+    fieldState,
+    disabled,
+    label,
+    renderIf,
+    icon,
+    checkedIcon,
+    ...custom
+  } = props;
+  const isError = !!fieldState.error;
+  if (!renderIf) {
+    return null;
+  }
+
+  return (
+    <div style={styles.checkboxContainer}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            {...field}
+            checked={field.value}
+            color="primary"
+            onChange={field.onChange}
+            style={styles.checkbox}
+            icon={icon}
+            checkedIcon={checkedIcon}
+          />
+        }
+        disabled={disabled}
+        label={<b>{label}</b>}
+        labelPlacement="start"
+        style={styles.checkboxStyle}
+        {...custom}
+      />
+      {isError && (
+        <FormHelperText error={isError} style={styles.errorText}>
+          {formatErrorMessage(fieldState.error.message)}
+        </FormHelperText>
+      )}
+    </div>
+  );
+};
+
+FormCheckboxField.defaultProps = {
+  renderIf: true,
+};
+
+FormCheckboxField.propTypes = {
+  field: PropTypes.object.isRequired,
+  fieldState: PropTypes.object.isRequired,
+  disabled: PropTypes.bool,
+  label: PropTypes.node,
+  renderIf: PropTypes.bool,
+  icon: PropTypes.element,
+  checkedIcon: PropTypes.element,
+};
+
+export default memo(FormCheckboxField, propsAreEqual);

--- a/client/app/lib/components/form/fields/CheckboxField.tsx
+++ b/client/app/lib/components/form/fields/CheckboxField.tsx
@@ -18,7 +18,7 @@ const styles = {
   errorText: { margin: 0 },
 };
 
-const FormCheckboxField = (props) => {
+const FormCheckboxField = (props): JSX.Element => {
   const {
     field,
     fieldState,
@@ -31,7 +31,7 @@ const FormCheckboxField = (props) => {
   } = props;
   const isError = !!fieldState.error;
   if (!renderIf) {
-    return null;
+    return <></>;
   }
 
   return (

--- a/client/app/lib/components/form/fields/CheckboxField.tsx
+++ b/client/app/lib/components/form/fields/CheckboxField.tsx
@@ -1,8 +1,20 @@
-import { memo } from 'react';
-import PropTypes from 'prop-types';
+import { FC, memo } from 'react';
 import { Checkbox, FormControlLabel, FormHelperText } from '@mui/material';
+import { ControllerFieldState } from 'react-hook-form';
 import { formatErrorMessage } from './utils/mapError';
 import propsAreEqual from './utils/propsAreEqual';
+
+interface Props {
+  // react-hook-form ControllerRenderProps requires generics for field
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  field: any;
+  fieldState: ControllerFieldState;
+  disabled?: boolean;
+  label?: JSX.Element;
+  renderIf?: boolean;
+  icon?: JSX.Element;
+  checkedIcon?: JSX.Element;
+}
 
 const styles = {
   checkboxContainer: {
@@ -18,13 +30,13 @@ const styles = {
   errorText: { margin: 0 },
 };
 
-const FormCheckboxField = (props): JSX.Element => {
+const FormCheckboxField: FC<Props> = (props) => {
   const {
     field,
     fieldState,
     disabled,
     label,
-    renderIf,
+    renderIf = true,
     icon,
     checkedIcon,
     ...custom
@@ -56,25 +68,11 @@ const FormCheckboxField = (props): JSX.Element => {
       />
       {isError && (
         <FormHelperText error={isError} style={styles.errorText}>
-          {formatErrorMessage(fieldState.error.message)}
+          {formatErrorMessage(fieldState.error?.message)}
         </FormHelperText>
       )}
     </div>
   );
-};
-
-FormCheckboxField.defaultProps = {
-  renderIf: true,
-};
-
-FormCheckboxField.propTypes = {
-  field: PropTypes.object.isRequired,
-  fieldState: PropTypes.object.isRequired,
-  disabled: PropTypes.bool,
-  label: PropTypes.node,
-  renderIf: PropTypes.bool,
-  icon: PropTypes.element,
-  checkedIcon: PropTypes.element,
 };
 
 export default memo(FormCheckboxField, propsAreEqual);

--- a/client/app/lib/components/form/fields/DataTableInlineEditable/TextField.tsx
+++ b/client/app/lib/components/form/fields/DataTableInlineEditable/TextField.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { TextField } from '@mui/material';
 
 const styles = {
-  textFieldStyle: { margin: '8px 10px 8px 0px', width: '100%' },
+  textFieldStyle: { margin: '0px 10px 0px 0px', width: '100%' },
 };
 
 const InlineEditTextField = (props): JSX.Element | null => {

--- a/client/app/lib/components/form/fields/DateTimePickerField.jsx
+++ b/client/app/lib/components/form/fields/DateTimePickerField.jsx
@@ -25,6 +25,11 @@ const styles = {
   dateTimeTextField: {
     marginRight: 5,
   },
+  dialogStyle: {
+    '.MuiDialog-paper': {
+      overflowY: 'visible',
+    },
+  },
 };
 
 const onChangeDateTime = (newDateTime, onChange, afterChangeField) => {
@@ -60,6 +65,7 @@ const FormDateTimePickerField = (props) => {
         <MuiDateTimePicker
           {...field}
           ampm={false}
+          DialogProps={{ sx: styles.dialogStyle }}
           clearable
           disabled={disabled}
           inputFormat="DD-MM-YYYY HH:mm"

--- a/client/app/lib/components/form/fields/utils/mapError.js
+++ b/client/app/lib/components/form/fields/utils/mapError.js
@@ -7,7 +7,7 @@
  *   3) An object - { id: 'translations.module.id', defaultMessage: [{ id: 0, value: 'Translated Error'}] }
  * @param intl
  */
-export const formatErrorMessage = (errorOrWarning, intl) => {
+export const formatErrorMessage = (errorOrWarning, intl = false) => {
   if (!errorOrWarning || typeof errorOrWarning === 'string') {
     return errorOrWarning;
   }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -79,9 +79,7 @@ module Capybara::TestGroupHelpers
     # to ensure certain changes are made before continuing with the tests.
     # NOTE: if there is more than one toast visible, the search will only return the first toast
     def expect_toastify(message)
-      # byebug
       expect(page.find('div.Toastify__toast-body').text).to eq(message)
-      # expect(page).to have_content(message)
     end
   end
 end


### PR DESCRIPTION
As per @cysjonathan suggestions:
1. Reduce height of datatable rows (Manage Users, Enrol Requests, User Invitations)
2. Improve clarity of fixed personalized timeline toggle

**New**
- Save button only shown when values are changed/can be saved
- Tooltip on every row to explain fixed personalized timeline toggle
![image](https://user-images.githubusercontent.com/9080974/177259349-3db5a574-edd2-43d1-952d-bb0579a06d52.png)

**Old**
![image](https://user-images.githubusercontent.com/9080974/177241046-359bb89e-a6bd-493f-bb29-8262633af2bc.png)
