### PR TITLE
Groups: Some UI improvements

### DIFF
--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupManager.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupManager.jsx
@@ -271,7 +271,7 @@ const GroupManager = ({
               style={styles.groupButton}
               onClick={() => handleGroupSelect(group.id)}
             >
-              {group.name}
+              {`${group.name} (${group.members.length})`}
             </Button>
           ))}
         </div>

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManager.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManager.jsx
@@ -228,13 +228,16 @@ const GroupUserManager = ({
 
   const onCheck = useCallback(
     (user) => {
+      let groupRole = 'normal';
+      if (user.role !== 'student') groupRole = 'manager';
+
       const newGroup = {
         ...group,
         members: [
           ...group.members,
           {
             ...user,
-            groupRole: 'normal',
+            groupRole,
           },
         ],
       };

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManager.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManager.jsx
@@ -226,22 +226,26 @@ const GroupUserManager = ({
     [dispatch, categoryId, group.id, group.name, setIsConfirmingDelete],
   );
 
+  /**
+   * @param input - A user instance or array of users
+   */
   const onCheck = useCallback(
-    (user) => {
-      let groupRole = 'normal';
-      if (user.role !== 'student') groupRole = 'manager';
+    (input) => {
+      let users = input;
+      if (!Array.isArray(input)) users = [input];
+
+      const newMembers = users.map((user) => ({
+        ...user,
+        groupRole: user.role === 'student' ? 'normal' : 'manager',
+      }));
 
       const newGroup = {
         ...group,
-        members: [
-          ...group.members,
-          {
-            ...user,
-            groupRole,
-          },
-        ],
+        members: [...group.members, ...newMembers],
       };
+
       newGroup.members.sort(sortByName).sort(sortByGroupRole);
+
       return dispatch({
         type: actionTypes.MODIFY_GROUP,
         group: newGroup,
@@ -250,12 +254,21 @@ const GroupUserManager = ({
     [dispatch, group],
   );
 
+  /**
+   * @param input - A user instance or array of users
+   */
   const onUncheck = useCallback(
-    (user) => {
+    (input) => {
+      let users = input;
+      if (!Array.isArray(input)) users = [input];
+
+      const memberIdsToRemove = new Set(users.map((user) => user.id));
+
       const newGroup = {
         ...group,
-        members: group.members.filter((m) => m.id !== user.id),
+        members: group.members.filter((m) => !memberIdsToRemove.has(m.id)),
       };
+
       return dispatch({
         type: actionTypes.MODIFY_GROUP,
         group: newGroup,

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
@@ -67,12 +67,17 @@ const styles = {
   listItemTextSize: {
     fontSize: 13,
   },
+  listItemLabel: {
+    display: 'flex',
+    width: '100%',
+    paddingTop: 8,
+    paddingBottom: 8,
+    paddingLeft: 16,
+    paddingRight: 16,
+  },
   checkbox: {
     width: 'auto',
     padding: 0,
-  },
-  divider: {
-    marginTop: 16,
   },
 };
 
@@ -87,43 +92,44 @@ const GroupUserManagerListItem = ({
   <ListItem
     button
     className={showDropdown ? 'has-dropdown' : ''}
+    disablePadding
     style={
       colour
         ? { ...styles.listItem, backgroundColor: colour.light }
         : styles.listItem
     }
   >
-    <Checkbox
-      checked={isChecked}
-      onChange={() => onCheck(user)}
-      style={styles.checkbox}
-    />
-    <ListItemText
-      style={styles.listItemText}
-      primaryTypographyProps={{ style: styles.listItemTextSize }}
-    >
-      {showDropdown ? (
-        <div style={styles.listItemWithDropdown}>
-          <div onClick={() => onCheck(user)}>{user.name}</div>
-          <Select
-            className="group-user-manager-list-item-dropdown"
-            onChange={(event) => onChangeDropdown(event.target.value, user)}
-            value={user.groupRole}
-            style={styles.listItemTextSize}
-            variant="standard"
-          >
-            <MenuItem value="normal" style={styles.listItemTextSize}>
-              <FormattedMessage {...translations.normal} />
-            </MenuItem>
-            <MenuItem value="manager" style={styles.listItemTextSize}>
-              <FormattedMessage {...translations.manager} />
-            </MenuItem>
-          </Select>
-        </div>
-      ) : (
-        <div onClick={() => onCheck(user)}>{user.name}</div>
-      )}
-    </ListItemText>
+    <div onClick={() => onCheck(user)} style={styles.listItemLabel}>
+      <Checkbox
+        checked={isChecked}
+        onChange={() => onCheck(user)}
+        style={styles.checkbox}
+      />
+
+      <ListItemText primaryTypographyProps={{ style: styles.listItemTextSize }}>
+        {user.name}
+      </ListItemText>
+    </div>
+
+    {showDropdown ? (
+      <div style={styles.listItemWithDropdown}>
+        <Select
+          className="group-user-manager-list-item-dropdown"
+          onClick={() => {}}
+          onChange={(event) => onChangeDropdown(event.target.value, user)}
+          value={user.groupRole}
+          style={styles.listItemTextSize}
+          variant="standard"
+        >
+          <MenuItem value="normal" style={styles.listItemTextSize}>
+            <FormattedMessage {...translations.normal} />
+          </MenuItem>
+          <MenuItem value="manager" style={styles.listItemTextSize}>
+            <FormattedMessage {...translations.manager} />
+          </MenuItem>
+        </Select>
+      </div>
+    ) : null}
   </ListItem>
 );
 

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
@@ -138,60 +138,51 @@ const GroupUserManagerList = ({
   showDropdown = false,
   onChangeDropdown,
   isChecked = false,
-}) => (
-  <List style={styles.list}>
-    {students.length === 0 && staff.length === 0 ? (
-      <ListItem button style={{ color: grey[400] }}>
-        <ListItemText>
-          <FormattedMessage {...translations.noUsersFound} />
-        </ListItemText>
-      </ListItem>
-    ) : null}
-    {students.length > 0 && (
-      <>
-        <ListSubheader disableSticky>
-          <FormattedMessage {...translations.students} />
-        </ListSubheader>
-        {students.map((user) => {
-          const colour = colourMap[user.id];
-          return (
-            <GroupUserManagerListItem
-              key={user.id}
-              user={user}
-              colour={colour}
-              onCheck={onCheck}
-              showDropdown={showDropdown}
-              onChangeDropdown={onChangeDropdown}
-              isChecked={isChecked}
-            />
-          );
-        })}
-      </>
-    )}
-    {staff.length > 0 && (
-      <>
-        {students.length > 0 && <Divider style={styles.divider} />}
-        <ListSubheader disableSticky>
-          <FormattedMessage {...translations.staff} />
-        </ListSubheader>
-        {staff.map((user) => {
-          const colour = colourMap[user.id];
-          return (
-            <GroupUserManagerListItem
-              key={user.id}
-              user={user}
-              colour={colour}
-              onCheck={onCheck}
-              showDropdown={showDropdown}
-              onChangeDropdown={onChangeDropdown}
-              isChecked={isChecked}
-            />
-          );
-        })}
-      </>
-    )}
-  </List>
-);
+}) => {
+  const renderUsersListItems = (users, title) => (
+    <>
+      <ListSubheader disableSticky>
+        <FormattedMessage {...title} />
+      </ListSubheader>
+
+      {users.map((user) => {
+        const colour = colourMap[user.id]
+        return (
+          <GroupUserManagerListItem
+            key={user.id}
+            user={user}
+            colour={colour}
+            onCheck={onCheck}
+            showDropdown={showDropdown}
+            onChangeDropdown={onChangeDropdown}
+            isChecked={isChecked}
+          />
+        )
+      })}
+    </>
+  );
+
+  return (
+    <List style={styles.list}>
+      {students.length === 0 && staff.length === 0 ? (
+        <ListItem button style={{ color: grey[400] }}>
+          <ListItemText>
+            <FormattedMessage {...translations.noUsersFound} />
+          </ListItemText>
+        </ListItem>
+      ) : null}
+
+      {students.length > 0 && renderUsersListItems(students, translations.students)}
+
+      {staff.length > 0 && (
+        <>
+          {students.length > 0 && <Divider style={styles.divider} />}
+          {renderUsersListItems(staff, translations.staff)}
+        </>
+      )}
+    </List>
+  );
+};
 
 GroupUserManagerList.propTypes = {
   students: PropTypes.arrayOf(memberShape),

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
@@ -41,6 +41,12 @@ const styles = {
     border: 'solid 1px #d9d9d9',
     overflowY: 'scroll',
     height: 500,
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  listSubheader: {
+    backgroundColor: '#f0f0f0',
+    fontWeight: 'bold',
   },
   listItem: {
     height: 36,
@@ -141,7 +147,7 @@ const GroupUserManagerList = ({
 }) => {
   const renderUsersListItems = (users, title) => (
     <>
-      <ListSubheader disableSticky>
+      <ListSubheader style={styles.listSubheader}>
         <FormattedMessage {...title} />
       </ListSubheader>
 
@@ -174,12 +180,7 @@ const GroupUserManagerList = ({
 
       {students.length > 0 && renderUsersListItems(students, translations.students)}
 
-      {staff.length > 0 && (
-        <>
-          {students.length > 0 && <Divider style={styles.divider} />}
-          {renderUsersListItems(staff, translations.staff)}
-        </>
-      )}
+      {staff.length > 0 && renderUsersListItems(staff, translations.staff)}
     </List>
   );
 };

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManagerList.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import {
   Checkbox,
-  Divider,
   List,
   ListItem,
   ListItemText,
@@ -72,7 +71,7 @@ const styles = {
     width: '100%',
     paddingTop: 8,
     paddingBottom: 8,
-    paddingLeft: 16,
+    paddingLeft: 24,
     paddingRight: 16,
   },
   checkbox: {
@@ -154,11 +153,17 @@ const GroupUserManagerList = ({
   const renderUsersListItems = (users, title) => (
     <>
       <ListSubheader style={styles.listSubheader}>
+        <Checkbox
+          checked={isChecked}
+          onChange={() => onCheck(users)}
+          style={styles.checkbox}
+        />
+
         <FormattedMessage {...title} />
       </ListSubheader>
 
       {users.map((user) => {
-        const colour = colourMap[user.id]
+        const colour = colourMap[user.id];
         return (
           <GroupUserManagerListItem
             key={user.id}
@@ -169,7 +174,7 @@ const GroupUserManagerList = ({
             onChangeDropdown={onChangeDropdown}
             isChecked={isChecked}
           />
-        )
+        );
       })}
     </>
   );
@@ -184,7 +189,8 @@ const GroupUserManagerList = ({
         </ListItem>
       ) : null}
 
-      {students.length > 0 && renderUsersListItems(students, translations.students)}
+      {students.length > 0 &&
+        renderUsersListItems(students, translations.students)}
 
       {staff.length > 0 && renderUsersListItems(staff, translations.staff)}
     </List>


### PR DESCRIPTION
Closes #4591.

## Summary
- Added number of members in categories view (see below).
- Added un(select) all checkboxes on Students/Staff list subheaders (see below).
- Fixed clicking at the edge of a user list item does not trigger `onClick`.
- Adding Staff users automatically assigns them as `'manager'`.
- Students/Staff list subheaders are now sticky for ease of access when there are many users.
- Students/Staff list items are slightly indented to distinguish between the un(select) all checkboxes.

### Added number of members in categories view
| Before | After |
| -------- | ------- |
| ![image](https://user-images.githubusercontent.com/51525686/183369933-084ca5f2-4812-4d4e-abaa-ed99e9910960.png) | ![image](https://user-images.githubusercontent.com/51525686/183369605-7939a2c2-47d0-47eb-b495-1ace905c1e8b.png) |

### Added (Un)select All checkboxes
| Before | After |
| -------- | ------- |
| ![image](https://user-images.githubusercontent.com/51525686/183370501-5879b2a9-0644-484b-ae80-b0420dbf1a2d.png) | ![image](https://user-images.githubusercontent.com/51525686/183369682-2e1e74e3-a391-4dd6-9027-a9427a40f091.png) |

