### PR TITLE
Add loading indicator to confirm dialog

### DIFF
--- a/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
+++ b/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
@@ -47,6 +47,7 @@ const UserManagementButtons: FC<Props> = (props) => {
   const { intl, user } = props;
   const dispatch = useDispatch<AppDispatch>();
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const onSave = (data: CourseUserRowData): Promise<void> => {
     setIsSaving(true);
@@ -70,9 +71,13 @@ const UserManagementButtons: FC<Props> = (props) => {
   };
 
   const onDelete = (): Promise<void> => {
+    setIsDeleting(true);
     return dispatch(deleteUser(user.id))
       .then(() => {
         toast.success(intl.formatMessage(translations.deletionSuccess));
+      })
+      .finally(() => {
+        setIsDeleting(false);
       })
       .catch((error) => {
         toast.error(intl.formatMessage(translations.deletionFailure));
@@ -85,14 +90,15 @@ const UserManagementButtons: FC<Props> = (props) => {
       <SaveButton
         tooltip="Save Changes"
         className={`user-save-${user.id}`}
-        disabled={isSaving}
+        disabled={isSaving || isDeleting}
         onClick={(): Promise<void> => onSave(user)}
         sx={styles.buttonStyle}
       />
       <DeleteButton
         tooltip="Delete User"
         className={`user-delete-${user.id}`}
-        disabled={isSaving}
+        disabled={isSaving || isDeleting}
+        loading={isDeleting}
         onClick={onDelete}
         confirmMessage={intl.formatMessage(translations.deletionConfirm, {
           role: sharedConstants.COURSE_USER_ROLES[user.role],

--- a/client/app/lib/components/ConfirmationDialog.jsx
+++ b/client/app/lib/components/ConfirmationDialog.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
 import formTranslations from 'lib/translations/form';
+import { LoadingButton } from '@mui/lab';
 
 const buttonStyle = {
   margin: 3,
@@ -25,6 +26,7 @@ class ConfirmationDialog extends Component {
       confirmSubmit,
       disableCancelButton,
       disableConfirmButton,
+      loadingConfirmButton,
       form,
     } = this.props;
 
@@ -67,10 +69,11 @@ class ConfirmationDialog extends Component {
       >
         {cancelButtonText || intl.formatMessage(formTranslations.cancel)}
       </Button>,
-      <Button
+      <LoadingButton
         color="primary"
         className="confirm-btn"
         disabled={disableConfirmButton}
+        loading={loadingConfirmButton}
         key="confirmation-dialog-confirm-button"
         onClick={onConfirm}
         {...(form ? { form, type: 'submit' } : {})}
@@ -80,7 +83,7 @@ class ConfirmationDialog extends Component {
         style={buttonStyle}
       >
         {confirmationButtonText}
-      </Button>,
+      </LoadingButton>,
     ];
 
     if (onConfirmSecondary) {
@@ -108,6 +111,7 @@ class ConfirmationDialog extends Component {
         onClose={onCancel}
         open={open}
         maxWidth="md"
+        disableEscapeKeyDown
         style={{ zIndex: 9999 }}
       >
         <DialogContent>{confirmationMessage}</DialogContent>
@@ -131,6 +135,7 @@ ConfirmationDialog.propTypes = {
   confirmSubmit: PropTypes.bool,
   disableCancelButton: PropTypes.bool,
   disableConfirmButton: PropTypes.bool,
+  loadingConfirmButton: PropTypes.bool,
   form: PropTypes.string,
   intl: PropTypes.object.isRequired,
 };

--- a/client/app/lib/components/buttons/DeleteButton.tsx
+++ b/client/app/lib/components/buttons/DeleteButton.tsx
@@ -7,6 +7,7 @@ interface Props extends IconButtonProps {
   disabled: boolean;
   onClick: () => Promise<void>;
   confirmMessage?: string;
+  loading?: boolean;
   tooltip?: string;
 }
 
@@ -15,9 +16,16 @@ const DeleteButton = ({
   onClick,
   confirmMessage,
   tooltip = '',
+  loading = false,
   ...props
 }: Props): JSX.Element => {
   const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleDialogClose = (_event: object, reason: string): void => {
+    if (reason && reason !== 'backdropClick') {
+      setDialogOpen(false);
+    }
+  };
 
   return (
     <>
@@ -44,7 +52,8 @@ const DeleteButton = ({
           disableCancelButton={disabled}
           disableConfirmButton={disabled}
           open={dialogOpen}
-          onCancel={(): void => setDialogOpen(false)}
+          loadingConfirmButton={loading}
+          onCancel={handleDialogClose}
           onConfirm={(): void => {
             onClick().finally(() => setDialogOpen(false));
           }}


### PR DESCRIPTION
Certain actions take some time in the backend to process, for example deleting students.

This frontend fix adds loading indicators to confirmation dialog and disables interaction to prevent accidental cancellation.

![image](https://user-images.githubusercontent.com/9080974/180790155-2621653c-59f1-47d7-9fb7-7ae1edeb4321.png)
