### PR TITLE
Fix rubocop issues

### DIFF
--- a/app/controllers/concerns/course/assessment/question_bundle_assignment_concern.rb
+++ b/app/controllers/concerns/course/assessment/question_bundle_assignment_concern.rb
@@ -27,7 +27,7 @@ module Course::Assessment::QuestionBundleAssignmentConcern
     attr_accessor :assignments, :group_bundles
 
     def initialize(students, group_bundles)
-      @assignments = students.map { |x| [x, nil => []] }.to_h
+      @assignments = students.to_h { |x| [x, nil => []] }
       @group_bundles = group_bundles
       @group_bundles_lookup = group_bundles.flat_map do |group, bundles|
         bundles.map { |bundle| [bundle, group] }
@@ -51,7 +51,7 @@ module Course::Assessment::QuestionBundleAssignmentConcern
     def initialize(assessment)
       @assessment = assessment
       @students = assessment.course.user_ids
-      @group_bundles = assessment.question_group_ids.map { |x| [x, []] }.to_h
+      @group_bundles = assessment.question_group_ids.to_h { |x| [x, []] }
       assessment.question_bundles.each { |bundle| @group_bundles[bundle.group_id].append(bundle.id) }
 
       # Reverse lookup of user_id -> course_user.name or user.name

--- a/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
@@ -97,7 +97,7 @@ module Course::LessonPlan::LearningRateConcern
       course_user.course.assessments.
       with_submissions_by(course_user.user).
       select { |x| x.submissions.present? && x.submissions.first.submitted_at.present? }.
-      map { |x| [x.lesson_plan_item.id, x.submissions.first.submitted_at] }.to_h
+      to_h { |x| [x.lesson_plan_item.id, x.submissions.first.submitted_at] }
     )
   end
 
@@ -114,7 +114,7 @@ module Course::LessonPlan::LearningRateConcern
       course_user.course.videos.
       with_submissions_by(course_user.user).
       select { |x| x.submissions.present? }.
-      map { |x| [x.lesson_plan_item.id, nil] }.to_h
+      to_h { |x| [x.lesson_plan_item.id, nil] }
     )
   end
 end

--- a/app/controllers/concerns/course/survey/reordering_concern.rb
+++ b/app/controllers/concerns/course/survey/reordering_concern.rb
@@ -95,7 +95,7 @@ module Course::Survey::ReorderingConcern
   #   Each element in the second-level array consist of a section's id and an ordered array
   #   of question_ids for questions belonging to that section.
   def update_questions_ordering(ordering)
-    questions_hash = @survey.questions.map { |question| [question.id, question] }.to_h
+    questions_hash = @survey.questions.to_h { |question| [question.id, question] }
     Course::Survey::Question.transaction do
       ordering.each do |section_id, question_ids|
         question_ids.each_with_index do |question_id, index|

--- a/app/controllers/course/achievement/achievements_controller.rb
+++ b/app/controllers/course/achievement/achievements_controller.rb
@@ -96,9 +96,9 @@ class Course::Achievement::AchievementsController < Course::Achievement::Control
   #
   # @return [Hash{Integer => Course::Achievement}]
   def achievements_hash
-    @achievements_hash ||= current_course.achievements.map do |achievement|
+    @achievements_hash ||= current_course.achievements.to_h do |achievement|
       [achievement.id.to_s, achievement]
-    end.to_h
+    end
   end
 
   # Checks if a proposed achievement ordering is valid

--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -77,8 +77,8 @@ class Course::Assessment::Question::MultipleResponsesController < Course::Assess
     params.require(:question_multiple_response).permit(
       :title, :description, :staff_only_comments, :maximum_grade, :grading_scheme,
       :randomize_options, :skip_grading, question_assessment: { skill_ids: [] },
-                          options_attributes: [:_destroy, :id, :correct, :option,
-                                               :explanation, :weight, :ignore_randomization]
+                                         options_attributes: [:_destroy, :id, :correct, :option,
+                                                              :explanation, :weight, :ignore_randomization]
     )
   end
 

--- a/app/controllers/course/assessment/question_bundle_assignments_controller.rb
+++ b/app/controllers/course/assessment/question_bundle_assignments_controller.rb
@@ -7,8 +7,8 @@ class Course::Assessment::QuestionBundleAssignmentsController < Course::Assessme
   before_action :add_breadcrumbs
 
   def index
