### PR TITLE
Fix CKEditor popup and toolbar dropdown issue

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -99,3 +99,9 @@ $summernote-font-color: #000000;
   color: $summernote-font-color;
   padding: 10px;
 }
+
+// Below is needed to ensure ckeditor popup (eg link)
+// is rendered properly.
+.ck-body-wrapper {
+  position: absolute;
+}

--- a/client/app/lib/components/ProviderWrapper.jsx
+++ b/client/app/lib/components/ProviderWrapper.jsx
@@ -40,6 +40,11 @@ const themeSettings = {
         color: 'white !important',
       },
     },
+    MuiCard: {
+      root: {
+        overflow: 'visible',
+      },
+    },
     MuiDialogContent: {
       root: {
         color: 'black',


### PR DESCRIPTION
Closes #4974 

Fixes the two issues below:

1) CKEditor toolbar dropdowns are cut off / not shown entirely, when there the CKEditor component is located inside a MUI Card component. Fixed by setting overflow to be visible for MUI Card.
![image](https://user-images.githubusercontent.com/42570513/185540481-d45fa23b-1ce7-48bc-9ecf-a7e63f0827c2.png)

2) CKEditor link popup can't be found. Apparently, it is rendered by ck-body-wrapper off the screen. Fixed by setting its position to be absolute.

https://user-images.githubusercontent.com/42570513/185540937-76683368-8811-4be5-a4aa-445b8b2f72d7.mov
