### PR TITLE
Refactor Leaderboard page UI

### DIFF
--- a/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
+++ b/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
@@ -85,7 +85,6 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
   const [maxAvatars, setMaxAvatars] = useState(6);
 
   useEffect(() => {
-    console.log(`phone: ${phoneView}, tablet: ${tabletView}`);
     if (phoneView) {
       setMaxAvatars(2);
     } else if (tabletView) {

--- a/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
+++ b/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
@@ -70,10 +70,10 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         filter: false,
         sort: false,
         setCellHeaderProps: () => ({
-          style: { padding: '16px', textAlign: 'center'},
+          style: { padding: '16px', textAlign: 'center' },
         }),
         setCellProps: () => ({
-          style: { textAlign: 'center', maxWidth: '50px' }
+          style: { textAlign: 'center', maxWidth: '50px' },
         }),
         customBodyRenderLite: (dataIndex) => dataIndex + 1,
       },
@@ -91,7 +91,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         filter: false,
         sort: false,
         setCellProps: () => ({
-          style: { width: '100%' }
+          style: { width: '100%' },
         }),
         setCellHeaderProps: () => ({
           style: { padding: '0px' },
@@ -139,13 +139,9 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
             style: { padding: '0px', textAlign: 'center' },
           }),
           setCellProps: () => ({
-            style: { textAlign: 'center' }
+            style: { textAlign: 'center' },
           }),
-          customBodyRenderLite: (dataIndex) => (
-            <Box>
-              {pointData[dataIndex].level}
-            </Box>
-          ),
+          customBodyRenderLite: (dataIndex) => pointData[dataIndex].level,
         },
       },
       {
@@ -158,13 +154,9 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
             style: { padding: '16px', textAlign: 'center' },
           }),
           setCellProps: () => ({
-            style: { textAlign: 'center' }
+            style: { textAlign: 'center' },
           }),
-          customBodyRenderLite: (dataIndex) => (
-            <Box>
-              {pointData[dataIndex].experience.toString()}
-            </Box>
-          ),
+          customBodyRenderLite: (dataIndex) => pointData[dataIndex].experience,
         },
       },
     );
@@ -292,7 +284,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         sort: false,
         alignCenter: true,
         justifyCenter: true,
-        customHeadLabelRender: () => (<><div>Average</div><div>Experience</div></>),
+        customHeadLabelRender: () => (
+          <>
+            <div>Average</div>
+            <div>Experience</div>
+          </>
+        ),
         customBodyRenderLite: (_dataIndex: number) =>
           groupPointData[_dataIndex].averageExperiencePoints.toFixed(2),
       },
@@ -309,7 +306,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         sort: false,
         alignCenter: true,
         justifyCenter: true,
-        customHeadLabelRender: () => (<><div>Average</div><div>Achievements</div></>),
+        customHeadLabelRender: () => (
+          <>
+            <div>Average</div>
+            <div>Achievements</div>
+          </>
+        ),
         customBodyRenderLite: (_dataIndex: number) =>
           groupAchievementData[_dataIndex].averageAchievementCount.toFixed(2),
       },
@@ -362,7 +364,17 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
 
   // Update columns based on table type
   updateColumns();