-    @question_group_lookup = @assessment.question_groups.select(:id, :title).map { |qg| [qg.id, qg.title] }.to_h
-    @question_bundle_lookup = @assessment.question_bundles.select(:id, :title).map { |qb| [qb.id, qb.title] }.to_h
+    @question_group_lookup = @assessment.question_groups.select(:id, :title).to_h { |qg| [qg.id, qg.title] }
+    @question_bundle_lookup = @assessment.question_bundles.select(:id, :title).to_h { |qb| [qb.id, qb.title] }
     @past_assignments = past_assignments_hash
     @assignment_randomizer = AssignmentRandomizer.new(@assessment)
     @assignment_set = @assignment_randomizer.load
@@ -81,15 +81,15 @@ class Course::Assessment::QuestionBundleAssignmentsController < Course::Assessme
   private
 
   def past_assignments_hash
-    @group_bundles_lookup = @assessment.question_bundles.map { |bundle| [bundle.id, bundle.group_id] }.to_h
-    @assessment.submissions.eager_load(:question_bundle_assignments).map do |submission|
+    @group_bundles_lookup = @assessment.question_bundles.to_h { |bundle| [bundle.id, bundle.group_id] }
+    @assessment.submissions.eager_load(:question_bundle_assignments).to_h do |submission|
       hash = { submission_id: submission.id, nil => [] }
       submission.question_bundle_assignments.each do |qba|
         group = @group_bundles_lookup[qba.bundle_id]
         hash[group].nil? ? hash[group] = qba.bundle_id : hash[nil].append(qba.bundle_id)
       end
       [submission.creator_id, hash]
-    end.to_h
+    end
   end
 
   def add_breadcrumbs

--- a/app/controllers/course/controller.rb
+++ b/app/controllers/course/controller.rb
@@ -74,7 +74,7 @@ class Course::Controller < ApplicationController
     sidebar_settings = Course::Settings::Sidebar.new(current_course.settings,
                                                      current_component_host.sidebar_items)
     defined_sidebar_settings = sidebar_settings.sidebar_items.select { |item| item.id.present? }
-    defined_sidebar_settings.map { |item| [item.id, item.weight] }.to_h
+    defined_sidebar_settings.to_h { |item| [item.id, item.weight] }
   end
 
   def add_course_breadcrumb

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -76,7 +76,7 @@ class Course::CoursesController < Course::Controller
                          to_h { |survey| [survey.survey_id, survey] }
   end
 
-  def load_items_with_timeline # rubocop:disable Metrics/AbcSize
+  def load_items_with_timeline # rubocop:disable Metrics/CyclomaticComplexity
     item_ids = [*@video_todos&.map { |todo| todo.item.id },
                 *@assessment_todos&.map { |todo| todo.item.id },
                 *@survey_todos&.map { |todo| todo.item.id }]

--- a/app/controllers/course/courses_controller.rb
+++ b/app/controllers/course/courses_controller.rb
@@ -65,7 +65,7 @@ class Course::CoursesController < Course::Controller
                                current_user.id,
                                @assessment_todos.map(&:item).pluck(:actable_id)
                              ).
-                             map { |submission| [submission.assessment_id, submission] }.to_h
+                             to_h { |submission| [submission.assessment_id, submission] }
 
     @survey_todos_hash = Course::Survey::Response.
                          where(
@@ -73,7 +73,7 @@ class Course::CoursesController < Course::Controller
                            current_user.id,
                            @survey_todos.map(&:item).pluck(:actable_id)
                          ).
-                         map { |survey| [survey.survey_id, survey] }.to_h
+                         to_h { |survey| [survey.survey_id, survey] }
   end
 
   def load_items_with_timeline # rubocop:disable Metrics/AbcSize

--- a/app/controllers/course/group/group_categories_controller.rb
+++ b/app/controllers/course/group/group_categories_controller.rb
@@ -58,8 +58,8 @@ class Course::Group::GroupCategoriesController < Course::ComponentController
   def update_group_members
     update_groups_params[:groups].each do |group|
       existing_group = Course::Group.preload(:group_users).find_by_id(group[:id])
-      existing_users = existing_group.group_users.map { |u| [u.course_user.id, u] }.to_h
-      new_users = group[:members].map { |u| [u[:id], u] }.to_h
+      existing_users = existing_group.group_users.to_h { |u| [u.course_user.id, u] }
+      new_users = group[:members].to_h { |u| [u[:id], u] }
       partitioned_users = partition_new_users(new_users, existing_users)
 
       add_new_members(partitioned_users[:to_add], existing_group)

