### PR TITLE
fix(upload material): fix material upload endpoint regression

### DIFF
--- a/app/controllers/course/material/folders_controller.rb
+++ b/app/controllers/course/material/folders_controller.rb
@@ -49,8 +49,10 @@ class Course::Material::FoldersController < Course::Material::Controller
     respond_to do |format|
       if @folder.save
         format.json do
-          show
-          render 'show', status: :ok
+          if params[:render_show]
+            show
+            return render 'show', status: :ok
+          end
         end
       else
         format.json do

--- a/client/app/bundles/course/assessment/containers/MaterialUploader/index.jsx
+++ b/client/app/bundles/course/assessment/containers/MaterialUploader/index.jsx
@@ -98,7 +98,7 @@ class MaterialUploader extends PureComponent {
   // Remove given materials from uploading list and display error message.
   removeUploads(materials, response) {
     const messageFromServer =
-      response && response.data && response.data.message;
+      response && response.data && response.data.errors;
     const failureMessage = <FormattedMessage {...translations.uploadFail} />;
     this.setState((state) => ({
       uploadingMaterials: state.uploadingMaterials.filter(

--- a/client/app/bundles/course/material/folders/operations.ts
+++ b/client/app/bundles/course/material/folders/operations.ts
@@ -148,6 +148,7 @@ function formatMaterialUploadAttributes(
       }
     }
   });
+  payload.append('render_show', 'true');
   return payload;
 }
 

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -144,7 +144,11 @@ const FolderShow: FC<Props> = (props) => {
         <Breadcrumbs>
           {breadcrumbs.map((breadcrumb, index) => {
             if (index === breadcrumbs.length - 1) {
-              return <span>{breadcrumb.name}</span>;
+              return (
+                <span key={`folder-breadcrumb-${breadcrumb.id}`}>
+                  {breadcrumb.name}
+                </span>
+              );
             }
             return (
               <Link


### PR DESCRIPTION
upload_material endpoint is also used elsewhere. We now differentiate the json to be rendered depending on the caller by adding a params. When porting the whole react in the future, this endpoint will be standardised. Updated error handling for client side as well.