### PR TITLE
Fix CircleCI config regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,10 +128,10 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - checkout_with_submodules
+
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-
-      - checkout_with_submodules
 
       - restore_ruby_cache
       - restore_node_cache


### PR DESCRIPTION
On 11 Jan 2022, the tests suite in our CI suddenly all fail in the checkout step, even for past tests that were successful. The following error was returned `Directory (/home/circleci/repo) you are trying to checkout to is not empty and not a git repository`. Upon further investigation, it was found that installing chrome and chromedriver somewhat prevents CircleCI to checkout the code in the `repo` directory. This is weird as it did not happen in the past. To fix it, simply set the `checkout` step as the first step as seen in the commit to ensure that the `repo` directory is clean before the `checkout` step.