### PR TITLE
Fix watch button in video show page

### DIFF
--- a/app/views/course/video/videos/_video_data.json.jbuilder
+++ b/app/views/course/video/videos/_video_data.json.jbuilder
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-json.partial! 'video_list_data', video: video, can_analyze: can?(:analyze, video)
+submission = video.submissions.by_user(current_user)&.first&.id
+
+json.partial! 'video_list_data', video: video, can_analyze: can?(:analyze, video), submission: submission
 json.videoStatistics do
   json.partial! 'video_statistics'
 end

--- a/app/views/course/video/videos/_video_list_data.json.jbuilder
+++ b/app/views/course/video/videos/_video_list_data.json.jbuilder
@@ -20,7 +20,7 @@ json.startTimeInfo do
                 datetime_format: :long
 end
 
-json.videoSubmissionId video.submissions.first&.id
+json.videoSubmissionId submission if can_attempt && current_course_user.present?
 
 json.videoChildrenExist video.children_exist? if can_manage
 

--- a/app/views/course/video/videos/index.json.jbuilder
+++ b/app/views/course/video/videos/index.json.jbuilder
@@ -8,7 +8,7 @@ json.videoTabs @video_tabs do |video_tab|
 end
 
 json.videos @videos do |video|
-  json.partial! 'video_list_data', video: video, can_analyze: can_analyze
+  json.partial! 'video_list_data', video: video, can_analyze: can_analyze, submission: video.submissions.first&.id
 end
 
 json.metadata do


### PR DESCRIPTION
Fix wrong submission id passed for video show page. Previously, `video.submissions.first&.id` was used, which means that the submission id for an unrelated user will be sent to the frontend when show page is opened (No submission preloading for the current user in `def show`, whereas `def index` calls `with_submissions_by`.