### PR TITLE
Fix misaligned sticky, overflowing elements on Safari pre-16.0

### DIFF
--- a/client/app/lib/components/core/table/TableContainer.tsx
+++ b/client/app/lib/components/core/table/TableContainer.tsx
@@ -12,7 +12,7 @@ const TableContainer = (
 ): JSX.Element => {
   return (
     <MuiTableContainer
-      className={`${props.stickyHeader ? 'overflow-x-clip' : ''} ${
+      className={`${props.stickyHeader ? 'overflow-x-visible' : ''} ${
         props.className ?? ''
       }`}
       component={MuiPaper}


### PR DESCRIPTION
Safari pre-16.0 was not rendering elements with `position: sticky` in `overflow: clip` containers correctly. This was fixed in Safari 16.0; see https://github.com/WebKit/WebKit/commit/854716970c0750581f75ee43bb91578d9ac52451, but notably unfixed in previous releases of Safari that are still being widely used in macOS 10.14–12 and iOS 14–15.

This bug results in table headers rendered by `TableContainer` with `stickyHeader` to be pushed by the set `top` relative to the container's top, and not sticky. See below for illustration.

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/51525686/213075351-1192e0b0-48ea-4692-8ed3-e7ab7885e690.png">

## Solution
Change `TableContainer`'s style from `overflow-x-clip` to `overflow-x-visible` when `stickyHeader` is `true`. Note that this will result in a table that _cannot_ handle horizontally overflowing contents, i.e., no horizontal scrollbar. Developers will have to either choose to (a) not have sticky header, or (b) have sticky header, but ensure that the columns are flexboxes that resize correctly at different screen sizes (see `AssessmentsTable`).