### PR TITLE
fix : prevent disbursement table from being re-rendered whenever user's posts are clicked to be seen

### DIFF
--- a/client/app/bundles/course/experience-points/disbursement/components/forms/ForumDisbursementForm.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/components/forms/ForumDisbursementForm.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useEffect, useMemo, useState } from 'react';
+import { FC, memo, useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import {
   defineMessages,
@@ -69,14 +69,12 @@ const validationSchema = yup.object({
 const ForumDisbursementForm: FC<Props> = (props) => {
   const { intl, filters, forumUsers, onPostClick } = props;
 
-  const initialValues: DisbursementFormData = useMemo(() => {
-    return forumUsers.reduce(
-      (accumulator, value) => {
-        return { ...accumulator, [`courseUser_${value.id}`]: value.points };
-      },
-      { reason: intl.formatMessage(translations.reasonFill) },
-    );
-  }, []);
+  const initialValues: DisbursementFormData = forumUsers.reduce(
+    (users, value) => {
+      return { ...users, [`courseUser_${value.id}`]: value.points };
+    },
+    { reason: intl.formatMessage(translations.reasonFill) },
+  );
 
   const dispatch = useDispatch<AppDispatch>();
   const methods = useForm({
@@ -86,23 +84,11 @@ const ForumDisbursementForm: FC<Props> = (props) => {
   const {
     control,
     handleSubmit,
-    reset,
     setError,
     formState: { errors },
   } = methods;
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  useEffect(() => {
-    const obj = forumUsers.reduce(
-      (accumulator, value) => {
-        return { ...accumulator, [`courseUser_${value.id}`]: value.points };
-      },
-      { reason: intl.formatMessage(translations.reasonFill) },
-    );
-
-    reset(obj);
-  }, [forumUsers]);
 
   const onFormSubmit = (data: ForumDisbursementFormData): void => {
     setIsSubmitting(true);

--- a/client/app/bundles/course/experience-points/disbursement/pages/ForumDisbursement/index.tsx
+++ b/client/app/bundles/course/experience-points/disbursement/pages/ForumDisbursement/index.tsx
@@ -92,11 +92,13 @@ const ForumDisbursement: FC = () => {
         </Paper>
       </Grid>
       <Grid item xs>
-        <ForumDisbursementForm
-          filters={filters}
-          forumUsers={forumUsers}
-          onPostClick={onPostClick}
-        />
+        {Boolean(forumUsers.length) && (
+          <ForumDisbursementForm
+            filters={filters}
+            forumUsers={forumUsers}
+            onPostClick={onPostClick}
+          />
+        )}
         {selectedForumPostUser && (
           <Dialog
             fullWidth

--- a/spec/features/course/forum/post_management_spec.rb
+++ b/spec/features/course/forum/post_management_spec.rb
@@ -165,7 +165,7 @@ RSpec.feature 'Course: Forum: Post: Management', js: true do
         visit course_forum_topic_path(course, forum, topic)
         # Mark as answer
         within find("div.post_#{post.id}") do
-          find('svg[data-testId="StarBorderIcon"]').find(:xpath, '..').click
+          find('svg[data-testId="CheckCircleOutlineIcon"]').find(:xpath, '..').click
         end
         expect_toastify('The post has been updated.')
         expect(post.reload).to be_answer
@@ -176,7 +176,7 @@ RSpec.feature 'Course: Forum: Post: Management', js: true do
 
         # Unmark as answer
         within find("div.post_#{post.id}") do
-          find('svg[data-testId="StarIcon"]').find(:xpath, '..').click
+          find('svg[data-testId="CheckCircleIcon"]').find(:xpath, '..').click
         end
         expect_toastify('The post has been updated.')
         expect(post.reload).not_to be_answer


### PR DESCRIPTION
Previous issue:
Whenever posts are clicked to be seen, all the changes made towards "Reason for Disbursement" and "Experience Points Awarded" are reverted back to its initial value

After solving the issue:
Both fields will remain to be the last inputted value.