### PR TITLE
Fix instance table pagination issue 

### DIFF
--- a/app/controllers/system/admin/instances_controller.rb
+++ b/app/controllers/system/admin/instances_controller.rb
@@ -47,7 +47,7 @@ class System::Admin::InstancesController < System::Admin::Controller
 
   def preload_instances
     @instances_count = Instance.count
-    @instances = Instance.order_for_display.paginated(new_page_params).
+    @instances = Instance.order_for_display.
                  calculated(:active_course_count, :course_count, :active_user_count, :user_count)
   end
 end

--- a/app/views/system/admin/instance/user_invitations/_invitation_result_data.json.jbuilder
+++ b/app/views/system/admin/instance/user_invitations/_invitation_result_data.json.jbuilder
@@ -20,7 +20,7 @@ json.newInstanceUsers new_instance_users.each do |instance_user|
   json.id user.id if user.id
   json.name user.name.strip
   json.email user.email
-  json.role user.role
+  json.role instance_user.role
 end
 
 json.existingInstanceUsers existing_instance_users.each do |instance_user|
@@ -28,7 +28,7 @@ json.existingInstanceUsers existing_instance_users.each do |instance_user|
   json.id user.id if user.id
   json.name user.name.strip
   json.email user.email
-  json.role user.role
+  json.role instance_user.role
 end
 
 json.duplicateUsers duplicate_users.each do |duplicate_user, index|

