### PR TITLE
Survey: Support for Time Bonus EXP end time

### DIFF
--- a/app/models/course/survey/response.rb
+++ b/app/models/course/survey/response.rb
@@ -24,8 +24,7 @@ class Course::Survey::Response < ApplicationRecord
   def submit
     self.submitted_at = Time.zone.now
     self.points_awarded = survey.base_exp
-    self.points_awarded += survey.time_bonus_exp if \
-      survey.allow_response_after_end && submitted_at <= survey.end_at
+    self.points_awarded += survey.time_bonus_exp if survey.bonus_end_at && submitted_at <= survey.bonus_end_at
     self.awarded_at = Time.zone.now
     self.awarder = creator
   end

--- a/app/views/course/survey/surveys/_survey.json.jbuilder
+++ b/app/views/course/survey/surveys/_survey.json.jbuilder
@@ -3,6 +3,7 @@ json.(survey, :id, :title, :base_exp, :time_bonus_exp, :published,
       :anonymous, :allow_response_after_end, :allow_modify_after_submit)
 json.start_at survey.start_at&.iso8601
 json.end_at survey.end_at&.iso8601
+json.bonus_end_at survey.bonus_end_at&.iso8601
 json.closing_reminded_at survey.closing_reminded_at&.iso8601
 json.description format_ckeditor_rich_text(survey.description)
 

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { injectIntl, FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Controller, useForm } from 'react-hook-form';
 import * as yup from 'yup';
@@ -92,7 +92,7 @@ const SurveyForm = (props) => {
             field={field}
             fieldState={fieldState}
             disabled={disabled}
-            label={<FormattedMessage {...translations.title} />}
+            label={intl.formatMessage(translations.title)}
             fullWidth
             InputLabelProps={{
               shrink: true,
@@ -110,7 +110,7 @@ const SurveyForm = (props) => {
             field={field}
             fieldState={fieldState}
             disabled={disabled}
-            label={<FormattedMessage {...translations.description} />}
+            label={intl.formatMessage(translations.description)}
             fullWidth
             multiline
             InputLabelProps={{
@@ -130,7 +130,7 @@ const SurveyForm = (props) => {
               field={field}
               fieldState={fieldState}
               disabled={disabled}
-              label={<FormattedMessage {...translations.opensAt} />}
+              label={intl.formatMessage(translations.opensAt)}
               style={styles.oneColumn}
             />
           )}
@@ -143,7 +143,7 @@ const SurveyForm = (props) => {
               field={field}
               fieldState={fieldState}
               disabled={disabled}
-              label={<FormattedMessage {...translations.expiresAt} />}
+              label={intl.formatMessage(translations.expiresAt)}
               style={styles.oneColumn}
             />
           )}
@@ -156,7 +156,7 @@ const SurveyForm = (props) => {
               field={field}
               fieldState={fieldState}
               disabled={disabled}
-              label={<FormattedMessage {...translations.bonusEndsAt} />}
+              label={intl.formatMessage(translations.bonusEndsAt)}
               style={styles.oneColumn}
             />
           )}
@@ -173,7 +173,7 @@ const SurveyForm = (props) => {
                 fieldState={fieldState}
                 disabled={disabled}
                 fullWidth
-                label={<FormattedMessage {...translations.basePoints} />}
+                label={intl.formatMessage(translations.basePoints)}
                 InputLabelProps={{
                   shrink: true,
                 }}
@@ -194,7 +194,7 @@ const SurveyForm = (props) => {
                 fieldState={fieldState}
                 disabled={disabled}
                 fullWidth
-                label={<FormattedMessage {...translations.bonusPoints} />}
+                label={intl.formatMessage(translations.bonusPoints)}
                 InputLabelProps={{
                   shrink: true,
                 }}
@@ -215,7 +215,7 @@ const SurveyForm = (props) => {
             field={field}
             fieldState={fieldState}
             disabled={disabled}
-            label={<FormattedMessage {...translations.allowResponseAfterEnd} />}
+            label={intl.formatMessage(translations.allowResponseAfterEnd)}
             style={styles.toggle}
           />
         )}
@@ -228,9 +228,7 @@ const SurveyForm = (props) => {
             field={field}
             fieldState={fieldState}
             disabled={disabled}
-            label={
-              <FormattedMessage {...translations.allowModifyAfterSubmit} />
-            }
+            label={intl.formatMessage(translations.allowModifyAfterSubmit)}
             style={styles.toggle}
           />
         )}
@@ -246,7 +244,7 @@ const SurveyForm = (props) => {
             field={field}
             fieldState={fieldState}
             disabled={disabled || disableAnonymousToggle}
-            label={<FormattedMessage {...translations.anonymous} />}
+            label={intl.formatMessage(translations.anonymous)}
             style={styles.toggle}
           />
         )}

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -49,6 +49,12 @@ const validationSchema = yup.object({
         .typeError(formTranslations.invalidDate)
         .required(formTranslations.required),
     }),
+  bonus_end_at: yup
+    .date()
+    .nullable()
+    .typeError(formTranslations.invalidDate)
+    .min(yup.ref('start_at'), translations.bonusEndValidationError)
+    .max(yup.ref('end_at'), translations.bonusEndValidationError),
   base_exp: yup
     .number()
     .typeError(formTranslations.required)
@@ -145,6 +151,19 @@ const SurveyForm = (props) => {
             />
           )}
         />
+        <Controller
+          name="bonus_end_at"
+          control={control}
+          render={({ field, fieldState }) => (
+            <FormDateTimePickerField
+              field={field}
+              fieldState={fieldState}
+              disabled={disabled}
+              label={<FormattedMessage {...translations.bonusEndsAt} />}
+              style={styles.oneColumn}
+            />
+          )}
+        />
       </div>
       <div style={styles.columns}>
         <div style={styles.oneColumn}>
@@ -212,9 +231,6 @@ const SurveyForm = (props) => {
           />
         )}
       />
