### PR TITLE
Rake task to remove course users & improve delete button UI

### DIFF
--- a/client/app/bundles/course/achievement/components/buttons/AchievementManagementButtons.tsx
+++ b/client/app/bundles/course/achievement/components/buttons/AchievementManagementButtons.tsx
@@ -85,6 +85,7 @@ const AchievementManagementButtons: FC<Props> = (props) => {
         <DeleteButton
           className={`achievement-delete-${achievement.id}`}
           disabled={isDeleting}
+          loading={isDeleting}
           onClick={onDelete}
           confirmMessage={intl.formatMessage(translations.deletionConfirm)}
         />

--- a/client/app/bundles/course/announcements/components/misc/AnnouncementCard.tsx
+++ b/client/app/bundles/course/announcements/components/misc/AnnouncementCard.tsx
@@ -59,6 +59,7 @@ const AnnouncementCard: FC<Props> = (props) => {
 
   // For editing announcements form dialog
   const [isOpen, setIsOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const initialValues = {
     title: announcement.title,
@@ -70,6 +71,7 @@ const AnnouncementCard: FC<Props> = (props) => {
 
   const dispatch = useDispatch<AppDispatch>();
   const onDelete = (): Promise<void> => {
+    setIsDeleting(true);
     return dispatch(deleteAnnouncement(announcement.id))
       .then(() => {
         toast.success(intl.formatMessage(translations.deletionSuccess));
@@ -77,7 +79,8 @@ const AnnouncementCard: FC<Props> = (props) => {
       .catch((error) => {
         toast.error(intl.formatMessage(translations.deletionFailure));
         throw error;
-      });
+      })
+      .finally(() => setIsDeleting(false));
   };
 
   const onEdit = (): void => setIsOpen(true);
@@ -149,7 +152,8 @@ const AnnouncementCard: FC<Props> = (props) => {
               {announcement.permissions.canDelete && (
                 <DeleteButton
                   id={`announcement-delete-button-${announcement.id}`}
-                  disabled={false}
+                  disabled={isDeleting}
+                  loading={isDeleting}
                   confirmMessage={`${intl.formatMessage(
                     translations.deleteConfirmation,
                   )} (${announcement.title})?`}

--- a/client/app/bundles/course/assessment/skills/components/buttons/SkillManagementButtons.tsx
+++ b/client/app/bundles/course/assessment/skills/components/buttons/SkillManagementButtons.tsx
@@ -125,6 +125,7 @@ const SkillManagementButtons: FC<Props> = (props) => {
             isSkillBranch ? `skill-branch-delete-${id}` : `skill-delete-${id}`
           }
           disabled={isDeleting}
+          loading={isDeleting}
           onClick={onDelete}
         />
       )}

--- a/client/app/bundles/course/assessment/skills/components/buttons/SkillManagementButtons.tsx
+++ b/client/app/bundles/course/assessment/skills/components/buttons/SkillManagementButtons.tsx
@@ -114,7 +114,7 @@ const SkillManagementButtons: FC<Props> = (props) => {
           className={
             isSkillBranch ? `skill-branch-edit-${id}` : `skill-edit-${id}`
           }
-          disabled={!canUpdate}
+          disabled={!canUpdate || isDeleting}
           onClick={(): void => editClick(data)}
         />
       )}

--- a/client/app/bundles/course/enrol-requests/components/buttons/PendingEnrolRequestsButtons.tsx
+++ b/client/app/bundles/course/enrol-requests/components/buttons/PendingEnrolRequestsButtons.tsx
@@ -114,6 +114,7 @@ const PendingEnrolRequestsButtons: FC<Props> = (props) => {
         tooltip={intl.formatMessage(translations.rejectTooltip)}
         className={`enrol-request-reject-${enrolRequest.id}`}
         disabled={isApproving || isDeleting}
+        loading={isDeleting}
         onClick={onDelete}
         confirmMessage={intl.formatMessage(translations.rejectConfirm, {
           role: ROLES[enrolRequest.role!],

--- a/client/app/bundles/course/enrol-requests/components/buttons/PendingEnrolRequestsButtons.tsx
+++ b/client/app/bundles/course/enrol-requests/components/buttons/PendingEnrolRequestsButtons.tsx
@@ -57,6 +57,7 @@ const PendingEnrolRequestsButtons: FC<Props> = (props) => {
   const { intl, enrolRequest } = props;
   const dispatch = useDispatch<AppDispatch>();
   const [isApproving, setIsApproving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const onApprove = (): Promise<void> => {
     setIsApproving(true);
@@ -80,6 +81,7 @@ const PendingEnrolRequestsButtons: FC<Props> = (props) => {
   };
 
   const onDelete = (): Promise<void> => {
+    setIsDeleting(true);
     return dispatch(rejectEnrolRequest(enrolRequest.id))
       .then(() => {
         toast.success(
@@ -95,7 +97,8 @@ const PendingEnrolRequestsButtons: FC<Props> = (props) => {
           }),
         );
         throw error;
-      });
+      })
+      .finally(() => setIsDeleting(false));
   };
 
   const managementButtons = (
@@ -103,14 +106,14 @@ const PendingEnrolRequestsButtons: FC<Props> = (props) => {
       <AcceptButton
         tooltip={intl.formatMessage(translations.approveTooltip)}
         className={`enrol-request-approve-${enrolRequest.id}`}
-        disabled={isApproving}
+        disabled={isApproving || isDeleting}
         onClick={onApprove}
         sx={styles.buttonStyle}
       />
       <DeleteButton
         tooltip={intl.formatMessage(translations.rejectTooltip)}
         className={`enrol-request-reject-${enrolRequest.id}`}
-        disabled={isApproving}
+        disabled={isApproving || isDeleting}
         onClick={onDelete}
         confirmMessage={intl.formatMessage(translations.rejectConfirm, {
           role: ROLES[enrolRequest.role!],

--- a/client/app/bundles/course/user-invitations/components/buttons/PendingInvitationsButtons.tsx
+++ b/client/app/bundles/course/user-invitations/components/buttons/PendingInvitationsButtons.tsx
@@ -57,6 +57,7 @@ const PendingInvitationsButtons: FC<Props> = (props) => {
   const { intl, invitation } = props;
   const dispatch = useDispatch<AppDispatch>();
   const [isResending, setIsResending] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const onResend = (): Promise<void> => {
     setIsResending(true);
@@ -80,6 +81,7 @@ const PendingInvitationsButtons: FC<Props> = (props) => {
   };
 
   const onDelete = (): Promise<void> => {
+    setIsDeleting(true);
     return dispatch(deleteInvitation(invitation.id))
       .then(() => {
         toast.success(
@@ -95,7 +97,8 @@ const PendingInvitationsButtons: FC<Props> = (props) => {
           }),
         );
         throw error;
-      });
+      })
+      .finally(() => setIsDeleting(false));
   };
 
   const managementButtons = (
@@ -103,14 +106,14 @@ const PendingInvitationsButtons: FC<Props> = (props) => {
       <EmailButton
         tooltip={intl.formatMessage(translations.resendTooltip)}
         className={`invitation-resend-${invitation.id}`}
-        disabled={isResending}
+        disabled={isResending || isDeleting}
         onClick={onResend}
         sx={styles.buttonStyle}
       />
       <DeleteButton
         tooltip={intl.formatMessage(translations.deletionTooltip)}
         className={`invitation-delete-${invitation.id}`}
-        disabled={isResending}
+        disabled={isResending || isDeleting}
         onClick={onDelete}
         confirmMessage={intl.formatMessage(translations.deletionConfirm, {
           role: ROLES[invitation.role],

--- a/client/app/bundles/course/user-invitations/components/buttons/PendingInvitationsButtons.tsx
+++ b/client/app/bundles/course/user-invitations/components/buttons/PendingInvitationsButtons.tsx
@@ -114,6 +114,7 @@ const PendingInvitationsButtons: FC<Props> = (props) => {
         tooltip={intl.formatMessage(translations.deletionTooltip)}
         className={`invitation-delete-${invitation.id}`}
         disabled={isResending || isDeleting}
+        loading={isDeleting}
         onClick={onDelete}
         confirmMessage={intl.formatMessage(translations.deletionConfirm, {
           role: ROLES[invitation.role],

--- a/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
+++ b/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
@@ -96,6 +96,7 @@ const UserManagementButtons: FC<Props> = (props) => {
         tooltip="Delete User"
         className={`user-delete-${user.id}`}
         disabled={isSaving || isDeleting}
+        loading={isDeleting}
         onClick={onDelete}
         confirmMessage={intl.formatMessage(translations.deletionConfirm, {
           role: sharedConstants.COURSE_USER_ROLES[user.role],

--- a/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
+++ b/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
@@ -47,6 +47,7 @@ const UserManagementButtons: FC<Props> = (props) => {
   const { intl, user } = props;
   const dispatch = useDispatch<AppDispatch>();
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const onSave = (data: CourseUserRowData): Promise<void> => {
     setIsSaving(true);
@@ -70,6 +71,7 @@ const UserManagementButtons: FC<Props> = (props) => {
   };
 
   const onDelete = (): Promise<void> => {
+    setIsDeleting(true);
     return dispatch(deleteUser(user.id))
       .then(() => {
         toast.success(intl.formatMessage(translations.deletionSuccess));
@@ -77,7 +79,8 @@ const UserManagementButtons: FC<Props> = (props) => {
       .catch((error) => {
         toast.error(intl.formatMessage(translations.deletionFailure));
         throw error;
-      });
+      })
+      .finally(() => setIsDeleting(false));
   };
 
   const managementButtons = (
@@ -85,14 +88,14 @@ const UserManagementButtons: FC<Props> = (props) => {
       <SaveButton
         tooltip="Save Changes"
         className={`user-save-${user.id}`}
-        disabled={isSaving}
+        disabled={isSaving || isDeleting}
         onClick={(): Promise<void> => onSave(user)}
         sx={styles.buttonStyle}
       />
       <DeleteButton
         tooltip="Delete User"
         className={`user-delete-${user.id}`}
-        disabled={isSaving}
+        disabled={isSaving || isDeleting}
         onClick={onDelete}
         confirmMessage={intl.formatMessage(translations.deletionConfirm, {
           role: sharedConstants.COURSE_USER_ROLES[user.role],

--- a/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
+++ b/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
@@ -295,6 +295,7 @@ const PersonalTimeEditor: FC<Props> = (props) => {
               <DeleteButton
                 tooltip={intl.formatMessage(translations.delete)}
                 disabled={isSaving || isDeleting}
+                loading={isDeleting}
                 onClick={handleDelete}
                 confirmMessage={
                   item.new

--- a/client/app/lib/components/ConfirmationDialog.jsx
+++ b/client/app/lib/components/ConfirmationDialog.jsx
@@ -102,10 +102,21 @@ class ConfirmationDialog extends Component {
       actions.push(...confirmButtonSecondary);
     }
 
+    const handleDialogClose = (_event, reason) => {
+      if (reason && reason !== 'backdropClick') {
+        onCancel();
+      }
+    };
+
     return (
       <Dialog
         fullWidth
-        onClose={onCancel}
+        disableEscapeKeyDown={disableCancelButton || disableConfirmButton}
+        onClose={
+          disableCancelButton || disableConfirmButton
+            ? handleDialogClose
+            : onCancel
+        }
         open={open}
         maxWidth="md"
         style={{ zIndex: 9999 }}

--- a/client/app/lib/components/ConfirmationDialog.jsx
+++ b/client/app/lib/components/ConfirmationDialog.jsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
+import { LoadingButton } from '@mui/lab';
 import formTranslations from 'lib/translations/form';
 
 const buttonStyle = {
@@ -25,6 +26,7 @@ class ConfirmationDialog extends Component {
       confirmSubmit,
       disableCancelButton,
       disableConfirmButton,
+      loadingConfirmButton,
       form,
     } = this.props;
 
@@ -67,10 +69,11 @@ class ConfirmationDialog extends Component {
       >
         {cancelButtonText || intl.formatMessage(formTranslations.cancel)}
       </Button>,
-      <Button
+      <LoadingButton
         color="primary"
         className="confirm-btn"
         disabled={disableConfirmButton}
+        loading={loadingConfirmButton}
         key="confirmation-dialog-confirm-button"
         onClick={onConfirm}
         {...(form ? { form, type: 'submit' } : {})}
@@ -80,7 +83,7 @@ class ConfirmationDialog extends Component {
         style={buttonStyle}
       >
         {confirmationButtonText}
-      </Button>,
+      </LoadingButton>,
     ];
 
     if (onConfirmSecondary) {
@@ -142,6 +145,7 @@ ConfirmationDialog.propTypes = {
   confirmSubmit: PropTypes.bool,
   disableCancelButton: PropTypes.bool,
   disableConfirmButton: PropTypes.bool,
+  loadingConfirmButton: PropTypes.bool,
   form: PropTypes.string,
   intl: PropTypes.object.isRequired,
 };

--- a/client/app/lib/components/buttons/DeleteButton.tsx
+++ b/client/app/lib/components/buttons/DeleteButton.tsx
@@ -8,6 +8,7 @@ interface Props extends IconButtonProps {
   onClick: () => Promise<void>;
   confirmMessage?: string;
   tooltip?: string;
+  loading?: boolean;
 }
 
 const DeleteButton = ({
@@ -15,6 +16,7 @@ const DeleteButton = ({
   onClick,
   confirmMessage,
   tooltip = '',
+  loading = false,
   ...props
 }: Props): JSX.Element => {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -44,6 +46,7 @@ const DeleteButton = ({
           message={confirmMessage}
           disableCancelButton={disabled}
           disableConfirmButton={disabled}
+          loadingConfirmButton={loading}
           open={dialogOpen}
           onCancel={(): void => setDialogOpen(false)}
           onConfirm={(): void => {

--- a/client/app/lib/components/buttons/DeleteButton.tsx
+++ b/client/app/lib/components/buttons/DeleteButton.tsx
@@ -24,6 +24,7 @@ const DeleteButton = ({
       <Tooltip title={tooltip}>
         <span>
           <IconButton
+            disabled={disabled}
             onClick={(): void => {
               if (confirmMessage) {
                 setDialogOpen(true);

--- a/lib/tasks/db/delete_phantom_course_users.rake
+++ b/lib/tasks/db/delete_phantom_course_users.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+namespace :db do
+  task delete_phantom_course_users: :environment do
+    ActsAsTenant.without_tenant do
+      course_id = 2183
+      course = Course.find(course_id)
+      phantom_course_users = course.course_users.students.phantom
+      total_course_users = phantom_course_users.count
+
+      ActiveRecord::Base.transaction do
+        phantom_course_users.each_with_index do |cu, index|
+          puts "Deleting #{cu.name} (course_user_id: #{cu.id}) - #{index + 1}/#{total_course_users}"
+          cu.destroy!
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/db/delete_phantom_course_users.rake
+++ b/lib/tasks/db/delete_phantom_course_users.rake
@@ -2,16 +2,26 @@
 namespace :db do
   task delete_phantom_course_users: :environment do
     ActsAsTenant.without_tenant do
-      course_id = 2183
-      course = Course.find(course_id)
-      phantom_course_users = course.course_users.students.phantom
-      total_course_users = phantom_course_users.count
+      puts 'Input course id:'
+      course_id = $stdin.gets.strip
+      course = Course.find(course_id.to_i)
 
-      ActiveRecord::Base.transaction do
-        phantom_course_users.each_with_index do |cu, index|
-          puts "Deleting #{cu.name} (course_user_id: #{cu.id}) - #{index + 1}/#{total_course_users}"
-          cu.destroy!
+      puts "Are you sure you wish to remove phantom course users from the course #{course.title}? (Y/N): "
+      confirm = $stdin.gets.strip
+      if confirm == 'Y'
+        phantom_course_users = course.course_users.students.phantom
+        total_course_users = phantom_course_users.count
+
+        ActiveRecord::Base.transaction do
+          phantom_course_users.each_with_index do |cu, index|
+            puts "Deleting #{cu.name} (course_user_id: #{cu.id}) - #{index + 1}/#{total_course_users}"
+            cu.destroy!
+          end
         end
+
+        puts "Deleted #{total_course_users} users!"
+      else
+        puts 'Course user deletion cancelled!'
       end
     end
   end


### PR DESCRIPTION
Currently, course user removal is too slow to be executed from the client side. A rake script is created to assist mass course user deletion as of now.

In the future, course users deletion shall be refactored - https://github.com/Coursemology/coursemology2/issues/3403.

At the same time, added some fixes on the delete buttons in client side.