### PR TITLE
style(tabs): standardize tab styling

### DIFF
--- a/client/app/bundles/course/assessment/submissions/components/misc/SubmissionTabs.tsx
+++ b/client/app/bundles/course/assessment/submissions/components/misc/SubmissionTabs.tsx
@@ -104,6 +104,9 @@ const SubmissionTabs: FC<Props> = (props) => {
           value={tabValue}
           onChange={handleTabChange}
           TabIndicatorProps={{ style: { transition: 'none' } }}
+          sx={{
+            '.css-117fsft-MuiButtonBase-root-MuiTab-root': { minHeight: 48 },
+          }}
         >
           {isTeachingStaff && (
             <Tab

--- a/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
+++ b/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
-import { Badge, Box, Tab, Tabs } from '@mui/material';
+import { Badge, BadgeProps, Box, styled, Tab, Tabs } from '@mui/material';
 import {
   ManageCourseUsersPermissions,
   ManageCourseUsersSharedData,
@@ -11,12 +11,6 @@ import { getCourseURL } from 'lib/helpers/url-builders';
 interface Props extends WrappedComponentProps {
   permissions: ManageCourseUsersPermissions;
   sharedData: ManageCourseUsersSharedData;
-}
-
-interface LinkTabProps {
-  key: string;
-  label: string | JSX.Element;
-  href: string | undefined;
 }
 
 const translations = defineMessages({
@@ -47,19 +41,24 @@ const translations = defineMessages({
 });
 
 const styles = {
-  tabStyle: {
-    '&:focus': {
-      outline: 0,
-    },
-  },
   tabsIndicatorStyle: {
     // to show tab indicator on firefox
     '& .MuiTabs-indicator': {
       bottom: 'auto',
     },
+    '.css-117fsft-MuiButtonBase-root-MuiTab-root': { minHeight: 48 },
     minHeight: '50px',
   },
 };
+
+const CustomBadge = styled(Badge)<BadgeProps>(({ theme }) => ({
+  '& .MuiBadge-badge': {
+    right: -8,
+    top: -1,
+    border: `2px solid ${theme.palette.background.paper}`,
+    padding: '0 4px',
+  },
+}));
 
 interface TabData {
   label: { id: string; defaultMessage: string };
@@ -68,10 +67,6 @@ interface TabData {
 }
 
 const courseUrl = getCourseURL(getCourseId());
-
-const LinkTab = (props: LinkTabProps): JSX.Element => {
-  return <Tab component="a" {...props} sx={styles.tabStyle} />;
-};
 
 const allTabs = {
   studentsTab: {
@@ -143,21 +138,6 @@ const UserManagementTabs: FC<Props> = (props) => {
     return res === -1 ? 0 : res;
   };
 
-  const getTabLabel = (tab: TabData): string | JSX.Element => {
-    if (tab.count) {
-      return (
-        <Badge
-          badgeContent={tab.count}
-          color="error"
-          sx={{ '& .MuiBadge-badge': { right: '-2px' } }}
-        >
-          {intl.formatMessage(tab.label)}
-        </Badge>
-      );
-    }
-    return intl.formatMessage(tab.label);
-  };
-
   const managementTabs = (
     <>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -168,10 +148,17 @@ const UserManagementTabs: FC<Props> = (props) => {
           sx={styles.tabsIndicatorStyle}
         >
           {tabs.map((tab) => (
-            <LinkTab
+            <Tab
               key={tab.label.id}
-              label={getTabLabel(tab)}
+              label={intl.formatMessage(tab.label)}
+              icon={<CustomBadge badgeContent={tab.count} color="error" />}
+              iconPosition="end"
               href={tab.href}
+              component="a"
+              style={{
+                paddingRight:
+                  tab.count === 0 || tab.count === undefined ? 8 : 26,
+              }}
             />
           ))}
         </Tabs>

--- a/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
+++ b/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
-import { Badge, BadgeProps, Box, styled, Tab, Tabs } from '@mui/material';
+import { Badge, BadgeProps, styled, Tab, Tabs } from '@mui/material';
 import {
   ManageCourseUsersPermissions,
   ManageCourseUsersSharedData,
@@ -142,32 +142,27 @@ const UserManagementTabs: FC<Props> = (props) => {
   };
 
   const managementTabs = (
-    <>
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs
-          value={getCurrentTabIndex()}
-          variant="scrollable"
-          scrollButtons="auto"
-          sx={styles.tabsStyle}
-        >
-          {tabs.map((tab) => (
-            <Tab
-              key={tab.label.id}
-              label={intl.formatMessage(tab.label)}
-              icon={<CustomBadge badgeContent={tab.count} color="error" />}
-              iconPosition="end"
-              href={tab.href}
-              component="a"
-              style={{
-                paddingRight:
-                  tab.count === 0 || tab.count === undefined ? 8 : 26,
-                textDecoration: 'none',
-              }}
-            />
-          ))}
-        </Tabs>
-      </Box>
-    </>
+    <Tabs
+      value={getCurrentTabIndex()}
+      variant="scrollable"
+      scrollButtons="auto"
+      sx={styles.tabsStyle}
+    >
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.label.id}
+          label={intl.formatMessage(tab.label)}
+          icon={<CustomBadge badgeContent={tab.count} color="error" />}
+          iconPosition="end"
+          href={tab.href}
+          component="a"
+          style={{
+            paddingRight: tab.count === 0 || tab.count === undefined ? 8 : 26,
+            textDecoration: 'none',
+          }}
+        />
+      ))}
+    </Tabs>
   );
 
   return managementTabs;

--- a/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
+++ b/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
@@ -41,13 +41,16 @@ const translations = defineMessages({
 });
 
 const styles = {
-  tabsIndicatorStyle: {
+  tabsStyle: {
     // to show tab indicator on firefox
     '& .MuiTabs-indicator': {
       bottom: 'auto',
     },
     '.css-117fsft-MuiButtonBase-root-MuiTab-root': { minHeight: 48 },
     minHeight: '50px',
+    '& .MuiTab-root:focus': {
+      outline: 0,
+    },
   },
 };
 
@@ -145,7 +148,7 @@ const UserManagementTabs: FC<Props> = (props) => {
           value={getCurrentTabIndex()}
           variant="scrollable"
           scrollButtons="auto"
-          sx={styles.tabsIndicatorStyle}
+          sx={styles.tabsStyle}
         >
           {tabs.map((tab) => (
             <Tab
@@ -158,6 +161,7 @@ const UserManagementTabs: FC<Props> = (props) => {
               style={{
                 paddingRight:
                   tab.count === 0 || tab.count === undefined ? 8 : 26,
+                textDecoration: 'none',
               }}
             />
           ))}


### PR DESCRIPTION
standardize tab styling between manage users and submissions
Changed both to the thinner style, and notifications / badges appear on the right (instead of the top right)

New:
![image](https://user-images.githubusercontent.com/48171632/179659819-759496c0-7875-4c65-be1f-e5381186f3e0.png)
![image](https://user-images.githubusercontent.com/48171632/179659927-574a8d71-71cb-4568-a9b1-0a8b283efced.png)
