### PR TITLE
Update missing email settings rake task & fix missing email settings issue

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -240,14 +240,13 @@ class Course < ApplicationRecord
   end
 
   # Returns admin email id and settings for both phantom and regular users.
+  # If it doesnt exist for one reason or another
+  # (usually the settings are not populated after data migration), create one.
   #
   # @return [Course::Settings::Email]
   def email_enabled(component, setting, course_assessment_category_id = nil)
-    setting_emails.
-      where(component: component,
-            course_assessment_category_id: course_assessment_category_id,
-            setting: setting).
-      select(:id, :phantom, :regular).first
+    setting_emails.find_or_create_by(component: component, course_assessment_category_id: course_assessment_category_id,
+                                     setting: setting)
   end
 
   def email_settings_with_enabled_components

--- a/app/models/course/settings/email.rb
+++ b/app/models/course/settings/email.rb
@@ -22,6 +22,23 @@ class Course::Settings::Email < ApplicationRecord
                   post_replied: 8,
                   new_enrol_request: 9 }
 
+  DEFAULT_EMAIL_COURSE_SETTINGS = [{ announcements: :new_announcement },
+                                   { forums: :new_topic },
+                                   { forums: :post_replied },
+                                   { surveys: :opening_reminder },
+                                   { surveys: :closing_reminder },
+                                   { surveys: :closing_reminder_summary },
+                                   { videos: :opening_reminder },
+                                   { videos: :closing_reminder },
+                                   { users: :new_enrol_request }].freeze
+
+  DEFAULT_EMAIL_COURSE_ASSESSMENT_SETTINGS = [{ assessments: :opening_reminder },
+                                              { assessments: :closing_reminder },
+                                              { assessments: :closing_reminder_summary },
+                                              { assessments: :grades_released },
+                                              { assessments: :new_comment },
+                                              { assessments: :new_submission }].freeze
+
   # A set of email settings that students are able to manage.
   STUDENT_SETTING = Set[:opening_reminder, :closing_reminder, :grades_released, :new_comment,
                         :new_topic, :post_replied, ].map { |v| settings[v] }.freeze
@@ -62,17 +79,7 @@ class Course::Settings::Email < ApplicationRecord
   def self.after_course_initialize(course)
     return if course.persisted? || !course.setting_emails.empty?
 
-    default_email_settings = [{ announcements: :new_announcement },
-                              { forums: :new_topic },
-                              { forums: :post_replied },
-                              { surveys: :opening_reminder },
-                              { surveys: :closing_reminder },
-                              { surveys: :closing_reminder_summary },
-                              { videos: :opening_reminder },
-                              { videos: :closing_reminder },
-                              { users: :new_enrol_request }]
-
-    default_email_settings.each do |default_email_setting|
+    DEFAULT_EMAIL_COURSE_SETTINGS.each do |default_email_setting|
       component = default_email_setting.keys[0]
       setting = default_email_setting[component]
       course.setting_emails.build(component: component, setting: setting)
@@ -87,14 +94,7 @@ class Course::Settings::Email < ApplicationRecord
   end
 
   def self.build_assessment_email_settings(category)
-    default_email_settings = [{ assessments: :opening_reminder },
-                              { assessments: :closing_reminder },
-                              { assessments: :closing_reminder_summary },
-                              { assessments: :grades_released },
-                              { assessments: :new_comment },
-                              { assessments: :new_submission }]
-
-    default_email_settings.each do |default_email_setting|
+    DEFAULT_EMAIL_COURSE_ASSESSMENT_SETTINGS.each do |default_email_setting|
       component = default_email_setting.keys[0]
       setting = default_email_setting[component]
       category.setting_emails.build(course: category.course, component: component, setting: setting)

--- a/lib/tasks/db/add_missing_email_settings.rake
+++ b/lib/tasks/db/add_missing_email_settings.rake
@@ -1,22 +1,57 @@
 # frozen_string_literal: true
 namespace :db do
   task add_missing_email_settings: :environment do
-    def create_default_email_settings(category_ids)
+    def create_default_assessment_email_settings(category_ids)
       assessment_categories = Course::Assessment::Category.where(id: category_ids)
-      assessment_categories.each do |assessment_cat|
-        default_email_settings = [{ assessments: :opening_reminder },
-                                  { assessments: :closing_reminder },
-                                  { assessments: :closing_reminder_summary },
-                                  { assessments: :grades_released },
-                                  { assessments: :new_comment },
-                                  { assessments: :new_submission }]
+      default_email_assessment_settings = Course::Settings::Email::DEFAULT_EMAIL_COURSE_ASSESSMENT_SETTINGS
+      new_email_settings = []
 
+      assessment_categories.each do |assessment_cat|
+        default_email_assessment_settings.each do |default_email_assessment_setting|
+          component = default_email_assessment_setting.keys[0]
+          setting = default_email_assessment_setting[component]
+          new_email_settings << Course::Settings::Email.new(
+            course_id: assessment_cat.course_id,
+            course_assessment_category_id: assessment_cat.id,
+            component: component,
+            setting: setting,
+            phantom: true,
+            regular: true
+          )
+        end
+      end
+      Course::Settings::Email.import! new_email_settings, validate: false
+    end
+
+    # Non-assessment
+    def create_default_email_settings # rubocop:disable Metrics/MethodLength
+      course_with_email_settings = Course.includes(:setting_emails).
+                                   joins("LEFT JOIN course_settings_emails \
+                                    ON course_settings_emails.course_id = courses.id \
+                                    AND course_settings_emails.course_assessment_category_id IS NULL")
+      default_email_settings = Course::Settings::Email::DEFAULT_EMAIL_COURSE_SETTINGS
+
+      new_email_settings = []
+      course_with_email_settings.each do |course|
+        existing_email_settings = course.setting_emails.pluck(:component, :setting).map do |setting|
+          setting.join('#')
+        end.to_set
         default_email_settings.each do |default_email_setting|
           component = default_email_setting.keys[0]
           setting = default_email_setting[component]
-          assessment_cat.setting_emails.create!(course: assessment_cat.course, component: component, setting: setting)
+
+          next if existing_email_settings.include?("#{component}##{setting}")
+
+          new_email_settings << Course::Settings::Email.new(
+            course_id: course.id,
+            component: component,
+            setting: setting,
+            phantom: true,
+            regular: true
+          )
         end
       end
+      Course::Settings::Email.import! new_email_settings, validate: false
     end
 
     ActsAsTenant.without_tenant do
@@ -28,7 +63,9 @@ namespace :db do
         WHERE cse.id IS NULL
       SQL
       assessment_category_ids = assessment_categories_with_missing_email_settings.pluck('id')
-      create_default_email_settings(assessment_category_ids)
+      create_default_assessment_email_settings(assessment_category_ids)
+
+      create_default_email_settings
     end
   end
 end


### PR DESCRIPTION
Further refactoring to prevent #4531 

### Issues
Recently, after doing data migration from SLS, `add_missing_email_settings` rake task was run to populate the email settings for migrated courses. However, `add_missing_email_settings` only populated assessment-related email settings.

Another underlying issue is that, when there's missing email setting data, there should be at least fallback or default value.

### Solution
- We now update `add_missing_email_settings` rake task to create missing data for non-assessment related email settings
- When an email setting is not found, the setting is created on the fly using `find_or_create_by`