### PR TITLE
Topics: Fix 403 when accessing user profile from Comments

### DIFF
--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -75,13 +75,13 @@ class Course::Discussion::TopicsController < Course::ComponentController
 
   def all_topics
     @topics.globally_displayed.
-      ordered_by_updated_at.
       preload([:posts,
                actable: [:question,
                          { submission: [:assessment,
                                         :creator] },
                          file: { answer: [:question,
-                                          :submission] }]])
+                                          :submission] }]]).
+      order('course_discussion_topics.updated_at')
   end
 
   def my_students_topics

--- a/app/helpers/course/controller_helper.rb
+++ b/app/helpers/course/controller_helper.rb
@@ -30,6 +30,15 @@ module Course::ControllerHelper
     end
   end
 
+  # URL to the profile page of the given +CourseUser+ or +User+ in the current course
+  #
+  # @param [CourseUser|User] course_user The CourseUser/User to link to
+  # @return [String] A URL that points to the +CourseUser+ or +User+ profile page
+  def url_to_user_or_course_user(course, user)
+    return course_user_path(course, user) if user.is_a?(CourseUser)
+    return user_path(user) if user.is_a?(User)
+  end
+
   # Links to the given +CourseUser+.
   #
   # @param [CourseUser] user The User to display.
@@ -41,7 +50,7 @@ module Course::ControllerHelper
   #   string within a link to bring to the User page.
   def link_to_course_user(user, options = {})
     link_text = capture { block_given? ? yield(user) : display_course_user(user) }
-    link_path = course_user_path(user.course, user)
+    link_path = url_to_user_or_course_user(user.course, user)
     link_to(link_text, link_path, options)
   end
 

--- a/app/helpers/course/controller_helper.rb
+++ b/app/helpers/course/controller_helper.rb
@@ -50,7 +50,7 @@ module Course::ControllerHelper
   #   string within a link to bring to the User page.
   def link_to_course_user(user, options = {})
     link_text = capture { block_given? ? yield(user) : display_course_user(user) }
-    link_path = url_to_user_or_course_user(user.course, user)
+    link_path = course_user_path(user.course, user)
     link_to(link_text, link_path, options)
   end
 

--- a/app/helpers/course/users_helper.rb
+++ b/app/helpers/course/users_helper.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 module Course::UsersHelper
-  include Course::Achievement::AchievementsHelper
+  # Returns a hash that maps +User+ ids to their +CourseUser+ in a given +course_id+
+  #
+  # @param [Course] course_id The ID of the course
+  # @return [Hash]
+  def preload_course_users_hash(course)
+    course.course_users.to_h { |course_user| [course_user.user_id, course_user] }
+  end
 end

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -3,10 +3,10 @@ json.(post, :id, :title, :text)
 json.formattedText format_ckeditor_rich_text(simple_format(post.text))
 json.creator do
   creator = post.creator
-  user = @course_users_hash&.fetch(creator.id, creator)
-  json.id user&.id
+  user = @course_users_hash&.fetch(creator.id, creator) || creator
+  json.id user.id
   json.userUrl url_to_user_or_course_user(current_course, user)
-  json.name post.author_name
+  json.name display_user(user)
   json.imageUrl creator.profile_photo.medium.url || image_url('user_silhouette.svg')
 end
 json.createdAt post.created_at&.iso8601

--- a/app/views/course/discussion/posts/_post.json.jbuilder
+++ b/app/views/course/discussion/posts/_post.json.jbuilder
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 json.(post, :id, :title, :text)
 json.formattedText format_ckeditor_rich_text(simple_format(post.text))
-creator = post.creator
 json.creator do
-  json.id creator.id
+  creator = post.creator
+  user = @course_users_hash&.fetch(creator.id, creator)
+  json.id user&.id
+  json.userUrl url_to_user_or_course_user(current_course, user)
   json.name post.author_name
   json.imageUrl creator.profile_photo.medium.url || image_url('user_silhouette.svg')
 end