--- a/app/controllers/course/learning_map_controller.rb
+++ b/app/controllers/course/learning_map_controller.rb
@@ -121,9 +121,9 @@ class Course::LearningMapController < Course::ComponentController
   end
 
   def init_all_node_relations
-    { node_ids_to_children: @conditionals.map { |conditional| [get_node_id(conditional), []] }.to_h,
-      node_ids_to_parents: @conditionals.map { |conditional| [get_node_id(conditional), []] }.to_h,
-      node_ids_to_unlock_level: @conditionals.map { |conditional| [get_node_id(conditional), 0] }.to_h }
+    { node_ids_to_children: @conditionals.to_h { |conditional| [get_node_id(conditional), []] },
+      node_ids_to_parents: @conditionals.to_h { |conditional| [get_node_id(conditional), []] },
+      node_ids_to_unlock_level: @conditionals.to_h { |conditional| [get_node_id(conditional), 0] } }
   end
 
   def map_condition_to_parent(condition)
@@ -176,13 +176,13 @@ class Course::LearningMapController < Course::ComponentController
   end
 
   def init_depths(nodes)
-    nodes.map { |node| [node[:id], node[:parents].empty? ? 0 : NEGATIVE_INF] }.to_h
+    nodes.to_h { |node| [node[:id], node[:parents].empty? ? 0 : NEGATIVE_INF] }
   end
 
   def toposort(nodes)
     visited_node_ids = Set.new
     post_order_nodes = []
-    node_ids_to_nodes = nodes.map { |node| [node[:id], node] }.to_h
+    node_ids_to_nodes = nodes.to_h { |node| [node[:id], node] }
 
     nodes.each do |node|
       dfs(node, node_ids_to_nodes, visited_node_ids, post_order_nodes) unless visited_node_ids.include?(node[:id])

--- a/app/controllers/course/lesson_plan/items_controller.rb
+++ b/app/controllers/course/lesson_plan/items_controller.rb
@@ -65,18 +65,18 @@ class Course::LessonPlan::ItemsController < Course::LessonPlan::Controller
   #
   # @return [Hash{Array<String> => Boolean}]
   def assessment_tabs_visibility_hash
-    @assessment_tabs_visibility_hash = assessment_item_settings.map do |setting|
+    @assessment_tabs_visibility_hash = assessment_item_settings.to_h do |setting|
       [assessment_tabs_titles_hash[setting[:options][:tab_id]], setting[:visible]]
-    end.to_h
+    end
   end
 
   # Returns a hash that maps the component title to its visibility setting.
   #
   # @return [Hash{Array<String> => Boolean}]
   def component_visibility_hash
-    @component_visibility_hash = component_item_settings.map do |setting|
+    @component_visibility_hash = component_item_settings.to_h do |setting|
       [[setting[:component_title]], setting[:visible]]
-    end.to_h
+    end
   end
 
   # Returns a hash that maps tab ids to an array containing:
@@ -87,9 +87,9 @@ class Course::LessonPlan::ItemsController < Course::LessonPlan::Controller
   def assessment_tabs_titles_hash
     @assessment_tabs_titles_hash ||=
       current_course.assessment_categories.includes(:tabs).map(&:tabs).flatten.
-      map do |tab|
+      to_h do |tab|
         [tab.id, tab_title_array(tab)]
-      end.to_h
+      end
   end
 
   # Maps an assessment tab to an array of strings that describes its title. If the

--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -55,9 +55,9 @@ class Course::ObjectDuplicationsController < Course::ComponentController
                         where(role: CourseUser::MANAGER_ROLES.to_a)
       @destination_courses = Course.includes(:instance).find(course_managers.map(&:course_id))
       @root_folder_map = Course::Material::Folder.root.includes(:materials, :children).
-                         where(course_id: @destination_courses.map(&:id)).map do |folder|
+                         where(course_id: @destination_courses.map(&:id)).to_h do |folder|
                            [folder.course_id, folder]
-                         end.to_h
+                         end
     end
   end
 

--- a/app/models/concerns/course/assessment/questions_concern.rb
+++ b/app/models/concerns/course/assessment/questions_concern.rb
@@ -12,7 +12,7 @@ module Course::Assessment::QuestionsConcern
   # @return [Array<Course::Assessment::Answer>] The answers for the questions, in the same order
   #   specified. Newly initialized answers will not be persisted.
   def attempt(submission)
