### PR TITLE
Forum Post Response: Support for CSV and JSON download

### DIFF
--- a/app/models/course/assessment/answer/forum_post_response.rb
+++ b/app/models/course/assessment/answer/forum_post_response.rb
@@ -52,6 +52,16 @@ class Course::Assessment::Answer::ForumPostResponse < ApplicationRecord
     stripped_answer_to_array.to_json
   end
 
+  def download(dir)
+    return if post_packs.empty?
+
+    answer_json_path = File.join(dir, 'answer.json')
+    File.open(answer_json_path, 'w') do |file|
+      json = JSON.pretty_generate(stripped_answer_to_array)
+      file.write(json)
+    end
+  end
+
   private
 
   def stripped_answer_to_array

--- a/app/models/course/assessment/answer/forum_post_response.rb
+++ b/app/models/course/assessment/answer/forum_post_response.rb
@@ -48,7 +48,28 @@ class Course::Assessment::Answer::ForumPostResponse < ApplicationRecord
     same_text && same_post_packs_length && same_post_packs
   end
 
+  def csv_download
+    stripped_answer_to_array.to_json
+  end
+
   private
+
+  def stripped_answer_to_array
+    post_packs.map do |post|
+      {
+        selectedPost: readable_string_of(post.post_text),
+        parentPost: readable_string_of(post.parent_text),
+        textAnswer: readable_string_of(answer_text)
+      }.compact
+    end
+  end
+
+  def readable_string_of(text)
+    return nil unless text
+
+    cleaned_text = text.gsub('</p>', "</p>\n").gsub('<br />', "<br />\n").squish
+    ActionController::Base.helpers.strip_tags(cleaned_text)
+  end
 
   def destroy_previous_selection
     post_packs.destroy_all

--- a/app/models/course/assessment/question/forum_post_response.rb
+++ b/app/models/course/assessment/question/forum_post_response.rb
@@ -34,4 +34,8 @@ class Course::Assessment::Question::ForumPostResponse < ApplicationRecord
 
     errors.add(:max_posts, "has to be between 1 and #{max_posts_allowed}")
   end
+
+  def csv_downloadable?
+    true
+  end
 end

--- a/app/models/course/assessment/question/forum_post_response.rb
+++ b/app/models/course/assessment/question/forum_post_response.rb
@@ -38,4 +38,8 @@ class Course::Assessment::Question::ForumPostResponse < ApplicationRecord
   def csv_downloadable?
     true
   end
+
+  def files_downloadable?
+    true
+  end
 end


### PR DESCRIPTION
Forum Post Response questions now support CSV and JSON download. These menus should now be enabled for these questions.

![image](https://user-images.githubusercontent.com/51525686/196024199-2bcef2ae-a7ee-4054-b1a1-3971f663fd5b.png)

## JSON
The JSON generated will be in the following format: an array of answers, with each answer being an object with possible keys `selectedPost`, `parentPost`, and `textAnswer`. These keys will only be present if their values are not `nil`. If there is no answer for a given question, the JSON will not be generated.
```json
[
  {
    "selectedPost": "...",
    "parentPost": "...",
    "textAnswer": "..."
  },
  {
    "selectedPost": "...",
    "parentPost": "...",
    "textAnswer": "..."
  },
  ...
]
```

## CSV
The CSV generated plug in to the current `CsvDownloadService` format. The answer cells for Forum Post Response questions contain the exact same JSON format as above, except without any carriage returns, i.e., all one-liner. The following is a screenshot of a CSV exported from `courses/2087/assessments/47756/submissions` on Microsoft Excel.

![196024558-9d52f17a-5729-483b-8a32-f2c16084f980](https://user-images.githubusercontent.com/51525686/196027282-6c6e628a-93d7-4592-8e43-1835da5f6e1e.png)

## String processing
The values for each of the attributes above are processed by:
- adding a whitespace at the end of every paragraph (`<p>`),
- replacing all carriage returns (`\n`s and `<br>`s) with whitespaces,
- stripping all the HTML tags.

## A note on encoding
As all things should be, our forum POSTs content in the Unicode character set and UTF-8 encoding, as seen in our Content-Type header. In `csv_download`, the string returned is also of UTF-8 encoding. When opened with Visual Studio Code, nonstandard characters (e.g., Chinese characters, emojis, etc.) all show properly. This is not the case when opened with Microsoft Excel.

These nonstandard characters display as gibberish, because Microsoft Excel requires UTF-8 with BOM to correctly identify and display UTF-8 CSVs as UTF-8 encoding.

The following is an example taken from `courses/2087/assessments/47756/submissions/1371464`.

| Encoding | UTF-8 | UTF-8 with BOM |
| - | - | - |
| | ✅ | ✅ |
| Visual Studio Code | ![image](https://user-images.githubusercontent.com/51525686/196025272-9d10d169-eafa-4440-8962-93f9d3483e77.png) | ![image](https://user-images.githubusercontent.com/51525686/196025279-ae5c932f-e94e-4409-95f0-9dd12c085a29.png) |
| | ❌ | ✅ |
| Microsoft Excel | ![image](https://user-images.githubusercontent.com/51525686/196025232-4e81c8f2-93d6-48f6-ae4f-fa1c13d52beb.png) | ![image](https://user-images.githubusercontent.com/51525686/196025325-feb746ba-d375-4813-bba2-09ca3e8d35cb.png) |

In this case, the offending character is [U+2019 `’`](https://unicode-table.com/en/2019/).

Of course, we could always prepend our CSVs with the BOM `FE FF`, but I do not think this is a good idea. [UTF-8 by definition does not require a BOM, and it is really the CSV reader's problem](https://softwareengineering.stackexchange.com/questions/372692/should-utf-8-csv-files-contain-a-bom-byte-order-mark). If we are sticking by our invariant, i.e., to generate plain pure CSV, then our encoding should _strictly_ be UTF-8.

>**Note** UTF-8 with BOM will usually break Python reads (on Windows, at least, the last time I tried).

There are two ways for the end users to be able to view CSVs with offending characters on Excel:
1. Opening it with a text editor (like Visual Studio Code) and re-save with the UTF-8 with BOM encoding.
2. [Using Excel's built-in Get Data feature, and selecting Unicode (UTF-8) encoding](https://support.knowbe4.com/hc/en-us/articles/360041788374-Why-Aren-t-Special-Characters-Displaying-in-My-CSV-File-in-Microsoft-Excel-).

## A limitation for CSV exports in Microsoft Excel
CSVs do not have any character limit per cell. However, according to Microsoft's documentation, [Excel can only display a maximum of 32,767 characters in one cell](https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3#ID0EDBD=Newer_versions:~:text=Total%20number%20of%20characters,32%2C767%20characters).

If the user exports the CSV and opens it with Microsoft Excel, and there is a student that responds with a very long forum post and/or reply to a very long forum post and/or text answer, then it is possible for Excel to break the cell into more cells.
