### PR TITLE
UI Fixes: Disabled Assessment Edit fields, Content bulging in Submission Edit, Random MUIPopover floating glitch

### DIFF
--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -1,3 +1,6 @@
+$sidebar-width: 21rem;
+$sidebar-margin-side: 1.5rem;
+
 .course-layout {
   display: flex;
 
@@ -115,17 +118,30 @@
   }
 
   #full-sidebar {
-    margin-right: 1.5rem;
-    width: 21rem;
+    margin-right: $sidebar-margin-side;
+    width: $sidebar-width;
 
     @media (max-width: $screen-sm-min) {
-      margin-bottom: 1.5rem;
+      margin-bottom: $sidebar-margin-side;
       margin-right: 0;
       width: 100%;
     }
   }
 
+  // TODO: Revisit this once SPA and see if we can deal with just `width: 100%;`
+  // For some reasons in /courses/:id/assessments/:id/submissions/:id/edit page,
+  // `width: 100%` causes `.page-content` to take the width of `.course-layout`.
+  // This 'patch' calculates the true width of `.page-content` and ensure the
+  // content never bulges out of `.course-layout`. I am not proud of this patch.
   .page-content {
+    width: calc(100% - #{$sidebar-width} - #{$sidebar-margin-side});
+
+    @media (max-width: $screen-sm-min) {
+      width: 100%;
+    }
+  }
+
+  .collapse:not(.in) + .page-content {
     width: 100%;
   }
 }

--- a/client/app/bundles/course/assessment/components/AssessmentForm/__test__/index.test.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/__test__/index.test.tsx
@@ -53,6 +53,7 @@ beforeEach(() => {
       enable_materials_action: true,
     },
     onSubmit: (): void => {},
+    disabled: false,
   };
 
   form = render(getComponent());

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -109,7 +109,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
         render={({ field, fieldState }): JSX.Element => (
           <FormCheckboxField
             description={intl.formatMessage(t.sessionProtectionHint)}
-            disabled={disabled ?? autograded}
+            disabled={autograded || disabled}
             field={field}
             fieldState={fieldState}
             label={intl.formatMessage(t.sessionProtection)}
@@ -467,7 +467,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           render={({ field, fieldState }): JSX.Element => (
             <FormCheckboxField
               description={intl.formatMessage(t.delayedGradePublicationHint)}
-              disabled={disabled ?? autograded}
+              disabled={autograded || disabled}
               disabledHint={
                 <InfoLabel
                   label={intl.formatMessage(t.unavailableInAutograded)}
@@ -490,7 +490,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           name="skippable"
           render={({ field, fieldState }): JSX.Element => (
             <FormCheckboxField
-              disabled={disabled ?? !autograded}
+              disabled={!autograded || disabled}
               disabledHint={
                 <InfoLabel label={intl.formatMessage(t.skippableManualHint)} />
               }
@@ -505,7 +505,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           name="allow_partial_submission"
           render={({ field, fieldState }): JSX.Element => (
             <FormCheckboxField
-              disabled={disabled ?? !autograded}
+              disabled={!autograded || disabled}
               disabledHint={
                 <InfoLabel
                   label={intl.formatMessage(t.unavailableInManuallyGraded)}
@@ -572,7 +572,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           name="tabbed_view"
           render={({ field, fieldState }): JSX.Element => (
             <FormSelectField
-              disabled={disabled ?? autograded}
+              disabled={autograded || disabled}
               field={field}
               fieldState={fieldState}
               label={intl.formatMessage(t.displayAssessmentAs)}
@@ -606,7 +606,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
               description={intl.formatMessage(
                 t.blockStudentViewingAfterSubmittedHint,
               )}
-              disabled={disabled ?? autograded}
+              disabled={autograded || disabled}
               disabledHint={
                 <InfoLabel
                   label={intl.formatMessage(t.unavailableInAutograded)}
@@ -642,7 +642,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           render={({ field, fieldState }): JSX.Element => (
             <FormCheckboxField
               description={intl.formatMessage(t.showMcqAnswerHint)}
-              disabled={disabled ?? !autograded}
+              disabled={!autograded || disabled}
               disabledHint={
                 <InfoLabel
                   label={intl.formatMessage(t.unavailableInManuallyGraded)}
@@ -660,7 +660,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           name="password_protected"
           render={({ field, fieldState }): JSX.Element => (
             <FormCheckboxField
-              disabled={disabled ?? autograded}
+              disabled={autograded || disabled}
               disabledHint={
                 <InfoLabel
                   label={intl.formatMessage(t.unavailableInAutograded)}

--- a/client/app/lib/components/wrappers/ProviderWrapper.jsx
+++ b/client/app/lib/components/wrappers/ProviderWrapper.jsx
@@ -65,6 +65,11 @@ const ProviderWrapper = ({ store, persistor, children }) => {
         defaultProps: { container: rootElement },
       },
       MuiPopover: {
+        // TODO: *Must* remove once SPA is ready
+        // Popover elements, e.g., Menu, MenuItem, attaches an `overflow: hidden` style to this `container` to
+        // prevent scrolling and having the Popover floating senselessly in the `container`. Usually, this `container`
+        // defaults to `body`. This time, we set it to `rootElement` which is NOT `body` nor the viewport. This causes
+        // the senseless floating issue while the page scrolls.
         defaultProps: { container: rootElement },
       },
       MuiPopper: {


### PR DESCRIPTION
## ✅ Inconsistencies in disabled Assessment Edit fields across page loads 
Reported by @cysjonathan.
### Steps to reproduce
1. Go to an Assessment Edit page
2. Change _Grading mode_ to _Manual_ if not already
3. Click _Save_
4. Once in Assessment Show, click _Edit Assessment_
5. The fields that are supposed to be disabled are now enabled

## ✅ Content bulging in Submission Edit page 
Reported by @ekowidianto.

### Problem
https://user-images.githubusercontent.com/51525686/209097158-3286e317-8fa5-4054-bc2b-b69ac6eed74f.mov

### Resolution note
Resolved for now, but the solution is not exactly ideal. After hours of debugging the DOM, it is possible that the suspects who push `.page-content` out is either the `ReadOnlyEditor` or `VisibleTestCaseView.renderOutputStream`'s `AccordionDetails`, but still no definitive answer. In the interest of time, and that we are going to rewrite the course layout in React anyway, I think 3fabe95 is a good enough patch for now.

## ❌ Menu floating senselessly on page scroll 
Reported by @ekowidianto.

### Problem
https://user-images.githubusercontent.com/51525686/209097255-d94be88c-e306-4833-84ac-3f8ba127f669.mov

### Resolution note
This problem is NOT yet fixed, and applies for almost every MUIPopover/MUIPopper elements. It is mostly visual; no usability problems. We probably only can fix this issue the right way (see the TODO comment) once we move to SPA, where all of our DOM elements will be rooted at `div#root` just below `body`.