-    current_answers = submission.current_answers.map { |answer| [answer.question, answer] }.to_h
+    current_answers = submission.current_answers.to_h { |answer| [answer.question, answer] }
 
     map do |question|
       current_answers.fetch(question) { question.attempt(submission) }

--- a/app/models/course/assessment/answer/multiple_response.rb
+++ b/app/models/course/assessment/answer/multiple_response.rb
@@ -20,7 +20,7 @@ class Course::Assessment::Answer::MultipleResponse < ApplicationRecord
     self.options = question.specific.options.select { |option| option_ids.include?(option.id) }
   end
 
-  def get_random_seed
+  def retrieve_random_seed
     self.random_seed ||= Random.new_seed
     save
 

--- a/app/models/course/survey/response.rb
+++ b/app/models/course/survey/response.rb
@@ -70,12 +70,12 @@ class Course::Survey::Response < ApplicationRecord
   end
 
   def question_ids_hash
-    @question_ids_hash ||= answers.map { |answer| [answer.id, answer.question_id] }.to_h
+    @question_ids_hash ||= answers.to_h { |answer| [answer.id, answer.question_id] }
   end
 
   def valid_option_ids_hash
-    @valid_option_ids_hash ||= survey.questions.includes(:options).map do |question|
+    @valid_option_ids_hash ||= survey.questions.includes(:options).to_h do |question|
       [question.id, question.options.map(&:id).to_set]
-    end.to_h
+    end
   end
 end

--- a/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/process_invitation_concern.rb
@@ -56,7 +56,7 @@ module Course::UserInvitationService::ProcessInvitationConcern
   # @return [Array(Array<CourseUser>, Array<CourseUser>)] A tuple containing the list of users who were newly enrolled
   #   and already enrolled.
   def add_existing_users(users)
-    all_course_users = @current_course.course_users.map { |cu| [cu.user_id, cu] }.to_h
+    all_course_users = @current_course.course_users.to_h { |cu| [cu.user_id, cu] }
     existing_course_users = []
     new_course_users = []
     users.each do |user|
@@ -82,7 +82,7 @@ module Course::UserInvitationService::ProcessInvitationConcern
   # @return [Array(Array<Course::UserInvitation>, Array<Course::UserInvitation>)] A tuple containing the list of users
   #   who were newly invited and already invited.
   def invite_new_users(users)
-    all_invitations = @current_course.invitations.map { |i| [i.email.downcase, i] }.to_h
+    all_invitations = @current_course.invitations.to_h { |i| [i.email.downcase, i] }
     new_invitations = []
     existing_invitations = []
     users.each do |user|

--- a/app/services/concerns/instance/user_invitation_service/process_invitation_concern.rb
+++ b/app/services/concerns/instance/user_invitation_service/process_invitation_concern.rb
@@ -59,7 +59,7 @@ module Instance::UserInvitationService::ProcessInvitationConcern
   #   A tuple containing the list of users who were newly enrolled
   #   and already enrolled.
   def add_existing_users(users)
-    all_instance_users = @current_instance.instance_users.map { |iu| [iu.user_id, iu] }.to_h
+    all_instance_users = @current_instance.instance_users.to_h { |iu| [iu.user_id, iu] }
     existing_instance_users = []
     new_instance_users = []
     users.each do |user|
@@ -82,7 +82,7 @@ module Instance::UserInvitationService::ProcessInvitationConcern
   #   A tuple containing the list of users
   #   who were newly invited and already invited.
   def invite_new_users(users)
-    all_invitations = @current_instance.invitations.map { |i| [i.email.downcase, i] }.to_h
+    all_invitations = @current_instance.invitations.to_h { |i| [i.email.downcase, i] }
     new_invitations = []
     existing_invitations = []
     users.each do |user|

--- a/app/services/course/assessment/answer/programming_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_auto_grading_service.rb
@@ -35,9 +35,9 @@ class Course::Assessment::Answer::ProgrammingAutoGradingService < \
   # @return [Hash{String => String}] The files in the answer, with the file names as keys, and
   #   the file content as values.
   def build_submission_files(answer)
-    answer.files.map do |file|
+    answer.files.to_h do |file|
       [file.filename, file.content]
