### PR TITLE
Refactor forum posts preloading to include both earliest and latest posts of a forum topic

### DIFF
--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -19,7 +19,7 @@ class Course::Forum::ForumsController < Course::Forum::Controller
       format.html { render 'index' }
       format.json do
         @topics = @forum.topics.accessible_by(current_ability).order_by_latest_post.with_topic_statistics.
-                  with_read_marks_for(current_user).includes(:creator).with_latest_post
+                  with_read_marks_for(current_user).includes(:creator).with_earliest_and_latest_post
         @subscribed_discussion_topic_ids = preload_topic_subscriptons
         @course_users_hash = preload_course_users_hash(current_course)
 

--- a/spec/controllers/course/forum/forums_controller_spec.rb
+++ b/spec/controllers/course/forum/forums_controller_spec.rb
@@ -34,10 +34,12 @@ RSpec.describe Course::Forum::ForumsController, type: :controller do
       let!(:first_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
       let!(:second_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
 
-      it 'preloads the latest post for each topics of the forum' do
+      it 'preloads the latest and earliest posts for each topics of the forum' do
         get :show, params: { course_id: course, id: forum, format: :json }
-        expect(controller.instance_variable_get(:@topics).first.posts.first).
+        expect(controller.instance_variable_get(:@topics).first.posts.last).
           to eq(second_topic_post)
+        expect(controller.instance_variable_get(:@topics).first.posts.first).
+          to eq(topic.posts.first)
       end
     end
 

--- a/spec/models/course/forum/topic_spec.rb
+++ b/spec/models/course/forum/topic_spec.rb
@@ -128,13 +128,23 @@ RSpec.describe Course::Forum::Topic, type: :model do
       end
     end
 
-    describe '.with_latest_post' do
+    describe '.with_earliest_and_latest_post' do
       let(:topic) { create(:forum_topic, forum: forum) }
-      let!(:first_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
+      let!(:first_topic_post) { topic.posts.first }
       let!(:second_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
+      let!(:third_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
+      let!(:fourth_topic_post) { create(:course_discussion_post, topic: topic.acting_as) }
+
+      it 'preloads only two posts' do
+        expect(forum.topics.with_earliest_and_latest_post.first.posts.size).to eq(2)
+      end
 
       it 'preloads the latest post' do
-        expect(forum.topics.with_latest_post.first.posts.first).to eq(second_topic_post)
+        expect(forum.topics.with_earliest_and_latest_post.first.posts.last).to eq(fourth_topic_post)
+      end
+
+      it 'preloads the earliest post' do
+        expect(forum.topics.with_earliest_and_latest_post.first.posts.first).to eq(first_topic_post)
       end
     end
 


### PR DESCRIPTION
Improve forum topic posts performance by preloading the earliest and latest posts of a forum topic