### PR TITLE
Fix duplication error

### DIFF
--- a/app/models/concerns/course/duplication_concern.rb
+++ b/app/models/concerns/course/duplication_concern.rb
@@ -15,7 +15,7 @@ module Course::DuplicationConcern
   def duplication_manifest
     [
       *reference_timelines,
-      *material_folders.concrete,
+      *material_folders.concrete.ordered_topologically.flatten,
       *materials.in_concrete_folder,
       *levels,
       *assessment_categories,

--- a/app/models/concerns/course/material/folder/ordering_concern.rb
+++ b/app/models/concerns/course/material/folder/ordering_concern.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+module Course::Material::Folder::OrderingConcern
+  extend ActiveSupport::Concern
+
+  # Sorts all folders in a collection in topological order.
+  #
+  # By convention, each folder is represented by an array. The first element is the folder itself,
+  # the second is the children of the array.
+  class FolderSort
+    include Enumerable
+    delegate :each, to: :@sorted
+    delegate :length, to: :@sorted
+    delegate :flatten, to: :@sorted
+    alias_method :size, :length
+
+    # Constructor.
+    #
+    # @param [Array<Course::Material::Folder>] folders The folders to sort.
+    def initialize(folders)
+      @folders = folders
+      @sorted = sort(nil)
+    end
+
+    # Retrieves the last folder topologically -- the last folder at every branch.
+    #
+    # @return [Course::Material::Folder] The last folder topologically.
+    # @return [nil] When there are no folders.
+    def last
+      current_thread = @sorted.last
+      return nil unless current_thread
+
+      current_thread = current_thread.second.last until current_thread.second.empty?
+      current_thread.first
+    end
+
+    private
+
+    def sort(folder_id)
+      children_folders, @folders = @folders.partition { |child_folder| child_folder.parent_id == folder_id }
+      children_folders.map do |child_folder|
+        [child_folder].push(sort(child_folder.id))
+      end
+    end
+  end
+
+  # Returns a set of recursive arrays indicating the parent-child relationships of folders.
+  #
+  # @return [Enumerable]
+  def ordered_topologically
+    FolderSort.new(self)
+  end
+end

--- a/app/models/concerns/course/material_concern.rb
+++ b/app/models/concerns/course/material_concern.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Course::MaterialConcern
+  extend ActiveSupport::Concern
+  include Course::Material::Folder::OrderingConcern
+
+  # Reloads the association.
+  def reload
+    remove_instance_variable(:@ordered_topologically) if defined?(@ordered_topologically)
+    super
+  end
+
+  # Retrieves the topological ordering of the folders associated with this course.
+  #
+  # Call +reload+ to reset the ordering.
+  def ordered_topologically
+    @ordered_topologically ||= super
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -39,7 +39,9 @@ class Course < ApplicationRecord
   has_many :announcements, dependent: :destroy
   # The order needs to be preserved, this makes sure that the root_folder will be saved first
   has_many :material_folders, class_name: Course::Material::Folder.name, inverse_of: :course,
-                              dependent: :destroy
+                              dependent: :destroy do
+    include Course::MaterialConcern
+  end
   has_many :materials, through: :material_folders
   has_many :assessment_categories, class_name: Course::Assessment::Category.name,
                                    dependent: :destroy, inverse_of: :course

--- a/app/models/course/material/folder.rb
+++ b/app/models/course/material/folder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Material::Folder < ApplicationRecord
   acts_as_forest order: :name, dependent: :destroy, optional: true
+  extend Course::Material::Folder::OrderingConcern
   include Course::ModelComponentHost::Component
   include DuplicationStateTrackingConcern
 


### PR DESCRIPTION
### **Context**
A bug was reported whereby a course (id: 2167) was unable to be duplicated. Upon further investigation, it's found that the main issue is that there are multiple subfolders with the same name being temporarily parked under the root folder when these subfolders' parents have not been duplicated yet.  
(eg 
**Source course**
root > a > b 
root > c > b

**Temporary course**
root > b
root > b

**Duplicated course**
root > a > b
root > c > b)

To solve this issue, we need to make sure that the parents' folders are duplicated first before the children's folders are duplicated by using toposort.