### PR TITLE
Add workflow state to course discussion post

### DIFF
--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -48,7 +48,7 @@ module Course::Discussion::PostsConcern
   private
 
   def post_params
-    params.require(:discussion_post).permit(:title, :text, :parent_id, :is_delayed)
+    params.require(:discussion_post).permit(:title, :text, :parent_id, :workflow_state)
   end
 
   def set_topic

--- a/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
@@ -23,7 +23,7 @@ class Course::Assessment::Submission::Answer::Programming::AnnotationsController
     end
 
     if result
-      send_created_notification(@post) unless @post.is_delayed
+      send_created_notification(@post) if @post.published?
       render_create_response
     else
       head :bad_request

--- a/app/controllers/course/assessment/submission_question/comments_controller.rb
+++ b/app/controllers/course/assessment/submission_question/comments_controller.rb
@@ -15,7 +15,7 @@ class Course::Assessment::SubmissionQuestion::CommentsController < Course::Asses
     end
 
     if result
-      send_created_notification(@post) unless @post.is_delayed
+      send_created_notification(@post) if @post.published?
       render_create_response
     else
       head :bad_request

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -53,7 +53,7 @@ module Course::Discussion::TopicsHelper
     @all_student_unread_count ||=
       if current_course_user&.student?
         current_course.discussion_topics.globally_displayed.from_user(current_user.id).
-          unread_by(current_user).distinct.without_delayed_posts.count
+          unread_by(current_user).distinct.with_published_posts.count
       else
         0
       end

--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -239,7 +239,7 @@ module Course::Assessment::Submission::WorkflowEventConcern
     unless delayed_posts.empty?
       # Remove 'mark as read' (if any)
       topic.read_marks.where('reader_id = ?', creator.id)&.destroy_all
-      delayed_posts.update_all(is_delayed: false)
+      delayed_posts.update_all(workflow_state: 'published')
     end
     true
   end

--- a/app/models/course/discussion/topic.rb
+++ b/app/models/course/discussion/topic.rb
@@ -34,9 +34,9 @@ class Course::Discussion::Topic < ApplicationRecord
       where(actable_type: global_topic_models.map(&:name)).distinct
   end)
 
