### PR TITLE
Refactor[Announcement]: Add options for publish now or later

### DIFF
--- a/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
+++ b/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
@@ -1,9 +1,13 @@
 import { FC } from 'react';
 import { Controller, UseFormSetError } from 'react-hook-form';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+// import AccessTimeIcon from '@mui/icons-material/AccessTime';
+// import SendIcon from '@mui/icons-material/Send';
+import { RadioGroup } from '@mui/material';
 import { AnnouncementFormData } from 'types/course/announcements';
 import * as yup from 'yup';
 
+import IconRadio from 'lib/components/core/buttons/IconRadio';
 import FormDialog from 'lib/components/form/dialog/FormDialog';
 import FormDateTimePickerField from 'lib/components/form/fields/DateTimePickerField';
 import FormRichTextField from 'lib/components/form/fields/RichTextField';
@@ -49,19 +53,34 @@ const translations = defineMessages({
     id: 'course.announcements.AnnouncementForm.endTimeError',
     defaultMessage: 'End time cannot be earlier than start time',
   },
+  publishNow: {
+    id: 'course.announcements.AnnouncementForm.publishNow',
+    defaultMessage: 'Publish Now',
+  },
+  publishAtSetDate: {
+    id: 'course.announcements.AnnouncementForm.publishAtSetDate',
+    defaultMessage: 'Publish At:',
+  },
 });
 
 const validationSchema = yup.object({
   title: yup.string().required(formTranslations.required),
   content: yup.string().nullable(),
   sticky: yup.bool(),
-  startAt: yup.date().nullable().typeError(formTranslations.invalidDate),
+  whenToPublish: yup.string().oneOf(['now', 'later']),
+  startAt: yup
+    .date()
+    .nullable()
+    .typeError(formTranslations.invalidDate)
+    .min(new Date(new Date().setSeconds(0, 0))),
   endAt: yup.date().nullable().typeError(formTranslations.invalidDate),
 });
 
 const AnnouncementForm: FC<Props> = (props) => {
   const { open, editing, title, onClose, initialValues, onSubmit, canSticky } =
     props;
+
+  const intl = useIntl();
 
   return (
     <FormDialog
@@ -74,7 +93,7 @@ const AnnouncementForm: FC<Props> = (props) => {
       title={title}
       validationSchema={validationSchema}
     >
-      {(control, formState): JSX.Element => (
+      {(control, formState, watch): JSX.Element => (
         <>
           <Controller
             control={control}
@@ -128,31 +147,66 @@ const AnnouncementForm: FC<Props> = (props) => {
           )}
           <div style={{ marginBottom: 12 }} />
 
-          <div style={{ display: 'flex' }}>
+          {!editing && (
             <Controller
               control={control}
-              name="startAt"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormDateTimePickerField
-                  disabled={formState.isSubmitting}
-                  field={field}
-                  fieldState={fieldState}
-                  label={<FormattedMessage {...translations.startAt} />}
-                  style={{ flex: 1 }}
-                />
+              name="whenToPublish"
+              render={({ field }): JSX.Element => (
+                <RadioGroup {...field}>
+                  <div className="mb-2 grid grid-cols-2">
+                    <div>
+                      <IconRadio
+                        label={intl.formatMessage(translations.publishNow)}
+                        value="now"
+                      />
+                    </div>
+
+                    <div className="flex space-x-2">
+                      <IconRadio
+                        label={intl.formatMessage(
+                          translations.publishAtSetDate,
+                        )}
+                        value="later"
+                      />
+                      <Controller
+                        control={control}
+                        name="startAt"
+                        render={({
+                          field: innerField,
+                          fieldState,
+                        }): JSX.Element => (
+                          <FormDateTimePickerField
+                            disabled={
+                              formState.isSubmitting ||
+                              watch('whenToPublish') === 'now'
+                            }
+                            field={innerField}
+                            fieldState={fieldState}
+                            style={{ flex: 1, alignItems: 'center' }}
+                          />
+                        )}
+                      />
+                    </div>
+                  </div>
+                </RadioGroup>
               )}
             />
+          )}
+
+          <div className="flex w-1/2 flex-col space-y-1">
+            <FormattedMessage {...translations.endAt} />
             <Controller
               control={control}
               name="endAt"
               render={({ field, fieldState }): JSX.Element => (
-                <FormDateTimePickerField
-                  disabled={formState.isSubmitting}
-                  field={field}
-                  fieldState={fieldState}
-                  label={<FormattedMessage {...translations.endAt} />}
-                  style={{ flex: 1 }}
-                />
+                <div>
+                  <FormDateTimePickerField
+                    disabled={formState.isSubmitting}
+                    field={field}
+                    fieldState={fieldState}
+                    style={{ flex: 1 }}
+                  />
+                </div>
               )}
             />
           </div>
@@ -163,3 +217,5 @@ const AnnouncementForm: FC<Props> = (props) => {
 };
 
 export default AnnouncementForm;
+
+// 4. Read docs + component

--- a/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
+++ b/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
@@ -14,7 +14,7 @@ import FormToggleField from 'lib/components/form/fields/ToggleField';
 import useTranslation from 'lib/hooks/useTranslation';
 import formTranslations from 'lib/translations/form';
 
-export type PublishMode = 'now' | 'later';
+export type PublishTime = 'now' | 'later';
 
 interface Props {
   open: boolean;
@@ -25,7 +25,7 @@ interface Props {
   onSubmit: (
     data: AnnouncementFormData,
     setError: UseFormSetError<AnnouncementFormData>,
-    whenToPublish: PublishMode,
+    whenToPublish: PublishTime,
   ) => Promise<void>;
   canSticky: boolean;
 }
@@ -65,7 +65,7 @@ const translations = defineMessages({
   },
 });
 
-const validationSchema = (whenToPublish: PublishMode): yup.AnyObjectSchema =>
+const validationSchema = (whenToPublish: PublishTime): yup.AnyObjectSchema =>
   yup.object({
     title: yup.string().required(formTranslations.required),
     content: yup.string().nullable(),
@@ -87,7 +87,7 @@ const AnnouncementForm: FC<Props> = (props) => {
   const { open, editing, title, onClose, initialValues, onSubmit, canSticky } =
     props;
   const { t } = useTranslation();
-  const [whenToPublish, setWhenToPublish] = useState<PublishMode>('now');
+  const [whenToPublish, setWhenToPublish] = useState<PublishTime>('now');
 
   return (
     <FormDialog
@@ -141,6 +141,7 @@ const AnnouncementForm: FC<Props> = (props) => {
               />
             )}
           />
+
           {canSticky && (
             <Controller
               control={control}
@@ -158,16 +159,21 @@ const AnnouncementForm: FC<Props> = (props) => {
 
           {!editing && (
             <RadioGroup
-              onChange={(_, mode): void =>
-                setWhenToPublish(mode as PublishMode)
+              onChange={(_, value): void =>
+                setWhenToPublish(value as PublishTime)
               }
               value={whenToPublish}
             >
-              <div className="mb-2 flex space-x-5">
-                <IconRadio label={t(translations.publishNow)} value="now" />
+              <div className="flex space-x-3 max-sm:flex-col max-sm:space-x-0">
+                <IconRadio
+                  iconClassName="py-0"
+                  label={t(translations.publishNow)}
+                  value="now"
+                />
 
                 <div className="flex items-center space-x-3">
                   <IconRadio
+                    iconClassName="py-0"
                     label={t(translations.publishAtSetDate)}
                     value="later"
                   />
@@ -189,10 +195,9 @@ const AnnouncementForm: FC<Props> = (props) => {
             </RadioGroup>
           )}
 
-          <div className="flex w-full space-x-10 space-y-1">
+          <div className="flex w-full max-sm:flex-col max-sm:space-y-5">
             {editing && (
-              <div className="flex w-1/3 flex-col items-center">
-                {t(translations.startAt)}
+              <div className="w-1/3 max-sm:w-1/2">
                 <Controller
                   control={control}
                   name="startAt"
@@ -203,13 +208,13 @@ const AnnouncementForm: FC<Props> = (props) => {
                       }
                       field={field}
                       fieldState={fieldState}
+                      label={t(translations.startAt)}
                     />
                   )}
                 />
               </div>
             )}
-            <div className="flex w-1/3 flex-col">
-              {t(translations.endAt)}
+            <div className="w-1/3 max-sm:w-1/2">
               <Controller
                 control={control}
                 name="endAt"
@@ -218,6 +223,7 @@ const AnnouncementForm: FC<Props> = (props) => {
                     disabled={formState.isSubmitting}
                     field={field}
                     fieldState={fieldState}
+                    label={t(translations.endAt)}
                   />
                 )}
               />

--- a/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
+++ b/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
@@ -72,7 +72,10 @@ const validationSchema = yup.object({
     .date()
     .nullable()
     .typeError(formTranslations.invalidDate)
-    .min(new Date(new Date().setSeconds(0, 0))),
+    .min(
+      new Date(new Date().setSeconds(0, 0)),
+      formTranslations.startDateValidationError,
+    ),
   endAt: yup.date().nullable().typeError(formTranslations.invalidDate),
 });
 
@@ -145,7 +148,6 @@ const AnnouncementForm: FC<Props> = (props) => {
               )}
             />
           )}
-          <div style={{ marginBottom: 12 }} />
 
           {!editing && (
             <Controller
@@ -153,7 +155,7 @@ const AnnouncementForm: FC<Props> = (props) => {
               name="whenToPublish"
               render={({ field }): JSX.Element => (
                 <RadioGroup {...field}>
-                  <div className="mb-2 grid grid-cols-2">
+                  <div className="mb-2 flex space-x-5">
                     <div>
                       <IconRadio
                         label={intl.formatMessage(translations.publishNow)}
@@ -161,7 +163,7 @@ const AnnouncementForm: FC<Props> = (props) => {
                       />
                     </div>
 
-                    <div className="flex space-x-2">
+                    <div className="flex space-x-3">
                       <IconRadio
                         label={intl.formatMessage(
                           translations.publishAtSetDate,
@@ -193,7 +195,7 @@ const AnnouncementForm: FC<Props> = (props) => {
             />
           )}
 
-          <div className="flex w-1/2 flex-col space-y-1">
+          <div className="flex w-1/3 flex-col space-y-1">
             <FormattedMessage {...translations.endAt} />
             <Controller
               control={control}
@@ -217,5 +219,3 @@ const AnnouncementForm: FC<Props> = (props) => {
 };
 
 export default AnnouncementForm;
-
-// 4. Read docs + component

--- a/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
+++ b/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
@@ -65,13 +65,8 @@ const translations = defineMessages({
   },
 });
 
-const AnnouncementForm: FC<Props> = (props) => {
-  const { open, editing, title, onClose, initialValues, onSubmit, canSticky } =
-    props;
-  const { t } = useTranslation();
-  const [whenToPublish, setWhenToPublish] = useState<PublishMode>('now');
-
-  const validationSchema = yup.object({
+const validationSchema = (whenToPublish: PublishMode): yup.AnyObjectSchema =>
+  yup.object({
     title: yup.string().required(formTranslations.required),
     content: yup.string().nullable(),
     sticky: yup.bool(),
@@ -88,6 +83,12 @@ const AnnouncementForm: FC<Props> = (props) => {
       ),
   });
 
+const AnnouncementForm: FC<Props> = (props) => {
+  const { open, editing, title, onClose, initialValues, onSubmit, canSticky } =
+    props;
+  const { t } = useTranslation();
+  const [whenToPublish, setWhenToPublish] = useState<PublishMode>('now');
+
   return (
     <FormDialog
       editing={editing}
@@ -100,105 +101,78 @@ const AnnouncementForm: FC<Props> = (props) => {
       ): Promise<void> => onSubmit(data, setError, whenToPublish)}
       open={open}
       title={title}
-      validationSchema={validationSchema}
+      validationSchema={validationSchema(whenToPublish)}
     >
-      {(control, formState): JSX.Element => {
-        return (
-          <>
-            <Controller
-              control={control}
-              name="title"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormTextField
-                  disabled={formState.isSubmitting}
-                  field={field}
-                  fieldState={fieldState}
-                  fullWidth
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                  label={t(translations.title)}
-                  required
-                  variant="standard"
-                />
-              )}
-            />
-
-            <Controller
-              control={control}
-              name="content"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormRichTextField
-                  disabled={formState.isSubmitting}
-                  field={field}
-                  fieldState={fieldState}
-                  fullWidth
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                  label={t(translations.content)}
-                  variant="standard"
-                />
-              )}
-            />
-            {canSticky && (
-              <Controller
-                control={control}
-                name="sticky"
-                render={({ field, fieldState }): JSX.Element => (
-                  <FormToggleField
-                    disabled={formState.isSubmitting}
-                    field={field}
-                    fieldState={fieldState}
-                    label={t(translations.sticky)}
-                  />
-                )}
+      {(control, formState): JSX.Element => (
+        <>
+          <Controller
+            control={control}
+            name="title"
+            render={({ field, fieldState }): JSX.Element => (
+              <FormTextField
+                disabled={formState.isSubmitting}
+                field={field}
+                fieldState={fieldState}
+                fullWidth
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                label={t(translations.title)}
+                required
+                variant="standard"
               />
             )}
+          />
 
-            {!editing && (
-              <RadioGroup
-                onChange={(_, mode): void =>
-                  setWhenToPublish(mode as PublishMode)
-                }
-                value={whenToPublish}
-              >
-                <div className="mb-2 flex space-x-5">
-                  <div>
-                    <IconRadio label={t(translations.publishNow)} value="now" />
-                  </div>
-
-                  <div className="flex space-x-3">
-                    <IconRadio
-                      label={t(translations.publishAtSetDate)}
-                      value="later"
-                    />
-                    <Controller
-                      control={control}
-                      name="startAt"
-                      render={({
-                        field: innerField,
-                        fieldState,
-                      }): JSX.Element => (
-                        <FormDateTimePickerField
-                          disabled={
-                            formState.isSubmitting || whenToPublish === 'now'
-                          }
-                          field={innerField}
-                          fieldState={fieldState}
-                          style={{ flex: 1, alignItems: 'center' }}
-                        />
-                      )}
-                    />
-                  </div>
-                </div>
-              </RadioGroup>
+          <Controller
+            control={control}
+            name="content"
+            render={({ field, fieldState }): JSX.Element => (
+              <FormRichTextField
+                disabled={formState.isSubmitting}
+                field={field}
+                fieldState={fieldState}
+                fullWidth
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                label={t(translations.content)}
+                variant="standard"
+              />
             )}
+          />
+          {canSticky && (
+            <Controller
+              control={control}
+              name="sticky"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormToggleField
+                  disabled={formState.isSubmitting}
+                  field={field}
+                  fieldState={fieldState}
+                  label={t(translations.sticky)}
+                />
+              )}
+            />
+          )}
 
-            <div className="flex w-full space-x-10 space-y-1">
-              {editing && (
-                <div className="flex w-1/3 flex-col">
-                  {t(translations.startAt)}
+          {!editing && (
+            <RadioGroup
+              onChange={(_, mode): void =>
+                setWhenToPublish(mode as PublishMode)
+              }
+              value={whenToPublish}
+            >
+              <div className="mb-2 flex space-x-5">
+                <div>
+                  <IconRadio label={t(translations.publishNow)} value="now" />
+                </div>
+
+                <div className="flex space-x-3">
+                  <IconRadio
+                    label={t(translations.publishAtSetDate)}
+                    value="later"
+                  />
                   <Controller
                     control={control}
                     name="startAt"
@@ -208,7 +182,7 @@ const AnnouncementForm: FC<Props> = (props) => {
                     }): JSX.Element => (
                       <FormDateTimePickerField
                         disabled={
-                          formState.isSubmitting || whenToPublish === 'later'
+                          formState.isSubmitting || whenToPublish === 'now'
                         }
                         field={innerField}
                         fieldState={fieldState}
@@ -217,28 +191,50 @@ const AnnouncementForm: FC<Props> = (props) => {
                     )}
                   />
                 </div>
-              )}
+              </div>
+            </RadioGroup>
+          )}
+
+          <div className="flex w-full space-x-10 space-y-1">
+            {editing && (
               <div className="flex w-1/3 flex-col">
-                {t(translations.endAt)}
+                {t(translations.startAt)}
                 <Controller
                   control={control}
-                  name="endAt"
-                  render={({ field, fieldState }): JSX.Element => (
-                    <div>
-                      <FormDateTimePickerField
-                        disabled={formState.isSubmitting}
-                        field={field}
-                        fieldState={fieldState}
-                        style={{ flex: 1 }}
-                      />
-                    </div>
+                  name="startAt"
+                  render={({ field: innerField, fieldState }): JSX.Element => (
+                    <FormDateTimePickerField
+                      disabled={
+                        formState.isSubmitting || whenToPublish === 'later'
+                      }
+                      field={innerField}
+                      fieldState={fieldState}
+                      style={{ flex: 1, alignItems: 'center' }}
+                    />
                   )}
                 />
               </div>
+            )}
+            <div className="flex w-1/3 flex-col">
+              {t(translations.endAt)}
+              <Controller
+                control={control}
+                name="endAt"
+                render={({ field, fieldState }): JSX.Element => (
+                  <div>
+                    <FormDateTimePickerField
+                      disabled={formState.isSubmitting}
+                      field={field}
+                      fieldState={fieldState}
+                      style={{ flex: 1 }}
+                    />
+                  </div>
+                )}
+              />
             </div>
-          </>
-        );
-      }}
+          </div>
+        </>
+      )}
     </FormDialog>
   );
 };

--- a/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
+++ b/client/app/bundles/course/announcements/components/forms/AnnouncementForm.tsx
@@ -164,11 +164,9 @@ const AnnouncementForm: FC<Props> = (props) => {
               value={whenToPublish}
             >
               <div className="mb-2 flex space-x-5">
-                <div>
-                  <IconRadio label={t(translations.publishNow)} value="now" />
-                </div>
+                <IconRadio label={t(translations.publishNow)} value="now" />
 
-                <div className="flex space-x-3">
+                <div className="flex items-center space-x-3">
                   <IconRadio
                     label={t(translations.publishAtSetDate)}
                     value="later"
@@ -176,17 +174,13 @@ const AnnouncementForm: FC<Props> = (props) => {
                   <Controller
                     control={control}
                     name="startAt"
-                    render={({
-                      field: innerField,
-                      fieldState,
-                    }): JSX.Element => (
+                    render={({ field, fieldState }): JSX.Element => (
                       <FormDateTimePickerField
                         disabled={
                           formState.isSubmitting || whenToPublish === 'now'
                         }
-                        field={innerField}
+                        field={field}
                         fieldState={fieldState}
-                        style={{ flex: 1, alignItems: 'center' }}
                       />
                     )}
                   />
@@ -197,19 +191,18 @@ const AnnouncementForm: FC<Props> = (props) => {
 
           <div className="flex w-full space-x-10 space-y-1">
             {editing && (
-              <div className="flex w-1/3 flex-col">
+              <div className="flex w-1/3 flex-col items-center">
                 {t(translations.startAt)}
                 <Controller
                   control={control}
                   name="startAt"
-                  render={({ field: innerField, fieldState }): JSX.Element => (
+                  render={({ field, fieldState }): JSX.Element => (
                     <FormDateTimePickerField
                       disabled={
                         formState.isSubmitting || whenToPublish === 'later'
                       }
-                      field={innerField}
+                      field={field}
                       fieldState={fieldState}
-                      style={{ flex: 1, alignItems: 'center' }}
                     />
                   )}
                 />
@@ -221,14 +214,11 @@ const AnnouncementForm: FC<Props> = (props) => {
                 control={control}
                 name="endAt"
                 render={({ field, fieldState }): JSX.Element => (
-                  <div>
-                    <FormDateTimePickerField
-                      disabled={formState.isSubmitting}
-                      field={field}
-                      fieldState={fieldState}
-                      style={{ flex: 1 }}
-                    />
-                  </div>
+                  <FormDateTimePickerField
+                    disabled={formState.isSubmitting}
+                    field={field}
+                    fieldState={fieldState}
+                  />
                 )}
               />
             </div>

--- a/client/app/bundles/course/announcements/pages/AnnouncementEdit/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementEdit/index.tsx
@@ -29,9 +29,9 @@ interface Props {
 }
 
 const translations = defineMessages({
-  updateAnnouncement: {
-    id: 'course.announcements.AnnouncementEdit.updateAnnouncement',
-    defaultMessage: 'Update Announcement',
+  editAnnouncement: {
+    id: 'course.announcements.AnnouncementEdit.editAnnouncement',
+    defaultMessage: 'Edit Announcement',
   },
   updateSuccess: {
     id: 'course.announcements.AnnouncementEdit.updateSuccess',
@@ -85,7 +85,7 @@ const AnnouncementEdit: FC<Props> = (props) => {
       onClose={onClose}
       onSubmit={handleSubmit}
       open={open}
-      title={t(translations.updateAnnouncement)}
+      title={t(translations.editAnnouncement)}
     />
   );
 };

--- a/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
@@ -9,7 +9,7 @@ import { setReactHookFormError } from 'lib/helpers/react-hook-form-helper';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import AnnouncementForm, {
-  PublishMode,
+  PublishTime,
 } from '../../components/forms/AnnouncementForm';
 
 interface Props {
@@ -55,7 +55,7 @@ const AnnouncementNew: FC<Props> = (props) => {
   const handleSubmit = (
     data: AnnouncementFormData,
     setError,
-    whenToPublish: PublishMode,
+    whenToPublish: PublishTime,
   ): Promise<void> => {
     const updatedData = {
       ...data,

--- a/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
@@ -8,7 +8,9 @@ import { AppDispatch, Operation } from 'types/store';
 import { setReactHookFormError } from 'lib/helpers/react-hook-form-helper';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import AnnouncementForm from '../../components/forms/AnnouncementForm';
+import AnnouncementForm, {
+  PublishMode,
+} from '../../components/forms/AnnouncementForm';
 
 interface Props {
   open: boolean;
@@ -36,7 +38,6 @@ const initialValues: AnnouncementFormData = {
   title: '',
   content: '',
   sticky: false,
-  whenToPublish: 'now',
   // Dates need to be initialized for endtime to change automatically when start time changes
   startAt: new Date(),
   endAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // + one week
@@ -54,10 +55,11 @@ const AnnouncementNew: FC<Props> = (props) => {
   const handleSubmit = (
     data: AnnouncementFormData,
     setError,
+    whenToPublish: PublishMode,
   ): Promise<void> => {
     const updatedData = {
       ...data,
-      startAt: data.whenToPublish === 'now' ? new Date() : data.startAt,
+      startAt: whenToPublish === 'now' ? new Date() : data.startAt,
     };
     return dispatch(createOperation(updatedData))
       .then(() => {

--- a/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
@@ -59,8 +59,6 @@ const AnnouncementNew: FC<Props> = (props) => {
       ...data,
       startAt: data.whenToPublish === 'now' ? new Date() : data.startAt,
     };
-    console.log(updatedData.startAt);
-    console.log(new Date(new Date().setSeconds(0, 0)));
     return dispatch(createOperation(updatedData))
       .then(() => {
         onClose();

--- a/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementNew/index.tsx
@@ -32,10 +32,11 @@ const translations = defineMessages({
   },
 });
 
-const initialValues = {
+const initialValues: AnnouncementFormData = {
   title: '',
   content: '',
   sticky: false,
+  whenToPublish: 'now',
   // Dates need to be initialized for endtime to change automatically when start time changes
   startAt: new Date(),
   endAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // + one week
@@ -54,8 +55,14 @@ const AnnouncementNew: FC<Props> = (props) => {
     data: AnnouncementFormData,
     setError,
   ): Promise<void> => {
-    return dispatch(createOperation(data))
-      .then((_) => {
+    const updatedData = {
+      ...data,
+      startAt: data.whenToPublish === 'now' ? new Date() : data.startAt,
+    };
+    console.log(updatedData.startAt);
+    console.log(new Date(new Date().setSeconds(0, 0)));
+    return dispatch(createOperation(updatedData))
+      .then(() => {
         onClose();
         toast.success(t(translations.creationSuccess));
       })

--- a/client/app/bundles/system/admin/instance/instance/components/forms/InstanceUserRoleRequestForm.tsx
+++ b/client/app/bundles/system/admin/instance/instance/components/forms/InstanceUserRoleRequestForm.tsx
@@ -76,7 +76,7 @@ const InstanceUserRoleRequestForm: FC<Props> = (props) => {
     return handleOperations()
       .then((response) => {
         toast.success(t(translations.requestSuccess));
-        dispatch(saveInstanceRoleRequest({ ...response, ...data }));
+        dispatch(saveInstanceRoleRequest({ ...data, ...response }));
         onClose();
       })
       .catch((error) => {

--- a/client/app/lib/components/core/buttons/IconRadio.tsx
+++ b/client/app/lib/components/core/buttons/IconRadio.tsx
@@ -6,6 +6,7 @@ interface IconRadioProps {
   label?: string;
   description?: string;
   icon?: typeof SvgIcon;
+  iconClassName?: string;
   disabled?: boolean;
 }
 
@@ -15,7 +16,11 @@ const IconRadio = (props: IconRadioProps): JSX.Element => (
       props.description ? 'items-start' : 'items-center'
     }`}
   >
-    <Radio className="pl-0" disabled={props.disabled} value={props.value} />
+    <Radio
+      className={`pl-0 ${props.iconClassName ?? ''}`}
+      disabled={props.disabled}
+      value={props.value}
+    />
 
     {props.icon &&
       createElement(props.icon, {

--- a/client/app/lib/components/form/dialog/FormDialog.tsx
+++ b/client/app/lib/components/form/dialog/FormDialog.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { ReactNode, useState } from 'react';
-import { Control, FormState, useForm, UseFormSetError } from 'react-hook-form';
+import {
+  Control,
+  FormState,
+  useForm,
+  UseFormSetError,
+  UseFormWatch,
+} from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   Button,
@@ -28,7 +34,11 @@ interface Props {
   title: string;
   formName: string;
   validationSchema?: AnyObjectSchema;
-  children?: (control: Control, formState: FormState<any>) => ReactNode;
+  children?: (
+    control: Control,
+    formState: FormState<any>,
+    watch: UseFormWatch<any>,
+  ) => ReactNode;
   primaryActionText?: string;
 }
 
@@ -48,7 +58,7 @@ const FormDialog = (props: Props): JSX.Element => {
 
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
   const { t } = useTranslation();
-  const { control, handleSubmit, setError, formState } = useForm({
+  const { control, handleSubmit, setError, formState, watch } = useForm({
     defaultValues: initialValues,
     resolver: validationSchema && yupResolver(validationSchema),
   });
@@ -82,7 +92,7 @@ const FormDialog = (props: Props): JSX.Element => {
             onSubmit={handleSubmit((data) => onSubmit(data, setError))}
           >
             <ErrorText errors={formState.errors} />
-            {children?.(control, formState)}
+            {children?.(control, formState, watch)}
           </form>
         </DialogContent>
         <DialogActions>

--- a/client/app/lib/translations/form.ts
+++ b/client/app/lib/translations/form.ts
@@ -134,8 +134,12 @@ const formTranslations = defineMessages({
     id: 'lib.translations.form.validation.startEndDateValidationError',
     defaultMessage: 'Must be after Start Date',
   },
-  startDateValidationError: {
-    id: 'lib.translations.form.validation.startDateValidationError',
+  earlierThanStartTimeError: {
+    id: 'lib.translations.form.validation.earlierThanStartTimeError',
+    defaultMessage: 'Cannot be earlier that start date',
+  },
+  earlierThanCurrentTimeError: {
+    id: 'lib.translations.form.validation.earlierThanCurrentTimeError',
     defaultMessage: 'Cannot be earlier that current time',
   },
   characters: {

--- a/client/app/lib/translations/form.ts
+++ b/client/app/lib/translations/form.ts
@@ -136,11 +136,11 @@ const formTranslations = defineMessages({
   },
   earlierThanStartTimeError: {
     id: 'lib.translations.form.validation.earlierThanStartTimeError',
-    defaultMessage: 'Cannot be earlier that start date',
+    defaultMessage: 'Cannot be earlier than the start date',
   },
   earlierThanCurrentTimeError: {
     id: 'lib.translations.form.validation.earlierThanCurrentTimeError',
-    defaultMessage: 'Cannot be earlier that current time',
+    defaultMessage: 'Cannot be earlier than the current time',
   },
   characters: {
     id: 'lib.translations.form.validation.characters',

--- a/client/app/lib/translations/form.ts
+++ b/client/app/lib/translations/form.ts
@@ -134,6 +134,10 @@ const formTranslations = defineMessages({
     id: 'lib.translations.form.validation.startEndDateValidationError',
     defaultMessage: 'Must be after Start Date',
   },
+  startDateValidationError: {
+    id: 'lib.translations.form.validation.startDateValidationError',
+    defaultMessage: 'Cannot be earlier that current time',
+  },
   characters: {
     id: 'lib.translations.form.validation.characters',
     defaultMessage: 'Must be less than 255 characters',

--- a/client/app/types/course/announcements.ts
+++ b/client/app/types/course/announcements.ts
@@ -47,4 +47,5 @@ export interface AnnouncementFormData {
   sticky: boolean;
   startAt: Date;
   endAt: Date;
+  whenToPublish?: 'now' | 'later';
 }

--- a/client/app/types/course/announcements.ts
+++ b/client/app/types/course/announcements.ts
@@ -47,5 +47,4 @@ export interface AnnouncementFormData {
   sticky: boolean;
   startAt: Date;
   endAt: Date;
-  whenToPublish?: 'now' | 'later';
 }


### PR DESCRIPTION
Close #5426

Before:
<img width="770" alt="Screenshot 2023-02-01 at 12 15 03 AM" src="https://user-images.githubusercontent.com/16359075/215817850-5b910c1f-a64d-4cb3-9b75-0eec43ce50b5.png">

After:
**[The view while trying to make new announcement]**
<img width="769" alt="Screenshot 2023-02-01 at 12 14 08 AM" src="https://user-images.githubusercontent.com/16359075/215819142-b6788ef7-b870-4fa9-a689-1a47e029da05.png">

**[The view while trying to edit announcement]**
<img width="770" alt="Screenshot 2023-02-01 at 9 47 19 AM" src="https://user-images.githubusercontent.com/16359075/215925083-3783fac5-45fe-45c5-8eb9-07a620e1e579.png">

Some issues still remaining:
- In the new version, the setup of isDirty is somewhat still problematic (the Submit button is enabled whenever we change from publish now to publish later, even though not all required field has been filled in)
- Also, there are still some problem with the verification schema for startAt. Upon clicking to get the new Announcement form, and upon filling in all the required field, the verification done towards startAt will refer to the time we generate the new Announcement form and not upon submission.