-      <div style={styles.hint}>
-        {intl.formatMessage(surveyFormTranslations.allowResponseAfterEndHint)}
-      </div>
       <Controller
         name="allow_modify_after_submit"
         control={control}

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -10,7 +10,7 @@ import FormRichTextField from 'lib/components/form/fields/RichTextField';
 import FormTextField from 'lib/components/form/fields/TextField';
 import FormToggleField from 'lib/components/form/fields/ToggleField';
 import formTranslations from 'lib/translations/form';
-import translations from 'course/survey/translations';
+import translations from '../../translations';
 
 const styles = {
   columns: {

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import ReactTooltip from 'react-tooltip';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Controller, useForm } from 'react-hook-form';
@@ -27,44 +27,6 @@ const styles = {
     marginBottom: 12,
   },
 };
-
-const surveyFormTranslations = defineMessages({
-  startEndValidationError: {
-    id: 'course.surveys.SurveyForm.startEndValidationError',
-    defaultMessage: "Must be after 'Opens At'",
-  },
-  allowResponseAfterEndHint: {
-    id: 'course.surveys.SurveyForm.allowResponseAfterEndHint',
-    defaultMessage:
-      'Allow students to submit responses after the survey has expired. \
-      If this is enabled, students who submit before the deadline will get both the base and bonus \
-      points, whereas students who submit after the deadline will only be awarded the base points.',
-  },
-  allowModifyAfterSubmitHint: {
-    id: 'course.surveys.SurveyForm.allowModifyAfterSubmitHint',
-    defaultMessage:
-      'Allow students to modify their responses after they have submitted it. If \
-      this is disabled, you will have to manually unsubmit their responses to allow them to \
-      edit it.',
-  },
-  anonymousHint: {
-    id: 'course.surveys.SurveyForm.anonymousHint',
-    defaultMessage:
-      'If you make the survey anonymous, you will be able to see aggregate survey \
-      results but not individual responses. You may not toggle this setting once there is one \
-      or more student submissions.',
-  },
-  hasStudentResponse: {
-    id: 'course.surveys.SurveyForm.hasStudentResponse',
-    defaultMessage:
-      'At least one student has responded to this survey. You may not remove anonymity.',
-  },
-  timeBonusExpTooltip: {
-    id: 'course.surveys.SurveyForm.timeBonusExpTooltip',
-    defaultMessage:
-      'You must allow responses after the survey expires to set bonus points.',
-  },
-});
 
 const validationSchema = yup.object({
   title: yup.string().required(formTranslations.required),
@@ -233,7 +195,7 @@ const SurveyForm = (props) => {
             )}
           />
           <ReactTooltip id="timeBonusExpTooltip">
-            <FormattedMessage {...surveyFormTranslations.timeBonusExpTooltip} />
+            <FormattedMessage {...translations.timeBonusExpTooltip} />
           </ReactTooltip>
         </div>
       </div>
@@ -269,7 +231,7 @@ const SurveyForm = (props) => {
         )}
       />
       <div style={styles.hint}>
