### PR TITLE
Scribing: Fix bugs and inconsistent tools behaviours

### DIFF
--- a/client/app/bundles/course/assessment/submission/actions/scribing.js
+++ b/client/app/bundles/course/assessment/submission/actions/scribing.js
@@ -178,6 +178,14 @@ export function setCanvasStates(answerId, canvasStates) {
     });
 }
 
+export function updateCanvasState(answerId, canvasState) {
+  return (dispatch) =>
+    dispatch({
+      type: canvasActionTypes.UPDATE_CANVAS_STATE,
+      payload: { answerId, canvasState },
+    });
+}
+
 export function setActiveObject(answerId, activeObject) {
   return (dispatch) =>
     dispatch({

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -719,7 +719,7 @@ export default class ScribingCanvas extends Component {
     obj.setCoords();
   }
 
-  rehydrateCanvas = (scribbles) => {
+  rehydrateCanvas = (scribbles, scribbleCallback) => {
     this.isScribblesLoaded = false;
 
     this.canvas.clear();
@@ -729,7 +729,11 @@ export default class ScribingCanvas extends Component {
       this.canvas.add(layer.scribbleGroup),
     );
 
-    scribbles.forEach((scribble) => this.canvas.add(scribble));
+    scribbles.forEach((scribble) => {
+      scribbleCallback?.(scribble);
+      this.canvas.add(scribble);
+    });
+
     this.canvas.renderAll();
 
     this.isScribblesLoaded = true;
@@ -782,15 +786,11 @@ export default class ScribingCanvas extends Component {
   // This method clears the selection-disabled scribbles
   // and reloads them to enable selection again
   enableObjectSelection() {
-    const canvasState =
-      this.props.scribing.canvasStates[this.props.scribing.currentStateIndex];
-    const userScribbles = this.getFabricObjectsFromJson(canvasState);
-    this.canvas.clear();
-    this.canvas.setBackground();
-    this.props.scribing.layers.forEach((layer) =>
-      this.canvas.add(layer.scribbleGroup),
-    );
-    userScribbles.forEach((scribble) => {
+    const currentStateIndex = this.props.scribing.currentStateIndex;
+    const state = this.props.scribing.canvasStates[currentStateIndex];
+    const scribbles = this.getFabricObjectsFromJson(state);
+
+    this.rehydrateCanvas(scribbles, (scribble) => {
       if (scribble.type === 'i-text') {
         scribble.setControlsVisibility({
           bl: false,
@@ -803,10 +803,7 @@ export default class ScribingCanvas extends Component {
           tr: false,
         });
       }
-      this.canvas.add(scribble);
     });
-    this.canvas.renderAll();
-    this.isScribblesLoaded = true;
   }
 
   // Generates the left, top, width and height of the drag

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -674,7 +674,7 @@ export default class ScribingCanvas extends Component {
     });
 
     // Only save rescaled user scribings
-    const objects = this.canvas._objects;
+    const objects = this.canvas.getObjects();
     objects.forEach((obj) => {
       this.normaliseScribble(obj);
     });
@@ -994,11 +994,20 @@ export default class ScribingCanvas extends Component {
     if (!this.isScribblesLoaded) return null;
 
     return new Promise((resolve) => {
+      // See https://github.com/Coursemology/coursemology2/pull/4957 to learn
+      // discarding and resetting active objects matters
+      const activeObjects = this.canvas.getActiveObjects();
+      this.canvas.discardActiveObject();
+
       const answerId = this.props.answerId;
       const state = this.scribblesAsJson;
 
       this.updateAnswer(state);
       this.props.updateCanvasState(answerId, state);
+
+      this.canvas.setActiveObject(
+        new fabric.ActiveSelection(activeObjects, { canvas: this.canvas }),
+      );
 
       resolve();
     });

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -166,9 +166,7 @@ export default class ScribingCanvas extends Component {
         this.props.resetRedo(this.props.answerId);
       }
       if (nextProps.scribing.isDelete) {
-        const activeObjects = this.canvas.getActiveObjects();
-        this.canvas.discardActiveObject();
-        activeObjects.forEach((object) => this.canvas.remove(object));
+        this.deleteActiveObjects();
         this.props.resetCanvasDelete(this.props.answerId);
       }
     }
@@ -176,6 +174,20 @@ export default class ScribingCanvas extends Component {
     // Render canvas only at the beginning
     return !this.props.scribing.isCanvasLoaded;
   }
+
+  deleteActiveObjects = () => {
+    const activeObjects = this.canvas.getActiveObjects();
+    this.canvas.discardActiveObject();
+
+    const lastObjectIndex = Math.max(activeObjects.length - 1, 0);
+    this.isScribblesLoaded = false;
+    activeObjects.forEach((object, index) => {
+      if (index === lastObjectIndex) this.isScribblesLoaded = true;
+      this.canvas.remove(object);
+    });
+
+    this.isScribblesLoaded = true;
+  };
 
   onKeyDown = (event) => {
     if (!this.canvas) return;
@@ -187,8 +199,7 @@ export default class ScribingCanvas extends Component {
       case 8: // Backspace key
       case 46: {
         // Delete key
-        this.canvas.discardActiveObject();
-        activeObjects.forEach((object) => this.canvas.remove(object));
+        this.deleteActiveObjects();
         break;
       }
       case 67: {

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -1010,9 +1010,10 @@ export default class ScribingCanvas extends Component {
       this.updateAnswer(state);
       this.props.updateCanvasState(answerId, state);
 
-      this.canvas.setActiveObject(
-        new fabric.ActiveSelection(activeObjects, { canvas: this.canvas }),
-      );
+      if (activeObjects.length > 1)
+        this.canvas.setActiveObject(
+          new fabric.ActiveSelection(activeObjects, { canvas: this.canvas }),
+        );
 
       resolve();
     });

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -597,44 +597,15 @@ export default class ScribingCanvas extends Component {
     }
   };
 
-  // Limit moving of objects to within the canvas
-  onObjectMovingCanvas = (options) => {
-    const obj = options.target;
-    // if object is too big ignore
-    if (
-      obj.currentHeight > obj.canvas.height ||
-      obj.currentWidth > obj.canvas.width
-    ) {
-      return;
-    }
-    obj.setCoords();
-    // top-left  corner
-    if (obj.getBoundingRect().top < 0 || obj.getBoundingRect().left < 0) {
-      obj.top = Math.max(obj.top, obj.top - obj.getBoundingRect().top);
-      obj.left = Math.max(obj.left, obj.left - obj.getBoundingRect().left);
-    }
-    // bot-right corner
-    if (
-      obj.getBoundingRect().top + obj.getBoundingRect().height >
-        obj.canvas.height ||
-      obj.getBoundingRect().left + obj.getBoundingRect().width >
-        obj.canvas.width
-    ) {
-      obj.top = Math.min(
-        obj.top,
-        obj.canvas.height -
-          obj.getBoundingRect().height +
-          obj.top -
-          obj.getBoundingRect().top,
-      );
-      obj.left = Math.min(
-        obj.left,
-        obj.canvas.width -
-          obj.getBoundingRect().width +
-          obj.left -
-          obj.getBoundingRect().left,
-      );
-    }
+  onObjectMovingCanvas = ({ target: object }) => {
+    const canvas = this.canvas;
+    if (object.width > canvas.width || object.height > canvas.height) return;
+
+    // Limit movement of objects to only within canvas
+    object.top = Math.min(Math.max(0, object.top), canvas.height);
+    object.left = Math.min(Math.max(0, object.left), canvas.width);
+
+    object.setCoords();
   };
 
   onObjectSelected = (options) => {

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/ScribingCanvas.jsx
@@ -597,13 +597,18 @@ export default class ScribingCanvas extends Component {
     }
   };
 
-  onObjectMovingCanvas = ({ target: object }) => {
+  onObjectMovingCanvas = ({ target }) => {
+    const object = target;
     const canvas = this.canvas;
-    if (object.width > canvas.width || object.height > canvas.height) return;
+    const width = object.getBoundingRect().width;
+    const height = object.getBoundingRect().height;
+    if (width > canvas.width || height > canvas.height) return;
 
     // Limit movement of objects to only within canvas
-    object.top = Math.min(Math.max(0, object.top), canvas.height);
-    object.left = Math.min(Math.max(0, object.left), canvas.width);
+    const canvasRight = canvas.width - width;
+    const canvasBottom = canvas.height - height;
+    object.top = Math.min(Math.max(0, object.top), canvasBottom);
+    object.left = Math.min(Math.max(0, object.left), canvasRight);
 
     object.setCoords();
   };

--- a/client/app/bundles/course/assessment/submission/constants.js
+++ b/client/app/bundles/course/assessment/submission/constants.js
@@ -107,6 +107,7 @@ export const canvasActionTypes = mirrorCreator([
   'SET_CANVAS_CURSOR',
   'SET_CURRENT_STATE_INDEX',
   'SET_CANVAS_STATES',
+  'UPDATE_CANVAS_STATE',
   'SET_ACTIVE_OBJECT',
   'SET_CANVAS_ZOOM',
   'RESET_CHANGE_TOOL',

--- a/client/app/bundles/course/assessment/submission/reducers/scribing.js
+++ b/client/app/bundles/course/assessment/submission/reducers/scribing.js
@@ -1,3 +1,6 @@
+import produce from 'immer';
+import { isNumber } from 'lodash';
+
 import actions, {
   canvasActionTypes,
   scribingTools,
@@ -324,6 +327,36 @@ export default function (state = {}, action) {
           canvasStates,
         },
       };
+    }
+    case canvasActionTypes.UPDATE_CANVAS_STATE: {
+      const { answerId, canvasState } = action.payload;
+      return produce(state, (draft) => {
+        const currentState = draft[answerId];
+        if (!currentState) throw new Error(`currentState is ${currentState}`);
+
+        const currentStateIndex = currentState.currentStateIndex;
+        if (!isNumber(currentStateIndex))
+          throw new Error(`currentStateIndex is ${currentStateIndex}`);
+
+        const canvasStates = currentState.canvasStates;
+        if (!canvasStates)
+          throw new Error(`canvasStates for ${answerId} is not init`);
+
+        const lastIndex = canvasStates.length - 1;
+        const nextIndex = currentStateIndex + 1;
+
+        if (nextIndex <= lastIndex) canvasStates.splice(nextIndex);
+
+        canvasStates.push(canvasState);
+
+        const latestIndex = canvasStates.length - 1;
+        currentState.currentStateIndex = latestIndex;
+
+        if (latestIndex !== nextIndex)
+          throw new Error(
+            `canvasState index ${latestIndex} and nextIndex ${nextIndex} are different`,
+          );
+      });
     }
     case canvasActionTypes.SET_ACTIVE_OBJECT: {
       const { answerId, activeObject } = action.payload;


### PR DESCRIPTION
Closes #4523.

## Summary
- Resolved all bugs indicated in https://github.com/Coursemology/coursemology2/issues/4523#issuecomment-1211693883.
- Tested adding texts, scribbles, lines, and shapes, with different colours, thickness, fonts.
- Tested zooming in/out and panning with Move tool.
- Tested moving (multiple) objects around with Pointer tool.
- Tested Delete button with selected objects.
- Tested undo/redo with above actions, and also doing actions after undoing.

## Future recommendations
- Use Immer's `produce` or Redux Toolkit for the rest of scribing reducers. This will ensure all changes are immutable.
- Find a safer way to lazy-load `fabric` and `react-color` in `ScribingView/index.jsx`. This will ensure `ScribingCanvas` will never throw `fabric` not found error.  
This could be solved by using fetch-then-render, but `ScribingView/__test__/index.test.js:59` will fail because the `<canvas>` in `ScribingCanvas` will only be rendered after _the fetch-then-render triggers a re-render cycle_, which [Enzyme seem not to support](https://stackoverflow.com/a/59174911).
- Abstract all fabric stuff into its own wrapper.

## Bug fix reports
### Undoing after moving multiple objects moves the objects to the top-left edge of the canvas
This is where you should read if you were redirected by `ScribingCanvas.saveScribbles()`. See _Solution_ below for TL;DR.

#### Explanation
This problem originated because when multiple objects are selected, fabric.js creates a new [`ActiveSelection`](http://fabricjs.com/docs/fabric.ActiveSelection.html) object. In particular, the target `object` in `ScribingCanvas.onObjectMovingCanvas` can be:
- an [`ActiveSelection`](http://fabricjs.com/docs/fabric.ActiveSelection.html) object when **multiple** objects are selected, or
- the respective selected [`Object`](http://fabricjs.com/docs/fabric.Object.html) (or `klass`) type when a **single** object is selected.

The latter case is easy, but the former case is tricky. In the documentation, [`ActiveSelection` actually extends `Group`](http://fabricjs.com/docs/fabric.ActiveSelection.html). In a `Group`, [the object's coordinates become relative to their parent `Group`](https://stackoverflow.com/a/29926545), NOT the `Canvas` anymore. As such, the `top` and `left` of the object(s) in `ScribingCanvas.onObjectMovingCanvas` **can be negative**. When the objects are deselected, the `ActiveSelection` object "unwraps" and the individual objects' coordinates revert back to that of the `Canvas`.

Since `ScribingCanvas.saveScribbles()` is automatically fired on `object:modified` **and the `ActiveSelection` object is still there** (the objects are not yet deselected), the saved state is the state that contains an `ActiveSelection`, with the selected objects on their relative coordinates. Since `ScribingCanvas.scribblesAsJson` stringifies the `Canvas`, the `ActiveSelection` is not translated (because it's just a selection) **objects with relative coordinates are saved**. This results in the moved objects returning to (beyond) the top-left corner of the canvas since their `top`s and `left`s can be negative.

#### Solution
`ScribingCanvas.saveScribbles()` will then have to capture the selected objects with `canvas.getActiveObjects()` and **deselect the objects with `canvas.discardActiveObject()`** ❗ before saving. This way, the objects return to the canvas' coordinate. After saving, we then re-select the previously selected objects. Since the state saving is relatively fast, there should not be any jittering artifacts on the user's end.

>This whole issue would have been solved if instead of defining our own `scribblesAsJson` and `getFabricObjectsFromJson`, we instead use fabric.js' built-in [`toJSON()`](http://fabricjs.com/docs/fabric.Canvas.html#toJSON)/[`toObject().objects`](http://fabricjs.com/docs/fabric.Canvas.html#toObject) and [`loadFromJSON()`](http://fabricjs.com/docs/fabric.Canvas.html#loadFromJSON). These methods took care of the aforesaid coordinate mess.

### Inconsistent undo/redo behaviours
#### Explanation
See the following previous implementation of `ScribingCanvas.saveScribbles()`.
```js
saveScribbles = () =>
  new Promise((resolve) => {
    if (this.isScribblesLoaded) {
      const answerId = this.props.answerId;
      const answerActableId = this.props.scribing.answer.answer_id;
      const json = this.getScribbleJSON();
      this.props.updateScribingAnswerInLocal(answerId, json);
      this.props.updateScribingAnswer(answerId, answerActableId, json);

      let states = this.props.scribing.canvasStates;
      if (
        this.props.scribing.currentStateIndex <
        this.props.scribing.canvasStates.length - 1
      ) {
        const addedStateIndex = this.props.scribing.currentStateIndex + 1;
        states[addedStateIndex] = json;                   // <- mutable in-place changes!
        states = states.splice(0, addedStateIndex + 1);   // <- mutable in-place changes!
        this.props.setCanvasStates(this.props.answerId, states);
      } else {
        states.push(json);
        this.props.setCanvasStates(this.props.answerId, states);
      }
      this.props.setCurrentStateIndex(this.props.answerId, states.length - 1);
    }
    resolve();
  });
```
As one can see, there were mutable in-place changes to the Redux store that caused unpredictable undo/redo outcomes.

Also, notice the `splice` being used there. It actually removes all the states __from index zero (the earliest) to current index (the latest)__. This results in a behaviour that: (1) draw ten scribbles, (2) undo once and the tenth scribble undoes, (3) undo again and everything disappears.

#### Solution
Abstract state mutations in `reducers/scribing,js` and use Immer's `produce` for immutability assurance.

### Switching to the Pointer tool after scribbling removes all scribbles
#### Explanation
See the following previous implementation of `ScribingCanvas.setCurrentCanvasState()`.
```js
setCurrentCanvasState = (stateIndex) => {
  const userScribbles = this.getFabricObjectsFromJson(
    this.props.scribing.canvasStates[stateIndex],
  );

  this.canvas.clear();    // <- fires canvas.on('object:modified')!
  this.canvas.setBackground();
  this.props.scribing.layers.forEach((layer) =>
    this.canvas.add(layer.scribbleGroup),
  );
  userScribbles.forEach((scribble) => this.canvas.add(scribble));
  this.canvas.renderAll();
  this.isScribblesLoaded = true;

  this.props.setCurrentStateIndex(this.props.answerId, stateIndex);
};
```
Interestingly, `canvas.clear()` actually fires `object:modified`. Since selecting the Pointer tool,
- fires `ScribingToolbar.onClickSelectionMode()`, which,
- fires `scribing.setEnableObjectSelection` that changes the store and triggers `ScribingCanvas` re-render which,
- triggers `ScribingCanvas.shouldComponentUpdate` which,
- triggers `ScribingCanvas.this.enableObjectSelection()`, which,
- triggers `canvas.clear()`,
- fires the canvas' `object:modified` event, which,
- triggers `ScribingCanvas.saveScribbles()` (see `ScribingCanvas.initializeCanvas`),

the canvas states in the store are duplicated and the disappearing scribbles were caused by undoing into an empty-object state (caused by the splicing issue in the previous bug).

#### Solution
Since `ScribingCanvas.saveScribbles()` already ignores saving if `!this.isScribblesLoaded`, `ScribingCanvas.setCurrentCanvasState()` should set `this.isScribblesLoaded = false` before modifying the canvas.