### PR TITLE
Various fixes and refactoring

### DIFF
--- a/app/controllers/concerns/application_multitenancy_concern.rb
+++ b/app/controllers/concerns/application_multitenancy_concern.rb
@@ -43,7 +43,6 @@ module ApplicationMultitenancyConcern
   end
 
   module ClassMethods
-    # :nodoc:
     def set_current_tenant_through_filter
       super
       class_eval do

--- a/app/controllers/course/admin/admin_controller.rb
+++ b/app/controllers/course/admin/admin_controller.rb
@@ -3,7 +3,7 @@ class Course::Admin::AdminController < Course::Admin::Controller
   def index
   end
 
-  def update # :nodoc:
+  def update
     if current_course.update(course_setting_params)
       redirect_to course_admin_path(current_course),
                   success: t('.success', title: current_course.title)
@@ -12,7 +12,7 @@ class Course::Admin::AdminController < Course::Admin::Controller
     end
   end
 
-  def destroy # :nodoc:
+  def destroy
     if current_course.destroy
       destroy_success
     else
@@ -22,20 +22,20 @@ class Course::Admin::AdminController < Course::Admin::Controller
 
   private
 
-  def course_setting_params # :nodoc:
+  def course_setting_params
     params.require(:course).
       permit(:title, :description, :published, :enrollable, :start_at, :end_at, :logo, :gamified,
              :show_personalized_timeline_features, :default_timeline_algorithm,
              :time_zone, :advance_start_at_duration_days)
   end
 
-  def destroy_success # :nodoc:
+  def destroy_success
     redirect_to courses_path,
                 success: t('course.admin.admin.destroy.success',
                            title: current_course.title)
   end
 
-  def destroy_failure # :nodoc:
+  def destroy_failure
     redirect_to course_admin_path(current_course),
                 danger: t('course.admin.admin.destroy.failure',
                           error: current_course.errors.full_messages.to_sentence)

--- a/app/controllers/course/admin/announcement_settings_controller.rb
+++ b/app/controllers/course/admin/announcement_settings_controller.rb
@@ -2,10 +2,10 @@
 class Course::Admin::AnnouncementSettingsController < Course::Admin::Controller
   add_breadcrumb :edit, :course_admin_announcements_path
 
-  def edit # :nodoc:
+  def edit
   end
 
-  def update # :nodoc:
+  def update
     if @settings.update(announcement_settings_params) && current_course.save
       redirect_to course_admin_announcements_path(current_course), success: t('.success')
     else
@@ -15,7 +15,7 @@ class Course::Admin::AnnouncementSettingsController < Course::Admin::Controller
 
   private
 
-  def announcement_settings_params # :nodoc:
+  def announcement_settings_params
     params.require(:settings_announcements_component).permit(:title)
   end
 

--- a/app/controllers/course/admin/component_settings_controller.rb
+++ b/app/controllers/course/admin/component_settings_controller.rb
@@ -3,10 +3,10 @@ class Course::Admin::ComponentSettingsController < Course::Admin::Controller
   before_action :load_settings
   add_breadcrumb :edit, :course_admin_components_path
 
-  def edit # :nodoc:
+  def edit
   end
 
-  def update # :nodoc:
+  def update
     if @settings.update(settings_components_params) && current_course.save!
       redirect_to course_admin_components_path(current_course), success: t('.success')
     else

--- a/app/controllers/course/admin/forum_settings_controller.rb
+++ b/app/controllers/course/admin/forum_settings_controller.rb
@@ -15,7 +15,7 @@ class Course::Admin::ForumSettingsController < Course::Admin::Controller
 
   private
 
-  def forum_settings_params # :nodoc:
+  def forum_settings_params
     params.require(:settings_forums_component).permit(:title, :pagination)
   end
 

--- a/app/controllers/course/admin/leaderboard_settings_controller.rb
+++ b/app/controllers/course/admin/leaderboard_settings_controller.rb
@@ -2,10 +2,10 @@
 class Course::Admin::LeaderboardSettingsController < Course::Admin::Controller
   add_breadcrumb :edit, :course_admin_leaderboard_path
 
-  def edit # :nodoc:
+  def edit
   end
 
-  def update # :nodoc:
+  def update
     if @settings.update(leaderboard_settings_params) && current_course.save
       redirect_to course_admin_leaderboard_path(current_course), success: t('.success')
     else
@@ -15,7 +15,7 @@ class Course::Admin::LeaderboardSettingsController < Course::Admin::Controller
 
   private
 
-  def leaderboard_settings_params # :nodoc:
+  def leaderboard_settings_params
     params.require(:settings_leaderboard_component).
       permit(:title, :display_user_count, :enable_group_leaderboard, :group_leaderboard_title)
   end

--- a/app/controllers/course/admin/material_settings_controller.rb
+++ b/app/controllers/course/admin/material_settings_controller.rb
@@ -15,7 +15,7 @@ class Course::Admin::MaterialSettingsController < Course::Admin::Controller
 
   private
 
-  def material_settings_params # :nodoc:
+  def material_settings_params
     params.require(:settings_materials_component).permit(:title)
   end
 

--- a/app/controllers/course/admin/sidebar_settings_controller.rb
+++ b/app/controllers/course/admin/sidebar_settings_controller.rb
@@ -3,10 +3,10 @@ class Course::Admin::SidebarSettingsController < Course::Admin::Controller
   before_action :load_settings
   add_breadcrumb :index, :course_admin_sidebar_path
 
-  def edit # :nodoc:
+  def edit
   end
 
-  def update # :nodoc:
+  def update
     if @settings.update(settings_sidebar_params) && current_course.save
       redirect_to course_admin_sidebar_path(current_course), success: t('.success')
     else
@@ -16,7 +16,7 @@ class Course::Admin::SidebarSettingsController < Course::Admin::Controller
 
   private
 
-  def settings_sidebar_params # :nodoc:
+  def settings_sidebar_params
     params.require(:settings_sidebar)
   end
 

--- a/app/controllers/course/admin/video_settings_controller.rb
+++ b/app/controllers/course/admin/video_settings_controller.rb
@@ -17,7 +17,7 @@ class Course::Admin::VideoSettingsController < Course::Admin::Controller
 
   private
 
-  def video_settings_params # :nodoc:
+  def video_settings_params
     params.require(:settings_videos_component).permit(:title)
   end
 

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -3,7 +3,7 @@ class Course::AnnouncementsController < Course::ComponentController
   load_and_authorize_resource :announcement, through: :course, class: Course::Announcement.name
   before_action :add_announcement_breadcrumb
 
-  def index # :nodoc:
+  def index
     respond_to do |format|
       format.html
       format.json do
@@ -14,7 +14,7 @@ class Course::AnnouncementsController < Course::ComponentController
     end
   end
 
-  def create # :nodoc:
+  def create
     if @announcement.save
       # Return all announcements for re-rendering ordering purposes
       redirect_to course_announcements_path(current_course)
@@ -23,7 +23,7 @@ class Course::AnnouncementsController < Course::ComponentController
     end
   end
 
-  def update # :nodoc:
+  def update
     if @announcement.update(announcement_params)
       render partial: 'course/announcements/announcement_list_data',
              locals: { announcement: @announcement },
@@ -33,7 +33,7 @@ class Course::AnnouncementsController < Course::ComponentController
     end
   end
 
-  def destroy # :nodoc:
+  def destroy
     if @announcement.destroy
       head :ok
     else
@@ -43,7 +43,7 @@ class Course::AnnouncementsController < Course::ComponentController
 
   private
 
-  def announcement_params # :nodoc:
+  def announcement_params
     params.require(:announcement).permit(:title, :content, :sticky, :start_at, :end_at)
   end
 

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -10,6 +10,7 @@ class Course::AnnouncementsController < Course::ComponentController
         @announcements = @announcements.includes(:creator).sorted_by_sticky.sorted_by_date
         @announcements = @announcements.with_read_marks_for(current_user)
         mark_announcements_as_read
+        render 'index'
       end
     end
   end
@@ -17,7 +18,8 @@ class Course::AnnouncementsController < Course::ComponentController
   def create
     if @announcement.save
       # Return all announcements for re-rendering ordering purposes
-      redirect_to course_announcements_path(current_course)
+      @announcements = Course::Announcement.where(course_id: current_course.id)
+      index
     else
       render json: { errors: @announcement.errors }, status: :bad_request
     end

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -4,7 +4,7 @@ class Course::Assessment::SubmissionsController < Course::ComponentController
   before_action :add_submissions_breadcrumb
   before_action :load_group_managers, only: [:pending, :index]
 
-  def index # :nodoc:
+  def index
     respond_to do |format|
       format.html
       format.json do

--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -22,7 +22,7 @@ class Course::DuplicationsController < Course::ComponentController
 
   private
 
-  def create_duplication_params # :nodoc:
+  def create_duplication_params
     params.require(:duplication).permit(:new_start_at, :new_title)
   end
 

--- a/app/controllers/course/experience_points/disbursement_controller.rb
+++ b/app/controllers/course/experience_points/disbursement_controller.rb
@@ -11,7 +11,7 @@ class Course::ExperiencePoints::DisbursementController < Course::ComponentContro
     end
   end
 
-  def create # :nodoc:
+  def create
     if @disbursement.save
       render json: { count: recipient_count }, status: :ok
     else
@@ -21,11 +21,11 @@ class Course::ExperiencePoints::DisbursementController < Course::ComponentContro
 
   private
 
-  def load_resource # :nodoc:
+  def load_resource
     @disbursement ||= Course::ExperiencePoints::Disbursement.new(disbursement_params)
   end
 
-  def disbursement_params # :nodoc:
+  def disbursement_params
     case action_name
     when 'new'
       params.permit(:group_id)

--- a/app/controllers/course/experience_points/forum_disbursement_controller.rb
+++ b/app/controllers/course/experience_points/forum_disbursement_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::ExperiencePoints::ForumDisbursementController <
   Course::ExperiencePoints::DisbursementController
-  def create # :nodoc:
+  def create
     if @disbursement.save
       render json: { count: recipient_count }, status: :ok
     else
@@ -11,11 +11,11 @@ class Course::ExperiencePoints::ForumDisbursementController <
 
   private
 
-  def load_resource # :nodoc:
+  def load_resource
     @disbursement ||= Course::ExperiencePoints::ForumDisbursement.new(disbursement_params)
   end
 
-  def disbursement_params # :nodoc:
+  def disbursement_params
     case action_name
     when 'new'
       new_disbursement_params

--- a/app/controllers/course/experience_points_records_controller.rb
+++ b/app/controllers/course/experience_points_records_controller.rb
@@ -7,7 +7,7 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
                                                          class: Course::ExperiencePointsRecord.name
   before_action :add_breadcrumbs
 
-  def index # :nodoc:
+  def index
     updater_ids = @experience_points_records.active.pluck(:updater_id)
     @course_user_preload_service =
       Course::CourseUserPreloadService.new(updater_ids, current_course)
@@ -25,7 +25,7 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
     end
   end
 
-  def destroy # :nodoc:
+  def destroy
     if @experience_points_record.destroy
       destroy_success
     else
@@ -39,17 +39,17 @@ class Course::ExperiencePointsRecordsController < Course::ComponentController
     params.require(:experience_points_record).permit(:points_awarded, :reason)
   end
 
-  def destroy_success # :nodoc:
+  def destroy_success
     redirect_to course_user_experience_points_records_path(current_course, @course_user),
                 success: t('course.experience_points_records.destroy.success')
   end
 
-  def destroy_failure # :nodoc:
+  def destroy_failure
     redirect_to course_user_experience_points_records_path(current_course, @course_user),
                 danger: @experience_points_record.errors.full_messages.to_sentence
   end
 
-  def add_breadcrumbs # :nodoc:
+  def add_breadcrumbs
     add_breadcrumb @course_user.name, course_user_path(current_course, @course_user)
     add_breadcrumb :index
   end

--- a/app/controllers/course/leaderboards_controller.rb
+++ b/app/controllers/course/leaderboards_controller.rb
@@ -6,7 +6,7 @@ class Course::LeaderboardsController < Course::ComponentController
   before_action :preload_course_levels, only: [:index]
   before_action :fetch_course_users, only: [:index]
 
-  def index # :nodoc:
+  def index
     achievements_enabled = current_component_host[:course_achievements_component].present?
     groups_enabled = @settings.enable_group_leaderboard
 