-    end.to_h
+    end
   end
 
   # Evaluates the package to obtain the set of tests.
@@ -135,7 +135,7 @@ class Course::Assessment::Answer::ProgrammingAutoGradingService < \
   # @param [String] test_report The test case report from evaluating the package.
   # @return [Array<Course::Assessment::Question::ProgrammingTestCase>]
   def build_test_case_records_from_report(question, auto_grading, test_report)
-    test_cases = question.test_cases.map { |test_case| [test_case.identifier, test_case] }.to_h
+    test_cases = question.test_cases.to_h { |test_case| [test_case.identifier, test_case] }
     test_results = parse_test_report(question.language, test_report)
 
     test_results.map do |test_result|

--- a/app/services/course/assessment/submission/statistics_download_service.rb
+++ b/app/services/course/assessment/submission/statistics_download_service.rb
@@ -24,7 +24,7 @@ class Course::Assessment::Submission::StatisticsDownloadService
                   calculated(:log_count, :graded_at, :grade, :grader_ids).
                   includes(:course_user, :publisher)
     assessment = submissions&.first&.assessment&.calculated(:maximum_grade)
-    @course_users_hash ||= @current_course.course_users.map { |cu| [cu.user_id, [cu.id, cu.name]] }.to_h
+    @course_users_hash ||= @current_course.course_users.to_h { |cu| [cu.user_id, [cu.id, cu.name]] }
     statistics_file_path = File.join(@base_dir, 'statistics.csv')
     CSV.open(statistics_file_path, 'w') do |csv|
       download_statistics_header csv

--- a/app/services/course/assessment/submission/zip_download_service.rb
+++ b/app/services/course/assessment/submission/zip_download_service.rb
@@ -34,7 +34,7 @@ class Course::Assessment::Submission::ZipDownloadService
   def initialize(course_user, assessment, course_users)
     @course_user = course_user
     @assessment = assessment
-    @questions = assessment.questions.map { |q| [q.id, q] }.to_h
+    @questions = assessment.questions.to_h { |q| [q.id, q] }
     @course_users = course_users
     @base_dir = Dir.mktmpdir('coursemology-download-')
   end

--- a/app/services/course/course_user_preload_service.rb
+++ b/app/services/course/course_user_preload_service.rb
@@ -10,9 +10,9 @@ class Course::CourseUserPreloadService
   # @return [Hash{User => CourseUser}] Hash that maps users to course_user
   def initialize(users, course)
     course_users = CourseUser.includes(:user, :course).where(user: users.uniq, course: course)
-    @user_course_user_hash = course_users.map do |course_user|
+    @user_course_user_hash = course_users.to_h do |course_user|
       [course_user.user, course_user]
-    end.to_h
+    end
   end
 
   # Finds the user's course_user for the given course.

--- a/app/services/course/duplication/course_duplication_service.rb
+++ b/app/services/course/duplication/course_duplication_service.rb
@@ -67,7 +67,7 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
       rescue => _e # TO REMOVE - Testing for production duplication error
         Rails.logger.debug(message: 'Course duplication error debugging', error: _e, error_message: _e.message)
         raise ActiveRecord::Rollback
-      end 
+      end
     end
     notify_duplication_complete(duplicated_course)
     duplicated_course

--- a/app/services/course/material/preload_service.rb
+++ b/app/services/course/material/preload_service.rb
@@ -15,9 +15,9 @@ class Course::Material::PreloadService
   private
 
   def folders_for_assessment_hash
-    @folders_for_assessment_hash ||= assessments_folders.map do |folder|
+    @folders_for_assessment_hash ||= assessments_folders.to_h do |folder|
       [folder.owner_id, folder]
-    end.to_h
+    end
   end
 
   def assessments_folders

--- a/app/services/course/survey/survey_download_service.rb
+++ b/app/services/course/survey/survey_download_service.rb
@@ -52,7 +52,7 @@ class Course::Survey::SurveyDownloadService
     end
 
     def generate_row(response, questions)
-      answers_hash = response.answers.map { |answer| [answer.question_id, answer] }.to_h
+      answers_hash = response.answers.to_h { |answer| [answer.question_id, answer] }
       values = questions.map do |question|
         answer = answers_hash[question.id]
         generate_value(answer)

--- a/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/question/multiple_responses/_multiple_response.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
 
