### PR TITLE
Add Codaveri feedback generation status

### DIFF
--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -110,3 +110,14 @@ json.explanation do
 end
 
 json.attemptsLeft answer.attempting_times_left if question.attempt_limit
+
+if answer.codaveri_feedback_job_id && question.is_codaveri
+  codaveri_job = answer.codaveri_feedback_job
+  json.codaveriFeedback do
+    json.jobId answer.codaveri_feedback_job_id
+    json.jobStatus codaveri_job.status
+    if codaveri_job.error && codaveri_job.error['class'] == 'CodaveriError'
+      json.errorMessage codaveri_job.error['message']
+    end
+  end
+end

--- a/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
@@ -5,6 +5,7 @@ import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import ProgrammingFile from './ProgrammingFile';
 import ProgrammingImportEditor from '../../../containers/ProgrammingImportEditor';
 import TestCaseView from '../../../containers/TestCaseView';
+import CodaveriFeedbackStatus from '../../../containers/CodaveriFeedbackStatus';
 import { parseLanguages } from '../../../utils';
 import { questionShape } from '../../../propTypes';
 
@@ -63,6 +64,7 @@ const Programming = (props) => {
         />
       )}
       <TestCaseView questionId={question.id} />
+      <CodaveriFeedbackStatus questionId={question.id} answerId={answerId} />
     </div>
   );
 };

--- a/client/app/bundles/course/assessment/submission/containers/CodaveriFeedbackStatus.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/CodaveriFeedbackStatus.jsx
@@ -1,0 +1,90 @@
+import { Paper } from '@mui/material';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { defineMessages, injectIntl } from 'react-intl';
+import { workflowStates } from '../constants';
+import { codaveriFeedbackStatusShape } from '../propTypes';
+
+const translations = defineMessages({
+  codaveriFeedbackStatus: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.codaveriFeedbackStatus',
+    defaultMessage: 'Codaveri Feedback Status',
+  },
+  loadingFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.loadingFeedbackGeneration',
+    defaultMessage: 'Generating Feedback. Please wait.',
+  },
+  successfulFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.successfulFeedbackGeneration',
+    defaultMessage: 'Feedback has been successfully generated.',
+  },
+  failedFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.failedFeedbackGeneration',
+    defaultMessage: 'Failed to generate Feedback. Error: {error}',
+  },
+});
+
+const CodaveriFeedbackStatus = (props) => {
+  const { submissionState, graderView, codaveriFeedbackStatus, intl } = props;
+  if (
+    !codaveriFeedbackStatus ||
+    !graderView ||
+    submissionState === workflowStates.Attempting
+  )
+    return null;
+
+  let feedbackBgColor = 'bg-gray-100';
+  let feedbackDescription = '';
+  switch (codaveriFeedbackStatus.jobStatus) {
+    case 'submitted':
+      feedbackBgColor = 'bg-orange-100';
+      feedbackDescription = intl.formatMessage(
+        translations.loadingFeedbackGeneration,
+      );
+      break;
+    case 'completed':
+      feedbackBgColor = 'bg-green-100';
+      feedbackDescription = intl.formatMessage(
+        translations.successfulFeedbackGeneration,
+      );
+      break;
+    case 'errored':
+      feedbackBgColor = 'bg-red-100';
+      feedbackDescription = intl.formatMessage(
+        translations.failedFeedbackGeneration,
+        { error: codaveriFeedbackStatus.errorMessage },
+      );
+      break;
+    default:
+      break;
+  }
+
+  return (
+    <Paper className="mb-8">
+      <div className={`${feedbackBgColor} inline-block p-8 font-bold`}>
+        {intl.formatMessage(translations.codaveriFeedbackStatus)}
+      </div>
+      <div className="inline-block pl-5">{feedbackDescription}</div>
+    </Paper>
+  );
+};
+
+CodaveriFeedbackStatus.propTypes = {
+  submissionState: PropTypes.string,
+  graderView: PropTypes.bool,
+  codaveriFeedbackStatus: codaveriFeedbackStatusShape,
+  intl: PropTypes.object,
+};
+
+function mapStateToProps(state, ownProps) {
+  const { answerId, intl } = ownProps;
+
+  return {
+    submissionState: state.submission.workflowState,
+    graderView: state.submission.graderView,
+    codaveriFeedbackStatus: state.codaveriFeedbackStatus.answers[answerId],
+    ...intl,
+  };
+}
+
+export default connect(mapStateToProps)(injectIntl(CodaveriFeedbackStatus));

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -244,3 +244,8 @@ export const forumTopicPostPackShape = PropTypes.shape({
     }),
   ),
 });
+
+export const codaveriFeedbackStatusShape = PropTypes.shape({
+  jobStatus: PropTypes.oneOf(['submitted', 'completed', 'errored']),
+  errorMessage: PropTypes.string,
+});

--- a/client/app/bundles/course/assessment/submission/reducers/codaveriFeedbackStatus.js
+++ b/client/app/bundles/course/assessment/submission/reducers/codaveriFeedbackStatus.js
@@ -1,0 +1,27 @@
+import actions from '../constants';
+
+const initialState = {
+  answers: {},
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case actions.FETCH_SUBMISSION_SUCCESS:
+    case actions.FINALISE_SUCCESS: {
+      return {
+        ...state,
+        answers: {
+          ...action.payload.answers.reduce(
+            (obj, answer) => ({
+              ...obj,
+              [answer.fields.id]: answer.codaveriFeedback,
+            }),
+            {},
+          ),
+        },
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/assessment/submission/reducers/index.js
+++ b/client/app/bundles/course/assessment/submission/reducers/index.js
@@ -3,6 +3,7 @@ import answers from './answers';
 import annotations from './annotations';
 import assessment from './assessment';
 import attachments from './attachments';
+import codaveriFeedbackStatus from './codaveriFeedbackStatus';
 import commentForms from './commentForms';
 import explanations from './explanations';
 import notification from './notification';
@@ -24,6 +25,7 @@ export default combineReducers({
   answers,
   attachments,
   assessment,
+  codaveriFeedbackStatus,
   commentForms,
   explanations,
   notification,


### PR DESCRIPTION
In order to inform tutors if a codevari code feedback generation status (generating feedback, successful or failed generation). If there's an error with the feedback generation, the error message is also shown.

**Generating feedback** 
![image](https://user-images.githubusercontent.com/42570513/198931056-96da9aca-5acd-4cb3-b627-a2bc8c8b66fa.png)

**Failed feedback generation**
![image](https://user-images.githubusercontent.com/42570513/198931034-c8603f98-cc12-40bd-bfcb-ee62a7b7c8f4.png)

**Successful feedback generation**
![image](https://user-images.githubusercontent.com/42570513/198931217-2d6a1ec8-2f2b-4ec0-8be7-0d7dd29084e8.png)