--- a/client/app/api/system/Admin.ts
+++ b/client/app/api/system/Admin.ts
@@ -102,16 +102,14 @@ export default class AdminAPI extends BaseSystemAPI {
   /**
    * Fetches a list of instances.
    */
-  indexInstances(params?: FilterParams): Promise<
+  indexInstances(): Promise<
     AxiosResponse<{
       instances: InstanceListData[];
       permissions: InstancePermissions;
       counts: number;
     }>
   > {
-    return this.getClient().get(`${AdminAPI._getUrlPrefix()}/instances`, {
-      params,
-    });
+    return this.getClient().get(`${AdminAPI._getUrlPrefix()}/instances`);
   }
 
   /**

--- a/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardManager.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardManager.tsx
@@ -22,6 +22,7 @@ import ConfirmationDialog from 'lib/components/core/dialogs/ConfirmationDialog';
 import DataTable from 'lib/components/core/layouts/DataTable';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import Note from 'lib/components/core/Note';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import { getAchievementURL } from 'lib/helpers/url-builders';
 import { getCourseId } from 'lib/helpers/url-helpers';
 import { formatShortDateTime } from 'lib/moment';
@@ -180,8 +181,8 @@ const AchievementAwardManager: FC<Props> = (props) => {
     filter: false,
     jumpToPage: true,
     print: false,
-    rowsPerPage: 100,
-    rowsPerPageOptions: [100],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     selectableRows: 'none',
     setRowProps: (_row, dataIndex, _rowIndex) => {
       const obtainedAchievement =

--- a/client/app/bundles/course/assessment/submissions/components/misc/SubmissionTabs.tsx
+++ b/client/app/bundles/course/assessment/submissions/components/misc/SubmissionTabs.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
-import { Tab, Tabs } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 import { tabsStyle } from 'theme/mui-style';
 import { SubmissionsTabData } from 'types/course/assessment/submissions';
 import { AppDispatch } from 'types/store';
@@ -91,121 +91,131 @@ const SubmissionTabs: FC<Props> = (props) => {
   */
   if (tabValue === null) return null;
   return (
-    <Tabs
-      onChange={handleTabChange}
-      scrollButtons="auto"
-      sx={tabsStyle}
-      TabIndicatorProps={{ style: { transition: 'none' } }}
-      value={tabValue}
-      variant="scrollable"
-    >
-      {isTeachingStaff && (
-        <Tab
-          icon={
-            <CustomBadge
-              badgeContent={tabs.myStudentsPendingCount}
-              color="primary"
+    <Box className="max-w-full">
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          onChange={handleTabChange}
+          scrollButtons="auto"
+          sx={tabsStyle}
+          TabIndicatorProps={{ style: { transition: 'none' } }}
+          value={tabValue}
+          variant="scrollable"
+        >
+          {isTeachingStaff && (
+            <Tab
+              icon={
+                <CustomBadge
+                  badgeContent={tabs.myStudentsPendingCount}
+                  color="primary"
+                />
+              }
+              iconPosition="end"
+              id="my-students-pending-tab"
+              label={intl.formatMessage(translations.myStudentsPending)}
+              onClick={(): Promise<string | number | void> => {
+                // Prevent API calls when spam clicking the tab
+                if (tabValue !== 0) {
+                  setTableIsLoading(true);
+                  setIsTabChanging(true);
+                  return dispatch(fetchMyStudentsPendingSubmissions())
+                    .finally(() => {
+                      setTableIsLoading(false);
+                      setIsTabChanging(false);
+                    })
+                    .catch(() => {
+                      setTableIsLoading(false);
+                      setIsTabChanging(false);
+                      toast.error(
+                        intl.formatMessage(
+                          translations.fetchSubmissionsFailure,
+                        ),
+                      );
+                    });
+                }
+                return new Promise(() => {});
+              }}
+              style={{
+                minHeight: 48,
+                paddingRight: tabs.myStudentsPendingCount === 0 ? 8 : 26,
+                textDecoration: 'none',
+              }}
+              value={0}
             />
-          }
-          iconPosition="end"
-          id="my-students-pending-tab"
-          label={intl.formatMessage(translations.myStudentsPending)}
-          onClick={(): Promise<string | number | void> => {
-            // Prevent API calls when spam clicking the tab
-            if (tabValue !== 0) {
-              setTableIsLoading(true);
-              setIsTabChanging(true);
-              return dispatch(fetchMyStudentsPendingSubmissions())
-                .finally(() => {
-                  setTableIsLoading(false);
-                  setIsTabChanging(false);
-                })
-                .catch(() => {
-                  setTableIsLoading(false);
-                  setIsTabChanging(false);
-                  toast.error(
-                    intl.formatMessage(translations.fetchSubmissionsFailure),
-                  );
-                });
-            }
-            return new Promise(() => {});
-          }}
-          style={{
-            minHeight: 48,
-            paddingRight: tabs.myStudentsPendingCount === 0 ? 8 : 26,
-            textDecoration: 'none',
-          }}
-          value={0}
-        />
-      )}
+          )}
 
-      {isTeachingStaff && (
-        <Tab
-          icon={
-            <CustomBadge
-              badgeContent={tabs.allStudentsPendingCount}
-              color="primary"
+          {isTeachingStaff && (
+            <Tab
+              icon={
+                <CustomBadge
+                  badgeContent={tabs.allStudentsPendingCount}
+                  color="primary"
+                />
+              }
+              iconPosition="end"
+              id="all-students-pending-tab"
+              label={intl.formatMessage(translations.allStudentsPending)}
+              onClick={(): Promise<string | number | void> => {
+                // Prevent API calls when spam clicking the tab
+                if (tabValue !== 1) {
+                  setTableIsLoading(true);
+                  setIsTabChanging(true);
+                  return dispatch(fetchAllStudentsPendingSubmissions())
+                    .finally(() => {
+                      setTableIsLoading(false);
+                      setIsTabChanging(false);
+                    })
+                    .catch(() => {
+                      setTableIsLoading(false);
+                      setIsTabChanging(false);
+                      toast.error(
+                        intl.formatMessage(
+                          translations.fetchSubmissionsFailure,
+                        ),
+                      );
+                    });
+                }
+                return new Promise(() => {});
+              }}
+              style={{
+                paddingRight: tabs.allStudentsPendingCount === 0 ? 8 : 26,
+              }}
+              value={1}
             />
-          }
-          iconPosition="end"
-          id="all-students-pending-tab"
-          label={intl.formatMessage(translations.allStudentsPending)}
-          onClick={(): Promise<string | number | void> => {
-            // Prevent API calls when spam clicking the tab
-            if (tabValue !== 1) {
-              setTableIsLoading(true);
-              setIsTabChanging(true);
-              return dispatch(fetchAllStudentsPendingSubmissions())
-                .finally(() => {
-                  setTableIsLoading(false);
-                  setIsTabChanging(false);
-                })
-                .catch(() => {
-                  setTableIsLoading(false);
-                  setIsTabChanging(false);
-                  toast.error(
-                    intl.formatMessage(translations.fetchSubmissionsFailure),
-                  );
-                });
-            }
-            return new Promise(() => {});
-          }}
-          style={{
-            paddingRight: tabs.allStudentsPendingCount === 0 ? 8 : 26,
-          }}
-          value={1}
-        />
-      )}
+          )}
 
-      {tabs.categories.map((tab, index) => (
-        <Tab
-          key={tab.id}
-          id={`category-tab-${tab.id}`}
-          label={tab.title}
-          onClick={(): Promise<string | number | void> => {
-            // Prevent API calls when spam clicking the tab
-            if (tabValue !== index + 2) {
-              setTableIsLoading(true);
-              setIsTabChanging(true);
-              dispatch(fetchCategorySubmissions(tab.id))
-                .finally(() => {
-                  setTableIsLoading(false);
-                  setIsTabChanging(false);
-                })
-                .catch(() => {
-                  setTableIsLoading(false);
-                  setIsTabChanging(false);
-                  toast.error(
-                    intl.formatMessage(translations.fetchSubmissionsFailure),
-                  );
-                });
-            }
-            return new Promise(() => {});
-          }}
-          value={index + 2}
-        />
-      ))}
-    </Tabs>
+          {tabs.categories.map((tab, index) => (
+            <Tab
+              key={tab.id}
+              id={`category-tab-${tab.id}`}
+              label={tab.title}
+              onClick={(): Promise<string | number | void> => {
+                // Prevent API calls when spam clicking the tab
+                if (tabValue !== index + 2) {
+                  setTableIsLoading(true);
+                  setIsTabChanging(true);
+                  dispatch(fetchCategorySubmissions(tab.id))
+                    .finally(() => {
+                      setTableIsLoading(false);
+                      setIsTabChanging(false);
+                    })
+                    .catch(() => {
+                      setTableIsLoading(false);
+                      setIsTabChanging(false);
+                      toast.error(
+                        intl.formatMessage(
+                          translations.fetchSubmissionsFailure,
+                        ),
+                      );
+                    });
+                }
+                return new Promise(() => {});
+              }}
+              value={index + 2}
+            />
+          ))}
+        </Tabs>
+      </Box>
+    </Box>
   );
 };
 

