### PR TITLE
Add rollbar to CM frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ node_modules
 # Ignore env files
 /.env
 /.env.*
+/client/.env
+/client/.env.*

--- a/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardManager.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardManager.tsx
@@ -152,9 +152,8 @@ const AchievementAwardManager: FC<Props> = (props) => {
           navigate(getAchievementURL(getCourseId(), achievementId));
         }, 100);
       })
-      .catch((error) => {
+      .catch(() => {
         toast.error(intl.formatMessage(translations.awardFailure));
-        throw error;
       });
 
   const options: TableOptions = {

--- a/client/app/bundles/course/user-invitations/components/forms/IndividualInviteForm.tsx
+++ b/client/app/bundles/course/user-invitations/components/forms/IndividualInviteForm.tsx
@@ -121,9 +121,8 @@ const IndividualInviteForm: FC<Props> = (props) => {
       .then((response) => {
         openResultDialog(response);
       })
-      .catch((error) => {
+      .catch(() => {
         toast.error(intl.formatMessage(messagesTranslations.formUpdateError));
-        throw error;
       })
       .finally(() => {
         setIsLoading(false);

--- a/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
+++ b/client/app/bundles/course/users/components/misc/PersonalTimeEditor.tsx
@@ -196,7 +196,6 @@ const PersonalTimeEditor: FC<Props> = (props) => {
           }),
         );
         setReactHookFormError(setError, error.response.data.errors);
-        throw error;
       });
   };
 

--- a/client/app/lib/components/wrappers/ProviderWrapper.jsx
+++ b/client/app/lib/components/wrappers/ProviderWrapper.jsx
@@ -1,5 +1,5 @@
 import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
+import { Provider as ReduxProvider } from 'react-redux';
 import { ToastContainer } from 'react-toastify';
 import { injectStyle } from 'react-toastify/dist/inject-style';
 import {
@@ -20,6 +20,7 @@ import translations from '../../../../build/locales/locales.json';
 import tailwindUserConfig from '../../../../tailwind.config';
 
 import ErrorBoundary from './ErrorBoundary';
+import RollBarWrapper from './RollbarWrapper';
 
 injectStyle();
 
@@ -161,10 +162,14 @@ const ProviderWrapper = ({ store, persistor, children }) => {
   );
 
   if (store) {
-    providers = <Provider store={store}>{providers}</Provider>;
+    providers = <ReduxProvider store={store}>{providers}</ReduxProvider>;
   }
 
-  return <ErrorBoundary>{providers}</ErrorBoundary>;
+  return (
+    <RollBarWrapper>
+      <ErrorBoundary>{providers}</ErrorBoundary>
+    </RollBarWrapper>
+  );
 };
 
 ProviderWrapper.propTypes = propTypes;
@@ -180,7 +185,8 @@ export const StoreProviderWrapper = ({ store, persistor, children }) => {
     );
   }
 
-  if (store) providers = <Provider store={store}>{providers}</Provider>;
+  if (store)
+    providers = <ReduxProvider store={store}>{providers}</ReduxProvider>;
 
   return providers;
 };

--- a/client/app/lib/components/wrappers/RollbarWrapper.tsx
+++ b/client/app/lib/components/wrappers/RollbarWrapper.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+import { Provider } from '@rollbar/react';
+
+interface Props {
+  children: JSX.Element;
+}
+
+const RollBarWrapper: FC<Props> = (props) => {
+  // TODO: To report user id as well after we move to SPA.
+  const rollbarConfig =
+    process.env.NODE_ENV === 'development'
+      ? {}
+      : {
+          accessToken: process.env.ROLLBAR_POST_CLIENT_ITEM_KEY,
+          environment: 'production',
+          captureUncaught: true,
+          captureUnhandledRejections: true,
+          payload: {
+            client: {
+              javascript: {
+                source_map_enabled: true,
+              },
+            },
+          },
+        };
+
+  return <Provider config={rollbarConfig}>{props.children}</Provider>;
+};
+
+export default RollBarWrapper;

--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
     "@mui/material": "^5.10.16",
     "@mui/x-date-pickers": "^5.0.9",
     "@reduxjs/toolkit": "^1.9.0",
+    "@rollbar/react": "^0.11.1",
     "@tailwindcss/line-clamp": "^0.4.2",
     "ace-builds": "^1.13.1",
     "axios": "^1.2.0",
@@ -89,6 +90,7 @@
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.4.2",
     "reselect": "^4.1.7",
+    "rollbar": "^2.25.2",
     "sass": "^1.56.1",
     "webfontloader": "^1.6.28",
     "yup": "^0.32.11"
@@ -127,6 +129,7 @@
     "babel-plugin-react-remove-properties": "^0.3.0",
     "css-loader": "^6.7.2",
     "cssnano": "^5.1.14",
+    "dotenv-webpack": "^8.0.1",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.2",
     "eslint": "^8.28.0",

--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -1,6 +1,7 @@
 const { join, resolve } = require('path');
 const { IgnorePlugin, ContextReplacementPlugin } = require('webpack');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+const Dotenv = require('dotenv-webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
@@ -41,6 +42,7 @@ module.exports = {
     moduleIds: 'deterministic',
   },
   plugins: [
+    new Dotenv(),
     new IgnorePlugin({ resourceRegExp: /__test__/ }),
     new WebpackManifestPlugin({
       publicPath: '/webpack/',

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1820,6 +1820,13 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.7"
 
+"@rollbar/react@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@rollbar/react/-/react-0.11.1.tgz#91cfa39fe54f4c1939233c1f63e27d2f89abb20e"
+  integrity sha512-QwI8wPjX1xc/AuX39TSJx/tEtjmf8macRqYgX+R/uRh7Y3+4ilZX9OMwLg/4Je8+NN+9y7PFNKkQa9adn58d/g==
+  dependencies:
+    tiny-invariant "^1.1.0"
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.19"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.19.tgz#5297278e0d8a1aea084685a3216074910ac6c113"
@@ -2975,6 +2982,11 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+async@~3.2.3:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -3586,6 +3598,11 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
+console-polyfill@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/console-polyfill/-/console-polyfill-0.3.0.tgz#84900902a18c47a5eba932be75fa44d23e8af861"
+  integrity sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==
+
 content-disposition@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
@@ -3840,6 +3857,13 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+decache@^3.0.5:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/decache/-/decache-3.1.0.tgz#4f5036fbd6581fcc97237ac3954a244b9536c2da"
+  integrity sha512-p7D6wJ5EJFFq1CcF2lu1XeqKFLBob8jRQGNAvFLTsV3CbSKBl3VtliAVlUIGz2i9H6kEFnI2Amaft5ZopIG2Fw==
+  dependencies:
+    find "^0.2.4"
+
 decimal.js@^10.3.1, decimal.js@^10.4.1:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
@@ -4068,6 +4092,25 @@ domutils@^2.5.2, domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
+dotenv-webpack@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz#6656550460a8076fab20e5ac2eac867e72478645"
+  integrity sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -4182,7 +4225,43 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.2, es-abstract@^1.19.5, es-abstract@^1.20.1, es-abstract@^1.20.4:
+error-stack-parser@^2.0.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
+  integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
+  dependencies:
+    stackframe "^1.3.4"
+
+es-abstract@^1.19.0, es-abstract@^1.19.2, es-abstract@^1.19.5, es-abstract@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
+  integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    regexp.prototype.flags "^1.4.3"
+    string.prototype.trimend "^1.0.5"
+    string.prototype.trimstart "^1.0.5"
+    unbox-primitive "^1.0.2"
+
+es-abstract@^1.20.4:
   version "1.20.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.4.tgz#1d103f9f8d78d4cf0713edcd6d0ed1a46eed5861"
   integrity sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==
@@ -4805,6 +4884,13 @@ find-up@^5.0.0:
   dependencies:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
+
+find@^0.2.4:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
+  integrity sha512-7a4/LCiInB9xYMnAUEjLilL9FKclwbwK7VlXw+h5jMvT2TDFeYFCHM24O1XdnC/on/hx8mxVO3FTQkyHZnOghQ==
+  dependencies:
+    traverse-chain "~0.1.0"
 
 flat-cache@^3.0.4:
   version "3.0.4"
@@ -5542,6 +5628,11 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
+is_js@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
+  integrity sha512-8Y5EHSH+TonfUHX2g3pMJljdbGavg55q4jmHzghJCdqYDbdNROC8uw/YFQwIRCRqRJT1EY3pJefz+kglw+o7sg==
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -6127,6 +6218,11 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
+json-stringify-safe@~5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -6347,6 +6443,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@~2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
+  integrity sha512-Q5pAgXs+WEAfoEdw2qKQhNFFhMoFMTYqRVKKUMnzuiR7oKFHS7fWo848cPcTKw+4j/IdN17NyzdhVKgabFV0EA==
 
 lz-string@^1.4.4:
   version "1.4.4"
@@ -8046,6 +8147,13 @@ regjsparser@^0.8.2:
   dependencies:
     jsesc "~0.5.0"
 
+request-ip@~2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.0.2.tgz#deeae6d4af21768497db8cd05fa37143f8f1257e"
+  integrity sha512-Y6LxqTmxLKKDk2I5tU2sxoCSKAnWJ42jmGqixNrH+oYoAyncpal7fFF5gqJ2bbgkRmb9qYNxdD6KFHfLS4dKBA==
+  dependencies:
+    is_js "^0.9.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -8142,6 +8250,21 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollbar@^2.25.2:
+  version "2.25.2"
+  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.25.2.tgz#2501875ec1bedbbaa6660ecc8d1dc1868d9aefde"
+  integrity sha512-aZIr/wXaVgkY73ynIpgQNyPhS04WwWUF7BGW7sOS0sU04+C39vDoloqIAOxTCU8MLgGQIiGMKIpQ8hYTl2obAA==
+  dependencies:
+    async "~3.2.3"
+    console-polyfill "0.3.0"
+    error-stack-parser "^2.0.4"
+    json-stringify-safe "~5.0.0"
+    lru-cache "~2.2.1"
+    request-ip "~2.0.1"
+    source-map "^0.5.7"
+  optionalDependencies:
+    decache "^3.0.5"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -8492,6 +8615,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackframe@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
+  integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -8766,10 +8894,10 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tiny-invariant@^1.0.6:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
-  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+tiny-invariant@^1.0.6, tiny-invariant@^1.1.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
+  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
 
 tinycolor2@^1.4.1:
   version "1.4.2"
@@ -8824,6 +8952,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+traverse-chain@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
+  integrity sha512-up6Yvai4PYKhpNp5PkYtx50m3KbwQrqDwbuZP/ItyL64YEWHAvH6Md83LFLV/GRSk/BoUVwwgUzX6SOQSbsfAg==
 
 ts-jest@^29.0.3:
   version "29.0.3"

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -100,6 +100,7 @@ RSpec.feature 'Course: Forum: Post: Management', js: true do
 
         # Reply a post with empty content.
         find('.reply-button').click
+        sleep 0.5
         expect_toastify('Post cannot be empty!')
 
         # Reply a post with the default title.


### PR DESCRIPTION
## Context
In a production system, oftentimes bugs due to application errors (eg uncaught errors, runtime errors, etc) go undetected when users do not report the issues. As such, an error logging system is needed to ensure that developers are aware of the unnoticed errors so that these can be fixed accordingly.

At present, we are only logging errors occurring in production environment for our rails backend using rollbar. In this PR, we are adding the error logging feature for our react frontend.

## Main Changes
- Added rollbar for https://github.com/Coursemology/coursemology2/pull/5306/commits/e5abd3a08703696b34d04eb676edc9ca112cddaa React Frontend

## Deployment Plan
- Get `post_client_item` token from `Coursemology` rollbar project and add it to ROLLBAR_POST_CLIENT_ITEM_KEY to frontend env file.

## Test Plan
1. Add `ROLLBAR_POST_CLIENT_ITEM_KEY` to backend src's dev env file. The token (post_client_item) can be retrieved from the `Testing` project in Coursemology's rollbar. 
2. Disable environment check here - https://github.com/Coursemology/coursemology2/pull/5306/commits/e5abd3a08703696b34d04eb676edc9ca112cddaa#diff-b10633c7151a08aefa634c5825a58eb540e585e2ae72bfea4ec005774f37c55fR9
3. Trigger an error in React.
4. The error should appear in rollbar as seen below.
![image](https://user-images.githubusercontent.com/42570513/202375405-71762388-791a-4f43-96f5-5115e2a8c2ad.png)

## Note
- Securing and storing rollbar's post client item key (See https://docs.rollbar.com/docs/preventing-client-side-access-token-abuse).
- Added `dotenv-webpack` webpack plugin to enable env variable loading from `.env` file. This is needed as we are not using CRA which would have included `dotenv` in the default package.
- To add `.env` file to the production folder.