-  # Topics of which there is at least 1 normal post
-  scope :without_delayed_posts, (lambda do
-    joins(:posts).where('course_discussion_posts.is_delayed = ?', false).distinct
+  # Topics of which there is at least 1 published post
+  scope :with_published_posts, (lambda do
+    joins(:posts).where('course_discussion_posts.workflow_state = ?', 'published').distinct
   end)
 
   # Returns the topics from the user(s) specified.

--- a/app/notifiers/course/assessment/answer/comment_notifier.rb
+++ b/app/notifiers/course/assessment/answer/comment_notifier.rb
@@ -15,7 +15,7 @@ class Course::Assessment::Answer::CommentNotifier < Notifier::Base
       course_user = category.course.course_users.find_by(user: subscription.user)
       is_disabled_as_phantom = course_user.phantom? && !email_enabled.phantom
       is_disabled_as_regular = !course_user.phantom? && !email_enabled.regular
-      is_disabled_delayed = course_user.student? && post.is_delayed
+      is_disabled_delayed = course_user.student? && post.delayed?
       exclude_user = subscription.user == user ||
                      is_disabled_as_phantom ||
                      is_disabled_as_regular ||

--- a/app/notifiers/course/assessment/submission_question/comment_notifier.rb
+++ b/app/notifiers/course/assessment/submission_question/comment_notifier.rb
@@ -15,7 +15,7 @@ class Course::Assessment::SubmissionQuestion::CommentNotifier < Notifier::Base
       course_user = category.course.course_users.find_by(user: subscription.user)
       is_disabled_as_phantom = course_user.phantom? && !email_enabled.phantom
       is_disabled_as_regular = !course_user.phantom? && !email_enabled.regular
-      is_disabled_delayed = course_user.student? && post.is_delayed
+      is_disabled_delayed = course_user.student? && post.delayed?
       exclude_user = subscription.user == user ||
                      is_disabled_as_phantom ||
                      is_disabled_as_regular ||

--- a/app/views/course/assessment/submission/submissions/_topics.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_topics.json.jbuilder
@@ -4,7 +4,7 @@ json.topics submission_questions do |submission_question|
   json.id topic.id
   json.submissionQuestionId submission_question.id
   json.questionId submission_question.question_id
-  json.postIds can_grade ? topic.post_ids : topic.posts.exclude_delayed_posts.ids
+  json.postIds can_grade ? topic.post_ids : topic.posts.only_published_posts.ids
 end
 
 programming_answers = submission.answers.where(question: submission.questions).
@@ -17,9 +17,9 @@ json.annotations programming_answers.flat_map(&:files) do |file|
   json.fileId file.id
   json.topics(file.annotations.reject { |a| a.discussion_topic.post_ids.empty? }) do |annotation|
     topic = annotation.discussion_topic
-    if can_grade || !topic.posts.exclude_delayed_posts.empty?
+    if can_grade || !topic.posts.only_published_posts.empty?
       json.id topic.id
-      json.postIds can_grade ? topic.post_ids : topic.posts.exclude_delayed_posts.ids
+      json.postIds can_grade ? topic.post_ids : topic.posts.only_published_posts.ids
       json.line annotation.line
     end
   end
@@ -29,5 +29,5 @@ posts = submission_questions.map(&:discussion_topic).flat_map(&:posts)
 posts += programming_answers.flat_map(&:files).flat_map(&:annotations).map(&:discussion_topic).flat_map(&:posts)
 
 json.posts posts do |post|
-  json.partial! post, post: post if can_grade || !post.is_delayed
+  json.partial! post, post: post if can_grade || post.published?
 end

--- a/app/views/course/discussion/_posts.html.slim
+++ b/app/views/course/discussion/_posts.html.slim
@@ -1,6 +1,6 @@
 - post_locals ||= {}
 - posts.each do |post|
-  - unless post.first.is_delayed
+  - if post.first.published?
     = render partial: post_partial, object: post.first, locals: post_locals
   - nest_replies = max_depth > 1
   - replies_class = nest_replies ? 'nested' : nil

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -11,4 +11,4 @@ json.createdAt post.created_at&.iso8601
 json.topicId post.topic_id
 json.canUpdate can?(:update, post)
 json.canDestroy can?(:destroy, post)
-json.isDelayed post.is_delayed
+json.isDelayed post.delayed?

--- a/app/views/course/discussion/topics/_discussion_topic_programming_file_annotation.jbuilder
+++ b/app/views/course/discussion/topics/_discussion_topic_programming_file_annotation.jbuilder
@@ -17,7 +17,7 @@ json.creator do
 end
 json.content display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
 
-json.partial! 'topic', topic: topic, can_grade: true
+json.partial! 'topic', topic: topic, can_grade: can?(:grade, submission)
 
 json.links do
   json.titleLink edit_course_assessment_submission_path(current_course, assessment, submission,

--- a/app/views/course/discussion/topics/_topic.json.jbuilder
+++ b/app/views/course/discussion/topics/_topic.json.jbuilder
@@ -16,5 +16,5 @@ end
 
 # looping through linked list of posts
 json.postList posts.ordered_topologically.flatten.each do |post|
-  json.partial! 'course/discussion/posts/post', post: post if can_grade || !post.is_delayed
+  json.partial! 'course/discussion/posts/post', post: post if can_grade || post.published?
 end

--- a/app/views/course/discussion/topics/topics_list_data.json.jbuilder
+++ b/app/views/course/discussion/topics/topics_list_data.json.jbuilder
@@ -2,7 +2,7 @@
 json.topicCount @topic_count
 
 json.topicList @topics.map(&:specific) do |topic|
-  unless topic.posts.exclude_delayed_posts.empty?
+  unless topic.posts.only_published_posts.empty?
     actable = topic.actable
     case actable
     when Course::Assessment::SubmissionQuestion

--- a/client/app/bundles/course/assessment/submission/actions/annotations.js
+++ b/client/app/bundles/course/assessment/submission/actions/annotations.js
@@ -20,7 +20,10 @@ export function create(
 ) {
   const payload = {
     annotation: { line },
-    discussion_post: { text, is_delayed: isDelayedComment },
+    discussion_post: {
+      text,
+      workflow_state: isDelayedComment ? 'delayed' : 'published',
+    },
   };
   return (dispatch) => {
     dispatch({ type: actionTypes.CREATE_ANNOTATION_REQUEST, isDelayedComment });

--- a/client/app/bundles/course/assessment/submission/actions/comments.js
+++ b/client/app/bundles/course/assessment/submission/actions/comments.js
@@ -12,7 +12,10 @@ export function onCreateChange(topicId, text) {
 
 export function create(submissionQuestionId, text, isDelayedComment) {
   const payload = {
-    discussion_post: { text, is_delayed: isDelayedComment },
+    discussion_post: {
+      text,
+      workflow_state: isDelayedComment ? 'delayed' : 'published',
+    },
   };
   return (dispatch) => {
     dispatch({ type: actionTypes.CREATE_COMMENT_REQUEST, isDelayedComment });

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -19,7 +19,7 @@ import {
   StepButton,
   SvgIcon,
 } from '@mui/material';
-import { blue, yellow, red } from '@mui/material/colors';
+import { blue, yellow, red, grey } from '@mui/material/colors';
 
 /* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
@@ -244,15 +244,16 @@ const SubmissionEditForm = (props) => {
     const anyUngraded = Object.values(grading).some(
       (q) => q.grade === undefined || q.grade === null,
     );
+    const disabled = isSaving || anyUngraded;
     return (
       <Button
         variant="contained"
-        disabled={isSaving || anyUngraded}
+        disabled={disabled}
         onClick={handleMark}
         style={{
           ...styles.formButton,
-          backgroundColor: yellow[900],
-          color: 'white',
+          backgroundColor: disabled ? grey[300] : yellow[900],
+          color: disabled ? grey[600] : 'white',
         }}
       >
         {intl.formatMessage(translations.mark)}

--- a/db/migrate/20220819071113_add_workflow_state_to_post.rb
+++ b/db/migrate/20220819071113_add_workflow_state_to_post.rb
@@ -1,0 +1,23 @@
+class AddWorkflowStateToPost < ActiveRecord::Migration[6.0]
+  def up
+    add_column :course_discussion_posts, :workflow_state, :string, default: 'published'
+
+    ActiveRecord::Base.connection.exec_update(
+      "UPDATE course_discussion_posts
+       SET workflow_state = 'delayed'
+       WHERE is_delayed = TRUE"
+    )
+    # remove_column :course_discussion_posts, :is_delayed
+  end
+
+  def down
+    # add_column :course_discussion_posts, :is_delayed, :boolean, default: false, null: false
+    ActiveRecord::Base.connection.exec_update(
+      "UPDATE course_discussion_posts
+       SET is_delayed = TRUE
+       WHERE workflow_state = 'delayed'"
+    )
+
+    remove_column :course_discussion_posts, :workflow_state
+  end
+end

--- a/db/migrate/20220819071113_add_workflow_state_to_post.rb
+++ b/db/migrate/20220819071113_add_workflow_state_to_post.rb
@@ -1,7 +1,7 @@
 class AddWorkflowStateToPost < ActiveRecord::Migration[6.0]
   def up
     add_column :course_discussion_posts, :workflow_state, :string, default: 'published'
-
+    add_index :course_discussion_posts, :workflow_state, unique: false
     ActiveRecord::Base.connection.exec_update(
       "UPDATE course_discussion_posts
        SET workflow_state = 'delayed'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_01_045213) do
+ActiveRecord::Schema.define(version: 2022_08_19_071113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -536,6 +536,7 @@ ActiveRecord::Schema.define(version: 2022_07_01_045213) do
     t.datetime "updated_at", null: false
     t.boolean "answer", default: false
     t.boolean "is_delayed", default: false, null: false
+    t.string "workflow_state", default: "published"
     t.index ["creator_id"], name: "fk__course_discussion_posts_creator_id"
     t.index ["parent_id"], name: "fk__course_discussion_posts_parent_id"
     t.index ["topic_id"], name: "fk__course_discussion_posts_topic_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -541,6 +541,7 @@ ActiveRecord::Schema.define(version: 2022_08_19_071113) do
     t.index ["parent_id"], name: "fk__course_discussion_posts_parent_id"
     t.index ["topic_id"], name: "fk__course_discussion_posts_topic_id"
     t.index ["updater_id"], name: "fk__course_discussion_posts_updater_id"
+    t.index ["workflow_state"], name: "index_course_discussion_posts_on_workflow_state"
   end
 
   create_table "course_discussion_topic_subscriptions", id: :serial, force: :cascade do |t|

--- a/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/answer/programming/annotations_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
 
     describe '#create' do
       let(:post_text) { 'test post text' }
-      let(:is_delayed) { false }
+      let(:workflow_state) { 'published' }
       subject do
         post :create, as: :js, params: {
           course_id: course, assessment_id: assessment,
@@ -31,7 +31,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
           },
           discussion_post: {
             text: post_text,
-            is_delayed: is_delayed
+            workflow_state: workflow_state
           }
         }
       end
@@ -68,7 +68,7 @@ RSpec.describe Course::Assessment::Submission::Answer::Programming::AnnotationsC
           end
 
           context 'when the new comment is posted as delayed post' do
-            let!(:is_delayed) { true }
+            let!(:workflow_state) { 'delayed' }
             it 'does not send email notifications' do
               expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end

--- a/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission_question/comments_controller_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
     before { sign_in(user) }
 
     describe '#create' do
-      let(:is_delayed) { false }
+      let(:workflow_state) { 'published' }
       subject do
         post :create, as: :js, params: {
           course_id: course, assessment_id: assessment,
           submission_question_id: submission_question,
           discussion_post: {
             text: comment,
-            is_delayed: is_delayed
+            workflow_state: workflow_state
           }
         }
       end
@@ -60,7 +60,7 @@ RSpec.describe Course::Assessment::SubmissionQuestion::CommentsController do
           end
 
           context 'when the new comment is posted as delayed post' do
-            let!(:is_delayed) { true }
+            let!(:workflow_state) { 'delayed' }
             it 'does not send email notifications' do
               expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
             end

--- a/spec/factories/course_discussion_posts.rb
+++ b/spec/factories/course_discussion_posts.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
     parent { nil }
     association :topic, factory: :course_discussion_topic
     text { 'This is a test post' }
-    is_delayed { false }
 
     after(:create) do |post, evaluator|
       Array(evaluator.upvoted_by).each do |user|
@@ -23,8 +22,16 @@ FactoryBot.define do
       end
     end
 
+    trait :draft do
+      workflow_state { :draft }
+    end
+
     trait :delayed do
-      is_delayed { true }
+      workflow_state { :delayed }
+    end
+
+    trait :published do
+      workflow_state { :published }
     end
   end
 end

--- a/spec/models/course/assessment/submission_spec.rb
+++ b/spec/models/course/assessment/submission_spec.rb
@@ -542,10 +542,10 @@ RSpec.describe Course::Assessment::Submission do
         let!(:submission_question_post) do
           create(:course_discussion_post, :delayed, topic: submission_question.discussion_topic, creator: user)
         end
-        it 'is set as not delayed after publication' do
+        it 'is set as published after publication' do
           submission.publish!
-          expect(annotation_post.reload.is_delayed).to be(false)
-          expect(submission_question_post.reload.is_delayed).to be(false)
+          expect(annotation_post.reload.published?).to be(true)
+          expect(submission_question_post.reload.published?).to be(true)
         end
       end
     end

--- a/spec/models/course/discussion/topic_spec.rb
+++ b/spec/models/course/discussion/topic_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Course::Discussion::Topic, type: :model do
       end
     end
 
-    describe '.without_delayed_posts' do
+    describe '.with_published_posts' do
       let(:course) { create(:course) }
       let!(:annotation) do
         create(:course_assessment_answer_programming_file_annotation, :with_delayed_post, course: course).
@@ -112,7 +112,7 @@ RSpec.describe Course::Discussion::Topic, type: :model do
       end
 
       it 'only returns comments and annotations with non-delayed posts' do
-        expect(course.discussion_topics.without_delayed_posts).to contain_exactly(comment)
+        expect(course.discussion_topics.with_published_posts).to contain_exactly(comment)
       end
     end
 


### PR DESCRIPTION
Previously, a post could only be of delayed or non-delayed state. In order to support the codaveri evaluation feature, we need to add 'draft' state for discussion post (codaveri annotation will be marked as draft for a tutor to update then published). 

This PR refactors the current discussion post state tracking by adding workflow_state which consists of either draft, delayed or published state. For a delayed and normal comment, the post will be marked as delayed and published respectively. When a post is marked as draft, it can be updated and marked as delayed or published.

Adding the draft state will also ease the development of draft comment feature in the future.