-        {intl.formatMessage(surveyFormTranslations.allowModifyAfterSubmitHint)}
+        {intl.formatMessage(translations.allowModifyAfterSubmitHint)}
       </div>
       <Controller
         name="anonymous"
@@ -286,8 +248,8 @@ const SurveyForm = (props) => {
       />
       <div style={styles.hint}>
         {disableAnonymousToggle
-          ? intl.formatMessage(surveyFormTranslations.hasStudentResponse)
-          : intl.formatMessage(surveyFormTranslations.anonymousHint)}
+          ? intl.formatMessage(translations.hasStudentResponse)
+          : intl.formatMessage(translations.anonymousHint)}
       </div>
     </form>
   );

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import { injectIntl, FormattedMessage } from 'react-intl';
-import ReactTooltip from 'react-tooltip';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Controller, useForm } from 'react-hook-form';
 import * as yup from 'yup';
@@ -72,13 +71,11 @@ const SurveyForm = (props) => {
     control,
     handleSubmit,
     setError,
-    watch,
     formState: { errors },
   } = useForm({
     defaultValues: initialValues,
     resolver: yupResolver(validationSchema),
   });
-  const allowResponseAfterEnd = watch('allow_response_after_end');
 
   return (
     <form
@@ -187,12 +184,7 @@ const SurveyForm = (props) => {
             )}
           />
         </div>
-        <div
-          style={styles.oneColumn}
-          data-tip
-          data-for="timeBonusExpTooltip"
-          data-tip-disable={allowResponseAfterEnd}
-        >
+        <div style={styles.oneColumn}>
           <Controller
             name="time_bonus_exp"
             control={control}
