### PR TITLE
Assessments Index, Details: Additional UI improvements

### DIFF
--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -1,4 +1,10 @@
 .course-layout {
+  display: flex;
+
+  @media (max-width: $screen-sm-min) {
+    flex-direction: column;
+  }
+
   #course-badge-achievement {
     margin-bottom: 1em;
     margin-left: 0.5em;
@@ -106,5 +112,20 @@
     border: 0;
     position: absolute;
     z-index: 999;
+  }
+
+  #full-sidebar {
+    margin-right: 1.5rem;
+    width: 21rem;
+
+    @media (max-width: $screen-sm-min) {
+      margin-bottom: 1.5rem;
+      margin-right: 0;
+      width: 100%;
+    }
+  }
+
+  .page-content {
+    width: 100%;
   }
 }

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -28,7 +28,10 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def show
-    render 'authenticate' unless can_access_assessment?
+    unless can_access_assessment?
+      render 'authenticate'
+      return
+    end
 
     respond_to do |format|
       format.html
@@ -119,6 +122,14 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
     Course::Assessment::ReminderService.
       send_closing_reminder(@assessment, course_user_ids.pluck(:id), include_unsubscribed: true)
     head :ok
+  end
+
+  def requirements
+    requirements = @assessment.specific_conditions.filter_map do |condition|
+      condition.title unless current_course_user.present? && condition.satisfied_by?(current_course_user)
+    end
+
+    render json: requirements
   end
 
   protected

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -46,6 +46,7 @@ module Course::Assessment::AssessmentAbility
     can :read_material, Course::Assessment::Category, course_id: course.id
     can :read_material, Course::Assessment::Tab, category: { course_id: course.id }
     can :authenticate, Course::Assessment, lesson_plan_item: { published: true, course_id: course.id }
+    can :requirements, Course::Assessment, lesson_plan_item: { published: true, course_id: course.id }
   end
 
   # 'access' refers to the ability to access password-protected assessments.

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -1,10 +1,10 @@
 - layout = controller.parent_layout(of_layout: 'course') || controller.current_layout
 = render within_layout: layout do
   = render_breadcrumbs
-  div.row.course-layout data-course-id=current_course.id
+  div.course-layout data-course-id=current_course.id
     button.btn.btn-default.collapse#show-sidebar type="button" data-toggle="collapse" data-target="#full-sidebar,#show-sidebar" aria-expanded="false" aria-controls="navbar"
       = fa_icon 'chevron-right'.freeze
-    div.col-lg-2.col-md-3.col-sm-4.collapse.in#full-sidebar
+    aside.collapse.in#full-sidebar
       div.row
         div.hidden-xs.text-center#course-sidebar-logo
           button.btn.btn-default.pull-left#hide-sidebar type="button" data-toggle="collapse" data-target="#full-sidebar,#show-sidebar" aria-expanded="false" aria-controls="navbar"
@@ -28,7 +28,7 @@
               h4#admin-header-sidebar = t('.administration')
               = sidebar_items(admin_sidebar_items)
 
-    div.col-lg-10.col-md-9.col-sm-8 class=page_class
+    div.page-content class=page_class
       = yield
 
     - if current_course_user && UserNotification.next_unread_popup_for(current_course_user).present?

--- a/client/app/api/course/Assessment/Assessments.js
+++ b/client/app/api/course/Assessment/Assessments.js
@@ -22,6 +22,17 @@ export default class AssessmentsAPI extends BaseCourseAPI {
     return this.getClient().get(`${this._getUrlPrefix()}/${assessmentId}`);
   }
 
+  /**
+   * Fetches the remaining unlock requirements for an assessment.
+   * @param {number} assessmentId
+   * @returns An `AssessmentUnlockRequirements` object
+   */
+  fetchUnlockRequirements(assessmentId) {
+    return this.getClient().get(
+      `${this._getUrlPrefix()}/${assessmentId}/requirements`,
+    );
+  }
+
   fetchEditData(assessmentId) {
     return this.getClient().get(`${this._getUrlPrefix()}/${assessmentId}/edit`);
   }

--- a/client/app/bundles/course/assessment/actions.js
+++ b/client/app/bundles/course/assessment/actions.js
@@ -20,6 +20,12 @@ export const fetchAssessment = async (id) => {
   return response.data;
 };
 
