### PR TITLE
Add forum post anonymous feature and various minor fixes

### DIFF
--- a/app/controllers/concerns/course/discussion/posts_concern.rb
+++ b/app/controllers/concerns/course/discussion/posts_concern.rb
@@ -48,7 +48,7 @@ module Course::Discussion::PostsConcern
   private
 
   def post_params
-    params.require(:discussion_post).permit(:title, :text, :parent_id, :workflow_state,
+    params.require(:discussion_post).permit(:title, :text, :parent_id, :workflow_state, :is_anonymous,
                                             codaveri_feedback_attributes: [:id, :rating, :status])
   end
 

--- a/app/controllers/course/admin/forum_settings_controller.rb
+++ b/app/controllers/course/admin/forum_settings_controller.rb
@@ -20,7 +20,8 @@ class Course::Admin::ForumSettingsController < Course::Admin::Controller
   private
 
   def forum_settings_params
-    params.require(:settings_forums_component).permit(:title, :pagination, :mark_post_as_answer_setting)
+    params.require(:settings_forums_component).
+      permit(:title, :pagination, :mark_post_as_answer_setting, :allow_anonymous_post)
   end
 
   def component

--- a/app/models/components/ability_host.rb
+++ b/app/models/components/ability_host.rb
@@ -2,65 +2,6 @@
 class AbilityHost
   include Componentize
 
-  # Helpers for defining abilities associated with a course user.
-  module CourseHelpers
-    protected
-
-    # Creates a hash which allows referencing a set of course users.
-    #
-    # @param [Array<Symbol>] roles The roles {CourseUser::Roles} which should be referenced by this
-    #   rule.
-    # @return [Hash] This hash is relative to a Course.
-    def course_user_hash(*roles)
-      course_users = { user_id: user.id }
-      course_users[:role] = roles unless roles.empty?
-
-      { course_users: course_users }
-    end
-
-    # @return [Hash] Hash relative to a component with a +has_many+ association with CourseUser.
-    def staff_hash
-      course_user_hash(*CourseUser::STAFF_ROLES.to_a)
-    end
-
-    # @return [Hash] Hash relative to a component with a +has_many+ association with CourseUser.
-    def teaching_staff_hash
-      course_user_hash(*CourseUser::TEACHING_STAFF_ROLES.to_a)
-    end
-
-    # @return [Hash] Hash relative to a component with a +has_many+ association with CourseUser.
-    def managers_hash
-      course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
-    end
-
-    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
-    def course_course_user_hash(*roles)
-      { course: course_user_hash(*roles) }
-    end
-
-    alias_method :course_all_course_users_hash, :course_course_user_hash
-
-    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
-    def course_staff_hash
-      course_course_user_hash(*CourseUser::STAFF_ROLES.to_a)
-    end
-
-    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
-    def course_teaching_staff_hash
-      course_course_user_hash(*CourseUser::TEACHING_STAFF_ROLES.to_a)
-    end
-
-    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
-    def course_teaching_assistants_hash
-      course_course_user_hash(:teaching_assistant)
-    end
-
-    # @return [Hash] Hash is relative to a component with a +belongs_to+ association with a Course.
-    def course_managers_hash
-      course_course_user_hash(*CourseUser::MANAGER_ROLES.to_a)
-    end
-  end
-
   module InstanceHelpers
     protected
 
@@ -121,7 +62,6 @@ class AbilityHost
   # Open the Componentize Base Component.
   const_get(:Component).module_eval do
     include InstanceHelpers
-    include CourseHelpers
     include TimeBoundedHelpers
   end
 

--- a/app/models/components/course/discussions_ability_component.rb
+++ b/app/models/components/course/discussions_ability_component.rb
@@ -6,9 +6,11 @@ module Course::DiscussionsAbilityComponent
     if course_user
       allow_course_users_show_topics
       allow_course_users_mark_topics_as_read
-      allow_course_teaching_staff_manage_discussion_topics
       allow_course_users_create_posts
       allow_course_users_reply_and_vote_posts
+      allow_course_users_view_own_anonymous_posts
+      allow_course_staff_view_anonymous_posts if course_user.staff?
+      allow_course_teaching_staff_manage_discussion_topics if course_user.teaching_staff?
       allow_course_teaching_staff_manage_posts if course_user.teaching_staff?
       allow_course_users_update_delete_own_post
     end
@@ -27,7 +29,7 @@ module Course::DiscussionsAbilityComponent
   end
 
   def allow_course_teaching_staff_manage_discussion_topics
-    can :manage, Course::Discussion::Topic, course_teaching_staff_hash
+    can :manage, Course::Discussion::Topic
   end
 
   def allow_course_users_create_posts
@@ -36,6 +38,14 @@ module Course::DiscussionsAbilityComponent
 
   def allow_course_users_reply_and_vote_posts
     can [:reply, :vote], Course::Discussion::Post, topic: { course_id: course.id }
+  end
+
+  def allow_course_users_view_own_anonymous_posts
+    can :view_anonymous, Course::Discussion::Post, creator_id: user.id
+  end
+
+  def allow_course_staff_view_anonymous_posts
+    can :view_anonymous, Course::Discussion::Post, topic: { course_id: course.id }
   end
 
   def allow_course_teaching_staff_manage_posts

--- a/app/models/components/course/duplication_ability_component.rb
+++ b/app/models/components/course/duplication_ability_component.rb
@@ -3,11 +3,12 @@ module Course::DuplicationAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    if user
-      disallow_superusers_duplicate_via_frontend
-      allow_managers_duplicate_to_course
-      allow_managers_duplicate_from_course
-      allow_observers_duplicate_from_course
+    disallow_superusers_duplicate_via_frontend if user
+
+    if course_user
+      allow_managers_duplicate_to_course if course_user.manager_or_owner?
+      allow_managers_duplicate_from_course if course_user.manager_or_owner?
+      allow_observers_duplicate_from_course if course_user.observer?
     end
 
     super
@@ -23,14 +24,14 @@ module Course::DuplicationAbilityComponent
   end
 
   def allow_managers_duplicate_to_course
-    can :duplicate_to, Course, managers_hash
+    can :duplicate_to, Course
   end
 
   def allow_managers_duplicate_from_course
-    can :duplicate_from, Course, managers_hash
+    can :duplicate_from, Course
   end
 
   def allow_observers_duplicate_from_course
-    can :duplicate_from, Course, course_user_hash(:observer)
+    can :duplicate_from, Course
   end
 end

--- a/app/models/components/course/experience_points_disbursement_ability_component.rb
+++ b/app/models/components/course/experience_points_disbursement_ability_component.rb
@@ -3,7 +3,7 @@ module Course::ExperiencePointsDisbursementAbilityComponent
   include AbilityHost::Component
 
   def define_permissions
-    allow_staff_disburse_experience_points if user
+    allow_staff_disburse_experience_points if course_user&.teaching_staff?
 
     super
   end
@@ -11,7 +11,7 @@ module Course::ExperiencePointsDisbursementAbilityComponent
   private
 
   def allow_staff_disburse_experience_points
-    can :disburse, Course::ExperiencePoints::Disbursement, course_teaching_staff_hash
-    can :disburse, Course::ExperiencePoints::ForumDisbursement, course_teaching_staff_hash
+    can :disburse, Course::ExperiencePoints::Disbursement
+    can :disburse, Course::ExperiencePoints::ForumDisbursement
   end
 end

--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -107,6 +107,6 @@ module Course::VideosAbilityComponent
   end
 
   def allow_course_managers_manage_video_tab
-    can :manage, Course::Video::Tab, course_managers_hash
+    can :manage, Course::Video::Tab
   end
 end

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -197,23 +197,19 @@ module Course::Assessment::AssessmentAbility
         discussion_topic: { course_id: course.id }
   end
 
-  def assessment_course_staff_hash
-    { tab: { category: course_staff_hash } }
-  end
-
   # Teaching assistants have all assessment abilities except :publish_grades
   def disallow_teaching_staff_publish_assessment_submission_grades
-    cannot :publish_grades, Course::Assessment, assessment_course_staff_hash
+    cannot :publish_grades, Course::Assessment
   end
 
   # Teaching assistants have all assessment abilities except :force_submit_submission
   def disallow_teaching_staff_force_submit_assessment_submissions
-    cannot :force_submit_assessment_submission, Course::Assessment, assessment_course_staff_hash
+    cannot :force_submit_assessment_submission, Course::Assessment
   end
 
   # Teaching assistants can only delete his/her own submission
   def disallow_teaching_staff_delete_assessment_submissions
-    cannot :delete_all_submissions, Course::Assessment, assessment_course_staff_hash
+    cannot :delete_all_submissions, Course::Assessment
   end
 
   def define_manager_assessment_permissions

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -33,6 +33,7 @@ class Course::Discussion::Post < ApplicationRecord
   validates :updater, presence: true
   validates :topic, presence: true
   validates :workflow_state, length: { maximum: 255 }, presence: true
+  validates :is_anonymous, inclusion: { in: [true, false] }
 
   belongs_to :topic, inverse_of: :posts, touch: true
   has_many :votes, inverse_of: :post, dependent: :destroy

--- a/app/models/course/settings/forums_component.rb
+++ b/app/models/course/settings/forums_component.rb
@@ -41,7 +41,7 @@ class Course::Settings::ForumsComponent < Course::Settings::Component
 
   # Returns the user type that can mark/unmark post as answer
   #
-  # @return [Integer] The pagination count of forum
+  # @return [Integer] The mark post as answer setting
   def mark_post_as_answer_setting
     settings.mark_post_as_answer_setting || 'creator_only'
   end
@@ -54,5 +54,19 @@ class Course::Settings::ForumsComponent < Course::Settings::Component
       unless FORUM_POST_MARK_ANSWER_USER_VALUES.include?(setting)
 
     settings.mark_post_as_answer_setting = setting
+  end
+
+  # Returns the forum setting to allow anonymous post
+  #
+  # @return [Integer] The allow anonymous post setting
+  def allow_anonymous_post
+    settings.allow_anonymous_post || false
+  end
+
+  # Sets if anonymous post is allowed in forums
+  #
+  # @param [Integer] count The new setting
+  def allow_anonymous_post=(allow_anonymous_post)
+    settings.allow_anonymous_post = allow_anonymous_post
   end
 end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -197,6 +197,13 @@ class CourseUser < ApplicationRecord
     TEACHING_STAFF_ROLES.include?(CourseUser.roles[role.to_sym])
   end
 
+  # Test whether this course_user is an observer
+  #
+  # @return [Boolean] True if course_user is an observer
+  def observer?
+    role.to_sym == :observer
+  end
+
   # Test whether this course_user is a real student (i.e. not phantom and not staff)
   #
   # @return [Boolean]

--- a/app/notifiers/course/forum/post_notifier.rb
+++ b/app/notifiers/course/forum/post_notifier.rb
@@ -12,7 +12,7 @@ class Course::Forum::PostNotifier < Notifier::Base
     return unless email_enabled.regular || email_enabled.phantom
 
     activity = create_activity(actor: user, object: post, event: :replied)
-    activity.notify(course, :feed) if course_user && !course_user.phantom?
+    activity.notify(course, :feed) if course_user && !course_user.phantom? && !post.is_anonymous
 
     post.topic.subscriptions.includes(:user).each do |subscription|
       course_user = course.course_users.find_by(user: subscription.user)

--- a/app/views/course/admin/forum_settings/edit.json.jbuilder
+++ b/app/views/course/admin/forum_settings/edit.json.jbuilder
@@ -2,3 +2,4 @@
 json.title @settings.title || ''
 json.pagination @settings.pagination.to_i
 json.markPostAsAnswerSetting @settings.mark_post_as_answer_setting
+json.allowAnonymousPost @settings.allow_anonymous_post

--- a/app/views/course/forum/posts/_post_list_data.json.jbuilder
+++ b/app/views/course/forum/posts/_post_list_data.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+allow_anonymous_post = current_course.settings(:course_forums_component).allow_anonymous_post
+is_anonymous = post.is_anonymous && allow_anonymous_post
 
 json.id post.id
 json.topicId @topic.id
@@ -11,18 +13,23 @@ json.isUnread post.unread?(current_user)
 json.hasUserVoted !post.vote_for(current_user).nil?
 json.userVoteFlag post.vote_for(current_user)&.vote_flag?
 json.voteTally post.vote_tally
+json.isAnonymous is_anonymous
 
-json.creator do
-  creator = post.creator
-  user = @course_users_hash&.fetch(creator.id, creator) || creator
-  json.id user.id
-  json.userUrl url_to_user_or_course_user(current_course, user)
-  json.name display_user(user)
-  json.imageUrl user_image(creator)
+if (is_anonymous && can?(:view_anonymous, post)) || !is_anonymous
+  json.creator do
+    creator = post.creator
+    user = @course_users_hash&.fetch(creator.id, creator) || creator
+    json.id user.id
+    json.userUrl url_to_user_or_course_user(current_course, user)
+    json.name display_user(user)
+    json.imageUrl user_image(creator)
+  end
 end
 
 json.permissions do
   json.canEditPost can?(:edit, post)
   json.canDeletePost can?(:destroy, post)
   json.canReplyPost can?(:reply, @topic)
+  json.canViewAnonymous can?(:view_anonymous, post)
+  json.isAnonymousEnabled allow_anonymous_post
 end

--- a/app/views/course/forum/topics/_topic_list_data.json.jbuilder
+++ b/app/views/course/forum/topics/_topic_list_data.json.jbuilder
@@ -57,4 +57,5 @@ json.permissions do
   json.canSetLockedTopic can?(:set_locked, topic)
   json.canReplyTopic can?(:reply, topic)
   json.canToggleAnswer can?(:toggle_answer, topic)
+  json.isAnonymousEnabled current_course.settings(:course_forums_component).allow_anonymous_post
 end

--- a/app/views/course/statistics/aggregate/all_students.json.jbuilder
+++ b/app/views/course/statistics/aggregate/all_students.json.jbuilder
@@ -17,7 +17,15 @@ json.students @all_students do |student|
   json.name student.name
   json.nameLink course_user_path(current_course, student)
   json.studentType student.phantom? ? 'Phantom' : 'Normal'
-  json.groupManagers @service.group_managers_of(student).map(&:name).join(', ') unless no_group_managers
+
+  unless no_group_managers
+    json.groupManagers @service.group_managers_of(student) do |manager|
+      json.id manager.id
+      json.name manager.name
+      json.nameLink course_user_path(current_course, manager)
+    end
+  end
+
   if is_course_gamified
     json.level student.level_number
     json.experiencePoints student.experience_points

--- a/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
+++ b/app/views/notifiers/course/forum/post_notifier/replied/user_notifications/email.html.slim
@@ -7,7 +7,7 @@
 
 - course_title = format_inline_text(course.title)
 - topic_title = format_inline_text(topic.title)
-- post_author = format_inline_text(post.author_name)
+- post_author = post.is_anonymous ? t('notifiers.course.anonymous_user') : format_inline_text(post.author_name)
 
 - message.subject = t('.subject', course: course_title, topic: topic_title)
 - message.subject += ' ' + t('notifiers.course.phantom') if course_user&.phantom?

--- a/client/app/api/course/Forum/Forums.ts
+++ b/client/app/api/course/Forum/Forums.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { ForumPostData } from 'types/course/disbursement';
+import { ForumDisbursementPostData } from 'types/course/disbursement';
 import {
   ForumData,
   ForumListData,
@@ -96,11 +96,9 @@ export default class ForumsAPI extends BaseCourseAPI {
   /**
    * Fetches forum post data with search params.
    */
-  search(params: ForumSearchParams): Promise<
-    AxiosResponse<{
-      userPosts: ForumPostData[];
-    }>
-  > {
+  search(
+    params: ForumSearchParams,
+  ): Promise<AxiosResponse<{ userPosts: ForumDisbursementPostData[] }>> {
     return this.getClient().get(`${this._getUrlPrefix()}/search`, params);
   }
 }

--- a/client/app/api/course/Forum/Forums.ts
+++ b/client/app/api/course/Forum/Forums.ts
@@ -4,7 +4,9 @@ import {
   ForumData,
   ForumListData,
   ForumMetadata,
+  ForumPatchData,
   ForumPermissions,
+  ForumPostData,
   ForumSearchParams,
   ForumTopicListData,
 } from 'types/course/forums';
@@ -43,7 +45,7 @@ export default class ForumsAPI extends BaseCourseAPI {
   /**
    * Creates a new forum.
    */
-  create(params: FormData): Promise<AxiosResponse<ForumListData>> {
+  create(params: ForumPostData): Promise<AxiosResponse<ForumListData>> {
     return this.getClient().post(this._getUrlPrefix(), params);
   }
 
@@ -52,7 +54,7 @@ export default class ForumsAPI extends BaseCourseAPI {
    */
   update(
     forumId: number,
-    params: FormData,
+    params: ForumPatchData,
   ): Promise<AxiosResponse<ForumListData>> {
     return this.getClient().patch(`${this._getUrlPrefix()}/${forumId}`, params);
   }

--- a/client/app/api/course/Forum/Posts.ts
+++ b/client/app/api/course/Forum/Posts.ts
@@ -1,6 +1,9 @@
 import { AxiosResponse } from 'axios';
 import { RecursiveArray } from 'types';
-import { ForumTopicPostListData } from 'types/course/forums';
+import {
+  ForumTopicPostListData,
+  ForumTopicPostPostData,
+} from 'types/course/forums';
 
 import BaseCourseAPI from '../Base';
 
@@ -15,8 +18,7 @@ export default class PostsAPI extends BaseCourseAPI {
   create(
     forumId: string,
     topicId: string,
-    postText: string,
-    parentId?: number,
+    discussionPost: ForumTopicPostPostData,
   ): Promise<
     AxiosResponse<{
       post: ForumTopicPostListData;
@@ -25,7 +27,7 @@ export default class PostsAPI extends BaseCourseAPI {
   > {
     return this.getClient().post(
       `${this._getUrlPrefix()}/${forumId}/topics/${topicId}/posts`,
-      { discussion_post: { text: postText, parent_id: parentId } },
+      discussionPost,
     );
   }
 

--- a/client/app/api/course/Forum/Topics.ts
+++ b/client/app/api/course/Forum/Topics.ts
@@ -3,6 +3,8 @@ import { RecursiveArray } from 'types';
 import {
   ForumTopicData,
   ForumTopicListData,
+  ForumTopicPatchData,
+  ForumTopicPostData,
   ForumTopicPostListData,
 } from 'types/course/forums';
 
@@ -36,7 +38,7 @@ export default class TopicsAPI extends BaseCourseAPI {
    */
   create(
     forumId: string,
-    params: FormData,
+    params: ForumTopicPostData,
   ): Promise<
     AxiosResponse<{
       redirectUrl: string;
@@ -53,7 +55,7 @@ export default class TopicsAPI extends BaseCourseAPI {
    */
   update(
     urlSlug: string,
-    params: FormData,
+    params: ForumTopicPatchData,
   ): Promise<AxiosResponse<ForumTopicListData>> {
     return this.getClient().patch(`${urlSlug}`, params);
   }

--- a/client/app/bundles/course/admin/pages/ForumsSettings/ForumsSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/ForumsSettings/ForumsSettingsForm.tsx
@@ -7,6 +7,7 @@ import { number, object, string } from 'yup';
 import RadioButton from 'lib/components/core/buttons/RadioButton';
 import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormTextField from 'lib/components/form/fields/TextField';
 import Form, { FormEmitter } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -80,6 +81,21 @@ const ForumsSettingsForm = (props: ForumsSettingsFormProps): JSX.Element => {
               />
             )}
           />
+
+          <Subsection spaced title={t(translations.allowStudentsTo)}>
+            <Controller
+              control={control}
+              name="allowAnonymousPost"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormCheckboxField
+                  disabled={props.disabled}
+                  field={field}
+                  fieldState={fieldState}
+                  label={t(translations.allowAnonymousPost)}
+                />
+              )}
+            />
+          </Subsection>
 
           <Subsection
             className="!mt-8"

--- a/client/app/bundles/course/admin/pages/ForumsSettings/ForumsSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/ForumsSettings/ForumsSettingsForm.tsx
@@ -88,6 +88,7 @@ const ForumsSettingsForm = (props: ForumsSettingsFormProps): JSX.Element => {
               name="allowAnonymousPost"
               render={({ field, fieldState }): JSX.Element => (
                 <FormCheckboxField
+                  description={t(translations.allowAnonymousPostDescription)}
                   disabled={props.disabled}
                   field={field}
                   fieldState={fieldState}

--- a/client/app/bundles/course/admin/pages/ForumsSettings/operations.ts
+++ b/client/app/bundles/course/admin/pages/ForumsSettings/operations.ts
@@ -19,6 +19,7 @@ export const updateForumsSettings = async (data: ForumsSettingsData): Data => {
       title: data.title,
       pagination: data.pagination,
       mark_post_as_answer_setting: data.markPostAsAnswerSetting,
+      allow_anonymous_post: data.allowAnonymousPost,
     },
   };
 

--- a/client/app/bundles/course/admin/pages/ForumsSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/ForumsSettings/translations.ts
@@ -35,4 +35,9 @@ export default defineMessages({
     id: 'course.admin.ForumsSettings.allowAnonymousPost',
     defaultMessage: 'Post anonymously',
   },
+  allowAnonymousPostDescription: {
+    id: 'course.admin.ForumsSettings.allowAnonymousPostDescription',
+    defaultMessage:
+      'Post creator and course instructors are still able to view the identity of the original author.',
+  },
 });

--- a/client/app/bundles/course/admin/pages/ForumsSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/ForumsSettings/translations.ts
@@ -27,4 +27,12 @@ export default defineMessages({
     defaultMessage:
       'Everyone (including staff) can mark/unmark a post as the correct answer.',
   },
+  allowStudentsTo: {
+    id: 'course.admin.ForumsSettings.allowStudentsTo',
+    defaultMessage: 'Allow students to',
+  },
+  allowAnonymousPost: {
+    id: 'course.admin.ForumsSettings.allowAnonymousPost',
+    defaultMessage: 'Post anonymously',
+  },
 });

--- a/client/app/bundles/course/announcements/pages/AnnouncementsIndex/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementsIndex/index.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify';
 import { AppDispatch, AppState } from 'types/store';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Note from 'lib/components/core/Note';
 import PageHeader from 'lib/components/navigation/PageHeader';
 
 import NewAnnouncementButton from '../../components/buttons/NewAnnouncementButton';
@@ -86,7 +87,7 @@ const AnnouncementsIndex: FC<Props> = (props) => {
       ) : (
         <>
           {announcements.length === 0 ? (
-            <div>{intl.formatMessage(translations.noAnnouncements)}</div>
+            <Note message={intl.formatMessage(translations.noAnnouncements)} />
           ) : (
             <AnnouncementsDisplay
               announcementPermissions={announcementPermissions}

--- a/client/app/bundles/course/assessment/components/FileManager/index.tsx
+++ b/client/app/bundles/course/assessment/components/FileManager/index.tsx
@@ -175,7 +175,7 @@ const FileManager = (props: FileManagerProps): JSX.Element => {
     const url = getWorkbinFileURL(getCourseId(), props.folderId, material.id);
 
     return (
-      <a href={url} rel="noreferrer" target="_blank">
+      <a href={url} rel="noopener noreferrer" target="_blank">
         {value}
       </a>
     );

--- a/client/app/bundles/course/assessment/skills/components/tables/SkillsTable.tsx
+++ b/client/app/bundles/course/assessment/skills/components/tables/SkillsTable.tsx
@@ -24,6 +24,7 @@ import {
 } from 'types/course/assessment/skills/skills';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
+import Note from 'lib/components/core/Note';
 
 import { TableEnum } from '../../types';
 import SkillManagementButtons from '../buttons/SkillManagementButtons';
@@ -141,7 +142,7 @@ const SkillsTable: FC<Props> = (props: Props) => {
             );
           }
           if (tableData.length === 0) {
-            return <div>{intl.formatMessage(translations.noBranch)}</div>;
+            return <Note message={intl.formatMessage(translations.noBranch)} />;
           }
           title =
             tableData[dataIndex].title ??

--- a/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse/SelectedPostCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/ForumPostResponse/SelectedPostCard.jsx
@@ -61,7 +61,7 @@ export default class SelectedPostCard extends Component {
       renderedName = `${renderedName.slice(0, MAX_NAME_LENGTH)}...`;
     }
     return (
-      <a href={url} rel="noreferrer" target="_blank">
+      <a href={url} rel="noopener noreferrer" target="_blank">
         {renderedName} <i className="fa fa-external-link" />
       </a>
     );

--- a/client/app/bundles/course/assessment/submissions/components/tables/SubmissionsTable.tsx
+++ b/client/app/bundles/course/assessment/submissions/components/tables/SubmissionsTable.tsx
@@ -16,6 +16,7 @@ import { SubmissionMiniEntity } from 'types/course/assessment/submissions';
 
 import CustomTooltip from 'lib/components/core/CustomTooltip';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Note from 'lib/components/core/Note';
 import { getAssessmentURL, getCourseUserURL } from 'lib/helpers/url-builders';
 import { getCourseId } from 'lib/helpers/url-helpers';
 import { formatMiniDateTime } from 'lib/moment';
@@ -115,9 +116,7 @@ const SubmissionsTable: FC<Props> = (props) => {
 
   if (submissions.length === 0) {
     return (
-      <div style={{ marginTop: 10 }}>
-        {intl.formatMessage(translations.noSubmissionsMessage)}
-      </div>
+      <Note message={intl.formatMessage(translations.noSubmissionsMessage)} />
     );
   }
 

--- a/client/app/bundles/course/experience-points/disbursement/actions.ts
+++ b/client/app/bundles/course/experience-points/disbursement/actions.ts
@@ -2,8 +2,8 @@ import {
   DisbursementCourseGroupListData,
   DisbursementCourseUserListData,
   ForumDisbursementFilters,
+  ForumDisbursementPostData,
   ForumDisbursementUserData,
-  ForumPostData,
 } from 'types/course/disbursement';
 
 import {
@@ -46,7 +46,7 @@ export function removeForumDisbursementList(): RemoveForumDisbursementListAction
 }
 
 export function saveForumPostList(
-  posts: ForumPostData[],
+  posts: ForumDisbursementPostData[],
   userId: number,
 ): SaveForumPostListAction {
   return {

--- a/client/app/bundles/course/experience-points/disbursement/components/tables/DisbursementTable.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/components/tables/DisbursementTable.tsx
@@ -79,7 +79,7 @@ const DisbursementTable: FC<Props> = (props: Props) => {
         customBodyRenderLite: (dataIndex): JSX.Element => (
           <a
             href={getCourseUserURL(getCourseId(), filteredUsers[dataIndex].id)}
-            rel="noreferrer"
+            rel="noopener noreferrer"
             target="_blank"
           >
             {filteredUsers[dataIndex].name}

--- a/client/app/bundles/course/experience-points/disbursement/components/tables/ForumDisbursementTable.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/components/tables/ForumDisbursementTable.tsx
@@ -91,7 +91,7 @@ const ForumDisbursementTable: FC<Props> = (props: Props) => {
         customBodyRenderLite: (dataIndex): JSX.Element => (
           <a
             href={getCourseUserURL(getCourseId(), forumUsers[dataIndex].id)}
-            rel="noreferrer"
+            rel="noopener noreferrer"
             target="_blank"
           >
             {forumUsers[dataIndex].name}

--- a/client/app/bundles/course/experience-points/disbursement/components/tables/ForumPostTable.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/components/tables/ForumPostTable.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
 import { CardContent, TableCell, TableRow, Typography } from '@mui/material';
 import { TableColumns, TableOptions } from 'types/components/DataTable';
-import { ForumPostEntity } from 'types/course/disbursement';
+import { ForumDisbursementPostEntity } from 'types/course/disbursement';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
 import { getForumTopicURL } from 'lib/helpers/url-builders';
@@ -10,7 +10,7 @@ import { getCourseId } from 'lib/helpers/url-helpers';
 import { formatLongDateTime } from 'lib/moment';
 
 interface Props extends WrappedComponentProps {
-  posts: ForumPostEntity[];
+  posts: ForumDisbursementPostEntity[];
 }
 
 const translations = defineMessages({

--- a/client/app/bundles/course/experience-points/disbursement/operations.ts
+++ b/client/app/bundles/course/experience-points/disbursement/operations.ts
@@ -7,9 +7,9 @@ import {
   ForumDisbursementFilterParams,
   ForumDisbursementFilters,
   ForumDisbursementFormData,
+  ForumDisbursementPostData,
   ForumDisbursementUserData,
   ForumDisbursementUserEntity,
-  ForumPostData,
 } from 'types/course/disbursement';
 import { ForumSearchParams } from 'types/course/forums';
 import { Operation } from 'types/store';
@@ -179,7 +179,7 @@ export function fetchForumPost(
   filter: ForumDisbursementFilters,
 ): Operation<
   AxiosResponse<{
-    userPosts: ForumPostData[];
+    userPosts: ForumDisbursementPostData[];
   }>
 > {
   const searchAttributes: ForumSearchParams = formatSearchAttribute(

--- a/client/app/bundles/course/experience-points/disbursement/types.ts
+++ b/client/app/bundles/course/experience-points/disbursement/types.ts
@@ -4,10 +4,10 @@ import {
   DisbursementCourseUserListData,
   DisbursementCourseUserMiniEntity,
   ForumDisbursementFilters,
+  ForumDisbursementPostData,
+  ForumDisbursementPostEntity,
   ForumDisbursementUserData,
   ForumDisbursementUserEntity,
-  ForumPostData,
-  ForumPostEntity,
 } from 'types/course/disbursement';
 import { EntityStore } from 'types/store';
 
@@ -41,7 +41,7 @@ export interface RemoveForumDisbursementListAction {
 
 export interface SaveForumPostListAction {
   type: typeof SAVE_FORUM_POST_LIST;
-  posts: ForumPostData[];
+  posts: ForumDisbursementPostData[];
   userId: number;
 }
 
@@ -58,5 +58,5 @@ export interface DisbursementState {
   courseUsers: EntityStore<DisbursementCourseUserMiniEntity>;
   filters: ForumDisbursementFilters;
   forumUsers: EntityStore<ForumDisbursementUserEntity>;
-  forumPosts: EntityStore<ForumPostEntity>;
+  forumPosts: EntityStore<ForumDisbursementPostEntity>;
 }

--- a/client/app/bundles/course/forum/components/forms/ForumTopicPostForm.tsx
+++ b/client/app/bundles/course/forum/components/forms/ForumTopicPostForm.tsx
@@ -1,0 +1,93 @@
+import { FC } from 'react';
+import { Controller } from 'react-hook-form';
+import { defineMessages } from 'react-intl';
+import { ForumTopicPostFormData } from 'types/course/forums';
+import * as yup from 'yup';
+
+import FormDialog from 'lib/components/form/dialog/FormDialog';
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
+import FormRichTextField from 'lib/components/form/fields/RichTextField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  open: boolean;
+  editing: boolean;
+  title: string;
+  onClose: () => void;
+  onSubmit: (data: ForumTopicPostFormData) => void;
+  initialValues: ForumTopicPostFormData;
+  isAnonymousEnabled: boolean;
+}
+
+const translations = defineMessages({
+  postAnonymously: {
+    id: 'course.forum.ForumTopicPostForm.postAnonymously',
+    defaultMessage: 'Anonymous post',
+  },
+});
+
+const validationSchema = yup.object({
+  text: yup.string(),
+});
+
+const ForumTopicPostForm: FC<Props> = (props) => {
+  const {
+    open,
+    title,
+    editing,
+    onClose,
+    initialValues,
+    isAnonymousEnabled,
+    onSubmit,
+  } = props;
+  const { t } = useTranslation();
+
+  return (
+    <FormDialog
+      editing={editing}
+      formName="forum-topic-post-form"
+      initialValues={initialValues}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      open={open}
+      title={title}
+      validationSchema={validationSchema}
+    >
+      {(control, formState): JSX.Element => (
+        <>
+          <Controller
+            control={control}
+            name="text"
+            render={({ field, fieldState }): JSX.Element => (
+              <FormRichTextField
+                disabled={formState.isSubmitting}
+                disableMargins
+                field={field}
+                fieldState={fieldState}
+                fullWidth
+                required
+              />
+            )}
+          />
+
+          {isAnonymousEnabled && !editing && (
+            <Controller
+              control={control}
+              name="isAnonymous"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormCheckboxField
+                  disabled={formState.isSubmitting}
+                  field={field}
+                  fieldState={fieldState}
+                  label={t(translations.postAnonymously)}
+                />
+              )}
+            />
+          )}
+        </>
+      )}
+    </FormDialog>
+  );
+};
+
+export default ForumTopicPostForm;

--- a/client/app/bundles/course/forum/operations.ts
+++ b/client/app/bundles/course/forum/operations.ts
@@ -26,51 +26,6 @@ import {
   updatePostAsAnswer,
 } from './reducers';
 
-/**
- * Prepares and maps object attributes to a FormData object for an post/patch request.
- */
-const formatForumAttributes = (data: ForumFormData): FormData => {
-  const payload = new FormData();
-
-  ['name', 'description', 'forumTopicsAutoSubscribe'].forEach((field) => {
-    if (data[field] !== undefined && data[field] !== null) {
-      switch (field) {
-        case 'forumTopicsAutoSubscribe':
-          payload.append(
-            'forum[forum_topics_auto_subscribe]',
-            data[field].toString(),
-          );
-          break;
-        default:
-          payload.append(`forum[${field}]`, data[field]);
-          break;
-      }
-    }
-  });
-  return payload;
-};
-
-const formatForumTopicAttributes = (data: ForumTopicFormData): FormData => {
-  const payload = new FormData();
-
-  ['title', 'text', 'topicType'].forEach((field) => {
-    if (data[field] !== undefined && data[field] !== null) {
-      switch (field) {
-        case 'text':
-          payload.append('topic[posts_attributes][0][text]', data[field]!);
-          break;
-        case 'topicType':
-          payload.append('topic[topic_type]', data[field]);
-          break;
-        default:
-          payload.append(`topic[${field}]`, data[field]);
-          break;
-      }
-    }
-  });
-  return payload;
-};
-
 // Forum
 
 export function fetchForums(): Operation<void> {
@@ -98,21 +53,34 @@ export function fetchForum(forumId: string): Operation<number> {
       });
 }
 
-export function createForum(formData: ForumFormData): Operation<void> {
-  const attributes = formatForumAttributes(formData);
+export function createForum(forumFormData: ForumFormData): Operation<void> {
+  const adaptedData = {
+    forum: {
+      name: forumFormData.name,
+      description: forumFormData.description,
+      forum_topics_auto_subscribe: forumFormData.forumTopicsAutoSubscribe,
+    },
+  };
   return async (dispatch) =>
-    CourseAPI.forum.forums.create(attributes).then((response) => {
+    CourseAPI.forum.forums.create(adaptedData).then((response) => {
       dispatch(saveForumListData(response.data));
     });
 }
 
 export function updateForum(
-  formData: ForumFormData,
+  forumFormData: ForumFormData,
   forumId: number,
 ): Operation<{ forumUrl: string }> {
-  const attributes = formatForumAttributes(formData);
+  const adaptedData = {
+    forum: {
+      id: forumFormData.id,
+      name: forumFormData.name,
+      description: forumFormData.description,
+      forum_topics_auto_subscribe: forumFormData.forumTopicsAutoSubscribe,
+    },
+  };
   return async (dispatch) =>
-    CourseAPI.forum.forums.update(forumId, attributes).then((response) => {
+    CourseAPI.forum.forums.update(forumId, adaptedData).then((response) => {
       dispatch(updateForumListData(response.data));
       return { forumUrl: response.data.forumUrl };
     });
@@ -172,23 +140,36 @@ export function fetchForumTopic(
 
 export function createForumTopic(
   forumId: string,
-  formData: ForumTopicFormData,
+  topicFormData: ForumTopicFormData,
 ): Operation<
   AxiosResponse<{
     redirectUrl: string;
   }>
 > {
-  const attributes = formatForumTopicAttributes(formData);
-  return async (_) => CourseAPI.forum.topics.create(forumId, attributes);
+  const adaptedData = {
+    topic: {
+      title: topicFormData.title,
+      topic_type: topicFormData.topicType,
+      posts_attributes: [{ text: topicFormData.text }],
+    },
+  };
+  return async (_) => CourseAPI.forum.topics.create(forumId, adaptedData);
 }
 
 export function updateForumTopic(
   topicUrl: string,
-  formData: ForumTopicFormData,
+  topicFormData: ForumTopicFormData,
 ): Operation<{ topicUrl: string }> {
-  const attributes = formatForumTopicAttributes(formData);
+  const adaptedData = {
+    topic: {
+      id: topicFormData.id,
+      title: topicFormData.title,
+      topic_type: topicFormData.topicType,
+      posts_attributes: [{ text: topicFormData.text }],
+    },
+  };
   return async (dispatch) =>
-    CourseAPI.forum.topics.update(topicUrl, attributes).then((response) => {
+    CourseAPI.forum.topics.update(topicUrl, adaptedData).then((response) => {
       dispatch(updateForumTopicListData(response.data));
       return { topicUrl: response.data.topicUrl };
     });

--- a/client/app/bundles/course/forum/operations.ts
+++ b/client/app/bundles/course/forum/operations.ts
@@ -1,5 +1,9 @@
 import { AxiosResponse } from 'axios';
-import { ForumFormData, ForumTopicFormData } from 'types/course/forums';
+import {
+  ForumFormData,
+  ForumTopicFormData,
+  ForumTopicPostFormData,
+} from 'types/course/forums';
 import { Operation } from 'types/store';
 
 import CourseAPI from 'api/course';
@@ -229,12 +233,18 @@ export function updateForumTopicLocked(
 export function createForumTopicPost(
   forumId: string,
   topicId: string,
-  postText: string,
-  parentId?: number,
+  postFormData: ForumTopicPostFormData,
 ): Operation<{ postId: number }> {
-  return async (dispatch) =>
-    CourseAPI.forum.posts
-      .create(forumId, topicId, postText, parentId)
+  return async (dispatch) => {
+    const adaptedData = {
+      discussion_post: {
+        text: postFormData.text,
+        is_anonymous: postFormData.isAnonymous,
+        parent_id: postFormData.parentId,
+      },
+    };
+    return CourseAPI.forum.posts
+      .create(forumId, topicId, adaptedData)
       .then((response) => {
         dispatch(saveForumTopicPostListData(response.data.post));
         dispatch(
@@ -245,6 +255,7 @@ export function createForumTopicPost(
         );
         return { postId: response.data.post.id };
       });
+  };
 }
 
 export function updateForumTopicPost(

--- a/client/app/bundles/course/forum/pages/ForumTopicShow/index.tsx
+++ b/client/app/bundles/course/forum/pages/ForumTopicShow/index.tsx
@@ -15,8 +15,8 @@ import useTranslation from 'lib/hooks/useTranslation';
 import ForumTopicManagementButtons from '../../components/buttons/ForumTopicManagementButtons';
 import { fetchForumTopic } from '../../operations';
 import { getForumTopic } from '../../selectors';
+import ForumTopicPostNew from '../ForumTopicPostNew';
 
-import NewPostDialog from './NewPostDialog';
 import Topics from './Topics';
 
 const translations = defineMessages({
@@ -83,6 +83,7 @@ const ForumTopicShow: FC = () => {
     forumPageHeaderTitle = forumTopic.title;
     headerToolbars.push(
       <ForumTopicManagementButtons
+        key={forumTopic.id}
         navigateToIndexAfterDelete
         navigateToShowAfterUpdate
         topic={forumTopic}
@@ -118,7 +119,7 @@ const ForumTopicShow: FC = () => {
       <Box className="my-3 space-y-6">
         {topicNote && <Note message={topicNote} />}
         <Topics level={0} postIdsArray={forumTopic.postTreeIds} />
-        <NewPostDialog forumTopic={forumTopic} />
+        <ForumTopicPostNew forumTopic={forumTopic} />
       </Box>
     );
 

--- a/client/app/bundles/course/learning-map/components/Node/index.jsx
+++ b/client/app/bundles/course/learning-map/components/Node/index.jsx
@@ -133,7 +133,11 @@ const Node = (props) => {
           <div style={styles.content}>
             <CardContent style={styles.contentText}>
               <div>
-                <a href={`${node.contentUrl}`} rel="noreferrer" target="_blank">
+                <a
+                  href={`${node.contentUrl}`}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   {node.title}
                 </a>
               </div>

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/index.jsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/index.jsx
@@ -137,27 +137,27 @@ const StatisticsIndex = ({
             value={value}
           >
             <Tab
-              label={intl.formatMessage(translations.course)}
+              label={intl.formatMessage(translations.students)}
               {...a11yProps(0)}
             />
             <Tab
-              label={intl.formatMessage(translations.students)}
+              label={intl.formatMessage(translations.staff)}
               {...a11yProps(1)}
             />
             <Tab
-              label={intl.formatMessage(translations.staff)}
+              label={intl.formatMessage(translations.course)}
               {...a11yProps(2)}
             />
           </Tabs>
         </Box>
         <TabPanel index={0} value={value}>
-          <CourseStatistics {...courseStatistics} />
-        </TabPanel>
-        <TabPanel index={1} value={value}>
           <StudentsStatistics {...studentsStatistics} />
         </TabPanel>
-        <TabPanel index={2} value={value}>
+        <TabPanel index={1} value={value}>
           <StaffStatistics {...staffStatistics} />
+        </TabPanel>
+        <TabPanel index={2} value={value}>
+          <CourseStatistics {...courseStatistics} />
         </TabPanel>
       </Box>
       <NotificationBar notification={courseStatistics.notification} />

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/students/index.jsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/students/index.jsx
@@ -123,7 +123,46 @@ const StudentsStatistics = ({ metadata, students, isFetching, isError }) => {
       label: intl.formatMessage(translations.groupManagers),
       options: {
         filter: true,
+        filterType: 'multiselect',
+        filterOptions: {
+          names: [
+            ...new Set(
+              students.flatMap((s) => s.groupManagers.map((m) => m.name)),
+            ),
+          ],
+          logic: (managers, filters) => {
+            if (filters) {
+              const filterSet = new Set(filters);
+              return !managers
+                .map((m) => m.name)
+                .some((name) => filterSet.has(name));
+            }
+            return false;
+          },
+          fullWidth: true,
+        },
+        customFilterListOptions: {
+          render: (name) => `Tutor: ${name}`,
+        },
         sort: true,
+        customBodyRenderLite: (dataIndex) => {
+          const groupManagers = students[dataIndex].groupManagers;
+          if (!groupManagers) {
+            return '';
+          }
+          return (
+            <>
+              {groupManagers.map((m, index) => (
+                <span key={m.id}>
+                  <Link href={m.nameLink} opensInNewTab>
+                    {m.name}
+                  </Link>
+                  {index < groupManagers.length - 1 && ', '}
+                </span>
+              ))}
+            </>
+          );
+        },
       },
     });
   }

--- a/client/app/bundles/system/admin/instance/instance/components/tables/UsersTable.tsx
+++ b/client/app/bundles/system/admin/instance/instance/components/tables/UsersTable.tsx
@@ -270,7 +270,11 @@ const UsersTable: FC<Props> = (props) => {
               className="user_courses"
               variant="body2"
             >
-              <a href={`/users/${user.id}`} rel="noreferrer" target="_blank">
+              <a
+                href={`/users/${user.id}`}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
                 {user.courses}
               </a>
             </Typography>

--- a/client/app/bundles/system/admin/instance/instance/pages/InstanceAnnouncementsIndex/index.tsx
+++ b/client/app/bundles/system/admin/instance/instance/pages/InstanceAnnouncementsIndex/index.tsx
@@ -8,6 +8,7 @@ import AnnouncementsDisplay from 'bundles/course/announcements/components/misc/A
 import AnnouncementNew from 'bundles/course/announcements/pages/AnnouncementNew';
 import AddButton from 'lib/components/core/buttons/AddButton';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Note from 'lib/components/core/Note';
 import PageHeader from 'lib/components/navigation/PageHeader';
 
 import {
@@ -80,7 +81,7 @@ const InstanceAnnouncementsIndex: FC<Props> = (props) => {
   const renderBody: JSX.Element = (
     <>
       {announcements.length === 0 ? (
-        <div>{intl.formatMessage(translations.noAnnouncements)}</div>
+        <Note message={intl.formatMessage(translations.noAnnouncements)} />
       ) : (
         <AnnouncementsDisplay
           announcementPermissions={{ canCreate: announcementPermission }}

--- a/client/app/bundles/system/admin/instance/instance/pages/InstanceUsersInvitations/index.tsx
+++ b/client/app/bundles/system/admin/instance/instance/pages/InstanceUsersInvitations/index.tsx
@@ -28,10 +28,6 @@ const translations = defineMessages({
     id: 'system.admin.instance.instance.InstanceUsersInvitations.fetch.failure',
     defaultMessage: 'Failed to fetch invitations.',
   },
-  noInvitations: {
-    id: 'system.admin.instance.instance.InstanceUsersInvitations.noInvitations',
-    defaultMessage: 'There are no instance user invitations sent yet.',
-  },
   pending: {
     id: 'system.admin.instance.instance.InstanceUsersInvitations.pending',
     defaultMessage: 'Pending Invitations',

--- a/client/app/bundles/users/components/tables/CoursesTable.tsx
+++ b/client/app/bundles/users/components/tables/CoursesTable.tsx
@@ -52,7 +52,7 @@ const CoursesTable: FC<Props> = ({ title, courses, intl }: Props) => {
                 <Typography className="course_title" variant="body2">
                   <a
                     href={`/courses/${course.id}`}
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     target="_blank"
                   >
                     {course.title}
@@ -62,7 +62,7 @@ const CoursesTable: FC<Props> = ({ title, courses, intl }: Props) => {
               <TableCell>
                 <a
                   href={`/users/${course.courseUserId}`}
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   {course.courseUserName}

--- a/client/app/bundles/users/components/tables/InstancesTable.tsx
+++ b/client/app/bundles/users/components/tables/InstancesTable.tsx
@@ -40,7 +40,7 @@ const InstancesTable: FC<Props> = ({ title, instances, intl }: Props) => {
                 <Typography className="instance_title" variant="body2">
                   <a
                     href={`//${instance.host}/users/${userId}`}
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     target="_blank"
                   >
                     {instance.name}

--- a/client/app/lib/components/core/buttons/DeleteButton.tsx
+++ b/client/app/lib/components/core/buttons/DeleteButton.tsx
@@ -19,18 +19,30 @@ interface DeleteButtonProps extends IconButtonProps {
 }
 
 const DeleteButton = (props: DeleteButtonProps): JSX.Element => {
+  const {
+    disabled,
+    onClick,
+    confirmMessage,
+    children,
+    tooltip,
+    loading,
+    title,
+    confirmLabel,
+    ...otherProps
+  } = props;
   const { t } = useTranslation();
   const [dialogOpen, setDialogOpen] = useState(false);
-  const promptContents = props.confirmMessage ?? props.children;
+  const promptContents = confirmMessage ?? children;
 
   return (
     <>
-      <Tooltip title={props.tooltip ?? t(formTranslations.delete)}>
+      <Tooltip title={tooltip ?? t(formTranslations.delete)}>
         <span>
           <IconButton
             color="error"
-            {...props}
             data-testid="DeleteIconButton"
+            disabled={disabled}
+            {...otherProps}
             onClick={(): void => {
               if (promptContents) {
                 setDialogOpen(true);
@@ -46,15 +58,15 @@ const DeleteButton = (props: DeleteButtonProps): JSX.Element => {
 
       <Prompt
         contentClassName="space-y-4"
-        disabled={props.loading ?? props.disabled}
+        disabled={loading ?? disabled}
         onClickPrimary={(): void => {
-          props.onClick().finally(() => setDialogOpen(false));
+          onClick().finally(() => setDialogOpen(false));
         }}
         onClose={(): void => setDialogOpen(false)}
         open={dialogOpen}
         primaryColor="error"
-        primaryLabel={props.confirmLabel ?? t(formTranslations.delete)}
-        title={props.title}
+        primaryLabel={confirmLabel ?? t(formTranslations.delete)}
+        title={title}
       >
         {promptContents}
       </Prompt>

--- a/client/app/lib/components/core/fields/CKEditorRichText.tsx
+++ b/client/app/lib/components/core/fields/CKEditorRichText.tsx
@@ -2,23 +2,24 @@
 import { forwardRef, useState } from 'react';
 import CustomEditor from '@ckeditor/ckeditor5-build-custom';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
-import { InputLabel } from '@mui/material';
+import { FormHelperText, InputLabel } from '@mui/material';
 import { cyan } from '@mui/material/colors';
 
 import axios from 'lib/axios';
 
 interface Props {
-  label?: string;
-  value: string;
-  onChange: (text: string) => void;
-  disabled?: boolean;
-  field?: string | undefined;
-  required?: boolean | undefined;
-  name: string;
   inputId: string;
-  disableMargins?: boolean;
-  placeholder?: string;
+  name: string;
+  onChange: (text: string) => void;
+  value: string;
   autofocus?: boolean;
+  disabled?: boolean;
+  disableMargins?: boolean;
+  error?: string;
+  field?: string | undefined;
+  label?: string;
+  placeholder?: string;
+  required?: boolean | undefined;
 }
 
 const uploadAdapter = (loader) => {
@@ -53,6 +54,7 @@ const CKEditorRichText = forwardRef((props: Props, ref) => {
     value,
     onChange,
     disabled,
+    error,
     field,
     required,
     name,
@@ -81,6 +83,7 @@ const CKEditorRichText = forwardRef((props: Props, ref) => {
       {label && (
         <InputLabel
           disabled={disabled}
+          error={!!error}
           htmlFor={field}
           required={required}
           shrink
@@ -161,6 +164,7 @@ const CKEditorRichText = forwardRef((props: Props, ref) => {
           }}
         />
       </div>
+      {error && <FormHelperText error={!!error}>{error}</FormHelperText>}
     </div>
   );
 });

--- a/client/app/lib/components/form/FormDialogue.jsx
+++ b/client/app/lib/components/form/FormDialogue.jsx
@@ -15,7 +15,6 @@ import formTranslations from 'lib/translations/form';
 const propTypes = {
   title: PropTypes.string,
   hideForm: PropTypes.func,
-  submitForm: PropTypes.func,
   skipConfirmation: PropTypes.bool.isRequired,
   disabled: PropTypes.bool.isRequired,
   open: PropTypes.bool.isRequired,
@@ -56,8 +55,7 @@ class FormDialogue extends Component {
   };
 
   render() {
-    const { intl, title, disabled, form, open, submitForm, children } =
-      this.props;
+    const { intl, title, disabled, form, open, children } = this.props;
     const formActions = [
       <Button
         key="form-dialogue-cancel-button"
@@ -75,7 +73,8 @@ class FormDialogue extends Component {
         }}
         className="btn-submit"
         color="primary"
-        {...(form ? { form, type: 'submit' } : { onClick: submitForm })}
+        form={form}
+        type="submit"
         {...{ disabled }}
       >
         {intl.formatMessage(formTranslations.submit)}

--- a/client/app/lib/components/form/fields/RichTextField.jsx
+++ b/client/app/lib/components/form/fields/RichTextField.jsx
@@ -3,15 +3,19 @@ import PropTypes from 'prop-types';
 
 import CKEditorRichText from '../../core/fields/CKEditorRichText';
 
+import { formatErrorMessage } from './utils/mapError';
 import propsAreEqual from './utils/propsAreEqual';
 
 const FormRichTextField = (props) => {
   const { field, fieldState, disabled, label, ...custom } = props;
+  const error =
+    fieldState.error?.message && formatErrorMessage(fieldState.error?.message);
 
   return (
     <CKEditorRichText
       {...field}
       disabled={disabled}
+      error={error}
       label={label}
       {...custom}
     />

--- a/client/app/types/course/admin/forums.ts
+++ b/client/app/types/course/admin/forums.ts
@@ -2,6 +2,7 @@ export interface ForumsSettingsData {
   title: string;
   pagination: number;
   markPostAsAnswerSetting: 'creator_only' | 'everyone';
+  allowAnonymousPost: boolean;
 }
 
 export interface ForumsSettingsPostData {
@@ -9,5 +10,6 @@ export interface ForumsSettingsPostData {
     title: ForumsSettingsData['title'];
     pagination: ForumsSettingsData['pagination'];
     mark_post_as_answer_setting: ForumsSettingsData['markPostAsAnswerSetting'];
+    allow_anonymous_post: ForumsSettingsData['allowAnonymousPost'];
   };
 }

--- a/client/app/types/course/disbursement.ts
+++ b/client/app/types/course/disbursement.ts
@@ -18,7 +18,7 @@ export interface ForumDisbursementUserData {
   points: number;
 }
 
-export interface ForumPostData {
+export interface ForumDisbursementPostData {
   id: number;
   title: string;
   topicSlug: string;
@@ -65,14 +65,14 @@ export interface ForumDisbursementUserEntity {
   points: ForumDisbursementUserData['points'];
 }
 
-export interface ForumPostEntity {
-  id: ForumPostData['id'];
-  title: ForumPostData['title'];
-  topicSlug: ForumPostData['topicSlug'];
-  forumSlug: ForumPostData['forumSlug'];
-  content: ForumPostData['content'];
-  voteTally: ForumPostData['voteTally'];
-  createdAt: ForumPostData['createdAt'];
+export interface ForumDisbursementPostEntity {
+  id: ForumDisbursementPostData['id'];
+  title: ForumDisbursementPostData['title'];
+  topicSlug: ForumDisbursementPostData['topicSlug'];
+  forumSlug: ForumDisbursementPostData['forumSlug'];
+  content: ForumDisbursementPostData['content'];
+  voteTally: ForumDisbursementPostData['voteTally'];
+  createdAt: ForumDisbursementPostData['createdAt'];
   userId: number;
 }
 

--- a/client/app/types/course/forums.ts
+++ b/client/app/types/course/forums.ts
@@ -25,10 +25,15 @@ export type ForumTopicListDataPermissions = Permissions<
   | 'canSetLockedTopic'
   | 'canReplyTopic'
   | 'canToggleAnswer'
+  | 'isAnonymousEnabled'
 >;
 
 export type ForumTopicPostListDataPermissions = Permissions<
-  'canEditPost' | 'canDeletePost' | 'canReplyPost'
+  | 'canEditPost'
+  | 'canDeletePost'
+  | 'canReplyPost'
+  | 'canViewAnonymous'
+  | 'isAnonymousEnabled'
 >;
 
 export enum TopicType {
@@ -95,7 +100,8 @@ export interface ForumTopicPostListData {
   hasUserVoted: boolean;
   userVoteFlag: boolean | null;
   voteTally: number;
-  creator: { id: number; userUrl: string; name: string; imageUrl: string };
+  isAnonymous: boolean;
+  creator?: { id: number; userUrl: string; name: string; imageUrl: string };
 
   permissions: ForumTopicPostListDataPermissions;
 }
@@ -166,7 +172,8 @@ export interface ForumTopicPostEntity {
   hasUserVoted: ForumTopicPostListData['hasUserVoted'];
   userVoteFlag: ForumTopicPostListData['userVoteFlag'];
   voteTally: ForumTopicPostListData['voteTally'];
-  creator: ForumTopicPostListData['creator'];
+  isAnonymous: ForumTopicPostListData['isAnonymous'];
+  creator?: ForumTopicPostListData['creator'];
 
   permissions: ForumTopicPostListData['permissions'];
 }
@@ -226,6 +233,15 @@ export interface ForumTopicPatchData {
 export interface ForumTopicPostFormData {
   text: string;
   parentId: number | null;
+  isAnonymous?: boolean;
+}
+
+export interface ForumTopicPostPostData {
+  discussion_post: {
+    text: ForumTopicPostFormData['text'];
+    parent_id: ForumTopicPostFormData['parentId'];
+    is_anonymous?: ForumTopicPostFormData['isAnonymous'];
+  };
 }
 
 /**

--- a/client/app/types/course/forums.ts
+++ b/client/app/types/course/forums.ts
@@ -182,6 +182,23 @@ export interface ForumFormData {
   forumTopicsAutoSubscribe: boolean;
 }
 
+export interface ForumPostData {
+  forum: {
+    name: ForumFormData['name'];
+    description: ForumFormData['description'];
+    forum_topics_auto_subscribe: ForumFormData['forumTopicsAutoSubscribe'];
+  };
+}
+
+export interface ForumPatchData {
+  forum: {
+    id: ForumFormData['id'];
+    name: ForumFormData['name'];
+    description: ForumFormData['description'];
+    forum_topics_auto_subscribe: ForumFormData['forumTopicsAutoSubscribe'];
+  };
+}
+
 export interface ForumTopicFormData {
   id?: number;
   title: string;
@@ -189,14 +206,27 @@ export interface ForumTopicFormData {
   topicType: TopicType;
 }
 
+export interface ForumTopicPostData {
+  topic: {
+    title: ForumTopicFormData['title'];
+    topic_type: ForumTopicFormData['topicType'];
+    posts_attributes: { text: ForumTopicFormData['text'] }[];
+  };
+}
+
+export interface ForumTopicPatchData {
+  topic: {
+    id: ForumTopicFormData['id'];
+    title: ForumTopicFormData['title'];
+    topic_type: ForumTopicFormData['topicType'];
+    posts_attributes: { text: ForumTopicFormData['text'] }[];
+  };
+}
+
 export interface ForumTopicPostFormData {
   text: string;
   parentId: number | null;
 }
-
-// export interface VideoEditFormData extends VideoFormData {
-//   id: number;
-// }
 
 /**
  * Data types for forum search data sent to backend

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -533,6 +533,15 @@
   "course.admin.CourseSettingst.pleaseTypeChallengeToConfirmDelete": {
     "defaultMessage": "Please type {challenge} to confirm deletion."
   },
+  "course.admin.ForumsSettings.allowAnonymousPost": {
+    "defaultMessage": "Post anonymously"
+  },
+  "course.admin.ForumsSettings.allowAnonymousPostDescription": {
+    "defaultMessage": "Post creator and course instructors are still able to view the identity of the original author."
+  },
+  "course.admin.ForumsSettings.allowStudentsTo": {
+    "defaultMessage": "Allow students to"
+  },
   "course.admin.ForumsSettings.creatorOnly": {
     "defaultMessage": "Creator only"
   },
@@ -3560,6 +3569,9 @@
   "course.forum.ForumTopicNew.newTopic": {
     "defaultMessage": "New Topic"
   },
+  "course.forum.ForumTopicPostForm.postAnonymously": {
+    "defaultMessage": "Anonymous post"
+  },
   "course.forum.ForumTopicPostManagementButtons.deletionConfirm": {
     "defaultMessage": "Are you sure you wish to delete this topic post?"
   },
@@ -3569,13 +3581,13 @@
   "course.forum.ForumTopicPostManagementButtons.deletionSuccess": {
     "defaultMessage": "The post has been deleted."
   },
-  "course.forum.ForumTopicShow.NewPostDialog.creationFailure": {
+  "course.forum.ForumTopicPostNew.creationFailure": {
     "defaultMessage": "Failed to create the post - {error}"
   },
-  "course.forum.ForumTopicShow.NewPostDialog.creationSuccess": {
+  "course.forum.ForumTopicPostNew.creationSuccess": {
     "defaultMessage": "The post has been created."
   },
-  "course.forum.ForumTopicShow.NewPostDialog.header": {
+  "course.forum.ForumTopicPostNew.newPost": {
     "defaultMessage": "Create a New Post"
   },
   "course.forum.ForumTopicShow.fetchPostsFailure": {
@@ -3713,14 +3725,29 @@
   "course.forum.MarkAnswerButton.unmarkAsAnswer": {
     "defaultMessage": "Unmark as Answer"
   },
+  "course.forum.PostCard.anonymousUser": {
+    "defaultMessage": "Anonymous User"
+  },
   "course.forum.PostCard.emptyPost": {
     "defaultMessage": "Post cannot be empty!"
+  },
+  "course.forum.PostCard.maskUser": {
+    "defaultMessage": "Mask User"
+  },
+  "course.forum.PostCard.postAnonymously": {
+    "defaultMessage": "Anonymous post"
   },
   "course.forum.PostCard.replyFailure": {
     "defaultMessage": "Failed to submit the post - {error}"
   },
   "course.forum.PostCard.replySuccess": {
     "defaultMessage": "The reply post has been created."
+  },
+  "course.forum.PostCard.replyTo": {
+    "defaultMessage": "Reply to {user}"
+  },
+  "course.forum.PostCard.unmaskUser": {
+    "defaultMessage": "Unmask User"
   },
   "course.forum.PostCard.updateFailure": {
     "defaultMessage": "Failed to update the post - {error}"
@@ -6256,9 +6283,6 @@
   },
   "system.admin.instance.instance.InstanceUsersInvitations.header": {
     "defaultMessage": "Invitations"
-  },
-  "system.admin.instance.instance.InstanceUsersInvitations.noInvitations": {
-    "defaultMessage": "There are no instance user invitations sent yet."
   },
   "system.admin.instance.instance.InstanceUsersInvitations.pending": {
     "defaultMessage": "Pending Invitations"

--- a/config/locales/en/notifiers.yml
+++ b/config/locales/en/notifiers.yml
@@ -2,3 +2,4 @@ en:
   notifiers:
     course:
       phantom: "(Phantom)"
+      anonymous_user: "An anonymous user"

--- a/db/migrate/20230104073345_add_anonymous_to_forum_post.rb
+++ b/db/migrate/20230104073345_add_anonymous_to_forum_post.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddAnonymousToForumPost < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_discussion_posts, :is_anonymous, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_19_091113) do
+ActiveRecord::Schema.define(version: 2023_01_04_073345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -554,6 +554,7 @@ ActiveRecord::Schema.define(version: 2022_08_19_091113) do
     t.boolean "answer", default: false
     t.boolean "is_delayed", default: false, null: false
     t.string "workflow_state", default: "published"
+    t.boolean "is_anonymous", default: false, null: false
     t.index ["creator_id"], name: "fk__course_discussion_posts_creator_id"
     t.index ["parent_id"], name: "fk__course_discussion_posts_parent_id"
     t.index ["topic_id"], name: "fk__course_discussion_posts_topic_id"

--- a/spec/factories/course_discussion_posts.rb
+++ b/spec/factories/course_discussion_posts.rb
@@ -33,5 +33,9 @@ FactoryBot.define do
     trait :published do
       workflow_state { :published }
     end
+
+    trait :anonymous_post do
+      is_anonymous { true }
+    end
   end
 end

--- a/spec/features/course/admin/forum_settings_spec.rb
+++ b/spec/features/course/admin/forum_settings_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Course: Administration: Forums', js: true do
         click_button 'Save changes'
         expect_toastify('Your changes have been saved.')
         expect(page).to have_field(title_field, with: new_title)
+        expect(course.reload.settings(:course_forums_component).title).to eq(new_title)
 
         visit current_path
         expect(page).to have_selector('li a', text: new_title)
@@ -29,6 +30,7 @@ RSpec.feature 'Course: Administration: Forums', js: true do
         fill_in title_field, with: empty_title
         click_button 'Save changes'
         expect_toastify('Your changes have been saved.')
+        expect(course.reload.settings(:course_forums_component).title).to eq(nil)
 
         visit current_path
         expect(page).to have_selector('li a', text: I18n.t('course.forum.forums.sidebar_title'))
@@ -46,11 +48,30 @@ RSpec.feature 'Course: Administration: Forums', js: true do
         expect_toastify('Your changes have been saved.')
         expect(page).
           to have_field(pagination_field, with: invalid_pagination_count.abs)
+        expect(course.reload.settings(:course_forums_component).pagination).to eq(invalid_pagination_count.abs)
 
         fill_in pagination_field, with: valid_pagination_count
         click_button 'Save changes'
         expect_toastify('Your changes have been saved.')
         expect(page).to have_field(pagination_field, with: valid_pagination_count)
+        expect(course.reload.settings(:course_forums_component).pagination).to eq(valid_pagination_count)
+      end
+
+      scenario 'I can change the forum anonymous settings' do
+        visit course_admin_forums_path(course)
+
+        find_field('allowAnonymousPost', visible: false).set(true)
+
+        click_button 'Save changes'
+        expect_toastify('Your changes have been saved.')
+        expect(page).to have_field('allowAnonymousPost', checked: true, visible: false)
+        expect(course.reload.settings(:course_forums_component).allow_anonymous_post).to be_truthy
+
+        find_field('allowAnonymousPost', visible: false).set(false)
+        click_button 'Save changes'
+        expect_toastify('Your changes have been saved.')
+        expect(page).to have_field('allowAnonymousPost', checked: false, visible: false)
+        expect(course.reload.settings(:course_forums_component).allow_anonymous_post).to be_falsy
       end
     end
   end

--- a/spec/models/duplication_ability_spec.rb
+++ b/spec/models/duplication_ability_spec.rb
@@ -5,39 +5,44 @@ RSpec.describe Course, type: :model do
   let(:instance) { create(:instance) }
 
   with_tenant(:instance) do
-    subject { Ability.new(user) }
+    subject { Ability.new(user, course, course_user) }
     let!(:course) { create(:course, :enrollable) }
 
     context 'when the user is a Normal User' do
       let(:user) { create(:user) }
+      let(:course_user) { nil }
 
       it { is_expected.not_to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }
     end
 
     context 'when the user is a Course Student' do
-      let(:user) { create(:course_student, course: course).user }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.not_to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }
     end
 
     context 'when the user is a Course Teaching Assistant' do
-      let(:user) { create(:course_teaching_assistant, course: course).user }
+      let(:course_user) { create(:course_teaching_assistant, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.not_to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }
     end
 
     context 'when the user is a Course Manager' do
-      let(:user) { create(:course_manager, course: course).user }
+      let(:course_user) { create(:course_manager, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:duplicate_from, course) }
       it { is_expected.to be_able_to(:duplicate_to, course) }
     end
 
     context 'when the user is a Course Observer' do
-      let(:user) { create(:course_observer, course: course).user }
+      let(:course_user) { create(:course_observer, course: course) }
+      let(:user) { course_user.user }
 
       it { is_expected.to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }


### PR DESCRIPTION
Closes #5566

### Main Changes
- Added enable anonymous post option in the forum setting.
- Added anonymous post feature in course forum.

### Schema Changes
- Added `is_anonymous` column to `course_discussion_posts` table.

### Screenshots
1. Anonymous setting in forum settings page.
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/42570513/210964479-1f9341a5-4563-4d47-b48e-684bb10e2282.png">

2. Forum post (Instructor's view)
https://user-images.githubusercontent.com/42570513/210950937-24d81d99-32db-49f6-aa06-d6f4c9b63109.mov

3. Forum post (Student's view)
https://user-images.githubusercontent.com/42570513/210950956-5fdd8da0-01fe-45b2-8e28-7250f09d2d0f.mov

### Other Misc Changes
- Rename forum disbursement post type.
- Refactor request payload typing for forum and forum topic post/patch .
- Add error warning for rich text field.
- Fix `IconButton` props passing in `DeleteButton` component.
- Use `Note` component for pages with no data.
- Improve performance for authorization check by removing unnecessary table joins to check roles.
- Add `noopener` attribute for `<a />` tag.
- Reorders statistics tab and improve tutor filtering in the student statistics table.