### PR TITLE
Fix ClickAwayListener incompatibility with CKEditor Link popup

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
@@ -80,7 +80,9 @@ const LineNumberColumn = (props) => {
 
     if (expanded[lineNumber - 1]) {
       return (
-        <ClickAwayListener onClickAway={() => collapseComment(lineNumber)}>
+        <ClickAwayListener
+          onClickAway={(event) => collapseComment(lineNumber, event)}
+        >
           <div
             style={{
               width: Math.max(0, editorWidth - 2),
@@ -171,8 +173,14 @@ export default function NarrowEditor(props) {
     props.toggleLine(lineNumber);
   };
 
-  const collapseComment = (lineNumber) => {
-    props.collapseLine(lineNumber);
+  const collapseComment = (lineNumber, event) => {
+    // CKEditor's Link popup dialog is rendered separately in a separate wrapper (ck-body-wrapper)
+    // and not rendered as a child of the main CKEditor's toolbar.
+    // As a result, the clickawaylistener would be triggered when the Link popup dialog is clicked.
+    // Here, we check the class' of the clicked element and if contains "ck", the comment is not collapsed.
+    // There is a downside to this that lets say if another ckeditor toolbar is clicked, the comment is also
+    // not collapsed, however, this is not a big issue as the former issue would be more disruptive for users.
+    if (!event.target.classList.contains('ck')) props.collapseLine(lineNumber);
   };
 
   const renderLineNumberColumn = (lineNumber) => (

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -120,6 +120,7 @@ class VisibleGradingPanel extends Component {
             type="number"
             min={0}
             max={1}
+            step="any"
             value={expMultiplier}
             onChange={(e) => this.handleMultiplierField(e.target.value)}
             ref={(ref) => {

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -580,8 +580,8 @@ const SubmissionEditForm = (props) => {
         {question.type === questionTypes.Programming && !viewHistory
           ? renderExplanationPanel(questionId)
           : null}
-        {viewHistory ? null : renderQuestionGrading(questionId)}
         {viewHistory ? null : renderProgrammingQuestionActions(questionId)}
+        {viewHistory ? null : renderQuestionGrading(questionId)}
         <Suspense
           fallback={
             <>


### PR DESCRIPTION
### Issue
For CKEditor field inside the `<NarrowEditor />`, the comment field will disappear whenever any button or field inside the CKEditor's Link popup dialog is clicked. It was found that the CKEditor's Link popup dialog is rendered not as a child of the CKEditor's toolbar, but it is rendered separately in a separate wrapper (ck-body-wrapper). 

As a result, when the `ClickAwayListener` would be triggered when anything inside the link popup dialog is clicked and hence, the comment field is collapsed. 

### Solution
Before collapsing the comment field, the event target is first checked and if the `ck` class is detected (it means that the user is interacting inside the CKEditor's link popup dialog), the comment field is not collapsed.

### Caveat
A downside to this approach is that if another ckeditor toolbar is clicked, the comment field will not be collapsed as the toolbar also contains the `ck` class name. However, this should not a big issue as the former issue would be more disruptive for users if left unfixed.