--- a/client/app/bundles/course/discussion/topics/pages/CommentIndex/index.tsx
+++ b/client/app/bundles/course/discussion/topics/pages/CommentIndex/index.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
-import { Tab, Tabs } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 import { tabsStyle } from 'theme/mui-style';
 import {
   CommentPermissions,
@@ -145,34 +145,40 @@ const CommentTabs: FC<CommentTabProps> = (props) => {
   }, [permissions, tabs]);
 
   return (
-    <Tabs
-      onChange={(_, value): void => {
-        dispatch(changeTabValue(value));
-      }}
-      scrollButtons="auto"
-      sx={tabsStyle}
-      TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
-      value={tabValue}
-      variant="scrollable"
-    >
-      {tabTypesToRender.length > 0 &&
-        tabTypesToRender.map((tabData: CommentTabData) => (
-          <Tab
-            key={tabData.type}
-            icon={<CustomBadge badgeContent={tabData.count} color="primary" />}
-            iconPosition="end"
-            id={`${tabData.type}_tab`}
-            label={tabTranslation(intl, tabData.type)}
-            style={{
-              minHeight: 48,
-              paddingRight:
-                tabData.count === 0 || tabData.count === undefined ? 8 : 26,
-              textDecoration: 'none',
-            }}
-            value={tabData.type}
-          />
-        ))}
-    </Tabs>
+    <Box className="max-w-full">
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          onChange={(_, value): void => {
+            dispatch(changeTabValue(value));
+          }}
+          scrollButtons="auto"
+          sx={tabsStyle}
+          TabIndicatorProps={{ color: 'primary', style: { height: 5 } }}
+          value={tabValue}
+          variant="scrollable"
+        >
+          {tabTypesToRender.length > 0 &&
+            tabTypesToRender.map((tabData: CommentTabData) => (
+              <Tab
+                key={tabData.type}
+                icon={
+                  <CustomBadge badgeContent={tabData.count} color="primary" />
+                }
+                iconPosition="end"
+                id={`${tabData.type}_tab`}
+                label={tabTranslation(intl, tabData.type)}
+                style={{
+                  minHeight: 48,
+                  paddingRight:
+                    tabData.count === 0 || tabData.count === undefined ? 8 : 26,
+                  textDecoration: 'none',
+                }}
+                value={tabData.type}
+              />
+            ))}
+        </Tabs>
+      </Box>
+    </Box>
   );
 };
 

--- a/client/app/bundles/course/enrol-requests/components/tables/EnrolRequestsTable.tsx
+++ b/client/app/bundles/course/enrol-requests/components/tables/EnrolRequestsTable.tsx
@@ -20,6 +20,7 @@ import Note from 'lib/components/core/Note';
 import InlineEditTextField from 'lib/components/form/fields/DataTableInlineEditable/TextField';
 import {
   COURSE_USER_ROLES,
+  DEFAULT_TABLE_ROWS_PER_PAGE,
   TIMELINE_ALGORITHMS,
 } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