--- a/app/views/course/discussion/topics/_discussion_topic_programming_file_annotation.jbuilder
+++ b/app/views/course/discussion/topics/_discussion_topic_programming_file_annotation.jbuilder
@@ -11,8 +11,8 @@ json.id topic.id
 json.title "#{assessment.title}: #{question_assessment.display_title}"
 json.creator do
   creator = submission.creator
-  user = @course_users_hash&.fetch(creator.id, creator)
-  json.id user&.id
+  user = @course_users_hash.fetch(creator.id, creator)
+  json.id user.id
   json.userUrl url_to_user_or_course_user(current_course, user)
   json.name display_user(creator)
   json.imageUrl creator.profile_photo.url

--- a/app/views/course/discussion/topics/_discussion_topic_programming_file_annotation.jbuilder
+++ b/app/views/course/discussion/topics/_discussion_topic_programming_file_annotation.jbuilder
@@ -10,10 +10,12 @@ question_assessment = assessment.question_assessments.find_by!(question: questio
 json.id topic.id
 json.title "#{assessment.title}: #{question_assessment.display_title}"
 json.creator do
-  user = submission.creator
-  json.id user.id
-  json.name display_user(user)
-  json.imageUrl user.profile_photo.url
+  creator = submission.creator
+  user = @course_users_hash&.fetch(creator.id, creator)
+  json.id user&.id
+  json.userUrl url_to_user_or_course_user(current_course, user)
+  json.name display_user(creator)
+  json.imageUrl creator.profile_photo.url
 end
 json.content display_code_lines(file_annotation.file, file_annotation.line - 5, file_annotation.line)
 

--- a/app/views/course/discussion/topics/_discussion_topic_submission_question.json.jbuilder
+++ b/app/views/course/discussion/topics/_discussion_topic_submission_question.json.jbuilder
@@ -11,8 +11,8 @@ json.id topic.id
 json.title "#{assessment.title}: #{question_assessment.display_title}"
 json.creator do
   creator = submission.creator
-  user = @course_users_hash&.fetch(creator.id, creator)
-  json.id user&.id
+  user = @course_users_hash.fetch(creator.id, creator)
+  json.id user.id
   json.userUrl url_to_user_or_course_user(current_course, user)
   json.name display_user(creator)
   json.imageUrl creator.profile_photo.url

--- a/app/views/course/discussion/topics/_discussion_topic_submission_question.json.jbuilder
+++ b/app/views/course/discussion/topics/_discussion_topic_submission_question.json.jbuilder
@@ -10,10 +10,12 @@ can_grade = can?(:grade, submission)
 json.id topic.id
 json.title "#{assessment.title}: #{question_assessment.display_title}"
 json.creator do
-  user = submission.creator
-  json.id user.id
-  json.name display_user(user)
-  json.imageUrl user.profile_photo.url
+  creator = submission.creator
+  user = @course_users_hash&.fetch(creator.id, creator)
+  json.id user&.id
+  json.userUrl url_to_user_or_course_user(current_course, user)
+  json.name display_user(creator)
+  json.imageUrl creator.profile_photo.url
 end
 
 json.partial! 'topic', topic: topic, can_grade: can_grade

--- a/app/views/course/discussion/topics/_discussion_topic_video.json.jbuilder
+++ b/app/views/course/discussion/topics/_discussion_topic_video.json.jbuilder
@@ -9,8 +9,8 @@ json.id topic.id
 json.title video.title
 json.creator do
   creator = submission.creator
-  user = @course_users_hash&.fetch(creator.id, creator)
-  json.id user&.id
+  user = @course_users_hash.fetch(creator.id, creator)
+  json.id user.id
   json.userUrl url_to_user_or_course_user(current_course, user)
   json.name display_user(creator)
   json.imageUrl creator.profile_photo.url

--- a/app/views/course/discussion/topics/_discussion_topic_video.json.jbuilder
+++ b/app/views/course/discussion/topics/_discussion_topic_video.json.jbuilder
@@ -8,10 +8,12 @@ submission = video.submissions.by_user(creator).first
 json.id topic.id
 json.title video.title
 json.creator do
-  user = submission.creator
-  json.id user.id
-  json.name display_user(user)
-  json.imageUrl user.profile_photo.url
+  creator = submission.creator
+  user = @course_users_hash&.fetch(creator.id, creator)
+  json.id user&.id
+  json.userUrl url_to_user_or_course_user(current_course, user)
+  json.name display_user(creator)
+  json.imageUrl creator.profile_photo.url
 end
 json.timestamp Time.at(video_topic.timestamp).utc.strftime('%H:%M:%S')
 

--- a/client/app/bundles/course/discussion/topics/components/cards/CommentCard.tsx
+++ b/client/app/bundles/course/discussion/topics/components/cards/CommentCard.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Button, CardHeader } from '@mui/material';
+import { Avatar, Button, CardHeader, Link } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { grey, orange, red } from '@mui/material/colors';
 import Delete from '@mui/icons-material/Delete';