--- a/app/controllers/course/lesson_plan/events_controller.rb
+++ b/app/controllers/course/lesson_plan/events_controller.rb
@@ -7,7 +7,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
   load_and_authorize_resource :event, class: Course::LessonPlan::Event.name, through: :course,
                                       through_association: :lesson_plan_events, except: [:new, :create]
 
-  def create # :nodoc:
+  def create
     if @event.save
       render partial: 'event_lesson_plan_item', locals: { item: @event }
     else
@@ -15,7 +15,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
     end
   end
 
-  def update # :nodoc:
+  def update
     if @event.update(event_params)
       render partial: 'event_lesson_plan_item', locals: { item: @event }
     else
@@ -23,7 +23,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
     end
   end
 
-  def destroy # :nodoc:
+  def destroy
     if @event.destroy
       head :ok
     else
@@ -33,7 +33,7 @@ class Course::LessonPlan::EventsController < Course::LessonPlan::Controller
 
   private
 
-  def event_params # :nodoc:
+  def event_params
     params.require(:lesson_plan_event).
       permit(:event_type, :title, :description, :location, :start_at, :end_at, :published)
   end

--- a/app/controllers/course/lesson_plan/milestones_controller.rb
+++ b/app/controllers/course/lesson_plan/milestones_controller.rb
@@ -9,7 +9,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
                               through: :course, through_association: :lesson_plan_milestones,
                               class: Course::LessonPlan::Milestone.name, except: [:new, :create]
 
-  def create # :nodoc:
+  def create
     if @milestone.save
       render partial: 'milestone', locals: { milestone: @milestone }
     else
@@ -17,7 +17,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
     end
   end
 
-  def update # :nodoc:
+  def update
     if @milestone.update(milestone_params)
       render partial: 'milestone', locals: { milestone: @milestone }
     else
@@ -25,7 +25,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
     end
   end
 
-  def destroy # :nodoc:
+  def destroy
     if @milestone.destroy
       head :ok
     else
@@ -35,7 +35,7 @@ class Course::LessonPlan::MilestonesController < Course::LessonPlan::Controller
 
   private
 
-  def milestone_params # :nodoc:
+  def milestone_params
     params.require(:lesson_plan_milestone).
       permit(:title, :description, :start_at)
   end

--- a/app/controllers/course/levels_controller.rb
+++ b/app/controllers/course/levels_controller.rb
@@ -3,10 +3,10 @@ class Course::LevelsController < Course::ComponentController
   load_and_authorize_resource :level, through: :course, class: Course::Level.name
   add_breadcrumb :index, :course_levels_path
 
-  def index # :nodoc:
+  def index
   end
 
-  def create # :nodoc:
+  def create
     respond_to do |format|
       if current_course.mass_update_levels(params[:levels])
         format.json { render json: current_course.levels, status: :created }

--- a/app/controllers/course/personal_times_controller.rb
+++ b/app/controllers/course/personal_times_controller.rb
@@ -6,18 +6,22 @@ class Course::PersonalTimesController < Course::ComponentController
   before_action :authorize_personal_times!
 
   def index
-    if params[:user_id].present?
-      @course_user ||= CourseUser.find_by(course: @course, id: params[:user_id])
-      @learning_rate_record = @course_user.latest_learning_rate_record
+    respond_to do |format|
+      format.html
+      format.json do
+        if params[:user_id].present?
+          @course_user ||= CourseUser.find_by(course: @course, id: params[:user_id])
+          @learning_rate_record = @course_user.latest_learning_rate_record
 
-      # Only show for assessments and videos
-      @items = @course.lesson_plan_items.where(actable_type: [Course::Assessment.name, Course::Video.name]).
-               ordered_by_date_and_title.
-               with_reference_times_for(@course_user).
-               with_personal_times_for(@course_user)
+          # Only show for assessments and videos
+          @items = @course.lesson_plan_items.where(actable_type: [Course::Assessment.name, Course::Video.name]).
+                   ordered_by_date_and_title.
+                   with_reference_times_for(@course_user).
+                   with_personal_times_for(@course_user)
+          render 'index'
+        end
+      end
     end
-
-    render 'index'
   end
 
   def create

--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -6,12 +6,13 @@ class Course::UserInvitationsController < Course::ComponentController
   add_breadcrumb :index, :course_users_students_path
 
   def index
-    @invitations = current_course.invitations.order(name: :asc)
-    @without_invitations = params[:without_invitations]
-  end
-
-  def new
-    current_course.invitations.build
+    respond_to do |format|
+      format.html
+      format.json do
+        @invitations = current_course.invitations.order(name: :asc)
+        @without_invitations = params[:without_invitations]
+      end
+    end
   end
 
   def create
@@ -56,7 +57,7 @@ class Course::UserInvitationsController < Course::ComponentController
 
   private
 