-json.options question.ordered_options(current_course, answer&.actable&.get_random_seed) do |option|
+json.options question.ordered_options(current_course, answer&.actable&.retrieve_random_seed) do |option|
   json.option format_ckeditor_rich_text(option.option)
   json.id option.id
   json.correct option.correct if can_grade || (@assessment.show_mcq_mrq_solution && @submission.published?)

--- a/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/_questions.json.jbuilder
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-answer_ids_hash = answers.map do |a|
+answer_ids_hash = answers.to_h do |a|
   [a.question_id, a]
-end.to_h
+end
 
-sq_topic_ids_hash = submission_questions.map do |sq|
+sq_topic_ids_hash = submission_questions.to_h do |sq|
   [sq.question_id, [sq, sq.discussion_topic.id]]
-end.to_h
+end
 
 question_assessments = Course::QuestionAssessment.
                        where(question: submission.questions, assessment: assessment).

--- a/app/views/course/assessment/submission/submissions/index.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-submissions_hash ||= @submissions.map { |s| [s.creator_id, s] }.to_h
-course_users_hash ||= @course_users.map { |cu| [cu.user_id, [cu.id, cu.name]] }.to_h
+submissions_hash ||= @submissions.to_h { |s| [s.creator_id, s] }
+course_users_hash ||= @course_users.to_h { |cu| [cu.user_id, [cu.id, cu.name]] }
 course_users_hash[0] = [0, 'System']
 
 json.assessment do

--- a/app/views/course/survey/responses/index.json.jbuilder
+++ b/app/views/course/survey/responses/index.json.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-responses = @responses.map { |r| [r.course_user_id, r] }.to_h
+responses = @responses.to_h { |r| [r.course_user_id, r] }
 json.responses @course_students do |student|
   response = responses[student.id]
   can_read_answers = response.present? && can?(:read_answers, response)

--- a/app/views/course/survey/responses/index.json.jbuilder
+++ b/app/views/course/survey/responses/index.json.jbuilder
@@ -10,7 +10,7 @@ json.responses @course_students do |student|
     json.path course_user_path(current_course, student)
   end
 
-  json.present !!response
+  json.present !response.nil?
   if response
     json.id response.id
     json.submitted_at response.submitted_at&.iso8601

--- a/app/views/course/user_invitations/index.json.jbuilder
+++ b/app/views/course/user_invitations/index.json.jbuilder
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
-unless @without_invitations
-  json.partial! 'course_user_invitation_list'
-end
+json.partial! 'course_user_invitation_list' unless @without_invitations
 
 json.permissions do
   json.partial! 'course/users/permissions_data', current_course: current_course

--- a/lib/autoload/course/assessment/programming_package.rb
+++ b/lib/autoload/course/assessment/programming_package.rb
@@ -224,11 +224,11 @@ class Course::Assessment::ProgrammingPackage
   #   file.
   def get_folder_files(folder_path)
     ensure_file_open!
-    @file.glob("#{folder_path}/**/*").map do |entry|
+    @file.glob("#{folder_path}/**/*").to_h do |entry|
       entry_file_name = Pathname.new(entry.name)
       file_name = entry_file_name.relative_path_from(folder_path)
       [file_name, entry.get_input_stream(&:read)]
-    end.to_h
+    end
   end
 
   # Get the contents of a file.

--- a/spec/controllers/course/material/folders_controller_spec.rb
+++ b/spec/controllers/course/material/folders_controller_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe Course::Material::FoldersController, type: :controller do
       let(:file) { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'files', 'text.txt')) }
       subject do
         patch :upload_materials, as: :json,
-              params: { course_id: course, id: folder_stub, material_folder: { files_attributes: [file] } }
+                                 params: { course_id: course,
+                                           id: folder_stub,
+                                           material_folder: { files_attributes: [file] } }
       end
 
       context 'when files cannot be uploaded' do

--- a/spec/controllers/system/admin/instances_controller_spec.rb
+++ b/spec/controllers/system/admin/instances_controller_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe System::Admin::InstancesController do
 
       subject { delete :destroy, params: { id: instance_to_delete } }
 
-
       it 'succeeds with http status ok' do
         expect(subject).to have_http_status(:ok)
       end

--- a/spec/features/system/admin/components_settings_spec.rb
+++ b/spec/features/system/admin/components_settings_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'System: Administration: Components', type: :feature, js: true do
       login_as(admin, scope: :user)
     end
 
