### PR TITLE
fix(comments): fix default tab of group manager to students pending

### DIFF
--- a/client/app/bundles/course/discussion/topics/reducers.ts
+++ b/client/app/bundles/course/discussion/topics/reducers.ts
@@ -59,8 +59,9 @@ const reducer = produce((draft: CommentState, action: CommentActionType) => {
       if (action.permissions.canManage) {
         if (action.tabs.myStudentExist) {
           draft.pageState.tabValue = CommentTabTypes.MY_STUDENTS_PENDING;
+        } else {
+          draft.pageState.tabValue = CommentTabTypes.PENDING;
         }
-        draft.pageState.tabValue = CommentTabTypes.PENDING;
       } else {
         draft.pageState.tabValue = CommentTabTypes.UNREAD;
       }


### PR DESCRIPTION
Closes https://github.com/Coursemology/coursemology2/issues/5001