### PR TITLE
Fix broken layouts after Tailwind integration

### DIFF
--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -89,7 +89,6 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
             fieldState={fieldState}
             disabled={disabled}
             label={intl.formatMessage(t.viewPassword)}
-            description={intl.formatMessage(t.viewPasswordHint)}
             fullWidth
             required
             variant="filled"
@@ -97,6 +96,10 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           />
         )}
       />
+
+      <Typography variant="body2" color="text.secondary" className="!mt-0">
+        {intl.formatMessage(t.viewPasswordHint)}
+      </Typography>
 
       <Controller
         name="session_protected"
@@ -113,23 +116,28 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
       />
 
       {sessionProtected && (
-        <Controller
-          name="session_password"
-          control={control}
-          render={({ field, fieldState }): JSX.Element => (
-            <FormTextField
-              field={field}
-              fieldState={fieldState}
-              disabled={disabled}
-              label={intl.formatMessage(t.sessionPassword)}
-              description={intl.formatMessage(t.sessionPasswordHint)}
-              fullWidth
-              required
-              variant="filled"
-              type="password"
-            />
-          )}
-        />
+        <>
+          <Controller
+            name="session_password"
+            control={control}
+            render={({ field, fieldState }): JSX.Element => (
+              <FormTextField
+                field={field}
+                fieldState={fieldState}
+                disabled={disabled}
+                label={intl.formatMessage(t.sessionPassword)}
+                fullWidth
+                required
+                variant="filled"
+                type="password"
+              />
+            )}
+          />
+
+          <Typography variant="body2" color="text.secondary" className="!mt-0">
+            {intl.formatMessage(t.sessionPasswordHint)}
+          </Typography>
+        </>
       )}
     </>
   );

--- a/client/app/lib/components/DataTable.jsx
+++ b/client/app/lib/components/DataTable.jsx
@@ -1,6 +1,5 @@
-import { createTheme, ThemeProvider } from '@mui/material';
+import { createTheme, ThemeProvider, useTheme } from '@mui/material';
 import MUIDataTable from 'mui-datatables';