-
     scenario 'Admin visits the page' do
       visit admin_instance_components_path
       settings = Instance::Settings::Components.new(instance)

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe Course::UserInvitationService, type: :service do
     let(:timeline_algorithms) { existing_timeline_algorithms + new_timeline_algorithms }
     let(:user_attributes) { existing_user_attributes + new_user_attributes + invalid_user_attributes }
     let(:user_form_attributes) do
-      user_attributes.map do |hash|
+      user_attributes.to_h do |hash|
         [generate(:nested_attribute_new_id),
          name: hash[:name],
          email: hash[:email],
          role: hash[:role],
          phantom: hash[:phantom],
          timeline_algorithm: hash[:timeline_algorithm]]
-      end.to_h
+      end
     end
 
     describe '#invite' do

--- a/spec/services/instance/user_invitation_service_spec.rb
+++ b/spec/services/instance/user_invitation_service_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Instance::UserInvitationService, type: :service do
 
         it 'succeeds' do
           expect(invite.map(&:size)).to eq([new_users.size - users_invited.size, users_invited.size,
-                                existing_users.size - users_in_instance.size, users_in_instance.size, 0])
+                                            existing_users.size - users_in_instance.size, users_in_instance.size, 0])
         end
 
         with_active_job_queue_adapter(:test) do

--- a/spec/services/instance/user_invitation_service_spec.rb
+++ b/spec/services/instance/user_invitation_service_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Instance::UserInvitationService, type: :service do
   let(:other_instance) { create(:instance) }
   with_tenant(:instance) do
     def temp_form_hash_from_attributes(records)
-      records.map do |record|
+      records.to_h do |record|
         [generate(:nested_attribute_new_id),
          name: record.name,
          email: record.email]
-      end.to_h
+      end
     end
 
     let(:user) { create(:user) }
@@ -56,12 +56,12 @@ RSpec.describe Instance::UserInvitationService, type: :service do
     let(:roles) { existing_roles + new_roles }
     let(:user_attributes) { existing_user_attributes + new_user_attributes + invalid_user_attributes }
     let(:user_form_attributes) do
-      user_attributes.map do |hash|
+      user_attributes.to_h do |hash|
         [generate(:nested_attribute_new_id),
          name: hash[:name],
          email: hash[:email],
          role: hash[:role]]
-      end.to_h
+      end
     end
 
     describe '#invite' do

--- a/spec/support/stubs/course/assessment/stubbed_programming_codaveri.rb
+++ b/spec/support/stubs/course/assessment/stubbed_programming_codaveri.rb
@@ -1,4 +1,4 @@
-# rubocop: disable Layout/LineEndStringConcatenationIndentation, Layout/SpaceAroundOperators, Style/StringConcatenation, Metrics/AbcSize
+# rubocop: disable Layout/LineEndStringConcatenationIndentation, Layout/SpaceAroundOperators, Style/StringConcatenation
 # frozen_string_literal: true
 module Course::Assessment::StubbedProgrammingCodaveriEvaluationService
   private
@@ -67,4 +67,4 @@ module Course::Assessment::StubbedProgrammingCodaveriEvaluationServiceWrongAnswe
   end
 end
 
-# rubocop: enable Layout/LineEndStringConcatenationIndentation, Layout/SpaceAroundOperators, Style/StringConcatenation, Metrics/AbcSize
+# rubocop: enable Layout/LineEndStringConcatenationIndentation, Layout/SpaceAroundOperators, Style/StringConcatenation

--- a/spec/support/stubs/course/discussion/post/stubbed_codaveri_feedback.rb
+++ b/spec/support/stubs/course/discussion/post/stubbed_codaveri_feedback.rb
@@ -4,7 +4,7 @@ module Course::Discussion::Post::StubbedCodaveriFeedback
 
   def connect_to_codaveri(_payload)
     Excon::Response.new(status: 200,
-                        body: '{"success":true,"message":"OK",''"data":{}}')
+                        body: '{"success":true,"message":"OK","data":{}}')
   end
 end
 


### PR DESCRIPTION
Fix the following rubocop warnings:
- Layout/EmptyLines
- Layout/TrailingWhitespace
- Style/DoubleNegation
- Style/MapToHash
- Style/IfUnlessModifier
- Layout/HashAlignment
- Lint/RedundantCopDisableDirective
- Lint/ImplicitStringConcatenation
- Layout/ArrayAlignment
- Naming/AccessorMethodName