### PR TITLE
Fix image tag css

### DIFF
--- a/app/assets/stylesheets/course/_announcement.scss
+++ b/app/assets/stylesheets/course/_announcement.scss
@@ -76,8 +76,4 @@
     margin: 0 0 18px;
     padding: 0 0 0 15px;
   }
-
-  img {
-    max-width: 100%;
-  }
 }

--- a/client/app/bundles/course/courses/components/misc/CourseInfoBox.scss
+++ b/client/app/bundles/course/courses/components/misc/CourseInfoBox.scss
@@ -14,7 +14,9 @@
   border-radius: 10px;
 }
 
-img {
-  height: 100px;
-  width: 100px;
+.coursePicture {
+  img {
+    height: 100px;
+    width: 100px;
+  }
 }

--- a/client/app/bundles/course/courses/components/misc/CourseInfoBox.tsx
+++ b/client/app/bundles/course/courses/components/misc/CourseInfoBox.tsx
@@ -3,9 +3,8 @@ import { FC } from 'react';
 import { CardContent, Typography, Grid, Link } from '@mui/material';
 import { blue } from '@mui/material/colors';
 import { CourseMiniEntity } from 'types/course/courses';
-
-import './CourseInfoBox.scss';
 import { getCourseURL } from 'lib/helpers/url-builders';
+import styles from './CourseInfoBox.scss';
 
 interface Props extends WrappedComponentProps {
   course: CourseMiniEntity;
@@ -44,6 +43,7 @@ const CourseInfoBox: FC<Props> = (props) => {
               marginBottom: 0,
               marginTop: 10,
             }}
+            className={styles.coursePicture}
             dangerouslySetInnerHTML={{ __html: course.logoUrl }}
           />
           <CardContent style={{ padding: 5 }}>

--- a/client/app/lib/components/layouts/layout.scss
+++ b/client/app/lib/components/layouts/layout.scss
@@ -31,3 +31,7 @@ footer {
   background-color: #ffffff;
   z-index: 2;
 }
+
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
The css in the CourseInfoBox is targeting global image tag. This PR increases the specificity of the intended img tag styling target. 

Also added max-width of 100% for the global image tag to prevent any image to overflow its parent's component.