### PR TITLE
[Issue #5581] Add an indicator to show that survey question can be re-ordered by dragging

### DIFF
--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionForm.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionForm.jsx
@@ -12,6 +12,7 @@ import { questionTypes } from 'course/survey/constants';
 import translations from 'course/survey/translations';
 import ErrorText from 'lib/components/core/ErrorText';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
+import FormRichTextField from 'lib/components/form/fields/RichTextField';
 import FormSelectField from 'lib/components/form/fields/SelectField';
 import FormTextField from 'lib/components/form/fields/TextField';
 import formTranslations from 'lib/translations/form';
@@ -431,7 +432,7 @@ const QuestionForm = (props) => {
         control={control}
         name="description"
         render={({ field, fieldState }) => (
-          <FormTextField
+          <FormRichTextField
             disabled={disabled}
             field={field}
             fieldState={fieldState}

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/Question.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/Question.jsx
@@ -107,7 +107,7 @@ class Question extends Component {
   }
 
   render() {
-    const { question, expanded, index } = this.props;
+    const { question, dragging, expanded, index } = this.props;
 
     return (
       <Draggable draggableId={`question-${question.id}`} index={index}>
@@ -119,7 +119,7 @@ class Question extends Component {
             {...provided.dragHandleProps}
           >
             <QuestionCard
-              {...{ question, expanded }}
+              {...{ question, dragging, expanded }}
               adminFunctions={this.adminFunctions()}
             />
           </div>
@@ -131,6 +131,7 @@ class Question extends Component {
 
 Question.propTypes = {
   question: questionShape,
+  dragging: PropTypes.bool,
   expanded: PropTypes.bool.isRequired,
   index: PropTypes.number.isRequired,
 

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
@@ -4,14 +4,16 @@ import { DragIndicator } from '@mui/icons-material';
 import MoreVert from '@mui/icons-material/MoreVert';
 import {
   Accordion,
+  AccordionDetails,
   AccordionSummary,
-  CardContent,
   Checkbox,
+  Chip,
   IconButton,
   Menu,
   MenuItem,
   Radio,
   TextField,
+  Typography,
 } from '@mui/material';
 import PropTypes from 'prop-types';
 
@@ -111,16 +113,13 @@ class QuestionCard extends Component {
   renderAdminMenu() {
     const { adminFunctions } = this.props;
 
-    if (!adminFunctions || adminFunctions.length < 1) {
+    if (!adminFunctions || adminFunctions.length === 0) {
       return null;
     }
 
     return (
-      <>
-        <IconButton
-          className="absolute right-8 top-5"
-          onClick={this.handleClick}
-        >
+      <div>
+        <IconButton onClick={this.handleClick}>
           <MoreVert />
         </IconButton>
         <Menu
@@ -137,7 +136,7 @@ class QuestionCard extends Component {
             </MenuItem>
           ))}
         </Menu>
-      </>
+      </div>
     );
   }
 
@@ -146,27 +145,44 @@ class QuestionCard extends Component {
 
     return (
       <Accordion expanded={expanded}>
-        <AccordionSummary className="p-0">
-          <div className="flex">
+        <AccordionSummary
+          className="p-0"
+          sx={{
+            '.Mui-expanded': {
+              marginBottom: '0px',
+            },
+          }}
+        >
+          <div className="flex grow">
             <DragIndicator
               className={dragging ? 'invisible' : 'visible'}
               color="disabled"
               fontSize="small"
             />
-            <div className="flex-col">
-              <p dangerouslySetInnerHTML={{ __html: question.description }} />
+            <div>
+              <Typography
+                className="whitespace-normal"
+                dangerouslySetInnerHTML={{
+                  __html: question.description,
+                }}
+              />
               {question.required && (
-                <p className="italic">
-                  <FormattedMessage {...formTranslations.starRequired} />
-                </p>
+                <Chip
+                  color="error"
+                  label={
+                    <FormattedMessage {...formTranslations.starRequired} />
+                  }
+                  size="small"
+                  variant="outlined"
+                />
               )}
-              <CardContent className="mt-0 pt-0">
-                {QuestionCard.renderSpecificFields(question)}
-              </CardContent>
             </div>
           </div>
           {this.renderAdminMenu()}
         </AccordionSummary>
+        <AccordionDetails>
+          {QuestionCard.renderSpecificFields(question)}
+        </AccordionDetails>
       </Accordion>
     );
   }

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { DragIndicator } from '@mui/icons-material';
 import MoreVert from '@mui/icons-material/MoreVert';
 import {
   Accordion,
@@ -13,44 +14,12 @@ import {
   TextField,
 } from '@mui/material';
 import PropTypes from 'prop-types';
-import { DragIndicator } from '@mui/icons-material';
 
 import OptionsListItem from 'course/survey/components/OptionsListItem';
 import { questionTypes } from 'course/survey/constants';
 import { questionShape } from 'course/survey/propTypes';
 import translations from 'course/survey/translations';
 import formTranslations from 'lib/translations/form';
-
-const styles = {
-  optionWidget: {
-    padding: 0,
-    width: 'auto',
-  },
-  grid: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
-  gridOptionWidget: {
-    marginTop: 5,
-    padding: 0,
-    width: 'auto',
-  },
-  adminMenu: {
-    position: 'absolute',
-    right: 8,
-    top: 0,
-  },
-  fields: {
-    marginTop: 0,
-    paddingTop: 0,
-  },
-  panelSummaryText: {
-    display: 'flex',
-  },
-  required: {
-    fontStyle: 'italic',
-  },
-};
 
 class QuestionCard extends Component {
   static renderOptionsFields(question) {
@@ -69,10 +38,10 @@ class QuestionCard extends Component {
 
   static renderOptionsGrid(question, Widget) {
     return (
-      <div style={styles.grid}>
+      <div className="flex flex-wrap">
         {question.options.map((option) => {
           const { option: optionText, image_url: imageUrl } = option;
-          const widget = <Widget disabled style={styles.gridOptionWidget} />;
+          const widget = <Widget className="mt-0 w-auto p-0" disabled />;
           return (
             <OptionsListItem
               key={option.id}
@@ -90,7 +59,7 @@ class QuestionCard extends Component {
       <>
         {question.options.map((option) => {
           const { option: optionText, image_url: imageUrl } = option;
-          const widget = <Widget disabled style={styles.optionWidget} />;
+          const widget = <Widget className="mt-0 w-auto p-0" disabled />;
           return (
             <OptionsListItem
               key={option.id}
@@ -148,7 +117,10 @@ class QuestionCard extends Component {
 
     return (
       <>
-        <IconButton onClick={this.handleClick} style={styles.adminMenu}>
+        <IconButton
+          className="absolute right-8 top-5"
+          onClick={this.handleClick}
+        >
           <MoreVert />
         </IconButton>
         <Menu
@@ -174,17 +146,21 @@ class QuestionCard extends Component {
 
     return (
       <Accordion expanded={expanded}>
-        <AccordionSummary style={{padding: 0}}>
-          <div style={styles.panelSummaryText}>
-            <DragIndicator className={dragging ? 'invisible' : 'visible'} color="disabled" fontSize="small"/>
-            <div style={{ flexDirection: 'column' }}>
+        <AccordionSummary className="p-0">
+          <div className="flex">
+            <DragIndicator
+              className={dragging ? 'invisible' : 'visible'}
+              color="disabled"
+              fontSize="small"
+            />
+            <div className="flex-col">
               <p dangerouslySetInnerHTML={{ __html: question.description }} />
               {question.required && (
-                <p style={styles.required}>
+                <p className="italic">
                   <FormattedMessage {...formTranslations.starRequired} />
                 </p>
               )}
-              <CardContent style={styles.fields}>
+              <CardContent className="mt-0 pt-0">
                 {QuestionCard.renderSpecificFields(question)}
               </CardContent>
             </div>

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/QuestionCard.jsx
@@ -13,6 +13,7 @@ import {
   TextField,
 } from '@mui/material';
 import PropTypes from 'prop-types';
+import { DragIndicator } from '@mui/icons-material';
 
 import OptionsListItem from 'course/survey/components/OptionsListItem';
 import { questionTypes } from 'course/survey/constants';
@@ -44,7 +45,7 @@ const styles = {
     paddingTop: 0,
   },
   panelSummaryText: {
-    flexDirection: 'column',
+    display: 'flex',
   },
   required: {
     fontStyle: 'italic',
@@ -169,24 +170,27 @@ class QuestionCard extends Component {
   }
 
   render() {
-    const { question, expanded } = this.props;
+    const { question, dragging, expanded } = this.props;
 
     return (
       <Accordion expanded={expanded}>
-        <AccordionSummary>
+        <AccordionSummary style={{padding: 0}}>
           <div style={styles.panelSummaryText}>
-            <p dangerouslySetInnerHTML={{ __html: question.description }} />
-            {question.required && (
-              <p style={styles.required}>
-                <FormattedMessage {...formTranslations.starRequired} />
-              </p>
-            )}
+            <DragIndicator className={dragging ? 'invisible' : 'visible'} color="disabled" fontSize="small"/>
+            <div style={{ flexDirection: 'column' }}>
+              <p dangerouslySetInnerHTML={{ __html: question.description }} />
+              {question.required && (
+                <p style={styles.required}>
+                  <FormattedMessage {...formTranslations.starRequired} />
+                </p>
+              )}
+              <CardContent style={styles.fields}>
+                {QuestionCard.renderSpecificFields(question)}
+              </CardContent>
+            </div>
           </div>
           {this.renderAdminMenu()}
         </AccordionSummary>
-        <CardContent style={styles.fields}>
-          {QuestionCard.renderSpecificFields(question)}
-        </CardContent>
       </Accordion>
     );
   }
@@ -194,6 +198,7 @@ class QuestionCard extends Component {
 
 QuestionCard.propTypes = {
   question: questionShape,
+  dragging: PropTypes.bool,
   adminFunctions: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/index.jsx
@@ -20,22 +20,6 @@ import MoveUpButton from './MoveUpButton';
 import NewQuestionButton from './NewQuestionButton';
 import Question from './Question';
 
-// const styles = {
-//   card: {
-//     marginBottom: 15,
-//   },
-//   expandIcon: {
-//     float: 'right',
-//   },
-//   expandIconRotated: {
-//     float: 'right',
-//     transform: 'rotate(180deg)',
-//   },
-//   subtitle: {
-//     paddingRight: 64,
-//   },
-// };
-
 const translations = defineMessages({
   noQuestions: {
     id: 'course.survey.Section.noQuestions',
@@ -55,21 +39,19 @@ class Section extends Component {
     const { section, first, last, disabled, index: sectionIndex } = this.props;
     return (
       <CardActions>
-        {section.canCreateQuestion ? (
+        {section.canCreateQuestion && (
           <NewQuestionButton sectionId={section.id} {...{ disabled }} />
-        ) : null}
-        {section.canUpdate ? (
-          <EditSectionButton {...{ section, disabled }} />
-        ) : null}
-        {section.canDelete ? (
+        )}
+        {section.canUpdate && <EditSectionButton {...{ section, disabled }} />}
+        {section.canDelete && (
           <DeleteSectionButton sectionId={section.id} {...{ disabled }} />
-        ) : null}
-        {section.canUpdate && !first ? (
+        )}
+        {section.canUpdate && !first && (
           <MoveUpButton {...{ sectionIndex, disabled }} />
-        ) : null}
-        {section.canUpdate && !last ? (
+        )}
+        {section.canUpdate && !last && (
           <MoveDownButton {...{ sectionIndex, disabled }} />
-        ) : null}
+        )}
       </CardActions>
     );
   }
@@ -77,22 +59,17 @@ class Section extends Component {
   render() {
     const { section, index: sectionIndex } = this.props;
     return (
-      <Card className="mb-4">
+      <Card>
         <CardHeader
           subheader={
             <div dangerouslySetInnerHTML={{ __html: section.description }} />
           }
-          subheaderTypographyProps={{ className: 'pr-16' }}
           title={
-            <>
+            <div className="flex justify-between">
               {section.title}
               {section.questions.length > 0 && (
                 <ExpandMoreIcon
-                  className={
-                    this.state.expanded
-                      ? 'float-right'
-                      : 'float-right rotate-180'
-                  }
+                  className={!this.state.expanded && 'rotate-180'}
                   onClick={() =>
                     this.setState((prevState) => ({
                       expanded: !prevState.expanded,
@@ -100,17 +77,17 @@ class Section extends Component {
                   }
                 />
               )}
-            </>
+            </div>
           }
         />
-        {section.questions.length > 1 ? this.renderActions() : null}
+        {section.questions.length > 1 && this.renderActions()}
 
         <CardContent>
-          {section.questions.length < 1 ? (
+          {section.questions.length === 0 && (
             <ListSubheader disableSticky>
               <FormattedMessage {...translations.noQuestions} />
             </ListSubheader>
-          ) : null}
+          )}
 
           <Droppable droppableId={`section-${sectionIndex}`}>
             {(provided) => (

--- a/client/app/bundles/course/survey/pages/SurveyShow/Section/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/Section/index.jsx
@@ -20,21 +20,21 @@ import MoveUpButton from './MoveUpButton';
 import NewQuestionButton from './NewQuestionButton';
 import Question from './Question';
 
-const styles = {
-  card: {
-    marginBottom: 15,
-  },
-  expandIcon: {
-    float: 'right',
-  },
-  expandIconRotated: {
-    float: 'right',
-    transform: 'rotate(180deg)',
-  },
-  subtitle: {
-    paddingRight: 64,
-  },
-};
+// const styles = {
+//   card: {
+//     marginBottom: 15,
+//   },
+//   expandIcon: {
+//     float: 'right',
+//   },
+//   expandIconRotated: {
+//     float: 'right',
+//     transform: 'rotate(180deg)',
+//   },
+//   subtitle: {
+//     paddingRight: 64,
+//   },
+// };
 
 const translations = defineMessages({
   noQuestions: {
@@ -77,26 +77,26 @@ class Section extends Component {
   render() {
     const { section, index: sectionIndex } = this.props;
     return (
-      <Card style={styles.card}>
+      <Card className="mb-4">
         <CardHeader
           subheader={
             <div dangerouslySetInnerHTML={{ __html: section.description }} />
           }
-          subheaderTypographyProps={{ style: styles.subtitle }}
+          subheaderTypographyProps={{ className: 'pr-16' }}
           title={
             <>
               {section.title}
               {section.questions.length > 0 && (
                 <ExpandMoreIcon
+                  className={
+                    this.state.expanded
+                      ? 'float-right'
+                      : 'float-right rotate-180'
+                  }
                   onClick={() =>
                     this.setState((prevState) => ({
                       expanded: !prevState.expanded,
                     }))
-                  }
-                  style={
-                    this.state.expanded
-                      ? styles.expandIcon
-                      : styles.expandIconRotated
                   }
                 />
               )}

--- a/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
+++ b/client/app/bundles/course/survey/pages/SurveyShow/index.jsx
@@ -98,14 +98,16 @@ const SurveyShow = ({
         </ListSubheader>
 
         <DragDropContext onDragEnd={reorderQuestion}>
-          {sections.map((section, index) => (
-            <Section
-              key={section.id}
-              first={index === 0}
-              last={index === lastIndex}
-              {...{ section, index, survey, disabled }}
-            />
-          ))}
+          <section className="space-y-4">
+            {sections.map((section, index) => (
+              <Section
+                key={section.id}
+                first={index === 0}
+                last={index === lastIndex}
+                {...{ section, index, survey, disabled }}
+              />
+            ))}
+          </section>
         </DragDropContext>
       </>
     );


### PR DESCRIPTION
Closes https://github.com/Coursemology/coursemology2/issues/5581
_Add an indicator to show that survey question can be re-ordered by dragging_

### After
<img width="1205" alt="image" src="https://user-images.githubusercontent.com/42570513/211970694-8ab2ffa3-82e3-463a-a590-afd4dea11579.png">

### Before
<img width="1205" alt="image" src="https://user-images.githubusercontent.com/42570513/211970715-6ea67f8f-8501-45e4-bc82-44e31adc54fc.png">