-  return <DataTable data={data} options={options} columns={columns} title={title} titleGrid titleAlignCenter padding="0px" />;
+  return (
+    <DataTable
+      data={data}
+      options={options}
+      columns={columns}
+      title={title}
+      titleGrid
+      titleAlignCenter
+      padding="0px"
+    />
+  );
 };
 
 export default memo(

--- a/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
+++ b/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
@@ -36,7 +36,7 @@ const translations = defineMessages({
 const styles = {
   title: {
     flexDirection: 'column',
-    textAlign: 'right',
+    textAlign: 'center',
     fontSize: 20,
   },
   link: {
@@ -53,7 +53,7 @@ const styles = {
   avatar: {
     maxWidth: '250px',
     wordWrap: 'break-word',
-    display: 'inline-flex',
+    display: 'flex',
     alignItems: 'center',
     minWidth: '150px',
   },
@@ -69,8 +69,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
       options: {
         filter: false,
         sort: false,
-        alignCenter: true,
-        justifyCenter: true,
+        setCellHeaderProps: () => ({
+          style: { padding: '16px', textAlign: 'center'},
+        }),
+        setCellProps: () => ({
+          style: { textAlign: 'center', maxWidth: '50px' }
+        }),
         customBodyRenderLite: (dataIndex) => dataIndex + 1,
       },
     },
@@ -86,8 +90,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
       options: {
         filter: false,
         sort: false,
-        alignLeft: true,
-        justifyCenter: true,
+        setCellProps: () => ({
+          style: { width: '100%' }
+        }),
+        setCellHeaderProps: () => ({
+          style: { padding: '0px' },
+        }),
         customBodyRenderLite: (dataIndex) => (
           <Box
             sx={styles.avatar}
@@ -127,9 +135,17 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         options: {
           filter: false,
           sort: false,
-          alignCenter: true,
-          justifyCenter: true,
-          customBodyRenderLite: (dataIndex) => pointData[dataIndex].level,
+          setCellHeaderProps: () => ({
+            style: { padding: '0px', textAlign: 'center' },
+          }),
+          setCellProps: () => ({
+            style: { textAlign: 'center' }
+          }),
+          customBodyRenderLite: (dataIndex) => (
+            <Box>
+              {pointData[dataIndex].level}
+            </Box>
+          ),
         },
       },
       {
@@ -138,9 +154,17 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         options: {
           filter: false,
           sort: false,
-          alignCenter: true,
-          justifyCenter: true,
-          customBodyRenderLite: (dataIndex) => pointData[dataIndex].experience,
+          setCellHeaderProps: () => ({
+            style: { padding: '16px', textAlign: 'center' },
+          }),
+          setCellProps: () => ({
+            style: { textAlign: 'center' }
+          }),
+          customBodyRenderLite: (dataIndex) => (
+            <Box>
+              {pointData[dataIndex].experience.toString()}
+            </Box>
+          ),
         },
       },
     );
@@ -156,6 +180,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         sort: false,
         alignLeft: true,
         justifyCenter: true,
+        setCellHeaderProps: () => ({
+          style: { padding: '0px 16px 0px 1px' },
+        }),
+        setCellProps: () => ({
+          style: { padding: '0px 16px 0px 0px' },
+        }),
         customBodyRenderLite: (dataIndex) => (
           <AvatarGroup
             total={achievementData[dataIndex].achievementCount}
@@ -204,8 +234,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         options: {
           filter: false,
           sort: false,
-          alignCenter: true,
-          justifyCenter: true,
+          setCellHeaderProps: () => ({
+            style: { padding: '0px 16px 0px 1px', minWidth: '80px' },
+          }),
+          setCellProps: () => ({
+            style: { padding: '0px 16px 0px 0px', minWidth: '80px' },
+          }),
           customBodyRenderLite: (dataIndex) => (
             <Box className="group" id={`group_${groupData[dataIndex].id}`}>
               {groupData[dataIndex].name}
@@ -219,8 +253,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         options: {
           filter: false,
           sort: false,
-          alignLeft: true,
-          justifyCenter: true,
+          setCellHeaderProps: () => ({
+            style: { padding: '0px 16px 0px 1px', width: '100%' },
+          }),
+          setCellProps: () => ({
+            style: { padding: '0px 16px 0px 0px', width: '100%' },
+          }),
           customBodyRenderLite: (dataIndex) => (
             <AvatarGroup
               total={groupData[dataIndex].group.length}
@@ -254,8 +292,9 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         sort: false,
         alignCenter: true,
         justifyCenter: true,
-        customBodyRenderLite: (dataIndex) =>
-          groupPointData[dataIndex].averageExperiencePoints.toFixed(2),
+        customHeadLabelRender: () => (<><div>Average</div><div>Experience</div></>),
+        customBodyRenderLite: (_dataIndex: number) =>
+          groupPointData[_dataIndex].averageExperiencePoints.toFixed(2),
       },
     });
   };
@@ -270,8 +309,9 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         sort: false,
         alignCenter: true,
         justifyCenter: true,
-        customBodyRenderLite: (dataIndex) =>
-          groupAchievementData[dataIndex].averageAchievementCount.toFixed(2),
+        customHeadLabelRender: () => (<><div>Average</div><div>Achievements</div></>),
+        customBodyRenderLite: (_dataIndex: number) =>
+          groupAchievementData[_dataIndex].averageAchievementCount.toFixed(2),
       },
     });
   };
@@ -322,9 +362,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
 
   // Update columns based on table type
   updateColumns();
-  return (
-    <DataTable data={data} options={options} columns={columns} title={title} />
-  );
+  return <DataTable data={data} options={options} columns={columns} title={title} titleGrid titleAlignCenter padding="0px" />;
 };
 
 export default memo(

--- a/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
+++ b/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
@@ -80,11 +80,12 @@ const styles = {
 
 const LeaderboardTable: FC<Props> = (props: Props) => {
   const { data, id: tableType } = props;
-  const tabletView = !useMediaQuery('(min-width:600px)');
-  const phoneView = !useMediaQuery('(min-width:450px)');
+  const tabletView = useMediaQuery('(max-width:600px)');
+  const phoneView = useMediaQuery('(max-width:450px)');
   const [maxAvatars, setMaxAvatars] = useState(6);
 
   useEffect(() => {
+    console.log(`phone: ${phoneView}, tablet: ${tabletView}`);
     if (phoneView) {
       setMaxAvatars(2);
     } else if (tabletView) {

--- a/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
+++ b/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
@@ -1,7 +1,14 @@
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { Avatar, AvatarGroup, Box, Link, Tooltip } from '@mui/material';
+import {
+  Avatar,
+  AvatarGroup,
+  Box,
+  Link,
+  Tooltip,
+  useMediaQuery,
+} from '@mui/material';
 import DataTable from 'lib/components/DataTable';
-import { FC, memo } from 'react';
+import { FC, memo, useEffect, useState } from 'react';
 import {
   GroupLeaderboardAchievement,
   GroupLeaderboardPoints,
@@ -30,6 +37,18 @@ const translations = defineMessages({
   titleAchievements: {
     id: 'course.leaderboard.components.LeaderboardTable.titleAcheivements',
     defaultMessage: 'By Achievements',
+  },
+  average: {
+    id: 'course.leaderboard.components.LeaderboardTable.average',
+    defaultMessage: 'Average',
+  },
+  experience: {
+    id: 'course.leaderboard.components.LeaderboardTable.experience',
+    defaultMessage: 'Experience',
+  },
+  achievements: {
+    id: 'course.leaderboard.components.LeaderboardTable.achievements',
+    defaultMessage: 'Achievements',
   },
 });
 
@@ -61,6 +80,19 @@ const styles = {
 
 const LeaderboardTable: FC<Props> = (props: Props) => {
   const { data, id: tableType } = props;
+  const tabletView = !useMediaQuery('(min-width:600px)');
+  const phoneView = !useMediaQuery('(min-width:450px)');
+  const [maxAvatars, setMaxAvatars] = useState(6);
+
+  useEffect(() => {
+    if (phoneView) {
+      setMaxAvatars(2);
+    } else if (tabletView) {
+      setMaxAvatars(4);
+    } else {
+      setMaxAvatars(6);
+    }
+  }, [phoneView, tabletView]);
 
   const columns: TableColumns[] = [
     {
@@ -181,7 +213,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         customBodyRenderLite: (dataIndex) => (
           <AvatarGroup
             total={achievementData[dataIndex].achievementCount}
-            max={6}
+            max={maxAvatars}
             sx={styles.avatarGroup}
             componentsProps={{
               additionalAvatar: {
@@ -254,7 +286,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
           customBodyRenderLite: (dataIndex) => (
             <AvatarGroup
               total={groupData[dataIndex].group.length}
-              max={6}
+              max={maxAvatars}
               sx={styles.avatarGroup}
             >
               {groupData[dataIndex].group.map((user) => (
@@ -286,8 +318,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         justifyCenter: true,
         customHeadLabelRender: () => (
           <>
-            <div>Average</div>
-            <div>Experience</div>
+            <div>
+              <FormattedMessage {...translations.average} />
+            </div>
+            <div>
+              <FormattedMessage {...translations.experience} />
+            </div>
           </>
         ),
         customBodyRenderLite: (_dataIndex: number) =>
@@ -308,8 +344,12 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
         justifyCenter: true,
         customHeadLabelRender: () => (
           <>
-            <div>Average</div>
-            <div>Achievements</div>
+            <div>
+              <FormattedMessage {...translations.average} />
+            </div>
+            <div>
+              <FormattedMessage {...translations.achievements} />
+            </div>
           </>
         ),
         customBodyRenderLite: (_dataIndex: number) =>

--- a/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
+++ b/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
@@ -55,7 +55,7 @@ const LeaderboardIndex: FC<Props> = (props) => {
   const { intl } = props;
   const dispatch = useDispatch<AppDispatch>();
   const theme = useTheme();
-  const tabView = !useMediaQuery(theme.breakpoints.up('lg'));
+  const tabView = useMediaQuery(theme.breakpoints.down('lg'));
   const [isLoading, setIsLoading] = useState(true);
   const [tabValue, setTabValue] = useState('leaderboard-tab');
   const [innerTabValue, setInnerTabValue] = useState('experience-tab');

--- a/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
+++ b/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
@@ -14,6 +14,7 @@ import LoadingIndicator from 'lib/components/LoadingIndicator';
 import PageHeader from 'lib/components/pages/PageHeader';
 import { Grid, Tab, Tabs, useMediaQuery, useTheme } from '@mui/material';
 import palette from 'theme/palette';
+import { AutoFixHigh, EmojiEvents } from '@mui/icons-material';
 import fetchLeaderboard from '../../operations';
 import LeaderboardTable from '../../components/tables/LeaderboardTable';
 import {
@@ -24,7 +25,6 @@ import {
   getLeaderboardSettings,
 } from '../../selectors';
 import { LeaderboardTableType } from '../../types';
-import { AutoFixHigh, EmojiEvents } from '@mui/icons-material';
 
 type Props = WrappedComponentProps;
 
@@ -187,14 +187,15 @@ const LeaderboardIndex: FC<Props> = (props) => {
             />
           </Grid>
         )}
-        {!isAchievementHidden && (!tabView || innerTabValue === 'achievement-tab') && (
-          <Grid item xs id="leaderboard-achievement">
-            <LeaderboardTable
-              data={leaderboardAchievements}
-              id={LeaderboardTableType.LeaderboardAchievement}
-            />
-          </Grid>
-        )}
+        {!isAchievementHidden &&
+          (!tabView || innerTabValue === 'achievement-tab') && (
+            <Grid item xs id="leaderboard-achievement">
+              <LeaderboardTable
+                data={leaderboardAchievements}
+                id={LeaderboardTableType.LeaderboardAchievement}
+              />
+            </Grid>
+          )}
       </Grid>
       <Grid
         container
@@ -211,14 +212,15 @@ const LeaderboardIndex: FC<Props> = (props) => {
             />
           </Grid>
         )}
-        {!isAchievementHidden && (!tabView || innerTabValue === 'achievement-tab') && (
-          <Grid item xs id="group-leaderboard-achievement">
-            <LeaderboardTable
-              data={groupLeaderboardAchievements}
-              id={LeaderboardTableType.GroupLeaderboardAchievement}
-            />
-          </Grid>
-        )}
+        {!isAchievementHidden &&
+          (!tabView || innerTabValue === 'achievement-tab') && (
+            <Grid item xs id="group-leaderboard-achievement">
+              <LeaderboardTable
+                data={groupLeaderboardAchievements}
+                id={LeaderboardTableType.GroupLeaderboardAchievement}
+              />
+            </Grid>
+          )}
       </Grid>
     </>
   );

--- a/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
+++ b/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
@@ -58,7 +58,7 @@ const LeaderboardIndex: FC<Props> = (props) => {
   const tabView = useMediaQuery(theme.breakpoints.down('lg'));
   const [isLoading, setIsLoading] = useState(true);
   const [tabValue, setTabValue] = useState('leaderboard-tab');
-  const [innerTabValue, setInnerTabValue] = useState('experience-tab');
+  const [innerTabValue, setInnerTabValue] = useState('points-tab');
   const settings = useSelector((state: AppState) =>
     getLeaderboardSettings(state),
   );
@@ -149,7 +149,7 @@ const LeaderboardIndex: FC<Props> = (props) => {
           sx={{ marginBottom: 2 }}
         >
           <Tab
-            id="experience-tab"
+            id="points-tab"
             style={{ color: palette.submissionIcon.person }}
             icon={<AutoFixHigh />}
             label={
@@ -157,7 +157,7 @@ const LeaderboardIndex: FC<Props> = (props) => {
                 <FormattedMessage {...translations.experience} />
               )
             }
-            value="experience-tab"
+            value="points-tab"
           />
           <Tab
             id="achievement-tab"
@@ -179,7 +179,7 @@ const LeaderboardIndex: FC<Props> = (props) => {
         rowSpacing={2}
         display={tabValue === 'leaderboard-tab' ? 'flex' : 'none'}
       >
-        {(!tabView || innerTabValue === 'experience-tab') && (
+        {(!tabView || innerTabValue === 'points-tab') && (
           <Grid item xs id="leaderboard-level">
             <LeaderboardTable
               data={leaderboardPoints}
@@ -204,7 +204,7 @@ const LeaderboardIndex: FC<Props> = (props) => {
         rowSpacing={2}
         display={tabValue !== 'leaderboard-tab' ? 'flex' : 'none'}
       >
-        {(!tabView || innerTabValue === 'experience-tab') && (
+        {(!tabView || innerTabValue === 'points-tab') && (
           <Grid item xs id="group-leaderboard-level">
             <LeaderboardTable
               data={groupLeaderboardPoints}

--- a/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
+++ b/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
@@ -12,7 +12,7 @@ import Person from '@mui/icons-material/Person';
 import { toast } from 'react-toastify';
 import LoadingIndicator from 'lib/components/LoadingIndicator';
 import PageHeader from 'lib/components/pages/PageHeader';
-import { Grid, Tab, Tabs } from '@mui/material';
+import { Grid, Tab, Tabs, useMediaQuery, useTheme } from '@mui/material';
 import palette from 'theme/palette';
 import fetchLeaderboard from '../../operations';
 import LeaderboardTable from '../../components/tables/LeaderboardTable';
@@ -24,6 +24,7 @@ import {
   getLeaderboardSettings,
 } from '../../selectors';
 import { LeaderboardTableType } from '../../types';
+import { AutoFixHigh, EmojiEvents } from '@mui/icons-material';
 
 type Props = WrappedComponentProps;
 
@@ -40,13 +41,24 @@ const translations = defineMessages({
     id: 'course.leaderboards.index.groupLeaderboard',
     defaultMessage: 'Group Leaderboard',
   },
+  experience: {
+    id: 'course.leaderboards.index.leaderboard',
+    defaultMessage: 'By Experience Points',
+  },
+  achievemnt: {
+    id: 'course.leaderboards.index.groupLeaderboard',
+    defaultMessage: 'By Achievements',
+  },
 });
 
 const LeaderboardIndex: FC<Props> = (props) => {
   const { intl } = props;
   const dispatch = useDispatch<AppDispatch>();
+  const theme = useTheme();
+  const tabView = !useMediaQuery(theme.breakpoints.up('lg'));
   const [isLoading, setIsLoading] = useState(true);
   const [tabValue, setTabValue] = useState('leaderboard-tab');
+  const [innerTabValue, setInnerTabValue] = useState('experience-tab');
   const settings = useSelector((state: AppState) =>
     getLeaderboardSettings(state),
   );
@@ -123,6 +135,43 @@ const LeaderboardIndex: FC<Props> = (props) => {
           />
         </Tabs>
       )}
+      {tabView && (
+        <Tabs
+          onChange={(_, value): void => {
+            setInnerTabValue(value);
+          }}
+          style={{
+            backgroundColor: palette.background.default,
+          }}
+          TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
+          value={innerTabValue}
+          variant="fullWidth"
+          sx={{ marginBottom: 2 }}
+        >
+          <Tab
+            id="experience-tab"
+            style={{ color: palette.submissionIcon.person }}
+            icon={<AutoFixHigh />}
+            label={
+              settings.leaderboardTitle ?? (
+                <FormattedMessage {...translations.experience} />
+              )
+            }
+            value="experience-tab"
+          />
+          <Tab
+            id="achievement-tab"
+            style={{ color: palette.submissionIcon.person }}
+            icon={<EmojiEvents />}
+            label={
+              settings.groupleaderboardTitle ?? (
+                <FormattedMessage {...translations.achievemnt} />
+              )
+            }
+            value="achievement-tab"
+          />
+        </Tabs>
+      )}
       <Grid
         container
         direction="row"
@@ -130,13 +179,15 @@ const LeaderboardIndex: FC<Props> = (props) => {
         rowSpacing={2}
         display={tabValue === 'leaderboard-tab' ? 'flex' : 'none'}
       >
-        <Grid item xs id="leaderboard-level">
-          <LeaderboardTable
-            data={leaderboardPoints}
-            id={LeaderboardTableType.LeaderboardPoints}
-          />
-        </Grid>
-        {!isAchievementHidden && (
+        {(!tabView || innerTabValue === 'experience-tab') && (
+          <Grid item xs id="leaderboard-level">
+            <LeaderboardTable
+              data={leaderboardPoints}
+              id={LeaderboardTableType.LeaderboardPoints}
+            />
+          </Grid>
+        )}
+        {!isAchievementHidden && (!tabView || innerTabValue === 'achievement-tab') && (
           <Grid item xs id="leaderboard-achievement">
             <LeaderboardTable
               data={leaderboardAchievements}
@@ -152,13 +203,15 @@ const LeaderboardIndex: FC<Props> = (props) => {
         rowSpacing={2}
         display={tabValue !== 'leaderboard-tab' ? 'flex' : 'none'}
       >
-        <Grid item xs id="group-leaderboard-level">
-          <LeaderboardTable
-            data={groupLeaderboardPoints}
-            id={LeaderboardTableType.GroupLeaderboardPoints}
-          />
-        </Grid>
-        {!isAchievementHidden && (
+        {(!tabView || innerTabValue === 'experience-tab') && (
+          <Grid item xs id="group-leaderboard-level">
+            <LeaderboardTable
+              data={groupLeaderboardPoints}
+              id={LeaderboardTableType.GroupLeaderboardPoints}
+            />
+          </Grid>
+        )}
+        {!isAchievementHidden && (!tabView || innerTabValue === 'achievement-tab') && (
           <Grid item xs id="group-leaderboard-achievement">
             <LeaderboardTable
               data={groupLeaderboardAchievements}

--- a/client/app/lib/components/DataTable.jsx
+++ b/client/app/lib/components/DataTable.jsx
@@ -9,7 +9,7 @@ const options = {
   fixedSelectColumn: false,
 };
 
-const processTheme = (newHeight) =>
+const processTheme = (newHeight, grid, alignCenter, newPadding) =>
   createTheme({
     ...adaptedTheme,
     components: {
@@ -42,9 +42,20 @@ const processTheme = (newHeight) =>
             height:
               newHeight ??
               adaptedTheme.components.MuiTableCell.styleOverrides.root.height,
+            padding: newPadding ?? adaptedTheme.components.MuiTableCell.styleOverrides.root.padding,
           },
         },
       },
+      MuiToolbar: {
+        styleOverrides: {
+          ...adaptedTheme.components.MuiTableCell.styleOverrides,
+          root: {
+            ...adaptedTheme.components.MuiTableCell.styleOverrides.root,
+            display: grid ? 'grid' : 'flex',
+            alignContent: alignCenter ? 'center' : 'inherit',
+          },
+        },
+      }
     },
     overrides: {
       MUIDataTableSelectCell: {
@@ -97,7 +108,7 @@ const processColumns = (includeRowNumber, columns) => {
  * Refer to https://github.com/gregnb/mui-datatables for the documentation.
  */
 const DataTable = (props) => (
-  <ThemeProvider theme={processTheme(props.height)}>
+  <ThemeProvider theme={processTheme(props.height, props.titleGrid, props.titleAlignCenter, props.padding)}>
     <MUIDataTable
       {...props}
       columns={processColumns(props.includeRowNumber, props.columns)}

--- a/client/app/lib/components/DataTable.jsx
+++ b/client/app/lib/components/DataTable.jsx
@@ -42,7 +42,9 @@ const processTheme = (newHeight, grid, alignCenter, newPadding) =>
             height:
               newHeight ??
               adaptedTheme.components.MuiTableCell.styleOverrides.root.height,
-            padding: newPadding ?? adaptedTheme.components.MuiTableCell.styleOverrides.root.padding,
+            padding:
+              newPadding ??
+              adaptedTheme.components.MuiTableCell.styleOverrides.root.padding,
           },
         },
       },
@@ -55,7 +57,7 @@ const processTheme = (newHeight, grid, alignCenter, newPadding) =>
             alignContent: alignCenter ? 'center' : 'inherit',
           },
         },
-      }
+      },
     },
     overrides: {
       MUIDataTableSelectCell: {
@@ -108,7 +110,14 @@ const processColumns = (includeRowNumber, columns) => {
  * Refer to https://github.com/gregnb/mui-datatables for the documentation.
  */
 const DataTable = (props) => (
-  <ThemeProvider theme={processTheme(props.height, props.titleGrid, props.titleAlignCenter, props.padding)}>
+  <ThemeProvider
+    theme={processTheme(
+      props.height,
+      props.titleGrid,
+      props.titleAlignCenter,
+      props.padding,
+    )}
+  >
     <MUIDataTable
       {...props}
       columns={processColumns(props.includeRowNumber, props.columns)}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -169,14 +169,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-imports@^7.12.13":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
-  integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
-  dependencies:
-    "@babel/types" "^7.16.7"
-
-"@babel/helper-module-imports@^7.18.6":
+"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
@@ -204,7 +197,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.17.12", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz#9448974dd4fb1d80fefe72e8a0af37809cd30d6d"
   integrity sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==
@@ -251,11 +244,6 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
-
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
@@ -285,16 +273,7 @@
     "@babel/traverse" "^7.18.6"
     "@babel/types" "^7.18.6"
 
-"@babel/highlight@^7.10.4":
-  version "7.17.12"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.12.tgz#257de56ee5afbd20451ac0a75686b6b404257351"
-  integrity sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.18.6":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
   integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
@@ -591,19 +570,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.18.6":
+"@babel/plugin-syntax-typescript@^7.18.6", "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz#1c09cd25795c7c2b8a4ba9ae49394576d4133285"
   integrity sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
-
-"@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.17.12"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.17.12.tgz#b54fc3be6de734a56b87508f99d6428b5b605a7b"
-  integrity sha512-TYY0SXFiO31YXtNg3HtFwNJHjLsAyIIhAhNWkQ5whPPS7HWUFlg9z0Ta4qAQNjQbP1wsSt/oKkmZ/4/WWdMUpw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.17.12"
 
 "@babel/plugin-transform-arrow-functions@^7.18.6":
   version "7.18.6"
@@ -1071,7 +1043,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.16.7", "@babel/types@^7.18.6", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.18.6", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.6.tgz#5d781dd10a3f0c9f1f931bd19de5eb26ec31acf0"
   integrity sha512-NdBNzPDwed30fZdDQtVR7ZgaO4UKjuaQFH9VArS+HMnurlOY0JWN+4ROlu/iapMFwjRQU4pOG4StZfDmulEwGA==
@@ -1249,14 +1221,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@formatjs/ecma402-abstract@1.11.7":
-  version "1.11.7"
-  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.7.tgz#47f1a854f679f813d9baa1ee55adae94880ec706"
-  integrity sha512-uNaok4XWMJBtPZk/veTDamFCm5HeWJUk2jwoVfH5/+wenQ60QHjH6T3UQ0GOOCz9jpKmed7vqOri7xSf//Dt7g==
-  dependencies:
-    "@formatjs/intl-localematcher" "0.2.28"
-    tslib "2.4.0"
-
 "@formatjs/ecma402-abstract@1.11.8":
   version "1.11.8"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz#f4015dfb6a837369d94c6ba82455c609e45bce20"
@@ -1270,15 +1234,6 @@
   resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-1.2.4.tgz#4b5ddce9eb7803ff0bd4052387672151a8b7f8a0"
   integrity sha512-9ARYoLR8AEzXvj2nYrOVHY/h1dDMDWGTnKDLXSISF1uoPakSmfcZuSqjiqZX2wRkEUimPxdwTu/agyozBtZRHA==
   dependencies:
-    tslib "2.4.0"
-
-"@formatjs/icu-messageformat-parser@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.3.tgz#d228ac26f22630689a1263e83192227f1d085bd3"
-  integrity sha512-hsdAn1dXcujW/G8DHw0iiIy7357pw10yOulCrL6xrQOKJAxT7m7EgpG0Hm1OW9xqaLEzqWyE/jA2AGVnOCaCQw==
-  dependencies:
-    "@formatjs/ecma402-abstract" "1.11.7"
-    "@formatjs/icu-skeleton-parser" "1.3.9"
     tslib "2.4.0"
 
 "@formatjs/icu-messageformat-parser@2.1.4":
@@ -1296,14 +1251,6 @@
   integrity sha512-kXJmtLDqFF5aLTf8IxdJXnhrIX1Qb4Qp3a9jqRecGDYfzOa9hMhi9U0nKyhrJJ4cXxBzptcgb+LWkyeHL6nlBQ==
   dependencies:
     "@formatjs/ecma402-abstract" "1.11.8"
-    tslib "2.4.0"
-
-"@formatjs/icu-skeleton-parser@1.3.9":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.9.tgz#149badc16ffd15dd928f8047ae21aa9136e0ea73"
-  integrity sha512-s9THwwhiiSzbGSk73FP6Ur2MBwEj1vfgYDHKa5FiXGQMfYzdRdRvyH1dgqNgSFJPB6PM3DKtkloJLjpqpSDNUg==
-  dependencies:
-    "@formatjs/ecma402-abstract" "1.11.7"
     tslib "2.4.0"
 
 "@formatjs/intl-displaynames@6.0.3":
@@ -1646,18 +1593,10 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
 
-"@jridgewell/trace-mapping@^0.3.13":
+"@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.8", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
   integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
-"@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.8", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
-  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"

--- a/spec/features/course/leaderboard_viewing_spec.rb
+++ b/spec/features/course/leaderboard_viewing_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Course: Leaderboard: View' do
       scenario 'I can view the leaderboard sorted by achievement count' do
         create(:course_user_achievement, course_user: students[0])
         visit course_leaderboard_path(course)
+        find('button#achievement-tab').click
 
         within find('#leaderboard-achievement') do
           sorted_course_users = course.course_users.students.without_phantom_users.
@@ -96,6 +97,7 @@ RSpec.describe 'Course: Leaderboard: View' do
           visit course_leaderboard_path(course)
           expect(page).to have_selector('button#group-leaderboard-tab')
           find('button#group-leaderboard-tab').click
+          find('button#achievement-tab').click
 
           within find('#group-leaderboard-achievement') do
             sorted_course_groups = course.groups.ordered_by_average_achievement_count


### PR DESCRIPTION
Changed leaderboard page UI layout based on Prof Ben's comments:
- Added media query for different port sizes
- Added new tabs when screen size gets smaller (responsive)
- Reduced height of rows
- Fixed responsiveness of headers of tables to be centered
- Fixed paddings for each cell to be able to fit smaller screen sizes

TODO:
- [x] Change achievements to be responsive to screen size: less achievements shown as screen gets smaller. (may require re-rendering)