### PR TITLE
Add usePrompt hook

### DIFF
--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -21,9 +21,9 @@ import {
 } from '@mui/material';
 import { blue, yellow, red, grey } from '@mui/material/colors';
 
-/* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 import ErrorText from 'lib/components/ErrorText';
+import usePrompt from 'lib/hooks/router/usePrompt';
 import {
   explanationShape,
   questionShape,
@@ -130,6 +130,7 @@ const SubmissionEditForm = (props) => {
     setValue,
     formState: { errors, isDirty },
   } = methods;
+  usePrompt(isDirty);
 
   useEffect(() => {
     reset(initialValues);

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -22,6 +22,7 @@ import { blue, green, lightBlue, red } from '@mui/material/colors';
 /* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
 import ErrorText from 'lib/components/ErrorText';
+import { usePrompt } from 'lib/hooks/router/usePrompt';
 import {
   explanationShape,
   questionShape,
@@ -122,6 +123,7 @@ const SubmissionEditStepForm = (props) => {
     setValue,
     formState: { errors, isDirty },
   } = methods;
+  usePrompt(isDirty);
 
   useEffect(() => {
     reset(initialValues);

--- a/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
+++ b/client/app/bundles/course/survey/containers/ResponseForm/index.jsx
@@ -5,6 +5,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { Button } from '@mui/material';
 import { useFieldArray, useForm } from 'react-hook-form';
 import ErrorText from 'lib/components/ErrorText';
+import { usePrompt } from 'lib/hooks/router/usePrompt';
 import formTranslations from 'lib/translations/form';
 import { responseShape } from 'course/survey/propTypes';
 import ResponseSection from './ResponseSection';
@@ -92,6 +93,8 @@ const ResponseForm = (props) => {
   } = useForm({
     defaultValues: initialValues,
   });
+  usePrompt(isDirty);
+
   const { fields } = useFieldArray({
     control,
     name: 'sections',

--- a/client/app/lib/hooks/router/usePrompt.tsx
+++ b/client/app/lib/hooks/router/usePrompt.tsx
@@ -1,0 +1,44 @@
+import { History, Transition } from 'history';
+import { useCallback, useContext, useEffect } from 'react';
+import {
+  UNSAFE_NavigationContext as NavigationContext,
+  Navigator,
+} from 'react-router-dom';
+
+type ExtendNavigator = Navigator & Pick<History, 'block'>;
+
+export const useBlocker = (
+  blocker: (tx: Transition) => void,
+  when = true,
+): void => {
+  const { navigator } = useContext(NavigationContext);
+
+  useEffect(() => {
+    if (!when) return undefined;
+
+    const unblock = (navigator as ExtendNavigator).block((tx) => {
+      const autoUnblockingTx = {
+        ...tx,
+        retry(): void {
+          unblock();
+          tx.retry();
+        },
+      };
+
+      blocker(autoUnblockingTx);
+    });
+
+    return unblock;
+  }, [navigator, blocker, when]);
+};
+
+export const usePrompt = (when = true): void => {
+  const blocker = useCallback((tx: Transition) => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm()) tx.retry();
+  }, []);
+
+  useBlocker(blocker, when);
+};
+
+export default usePrompt;


### PR DESCRIPTION
In React router v6, `usePrompt` and `<Prompt />` have been removed temporarily. It was mentioned in the react hook form repo that this feature will be returned in the future (https://github.com/remix-run/react-router/issues/8139). However, no update so far yet and thus, we are adding a custom `usePrompt` hook instead based on (https://stackoverflow.com/questions/71572678/react-router-v-6-useprompt-typescript).