+export const fetchAssessmentUnlockRequirements = async (id) => {
+  const response =
+    await CourseAPI.assessment.assessments.fetchUnlockRequirements(id);
+  return response.data;
+};
+
 export const fetchAssessmentEditData = async (assessmentId) => {
   const response = await CourseAPI.assessment.assessments.fetchEditData(
     assessmentId,

--- a/client/app/bundles/course/assessment/pages/AssessmentShow/prompts/DuplicationPrompt.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentShow/prompts/DuplicationPrompt.tsx
@@ -196,7 +196,9 @@ const DuplicationPrompt = (props: DuplicationPromptProps): JSX.Element => {
     >
       <PromptText>{t(translations.duplicatingThisQuestion)}</PromptText>
 
-      <PromptText className="italic line-clamp-2">{question.title}</PromptText>
+      <PromptText className="pb-7 italic line-clamp-2">
+        {question.title}
+      </PromptText>
 
       <TextField
         autoFocus

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/ActionButtons.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/ActionButtons.tsx
@@ -76,15 +76,6 @@ const ActionButtons = (props: ActionButtonsProps): JSX.Element => {
         <UnavailableMessage for={assessment} />
       )}
 
-      {assessment.status === 'attempting' && (
-        <Tooltip
-          disableInteractive
-          title={t(translations.hasOngoingSubmissions)}
-        >
-          <div className="ml-4 rounded-full bg-amber-500 wh-4 group-hover?:animate-pulse" />
-        </Tooltip>
-      )}
-
       {student && assessment.status === 'locked' && (
         <Tooltip
           disableInteractive

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/ActionButtons.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/ActionButtons.tsx
@@ -26,50 +26,54 @@ const ActionButtons = (props: ActionButtonsProps): JSX.Element => {
   const { for: assessment, student } = props;
   const { t } = useTranslation();
 
+  const actionButton = assessment.actionButtonUrl && (
+    <Button
+      className="min-w-[8.5rem]"
+      // TODO: Change to react-router Link once SPA
+      href={assessment.actionButtonUrl}
+      size="small"
+      variant={assessment.status === 'submitted' ? 'outlined' : 'contained'}
+      // Temporary fix for blue link on hover caused by Bootstrap
+      // TODO: Remove when Bootstrap is finally removed
+      {...((assessment.status === 'open' ||
+        assessment.status === 'attempting' ||
+        assessment.status === 'locked') && {
+        className: 'min-w-[8.5rem] hover:text-white',
+      })}
+    >
+      {t(ACTION_LABELS[assessment.status])}
+    </Button>
+  );
+
   return (
     <div className="flex items-center">
-      {(assessment.editUrl || assessment.submissionsUrl) && (
+      {student ? (
+        actionButton
+      ) : (
         <div className="hoverable:invisible group-hover?:visible flex h-full items-center transition-position no-hover:mr-4 hoverable:absolute hoverable:right-0 hoverable:pl-8 hoverable:opacity-0 hoverable:bg-fade-to-l-slot-2 group-hover?:right-full group-hover?:opacity-100">
-          {assessment.editUrl && (
-            <Tooltip disableInteractive title={t(translations.editAssessment)}>
-              <Link to={assessment.editUrl}>
-                <IconButton className="max-sm:!hidden">
-                  <Create />
-                </IconButton>
-              </Link>
-            </Tooltip>
-          )}
-
-          {assessment.submissionsUrl && (
-            <Tooltip disableInteractive title={t(translations.submissions)}>
-              <IconButton
-                // TODO: Change to react-router Link once SPA
-                href={assessment.submissionsUrl}
-              >
-                <Inventory />
-              </IconButton>
-            </Tooltip>
-          )}
+          {actionButton}
         </div>
       )}
 
-      {assessment.actionButtonUrl && (
-        <Button
-          className="min-w-[8.5rem]"
-          // TODO: Change to react-router Link once SPA
-          href={assessment.actionButtonUrl}
-          size="small"
-          variant={assessment.status === 'submitted' ? 'outlined' : 'contained'}
-          // Temporary fix for blue link on hover caused by Bootstrap
-          // TODO: Remove when Bootstrap is finally removed
-          {...((assessment.status === 'open' ||
-            assessment.status === 'attempting' ||
-            assessment.status === 'locked') && {
-            className: 'min-w-[8.5rem] hover:text-white',
-          })}
-        >
-          {t(ACTION_LABELS[assessment.status])}
-        </Button>
+      {assessment.editUrl && (
+        <Tooltip disableInteractive title={t(translations.editAssessment)}>
+          <Link to={assessment.editUrl}>
+            <IconButton className="max-sm:!hidden">
+              <Create />
+            </IconButton>
+          </Link>
+        </Tooltip>
+      )}
+
+      {assessment.submissionsUrl && (
+        <Tooltip disableInteractive title={t(translations.submissions)}>
+          <IconButton
+            // TODO: Change to react-router Link once SPA
+            href={assessment.submissionsUrl}
+          >
+            <Inventory />
+          </IconButton>
+        </Tooltip>
       )}
 
       {assessment.status === 'unavailable' && (

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
@@ -143,6 +143,10 @@ const AssessmentsTable = (props: AssessmentsTableProps): JSX.Element => {
           assessment.status === 'submitted'
             ? '!slot-1-lime-50 !slot-2-lime-100'
             : ''
+        } ${
+          assessment.status === 'attempting'
+            ? 'shadow-[2px_0_0_0_inset] shadow-amber-500'
+            : ''
         }`
       }
       rowKey={(assessment): string => assessment.id.toString()}

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { Typography } from '@mui/material';
 import {
   AssessmentListData,
   AssessmentsListData,
@@ -126,6 +127,13 @@ const AssessmentsTable = (props: AssessmentsTableProps): JSX.Element => {
     ],
     [display],
   );
+
+  if (assessments.length <= 0)
+    return (
+      <Typography className="mt-8 text-center text-neutral-500">
+        {t(translations.noAssessments, { category: display.category.title })}
+      </Typography>
+    );
 
   return (
     <VerticalTable

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/UnavailableMessage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/UnavailableMessage.tsx
@@ -1,5 +1,5 @@
 import { Lock } from '@mui/icons-material';
-import { Tooltip, Typography } from '@mui/material';
+import { Tooltip } from '@mui/material';
 import { AssessmentListData } from 'types/course/assessment/assessments';
 
 import useTranslation from 'lib/hooks/useTranslation';
@@ -10,34 +10,29 @@ interface UnavailableMessageProps {
   for: AssessmentListData;
 }
 
-const UnavailableMessage = (props: UnavailableMessageProps): JSX.Element => {
+const UnavailableMessage = (
+  props: UnavailableMessageProps,
+): JSX.Element | null => {
   const { for: assessment } = props;
   const { t } = useTranslation();
 
-  if (!assessment.isStartTimeBegin || !assessment.conditionSatisfied)
-    return (
-      <Tooltip
-        disableInteractive
-        title={
-          !assessment.isStartTimeBegin
-            ? t(translations.openingSoon)
-            : t(translations.unlockableHint)
-        }
-      >
-        <div className="flex min-w-[8.5rem] justify-center hover?:animate-shake">
-          <Lock
-            className="text-neutral-500 hover?:text-neutral-600"
-            fontSize="small"
-          />
-        </div>
-      </Tooltip>
-    );
+  if (assessment.isStartTimeBegin && assessment.conditionSatisfied) return null;
 
   return (
-    <Tooltip disableInteractive title={t(translations.unavailableHint)}>
-      <Typography className="italic text-neutral-400" variant="body2">
-        {t(translations.unavailable)}
-      </Typography>
+    <Tooltip
+      disableInteractive
+      title={
+        !assessment.isStartTimeBegin
+          ? t(translations.openingSoon)
+          : t(translations.unlockableHint)
+      }
+    >
+      <div className="flex min-w-[8.5rem] justify-center hover?:animate-shake">
+        <Lock
+          className="text-neutral-500 hover?:text-neutral-600"
+          fontSize="small"
+        />
+      </div>
     </Tooltip>
   );
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/UnavailableMessage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/UnavailableMessage.tsx
@@ -1,14 +1,32 @@
+import { ReactNode } from 'react';
 import { Lock } from '@mui/icons-material';
-import { Tooltip } from '@mui/material';
-import { AssessmentListData } from 'types/course/assessment/assessments';
+import { Tooltip, Typography } from '@mui/material';
+import {
+  AssessmentListData,
+  AssessmentUnlockRequirements,
+} from 'types/course/assessment/assessments';
 
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
 import useTranslation from 'lib/hooks/useTranslation';
 
+import { fetchAssessmentUnlockRequirements } from '../../actions';
 import translations from '../../translations';
 
 interface UnavailableMessageProps {
   for: AssessmentListData;
 }
+
+const ShakyLock = ({ title }: { title: string | ReactNode }): JSX.Element => (
+  <div className="flex min-w-[8.5rem] justify-center">
+    <Tooltip arrow placement="left" title={title}>
+      <Lock
+        className="text-neutral-500 hover?:animate-shake hover?:text-neutral-600"
+        fontSize="small"
+      />
+    </Tooltip>
+  </div>
+);
 
 const UnavailableMessage = (
   props: UnavailableMessageProps,
@@ -16,25 +34,49 @@ const UnavailableMessage = (
   const { for: assessment } = props;
   const { t } = useTranslation();
 
-  if (assessment.isStartTimeBegin && assessment.conditionSatisfied) return null;
+  if (!assessment.isStartTimeBegin)
+    return <ShakyLock title={t(translations.openingSoon)} />;
 
-  return (
-    <Tooltip
-      disableInteractive
-      title={
-        !assessment.isStartTimeBegin
-          ? t(translations.openingSoon)
-          : t(translations.unlockableHint)
-      }
-    >
-      <div className="flex min-w-[8.5rem] justify-center hover?:animate-shake">
-        <Lock
-          className="text-neutral-500 hover?:text-neutral-600"
-          fontSize="small"
-        />
-      </div>
-    </Tooltip>
-  );
+  if (!assessment.conditionSatisfied)
+    return (
+      <ShakyLock
+        title={
+          <section className="flex flex-col space-y-2 pb-1">
+            <Typography variant="caption">
+              {t(translations.unlockableHint)}
+            </Typography>
+
+            <Preload
+              after={600}
+              render={
+                <LoadingIndicator bare className="text-white" size={15} />
+              }
+              while={async (): Promise<AssessmentUnlockRequirements> =>
+                (await fetchAssessmentUnlockRequirements(
+                  assessment.id,
+                )) as AssessmentUnlockRequirements
+              }
+            >
+              {(data): JSX.Element => (
+                <ul className="m-0 pl-6">
+                  {data.map((condition) => (
+                    <Typography
+                      key={condition}
+                      component="li"
+                      variant="caption"
+                    >
+                      {condition}
+                    </Typography>
+                  ))}
+                </ul>
+              )}
+            </Preload>
+          </section>
+        }
+      />
+    );
+
+  return null;
 };
 
 export default UnavailableMessage;

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -29,6 +29,10 @@ const translations = defineMessages({
     id: 'course.assessment.create.createAsDraft',
     defaultMessage: 'Create As Draft',
   },
+  noAssessments: {
+    id: 'course.assessments.index.noAssessments',
+    defaultMessage: 'Create an assessment to start populating {category}.',
+  },
   openingSoon: {
     id: 'course.assessments.index.openingSoon',
     defaultMessage: 'This assessment will be unlocked at a later time.',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -124,10 +124,6 @@ const translations = defineMessages({
     id: 'course.assessments.index.submissions',
     defaultMessage: 'Submissions',
   },
-  hasOngoingSubmissions: {
-    id: 'course.assessments.index.hasOngoingSubmissions',
-    defaultMessage: 'You have an ongoing submission.',
-  },
   needsPasswordToAccess: {
     id: 'course.assessments.index.needsPasswordToAccess',
     defaultMessage: 'You will need a password to access this assessment.',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -37,15 +37,6 @@ const translations = defineMessages({
     id: 'course.assessments.index.unlockableHint',
     defaultMessage: 'Unlock this assessment by completing its requirements.',
   },
-  unavailable: {
-    id: 'course.assessments.index.unavailable',
-    defaultMessage: 'Unavailable',
-  },
-  unavailableHint: {
-    id: 'course.assessments.index.unavailableHint',
-    defaultMessage:
-      'You cannot attempt this assessment because you are not a user in this course.',
-  },
   title: {
     id: 'course.assessments.index.title',
     defaultMessage: 'Title',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -35,7 +35,7 @@ const translations = defineMessages({
   },
   unlockableHint: {
     id: 'course.assessments.index.unlockableHint',
-    defaultMessage: 'Unlock this assessment by completing its requirements.',
+    defaultMessage: 'Unlock this assessment by fulfilling:',
   },
   title: {
     id: 'course.assessments.index.title',

--- a/client/app/lib/components/core/fields/PasswordTextField.tsx
+++ b/client/app/lib/components/core/fields/PasswordTextField.tsx
@@ -45,7 +45,7 @@ const PasswordTextField = forwardRef<HTMLDivElement, PasswordTextFieldProps>(
                   onClick={handleChangePasswordVisibility}
                   onMouseDown={(e): void => e.preventDefault()}
                 >
-                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                  {showPassword ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             ),

--- a/client/app/lib/components/wrappers/ProviderWrapper.jsx
+++ b/client/app/lib/components/wrappers/ProviderWrapper.jsx
@@ -63,19 +63,15 @@ const ProviderWrapper = ({ store, persistor, children }) => {
     components: {
       MuiDialog: {
         defaultProps: { container: rootElement },
-        styleOverrides: { root: { zIndex: 1040 } },
       },
       MuiPopover: {
         defaultProps: { container: rootElement },
-        styleOverrides: { root: { zIndex: 1040 } },
       },
       MuiPopper: {
         defaultProps: { container: rootElement },
-        styleOverrides: { root: { zIndex: 1040 } },
       },
       MuiCard: { styleOverrides: { root: { overflow: 'visible' } } },
       MuiMenuItem: { styleOverrides: { root: { height: '48px' } } },
-      MuiModal: { styleOverrides: { root: { zIndex: 1040 } } },
       MuiAppBar: {
         styleOverrides: {
           // When there is a MUI Dialog component, somehow

--- a/client/app/types/course/assessment/assessments.ts
+++ b/client/app/types/course/assessment/assessments.ts
@@ -167,3 +167,5 @@ export interface AssessmentDeleteResult {
 export interface QuestionOrderPostData {
   question_order: QuestionData['id'][];
 }
+
+export type AssessmentUnlockRequirements = string[];

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,10 +198,12 @@ Rails.application.routes.draw do
           post 'reorder', on: :member
           post 'authenticate', on: :member
           post 'remind', on: :member
+          get :requirements, on: :member
 
           resources :questions, only: [] do
             post 'duplicate/:destination_assessment_id', on: :member, action: 'duplicate', as: :duplicate
           end
+
           namespace :question do
             resources :multiple_responses, only: [:new, :create, :edit, :update, :destroy]
             resources :text_responses, only: [:new, :create, :edit, :update, :destroy]
@@ -210,6 +212,7 @@ Rails.application.routes.draw do
             resources :scribing, only: [:show, :new, :create, :edit, :update, :destroy]
             resources :forum_post_responses, only: [:new, :create, :edit, :update, :destroy]
           end
+
           scope module: :submission do
             get 'attempt' => 'submissions#create'
             resources :submissions, only: [:index, :edit, :update] do
@@ -246,12 +249,14 @@ Rails.application.routes.draw do
               end
             end
           end
+
           scope module: :submission_question do
             resources :submission_questions, only: [] do
               get :past_answers, on: :member
               resources :comments, only: [:create]
             end
           end
+
           concerns :conditional
 
           collection do
@@ -263,6 +268,7 @@ Rails.application.routes.draw do
               get 'pending', on: :collection
             end
           end
+
           resources :sessions, only: [:new, :create]
 
           # Randomized Assessment is temporarily hidden (PR#5406)

--- a/spec/features/course/assessment/assessment_attempt_spec.rb
+++ b/spec/features/course/assessment/assessment_attempt_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe 'Course: Assessments: Attempt', js: true do
         visit course_assessments_path(course)
 
         within find('tr', text: assessment_with_condition.title) do
-          click_link 'Attempt'
+          hover_then_click find_link('Attempt', visible: false)
         end
 
         created_submission = assessment_with_condition.submissions.last
@@ -185,7 +185,7 @@ RSpec.describe 'Course: Assessments: Attempt', js: true do
         visit course_assessments_path(course)
 
         within find('tr', text: not_started_assessment.title) do
-          click_link 'Attempt'
+          hover_then_click find_link('Attempt', visible: false)
         end
 
         created_submission = not_started_assessment.submissions.last


### PR DESCRIPTION
Part of #5098, follows #5406 up.

## Preload: Delayed Fetching
Preload now supports an `after` prop that allows you to define the _number of milliseconds_ before the fetching function provided in `while` is invoked. The timeout will be reset if the component is unmounted before the delay is completed. The race condition flag introduced in e33e7c2 should work as expected.
```jsx
<Preload after={500} render={<LoadingIndicator />} while={fetchNames}>
  {(names): JSX.Element => (
    <NamesList of={names} />
  )}
</Preload>
```
In the code snippet above, `LoadingIndicator` will be rendered immediately, and 500 ms later, if the component has not yet been unmounted, `fetchNames` will be executed and resolve to `names` to render `NamesList`.