### PR TITLE
chore(webpack): gzip bundle

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -93,6 +93,7 @@
     "babel-loader": "^8.2.5",
     "babel-plugin-formatjs": "^10.3.25",
     "chart.js": "^3.8.0",
+    "compression-webpack-plugin": "^10.0.0",
     "css-loader": "^6.7.1",
     "dnd-core": "^14.0.1",
     "expose-loader": "^4.0.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const path = require('path');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+const CompressionPlugin = require('compression-webpack-plugin');
 
 const env = process.env.NODE_ENV || 'development';
 const development = env === 'development';
@@ -53,6 +54,7 @@ const config = {
 
   plugins: [
     new webpack.IgnorePlugin({ resourceRegExp: /__test__/ }),
+    new CompressionPlugin(),
     new WebpackManifestPlugin({
       publicPath: '/webpack/',
       writeToFileEmit: true,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3256,6 +3256,14 @@ compressible@~2.0.16:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
+compression-webpack-plugin@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz#3496af1b0dc792e13efc474498838dbff915c823"
+  integrity sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==
+  dependencies:
+    schema-utils "^4.0.0"
+    serialize-javascript "^6.0.0"
+
 compression@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"


### PR DESCRIPTION
In order to reduce bundle size, we gzip the bundle using webpacker

@cysjonathan 
May need to update nginx configuration as per below but lets try it in staging first.
https://selvaganesh93.medium.com/how-to-serve-webpack-gzipped-file-in-production-using-nginx-692eadbb9f1c

When i tried to build the bundle locally, it seems like both gzip and js formats are generated. Need to check how to serve only the gzipped bundle.

<img width="854" alt="image" src="https://user-images.githubusercontent.com/42570513/177957861-03f3dae7-d20d-4fc6-9bc3-34a023a977f7.png">
