### PR TITLE
Assessment, Video: Fix 403 when Attempt/Watch in new tab

### DIFF
--- a/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
+++ b/app/views/course/assessment/assessments/_assessment_management_buttons.html.slim
@@ -19,8 +19,8 @@ div.btn-group
       = link_to(t('.enter_password'), course_assessment_path(current_course, assessment),
                 class: ['btn', 'btn-info'])
     - elsif can_attempt_assessment
-      = link_to t('.attempt'), course_assessment_submissions_path(current_course, assessment),
-                class: ['btn','btn-info'], method: :post
+      = link_to t('.attempt'), course_assessment_attempt_path(current_course, assessment),
+                class: ['btn','btn-info']
   - else
     = link_to(t('.attempt'), '#', class: ['btn', 'btn-info', 'disabled'])
 

--- a/app/views/course/video/submission/submissions/_watch_next_video_url.json.jbuilder
+++ b/app/views/course/video/submission/submissions/_watch_next_video_url.json.jbuilder
@@ -5,7 +5,7 @@ if next_video && can?(:attempt, next_video) && current_course_user
     json.watchNextVideoUrl edit_course_video_submission_path(current_course, next_video, submission)
     json.nextVideoSubmissionExists true
   else
-    json.watchNextVideoUrl course_video_submissions_path(current_course, next_video)
+    json.watchNextVideoUrl course_video_attempt_path(current_course, next_video)
     json.nextVideoSubmissionExists false
   end
 end

--- a/app/views/course/video/videos/_video_attempt_button.html.slim
+++ b/app/views/course/video/videos/_video_attempt_button.html.slim
@@ -5,7 +5,7 @@
       edit_course_video_submission_path(current_course, video, submission),
       class: ['btn', 'btn-info']
   - else
-    = link_to t('.watch'), course_video_submissions_path(current_course, video),
-      class: ['btn', 'btn-info'], method: :post
+    = link_to t('.watch'), course_video_attempt_path(current_course, video),
+      class: ['btn', 'btn-info']
 - else
   = link_to(t('.watch'), '#', class: ['btn', 'btn-info', 'disabled'])

--- a/client/app/bundles/course/courses/components/buttons/TodoAccessButton.tsx
+++ b/client/app/bundles/course/courses/components/buttons/TodoAccessButton.tsx
@@ -6,6 +6,7 @@ import axios from 'lib/axios';
 interface Props extends WrappedComponentProps {
   accessButtonText: string;
   accessButtonLink: string;
+  submissionUrl: string;
   isVideo: boolean;
   isNewAttempt: boolean;
 }