-  def course_user_invitation_params # :nodoc:
+  def course_user_invitation_params
     @course_user_invitation_params ||= begin
       params[:course] = { invitations_attributes: {} } unless params.key?(:course)
       params.require(:course).permit(:invitations_file, :registration_key,
@@ -219,7 +220,7 @@ class Course::UserInvitationsController < Course::ComponentController
     current_component_host[:course_users_component]
   end
 
-  def resend_invitation_success # :nodoc:
+  def resend_invitation_success
     respond_to do |format|
       format.json do
         render partial: 'course_user_invitation_list_data', locals: { invitation: @invitation.reload }, status: :ok
@@ -227,13 +228,13 @@ class Course::UserInvitationsController < Course::ComponentController
     end
   end
 
-  def resend_invitation_failure # :nodoc:
+  def resend_invitation_failure
     respond_to do |format|
       format.json { head :bad_request }
     end
   end
 
-  def resend_invitations_success # :nodoc:
+  def resend_invitations_success
     respond_to do |format|
       format.json do
         render partial: 'course_user_invitation_list', locals: { invitations: @invitations.reload }, status: :ok
@@ -241,25 +242,25 @@ class Course::UserInvitationsController < Course::ComponentController
     end
   end
 
-  def resend_invitations_failure # :nodoc:
+  def resend_invitations_failure
     respond_to do |format|
       format.json { head :bad_request }
     end
   end
 
-  def destroy_invitation_success # :nodoc:
+  def destroy_invitation_success
     respond_to do |format|
       format.json { render json: { id: @invitation.id }, status: :ok }
     end
   end
 
-  def destroy_invitation_failure # :nodoc:
+  def destroy_invitation_failure
     respond_to do |format|
       format.json { render json: { errors: @invitation.errors.full_messages.to_sentence }, status: :bad_request }
     end
   end
 
-  def create_invitation_success(result) # :nodoc:
+  def create_invitation_success(result)
     respond_to do |format|
       format.json do
         render json: {

--- a/app/controllers/course/user_registrations_controller.rb
+++ b/app/controllers/course/user_registrations_controller.rb
@@ -4,7 +4,7 @@ class Course::UserRegistrationsController < Course::ComponentController
   before_action :load_registration
   skip_authorize_resource :course, only: [:create]
 
-  def create # :nodoc:
+  def create
     @registration.update(registration_params.reverse_merge(course: current_course,
                                                            user: current_user))
     if registration_service.register(@registration)
@@ -16,7 +16,7 @@ class Course::UserRegistrationsController < Course::ComponentController
 
   private
 
-  def registration_params # :nodoc:
+  def registration_params
     @registration_params ||= params.require(:registration).permit(:code)
   end
 
@@ -39,7 +39,7 @@ class Course::UserRegistrationsController < Course::ComponentController
     @registration_service ||= Course::UserRegistrationService.new
   end
 
-  def create_success # :nodoc:
+  def create_success
     success =
       if @registration.course_user.present?
         role = t("course.users.role.#{@registration.course_user.role}")

--- a/app/controllers/course/users_controller.rb
+++ b/app/controllers/course/users_controller.rb
@@ -6,7 +6,7 @@ class Course::UsersController < Course::ComponentController
   before_action :load_resource
   authorize_resource :course_user, through: :course, parent: false
 
-  def index # :nodoc:
+  def index
   end
 
   def show
@@ -25,7 +25,7 @@ class Course::UsersController < Course::ComponentController
     case params[:action]
     when 'index'
       if params[:as_basic_data] == 'true'
-        @user_options = course_users.order_alphabetically.pluck(:id, :name)
+        @user_options = course_users.order_alphabetically.pluck(:id, :name, :role)
       else
         @course_users ||= course_users.without_phantom_users.students.
                           includes(user: [:emails]).order_alphabetically

--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -3,7 +3,7 @@ class Course::Video::VideosController < Course::Video::Controller
   skip_load_and_authorize_resource :video, only: [:new, :create]
   build_and_authorize_new_lesson_plan_item :video, class: Course::Video, through: :course, only: [:new, :create]
 
-  def index # :nodoc:
+  def index
     @videos = @videos.
               from_tab(current_tab).
               with_student_submission_count.

--- a/app/controllers/course/video_submissions_controller.rb
+++ b/app/controllers/course/video_submissions_controller.rb
@@ -7,7 +7,7 @@ class Course::VideoSubmissionsController < Course::ComponentController
   before_action :load_video_submissions
   before_action :add_breadcrumbs
 
-  def index # :nodoc:
+  def index
     @videos = @course.videos
     @video_submissions = @video_submissions.
                          includes([:video, { experience_points_record: :course_user }, :statistic]).
@@ -16,7 +16,7 @@ class Course::VideoSubmissionsController < Course::ComponentController
 
   private
 
-  def add_breadcrumbs # :nodoc:
+  def add_breadcrumbs
     add_breadcrumb @course_user.name, course_user_path(current_course, @course_user)
     add_breadcrumb :index
   end

--- a/app/controllers/system/admin/instance/components_controller.rb
+++ b/app/controllers/system/admin/instance/components_controller.rb
@@ -3,10 +3,10 @@ class System::Admin::Instance::ComponentsController < System::Admin::Instance::C
   before_action :load_settings
   add_breadcrumb :edit, :admin_instance_components_path
 
-  def edit # :nodoc:
+  def edit
   end
 
-  def update # :nodoc:
+  def update
     if @settings.update(settings_components_params) && current_tenant.save!
       redirect_to admin_instance_components_path, success: t('.success')
     else

--- a/app/controllers/system/admin/instance/user_invitations_controller.rb
+++ b/app/controllers/system/admin/instance/user_invitations_controller.rb
@@ -55,7 +55,7 @@ class System::Admin::Instance::UserInvitationsController < System::Admin::Instan
 
   private
 
-  def instance_user_invitation_params # :nodoc:
+  def instance_user_invitation_params
     @instance_user_invitation_params ||= begin
       params[:instance] = { invitations_attributes: {} } unless params.key?(:instance)
       params.require(:instance).permit(invitations_attributes: [:name, :email, :role, :_destroy, :id])

--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -3,7 +3,7 @@ class System::Admin::InstancesController < System::Admin::Controller
   load_and_authorize_resource :instance, class: ::Instance.name
   add_breadcrumb :index, :admin_instances_path
 
-  def index # :nodoc:
+  def index
     respond_to do |format|
       format.html { render 'system/admin/admin/index' }
       format.json do
@@ -12,7 +12,7 @@ class System::Admin::InstancesController < System::Admin::Controller
     end
   end
 
-  def create # :nodoc:
+  def create
     if @instance.save
       preload_instances
       render 'index', format: :json
@@ -21,7 +21,7 @@ class System::Admin::InstancesController < System::Admin::Controller
     end
   end
 
-  def update # :nodoc:
+  def update
     if @instance.update(instance_params)
       render 'system/admin/instances/_instance_list_data',
              locals: { instance: @instance },
@@ -31,7 +31,7 @@ class System::Admin::InstancesController < System::Admin::Controller
     end
   end
 
-  def destroy # :nodoc:
+  def destroy
     if @instance.destroy
       head :ok
     else
@@ -41,7 +41,7 @@ class System::Admin::InstancesController < System::Admin::Controller
 
   private
 
-  def instance_params # :nodoc:
+  def instance_params
     params.require(:instance).permit(:name, :host)
   end
 

--- a/app/controllers/user/emails_controller.rb
+++ b/app/controllers/user/emails_controller.rb
@@ -3,11 +3,11 @@ class User::EmailsController < ApplicationController
   load_and_authorize_resource :email, through: :current_user, class: User::Email.name
   layout 'user_admin'
 
-  def index # :nodoc:
+  def index
     @new_email = current_user.emails.build
   end
 
-  def create # :nodoc:
+  def create
     if @email.save
       redirect_to user_emails_path, success: t('.success')
     else
@@ -15,7 +15,7 @@ class User::EmailsController < ApplicationController
     end
   end
 
-  def destroy # :nodoc:
+  def destroy
     if @email.destroy
       redirect_to user_emails_path, success: t('.success')
     else

--- a/app/models/course/settings/sidebar.rb
+++ b/app/models/course/settings/sidebar.rb
@@ -36,11 +36,11 @@ class Course::Settings::Sidebar
     end
   end
 
-  def persisted? # :nodoc:
+  def persisted?
     true
   end
 
-  def valid? # :nodoc:
+  def valid?
     sidebar_items.all?(&:valid?)
   end
 end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -212,7 +212,7 @@ class CourseUser < ApplicationRecord
 
   private
 
-  def set_defaults # :nodoc:
+  def set_defaults
     self.name ||= user.name if user
     self.role ||= :student
   end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -138,7 +138,7 @@ class Instance < ApplicationRecord
 
   private
 
-  def should_validate_host? # :nodoc:
+  def should_validate_host?
     new_record? || changed_attributes.keys.include?('host')
   end
 end

--- a/app/models/instance_user.rb
+++ b/app/models/instance_user.rb
@@ -23,7 +23,7 @@ class InstanceUser < ApplicationRecord
 
   private
 
-  def set_defaults # :nodoc:
+  def set_defaults
     self.role ||= InstanceUser.roles[:normal]
   end
 end

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 json.question do
-  json.(@programming_question, :id, :title, :description, :staff_only_comments, :maximum_grade,
+  json.(@programming_question, :id, :title, :staff_only_comments, :maximum_grade,
         :language_id, :memory_limit, :time_limit)
+  json.description format_ckeditor_rich_text(@programming_question.description)
   json.languages Coursemology::Polyglot::Language.all.order(:name) do |lang|
     json.(lang, :id, :name)
     json.editor_mode lang.ace_mode

--- a/app/views/course/assessment/question/scribing/_scribing_question.json.jbuilder
+++ b/app/views/course/assessment/question/scribing/_scribing_question.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.question do
-  json.(@scribing_question, :id, :title, :description, :staff_only_comments, :maximum_grade)
-
+  json.(@scribing_question, :id, :title, :staff_only_comments, :maximum_grade)
+  json.description format_ckeditor_rich_text(@scribing_question.description)
   if @scribing_question.attachment_reference
     json.attachment_reference do
       json.partial! 'attachments/attachment_reference.json',

--- a/app/views/course/enrol_requests/index.html.slim
+++ b/app/views/course/enrol_requests/index.html.slim
@@ -1,3 +1,3 @@
 - add_breadcrumb t('.header')
 
-div#enrol-requests-component
+div#course-users-component

--- a/app/views/course/personal_times/_personal_time_list_data.json.jbuilder
+++ b/app/views/course/personal_times/_personal_time_list_data.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+# When changing the following, need to ensure that
+# personal_times/index is also changed.
 
 personal_time = item.find_or_create_personal_time_for(@course_user)
 

--- a/app/views/course/personal_times/index.json.jbuilder
+++ b/app/views/course/personal_times/index.json.jbuilder
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
 json.personalTimes @items.each do |item|
-  json.partial! 'personal_time_list_data', item: item
+  # The followings are duplicate from _personal_time_list_data
+  # We are not using _personal_time_list_data as nested jbuilder compromises
+  # the performance. When changing the following, need to ensure that
+  # _personal_time_list_data is also changed.
+  personal_time = item.find_or_create_personal_time_for(@course_user)
+
+  json.id personal_time.lesson_plan_item_id
+  json.personalTimeId personal_time.id
+  json.actableId item.actable_id
+  json.type item.actable_type
+  json.title item.title
+  if item.reference_time_for(@course_user).start_at.nil?
+    json.itemStartAt nil
+  else
+    json.itemStartAt format_datetime(item.reference_time_for(@course_user).start_at, :short)
+  end
+  if item.reference_time_for(@course_user).bonus_end_at.nil?
+    json.itemBonusEndAt nil
+  else
+    json.itemBonusEndAt format_datetime(item.reference_time_for(@course_user).bonus_end_at, :short)
+  end
+  if item.reference_time_for(@course_user).end_at.nil?
+    json.itemEndAt nil
+  else
+    json.itemEndAt format_datetime(item.reference_time_for(@course_user).end_at, :short)
+  end
+
+  json.personalStartAt personal_time.start_at || nil
+  json.personalBonusEndAt personal_time.bonus_end_at || nil
+  json.personalEndAt personal_time.end_at || nil
+
+  json.fixed personal_time.fixed
+  json.new personal_time.new_record?
 end

--- a/app/views/course/user_invitations/_course_user_invitation_list.json.jbuilder
+++ b/app/views/course/user_invitations/_course_user_invitation_list.json.jbuilder
@@ -1,4 +1,18 @@
 # frozen_string_literal: true
+# The followings are duplicate from _course_user_invitation_list_data.json
+# We are not using _course_user_invitation_list_data.json as nested jbuilder compromises
+# the performance. When changing the following, need to ensure that
+# _course_user_invitation_list_data.json is also changed.
+
 json.invitations @invitations.each do |invitation|
-  json.partial! 'course_user_invitation_list_data', invitation: invitation
+  json.id invitation.id
+  json.name invitation.name
+  json.email invitation.email
+  json.role invitation.role
+  json.phantom invitation.phantom
+  json.timelineAlgorithm invitation.timeline_algorithm
+  json.invitationKey invitation.invitation_key
+  json.confirmed invitation.confirmed?
+  json.sentAt format_datetime(invitation.sent_at, :short) if invitation.sent_at
+  json.confirmedAt format_datetime(invitation.confirmed_at, :short) if invitation.confirmed_at
 end

--- a/app/views/course/user_invitations/_course_user_invitation_list_data.json.jbuilder
+++ b/app/views/course/user_invitations/_course_user_invitation_list_data.json.jbuilder
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+# When changing the following, need to ensure that
+# user_invitations/_course_user_invitation_list is also changed.
+
 json.id invitation.id
 json.name invitation.name
 json.email invitation.email

--- a/app/views/course/user_invitations/index.html.slim
+++ b/app/views/course/user_invitations/index.html.slim
@@ -1,3 +1,3 @@
 - add_breadcrumb :index
 
-div#user-invitations-component
+div#course-users-component

--- a/app/views/course/user_invitations/index.json.jbuilder
+++ b/app/views/course/user_invitations/index.json.jbuilder
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 unless @without_invitations
-  json.invitations @invitations.each do |invitation|
-    json.partial! 'course_user_invitation_list_data', invitation: invitation
-  end
+  json.partial! 'course_user_invitation_list'
 end
 
 json.permissions do

--- a/app/views/course/user_invitations/new.html.slim
+++ b/app/views/course/user_invitations/new.html.slim
@@ -1,3 +1,3 @@
 - add_breadcrumb :invite, :course_users_students_path
 
-div#user-invitations-component
+div#course-users-component

--- a/app/views/course/users/index.json.jbuilder
+++ b/app/views/course/users/index.json.jbuilder
@@ -9,6 +9,7 @@ unless @user_options.nil?
     # course_user comes from @user_options which only plucks(:id, :name)
     json.id course_user[0]
     json.name course_user[1]
+    json.role course_user[2]
   end
 end
 

--- a/app/views/course/users/staff.json.jbuilder
+++ b/app/views/course/users/staff.json.jbuilder
@@ -10,9 +10,10 @@ json.users @course_users do |course_user|
 end
 
 json.userOptions @student_options do |course_user|
-  # course_user comes from @user_options which only plucks(:id, :name)
+  # course_user comes from @student_options which only plucks(:id, :name)
   json.id course_user[0]
   json.name course_user[1]
+  json.role course_user[2]
 end
 
 json.permissions do

--- a/client/app/bundles/course/achievement/pages/AchievementEdit/index.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementEdit/index.tsx
@@ -51,10 +51,6 @@ const AchievementEdit: FC<Props> = (props) => {
     }
   }, [dispatch, achievementId]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   if (!achievement) {
     return (
       <Typography variant="h5">
@@ -97,28 +93,34 @@ const AchievementEdit: FC<Props> = (props) => {
         title={`Edit Achievement - ${achievement.title}`}
         returnLink={`/courses/${courseId}/achievements/`}
       />
-      <AchievementForm
-        conditionAttributes={{
-          enabledConditions: achievement.enabledConditions,
-          conditions: achievement.conditions,
-        }}
-        editing
-        handleClose={(isDirty): void => {
-          if (isDirty) {
-            setConfirmationDialogOpen(true);
-          }
-        }}
-        initialValues={initialValues}
-        onSubmit={onSubmit}
-      />
-      <ConfirmationDialog
-        confirmDiscard
-        open={confirmationDialogOpen}
-        onCancel={(): void => setConfirmationDialogOpen(false)}
-        onConfirm={(): void => {
-          setConfirmationDialogOpen(false);
-        }}
-      />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <AchievementForm
+            conditionAttributes={{
+              enabledConditions: achievement.enabledConditions,
+              conditions: achievement.conditions,
+            }}
+            editing
+            handleClose={(isDirty): void => {
+              if (isDirty) {
+                setConfirmationDialogOpen(true);
+              }
+            }}
+            initialValues={initialValues}
+            onSubmit={onSubmit}
+          />
+          <ConfirmationDialog
+            confirmDiscard
+            open={confirmationDialogOpen}
+            onCancel={(): void => setConfirmationDialogOpen(false)}
+            onConfirm={(): void => {
+              setConfirmationDialogOpen(false);
+            }}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/achievement/pages/AchievementShow/index.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementShow/index.tsx
@@ -11,7 +11,10 @@ import { AppDispatch, AppState } from 'types/store';
 import AvatarWithLabel from 'lib/components/AvatarWithLabel';
 import AchievementManagementButtons from '../../components/buttons/AchievementManagementButtons';
 import { loadAchievement } from '../../operations';
-import { getAchievementEntity } from '../../selectors';
+import {
+  getAchievementEntity,
+  getAchievementMiniEntity,
+} from '../../selectors';
 
 type Props = WrappedComponentProps;
 
@@ -43,6 +46,9 @@ const AchievementShow: FC<Props> = (props) => {
   const [isLoading, setIsLoading] = useState(true);
   const dispatch = useDispatch<AppDispatch>();
   const { achievementId } = useParams();
+  const achievementMiniEntity = useSelector((state: AppState) =>
+    getAchievementMiniEntity(state, +achievementId!),
+  );
   const achievement = useSelector((state: AppState) =>
     getAchievementEntity(state, +achievementId!),
   );
@@ -55,21 +61,20 @@ const AchievementShow: FC<Props> = (props) => {
     }
   }, [dispatch, achievementId]);
 
-  if (isLoading) {
+  if (!achievementMiniEntity && isLoading) {
     return <LoadingIndicator />;
   }
-
-  if (!achievement) {
+  if (!achievementMiniEntity) {
     return null;
   }
 
   const headerToolbars: ReactElement[] = [];
 
-  if (achievement.permissions?.canManage) {
+  if (achievementMiniEntity.permissions?.canManage) {
     headerToolbars.push(
       <AchievementManagementButtons
-        key={achievement.id}
-        achievement={achievement}
+        key={achievementMiniEntity.id}
+        achievement={achievementMiniEntity}
         navigateToIndex
       />,
     );
@@ -78,58 +83,66 @@ const AchievementShow: FC<Props> = (props) => {
   return (
     <>
       <PageHeader
-        title={`Achievement - ${achievement.title}`}
+        title={`Achievement - ${achievementMiniEntity.title}`}
         returnLink={`/courses/${courseId}/achievements/`}
         toolbars={headerToolbars}
       />
-      <Grid container>
-        <Grid
-          item
-          xs={12}
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          style={{ marginBottom: 8 }}
-        >
-          <Tooltip
-            title={
-              achievement.achievementStatus ? achievement.achievementStatus : ''
-            }
-          >
-            <img
-              src={achievement.badge.url}
-              alt={achievement.badge.name}
-              style={styles.badge}
-            />
-          </Tooltip>
-          <div style={styles.description}>
-            <p
-              style={{ whiteSpace: 'normal' }}
-              dangerouslySetInnerHTML={{ __html: achievement.description }}
-            />
-          </div>
-        </Grid>
-        <Grid item xs={12} display="flex" justifyContent="center">
-          <Typography variant="h5">
-            {intl.formatMessage(translations.studentsWithAchievement)}
-          </Typography>
-        </Grid>
-        {achievement.achievementUsers.map((courseUser) => (
-          <>
-            {courseUser.obtainedAt !== null && (
-              <Grid item key={courseUser.id} xs={4} sm={3} lg={1}>
-                <a href={getCourseUserURL(courseId, courseUser.id)}>
-                  <AvatarWithLabel
-                    label={courseUser.name}
-                    imageUrl={courseUser.imageUrl!}
-                    size="sm"
-                  />
-                </a>
-              </Grid>
-            )}
-          </>
-        ))}
-      </Grid>
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        achievement && (
+          <Grid container>
+            <Grid
+              item
+              xs={12}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              style={{ marginBottom: 8 }}
+            >
+              <Tooltip
+                title={
+                  achievement.achievementStatus
+                    ? achievement.achievementStatus
+                    : ''
+                }
+              >
+                <img
+                  src={achievement.badge.url}
+                  alt={achievement.badge.name}
+                  style={styles.badge}
+                />
+              </Tooltip>
+              <div style={styles.description}>
+                <p
+                  style={{ whiteSpace: 'normal' }}
+                  dangerouslySetInnerHTML={{ __html: achievement.description }}
+                />
+              </div>
+            </Grid>
+            <Grid item xs={12} display="flex" justifyContent="center">
+              <Typography variant="h5">
+                {intl.formatMessage(translations.studentsWithAchievement)}
+              </Typography>
+            </Grid>
+            {achievement.achievementUsers.map((courseUser) => (
+              <>
+                {courseUser.obtainedAt !== null && (
+                  <Grid item key={courseUser.id} xs={4} sm={3} lg={1}>
+                    <a href={getCourseUserURL(courseId, courseUser.id)}>
+                      <AvatarWithLabel
+                        label={courseUser.name}
+                        imageUrl={courseUser.imageUrl!}
+                        size="sm"
+                      />
+                    </a>
+                  </Grid>
+                )}
+              </>
+            ))}
+          </Grid>
+        )
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/achievement/pages/AchievementsIndex/index.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementsIndex/index.tsx
@@ -62,10 +62,6 @@ const AchievementsIndex: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const headerToolbars: ReactElement[] = []; // To Add: Reorder Button
 
   if (achievementPermissions?.canReorder) {
@@ -107,15 +103,21 @@ const AchievementsIndex: FC<Props> = (props) => {
         })}
         toolbars={headerToolbars}
       />
-      <AchievementNew
-        open={isOpen}
-        handleClose={(): void => setIsOpen(false)}
-      />
-      <AchievementTable
-        achievements={achievements}
-        permissions={achievementPermissions}
-        onTogglePublished={onTogglePublished}
-      />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <AchievementNew
+            open={isOpen}
+            handleClose={(): void => setIsOpen(false)}
+          />
+          <AchievementTable
+            achievements={achievements}
+            permissions={achievementPermissions}
+            onTogglePublished={onTogglePublished}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/announcements/pages/AnnouncementsIndex/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementsIndex/index.tsx
@@ -68,10 +68,6 @@ const AnnouncementsIndex: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   return (
     <>
       <PageHeader
@@ -87,21 +83,27 @@ const AnnouncementsIndex: FC<Props> = (props) => {
             : undefined
         }
       />
-      {announcements.length === 0 ? (
-        <div>{intl.formatMessage(translations.noAnnouncements)}</div>
+      {isLoading ? (
+        <LoadingIndicator />
       ) : (
-        <AnnouncementsDisplay
-          announcements={announcements}
-          announcementPermissions={announcementPermissions}
-          updateOperation={updateAnnouncement}
-          deleteOperation={deleteAnnouncement}
-        />
+        <>
+          {announcements.length === 0 ? (
+            <div>{intl.formatMessage(translations.noAnnouncements)}</div>
+          ) : (
+            <AnnouncementsDisplay
+              announcements={announcements}
+              announcementPermissions={announcementPermissions}
+              updateOperation={updateAnnouncement}
+              deleteOperation={deleteAnnouncement}
+            />
+          )}
+          <AnnouncementNew
+            open={isOpen}
+            handleClose={(): void => setIsOpen(false)}
+            createOperation={createAnnouncement}
+          />
+        </>
       )}
-      <AnnouncementNew
-        open={isOpen}
-        handleClose={(): void => setIsOpen(false)}
-        createOperation={createAnnouncement}
-      />
     </>
   );
 };

--- a/client/app/bundles/course/assessment/skills/pages/SkillsIndex/index.tsx
+++ b/client/app/bundles/course/assessment/skills/pages/SkillsIndex/index.tsx
@@ -100,10 +100,6 @@ const SkillsIndex: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const newSkillClick = (): void => {
     setIsDialogOpen(true);
     setDialogType(DialogTypes.NewSkill);
@@ -148,46 +144,52 @@ const SkillsIndex: FC<Props> = (props) => {
   return (
     <>
       <PageHeader title={intl.formatMessage({ ...translations.skills })} />
-      <Grid container direction="row" columnGap={0.2}>
-        <Grid item xs id="skill-branches">
-          <SkillsTable
-            data={data}
-            editClick={editSkillBranchClick}
-            addClick={newSkillBranchClick}
-            addDisabled={!skillPermissions.canCreateSkill}
-            tableType={TableEnum.SkillBranches}
-            skillBranchIndex={branchSelected}
-            skillIndex={skillSelected}
-            changeSkillBranch={changeSkillBranch}
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <Grid container direction="row" columnGap={0.2}>
+            <Grid item xs id="skill-branches">
+              <SkillsTable
+                data={data}
+                editClick={editSkillBranchClick}
+                addClick={newSkillBranchClick}
+                addDisabled={!skillPermissions.canCreateSkill}
+                tableType={TableEnum.SkillBranches}
+                skillBranchIndex={branchSelected}
+                skillIndex={skillSelected}
+                changeSkillBranch={changeSkillBranch}
+              />
+            </Grid>
+            <Grid item xs id="skills">
+              <SkillsTable
+                data={data}
+                editClick={editSkillClick}
+                addClick={newSkillClick}
+                addDisabled={!skillPermissions.canCreateSkill}
+                tableType={TableEnum.Skills}
+                skillBranchIndex={branchSelected}
+                skillIndex={skillSelected}
+                changeSkillBranch={changeSkillBranch}
+              />
+            </Grid>
+          </Grid>
+          <SkillDialog
+            dialogType={dialogType}
+            open={isDialogOpen}
+            handleClose={(): void => setIsDialogOpen(false)}
+            skillBranchOptions={skillBranchOptions}
+            data={dialogData ?? null}
+            skillBranchId={
+              (dialogType === DialogTypes.NewSkill &&
+                branchSelected !== -1 &&
+                data[branchSelected].id) ||
+              -1
+            }
+            setNewSelected={setNewSelected}
           />
-        </Grid>
-        <Grid item xs id="skills">
-          <SkillsTable
-            data={data}
-            editClick={editSkillClick}
-            addClick={newSkillClick}
-            addDisabled={!skillPermissions.canCreateSkill}
-            tableType={TableEnum.Skills}
-            skillBranchIndex={branchSelected}
-            skillIndex={skillSelected}
-            changeSkillBranch={changeSkillBranch}
-          />
-        </Grid>
-      </Grid>
-      <SkillDialog
-        dialogType={dialogType}
-        open={isDialogOpen}
-        handleClose={(): void => setIsDialogOpen(false)}
-        skillBranchOptions={skillBranchOptions}
-        data={dialogData ?? null}
-        skillBranchId={
-          (dialogType === DialogTypes.NewSkill &&
-            branchSelected !== -1 &&
-            data[branchSelected].id) ||
-          -1
-        }
-        setNewSelected={setNewSelected}
-      />
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/SavingIndicator.test.js
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/SavingIndicator.test.js
@@ -26,7 +26,7 @@ const mockSubmission = {
     maximumGrade: 70,
     pointsAwarded: null,
     submittedAt: '2017-05-11T17:02:17.000+08:00',
-    submitter: 'Jane',
+    submitter: { id: 10, name: 'Jane' },
     workflowState: 'submitted',
   },
   assessment: {},

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/ScribingToolbar.test.js
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/ScribingToolbar.test.js
@@ -34,7 +34,7 @@ const mockSubmission = {
     maximumGrade: 70,
     pointsAwarded: null,
     submittedAt: '2017-05-11T17:02:17.000+08:00',
-    submitter: 'Jane',
+    submitter: { id: 10, name: 'Jane' },
     workflowState: 'submitted',
   },
   assessment: {},

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/index.test.js
@@ -21,7 +21,7 @@ const mockSubmission = {
     maximumGrade: 70,
     pointsAwarded: null,
     submittedAt: '2017-05-11T17:02:17.000+08:00',
-    submitter: 'Jane',
+    submitter: { id: 10, name: 'Jane' },
     workflowState: 'submitted',
   },
   assessment: {},

--- a/client/app/bundles/course/assessment/submissions/pages/SubmissionsIndex/index.tsx
+++ b/client/app/bundles/course/assessment/submissions/pages/SubmissionsIndex/index.tsx
@@ -144,62 +144,65 @@ const SubmissionsIndex: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (pageIsLoading) {
-    return <LoadingIndicator />;
-  }
   return (
     <>
       <PageHeader title={intl.formatMessage(translations.header)} />
-      <SubmissionTabs
-        canManage={submissionPermissions.canManage}
-        isTeachingStaff={submissionPermissions.isTeachingStaff}
-        tabs={tabs}
-        tabValue={tabValue}
-        setTabValue={setTabValue}
-        setIsTabChanging={setIsTabChanging}
-        setTableIsLoading={setTableIsLoading}
-        setPageNum={setPageNum}
-      />
+      {pageIsLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <SubmissionTabs
+            canManage={submissionPermissions.canManage}
+            isTeachingStaff={submissionPermissions.isTeachingStaff}
+            tabs={tabs}
+            tabValue={tabValue}
+            setTabValue={setTabValue}
+            setIsTabChanging={setIsTabChanging}
+            setTableIsLoading={setTableIsLoading}
+            setPageNum={setPageNum}
+          />
 
-      <SubmissionFilter
-        key={`submission-filter-${tabValue}`}
-        showDetailFilter={submissionPermissions.canManage && tabValue > 1}
-        tabCategories={tabs.categories}
-        categoryNum={tabValue - 2}
-        filter={filter}
-        setPageNum={setPageNum}
-        setTableIsLoading={setTableIsLoading}
-        setSelectedAssessment={setselectedAssessment}
-        setSelectedGroup={setselectedGroup}
-        setSelectedUser={setselectedUser}
-        handleFilterOnClick={handleFilter}
-      />
+          <SubmissionFilter
+            key={`submission-filter-${tabValue}`}
+            showDetailFilter={submissionPermissions.canManage && tabValue > 1}
+            tabCategories={tabs.categories}
+            categoryNum={tabValue - 2}
+            filter={filter}
+            setPageNum={setPageNum}
+            setTableIsLoading={setTableIsLoading}
+            setSelectedAssessment={setselectedAssessment}
+            setSelectedGroup={setselectedGroup}
+            setSelectedUser={setselectedUser}
+            handleFilterOnClick={handleFilter}
+          />
 
-      {!isTabChanging && (
-        <SubmissionPagination
-          submissionCount={submissionCount}
-          rowsPerPage={ROWS_PER_PAGE}
-          pageNum={pageNum}
-          handlePageChange={handlePageChange}
-        />
-      )}
+          {!isTabChanging && (
+            <SubmissionPagination
+              submissionCount={submissionCount}
+              rowsPerPage={ROWS_PER_PAGE}
+              pageNum={pageNum}
+              handlePageChange={handlePageChange}
+            />
+          )}
 
-      <SubmissionsTable
-        isGamified={isGamified}
-        submissions={submissions}
-        isPendingTab={submissionPermissions.isTeachingStaff && tabValue < 2}
-        tableIsLoading={tableIsLoading}
-        rowsPerPage={ROWS_PER_PAGE}
-        pageNum={pageNum}
-      />
+          <SubmissionsTable
+            isGamified={isGamified}
+            submissions={submissions}
+            isPendingTab={submissionPermissions.isTeachingStaff && tabValue < 2}
+            tableIsLoading={tableIsLoading}
+            rowsPerPage={ROWS_PER_PAGE}
+            pageNum={pageNum}
+          />
 
-      {!isTabChanging && submissions.length > 15 && !tableIsLoading && (
-        <SubmissionPagination
-          submissionCount={submissionCount}
-          rowsPerPage={ROWS_PER_PAGE}
-          pageNum={pageNum}
-          handlePageChange={handlePageChange}
-        />
+          {!isTabChanging && submissions.length > 15 && !tableIsLoading && (
+            <SubmissionPagination
+              submissionCount={submissionCount}
+              rowsPerPage={ROWS_PER_PAGE}
+              pageNum={pageNum}
+              handlePageChange={handlePageChange}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/client/app/bundles/course/courses/pages/CoursesIndex/index.tsx
+++ b/client/app/bundles/course/courses/pages/CoursesIndex/index.tsx
@@ -72,10 +72,6 @@ const CoursesIndex: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   // Adding appropriate button to the header
   const headerToolbars: ReactElement[] = [];
   if (coursesPermissions?.canCreate) {
@@ -91,7 +87,7 @@ const CoursesIndex: FC<Props> = (props) => {
         {intl.formatMessage(translations.newCourse)}
       </Button>,
     );
-  } else {
+  } else if (!isLoading) {
     headerToolbars.push(
       <Button
         key="role-request-button"
@@ -124,8 +120,17 @@ const CoursesIndex: FC<Props> = (props) => {
         })}
         toolbars={headerToolbars}
       />
-      <CourseDisplay courses={courses} />
-      <CoursesNew open={isOpen} handleClose={(): void => setIsOpen(false)} />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <CourseDisplay courses={courses} />
+          <CoursesNew
+            open={isOpen}
+            handleClose={(): void => setIsOpen(false)}
+          />{' '}
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/discussion/topics/pages/CommentIndex/index.tsx
+++ b/client/app/bundles/course/discussion/topics/pages/CommentIndex/index.tsx
@@ -191,19 +191,23 @@ const CommentIndex: FC<Props> = (props) => {
       .finally(() => setIsLoading(false));
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   return (
     <>
       <PageHeader
         title={
-          settings.title ?? intl.formatMessage({ ...translations.comments })
+          settings.title
+            ? settings.title
+            : intl.formatMessage({ ...translations.comments })
         }
       />
-      <CommentTabs tabValue={tabValue} intl={intl} />
-      <TopicList key={tabValue} tabValue={tabValue} settings={settings} />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <CommentTabs tabValue={tabValue} intl={intl} />
+          <TopicList key={tabValue} tabValue={tabValue} settings={settings} />
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/enrol-requests/index.tsx
+++ b/client/app/bundles/course/enrol-requests/index.tsx
@@ -1,27 +1,3 @@
-import { render } from 'react-dom';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import ProviderWrapper from 'lib/components/ProviderWrapper';
-import UserRequests from './pages/UserRequests';
-import configureStore from './store';
-
-$(() => {
-  const mountNode = document.getElementById('enrol-requests-component');
-
-  if (mountNode) {
-    const store = configureStore();
-
-    render(
-      <ProviderWrapper {...{ store }}>
-        <BrowserRouter>
-          <Routes>
-            <Route
-              path="/courses/:courseId/enrol_requests"
-              element={<UserRequests />}
-            />
-          </Routes>
-        </BrowserRouter>
-      </ProviderWrapper>,
-      mountNode,
-    );
-  }
-});
+// This is the entry point for the enrol request component
+// It's redirected to users/index file as all routes are combined there to be rendered as a single page.
+import '../users/index';

--- a/client/app/bundles/course/enrol-requests/pages/UserRequests/index.tsx
+++ b/client/app/bundles/course/enrol-requests/pages/UserRequests/index.tsx
@@ -80,10 +80,6 @@ const UserRequests: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const renderEmptyState = (): JSX.Element | undefined => {
     if (
       pendingEnrolRequests.length === 0 &&
@@ -102,31 +98,40 @@ const UserRequests: FC<Props> = (props) => {
   return (
     <Box>
       <PageHeader title={intl.formatMessage(translations.manageUsersHeader)} />
-      <UserManagementTabs permissions={permissions} sharedData={sharedData} />
-      {renderEmptyState()}
-      {pendingEnrolRequests.length > 0 && (
-        <EnrolRequestsTable
-          title={intl.formatMessage(translations.pending)}
-          enrolRequests={pendingEnrolRequests}
-          pendingEnrolRequests
-          renderRowActionComponent={(enrolRequest): JSX.Element => (
-            <PendingEnrolRequestsButtons enrolRequest={enrolRequest} />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <UserManagementTabs
+            permissions={permissions}
+            sharedData={sharedData}
+          />
+          {renderEmptyState()}
+          {pendingEnrolRequests.length > 0 && (
+            <EnrolRequestsTable
+              title={intl.formatMessage(translations.pending)}
+              enrolRequests={pendingEnrolRequests}
+              pendingEnrolRequests
+              renderRowActionComponent={(enrolRequest): JSX.Element => (
+                <PendingEnrolRequestsButtons enrolRequest={enrolRequest} />
+              )}
+            />
           )}
-        />
-      )}
-      {approvedEnrolRequests.length > 0 && (
-        <EnrolRequestsTable
-          title={intl.formatMessage(translations.approved)}
-          enrolRequests={approvedEnrolRequests}
-          approvedEnrolRequests
-        />
-      )}
-      {rejectedEnrolRequests.length > 0 && (
-        <EnrolRequestsTable
-          title={intl.formatMessage(translations.rejected)}
-          enrolRequests={rejectedEnrolRequests}
-          rejectedEnrolRequests
-        />
+          {approvedEnrolRequests.length > 0 && (
+            <EnrolRequestsTable
+              title={intl.formatMessage(translations.approved)}
+              enrolRequests={approvedEnrolRequests}
+              approvedEnrolRequests
+            />
+          )}
+          {rejectedEnrolRequests.length > 0 && (
+            <EnrolRequestsTable
+              title={intl.formatMessage(translations.rejected)}
+              enrolRequests={rejectedEnrolRequests}
+              rejectedEnrolRequests
+            />
+          )}
+        </>
       )}
     </Box>
   );

--- a/client/app/bundles/course/experience-points/disbursement/pages/DisbursementIndex/index.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/pages/DisbursementIndex/index.tsx
@@ -74,91 +74,93 @@ const DisbursementIndex: FC<Props> = (props) => {
       .finally(() => setIsLoading(false));
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   return (
     <>
       <PageHeader
         title={intl.formatMessage({ ...translations.disbursements })}
       />
-      <Tabs
-        onChange={(_, value): void => {
-          setTabValue(value);
-        }}
-        style={{
-          backgroundColor: palette.background.default,
-        }}
-        TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
-        value={tabValue}
-        variant="fullWidth"
-        sx={{ marginBottom: 2 }}
-      >
-        <Tab
-          id="forum-disbursement-tab"
-          style={{ color: palette.submissionIcon.person }}
-          icon={<FormatListBulletedIcon />}
-          label={<FormattedMessage {...translations.forumTab} />}
-          value="forum-disbursement-tab"
-        />
-        <Tab
-          id="general-disbursement-tab"
-          style={{ color: palette.submissionIcon.person }}
-          icon={<Group />}
-          label={<FormattedMessage {...translations.generalTab} />}
-          value="general-disbursement-tab"
-        />
-      </Tabs>
-      <Grid
-        container
-        direction="row"
-        columnSpacing={2}
-        rowSpacing={2}
-        id="general-disbursement-tab"
-        display={tabValue === 'general-disbursement-tab' ? 'flex' : 'none'}
-      >
-        <Grid item xs>
-          <DisbursementForm users={users} />
-        </Grid>
-      </Grid>
-      <Grid
-        container
-        direction="column"
-        columnSpacing={2}
-        rowSpacing={2}
-        id="forum-disbursement-tab"
-        display={tabValue === 'forum-disbursement-tab' ? 'flex' : 'none'}
-      >
-        <Grid item xs>
-          <Paper
-            elevation={3}
-            sx={{
-              padding: '5px 10px 0px 10px',
-              marginBottom: '5px',
-              display: 'flex',
-              alignItems: 'center',
-              backgroundColor: '#eeeeee',
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <Tabs
+            onChange={(_, value): void => {
+              setTabValue(value);
             }}
+            style={{
+              backgroundColor: palette.background.default,
+            }}
+            TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
+            value={tabValue}
+            variant="fullWidth"
+            sx={{ marginBottom: 2 }}
           >
-            <FilterForm
-              initialValues={{
-                startTime: filters.startTime,
-                endTime: filters.endTime,
-                weeklyCap: filters.weeklyCap,
-              }}
+            <Tab
+              id="forum-disbursement-tab"
+              style={{ color: palette.submissionIcon.person }}
+              icon={<FormatListBulletedIcon />}
+              label={<FormattedMessage {...translations.forumTab} />}
+              value="forum-disbursement-tab"
             />
-          </Paper>
-        </Grid>
-        <Grid item xs>
-          <ForumDisbursementForm
-            numberOfUsers={users.length}
-            forumUsers={forumUsers}
-            filters={filters}
-            forumPosts={forumPosts}
-          />
-        </Grid>
-      </Grid>
+            <Tab
+              id="general-disbursement-tab"
+              style={{ color: palette.submissionIcon.person }}
+              icon={<Group />}
+              label={<FormattedMessage {...translations.generalTab} />}
+              value="general-disbursement-tab"
+            />
+          </Tabs>
+          <Grid
+            container
+            direction="row"
+            columnSpacing={2}
+            rowSpacing={2}
+            id="general-disbursement-tab"
+            display={tabValue === 'general-disbursement-tab' ? 'flex' : 'none'}
+          >
+            <Grid item xs>
+              <DisbursementForm users={users} />
+            </Grid>
+          </Grid>
+          <Grid
+            container
+            direction="column"
+            columnSpacing={2}
+            rowSpacing={2}
+            id="forum-disbursement-tab"
+            display={tabValue === 'forum-disbursement-tab' ? 'flex' : 'none'}
+          >
+            <Grid item xs>
+              <Paper
+                elevation={3}
+                sx={{
+                  padding: '5px 10px 0px 10px',
+                  marginBottom: '5px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  backgroundColor: '#eeeeee',
+                }}
+              >
+                <FilterForm
+                  initialValues={{
+                    startTime: filters.startTime,
+                    endTime: filters.endTime,
+                    weeklyCap: filters.weeklyCap,
+                  }}
+                />
+              </Paper>
+            </Grid>
+            <Grid item xs>
+              <ForumDisbursementForm
+                numberOfUsers={users.length}
+                forumUsers={forumUsers}
+                filters={filters}
+                forumPosts={forumPosts}
+              />
+            </Grid>
+          </Grid>
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
+++ b/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
@@ -83,10 +83,6 @@ const LeaderboardIndex: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const isAchievementHidden = leaderboardAchievements.length === 0;
   const isGroupHidden = groupLeaderboardPoints.length === 0;
 
@@ -94,134 +90,141 @@ const LeaderboardIndex: FC<Props> = (props) => {
     <>
       <PageHeader
         title={
-          settings.leaderboardTitle ??
-          intl.formatMessage({ ...translations.leaderboard })
+          settings.groupleaderboardTitle
+            ? settings.groupleaderboardTitle
+            : intl.formatMessage({ ...translations.leaderboard })
         }
       />
-      {!isGroupHidden && (
-        <Tabs
-          onChange={(_, value): void => {
-            setTabValue(value);
-          }}
-          style={{
-            backgroundColor: palette.background.default,
-          }}
-          TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
-          value={tabValue}
-          variant="fullWidth"
-          sx={{ marginBottom: 2 }}
-        >
-          <Tab
-            id="leaderboard-tab"
-            style={{ color: palette.submissionIcon.person }}
-            icon={<Person />}
-            label={
-              settings.leaderboardTitle ?? (
-                <FormattedMessage {...translations.leaderboard} />
-              )
-            }
-            value="leaderboard-tab"
-          />
-          <Tab
-            id="group-leaderboard-tab"
-            style={{ color: palette.submissionIcon.person }}
-            icon={<Group />}
-            label={
-              settings.groupleaderboardTitle ?? (
-                <FormattedMessage {...translations.groupLeaderboard} />
-              )
-            }
-            value="group-leaderboard-tab"
-          />
-        </Tabs>
-      )}
-      {tabView && (
-        <Tabs
-          onChange={(_, value): void => {
-            setInnerTabValue(value);
-          }}
-          style={{
-            backgroundColor: palette.background.default,
-          }}
-          TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
-          value={innerTabValue}
-          variant="fullWidth"
-          sx={{ marginBottom: 2 }}
-        >
-          <Tab
-            id="points-tab"
-            style={{ color: palette.submissionIcon.person }}
-            icon={<AutoFixHigh />}
-            label={
-              settings.leaderboardTitle ?? (
-                <FormattedMessage {...translations.experience} />
-              )
-            }
-            value="points-tab"
-          />
-          <Tab
-            id="achievement-tab"
-            style={{ color: palette.submissionIcon.person }}
-            icon={<EmojiEvents />}
-            label={
-              settings.groupleaderboardTitle ?? (
-                <FormattedMessage {...translations.achievemnt} />
-              )
-            }
-            value="achievement-tab"
-          />
-        </Tabs>
-      )}
-      <Grid
-        container
-        direction="row"
-        columnSpacing={2}
-        rowSpacing={2}
-        display={tabValue === 'leaderboard-tab' ? 'flex' : 'none'}
-      >
-        {(!tabView || innerTabValue === 'points-tab') && (
-          <Grid item xs id="leaderboard-level">
-            <LeaderboardTable
-              data={leaderboardPoints}
-              id={LeaderboardTableType.LeaderboardPoints}
-            />
-          </Grid>
-        )}
-        {!isAchievementHidden &&
-          (!tabView || innerTabValue === 'achievement-tab') && (
-            <Grid item xs id="leaderboard-achievement">
-              <LeaderboardTable
-                data={leaderboardAchievements}
-                id={LeaderboardTableType.LeaderboardAchievement}
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          {!isGroupHidden && (
+            <Tabs
+              onChange={(_, value): void => {
+                setTabValue(value);
+              }}
+              style={{
+                backgroundColor: palette.background.default,
+              }}
+              TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
+              value={tabValue}
+              variant="fullWidth"
+              sx={{ marginBottom: 2 }}
+            >
+              <Tab
+                id="leaderboard-tab"
+                style={{ color: palette.submissionIcon.person }}
+                icon={<Person />}
+                label={
+                  settings.leaderboardTitle ?? (
+                    <FormattedMessage {...translations.leaderboard} />
+                  )
+                }
+                value="leaderboard-tab"
               />
-            </Grid>
-          )}
-      </Grid>
-      <Grid
-        container
-        direction="row"
-        columnSpacing={2}
-        rowSpacing={2}
-        display={tabValue !== 'leaderboard-tab' ? 'flex' : 'none'}
-      >
-        {(!tabView || innerTabValue === 'points-tab') && (
-          <Grid item xs id="group-leaderboard-level">
-            <LeaderboardTable
-              data={groupLeaderboardPoints}
-              id={LeaderboardTableType.GroupLeaderboardPoints}
-            />
-          </Grid>
-        )}
-        {!isAchievementHidden &&
-          (!tabView || innerTabValue === 'achievement-tab') && (
-            <Grid item xs id="group-leaderboard-achievement">
-              <LeaderboardTable
-                data={groupLeaderboardAchievements}
-                id={LeaderboardTableType.GroupLeaderboardAchievement}
+              <Tab
+                id="group-leaderboard-tab"
+                style={{ color: palette.submissionIcon.person }}
+                icon={<Group />}
+                label={
+                  settings.groupleaderboardTitle ?? (
+                    <FormattedMessage {...translations.groupLeaderboard} />
+                  )
+                }
+                value="group-leaderboard-tab"
               />
-            </Grid>
+            </Tabs>
           )}
-      </Grid>
+          {tabView && (
+            <Tabs
+              onChange={(_, value): void => {
+                setInnerTabValue(value);
+              }}
+              style={{
+                backgroundColor: palette.background.default,
+              }}
+              TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
+              value={innerTabValue}
+              variant="fullWidth"
+              sx={{ marginBottom: 2 }}
+            >
+              <Tab
+                id="points-tab"
+                style={{ color: palette.submissionIcon.person }}
+                icon={<AutoFixHigh />}
+                label={
+                  settings.leaderboardTitle ?? (
+                    <FormattedMessage {...translations.experience} />
+                  )
+                }
+                value="points-tab"
+              />
+              <Tab
+                id="achievement-tab"
+                style={{ color: palette.submissionIcon.person }}
+                icon={<EmojiEvents />}
+                label={
+                  settings.groupleaderboardTitle ?? (
+                    <FormattedMessage {...translations.achievemnt} />
+                  )
+                }
+                value="achievement-tab"
+              />
+            </Tabs>
+          )}
+          <Grid
+            container
+            direction="row"
+            columnSpacing={2}
+            rowSpacing={2}
+            display={tabValue === 'leaderboard-tab' ? 'flex' : 'none'}
+          >
+            {(!tabView || innerTabValue === 'points-tab') && (
+              <Grid item xs id="leaderboard-level">
+                <LeaderboardTable
+                  data={leaderboardPoints}
+                  id={LeaderboardTableType.LeaderboardPoints}
+                />
+              </Grid>
+            )}
+            {!isAchievementHidden &&
+              (!tabView || innerTabValue === 'achievement-tab') && (
+                <Grid item xs id="leaderboard-achievement">
+                  <LeaderboardTable
+                    data={leaderboardAchievements}
+                    id={LeaderboardTableType.LeaderboardAchievement}
+                  />
+                </Grid>
+              )}
+          </Grid>
+          <Grid
+            container
+            direction="row"
+            columnSpacing={2}
+            rowSpacing={2}
+            display={tabValue !== 'leaderboard-tab' ? 'flex' : 'none'}
+          >
+            {(!tabView || innerTabValue === 'points-tab') && (
+              <Grid item xs id="group-leaderboard-level">
+                <LeaderboardTable
+                  data={groupLeaderboardPoints}
+                  id={LeaderboardTableType.GroupLeaderboardPoints}
+                />
+              </Grid>
+            )}
+            {!isAchievementHidden &&
+              (!tabView || innerTabValue === 'achievement-tab') && (
+                <Grid item xs id="group-leaderboard-achievement">
+                  <LeaderboardTable
+                    data={groupLeaderboardAchievements}
+                    id={LeaderboardTableType.GroupLeaderboardAchievement}
+                  />
+                </Grid>
+              )}
+          </Grid>
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/lesson-plan/containers/EventFormDialog/index.jsx
+++ b/client/app/bundles/course/lesson-plan/containers/EventFormDialog/index.jsx
@@ -64,8 +64,11 @@ EventFormDialog.propTypes = {
     event_type: PropTypes.string,
     location: PropTypes.string,
     description: PropTypes.string,
-    start_at: PropTypes.string,
-    end_at: PropTypes.string,
+    start_at: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Date),
+    ]),
+    end_at: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
     published: PropTypes.bool,
   }),
   items: PropTypes.arrayOf(

--- a/client/app/bundles/course/lesson-plan/containers/MilestoneFormDialog/index.jsx
+++ b/client/app/bundles/course/lesson-plan/containers/MilestoneFormDialog/index.jsx
@@ -41,7 +41,10 @@ MilestoneFormDialog.propTypes = {
   initialValues: PropTypes.shape({
     title: PropTypes.string,
     description: PropTypes.string,
-    start_at: PropTypes.string,
+    start_at: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Date),
+    ]),
   }),
   onSubmit: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,

--- a/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/LessonPlanItem/AdminTools.jsx
+++ b/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/LessonPlanItem/AdminTools.jsx
@@ -144,8 +144,11 @@ AdminTools.propTypes = {
     published: PropTypes.bool,
     location: PropTypes.string,
     description: PropTypes.string,
-    start_at: PropTypes.string,
-    end_at: PropTypes.string,
+    start_at: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Date),
+    ]),
+    end_at: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
     lesson_plan_item_type: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   canManageLessonPlan: PropTypes.bool.isRequired,

--- a/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/MilestoneAdminTools.jsx
+++ b/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/MilestoneAdminTools.jsx
@@ -123,7 +123,10 @@ MilestoneAdminTools.propTypes = {
   milestone: PropTypes.shape({
     id: PropTypes.number,
     description: PropTypes.string,
-    start_at: PropTypes.string,
+    start_at: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Date),
+    ]),
     title: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.node, // Allow node containing translation

--- a/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/__test__/LessonPlanShow.test.jsx
+++ b/client/app/bundles/course/lesson-plan/pages/LessonPlanShow/__test__/LessonPlanShow.test.jsx
@@ -48,7 +48,7 @@ describe('<LessonPlanShow />', () => {
 
   describe('when all milestones are expanded by default', () => {
     const wrapper = mount(
-      <LessonPlanShow milestonesExpanded="all" {...data} />,
+      <LessonPlanShow milestonesExpanded="all" canManageLessonPlan {...data} />,
       contextOptions,
     );
 
@@ -59,7 +59,11 @@ describe('<LessonPlanShow />', () => {
 
   describe('when none of the milestones are expanded by default', () => {
     const wrapper = mount(
-      <LessonPlanShow milestonesExpanded="none" {...data} />,
+      <LessonPlanShow
+        milestonesExpanded="none"
+        canManageLessonPlan
+        {...data}
+      />,
       contextOptions,
     );
 
@@ -70,7 +74,11 @@ describe('<LessonPlanShow />', () => {
 
   describe('when only of the current milestone is expanded by default', () => {
     const wrapper = mount(
-      <LessonPlanShow milestonesExpanded="current" {...data} />,
+      <LessonPlanShow
+        milestonesExpanded="current"
+        canManageLessonPlan
+        {...data}
+      />,
       contextOptions,
     );
 

--- a/client/app/bundles/course/survey/pages/ResponseIndex/__test__/RemindButton.test.jsx
+++ b/client/app/bundles/course/survey/pages/ResponseIndex/__test__/RemindButton.test.jsx
@@ -10,7 +10,10 @@ describe('<RemindButton />', () => {
   it('injects handlers that trigger the reminder', () => {
     const spyRemind = jest.spyOn(CourseAPI.survey.surveys, 'remind');
     const store = storeCreator({ surveys: {} });
-    const remindButton = mount(<RemindButton />, buildContextOptions(store));
+    const remindButton = mount(
+      <RemindButton includePhantom />,
+      buildContextOptions(store),
+    );
     remindButton.find('button').simulate('click');
     const cancelButton = remindButton
       .find('ConfirmationDialog')

--- a/client/app/bundles/course/user-invitations/index.tsx
+++ b/client/app/bundles/course/user-invitations/index.tsx
@@ -1,32 +1,3 @@
-import { render } from 'react-dom';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import ProviderWrapper from 'lib/components/ProviderWrapper';
-import InviteUsers from './pages/InviteUsers';
-import InvitationsIndex from './pages/InvitationsIndex';
-import configureStore from './store';
-
-$(() => {
-  const mountNode = document.getElementById('user-invitations-component');
-
-  if (mountNode) {
-    const store = configureStore();
-
-    render(
-      <ProviderWrapper {...{ store }}>
-        <BrowserRouter>
-          <Routes>
-            <Route
-              path="/courses/:courseId/users/invite/"
-              element={<InviteUsers />}
-            />
-            <Route
-              path="/courses/:courseId/user_invitations"
-              element={<InvitationsIndex />}
-            />
-          </Routes>
-        </BrowserRouter>
-      </ProviderWrapper>,
-      mountNode,
-    );
-  }
-});
+// This is the entry point for the user invitation component
+// It's redirected to users/index file as all routes are combined there to be rendered as a single page.
+import '../users/index';

--- a/client/app/bundles/course/user-invitations/pages/InvitationsIndex/index.tsx
+++ b/client/app/bundles/course/user-invitations/pages/InvitationsIndex/index.tsx
@@ -72,41 +72,46 @@ const InviteUsers: FC<Props> = (props) => {
       .catch(() => toast.error(intl.formatMessage(translations.failure)));
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   return (
     <Box>
       <PageHeader title={intl.formatMessage(translations.manageUsersHeader)} />
-      <UserManagementTabs permissions={permissions} sharedData={sharedData} />
-      <Box sx={{ margin: '12px 0px' }} className="invitations-bar-chart">
-        <InvitationsBarChart
-          accepted={acceptedInvitations.length}
-          pending={pendingInvitations.length}
-        />
-      </Box>
-      <Typography variant="body2" style={{ whiteSpace: 'pre-line' }}>
-        {intl.formatMessage(translations.invitationsInfo)}
-      </Typography>
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <UserManagementTabs
+            permissions={permissions}
+            sharedData={sharedData}
+          />
+          <Box sx={{ margin: '12px 0px' }} className="invitations-bar-chart">
+            <InvitationsBarChart
+              accepted={acceptedInvitations.length}
+              pending={pendingInvitations.length}
+            />
+          </Box>
+          <Typography variant="body2" style={{ whiteSpace: 'pre-line' }}>
+            {intl.formatMessage(translations.invitationsInfo)}
+          </Typography>
 
-      {pendingInvitations.length > 0 && (
-        <UserInvitationsTable
-          title={intl.formatMessage(translations.pending)}
-          invitations={pendingInvitations}
-          pendingInvitations
-          renderRowActionComponent={(invitation): JSX.Element => (
-            <PendingInvitationsButtons invitation={invitation} />
+          {pendingInvitations.length > 0 && (
+            <UserInvitationsTable
+              title={intl.formatMessage(translations.pending)}
+              invitations={pendingInvitations}
+              pendingInvitations
+              renderRowActionComponent={(invitation): JSX.Element => (
+                <PendingInvitationsButtons invitation={invitation} />
+              )}
+            />
           )}
-        />
-      )}
 
-      {acceptedInvitations.length > 0 && (
-        <UserInvitationsTable
-          title={intl.formatMessage(translations.accepted)}
-          invitations={acceptedInvitations}
-          acceptedInvitations
-        />
+          {acceptedInvitations.length > 0 && (
+            <UserInvitationsTable
+              title={intl.formatMessage(translations.accepted)}
+              invitations={acceptedInvitations}
+              acceptedInvitations
+            />
+          )}
+        </>
       )}
     </Box>
   );

--- a/client/app/bundles/course/user-invitations/pages/InviteUsers/index.tsx
+++ b/client/app/bundles/course/user-invitations/pages/InviteUsers/index.tsx
@@ -58,10 +58,6 @@ const InviteUsers: FC<Props> = (props) => {
       .catch(() => toast.error(intl.formatMessage(translations.loadFailure)));
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const openResultDialog = (result: InvitationResult): void => {
     setInvitationResult(result);
     setShowInvitationResultDialog(true);
@@ -70,30 +66,39 @@ const InviteUsers: FC<Props> = (props) => {
   return (
     <>
       <PageHeader title={intl.formatMessage(translations.manageUsersHeader)} />
-      <UserManagementTabs permissions={permissions} sharedData={sharedData} />
-      <Box>
-        <Grid
-          container
-          flexDirection="row"
-          justifyContent="space-between"
-          alignItems="flex-end"
-          sx={{ margin: '12px 0px' }}
-        >
-          <Typography variant="h5">
-            {intl.formatMessage(translations.inviteUsersHeader)}
-          </Typography>
-          <Grid item style={{ display: 'flex', gap: 12 }}>
-            <UploadFileButton openResultDialog={openResultDialog} />
-            <RegistrationCodeButton />
-          </Grid>
-        </Grid>
-        <IndividualInviteForm openResultDialog={openResultDialog} />
-      </Box>
-      <InvitationResultDialog
-        open={showInvitationResultDialog}
-        handleClose={(): void => setShowInvitationResultDialog(false)}
-        invitationResult={invitationResult}
-      />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <UserManagementTabs
+            permissions={permissions}
+            sharedData={sharedData}
+          />
+          <Box>
+            <Grid
+              container
+              flexDirection="row"
+              justifyContent="space-between"
+              alignItems="flex-end"
+              sx={{ margin: '12px 0px' }}
+            >
+              <Typography variant="h5">
+                {intl.formatMessage(translations.inviteUsersHeader)}
+              </Typography>
+              <Grid item style={{ display: 'flex', gap: 12 }}>
+                <UploadFileButton openResultDialog={openResultDialog} />
+                <RegistrationCodeButton />
+              </Grid>
+            </Grid>
+            <IndividualInviteForm openResultDialog={openResultDialog} />
+          </Box>
+          <InvitationResultDialog
+            open={showInvitationResultDialog}
+            handleClose={(): void => setShowInvitationResultDialog(false)}
+            invitationResult={invitationResult}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/user-invitations/user-invitations.tsx
+++ b/client/app/bundles/course/user-invitations/user-invitations.tsx
@@ -1,2 +1,2 @@
-// This is the entry point for the user invitations component
+// This is the entry point for the user invite (course/xxxx/users/invite) component
 import './index';

--- a/client/app/bundles/course/users/components/misc/UpgradeToStaff.tsx
+++ b/client/app/bundles/course/users/components/misc/UpgradeToStaff.tsx
@@ -19,7 +19,7 @@ import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import { LoadingButton } from '@mui/lab';
 import { upgradeToStaff } from '../../operations';
-import { getAllUserOptionMiniEntities } from '../../selectors';
+import { getStudentOptionMiniEntities } from '../../selectors';
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
@@ -54,7 +54,7 @@ const UpgradeToStaff: FC<Props> = (props) => {
   const { intl } = props;
 
   const students = useSelector((state: AppState) =>
-    getAllUserOptionMiniEntities(state),
+    getStudentOptionMiniEntities(state),
   );
   const [isLoading, setIsLoading] = useState(false);
   const [selectedStudents, setSelectedStudents] = useState<

--- a/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
+++ b/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
+import { Link } from 'react-router-dom';
 import { Tab, Tabs } from '@mui/material';
 import {
   ManageCourseUsersPermissions,
@@ -44,7 +45,7 @@ const translations = defineMessages({
 
 interface TabData {
   label: { id: string; defaultMessage: string };
-  href?: string;
+  href: string;
   count?: number;
 }
 
@@ -133,8 +134,8 @@ const UserManagementTabs: FC<Props> = (props) => {
           label={intl.formatMessage(tab.label)}
           icon={<CustomBadge badgeContent={tab.count} color="error" />}
           iconPosition="end"
-          href={tab.href}
-          component="a"
+          component={Link}
+          to={tab.href}
           style={{
             minHeight: 48,
             paddingRight: tab.count === 0 || tab.count === undefined ? 8 : 26,

--- a/client/app/bundles/course/users/index.tsx
+++ b/client/app/bundles/course/users/index.tsx
@@ -7,6 +7,9 @@ import ManageStudents from './pages/ManageStudents';
 import ManageStaff from './pages/ManageStaff';
 import PersonalTimes from './pages/PersonalTimes';
 import PersonalTimesShow from './pages/PersonalTimesShow';
+import UserRequests from '../enrol-requests/pages/UserRequests';
+import InviteUsers from '../user-invitations/pages/InviteUsers';
+import InvitationsIndex from '../user-invitations/pages/InvitationsIndex';
 import configureStore from './store';
 
 $(() => {
@@ -27,6 +30,18 @@ $(() => {
             <Route
               path="/courses/:courseId/students"
               element={<ManageStudents />}
+            />
+            <Route
+              path="/courses/:courseId/enrol_requests"
+              element={<UserRequests />}
+            />
+            <Route
+              path="/courses/:courseId/users/invite/"
+              element={<InviteUsers />}
+            />
+            <Route
+              path="/courses/:courseId/user_invitations"
+              element={<InvitationsIndex />}
             />
             <Route path="/courses/:courseId/staff" element={<ManageStaff />} />
             <Route

--- a/client/app/bundles/course/users/pages/ManageStaff/index.tsx
+++ b/client/app/bundles/course/users/pages/ManageStaff/index.tsx
@@ -55,10 +55,6 @@ const ManageStaff: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const renderEmptyState = (): JSX.Element => {
     return (
       <Typography variant="body1">
@@ -72,19 +68,28 @@ const ManageStaff: FC<Props> = (props) => {
       <PageHeader
         title={intl.formatMessage(manageUsersTranslations.manageUsersHeader)}
       />
-      <UserManagementTabs permissions={permissions} sharedData={sharedData} />
-      <UpgradeToStaff />
-      {staff.length > 0 ? (
-        <ManageUsersTable
-          title={intl.formatMessage(translations.manageStaffTitle)}
-          users={staff}
-          manageStaff
-          renderRowActionComponent={(user): JSX.Element => (
-            <UserManagementButtons user={user} />
-          )}
-        />
+      {isLoading ? (
+        <LoadingIndicator />
       ) : (
-        renderEmptyState()
+        <>
+          <UserManagementTabs
+            permissions={permissions}
+            sharedData={sharedData}
+          />
+          <UpgradeToStaff />
+          {staff.length > 0 ? (
+            <ManageUsersTable
+              title={intl.formatMessage(translations.manageStaffTitle)}
+              users={staff}
+              manageStaff
+              renderRowActionComponent={(user): JSX.Element => (
+                <UserManagementButtons user={user} />
+              )}
+            />
+          ) : (
+            renderEmptyState()
+          )}
+        </>
       )}
     </>
   );

--- a/client/app/bundles/course/users/pages/ManageStudents/index.tsx
+++ b/client/app/bundles/course/users/pages/ManageStudents/index.tsx
@@ -56,10 +56,6 @@ const ManageStudents: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const renderEmptyState = (): JSX.Element => {
     return (
       <Typography variant="body1">
@@ -73,17 +69,26 @@ const ManageStudents: FC<Props> = (props) => {
       <PageHeader
         title={intl.formatMessage(manageUsersTranslations.manageUsersHeader)}
       />
-      <UserManagementTabs permissions={permissions} sharedData={sharedData} />
-      {students.length > 0 ? (
-        <ManageUsersTable
-          title={intl.formatMessage(translations.manageStudentsTitle)}
-          users={students}
-          renderRowActionComponent={(user): JSX.Element => (
-            <UserManagementButtons user={user} />
-          )}
-        />
+      {isLoading ? (
+        <LoadingIndicator />
       ) : (
-        renderEmptyState()
+        <>
+          <UserManagementTabs
+            permissions={permissions}
+            sharedData={sharedData}
+          />
+          {students.length > 0 ? (
+            <ManageUsersTable
+              title={intl.formatMessage(translations.manageStudentsTitle)}
+              users={students}
+              renderRowActionComponent={(user): JSX.Element => (
+                <UserManagementButtons user={user} />
+              )}
+            />
+          ) : (
+            renderEmptyState()
+          )}
+        </>
       )}
     </>
   );

--- a/client/app/bundles/course/users/pages/PersonalTimes/index.tsx
+++ b/client/app/bundles/course/users/pages/PersonalTimes/index.tsx
@@ -52,24 +52,29 @@ const PersonalTimes: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   return (
     <>
       <PageHeader title={intl.formatMessage(translations.manageUsersHeader)} />
-      <UserManagementTabs permissions={permissions} sharedData={sharedData} />
-      <Paper
-        elevation={3}
-        sx={{ padding: '12px 24px 24px 24px', margin: '12px 0px' }}
-      >
-        <Typography variant="h6" sx={{ marginBottom: '24px' }}>
-          {intl.formatMessage(translations.courseUserHeader)}
-        </Typography>
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <UserManagementTabs
+            permissions={permissions}
+            sharedData={sharedData}
+          />
+          <Paper
+            elevation={3}
+            sx={{ padding: '12px 24px 24px 24px', margin: '12px 0px' }}
+          >
+            <Typography variant="h6" sx={{ marginBottom: '24px' }}>
+              {intl.formatMessage(translations.courseUserHeader)}
+            </Typography>
 
-        <SelectCourseUser />
-      </Paper>
+            <SelectCourseUser />
+          </Paper>
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/users/pages/UsersIndex/index.tsx
+++ b/client/app/bundles/course/users/pages/UsersIndex/index.tsx
@@ -57,10 +57,6 @@ const UsersIndex: FC<Props> = (props) => {
       );
   }, [dispatch]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
-
   const renderEmptyState = (): JSX.Element => {
     return (
       <Typography variant="body1">
@@ -72,43 +68,51 @@ const UsersIndex: FC<Props> = (props) => {
   return (
     <>
       <PageHeader title={intl.formatMessage(translations.studentsHeader)} />
-      <Grid container>
-        {users.length > 0
-          ? users.map((courseUser) => (
-              <Grid
-                item
-                className={`course-user-${courseUser.id}`}
-                key={courseUser.id}
-                xs={12}
-                md={6}
-                lg={4}
-              >
-                <Link
-                  to={getCourseUserURL(courseId, courseUser.id)}
-                  style={{ textDecoration: 'none' }}
-                >
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <Grid container>
+            {users.length > 0
+              ? users.map((courseUser) => (
                   <Grid
-                    container
-                    direction="row"
-                    spacing={1}
-                    alignItems="center"
+                    item
+                    className={`course-user-${courseUser.id}`}
+                    key={courseUser.id}
+                    xs={12}
+                    md={6}
+                    lg={4}
                   >
-                    <Grid container item xs={3} justifyContent="center">
-                      <Avatar
-                        src={courseUser.imageUrl}
-                        alt={courseUser.name}
-                        sx={styles.courseUserImage}
-                      />
-                    </Grid>
-                    <Grid item xs style={styles.courseUserName}>
-                      <Typography variant="body1">{courseUser.name}</Typography>
-                    </Grid>
+                    <Link
+                      to={getCourseUserURL(courseId, courseUser.id)}
+                      style={{ textDecoration: 'none' }}
+                    >
+                      <Grid
+                        container
+                        direction="row"
+                        spacing={1}
+                        alignItems="center"
+                      >
+                        <Grid container item xs={3} justifyContent="center">
+                          <Avatar
+                            src={courseUser.imageUrl}
+                            alt={courseUser.name}
+                            sx={styles.courseUserImage}
+                          />
+                        </Grid>
+                        <Grid item xs style={styles.courseUserName}>
+                          <Typography variant="body1">
+                            {courseUser.name}
+                          </Typography>
+                        </Grid>
+                      </Grid>
+                    </Link>
                   </Grid>
-                </Link>
-              </Grid>
-            ))
-          : renderEmptyState()}
-      </Grid>
+                ))
+              : renderEmptyState()}
+          </Grid>
+        </>
+      )}
     </>
   );
 };

--- a/client/app/bundles/course/users/selectors.ts
+++ b/client/app/bundles/course/users/selectors.ts
@@ -43,6 +43,13 @@ export function getAllUserOptionMiniEntities(state: AppState) {
   );
 }
 
+export function getStudentOptionMiniEntities(state: AppState) {
+  return selectMiniEntities(
+    getLocalState(state).userOptions,
+    getLocalState(state).userOptions.ids,
+  ).filter((entity) => entity.role === 'student');
+}
+
 export function getManageCourseUserPermissions(state: AppState) {
   return getLocalState(state).permissions;
 }

--- a/client/app/bundles/course/users/store.ts
+++ b/client/app/bundles/course/users/store.ts
@@ -2,11 +2,15 @@ import { enableMapSet } from 'immer';
 import { applyMiddleware, createStore, compose, combineReducers } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import usersReducer from './reducers';
+import invitationsReducer from '../user-invitations/reducers';
+import enrolRequestsReducer from '../enrol-requests/reducers';
 
 const defaultReducers = {};
 
 const rootReducer = combineReducers({
   users: usersReducer,
+  invitations: invitationsReducer,
+  enrolRequests: enrolRequestsReducer,
 });
 
 enableMapSet();

--- a/client/app/bundles/system/admin/admin/components/navigation/SystemAdminSidebar.tsx
+++ b/client/app/bundles/system/admin/admin/components/navigation/SystemAdminSidebar.tsx
@@ -127,6 +127,25 @@ const SystemAdminSidebar: FC<Props> = (props) => {
       >
         <Grid item>
           <List style={{ marginTop: '60px' }}>
+            <ListItem button onClick={handleExpandClick}>
+              <ListItemIcon sx={{ minWidth: '32px' }}>
+                {isExpanded ? (
+                  <KeyboardDoubleArrowLeft />
+                ) : (
+                  <Tooltip
+                    placement="right"
+                    title={intl.formatMessage(translations.expandSidebar)}
+                  >
+                    <KeyboardDoubleArrowRight />
+                  </Tooltip>
+                )}
+              </ListItemIcon>
+              {isExpanded && (
+                <ListItemText
+                  primary={intl.formatMessage(translations.collapseSidebar)}
+                />
+              )}
+            </ListItem>
             <ListItemLink
               to="/admin/announcements"
               primary={intl.formatMessage(translations.announcements)}
@@ -155,29 +174,6 @@ const SystemAdminSidebar: FC<Props> = (props) => {
               icon={<AutoStories />}
               expanded={isExpanded}
             />
-          </List>
-        </Grid>
-        <Grid item>
-          <List>
-            <ListItem button onClick={handleExpandClick}>
-              <ListItemIcon sx={{ minWidth: '32px' }}>
-                {isExpanded ? (
-                  <KeyboardDoubleArrowLeft />
-                ) : (
-                  <Tooltip
-                    placement="right"
-                    title={intl.formatMessage(translations.expandSidebar)}
-                  >
-                    <KeyboardDoubleArrowRight />
-                  </Tooltip>
-                )}
-              </ListItemIcon>
-              {isExpanded && (
-                <ListItemText
-                  primary={intl.formatMessage(translations.collapseSidebar)}
-                />
-              )}
-            </ListItem>
           </List>
         </Grid>
       </Grid>

--- a/client/app/lib/components/layouts/layout.scss
+++ b/client/app/lib/components/layouts/layout.scss
@@ -26,3 +26,8 @@ body {
     }
   }
 }
+
+footer {
+  background-color: #ffffff;
+  z-index: 2;
+}

--- a/client/app/lib/components/navigation/Sidebar.tsx
+++ b/client/app/lib/components/navigation/Sidebar.tsx
@@ -57,6 +57,7 @@ const Sidebar: FC<Props> = (props) => {
           display: { xs: 'none', sm: 'block' },
         }}
         className={`${styles.sidebarContainer}`}
+        transitionDuration={1000}
       >
         {renderDrawer(isDrawerOpen, handleDrawerToggle)}
       </Drawer>

--- a/client/app/types/course/courseUsers.ts
+++ b/client/app/types/course/courseUsers.ts
@@ -32,6 +32,7 @@ export interface CourseUserBasicListData {
   id: number;
   name: string;
   imageUrl?: string;
+  role?: CourseUserRole;
 }
 
 export interface CourseUserListData extends CourseUserBasicListData {
@@ -45,6 +46,7 @@ export interface CourseUserBasicMiniEntity {
   id: number;
   name: string;
   imageUrl?: string;
+  role?: CourseUserRole;
 }
 
 export interface CourseUserMiniEntity extends CourseUserBasicMiniEntity {

--- a/client/package.json
+++ b/client/package.json
@@ -79,7 +79,7 @@
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-react": "^7.18.6",
     "@babel/runtime": "^7.18.9",
-    "@ckeditor/ckeditor5-build-custom": "github:syoopie/CKEditor5-build-custom#v1",
+    "@ckeditor/ckeditor5-build-custom": "github:ekowidianto/CKEditor5-build-coursemology#v1",
     "@ckeditor/ckeditor5-react": "^5.0.2",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -200,17 +200,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz#4b8aea3b069d8cb8a72cdfe28ddf5ceca695ef2f"
   integrity sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==
 
-"@babel/helper-remap-async-to-generator@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.18.6.tgz#fa1f81acd19daee9d73de297c0308783cd3cfc23"
-  integrity sha512-z5wbmV55TveUPZlCLZvxWHtrjuJd+8inFhk7DG0WW87/oJuGDcjDiu7HIvGcpf5464L6xKCg3vNkmlVVz9hwyQ==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.18.6"
-    "@babel/helper-environment-visitor" "^7.18.6"
-    "@babel/helper-wrap-function" "^7.18.6"
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-remap-async-to-generator@^7.18.9":
+"@babel/helper-remap-async-to-generator@^7.18.6", "@babel/helper-remap-async-to-generator@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.18.9.tgz#997458a0e3357080e54e1d79ec347f8a8cd28519"
   integrity sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==
@@ -267,17 +257,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
-"@babel/helper-wrap-function@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.18.6.tgz#ec44ea4ad9d8988b90c3e465ba2382f4de81a073"
-  integrity sha512-I5/LZfozwMNbwr/b1vhhuYD+J/mU+gfGAj5td7l5Rv9WYmH6i3Om69WGKNmlIpsVW/mF6O5bvTKbvDQZVgjqOw==
-  dependencies:
-    "@babel/helper-function-name" "^7.18.6"
-    "@babel/template" "^7.18.6"
-    "@babel/traverse" "^7.18.6"
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-wrap-function@^7.18.9":
+"@babel/helper-wrap-function@^7.18.6", "@babel/helper-wrap-function@^7.18.9":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.18.10.tgz#a7fcd3ab9b1be4c9b52cf7d7fdc1e88c2ce93396"
   integrity sha512-95NLBP59VWdfK2lyLKe6eTMq9xg+yWKzxzxbJ1wcYNi1Auz200+83fMDADjRxBvc2QQor5zja2yTQzXGhk2GtQ==
@@ -1080,9 +1060,9 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ckeditor/ckeditor5-build-custom@github:syoopie/CKEditor5-build-custom#v1":
+"@ckeditor/ckeditor5-build-custom@github:ekowidianto/CKEditor5-build-coursemology#v1":
   version "0.0.1"
-  resolved "https://codeload.github.com/syoopie/CKEditor5-build-custom/tar.gz/c22c7a20899efb9dc9bd3e2a29fbca9848372ce4"
+  resolved "https://codeload.github.com/ekowidianto/CKEditor5-build-coursemology/tar.gz/c22c7a20899efb9dc9bd3e2a29fbca9848372ce4"
 
 "@ckeditor/ckeditor5-react@^5.0.2":
   version "5.0.2"

--- a/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
+++ b/lib/autoload/active_job/queue_adapters/background_thread_adapter.rb
@@ -31,7 +31,7 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
     super
   end
 
-  def enqueue(job) # :nodoc:
+  def enqueue(job)
     ActiveSupport::Notifications.instrument(ENQUEUE_EVENT, job: job, caller: caller) do |payload|
       with_thread_pool { @pending_jobs << job.serialize }
       ensure_threads
@@ -40,7 +40,7 @@ class ActiveJob::QueueAdapters::BackgroundThreadAdapter < ActiveJob::QueueAdapte
     end
   end
 
-  def enqueue_at(job, timestamp) # :nodoc:
+  def enqueue_at(job, timestamp)
     @future_jobs << { job: job, at: timestamp }
   end
 

--- a/lib/autoload/notifier/base/activity_wrapper.rb
+++ b/lib/autoload/notifier/base/activity_wrapper.rb
@@ -21,7 +21,7 @@ class Notifier::Base::ActivityWrapper < SimpleDelegator
     super.tap { |_| send_pending_email }
   end
 
-  def initialize(notifier, activity) # :nodoc:
+  def initialize(notifier, activity)
     super(activity)
     @notifier = notifier
   end

--- a/spec/controllers/course/personal_times_controller_spec.rb
+++ b/spec/controllers/course/personal_times_controller_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Course::PersonalTimesController, type: :controller do
 
     describe '#recompute' do
       subject do
-        post :recompute, params: { course_id: course.id, user_id: course_user.id }
+        post :recompute, as: :json, params: { course_id: course.id, user_id: course_user.id }
       end
 
       context 'when a normal user recomputes a personal timeline' do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -78,6 +78,7 @@ module Capybara::TestGroupHelpers
     # Since capybara's `find` has a default timeout until the element is found, this helps
     # to ensure certain changes are made before continuing with the tests.
     def expect_toastify(message)
+      sleep 0.5 # To ensure toast is open
       within find('div.Toastify__toast') do
         expect(find('div.Toastify__toast-body', visible: true).text).to eq(message)
         find('button.Toastify__close-button').click


### PR DESCRIPTION
This PR contains the following:
- Refactor react pages to show page header when loading the page content
- Improve API response performance for manage user pages by removing nested jbuilder
- Fix flaky rspec due to tast
- Create a single entry point for all pages in the manage_user component
- Remove `:nodoc:` comment from rails codebase
- Refactor announcement creation from redirection to API JSON response
- Fixes https://github.com/Coursemology/coursemology2/issues/4908
- Fixes footer and sidebar drawer layout for admin setting page