@@ -117,8 +118,8 @@ const EnrolRequestsTable: FC<Props> = (props) => {
     filter: false,
     pagination: true,
     print: false,
-    rowsPerPage: 100,
-    rowsPerPageOptions: [100],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: true,
     selectableRows: 'none',
     setTableProps: (): object => {

--- a/client/app/bundles/course/experience-points/disbursement/components/tables/DisbursementTable.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/components/tables/DisbursementTable.tsx
@@ -5,7 +5,7 @@ import { TableColumns, TableOptions } from 'types/components/DataTable';
 import { DisbursementCourseUserMiniEntity } from 'types/course/disbursement';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import { getCourseUserURL } from 'lib/helpers/url-builders';
 import { getCourseId } from 'lib/helpers/url-helpers';
 
@@ -152,8 +152,8 @@ const DisbursementTable: FC<Props> = (props: Props) => {
     download: false,
     filter: false,
     pagination: true,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     print: false,
     search: false,
     selectableRows: 'none',

--- a/client/app/bundles/course/experience-points/disbursement/components/tables/ForumDisbursementTable.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/components/tables/ForumDisbursementTable.tsx
@@ -12,7 +12,7 @@ import { TableColumns, TableOptions } from 'types/components/DataTable';
 import { ForumDisbursementUserEntity } from 'types/course/disbursement';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import { getCourseUserURL } from 'lib/helpers/url-builders';
 import { getCourseId } from 'lib/helpers/url-helpers';
 
@@ -226,8 +226,8 @@ const ForumDisbursementTable: FC<Props> = (props: Props) => {
     download: false,
     filter: false,
     pagination: true,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     print: false,
     search: false,
     selectableRows: 'none',

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/staff/index.jsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/staff/index.jsx
@@ -4,7 +4,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import ErrorCard from 'lib/components/core/ErrorCard';
 import DataTable from 'lib/components/core/layouts/DataTable';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 
 import { staffIndexShape } from '../../../propTypes/staff';
 
@@ -13,8 +13,8 @@ const options = {
     filename: 'staff_statistics',
   },
   print: false,
-  rowsPerPage: TABLE_ROWS_PER_PAGE,
-  rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+  rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+  rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
   selectableRows: 'none',
   sortOrder: {
     name: 'averageMarkingTime',

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/students/index.jsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/students/index.jsx
@@ -8,7 +8,7 @@ import ErrorCard from 'lib/components/core/ErrorCard';
 import DataTable from 'lib/components/core/layouts/DataTable';
 import Link from 'lib/components/core/Link';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 
 import { studentsIndexShape } from '../../../propTypes/students';
 
@@ -17,8 +17,8 @@ const options = {
     filename: 'students_statistics',
   },
   print: false,
-  rowsPerPage: TABLE_ROWS_PER_PAGE,
-  rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+  rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+  rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
   selectableRows: 'none',
   sortOrder: {
     name: 'experiencePoints',

--- a/client/app/bundles/course/user-invitations/components/tables/InvitationResultInvitationsTable.tsx
+++ b/client/app/bundles/course/user-invitations/components/tables/InvitationResultInvitationsTable.tsx
@@ -8,7 +8,7 @@ import { InvitationListData } from 'types/course/userInvitations';
 import DataTable from 'lib/components/core/layouts/DataTable';
 import {
   COURSE_USER_ROLES,
-  TABLE_ROWS_PER_PAGE,
+  DEFAULT_TABLE_ROWS_PER_PAGE,
 } from 'lib/constants/sharedConstants';
 import tableTranslations from 'lib/translations/table';
 
@@ -27,8 +27,8 @@ const InvitationResultInvitationsTable: FC<Props> = (props) => {
     filter: false,
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: false,
     selectableRows: 'none',
     setTableProps: (): object => {

--- a/client/app/bundles/course/user-invitations/components/tables/InvitationResultUsersTable.tsx
+++ b/client/app/bundles/course/user-invitations/components/tables/InvitationResultUsersTable.tsx
@@ -8,7 +8,7 @@ import { CourseUserData } from 'types/course/courseUsers';
 import DataTable from 'lib/components/core/layouts/DataTable';
 import {
   COURSE_USER_ROLES,
-  TABLE_ROWS_PER_PAGE,
+  DEFAULT_TABLE_ROWS_PER_PAGE,
 } from 'lib/constants/sharedConstants';
 import tableTranslations from 'lib/translations/table';
 
@@ -27,8 +27,8 @@ const InvitationResultUsersTable: FC<Props> = (props) => {
     filter: false,
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: false,
     selectableRows: 'none',
     setTableProps: (): object => {

--- a/client/app/bundles/course/user-invitations/components/tables/UserInvitationsTable.tsx
+++ b/client/app/bundles/course/user-invitations/components/tables/UserInvitationsTable.tsx
@@ -19,7 +19,7 @@ import DataTable from 'lib/components/core/layouts/DataTable';
 import Note from 'lib/components/core/Note';
 import {
   COURSE_USER_ROLES,
-  TABLE_ROWS_PER_PAGE,
+  DEFAULT_TABLE_ROWS_PER_PAGE,
   TIMELINE_ALGORITHMS,
 } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
@@ -86,8 +86,8 @@ const UserInvitationsTable: FC<Props> = (props) => {
     filter: false,
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: true,
     selectableRows: 'none',
     setTableProps: (): Record<string, unknown> => {

--- a/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
+++ b/client/app/bundles/course/users/components/navigation/UserManagementTabs.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { Tab, Tabs } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 import { tabsStyle } from 'theme/mui-style';
 import {
   ManageCourseUsersPermissions,
@@ -123,28 +123,33 @@ const UserManagementTabs: FC<Props> = (props) => {
   };
 
   return (
-    <Tabs
-      scrollButtons="auto"
-      sx={tabsStyle}
-      value={getCurrentTabIndex()}
-      variant="scrollable"
-    >
-      {tabs.map((tab) => (
-        <Tab
-          key={tab.label.id}
-          component={Link}
-          icon={<CustomBadge badgeContent={tab.count} color="error" />}
-          iconPosition="end"
-          label={intl.formatMessage(tab.label)}
-          style={{
-            minHeight: 48,
-            paddingRight: tab.count === 0 || tab.count === undefined ? 8 : 26,
-            textDecoration: 'none',
-          }}
-          to={tab.href}
-        />
-      ))}
-    </Tabs>
+    <Box className="max-w-full">
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          scrollButtons="auto"
+          sx={tabsStyle}
+          value={getCurrentTabIndex()}
+          variant="scrollable"
+        >
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.label.id}
+              component={Link}
+              icon={<CustomBadge badgeContent={tab.count} color="error" />}
+              iconPosition="end"
+              label={intl.formatMessage(tab.label)}
+              style={{
+                minHeight: 48,
+                paddingRight:
+                  tab.count === 0 || tab.count === undefined ? 8 : 26,
+                textDecoration: 'none',
+              }}
+              to={tab.href}
+            />
+          ))}
+        </Tabs>
+      </Box>
+    </Box>
   );
 };
 

--- a/client/app/bundles/course/users/components/tables/ManageUsersTable.tsx
+++ b/client/app/bundles/course/users/components/tables/ManageUsersTable.tsx
@@ -27,7 +27,7 @@ import Note from 'lib/components/core/Note';
 import InlineEditTextField from 'lib/components/form/fields/DataTableInlineEditable/TextField';
 import {
   COURSE_USER_ROLES,
-  TABLE_ROWS_PER_PAGE,
+  DEFAULT_TABLE_ROWS_PER_PAGE,
   TIMELINE_ALGORITHMS,
 } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
@@ -263,8 +263,8 @@ const ManageUsersTable: FC<Props> = (props) => {
     filter: false,
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: true,
     searchPlaceholder: intl.formatMessage(translations.searchText),
     selectableRows: 'none',

--- a/client/app/bundles/course/video-submissions/components/tables/UserVideoSubmissionTable.tsx
+++ b/client/app/bundles/course/video-submissions/components/tables/UserVideoSubmissionTable.tsx
@@ -7,6 +7,7 @@ import { VideoSubmissionListData } from 'types/course/videoSubmissions';
 import DataTable from 'lib/components/core/layouts/DataTable';
 import LinearProgressWithLabel from 'lib/components/core/LinearProgressWithLabel';
 import Note from 'lib/components/core/Note';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import { formatShortDateTime } from 'lib/moment';
 import tableTranslations from 'lib/translations/table';
 
@@ -27,8 +28,8 @@ const UserVideoSubmissionsTable: FC<Props> = (props) => {
     jumpToPage: true,
     pagination: true,
     print: false,
-    rowsPerPage: 100,
-    rowsPerPageOptions: [100],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: false,
     selectableRows: 'none',
     setTableProps: (): object => {

--- a/client/app/bundles/course/video/components/misc/VideoTabs.tsx
+++ b/client/app/bundles/course/video/components/misc/VideoTabs.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { useSelector } from 'react-redux';
 import { URLSearchParamsInit } from 'react-router-dom';
-import { Tab, Tabs } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 import { AppState } from 'types/store';
 
 import { getVideoTabs } from '../../selectors';
@@ -25,18 +25,22 @@ const VideoTabs: FC<Props> = (props) => {
   const videoTabs = useSelector((state: AppState) => getVideoTabs(state));
   if (videoTabs.length <= 1) return null;
   return (
-    <Tabs
-      onChange={(_, value): void => {
-        setCurrentTab({ tab: value });
-      }}
-      scrollButtons="auto"
-      value={currentTab ?? videoTabs[0]?.id}
-      variant="scrollable"
-    >
-      {videoTabs.map((tab) => (
-        <Tab key={tab.id} label={tab.title} value={tab.id} />
-      ))}
-    </Tabs>
+    <Box className="max-w-full">
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          onChange={(_, value): void => {
+            setCurrentTab({ tab: value });
+          }}
+          scrollButtons="auto"
+          value={currentTab ?? videoTabs[0]?.id}
+          variant="scrollable"
+        >
+          {videoTabs.map((tab) => (
+            <Tab key={tab.id} label={tab.title} value={tab.id} />
+          ))}
+        </Tabs>
+      </Box>
+    </Box>
   );
 };
 

--- a/client/app/bundles/course/video/submission/components/tables/VideoSubmissionsTable.tsx
+++ b/client/app/bundles/course/video/submission/components/tables/VideoSubmissionsTable.tsx
@@ -6,6 +6,7 @@ import { VideoSubmissionListData } from 'types/course/video/submissions';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
 import LinearProgressWithLabel from 'lib/components/core/LinearProgressWithLabel';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import { getVideoSubmissionURL } from 'lib/helpers/url-builders';
 import { getCourseId, getVideoId } from 'lib/helpers/url-helpers';
 import { formatShortDateTime } from 'lib/moment';
@@ -25,8 +26,8 @@ const VideoSubmissionsTable: FC<Props> = (props) => {
     jumpToPage: true,
     pagination: true,
     print: false,
-    rowsPerPage: 100,
-    rowsPerPageOptions: [100],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: true,
     searchPlaceholder: 'Search by Name',
     selectableRows: 'none',

--- a/client/app/bundles/system/admin/admin/components/tables/CoursesTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/CoursesTable.tsx
@@ -16,8 +16,8 @@ import { AdminStats, UserBasicMiniEntity } from 'types/users';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
 import {
+  DEFAULT_TABLE_ROWS_PER_PAGE,
   FIELD_DEBOUNCE_DELAY,
-  TABLE_ROWS_PER_PAGE,
 } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
 import tableTranslations from 'lib/translations/table';
@@ -81,7 +81,7 @@ const CoursesTable: FC<Props> = (props) => {
     dispatch(
       indexOperation({
         'filter[page_num]': page,
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         active: filter.active,
       }),
     )
@@ -106,7 +106,7 @@ const CoursesTable: FC<Props> = (props) => {
     dispatch(
       indexOperation({
         'filter[page_num]': page,
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         active: filter.active,
         search: searchText ? searchText.trim() : searchText,
       }),
@@ -141,8 +141,8 @@ const CoursesTable: FC<Props> = (props) => {
     },
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: true,
     searchPlaceholder: intl.formatMessage(translations.searchText),
     selectableRows: 'none',

--- a/client/app/bundles/system/admin/admin/components/tables/InstancesTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/InstancesTable.tsx
@@ -1,23 +1,19 @@
-import { FC, ReactElement, useState } from 'react';
+import { FC, ReactElement } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
-import { CircularProgress, Typography } from '@mui/material';
-import {
-  TableColumns,
-  TableOptions,
-  TableState,
-} from 'types/components/DataTable';
+import { Typography } from '@mui/material';
+import { TableColumns, TableOptions } from 'types/components/DataTable';
 import { AppDispatch, AppState } from 'types/store';
 import { InstanceMiniEntity } from 'types/system/instances';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
 import InlineEditTextField from 'lib/components/form/fields/DataTableInlineEditable/TextField';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
 import tableTranslations from 'lib/translations/table';
 
-import { indexInstances, updateInstance } from '../../operations';
+import { updateInstance } from '../../operations';
 import { getAdminCounts, getAllInstanceMiniEntities } from '../../selectors';
 
 interface Props extends WrappedComponentProps {
@@ -55,15 +51,10 @@ const translations = defineMessages({
 const InstancesTable: FC<Props> = (props) => {
   const { renderRowActionComponent, title, intl } = props;
   const dispatch = useDispatch<AppDispatch>();
-  const [isLoading, setIsLoading] = useState(false);
   const instances = useSelector((state: AppState) =>
     getAllInstanceMiniEntities(state),
   );
   const counts = useSelector((state: AppState) => getAdminCounts(state));
-
-  const [tableState, setTableState] = useState<TableState>({
-    page: 1,
-  });
 
   const handleNameUpdate = (rowData, newName: string): Promise<void> => {
     const instance = rebuildObjectFromRow(
@@ -121,45 +112,14 @@ const InstancesTable: FC<Props> = (props) => {
       });
   };
 
-  const changePage = (page): void => {
-    setIsLoading(true);
-    setTableState({
-      ...tableState,
-      page,
-    });
-    dispatch(
-      indexInstances({
-        'filter[page_num]': page,
-        'filter[length]': TABLE_ROWS_PER_PAGE,
-      }),
-    )
-      .catch(() =>
-        toast.error(
-          intl.formatMessage(translations.fetchFilteredInstancesFailure),
-        ),
-      )
-      .finally(() => {
-        setIsLoading(false);
-      });
-  };
-
   const options: TableOptions = {
     count: counts.instancesCount,
     download: false,
     filter: false,
-    onTableChange: (action, newTableState) => {
-      switch (action) {
-        case 'changePage':
-          changePage(newTableState.page! + 1);
-          break;
-        default:
-          break;
-      }
-    },
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: false,
     selectableRows: 'none',
     serverSide: true,
@@ -319,16 +279,8 @@ const InstancesTable: FC<Props> = (props) => {
       columns={columns}
       data={instances}
       includeRowNumber
-      isLoading={isLoading}
       options={options}
-      title={
-        <Typography variant="h6">
-          {title}
-          {isLoading && (
-            <CircularProgress className="relative top-1 ml-4" size={24} />
-          )}
-        </Typography>
-      }
+      title={<Typography variant="h6">{title}</Typography>}
       withMargin
     />
   );

--- a/client/app/bundles/system/admin/admin/components/tables/UsersTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/UsersTable.tsx
@@ -20,8 +20,8 @@ import { AdminStats, UserMiniEntity, UserRole } from 'types/users';
 import DataTable from 'lib/components/core/layouts/DataTable';
 import InlineEditTextField from 'lib/components/form/fields/DataTableInlineEditable/TextField';
 import {
+  DEFAULT_TABLE_ROWS_PER_PAGE,
   FIELD_DEBOUNCE_DELAY,
-  TABLE_ROWS_PER_PAGE,
   USER_ROLES,
 } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
@@ -137,7 +137,7 @@ const UsersTable: FC<Props> = (props) => {
     dispatch(
       indexUsers({
         'filter[page_num]': page,
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         role: filter.role,
         active: filter.active,
       }),
@@ -159,7 +159,7 @@ const UsersTable: FC<Props> = (props) => {
     dispatch(
       indexUsers({
         'filter[page_num]': page,
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         role: filter.role,
         active: filter.active,
         search: searchText ? searchText.trim() : searchText,
@@ -193,8 +193,8 @@ const UsersTable: FC<Props> = (props) => {
     },
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: true,
     searchPlaceholder: intl.formatMessage(translations.searchText),
     selectableRows: 'none',

--- a/client/app/bundles/system/admin/admin/operations.ts
+++ b/client/app/bundles/system/admin/admin/operations.ts
@@ -164,9 +164,9 @@ export function deleteCourse(courseId: number): Operation<void> {
     });
 }
 
-export function indexInstances(params?): Operation<void> {
+export function indexInstances(): Operation<void> {
   return async (dispatch) =>
-    SystemAPI.admin.indexInstances(params).then((response) => {
+    SystemAPI.admin.indexInstances().then((response) => {
       const data = response.data;
       dispatch(
         actions.saveInstanceList(data.instances, data.permissions, data.counts),

--- a/client/app/bundles/system/admin/admin/pages/CoursesIndex/index.tsx
+++ b/client/app/bundles/system/admin/admin/pages/CoursesIndex/index.tsx
@@ -8,7 +8,7 @@ import { AppDispatch, AppState } from 'types/store';
 import SummaryCard from 'lib/components/core/layouts/SummaryCard';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import PageHeader from 'lib/components/navigation/PageHeader';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 
 import CoursesButtons from '../../components/buttons/CoursesButtons';
 import CoursesTable from '../../components/tables/CoursesTable';
@@ -77,7 +77,7 @@ const CoursesIndex: FC<Props> = (props) => {
     setIsLoading(true);
     dispatch(
       indexCourses({
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         active: filter.active,
       }),
     )

--- a/client/app/bundles/system/admin/admin/pages/InstancesIndex/index.tsx
+++ b/client/app/bundles/system/admin/admin/pages/InstancesIndex/index.tsx
@@ -7,7 +7,6 @@ import { AppDispatch, AppState } from 'types/store';
 import AddButton from 'lib/components/core/buttons/AddButton';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import PageHeader from 'lib/components/navigation/PageHeader';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import InstancesButtons from '../../components/buttons/InstancesButtons';
@@ -45,7 +44,7 @@ const InstancesIndex: FC = () => {
   const headerToolbars: ReactElement[] = [];
 
   useEffect(() => {
-    dispatch(indexInstances({ 'filter[length]': TABLE_ROWS_PER_PAGE }))
+    dispatch(indexInstances())
       .catch(() => toast.error(t(translations.fetchInstancesFailure)))
       .finally(() => setIsLoading(false));
   }, [dispatch]);

--- a/client/app/bundles/system/admin/admin/pages/UsersIndex/index.tsx
+++ b/client/app/bundles/system/admin/admin/pages/UsersIndex/index.tsx
@@ -8,7 +8,7 @@ import { AppDispatch, AppState } from 'types/store';
 import SummaryCard from 'lib/components/core/layouts/SummaryCard';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import PageHeader from 'lib/components/navigation/PageHeader';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 
 import UsersButtons from '../../components/buttons/UsersButtons';
 import UsersTable from '../../components/tables/UsersTable';
@@ -133,7 +133,7 @@ const UsersIndex: FC<Props> = (props) => {
     setIsLoading(true);
     dispatch(
       indexUsers({
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         role: filter.role,
         active: filter.active,
       }),

--- a/client/app/bundles/system/admin/instance/instance/components/navigation/InstanceUsersTabs.tsx
+++ b/client/app/bundles/system/admin/instance/instance/components/navigation/InstanceUsersTabs.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { Tab, Tabs } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 
 interface Props extends WrappedComponentProps {
   currentTab: string;
@@ -27,35 +27,39 @@ const InstanceUsersTabs: FC<Props> = (props) => {
   const [tabValue, setTabValue] = useState(currentTab);
 
   return (
-    <Tabs
-      onChange={(_, value): void => {
-        setTabValue(value);
-      }}
-      value={tabValue}
-      variant="fullWidth"
-    >
-      <Tab
-        component={Link}
-        id="instance-users-tab"
-        label={intl.formatMessage(translations.usersTab)}
-        to="/admin/instance/users"
-        value="users-tab"
-      />
-      <Tab
-        component={Link}
-        id="invite-users-tab"
-        label={intl.formatMessage(translations.inviteTab)}
-        to="/admin/instance/users/invite"
-        value="invite-users-tab"
-      />
-      <Tab
-        component={Link}
-        id="invitations-tab"
-        label={intl.formatMessage(translations.invitationsTab)}
-        to="/admin/instance/user_invitations"
-        value="invitations-tab"
-      />
-    </Tabs>
+    <Box className="max-w-full">
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          onChange={(_, value): void => {
+            setTabValue(value);
+          }}
+          value={tabValue}
+          variant="fullWidth"
+        >
+          <Tab
+            component={Link}
+            id="instance-users-tab"
+            label={intl.formatMessage(translations.usersTab)}
+            to="/admin/instance/users"
+            value="instance-users-tab"
+          />
+          <Tab
+            component={Link}
+            id="invite-users-tab"
+            label={intl.formatMessage(translations.inviteTab)}
+            to="/admin/instance/users/invite"
+            value="invite-users-tab"
+          />
+          <Tab
+            component={Link}
+            id="invitations-tab"
+            label={intl.formatMessage(translations.invitationsTab)}
+            to="/admin/instance/user_invitations"
+            value="invitations-tab"
+          />
+        </Tabs>
+      </Box>
+    </Box>
   );
 };
 

--- a/client/app/bundles/system/admin/instance/instance/components/tables/UsersTable.tsx
+++ b/client/app/bundles/system/admin/instance/instance/components/tables/UsersTable.tsx
@@ -23,9 +23,9 @@ import {
 
 import DataTable from 'lib/components/core/layouts/DataTable';
 import {
+  DEFAULT_TABLE_ROWS_PER_PAGE,
   FIELD_DEBOUNCE_DELAY,
   INSTANCE_USER_ROLES,
-  TABLE_ROWS_PER_PAGE,
 } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
 import tableTranslations from 'lib/translations/table';
@@ -116,7 +116,7 @@ const UsersTable: FC<Props> = (props) => {
     dispatch(
       indexUsers({
         'filter[page_num]': page,
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         role: filter.role,
         active: filter.active,
       }),
@@ -138,7 +138,7 @@ const UsersTable: FC<Props> = (props) => {
     dispatch(
       indexUsers({
         'filter[page_num]': page,
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         role: filter.role,
         active: filter.active,
         search: searchText ? searchText.trim() : searchText,
@@ -172,8 +172,8 @@ const UsersTable: FC<Props> = (props) => {
     },
     pagination: true,
     print: false,
-    rowsPerPage: TABLE_ROWS_PER_PAGE,
-    rowsPerPageOptions: [TABLE_ROWS_PER_PAGE],
+    rowsPerPage: DEFAULT_TABLE_ROWS_PER_PAGE,
+    rowsPerPageOptions: [DEFAULT_TABLE_ROWS_PER_PAGE],
     search: true,
     searchPlaceholder: intl.formatMessage(translations.searchText),
     selectableRows: 'none',

--- a/client/app/bundles/system/admin/instance/instance/pages/InstanceCoursesIndex/index.tsx
+++ b/client/app/bundles/system/admin/instance/instance/pages/InstanceCoursesIndex/index.tsx
@@ -10,7 +10,7 @@ import CoursesTable from 'bundles/system/admin/admin/components/tables/CoursesTa
 import SummaryCard from 'lib/components/core/layouts/SummaryCard';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import PageHeader from 'lib/components/navigation/PageHeader';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 
 import { deleteCourse, indexCourses } from '../../operations';
 import { getAdminCounts, getAllCourseMiniEntities } from '../../selectors';
@@ -77,7 +77,7 @@ const CoursesIndex: FC<Props> = (props) => {
     setIsLoading(true);
     dispatch(
       indexCourses({
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         active: filter.active,
       }),
     )

--- a/client/app/bundles/system/admin/instance/instance/pages/InstanceUsersIndex/index.tsx
+++ b/client/app/bundles/system/admin/instance/instance/pages/InstanceUsersIndex/index.tsx
@@ -8,7 +8,7 @@ import { AppDispatch, AppState } from 'types/store';
 import SummaryCard from 'lib/components/core/layouts/SummaryCard';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import PageHeader from 'lib/components/navigation/PageHeader';
-import { TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 
 import UsersButtons from '../../components/buttons/UsersButtons';
 import InstanceUsersTabs from '../../components/navigation/InstanceUsersTabs';
@@ -34,7 +34,7 @@ const translations = defineMessages({
   totalUsers: {
     id: 'system.admin.users.totalUsers',
     defaultMessage:
-      'Total Users: {allCount}({adminCount} Administrators' +
+      'Total Users: {allCount} ({adminCount} Administrators' +
       ', {instructorCount} Instructors, {normalCount} Normal)',
   },
   activeUsers: {
@@ -155,7 +155,7 @@ const UsersIndex: FC<Props> = (props) => {
     setIsLoading(true);
     dispatch(
       indexUsers({
-        'filter[length]': TABLE_ROWS_PER_PAGE,
+        'filter[length]': DEFAULT_TABLE_ROWS_PER_PAGE,
         role: filter.role,
         active: filter.active,
       }),

--- a/client/app/lib/constants/sharedConstants.ts
+++ b/client/app/lib/constants/sharedConstants.ts
@@ -11,7 +11,7 @@ export const FIELD_DEBOUNCE_DELAY = 250;
 
 // Table options
 
-export const TABLE_ROWS_PER_PAGE = 100;
+export const DEFAULT_TABLE_ROWS_PER_PAGE = 100;
 
 export const TIMELINE_ALGORITHMS = [
   { value: 'fixed', label: 'Fixed' },


### PR DESCRIPTION
Closes #5405 

### Issue
- After creating a new instance, the page params for backend pagination is not passed to the backend. As a result, the default number of records (25) are returned to the frontend.

### Solution
- Ideally, the pagination params should be passed to the backend. But there is no need for backend pagination for this page as there are not so many instances now and in the foreseeable future. As a result, there wont be any performance issue in loading the page. 
- The backend pagination is now removed for instance table.