### PR TITLE
fix(autograded assessment): prevent submission with incorrect answers

### DIFF
--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -190,7 +190,13 @@ module Course::Assessment::Submission::WorkflowEventConcern
       else
         last_non_current_answer = all_answers.reject(&:current_answer?).reject(&:attempting?).last
 
-        if current_answer.specific.compare_answer(last_non_current_answer.specific)
+        is_same_answer = current_answer.specific.compare_answer(last_non_current_answer.specific)
+
+        if assessment.autograded && !assessment.allow_partial_submission && !is_same_answer
+          self.has_unsubmitted_or_draft_answer = true
+        end
+
+        if is_same_answer
           # If the latest non-current answer and the current answer are the same, keep the latest non-current answer
           # and remove current answer
           all_answers.current_answers.select(&:attempting?).each(&:destroy!)

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -46,7 +46,7 @@ const formatAnswers = (answers = {}) => {
 };
 
 function buildErrorMessage(error) {
-  if (!error || !error.response || !error.data) {
+  if (!error && !error.response && !error.data) {
     return '';
   }
 

--- a/config/locales/en/activerecord/course/assessment/submission.yml
+++ b/config/locales/en/activerecord/course/assessment/submission.yml
@@ -21,5 +21,6 @@ en:
               or contact the Coursemology team
           submission_already_exists: 'Looks like you have already created a submission. Try again?'
           no_bundles_assigned: 'There are no question bundles assigned for you. Contact your instructor for assistance.'
+          autograded_no_partial_answer: 'There are updated answers which have not been re-submitted yet. Please re-submit all answers before finalising your submission.'
         course/assessment/category:
           deletion: 'the last category cannot be deleted'


### PR DESCRIPTION
Closes https://github.com/Coursemology/coursemology2/issues/4446

A backend validation is done when finalising a submission. If the assessment is of autograded type and it only allows submission with correct answers, the validation will check if there is any submitted answer that is different from the previously submitted answer.