@@ -198,7 +198,10 @@ const CommentCard: FC<Props> = (props) => {
           avatar={
             <Avatar
               src={post.creator.imageUrl}
+              alt={post.creator.name}
               style={{ height: '25px', width: '25px' }}
+              component={Link}
+              href={getCourseUserURL(getCourseId(), post.creator.id)}
             />
           }
           title={

--- a/client/app/bundles/course/discussion/topics/components/cards/CommentCard.tsx
+++ b/client/app/bundles/course/discussion/topics/components/cards/CommentCard.tsx
@@ -17,8 +17,6 @@ import { CommentPostMiniEntity } from 'types/course/comments';
 import { useDispatch } from 'react-redux';
 import { AppDispatch } from 'types/store';
 import { toast } from 'react-toastify';
-import { getCourseUserURL } from 'lib/helpers/url-builders';
-import { getCourseId } from 'lib/helpers/url-helpers';
 import { deletePost, updatePost } from '../../operations';
 
 interface Props extends WrappedComponentProps {
@@ -201,13 +199,15 @@ const CommentCard: FC<Props> = (props) => {
               alt={post.creator.name}
               style={{ height: '25px', width: '25px' }}
               component={Link}
-              href={getCourseUserURL(getCourseId(), post.creator.id)}
+              href={post.creator.userUrl}
             />
           }
           title={
-            <a href={getCourseUserURL(getCourseId(), post.creator.id)}>
-              {post.creator.name}
-            </a>
+            post.creator.userUrl ? (
+              <a href={post.creator.userUrl}>{post.creator.name}</a>
+            ) : (
+              post.creator.name
+            )
           }
           titleTypographyProps={{ display: 'block', marginright: 20 }}
           subheader={`${formatDateTime(post.createdAt)}${

--- a/client/app/types/course/courseUsers.ts
+++ b/client/app/types/course/courseUsers.ts
@@ -31,6 +31,7 @@ export type StaffRole = keyof typeof sharedConstants.STAFF_ROLES;
 export interface CourseUserBasicListData {
   id: number;
   name: string;
+  userUrl?: string;
   imageUrl?: string;
   role?: CourseUserRole;
 }
@@ -45,6 +46,7 @@ export interface CourseUserListData extends CourseUserBasicListData {
 export interface CourseUserBasicMiniEntity {
   id: number;
   name: string;
+  userUrl?: string;
   imageUrl?: string;
   role?: CourseUserRole;
 }


### PR DESCRIPTION
Closes #4990.

* Add user profile hyperlink to user's avatar in Comments
* `/courses/:course_id/comments/all` and `/courses/:course_id/comments/pending` now returns JSON with an additional `userUrl` field with the following behaviour:
  * If the `creator` is in the course, i.e., has/is a `CourseUser`, `id` is the course user ID, and `userUrl` is the course user URL.
  * If the `creator` is not in the course, `id` is the user ID, and `userUrl` is the user URL.