@@ -200,7 +192,7 @@ const SurveyForm = (props) => {
               <FormTextField
                 field={field}
                 fieldState={fieldState}
-                disabled={disabled || !allowResponseAfterEnd}
+                disabled={disabled}
                 fullWidth
                 label={<FormattedMessage {...translations.bonusPoints} />}
                 InputLabelProps={{
@@ -213,9 +205,6 @@ const SurveyForm = (props) => {
               />
             )}
           />
-          <ReactTooltip id="timeBonusExpTooltip">
-            <FormattedMessage {...translations.timeBonusExpTooltip} />
-          </ReactTooltip>
         </div>
       </div>
       <Controller

--- a/client/app/bundles/course/survey/containers/SurveyLayout/AdminMenu.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyLayout/AdminMenu.jsx
@@ -71,14 +71,14 @@ const AdminMenu = (props) => {
     setAnchorEl(null);
   };
 
-  const updateSurveyHandler = (data) => {
+  const updateSurveyHandler = (data, setError) => {
     const { updateSurvey } = surveyActions;
 
     const payload = { survey: data };
     const successMessage = intl.formatMessage(translations.updateSuccess, data);
     const failureMessage = intl.formatMessage(translations.updateFailure);
     return dispatch(
-      updateSurvey(surveyId, payload, successMessage, failureMessage),
+      updateSurvey(surveyId, payload, successMessage, failureMessage, setError),
     );
   };
 

--- a/client/app/bundles/course/survey/containers/SurveyLayout/AdminMenu.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyLayout/AdminMenu.jsx
@@ -7,7 +7,6 @@ import { IconButton, Menu, MenuItem } from '@mui/material';
 import MoreVert from '@mui/icons-material/MoreVert';
 import * as surveyActions from 'course/survey/actions/surveys';
 import { showDeleteConfirmation } from 'course/survey/actions';
-import { formatSurveyFormData } from 'course/survey/utils';
 import { surveyShape } from 'course/survey/propTypes';
 import { useNavigate } from 'react-router-dom';
 
@@ -75,7 +74,7 @@ const AdminMenu = (props) => {
   const updateSurveyHandler = (data) => {
     const { updateSurvey } = surveyActions;
 
-    const payload = formatSurveyFormData(data);
+    const payload = { survey: data };
     const successMessage = intl.formatMessage(translations.updateSuccess, data);
     const failureMessage = intl.formatMessage(translations.updateFailure);
     return dispatch(
@@ -92,6 +91,7 @@ const AdminMenu = (props) => {
       time_bonus_exp,
       start_at,
       end_at,
+      bonus_end_at,
       hasStudentResponse,
       allow_response_after_end,
       allow_modify_after_submit,
@@ -106,6 +106,9 @@ const AdminMenu = (props) => {
       allow_response_after_end,
       allow_modify_after_submit,
       anonymous,
+      start_at: new Date(start_at),
+      end_at: end_at && new Date(end_at),
+      bonus_end_at: bonus_end_at && new Date(bonus_end_at),
     };
 
     return dispatch(
@@ -113,11 +116,7 @@ const AdminMenu = (props) => {
         onSubmit: updateSurveyHandler,
         formTitle: intl.formatMessage(translations.editSurvey),
         hasStudentResponse,
-        initialValues: {
-          ...initialValues,
-          start_at: new Date(start_at),
-          end_at: end_at && new Date(end_at),
-        },
+        initialValues,
       }),
     );
   };

--- a/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { injectIntl, defineMessages } from 'react-intl';
 import moment from 'lib/moment';
 import { showSurveyForm, createSurvey } from 'course/survey/actions/surveys';
-import { formatSurveyFormData } from 'course/survey/utils';
 import AddButton from 'course/survey/components/AddButton';
 
 const translations = defineMessages({
@@ -45,7 +44,7 @@ const NewSurveyButton = (props) => {
   const createSurveyHandler = (data, setError) => {
     const { dispatch, intl } = props;
 
-    const payload = formatSurveyFormData(data);
+    const payload = { survey: data };
     const successMessage = intl.formatMessage(translations.success, data);
     const failureMessage = intl.formatMessage(translations.failure);
     return dispatch(
@@ -64,6 +63,7 @@ const NewSurveyButton = (props) => {
           title: '',
           description: '',
           ...aWeekStartingTomorrow(),
+          bonus_end_at: null,
           base_exp: 0,
           time_bonus_exp: 0,
           allow_response_after_end: true,

--- a/client/app/bundles/course/survey/pages/SurveyIndex/SurveysTable.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/SurveysTable.jsx
@@ -88,6 +88,9 @@ const SurveysTable = (props) => {
           <TableCell colSpan={5}>
             <FormattedMessage {...translations.expiresAt} />
           </TableCell>
+          <TableCell colSpan={5}>
+            <FormattedMessage {...translations.bonusEndsAt} />
+          </TableCell>
           {canCreate ? (
             <TableCell colSpan={2}>
               <FormattedMessage {...translations.published} />
@@ -105,14 +108,17 @@ const SurveysTable = (props) => {
               </Link>
             </TableCell>
             <TableCell colSpan={3}>{survey.base_exp}</TableCell>
-            <TableCell colSpan={3}>
-              {survey.allow_response_after_end ? survey.time_bonus_exp : '-'}
-            </TableCell>
+            <TableCell colSpan={3}>{survey.time_bonus_exp}</TableCell>
             <TableCell colSpan={5} style={styles.wrap}>
               {formatShortDateTime(survey.start_at)}
             </TableCell>
             <TableCell colSpan={5} style={styles.wrap}>
               {formatShortDateTime(survey.end_at)}
+            </TableCell>
+            <TableCell colSpan={5} style={styles.wrap}>
+              {survey.bonus_end_at
+                ? formatShortDateTime(survey.bonus_end_at)
+                : '-'}
             </TableCell>
             {canCreate ? (
               <TableCell colSpan={2}>{renderPublishToggle(survey)}</TableCell>

--- a/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/SurveyDetails.jsx
@@ -119,6 +119,16 @@ const SurveyDetails = (props) => {
             </TableRow>
             <TableRow>
               <TableCell>
+                <FormattedMessage {...surveyTranslations.bonusEndsAt} />
+              </TableCell>
+              <TableCell>
+                {survey.bonus_end_at
+                  ? formatLongDateTime(survey.bonus_end_at)
+                  : '-'}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
                 <FormattedMessage {...surveyTranslations.basePoints} />
               </TableCell>
               <TableCell>{survey.base_exp}</TableCell>
@@ -127,19 +137,7 @@ const SurveyDetails = (props) => {
               <TableCell>
                 <FormattedMessage {...surveyTranslations.bonusPoints} />
               </TableCell>
-              <TableCell>
-                {survey.allow_response_after_end ? survey.time_bonus_exp : '-'}
-              </TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell>
-                <FormattedMessage {...surveyTranslations.anonymous} />
-              </TableCell>
-              <TableCell>
-                <FormattedMessage
-                  {...libTranslations[survey.anonymous ? 'yes' : 'no']}
-                />
-              </TableCell>
+              <TableCell>{survey.time_bonus_exp}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell>
@@ -166,6 +164,16 @@ const SurveyDetails = (props) => {
                   {...libTranslations[
                     survey.allow_modify_after_submit ? 'yes' : 'no'
                   ]}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <FormattedMessage {...surveyTranslations.anonymous} />
+              </TableCell>
+              <TableCell>
+                <FormattedMessage
+                  {...libTranslations[survey.anonymous ? 'yes' : 'no']}
                 />
               </TableCell>
             </TableRow>

--- a/client/app/bundles/course/survey/translations.js
+++ b/client/app/bundles/course/survey/translations.js
@@ -109,6 +109,29 @@ const translations = defineMessages({
     id: 'course.surveys.responses',
     defaultMessage: 'Responses',
   },
+  startEndValidationError: {
+    id: 'course.surveys.SurveyForm.startEndValidationError',
+    defaultMessage: 'Must be after opening time.',
+  },
+  bonusEndValidationError: {
+    id: 'course.surveys.SurveyForm.bonusEndValidationError',
+    defaultMessage: 'Must be between opening and closing time.',
+  },
+  allowModifyAfterSubmitHint: {
+    id: 'course.surveys.SurveyForm.allowModifyAfterSubmitHint',
+    defaultMessage: 'Responses can be changed after being submitted.',
+  },
+  anonymousHint: {
+    id: 'course.surveys.SurveyForm.anonymousHint',
+    defaultMessage:
+      'If enabled, staff can see the survey results but not individual responses. \
+      Cannot be changed once there are submissions.',
+  },
+  hasStudentResponse: {
+    id: 'course.surveys.SurveyForm.hasStudentResponse',
+    defaultMessage:
+      'At least one student has responded to this survey. You may not remove anonymity.',
+  },
 });
 
 export default translations;

--- a/client/app/bundles/course/survey/translations.js
+++ b/client/app/bundles/course/survey/translations.js
@@ -15,11 +15,15 @@ const translations = defineMessages({
   },
   opensAt: {
     id: 'course.surveys.fields.openAt',
-    defaultMessage: 'Opens At',
+    defaultMessage: 'Opens at',
   },
   expiresAt: {
     id: 'course.surveys.fields.expiresAt',
-    defaultMessage: 'Expires At',
+    defaultMessage: 'Closes at',
+  },
+  bonusEndsAt: {
+    id: 'course.surveys.fields.bonusEndsAt',
+    defaultMessage: 'Bonus ends at',
   },
   closingRemindedAt: {
     id: 'course.surveys.fields.closingRemindedAt',
@@ -27,23 +31,23 @@ const translations = defineMessages({
   },
   anonymous: {
     id: 'course.surveys.fields.anonymous',
-    defaultMessage: 'Anonymous',
+    defaultMessage: 'Anonymous responses',
   },
   allowResponseAfterEnd: {
     id: 'course.surveys.fields.allowResponseAfterEnd',
-    defaultMessage: 'Allow Responses After Survey Expires',
+    defaultMessage: 'Allow responses after survey closes',
   },
   allowModifyAfterSubmit: {
     id: 'course.surveys.fields.allowModifyAfterSubmit',
-    defaultMessage: 'Allow Submitted Responses To Be Modified',
+    defaultMessage: 'Allow response editing',
   },
   basePoints: {
     id: 'course.surveys.fields.basePoints',
-    defaultMessage: 'Base Points',
+    defaultMessage: 'Base EXP',
   },
   bonusPoints: {
     id: 'course.surveys.fields.bonusPoints',
-    defaultMessage: 'Bonus Points',
+    defaultMessage: 'Time Bonus EXP',
   },
   published: {
     id: 'course.surveys.fields.published',

--- a/client/app/bundles/course/survey/utils/index.js
+++ b/client/app/bundles/course/survey/utils/index.js
@@ -123,15 +123,3 @@ export const formatQuestionFormData = (data) => {
 
   return payload;
 };
-
-export const formatSurveyFormData = (data) => {
-  const payload = { ...data };
-  if (data.allow_response_after_end) {
-    payload.bonus_end_at = data.end_at;
-  } else {
-    payload.bonus_end_at = null;
-    payload.time_bonus_exp = 0;
-  }
-
-  return { survey: payload };
-};

--- a/spec/controllers/course/survey/surveys_controller_spec.rb
+++ b/spec/controllers/course/survey/surveys_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Course::Survey::SurveysController do
 
         it 'responds with the necessary fields' do
           expect(json_response.keys).to contain_exactly(
-            'id', 'title', 'description', 'base_exp', 'time_bonus_exp', 'published',
+            'id', 'title', 'description', 'base_exp', 'time_bonus_exp', 'published', 'bonus_end_at',
             'start_at', 'end_at', 'closing_reminded_at', 'anonymous', 'allow_response_after_end',
             'allow_modify_after_submit', 'canUpdate', 'canDelete', 'canCreateSection',
             'canViewResults', 'canRespond', 'response', 'sections', 'hasStudentResponse'


### PR DESCRIPTION
Closes #4989.

Time Bonus EXP for surveys now follows the following behaviour:
- Bonus end time must be between survey opening and closing times.
- Time Bonus EXP is awarded if a survey is submitted between opening and bonus end times.
- Only Base EXP is awarded if a survey is submitted between bonus end and closing times.
- 'Allow responses after survey closes' option no longer modifies the Time Bonus EXP behaviour.