### PR TITLE
Update bootstrap-sass-extras and bump bundler version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ commands:
     steps:
       # Install bundler version
       - run:
-          name: Install bundler version 2.2.22
-          command: gem install bundler:2.2.22
+          name: Install bundler version 2.2.33
+          command: gem install bundler:2.2.33
 
       # Restore cached Ruby dependencies
       - restore_cache:

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'js-routes'
 gem 'jquery-rails'
 # Our Coursemology will be themed using Bootstrap
 gem 'bootstrap-sass'
-gem 'bootstrap-sass-extras', '>= 0.0.7', git: 'https://github.com/doabit/bootstrap-sass-extras'
+gem 'bootstrap-sass-extras', '>= 0.1.0'
 gem 'autoprefixer-rails'
 # Use font-awesome for icons
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -763,4 +763,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.32
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,6 @@ GIT
       activesupport (>= 4.2)
 
 GIT
-  remote: https://github.com/doabit/bootstrap-sass-extras
-  revision: 5db21def780a8d14b537ef8db0b3d34da881257a
-  specs:
-    bootstrap-sass-extras (0.1.0)
-      rails (>= 3.1.0)
-
-GIT
   remote: https://github.com/ekowidianto/active_record-acts_as.git
   revision: 9e01feb01438ba6736f2d4a8140d9be18464afdc
   branch: rails5.2.3
@@ -185,6 +178,8 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap-sass-extras (0.1.0)
+      rails (>= 3.1.0)
     bootstrap-select-rails (1.13.8)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
@@ -665,7 +660,7 @@ DEPENDENCIES
   autoprefixer-rails
   aws-sdk-s3
   bootstrap-sass
-  bootstrap-sass-extras (>= 0.0.7)!
+  bootstrap-sass-extras (>= 0.1.0)
   bootstrap-select-rails
   bootstrap3-datetimepicker-rails
   bootstrap_tokenfield_rails

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some fr
 2. Download bundler to install dependencies
 
    ```sh
-   $ gem install bundler:2.2.22
+   $ gem install bundler:2.2.33
    ```
 
 3. Install ruby dependencies
@@ -71,6 +71,7 @@ Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some fr
    ```
 
    Either way, run this command to compile the assets before running the test suite.
+
    ```
    $ cd client && yarn build:test
    ```


### PR DESCRIPTION
Currently, if you try to do a fresh bundle installation for this project, you will get the following error:

```
Your bundle is locked to bootstrap-sass-extras (0.1.0) from https://github.com/doabit/bootstrap-sass-extras (at master@5db21de), but that version can no longer be found in that source. That means the
author of bootstrap-sass-extras (0.1.0) has removed it. You'll need to update your bundle to a version other than bootstrap-sass-extras (0.1.0) that hasn't been removed in order to install.
```

Looking into the [GitHub repository](https://github.com/doabit/bootstrap-sass-extras), it seems like the package we need is no longer hosted there. But we can see that the creator has also published the gem on the official website/package repository: https://rubygems.org/gems/bootstrap-sass-extras/versions/0.1.0.

This PR switches the source of our gem. Additionally, bundler version is also bumped up to the latest version, with CI and docs being updated to match the version in our lockfile.