@@ -19,9 +20,9 @@ const TodoAccessButton: FC<Props> = (props) => {
       onClick={(): void => {
         if (isVideo) {
           axios
-            .post(accessButtonLink)
+            .get(accessButtonLink)
             .then((response) => {
-              window.location.href = `${accessButtonLink}/${response.data.submissionId}/edit`;
+              window.location.href = `${submissionUrl}/${response.data.submissionId}/edit`;
             })
             .catch((_e) => {});
         } else if (isNewAttempt) {

--- a/client/app/bundles/course/courses/components/buttons/TodoAccessButton.tsx
+++ b/client/app/bundles/course/courses/components/buttons/TodoAccessButton.tsx
@@ -12,7 +12,13 @@ interface Props extends WrappedComponentProps {
 }
 
 const TodoAccessButton: FC<Props> = (props) => {
-  const { accessButtonText, accessButtonLink, isVideo, isNewAttempt } = props;
+  const {
+    accessButtonText,
+    accessButtonLink,
+    submissionUrl,
+    isVideo,
+    isNewAttempt,
+  } = props;
   return (
     <Button
       variant="contained"
@@ -27,9 +33,9 @@ const TodoAccessButton: FC<Props> = (props) => {
             .catch((_e) => {});
         } else if (isNewAttempt) {
           axios
-            .post(accessButtonLink)
+            .get(accessButtonLink)
             .then((response) => {
-              window.location.href = `${accessButtonLink}/${response.data.submission.id}/edit`;
+              window.location.href = `${submissionUrl}/${response.data.submission.id}/edit`;
             })
             .catch((_e) => {});
         } else {

--- a/client/app/bundles/course/courses/components/tables/PendingTodosTable.tsx
+++ b/client/app/bundles/course/courses/components/tables/PendingTodosTable.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 import equal from 'fast-deep-equal';
 import {
+  getAssessmentAttemptURL,
   getAssessmentSubmissionURL,
   getAssessmentURL,
   getCourseURL,
@@ -128,7 +129,7 @@ const PendingTodosTable: FC<Props> = (props) => {
             accessButtonText = intl.formatMessage(
               translations.accessButtonAttempt,
             );
-            accessButtonLink = getAssessmentSubmissionURL(
+            accessButtonLink = getAssessmentAttemptURL(
               getCourseId(),
               todo.itemActableId,
             );
@@ -142,6 +143,11 @@ const PendingTodosTable: FC<Props> = (props) => {
             todo.itemActableId,
           )}/${todo.itemActableSpecificId}/edit`;
         }
+
+        submissionUrl = getAssessmentSubmissionURL(
+          getCourseId(),
+          todo.itemActableId,
+        );
         break;
 
       case 'videos':

--- a/client/app/bundles/course/courses/components/tables/PendingTodosTable.tsx
+++ b/client/app/bundles/course/courses/components/tables/PendingTodosTable.tsx
@@ -18,6 +18,7 @@ import {
   getIgnoreTodoURL,
   getSurveyResponseURL,
   getSurveyURL,
+  getVideoAttemptURL,
   getVideoSubmissionsURL,
 } from 'lib/helpers/url-builders';
 import { getCourseId } from 'lib/helpers/url-helpers';
@@ -98,6 +99,7 @@ const PendingTodosTable: FC<Props> = (props) => {
   const renderButtons = (todo: TodoData): JSX.Element => {
     let accessButtonText = '';
     let accessButtonLink = '';
+    let submissionUrl;
     switch (todoType) {
       case 'surveys':
         accessButtonText = intl.formatMessage(translations.accessButtonRespond);
@@ -144,7 +146,12 @@ const PendingTodosTable: FC<Props> = (props) => {
 
       case 'videos':
         accessButtonText = intl.formatMessage(translations.accessButtonWatch);
-        accessButtonLink = getVideoSubmissionsURL(
+        accessButtonLink = getVideoAttemptURL(
+          getCourseId(),
+          todo.itemActableId,
+        );
+
+        submissionUrl = getVideoSubmissionsURL(
           getCourseId(),
           todo.itemActableId,
         );
@@ -170,6 +177,7 @@ const PendingTodosTable: FC<Props> = (props) => {
             todo.canAccess! &&
             todo.canAttempt!
           }
+          submissionUrl={submissionUrl ?? accessButtonLink}
         />
         <TodoIgnoreButton
           ignoreLink={getIgnoreTodoURL(getCourseId(), todo.id)}

--- a/client/app/lib/helpers/url-builders.js
+++ b/client/app/lib/helpers/url-builders.js
@@ -60,6 +60,9 @@ export const getVideoURL = (courseId, videoId) =>
 export const getVideoSubmissionsURL = (courseId, videoId) =>
   `/courses/${courseId}/videos/${videoId}/submissions`;
 
+export const getVideoAttemptURL = (courseId, videoId) =>
+  `/courses/${courseId}/videos/${videoId}/attempt`;
+
 export const getIgnoreTodoURL = (courseId, todoId) =>
   `/courses/${courseId}/lesson_plan/todos/${todoId}/ignore`;
 

--- a/client/app/lib/helpers/url-builders.js
+++ b/client/app/lib/helpers/url-builders.js
@@ -47,6 +47,9 @@ export const getAssessmentURL = (courseId, assessmentId) =>
 export const getAssessmentSubmissionURL = (courseId, assessmentId) =>
   `/courses/${courseId}/assessments/${assessmentId}/submissions`;
 
+export const getAssessmentAttemptURL = (courseId, assessmentId) =>
+  `/courses/${courseId}/assessments/${assessmentId}/attempt`;
+
 export const getEditAssessmentSubmissionURL = (
   courseId,
   assessmentId,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,7 +201,8 @@ Rails.application.routes.draw do
             resources :forum_post_responses, only: [:new, :create, :edit, :update, :destroy]
           end
           scope module: :submission do
-            resources :submissions, only: [:index, :create, :edit, :update] do
+            get 'attempt' => 'submissions#create'
+            resources :submissions, only: [:index, :edit, :update] do
               post :auto_grade, on: :member
               post :reload_answer, on: :member
               patch :submit_answer, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -391,7 +391,8 @@ Rails.application.routes.draw do
         resources :videos do
           resources :topics, only: [:index, :create, :show]
           scope module: :submission do
-            resources :submissions, only: [:index, :create, :show, :edit] do
+            get 'attempt' => 'submissions#create'
+            resources :submissions, only: [:index, :show, :edit] do
               resources :sessions, only: [:create, :update]
             end
           end

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
         within find(content_tag_selector(assessment_with_condition)) do
           find_link(I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-                    href: course_assessment_submissions_path(course, assessment_with_condition)).
+                    href: course_assessment_attempt_path(course, assessment_with_condition)).
             click
         end
 
@@ -83,7 +83,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
         within find(content_tag_selector(assessment)) do
           find_link(I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-                    href: course_assessment_submissions_path(course, assessment)).click
+                    href: course_assessment_attempt_path(course, assessment)).click
         end
 
         created_submission = assessment.submissions.last
@@ -111,7 +111,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         within find(content_tag_selector(assessment_tabbed_single_question)) do
           find_link(
             I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-            href: course_assessment_submissions_path(course, assessment_tabbed_single_question)
+            href: course_assessment_attempt_path(course, assessment_tabbed_single_question)
           ).click
         end
 
@@ -123,7 +123,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
         within find(content_tag_selector(assessment_tabbed)) do
           find_link(
             I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-            href: course_assessment_submissions_path(course, assessment_tabbed)
+            href: course_assessment_attempt_path(course, assessment_tabbed)
           ).click
         end
 
@@ -187,7 +187,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
         within find(content_tag_selector(assessment_with_condition)) do
           find_link(I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-                    href: course_assessment_submissions_path(course, assessment_with_condition)).
+                    href: course_assessment_attempt_path(course, assessment_with_condition)).
             click
         end
 
@@ -203,7 +203,7 @@ RSpec.describe 'Course: Assessments: Attempt' do
 
         within find(content_tag_selector(not_started_assessment)) do
           find_link(I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-                    href: course_assessment_submissions_path(course, not_started_assessment)).click
+                    href: course_assessment_attempt_path(course, not_started_assessment)).click
         end
 
         created_submission = not_started_assessment.submissions.last

--- a/spec/features/course/assessment/assessment_viewing_spec.rb
+++ b/spec/features/course/assessment/assessment_viewing_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Course: Assessments: Viewing' do
 
         expect(page).to have_link(
           I18n.t('course.assessment.assessments.assessment_management_buttons.attempt'),
-          href: course_assessment_submissions_path(course, assessment)
+          href: course_assessment_attempt_path(course, assessment)
         )
       end
     end


### PR DESCRIPTION
Closes #4958.

## Summary
- Fix Access Denied when clicking Attempt or Watch on an assessment or video by opening in new tab.
- Attempt or Watch by opening in new tab **for Staff** now actually attempts/watches instead of showing the submissions page.

| Before | After |
| - | - |
| `POST` `course_assessment_submissions_path` <br> `POST` `/assessments/:id/submissions` | `GET` `course_assessment_attempt_path` <br> `GET` `/assessments/:id/attempt` |
| `POST` `course_video_submissions_path` <br> `POST` `/videos/:id/submissions` | `GET` `course_video_attempt_path` <br> `GET` `/videos/:id/attempt` |