-import { adaptedTheme } from 'lib/components/ProviderWrapper';
 
 const options = {
   filter: true,
@@ -9,70 +8,53 @@ const options = {
   fixedSelectColumn: false,
 };
 
-const processTheme = (newHeight, grid, alignCenter, newPadding) =>
+const processTheme = (theme, newHeight, grid, alignCenter, newPadding) =>
   createTheme({
-    ...adaptedTheme,
+    ...theme,
     components: {
-      ...adaptedTheme.components,
-      MUIDataTableHeadCell: {
-        styleOverrides: {
-          fixedHeader: {
-            zIndex: 0,
-          },
-        },
-      },
+      ...theme.components,
+      MUIDataTableHeadCell: { styleOverrides: { fixedHeader: { zIndex: 0 } } },
       MuiTablePagination: {
         styleOverrides: {
-          selectLabel: {
-            marginBottom: 0,
-          },
-          displayedRows: {
-            marginBottom: 0,
-          },
-          root: {
-            overflow: 'visible',
-          },
+          selectLabel: { marginBottom: 0 },
+          displayedRows: { marginBottom: 0 },
+          root: { overflow: 'visible' },
         },
       },
       MuiTableCell: {
         styleOverrides: {
-          ...adaptedTheme.components.MuiTableCell.styleOverrides,
+          ...theme.components.MuiTableCell?.styleOverrides,
           root: {
-            ...adaptedTheme.components.MuiTableCell.styleOverrides.root,
+            ...theme.components.MuiTableCell?.styleOverrides.root,
             height:
               newHeight ??
-              adaptedTheme.components.MuiTableCell.styleOverrides.root.height,
+              theme.components.MuiTableCell?.styleOverrides.root.height,
             padding:
               newPadding ??
-              adaptedTheme.components.MuiTableCell.styleOverrides.root.padding,
+              theme.components.MuiTableCell?.styleOverrides.root.padding,
           },
         },
       },
       MuiToolbar: {
         styleOverrides: {
-          ...adaptedTheme.components.MuiTableCell.styleOverrides,
+          ...theme.components.MuiTableCell?.styleOverrides,
           root: {
-            ...adaptedTheme.components.MuiTableCell.styleOverrides.root,
+            ...theme.components.MuiTableCell?.styleOverrides.root,
             display: grid ? 'grid' : 'flex',
             alignContent: alignCenter ? 'center' : 'inherit',
           },
         },
       },
-    },
-    overrides: {
       MUIDataTableSelectCell: {
-        expandDisabled: {
-          // Soft hide the button.
-          visibility: 'hidden',
-        },
+        // Soft hide the button.
+        styleOverrides: { expandDisabled: { visibility: 'hidden' } },
       },
     },
   });
 
 const processColumns = (includeRowNumber, columns) => {
-  if (!columns) {
-    return columns;
-  }
+  if (!columns) return columns;
+
   if (includeRowNumber) {
     columns.unshift({
       name: 'S/N',
@@ -110,23 +92,28 @@ const processColumns = (includeRowNumber, columns) => {
  *
  * Refer to https://github.com/gregnb/mui-datatables for the documentation.
  */
-const DataTable = (props) => (
-  <ThemeProvider
-    theme={processTheme(
-      props.height,
-      props.titleGrid,
-      props.titleAlignCenter,
-      props.padding,
-    )}
-  >
-    <MUIDataTable
-      {...props}
-      columns={processColumns(props.includeRowNumber, props.columns)}
-      elevation={1}
-      options={{ ...options, ...(props.options ?? {}) }}
-    />
-  </ThemeProvider>
-);
+const DataTable = (props) => {
+  const theme = useTheme();
+
+  return (
+    <ThemeProvider
+      theme={processTheme(
+        theme,
+        props.height,
+        props.titleGrid,
+        props.titleAlignCenter,
+        props.padding,
+      )}
+    >
+      <MUIDataTable
+        {...props}
+        columns={processColumns(props.includeRowNumber, props.columns)}
+        elevation={1}
+        options={{ ...options, ...(props.options ?? {}) }}
+      />
+    </ThemeProvider>
+  );
+};
 
 DataTable.propTypes = MUIDataTable.propTypes;
 

--- a/client/app/lib/components/ProviderWrapper.jsx
+++ b/client/app/lib/components/ProviderWrapper.jsx
@@ -6,7 +6,6 @@ import { ToastContainer } from 'react-toastify';
 import { injectStyle } from 'react-toastify/dist/inject-style';
 import {
   createTheme,
-  adaptV4Theme,
   ThemeProvider,
   StyledEngineProvider,
 } from '@mui/material/styles';
@@ -36,101 +35,88 @@ const tailwindConfig = resolveConfig(tailwindUserConfig);
 
 const pxInInt = (pixels) => parseInt(pixels.replace('px', ''), 10);
 
-const themeSettings = {
-  palette,
-  // https://material-ui.com/customization/themes/#typography---html-font-size
-  // https://material-ui.com/style/typography/#migration-to-typography-v2
-  typography: {
-    htmlFontSize: 10,
-  },
-  breakpoints: {
-    values: {
-      xs: 0,
-      sm: pxInInt(tailwindConfig.theme.screens.sm),
-      md: pxInInt(tailwindConfig.theme.screens.md),
-      lg: pxInInt(tailwindConfig.theme.screens.lg),
-      xl: pxInInt(tailwindConfig.theme.screens.xl),
-    },
-  },
-  overrides: {
-    MuiAppBar: {
-      // When there is a MUI Dialog component, somehow
-      // the color of appbar is changed... smh
-      root: {
-        background: `${palette.primary.main} !important`,
-        color: 'white !important',
-      },
-    },
-    MuiCard: {
-      root: {
-        overflow: 'visible',
-      },
-    },
-    MuiDialogContent: {
-      root: {
-        color: 'black',
-        fontSize: '16px',
-        fontFamily: `'Roboto', 'sans-serif'`,
-      },
-    },
-    MuiAccordionSummary: {
-      root: {
-        width: '100%',
-      },
-      content: {
-        margin: 0,
-        paddingLeft: '16px',
-        '&$expanded': { margin: 0 },
-      },
-    },
-    MuiMenuItem: {
-      root: {
-        height: '48px',
-      },
-    },
-    MuiModal: {
-      root: {
-        zIndex: 1,
-      },
-    },
-    MuiStepLabel: {
-      iconContainer: {
-        paddingLeft: '2px',
-        paddingRight: '2px',
-      },
-    },
-    MuiTableCell: {
-      root: {
-        padding: '8px 14px',
-        height: '48px',
-      },
-      head: {
-        color: grey[500],
-        padding: '16px 16px',
-      },
-      sizeSmall: {
-        padding: '6px 12px',
-        height: '40px',
-      },
-    },
-  },
-};
-
-export const adaptedTheme = adaptV4Theme(themeSettings);
-
 const ProviderWrapper = ({ store, persistor, children }) => {
   const localeWithoutRegionCode = i18nLocale.toLowerCase().split(/[_-]+/)[0];
 
   // TODO: Replace with React's createRoot once true SPA is ready
   const rootElement = document.getElementById('root');
 
-  const themeV5 = createTheme({
-    ...adaptedTheme,
+  const theme = createTheme({
+    palette,
+    // https://material-ui.com/customization/themes/#typography---html-font-size
+    // https://material-ui.com/style/typography/#migration-to-typography-v2
+    typography: {
+      htmlFontSize: 10,
+    },
+    breakpoints: {
+      values: {
+        xs: 0,
+        sm: pxInInt(tailwindConfig.theme.screens.sm),
+        md: pxInInt(tailwindConfig.theme.screens.md),
+        lg: pxInInt(tailwindConfig.theme.screens.lg),
+        xl: pxInInt(tailwindConfig.theme.screens.xl),
+      },
+    },
     components: {
-      ...adaptedTheme.components,
       MuiDialog: { defaultProps: { container: rootElement } },
       MuiPopover: { defaultProps: { container: rootElement } },
       MuiPopper: { defaultProps: { container: rootElement } },
+      MuiCard: { styleOverrides: { root: { overflow: 'visible' } } },
+      MuiMenuItem: { styleOverrides: { root: { height: '48px' } } },
+      MuiModal: { styleOverrides: { root: { zIndex: 1 } } },
+      MuiAppBar: {
+        styleOverrides: {
+          // When there is a MUI Dialog component, somehow
+          // the color of appbar is changed... smh
+          root: {
+            background: `${palette.primary.main} !important`,
+            color: 'white !important',
+          },
+        },
+      },
+      MuiDialogContent: {
+        styleOverrides: {
+          root: {
+            color: 'black',
+            fontSize: '16px',
+            fontFamily: `'Roboto', 'sans-serif'`,
+          },
+        },
+      },
+      MuiAccordionSummary: {
+        styleOverrides: {
+          root: { width: '100%' },
+          content: {
+            margin: 0,
+            paddingLeft: '16px',
+            '&$expanded': { margin: 0 },
+          },
+        },
+      },
+      MuiStepLabel: {
+        styleOverrides: {
+          iconContainer: {
+            paddingLeft: '2px',
+            paddingRight: '2px',
+          },
+        },
+      },
+      MuiTableCell: {
+        styleOverrides: {
+          root: {
+            padding: '8px 14px',
+            height: '48px',
+          },
+          head: {
+            color: grey[500],
+            padding: '16px 16px',
+          },
+          sizeSmall: {
+            padding: '6px 12px',
+            height: '40px',
+          },
+        },
+      },
     },
   });
 
@@ -168,7 +154,7 @@ const ProviderWrapper = ({ store, persistor, children }) => {
   providers = (
     <IntlProvider locale={i18nLocale} messages={messages} textComponent="span">
       <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={themeV5}>{providers}</ThemeProvider>
+        <ThemeProvider theme={theme}>{providers}</ThemeProvider>
       </StyledEngineProvider>
     </IntlProvider>
   );

--- a/client/app/lib/components/ProviderWrapper.jsx
+++ b/client/app/lib/components/ProviderWrapper.jsx
@@ -127,6 +127,7 @@ const ProviderWrapper = ({ store, persistor, children }) => {
   const themeV5 = createTheme({
     ...adaptedTheme,
     components: {
+      ...adaptedTheme.components,
       MuiDialog: { defaultProps: { container: rootElement } },
       MuiPopover: { defaultProps: { container: rootElement } },
       MuiPopper: { defaultProps: { container: rootElement } },

--- a/client/app/lib/components/TextField.tsx
+++ b/client/app/lib/components/TextField.tsx
@@ -2,50 +2,37 @@ import { useState, forwardRef, ComponentProps } from 'react';
 import {
   InputAdornment,
   TextField as MuiTextField,
-  Typography,
   IconButton,
 } from '@mui/material';
 import { VisibilityOff, Visibility } from '@mui/icons-material';
 
-type TextFieldProps = ComponentProps<typeof MuiTextField> & {
-  description?: string;
-};
+type TextFieldProps = ComponentProps<typeof MuiTextField>;
 
 const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
   (props, ref): JSX.Element => {
-    const { description, ...rest } = props;
-
     const [showPassword, setShowPassword] = useState(false);
 
     return (
-      <div>
-        <MuiTextField
-          ref={ref}
-          {...rest}
-          {...(props.type === 'password' && {
-            type: showPassword ? 'text' : 'password',
-            InputProps: {
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    onClick={(): void => setShowPassword((state) => !state)}
-                    onMouseDown={(e): void => e.preventDefault()}
-                    edge="end"
-                  >
-                    {showPassword ? <VisibilityOff /> : <Visibility />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            },
-          })}
-        />
-
-        {description && (
-          <Typography variant="body2" color="text.secondary">
-            {description}
-          </Typography>
-        )}
-      </div>
+      <MuiTextField
+        ref={ref}
+        {...props}
+        {...(props.type === 'password' && {
+          type: showPassword ? 'text' : 'password',
+          InputProps: {
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  onClick={(): void => setShowPassword((state) => !state)}
+                  onMouseDown={(e): void => e.preventDefault()}
+                  edge="end"
+                >
+                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          },
+        })}
+      />
     );
   },
 );

--- a/client/app/lib/components/form/fields/TextField.jsx
+++ b/client/app/lib/components/form/fields/TextField.jsx
@@ -110,7 +110,6 @@ FormTextField.propTypes = {
   id: PropTypes.string,
   sx: PropTypes.object,
   className: PropTypes.string,
-  description: PropTypes.string,
 };
 
 export default FormTextField;


### PR DESCRIPTION
`themeSettings.overrides` is converted to `.components.styleOverrides` by `adaptV4Theme`, so the `Portal` components' `container` settings in `components` overrode our default overrides. ~~In the future, we should probably move away from `adaptV4Theme` and consolidate our styles, so that `DataTable` also need not import `adaptedTheme` and create its own `ThemeProvider`.~~ `adaptV4Theme` has been removed as of https://github.com/Coursemology/coursemology2/pull/5071/commits/7e41297784636977bf1567097de98980a2da14b4.

The input width issue was caused by the one-level wrapping of the `<div>` I added to support description. I moved the description out from `TextField` to `AssessmentForm/index`, so our `TextField` is now a pure wrapper for MUI's `TextField`.