### PR TITLE
Fix missing border and red/green background on forum post after Tailwind integration

### DIFF
--- a/app/assets/stylesheets/course/forum/_post.scss
+++ b/app/assets/stylesheets/course/forum/_post.scss
@@ -1,5 +1,5 @@
 @mixin course-forum-post {
-  .contents {
+  .post-contents {
     border: 1px solid $course-discussion-post-border-color;
     border-radius: $course-discussion-post-border-radius;
     box-shadow: 0 1px 1px $course-discussion-post-shadow-color;
@@ -31,7 +31,7 @@
     }
   }
 
-  &.unread > .contents {
+  &.unread > .post-contents {
     background-color: $course-forum-unread-highlight;
   }
 }

--- a/app/views/course/forum/posts/_post.html.slim
+++ b/app/views/course/forum/posts/_post.html.slim
@@ -4,7 +4,7 @@
 = div_for(post, class: post_class) do
   a name=dom_id(post)
 
-  div.contents
+  div.post-contents
     div.title
       = div_for(post.creator) do
         = display_user_image(post.creator)


### PR DESCRIPTION
The `contents` class name used for forum posts clashed with [Tailwind's `contents` utility that sets `display: content`](https://tailwindcss.com/docs/display#contents), so the borders and background styles defined in Sass got overridden.