### PR TITLE
fix(bonus exp field): fix bonus exp field validation bug

### DIFF
--- a/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
+++ b/client/app/bundles/course/assessment/containers/AssessmentForm/index.jsx
@@ -63,8 +63,8 @@ const validationSchema = yup.object({
     .required(formTranslations.required),
   time_bonus_exp: yup
     .number()
-    .typeError(formTranslations.required)
-    .required(formTranslations.required),
+    .nullable(true)
+    .transform((_, val) => (val === Number(val) ? val : null)),
   published: yup.bool(),
   autograded: yup.bool(),
   block_student_viewing_after_submitted: yup.bool(),

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/index.jsx
@@ -25,8 +25,10 @@ class EditPage extends Component {
     const sessionPassword = data.password_protected
       ? data.session_password
       : null;
+    const timeBonusExp = data.time_bonus_exp ? data.time_bonus_exp : 0;
     const atrributes = {
       ...data,
+      time_bonus_exp: timeBonusExp,
       view_password: viewPassword,
       session_password: sessionPassword,
     };

--- a/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentIndex/index.jsx
@@ -23,11 +23,16 @@ class PopupDialog extends Component {
   onFormSubmit = (data, setError) => {
     const { categoryId, dispatch, intl, tabId } = this.props;
 
+    const attributes = {
+      ...data,
+      time_bonus_exp: data.time_bonus_exp ? data.time_bonus_exp : 0,
+    };
+
     return dispatch(
       actions.createAssessment(
         categoryId,
         tabId,
-        { assessment: data },
+        { assessment: attributes },
         intl.formatMessage(translations.creationSuccess),
         intl.formatMessage(translations.creationFailure),
         setError,

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -58,7 +58,10 @@ const validationSchema = yup.object({
     .number()
     .typeError(formTranslations.required)
     .required(formTranslations.required),
-  time_bonus_exp: yup.number(),
+  time_bonus_exp: yup
+    .number()
+    .nullable(true)
+    .transform((_, val) => (val === Number(val) ? val : null)),
   allow_response_after_end: yup.bool(),
   allow_modify_after_submit: yup.bool(),
   anonymous: yup.bool(),

--- a/client/app/bundles/course/survey/containers/SurveyLayout/AdminMenu.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyLayout/AdminMenu.jsx
@@ -9,6 +9,7 @@ import * as surveyActions from 'course/survey/actions/surveys';
 import { showDeleteConfirmation } from 'course/survey/actions';
 import { surveyShape } from 'course/survey/propTypes';
 import { useNavigate } from 'react-router-dom';
+import { formatSurveyFormData } from '../../utils';
 
 const translations = defineMessages({
   editSurvey: {
@@ -74,7 +75,7 @@ const AdminMenu = (props) => {
   const updateSurveyHandler = (data, setError) => {
     const { updateSurvey } = surveyActions;
 
-    const payload = { survey: data };
+    const payload = formatSurveyFormData(data);
     const successMessage = intl.formatMessage(translations.updateSuccess, data);
     const failureMessage = intl.formatMessage(translations.updateFailure);
     return dispatch(

--- a/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyIndex/NewSurveyButton.jsx
@@ -5,6 +5,7 @@ import { injectIntl, defineMessages } from 'react-intl';
 import moment from 'lib/moment';
 import { showSurveyForm, createSurvey } from 'course/survey/actions/surveys';
 import AddButton from 'course/survey/components/AddButton';
+import { formatSurveyFormData } from '../../utils';
 
 const translations = defineMessages({
   newSurvey: {
@@ -44,7 +45,7 @@ const NewSurveyButton = (props) => {
   const createSurveyHandler = (data, setError) => {
     const { dispatch, intl } = props;
 
-    const payload = { survey: data };
+    const payload = formatSurveyFormData(data);
     const successMessage = intl.formatMessage(translations.success, data);
     const failureMessage = intl.formatMessage(translations.failure);
     return dispatch(

--- a/client/app/bundles/course/survey/utils/index.js
+++ b/client/app/bundles/course/survey/utils/index.js
@@ -123,3 +123,11 @@ export const formatQuestionFormData = (data) => {
 
   return payload;
 };
+
+export const formatSurveyFormData = (data) => {
+  const payload = { ...data };
+  if (!data.time_bonus_exp) {
+    payload.time_bonus_exp = 0;
+  }
+  return { survey: payload };
+};


### PR DESCRIPTION
When bonus exp field is left empty in either assessment or survey form, user should still be able to submit the form by defaulting the value to 0.