### PR TITLE
Administrators can configure evaluator time limit in a course

### DIFF
--- a/app/controllers/course/admin/assessment_settings_controller.rb
+++ b/app/controllers/course/admin/assessment_settings_controller.rb
@@ -71,7 +71,7 @@ class Course::Admin::AssessmentSettingsController < Course::Admin::Controller
       # Randomized Assessment is temporarily hidden (PR#5406)
       # :allow_randomization,
       :allow_mrq_options_randomization,
-      :programming_time_limit,
+      :programming_timeout_limit,
       assessment_categories_attributes: [
         :id,
         :title,

--- a/app/controllers/course/admin/assessment_settings_controller.rb
+++ b/app/controllers/course/admin/assessment_settings_controller.rb
@@ -71,6 +71,7 @@ class Course::Admin::AssessmentSettingsController < Course::Admin::Controller
       # Randomized Assessment is temporarily hidden (PR#5406)
       # :allow_randomization,
       :allow_mrq_options_randomization,
+      :programming_time_limit,
       assessment_categories_attributes: [
         :id,
         :title,

--- a/app/controllers/course/admin/assessment_settings_controller.rb
+++ b/app/controllers/course/admin/assessment_settings_controller.rb
@@ -71,7 +71,7 @@ class Course::Admin::AssessmentSettingsController < Course::Admin::Controller
       # Randomized Assessment is temporarily hidden (PR#5406)
       # :allow_randomization,
       :allow_mrq_options_randomization,
-      :programming_timeout_limit,
+      :programming_max_time_limit,
       assessment_categories_attributes: [
         :id,
         :title,

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -6,11 +6,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
                               class: Course::Assessment::Question::Programming,
                               through: :assessment, parent: false, except: [:new, :create]
   before_action :load_question_assessment, only: [:edit, :update]
-  before_action :set_course_for_question
-
-  def set_course_for_question
-    @programming_question.course = current_course
-  end
+  before_action :set_attributes_for_programming_question
 
   def new
     @template = 'course/assessment/question/programming/new.json.jbuilder'
@@ -70,6 +66,10 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
   end
 
   private
+
+  def set_attributes_for_programming_question
+    @programming_question.max_time_limit = current_course.programming_max_time_limit
+  end
 
   def programming_question_params
     params.require(:question_programming).permit(

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -13,6 +13,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
 
   def create
     @template = 'course/assessment/question/programming/new.json.jbuilder'
+    @programming_question.course = current_course
     @programming_question.package_type =
       programming_question_params.key?(:file) ? :zip_upload : :online_editor
     process_package
@@ -34,6 +35,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
   end
 
   def update
+    @programming_question.course = current_course
     result = @programming_question.class.transaction do
       @question_assessment.skill_ids = programming_question_params[:question_assessment].
                                        try(:[], :skill_ids)

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -6,6 +6,11 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
                               class: Course::Assessment::Question::Programming,
                               through: :assessment, parent: false, except: [:new, :create]
   before_action :load_question_assessment, only: [:edit, :update]
+  before_action :set_course_for_question
+
+  def set_course_for_question
+    @programming_question.course = current_course
+  end
 
   def new
     @template = 'course/assessment/question/programming/new.json.jbuilder'
@@ -13,7 +18,6 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
 
   def create
     @template = 'course/assessment/question/programming/new.json.jbuilder'
-    @programming_question.course = current_course
     @programming_question.package_type =
       programming_question_params.key?(:file) ? :zip_upload : :online_editor
     process_package
@@ -35,7 +39,6 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
   end
 
   def update
-    @programming_question.course = current_course
     result = @programming_question.class.transaction do
       @question_assessment.skill_ids = programming_question_params[:question_assessment].
                                        try(:[], :skill_ids)

--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -10,8 +10,9 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   # @param [Course::Assessment::Question::Programming] question The programming question to
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
-  def perform_tracked(question, attachment, course)
-    ActsAsTenant.without_tenant { perform_import(question, attachment, course) }
+  def perform_tracked(question, attachment, course = nil)
+    question.course = course if course
+    ActsAsTenant.without_tenant { perform_import(question, attachment) }
   end
 
   private
@@ -21,11 +22,11 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   # @param [Course::Assessment::Question::Programming] question The programming question to
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
-  def perform_import(question, attachment, course)
-    Course::Assessment::Question::ProgrammingImportService.import(question, attachment, course)
+  def perform_import(question, attachment)
+    Course::Assessment::Question::ProgrammingImportService.import(question, attachment)
     # Make an API call to Codaveri to create/update question if the import above is succesful.
     if question.is_codaveri
-      Course::Assessment::Question::ProgrammingCodaveriService.create_or_update_question(question, attachment, course)
+      Course::Assessment::Question::ProgrammingCodaveriService.create_or_update_question(question, attachment)
     end
     # Re-run the tests since the test results are deleted with the old package.
     Course::Assessment::Question::AnswersEvaluationJob.perform_later(question)

--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -10,8 +10,7 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   # @param [Course::Assessment::Question::Programming] question The programming question to
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
-  def perform_tracked(question, attachment, course = nil)
-    question.course = course if course
+  def perform_tracked(question, attachment)
     ActsAsTenant.without_tenant { perform_import(question, attachment) }
   end
 

--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -11,8 +11,7 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
   def perform_tracked(question, attachment, course)
-    question.course = course
-    ActsAsTenant.without_tenant { perform_import(question, attachment) }
+    ActsAsTenant.without_tenant { perform_import(question, attachment, course) }
   end
 
   private
@@ -22,11 +21,11 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   # @param [Course::Assessment::Question::Programming] question The programming question to
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
-  def perform_import(question, attachment)
-    Course::Assessment::Question::ProgrammingImportService.import(question, attachment)
+  def perform_import(question, attachment, course)
+    Course::Assessment::Question::ProgrammingImportService.import(question, attachment, course)
     # Make an API call to Codaveri to create/update question if the import above is succesful.
     if question.is_codaveri
-      Course::Assessment::Question::ProgrammingCodaveriService.create_or_update_question(question, attachment)
+      Course::Assessment::Question::ProgrammingCodaveriService.create_or_update_question(question, attachment, course)
     end
     # Re-run the tests since the test results are deleted with the old package.
     Course::Assessment::Question::AnswersEvaluationJob.perform_later(question)

--- a/app/jobs/course/assessment/question/programming_import_job.rb
+++ b/app/jobs/course/assessment/question/programming_import_job.rb
@@ -10,7 +10,8 @@ class Course::Assessment::Question::ProgrammingImportJob < ApplicationJob
   # @param [Course::Assessment::Question::Programming] question The programming question to
   #   import the package to.
   # @param [Attachment] attachment The attachment containing the package.
-  def perform_tracked(question, attachment)
+  def perform_tracked(question, attachment, course)
+    question.course = course
     ActsAsTenant.without_tenant { perform_import(question, attachment) }
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,8 +6,6 @@ class Course < ApplicationRecord
   include TimeZoneConcern
   include Generic::CollectionConcern
 
-  DEFAULT_CPU_TIMEOUT = 30
-
   acts_as_tenant :instance, inverse_of: :courses
   has_settings_on :settings
   mount_uploader :logo, ImageUploader
@@ -28,7 +26,6 @@ class Course < ApplicationRecord
   validates :updater, presence: true
   validates :instance, presence: true
   validates :conditional_satisfiability_evaluation_time, presence: true
-  validates :programming_timeout_limit, numericality: { greater_than_or_equal_to: 0 }
 
   enum default_timeline_algorithm: CourseUser.timeline_algorithms
 
@@ -228,12 +225,13 @@ class Course < ApplicationRecord
     settings(:course_assessments_component).allow_mrq_options_randomization = option
   end
 
-  def programming_timeout_limit
-    settings(:course_assessments_component).programming_timeout_limit || DEFAULT_CPU_TIMEOUT
+  # Setting to allow customization of max CPU time limit for programming question
+  def programming_max_time_limit
+    settings(:course_assessments_component).programming_max_time_limit || 30.seconds
   end
 
-  def programming_timeout_limit=(time)
-    settings(:course_assessments_component).programming_timeout_limit = time
+  def programming_max_time_limit=(time)
+    settings(:course_assessments_component).programming_max_time_limit = time
   end
 
   def codaveri_itsp_enabled?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,6 +26,7 @@ class Course < ApplicationRecord
   validates :updater, presence: true
   validates :instance, presence: true
   validates :conditional_satisfiability_evaluation_time, presence: true
+  validates :programming_time_limit, numericality: { greater_than_or_equal_to: 0 }
 
   enum default_timeline_algorithm: CourseUser.timeline_algorithms
 
@@ -223,6 +224,14 @@ class Course < ApplicationRecord
   def allow_mrq_options_randomization=(option)
     option = ActiveRecord::Type::Boolean.new.cast(option)
     settings(:course_assessments_component).allow_mrq_options_randomization = option
+  end
+
+  def programming_time_limit
+    settings(:course_assessments_component).programming_time_limit || 300
+  end
+
+  def programming_time_limit=(time)
+    settings(:course_assessments_component).programming_time_limit = time
   end
 
   def codaveri_itsp_enabled?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,6 +6,8 @@ class Course < ApplicationRecord
   include TimeZoneConcern
   include Generic::CollectionConcern
 
+  DEFAULT_CPU_TIMEOUT = 30
+
   acts_as_tenant :instance, inverse_of: :courses
   has_settings_on :settings
   mount_uploader :logo, ImageUploader
@@ -227,7 +229,7 @@ class Course < ApplicationRecord
   end
 
   def programming_timeout_limit
-    settings(:course_assessments_component).programming_timeout_limit || 300
+    settings(:course_assessments_component).programming_timeout_limit || DEFAULT_CPU_TIMEOUT
   end
 
   def programming_timeout_limit=(time)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,7 +26,7 @@ class Course < ApplicationRecord
   validates :updater, presence: true
   validates :instance, presence: true
   validates :conditional_satisfiability_evaluation_time, presence: true
-  validates :programming_time_limit, numericality: { greater_than_or_equal_to: 0 }
+  validates :programming_timeout_limit, numericality: { greater_than_or_equal_to: 0 }
 
   enum default_timeline_algorithm: CourseUser.timeline_algorithms
 
@@ -226,12 +226,12 @@ class Course < ApplicationRecord
     settings(:course_assessments_component).allow_mrq_options_randomization = option
   end
 
-  def programming_time_limit
-    settings(:course_assessments_component).programming_time_limit || 300
+  def programming_timeout_limit
+    settings(:course_assessments_component).programming_timeout_limit || 300
   end
 
-  def programming_time_limit=(time)
-    settings(:course_assessments_component).programming_time_limit = time
+  def programming_timeout_limit=(time)
+    settings(:course_assessments_component).programming_timeout_limit = time
   end
 
   def codaveri_itsp_enabled?

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -23,7 +23,6 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   before_validation :assign_test_case_attributes
 
   validates :memory_limit, numericality: { greater_than: 0, less_than: 2_147_483_648 }, allow_nil: true
-  validates :time_limit, numericality: { greater_than: 0 }, allow_nil: true
   validates :attempt_limit, numericality: { only_integer: true,
                                             greater_than: 0, less_than: 2_147_483_648 }, allow_nil: true
   validates :package_type, presence: true
@@ -218,11 +217,11 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
 
   # time limit validation during duplication is skipped, and time limit is allowed to be nil
   def validate_time_limit(course)
-    return if duplicating? || !time_limit || time_limit > 0
-    return if time_limit <= max_timeout_limit(course)
+    return if duplicating? || time_limit.nil?
+    return if time_limit.is_a?(Integer) && time_limit > 0 && time_limit <= max_timeout_limit(course)
 
-    timeout_limit = max_timeout_limit(course)
-    errors.add(:base, "Time limit needs to be at most #{timeout_limit}")
+    errors.add(:base, "Time limit needs to be at most #{max_timeout_limit(course)}")
+    nil
   end
 
   def validate_codaveri_question # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -217,14 +217,10 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
 
   # time limit validation during duplication is skipped, and time limit is allowed to be nil
   def validate_time_limit(course)
-    return if duplicating? || time_limit.nil?
-    return if time_limit > 0 && time_limit <= max_timeout_limit(course)
+    time_limit_within_max_interval = time_limit && time_limit > 0 && time_limit <= max_timeout_limit(course)
+    return if duplicating? || time_limit.nil? || time_limit_within_max_interval
 
-    if time_limit < 0 || time_limit == 0
-      errors.add(:base, 'Time limit needs to be a positive integer')
-    elsif time_limit > max_timeout_limit(course)
-      errors.add(:base, "Time limit needs to be at most #{max_timeout_limit(course)}")
-    end
+    errors.add(:base, "Time limit #{time_limit} need to be a positive integer at most #{max_timeout_limit(course)}")
 
     nil
   end

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -218,9 +218,14 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   # time limit validation during duplication is skipped, and time limit is allowed to be nil
   def validate_time_limit(course)
     return if duplicating? || time_limit.nil?
-    return if time_limit.is_a?(Integer) && time_limit > 0 && time_limit <= max_timeout_limit(course)
+    return if time_limit > 0 && time_limit <= max_timeout_limit(course)
 
-    errors.add(:base, "Time limit needs to be at most #{max_timeout_limit(course)}")
+    if time_limit < 0 || time_limit == 0
+      errors.add(:base, 'Time limit needs to be a positive integer')
+    elsif time_limit > max_timeout_limit(course)
+      errors.add(:base, "Time limit needs to be at most #{max_timeout_limit(course)}")
+    end
+
     nil
   end
 

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -168,7 +168,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   def evaluate_package
     execute_after_commit do
       import_job =
-        Course::Assessment::Question::ProgrammingImportJob.perform_later(self, attachment)
+        Course::Assessment::Question::ProgrammingImportJob.perform_later(self, attachment, course)
       update_column(:import_job_id, import_job.job_id)
     end
   end
@@ -184,7 +184,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
     execute_after_commit do
       new_attachment.save!
       import_job =
-        Course::Assessment::Question::ProgrammingImportJob.perform_later(self, new_attachment)
+        Course::Assessment::Question::ProgrammingImportJob.perform_later(self, new_attachment, course)
       update_column(:import_job_id, import_job.job_id)
     end
   end

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -27,7 +27,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   validates :import_job_id, uniqueness: { allow_nil: true, if: :import_job_id_changed? }
   validates :language, presence: true
 
-  validate -> { validate_time_limit(course) }
+  # validate -> { validate_time_limit(course) }
   validate :validate_codaveri_question
 
   belongs_to :import_job, class_name: TrackableJob::Job.name, inverse_of: nil, optional: true
@@ -212,11 +212,11 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
     duplicating?
   end
 
-  def validate_time_limit(course)
-    return if time_limit <= max_timeout_limit(course)
+  # def validate_time_limit(course)
+  #   return if time_limit <= max_timeout_limit(course)
 
-    errors.add(:base, 'Time limit is higher than allowed')
-  end
+  #   errors.add(:base, 'Time limit is higher than allowed')
+  # end
 
   def validate_codaveri_question # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return if !is_codaveri || duplicating?

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -6,6 +6,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   self.table_name = table_name.singularize
 
   # Maximum CPU time a programming question can allow before the evaluation gets killed.
+  # CPU_TIMEOUT = Course.programming_timeout_limit.seconds
   CPU_TIMEOUT = 300.seconds
 
   # Maximum memory (in MB) the programming question can allow.

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -27,7 +27,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   validates :import_job_id, uniqueness: { allow_nil: true, if: :import_job_id_changed? }
   validates :language, presence: true
 
-  # validate -> { validate_time_limit(course) }
+  validate -> { validate_time_limit(course) }
   validate :validate_codaveri_question
 
   belongs_to :import_job, class_name: TrackableJob::Job.name, inverse_of: nil, optional: true
@@ -212,11 +212,14 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
     duplicating?
   end
 
-  # def validate_time_limit(course)
-  #   return if time_limit <= max_timeout_limit(course)
+  # time limit validation during duplication is skipped because it is possible for course assessment settings to be 
+  # set to less than the time limit of the programming question's time limit, which will cause duplication to fail
+  def validate_time_limit(course)
+    return if duplicating? || time_limit <= max_timeout_limit(course)
+    timeout_limit = max_timeout_limit(course)
 
-  #   errors.add(:base, 'Time limit is higher than allowed')
-  # end
+    errors.add(:base, "Time limit needs to be at most #{timeout_limit}")
+  end
 
   def validate_codaveri_question # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return if !is_codaveri || duplicating?

--- a/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
@@ -20,6 +20,7 @@ class Course::Assessment::Answer::ProgrammingCodaveriAutoGradingService < \
   #   correct status, grade and the programming auto grading record.
   def evaluate_answer(answer)
     question = answer.question.actable
+    question.max_time_limit = answer.submission.assessment.course.programming_max_time_limit
     assessment = answer.submission.assessment
     evaluation_result = evaluate_package(assessment.course.title, question, answer)
     build_result(question, evaluation_result,

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -90,8 +90,8 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
 
   private
 
-  def programming_timeout_limit(question)
-    question.course.programming_timeout_limit
+  def programming_timeout_limit(course)
+    course.programming_timeout_limit
   end
 
   def initialize(course_title, question, answer, timeout)
@@ -99,7 +99,7 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
     @answer = answer
     @language = question.language
     @memory_limit = question.memory_limit || MEMORY_LIMIT
-    @time_limit = question.time_limit ? [question.time_limit, programming_timeout_limit(question)].min : programming_timeout_limit(question)
+    @time_limit = question.time_limit ? [question.time_limit, programming_timeout_limit(course)].min : programming_timeout_limit(course)
     @timeout = timeout || DEFAULT_TIMEOUT
 
     @answer_object = { api_version: 'latest',

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -3,7 +3,6 @@
 class Course::Assessment::ProgrammingCodaveriEvaluationService
   # The default timeout for the job to finish.
   DEFAULT_TIMEOUT = 5.minutes
-  CPU_TIMEOUT = 300.seconds
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
   # Represents a result of evaluating an answer.
@@ -91,12 +90,16 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
 
   private
 
+  def programming_timeout_limit(question)
+    question.course.programming_timeout_limit
+  end
+
   def initialize(course_title, question, answer, timeout)
     @question = question
     @answer = answer
     @language = question.language
     @memory_limit = question.memory_limit || MEMORY_LIMIT
-    @time_limit = question.time_limit || CPU_TIMEOUT
+    @time_limit = question.time_limit ? [question.time_limit, programming_timeout_limit(question)].min : programming_timeout_limit(question)
     @timeout = timeout || DEFAULT_TIMEOUT
 
     @answer_object = { api_version: 'latest',

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -5,6 +5,9 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
   DEFAULT_TIMEOUT = 5.minutes
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
+  # Default programming timeout limit, only will be used if course is undefined
+  DEFAULT_CPU_TIMEOUT = 30
+
   # Represents a result of evaluating an answer.
   Result = Struct.new(:stdout, :stderr, :evaluation_results, :exit_code, :evaluation_id) do
     # Checks if the evaluation errored.
@@ -90,16 +93,17 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
 
   private
 
-  def programming_timeout_limit(course)
-    course.programming_timeout_limit
+  def prog_timeout_lim(course)
+    course ? course.programming_timeout_limit : DEFAULT_CPU_TIMEOUT
   end
 
   def initialize(course_title, question, answer, timeout)
     @question = question
     @answer = answer
+    @course = question.course
     @language = question.language
     @memory_limit = question.memory_limit || MEMORY_LIMIT
-    @time_limit = question.time_limit ? [question.time_limit, programming_timeout_limit(course)].min : programming_timeout_limit(course)
+    @time_limit = question.time_limit ? [question.time_limit, prog_timeout_lim(@course)].min : prog_timeout_lim(@course)
     @timeout = timeout || DEFAULT_TIMEOUT
 
     @answer_object = { api_version: 'latest',

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -3,7 +3,7 @@
 class Course::Assessment::ProgrammingCodaveriEvaluationService
   # The default timeout for the job to finish.
   DEFAULT_TIMEOUT = 5.minutes
-  CPU_TIMEOUT = Course::Assessment::Question::Programming::CPU_TIMEOUT
+  CPU_TIMEOUT = 300.seconds
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
   # Represents a result of evaluating an answer.

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -5,9 +5,6 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
   DEFAULT_TIMEOUT = 5.minutes
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
-  # Default programming timeout limit, only will be used if course is undefined
-  DEFAULT_CPU_TIMEOUT = 30
-
   # Represents a result of evaluating an answer.
   Result = Struct.new(:stdout, :stderr, :evaluation_results, :exit_code, :evaluation_id) do
     # Checks if the evaluation errored.
@@ -93,17 +90,12 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
 
   private
 
-  def prog_timeout_lim(course)
-    course ? course.programming_timeout_limit : DEFAULT_CPU_TIMEOUT
-  end
-
   def initialize(course_title, question, answer, timeout)
     @question = question
     @answer = answer
-    @course = question.course
     @language = question.language
     @memory_limit = question.memory_limit || MEMORY_LIMIT
-    @time_limit = question.time_limit ? [question.time_limit, prog_timeout_lim(@course)].min : prog_timeout_lim(@course)
+    @time_limit = question.time_limit ? [question.time_limit, question.max_time_limit].min : question.max_time_limit
     @timeout = timeout || DEFAULT_TIMEOUT
 
     @answer_object = { api_version: 'latest',

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -3,7 +3,7 @@
 class Course::Assessment::ProgrammingEvaluationService
   # The default timeout for the job to finish.
   DEFAULT_TIMEOUT = 5.minutes
-  CPU_TIMEOUT = Course::Assessment::Question::Programming::CPU_TIMEOUT
+  CPU_TIMEOUT = 300.seconds
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
   # The ratio to multiply the memory limits from our evaluation to the container by.

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -3,7 +3,6 @@
 class Course::Assessment::ProgrammingEvaluationService
   # The default timeout for the job to finish.
   DEFAULT_TIMEOUT = 5.minutes
-  CPU_TIMEOUT = 300.seconds
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
   # The ratio to multiply the memory limits from our evaluation to the container by.
@@ -84,8 +83,8 @@ class Course::Assessment::ProgrammingEvaluationService
     # @return [Result] The result of evaluating the template.
     #
     # @raise [Timeout::Error] When the operation times out.
-    def execute(language, memory_limit, time_limit, package, timeout = nil)
-      new(language, memory_limit, time_limit, package, timeout).execute
+    def execute(course, language, memory_limit, time_limit, package, timeout = nil)
+      new(course, language, memory_limit, time_limit, package, timeout).execute
     end
   end
 
@@ -100,10 +99,15 @@ class Course::Assessment::ProgrammingEvaluationService
 
   private
 
-  def initialize(language, memory_limit, time_limit, package, timeout)
+  def programming_timeout_limit(course)
+    course.programming_timeout_limit
+  end
+
+  def initialize(course, language, memory_limit, time_limit, package, timeout)
+    byebug
     @language = language
     @memory_limit = memory_limit || MEMORY_LIMIT
-    @time_limit = time_limit || CPU_TIMEOUT
+    @time_limit = time_limit ? [time_limit, programming_timeout_limit(course)].min : programming_timeout_limit(course)
     @package = package
     @timeout = timeout || DEFAULT_TIMEOUT
   end

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -5,6 +5,9 @@ class Course::Assessment::ProgrammingEvaluationService
   DEFAULT_TIMEOUT = 5.minutes
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
+  # Default programming timeout limit, only will be used if course is undefined
+  DEFAULT_CPU_TIMEOUT = 30
+
   # The ratio to multiply the memory limits from our evaluation to the container by.
   MEMORY_LIMIT_RATIO = 1.megabyte / 1.kilobyte
 
@@ -83,8 +86,8 @@ class Course::Assessment::ProgrammingEvaluationService
     # @return [Result] The result of evaluating the template.
     #
     # @raise [Timeout::Error] When the operation times out.
-    def execute(course, language, memory_limit, time_limit, package, timeout = nil)
-      new(course, language, memory_limit, time_limit, package, timeout).execute
+    def execute(course, question, time_limit, package, timeout = nil)
+      new(course, question, time_limit, package, timeout).execute
     end
   end
 
@@ -99,14 +102,14 @@ class Course::Assessment::ProgrammingEvaluationService
 
   private
 
-  def programming_timeout_limit(course)
-    course.programming_timeout_limit
+  def prog_timeout_lim(course)
+    course ? course.programming_timeout_limit : DEFAULT_CPU_TIMEOUT
   end
 
-  def initialize(course, language, memory_limit, time_limit, package, timeout)
-    @language = language
-    @memory_limit = memory_limit || MEMORY_LIMIT
-    @time_limit = time_limit ? [time_limit, programming_timeout_limit(course)].min : programming_timeout_limit(course)
+  def initialize(course, question, time_limit, package, timeout)
+    @language = question.language
+    @memory_limit = question.memory_limit || MEMORY_LIMIT
+    @time_limit = time_limit ? [time_limit, prog_timeout_lim(course)].min : prog_timeout_lim(course)
     @package = package
     @timeout = timeout || DEFAULT_TIMEOUT
   end

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -104,7 +104,6 @@ class Course::Assessment::ProgrammingEvaluationService
   end
 
   def initialize(course, language, memory_limit, time_limit, package, timeout)
-    byebug
     @language = language
     @memory_limit = memory_limit || MEMORY_LIMIT
     @time_limit = time_limit ? [time_limit, programming_timeout_limit(course)].min : programming_timeout_limit(course)

--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -69,15 +69,12 @@ class Course::Assessment::ProgrammingEvaluationService
   class << self
     # Executes the provided package.
     #
-    # @param [ActiveSupport::Hash] question_hash The hash that contains the following information
-    # -> @param [Coursemology::Polyglot::Language] language The language runtime to use to run this
+    # @param [Coursemology::Polyglot::Language] language The language runtime to use to run this
     #   package.
-    # -> @param [Integer] memory_limit The memory limit for the evaluation, in MiB.
-    # -> @param [Integer|ActiveSupport::Duration] time_limit The time limit for the evaluation, in
+    # @param [Integer] memory_limit The memory limit for the evaluation, in MiB.
+    # @param [Integer|ActiveSupport::Duration] time_limit The time limit for the evaluation, in
     #   seconds.
-    # -> @param [Integer|ActiveSupport::Duration] max_timeout_limit The maximum time limit for the
-    #    evaluation, in seconds
-    #
+    # @param [Integer|ActiveSupport::Duration] max_time_limit Max time limit.
     # @param [String] package The path to the package. The package is assumed to be a valid package;
     #   no parsing is done on the package.
     # @param [nil|Integer] timeout The duration to elapse before timing out. When the operation
@@ -87,8 +84,8 @@ class Course::Assessment::ProgrammingEvaluationService
     # @return [Result] The result of evaluating the template.
     #
     # @raise [Timeout::Error] When the operation times out.
-    def execute(question_attr, package, timeout = nil)
-      new(question_attr, package, timeout).execute
+    def execute(language, memory_limit, time_limit, max_time_limit, package, timeout = nil)
+      new(language, memory_limit, time_limit, max_time_limit, package, timeout).execute
     end
   end
 
@@ -103,14 +100,10 @@ class Course::Assessment::ProgrammingEvaluationService
 
   private
 
-  def initialize(question_attr, package, timeout)
-    @language = question_attr['language']
-    @memory_limit = question_attr['memory_limit'] || MEMORY_LIMIT
-    @time_limit = if question_attr['time_limit']
-                    [question_attr['time_limit'], question_attr['max_timeout_limit']].min
-                  else
-                    question_attr['max_timeout_limit']
-                  end
+  def initialize(language, memory_limit, time_limit, max_time_limit, package, timeout)
+    @language = language
+    @memory_limit = memory_limit || MEMORY_LIMIT
+    @time_limit = time_limit ? [time_limit, max_time_limit].min : max_time_limit
     @package = package
     @timeout = timeout || DEFAULT_TIMEOUT
   end

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -9,8 +9,8 @@ class Course::Assessment::Question::ProgrammingImportService
     # @param [Course::Assessment::Question::Programming] question The programming question for
     #   import.
     # @param [Attachment] attachment The attachment containing the package to import.
-    def import(question, attachment)
-      new(question, attachment).import
+    def import(question, attachment, course)
+      new(question, attachment, course).import
     end
   end
 
@@ -33,9 +33,10 @@ class Course::Assessment::Question::ProgrammingImportService
   #
   # @param [Course::Assessment::Question::Programming] question The programming question for import.
   # @param [Attachment] attachment The attachment containing the tests and files.
-  def initialize(question, attachment)
+  def initialize(question, attachment, course)
     @question = question
     @attachment = attachment
+    @course = course
   end
 
   # Imports the templates and tests from the given package.
@@ -59,7 +60,7 @@ class Course::Assessment::Question::ProgrammingImportService
   # @return [Course::Assessment::ProgrammingEvaluationService::Result]
   def evaluate_package(package)
     Course::Assessment::ProgrammingEvaluationService.
-      execute(@question.course, @question.language, @question.memory_limit, @question.time_limit, package.path)
+      execute(@course, @question.language, @question.memory_limit, @question.time_limit, package.path)
   end
 
   # Saves the templates and tests to the question.

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -9,8 +9,8 @@ class Course::Assessment::Question::ProgrammingImportService
     # @param [Course::Assessment::Question::Programming] question The programming question for
     #   import.
     # @param [Attachment] attachment The attachment containing the package to import.
-    def import(question, attachment, course)
-      new(question, attachment, course).import
+    def import(question, attachment)
+      new(question, attachment).import
     end
   end
 
@@ -33,10 +33,9 @@ class Course::Assessment::Question::ProgrammingImportService
   #
   # @param [Course::Assessment::Question::Programming] question The programming question for import.
   # @param [Attachment] attachment The attachment containing the tests and files.
-  def initialize(question, attachment, course)
+  def initialize(question, attachment)
     @question = question
     @attachment = attachment
-    @course = course
   end
 
   # Imports the templates and tests from the given package.
@@ -60,7 +59,7 @@ class Course::Assessment::Question::ProgrammingImportService
   # @return [Course::Assessment::ProgrammingEvaluationService::Result]
   def evaluate_package(package)
     Course::Assessment::ProgrammingEvaluationService.
-      execute(@course, @question.language, @question.memory_limit, @question.time_limit, package.path)
+      execute(@question.course, @question, @question.time_limit, package.path)
   end
 
   # Saves the templates and tests to the question.

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -38,6 +38,8 @@ class Course::Assessment::Question::ProgrammingImportService
     @attachment = attachment
   end
 
+  DEFAULT_CPU_TIMEOUT = 30
+
   # Imports the templates and tests from the given package.
   #
   # @param [Course::Assessment::ProgrammingPackage] package The package to import.
@@ -53,13 +55,23 @@ class Course::Assessment::Question::ProgrammingImportService
     save!(template_files, evaluation_result)
   end
 
+  def max_programming_timeout_limit(course)
+    course ? course.programming_timeout_limit : DEFAULT_CPU_TIMEOUT
+  end
+
   # Evaluates the package to obtain the set of tests.
   #
   # @param [Course::Assessment::ProgrammingPackage] package The package to import.
   # @return [Course::Assessment::ProgrammingEvaluationService::Result]
   def evaluate_package(package)
+    question_attr = {
+      'language' => @question.language,
+      'memory_limit' => @question.memory_limit,
+      'time_limit' => @question.time_limit,
+      'max_timeout_limit' => max_programming_timeout_limit(@question.course)
+    }
     Course::Assessment::ProgrammingEvaluationService.
-      execute(@question.course, @question, @question.time_limit, package.path)
+      execute(question_attr, package.path)
   end
 
   # Saves the templates and tests to the question.

--- a/app/services/course/assessment/question/programming_import_service.rb
+++ b/app/services/course/assessment/question/programming_import_service.rb
@@ -43,7 +43,6 @@ class Course::Assessment::Question::ProgrammingImportService
   # @param [Course::Assessment::ProgrammingPackage] package The package to import.
   def import_from_package(package)
     raise InvalidDataError unless package.valid?
-
     # Must extract template files before replacing them with the solution files.
     template_files = package.submission_files
     package.replace_submission_with_solution
@@ -51,7 +50,6 @@ class Course::Assessment::Question::ProgrammingImportService
     evaluation_result = evaluate_package(package)
 
     raise evaluation_result if evaluation_result.error?
-
     save!(template_files, evaluation_result)
   end
 
@@ -61,7 +59,7 @@ class Course::Assessment::Question::ProgrammingImportService
   # @return [Course::Assessment::ProgrammingEvaluationService::Result]
   def evaluate_package(package)
     Course::Assessment::ProgrammingEvaluationService.
-      execute(@question.language, @question.memory_limit, @question.time_limit, package.path)
+      execute(@question.course, @question.language, @question.memory_limit, @question.time_limit, package.path)
   end
 
   # Saves the templates and tests to the question.

--- a/app/services/course/duplication/course_duplication_service.rb
+++ b/app/services/course/duplication/course_duplication_service.rb
@@ -119,7 +119,9 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
     new_category_settings = {}
     old_course.assessment_categories.each do |old_category|
       new_category = duplicator.duplicate(old_category)
-      new_category_settings[new_category.id.to_s] = old_category_settings[old_category.id.to_s]
+      old_category_settings.each do |key, value|
+        new_category_settings[key] = value
+      end
     end
     new_course.settings.public_send("#{component_key}=", new_category_settings)
     new_course.save!

--- a/app/services/course/duplication/course_duplication_service.rb
+++ b/app/services/course/duplication/course_duplication_service.rb
@@ -64,7 +64,7 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
           new_course.reload
         end
 
-        update_course_settings(duplicator, new_course, source_course)
+        update_course_settings(new_course, source_course)
         update_sidebar_settings(duplicator, new_course, source_course)
 
         # As per carrierwave v2.1.0, carrierwave image mounter that retains uploaded file as a cache
@@ -111,17 +111,14 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
 
   # Updates category_ids in the duplicated course settings. This is to be run after the course has
   # been saved and category_ids are available.
-  def update_course_settings(duplicator, new_course, old_course)
+  def update_course_settings(new_course, old_course)
     component_key = Course::AssessmentsComponent.key
     old_category_settings = old_course.settings.public_send(component_key)
     return true if old_category_settings.nil?
 
     new_category_settings = {}
-    old_course.assessment_categories.each do |old_category|
-      new_category = duplicator.duplicate(old_category)
-      old_category_settings.each do |key, value|
-        new_category_settings[key] = value
-      end
+    old_category_settings.each do |key, value|
+      new_category_settings[key] = value
     end
     new_course.settings.public_send("#{component_key}=", new_category_settings)
     new_course.save!

--- a/app/views/course/admin/assessment_settings/edit.json.jbuilder
+++ b/app/views/course/admin/assessment_settings/edit.json.jbuilder
@@ -5,7 +5,7 @@ json.showPublicTestCasesOutput current_course.show_public_test_cases_output || f
 json.showStdoutAndStderr current_course.show_stdout_and_stderr || false
 json.allowRandomization current_course.allow_randomization || false
 json.allowMrqOptionsRandomization current_course.allow_mrq_options_randomization || false
-json.programmingTimeoutLimit current_course.programming_timeout_limit if can?(:manage, :all)
+json.maxProgrammingTimeLimit current_course.programming_max_time_limit if can?(:manage, :all)
 
 json.canCreateCategories can?(:create, Course::Assessment::Category.new(course: current_course))
 

--- a/app/views/course/admin/assessment_settings/edit.json.jbuilder
+++ b/app/views/course/admin/assessment_settings/edit.json.jbuilder
@@ -5,6 +5,7 @@ json.showPublicTestCasesOutput current_course.show_public_test_cases_output
 json.showStdoutAndStderr current_course.show_stdout_and_stderr
 json.allowRandomization current_course.allow_randomization
 json.allowMrqOptionsRandomization current_course.allow_mrq_options_randomization
+json.programmingTimeLimit current_course.programming_time_limit
 
 json.canCreateCategories can?(:create, Course::Assessment::Category.new(course: current_course))
 

--- a/app/views/course/admin/assessment_settings/edit.json.jbuilder
+++ b/app/views/course/admin/assessment_settings/edit.json.jbuilder
@@ -5,7 +5,7 @@ json.showPublicTestCasesOutput current_course.show_public_test_cases_output
 json.showStdoutAndStderr current_course.show_stdout_and_stderr
 json.allowRandomization current_course.allow_randomization
 json.allowMrqOptionsRandomization current_course.allow_mrq_options_randomization
-json.programmingTimeLimit current_course.programming_time_limit
+json.programmingTimeoutLimit current_course.programming_timeout_limit
 
 json.canCreateCategories can?(:create, Course::Assessment::Category.new(course: current_course))
 

--- a/app/views/course/admin/assessment_settings/edit.json.jbuilder
+++ b/app/views/course/admin/assessment_settings/edit.json.jbuilder
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 categories = current_course.assessment_categories.includes(:tabs)
 
-json.showPublicTestCasesOutput current_course.show_public_test_cases_output
-json.showStdoutAndStderr current_course.show_stdout_and_stderr
-json.allowRandomization current_course.allow_randomization
-json.allowMrqOptionsRandomization current_course.allow_mrq_options_randomization
-json.programmingTimeoutLimit current_course.programming_timeout_limit
+json.showPublicTestCasesOutput current_course.show_public_test_cases_output || false
+json.showStdoutAndStderr current_course.show_stdout_and_stderr || false
+json.allowRandomization current_course.allow_randomization || false
+json.allowMrqOptionsRandomization current_course.allow_mrq_options_randomization || false
+json.programmingTimeoutLimit current_course.programming_timeout_limit if can?(:manage, :all)
 
 json.canCreateCategories can?(:create, Course::Assessment::Category.new(course: current_course))
 

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -2,7 +2,7 @@
 json.question do
   json.(@programming_question, :id, :title, :staff_only_comments, :maximum_grade,
         :language_id, :memory_limit, :time_limit)
-  json.max_timeout_limit @programming_question.max_timeout_limit(current_course)
+  json.max_time_limit @programming_question.max_time_limit
   json.description format_ckeditor_rich_text(@programming_question.description)
   json.languages Coursemology::Polyglot::Language.all.order(:name) do |lang|
     json.(lang, :id, :name)

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -2,6 +2,7 @@
 json.question do
   json.(@programming_question, :id, :title, :staff_only_comments, :maximum_grade,
         :language_id, :memory_limit, :time_limit)
+  json.max_timeout_limit @programming_question.max_timeout_limit(current_course)
   json.description format_ckeditor_rich_text(@programming_question.description)
   json.languages Coursemology::Polyglot::Language.all.order(:name) do |lang|
     json.(lang, :id, :name)

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -5,6 +5,7 @@ import { AssessmentSettingsData } from 'types/course/admin/assessments';
 import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
+import FormTextField from 'lib/components/form/fields/TextField';
 import Form, { FormEmitter } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -108,6 +109,28 @@ const AssessmentsSettingsForm = (
                   categories={field.value}
                   disabled={props.disabled}
                   onUpdate={field.onChange}
+                />
+              )}
+            />
+          </Section>
+
+          <Section
+            sticksToNavbar
+            subtitle={t(translations.programmingTimeLimitSubtitle)}
+            title={t(translations.programmingTimeLimit)}
+          >
+            <Controller
+              control={control}
+              name="programmingTimeLimit"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormTextField
+                  disabled={props.disabled}
+                  field={field}
+                  fieldState={fieldState}
+                  fullWidth
+                  label={t(translations.programmingTimeLimitLabel)}
+                  type="number"
+                  variant="filled"
                 />
               )}
             />

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -94,6 +94,28 @@ const AssessmentsSettingsForm = (
                 )}
               />
             </Subsection>
+
+            <Subsection
+              className="!mt-8"
+              spaced
+              title={t(translations.programmingTimeoutLimit)}
+            >
+              <Controller
+                control={control}
+                name="programmingTimeoutLimit"
+                render={({ field, fieldState }): JSX.Element => (
+                  <FormTextField
+                    disabled={props.disabled}
+                    field={field}
+                    fieldState={fieldState}
+                    fullWidth
+                    label={t(translations.programmingTimeoutLimit)}
+                    type="number"
+                    variant="filled"
+                  />
+                )}
+              />
+            </Subsection>
           </Section>
 
           <Section
@@ -109,28 +131,6 @@ const AssessmentsSettingsForm = (
                   categories={field.value}
                   disabled={props.disabled}
                   onUpdate={field.onChange}
-                />
-              )}
-            />
-          </Section>
-
-          <Section
-            sticksToNavbar
-            subtitle={t(translations.programmingTimeoutLimitSubtitle)}
-            title={t(translations.programmingTimeoutLimit)}
-          >
-            <Controller
-              control={control}
-              name="programmingTimeoutLimit"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormTextField
-                  disabled={props.disabled}
-                  field={field}
-                  fieldState={fieldState}
-                  fullWidth
-                  label={t(translations.programmingTimeoutLimitLabel)}
-                  type="number"
-                  variant="filled"
                 />
               )}
             />

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -104,27 +104,29 @@ const AssessmentsSettingsForm = (
               />
             </Subsection>
 
-            <Subsection
-              className="!mt-8"
-              spaced
-              title={t(translations.programmingTimeoutLimit)}
-            >
-              <Controller
-                control={control}
-                name="programmingTimeoutLimit"
-                render={({ field, fieldState }): JSX.Element => (
-                  <FormTextField
-                    disabled={props.disabled}
-                    field={field}
-                    fieldState={fieldState}
-                    fullWidth
-                    label={t(translations.programmingTimeoutLimit)}
-                    type="number"
-                    variant="filled"
-                  />
-                )}
-              />
-            </Subsection>
+            {props.data.programmingTimeoutLimit && (
+              <Subsection
+                className="!mt-8"
+                spaced
+                title={t(translations.programmingTimeoutLimit)}
+              >
+                <Controller
+                  control={control}
+                  name="programmingTimeoutLimit"
+                  render={({ field, fieldState }): JSX.Element => (
+                    <FormTextField
+                      disabled={props.disabled}
+                      field={field}
+                      fieldState={fieldState}
+                      fullWidth
+                      label={t(translations.programmingTimeoutLimit)}
+                      type="number"
+                      variant="filled"
+                    />
+                  )}
+                />
+              </Subsection>
+            )}
           </Section>
 
           <Section

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -1,6 +1,7 @@
 import { Emits } from 'react-emitter-factory';
 import { Controller } from 'react-hook-form';
 import { AssessmentSettingsData } from 'types/course/admin/assessments';
+import * as yup from 'yup';
 
 import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
@@ -22,6 +23,13 @@ const AssessmentsSettingsForm = (
   props: AssessmentsSettingsFormProps,
 ): JSX.Element => {
   const { t } = useTranslation();
+  const validationSchema = yup.object({
+    programmingTimeoutLimit: yup
+      .number()
+      .nullable()
+      .typeError(t(translations.numberRequired))
+      .min(0, t(translations.positiveNumberRequired)),
+  });
 
   return (
     <Form
@@ -30,6 +38,7 @@ const AssessmentsSettingsForm = (
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
+      validates={validationSchema}
     >
       {(control): JSX.Element => (
         <>

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -116,19 +116,19 @@ const AssessmentsSettingsForm = (
 
           <Section
             sticksToNavbar
-            subtitle={t(translations.programmingTimeLimitSubtitle)}
-            title={t(translations.programmingTimeLimit)}
+            subtitle={t(translations.programmingTimeoutLimitSubtitle)}
+            title={t(translations.programmingTimeoutLimit)}
           >
             <Controller
               control={control}
-              name="programmingTimeLimit"
+              name="programmingTimeoutLimit"
               render={({ field, fieldState }): JSX.Element => (
                 <FormTextField
                   disabled={props.disabled}
                   field={field}
                   fieldState={fieldState}
                   fullWidth
-                  label={t(translations.programmingTimeLimitLabel)}
+                  label={t(translations.programmingTimeoutLimitLabel)}
                   type="number"
                   variant="filled"
                 />

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -24,11 +24,11 @@ const AssessmentsSettingsForm = (
 ): JSX.Element => {
   const { t } = useTranslation();
   const validationSchema = yup.object({
-    programmingTimeoutLimit: yup
+    maxProgrammingTimeLimit: yup
       .number()
       .nullable()
-      .typeError(t(translations.numberRequired))
-      .min(0, t(translations.positiveNumberRequired)),
+      .typeError(t(translations.maxTimeLimitRequired))
+      .min(1, t(translations.positiveMaxTimeLimitRequired)),
   });
 
   return (
@@ -104,22 +104,22 @@ const AssessmentsSettingsForm = (
               />
             </Subsection>
 
-            {props.data.programmingTimeoutLimit && (
+            {props.data.maxProgrammingTimeLimit && (
               <Subsection
                 className="!mt-8"
                 spaced
-                title={t(translations.programmingTimeoutLimit)}
+                title={t(translations.maxProgrammingTimeLimit)}
               >
                 <Controller
                   control={control}
-                  name="programmingTimeoutLimit"
+                  name="maxProgrammingTimeLimit"
                   render={({ field, fieldState }): JSX.Element => (
                     <FormTextField
                       disabled={props.disabled}
                       field={field}
                       fieldState={fieldState}
                       fullWidth
-                      label={t(translations.programmingTimeoutLimit)}
+                      label={t(translations.maxProgrammingTimeLimit)}
                       type="number"
                       variant="filled"
                     />

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/operations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/operations.ts
@@ -51,6 +51,7 @@ export const updateAssessmentSettings = async (
       show_stdout_and_stderr: data.showStdoutAndStderr,
       allow_randomization: data.allowRandomization,
       allow_mrq_options_randomization: data.allowMrqOptionsRandomization,
+      programming_time_limit: data.programmingTimeLimit,
       assessment_categories_attributes: data.categories.map((category) => ({
         id: category.id,
         title: category.title,

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/operations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/operations.ts
@@ -51,7 +51,7 @@ export const updateAssessmentSettings = async (
       show_stdout_and_stderr: data.showStdoutAndStderr,
       allow_randomization: data.allowRandomization,
       allow_mrq_options_randomization: data.allowMrqOptionsRandomization,
-      programming_time_limit: data.programmingTimeLimit,
+      programming_timeout_limit: data.programmingTimeoutLimit,
       assessment_categories_attributes: data.categories.map((category) => ({
         id: category.id,
         title: category.title,

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/operations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/operations.ts
@@ -51,7 +51,7 @@ export const updateAssessmentSettings = async (
       show_stdout_and_stderr: data.showStdoutAndStderr,
       allow_randomization: data.allowRandomization,
       allow_mrq_options_randomization: data.allowMrqOptionsRandomization,
-      programming_timeout_limit: data.programmingTimeoutLimit,
+      programming_max_time_limit: data.maxProgrammingTimeLimit,
       assessment_categories_attributes: data.categories.map((category) => ({
         id: category.id,
         title: category.title,

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -42,9 +42,9 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.outputsOfPublicTestCases',
     defaultMessage: 'Outputs of Public test cases',
   },
-  programmingTimeoutLimit: {
-    id: 'course.admin.AssessmentSettings.programmingTimeoutLimit',
-    defaultMessage: 'Programming Timeout Limit',
+  maxProgrammingTimeLimit: {
+    id: 'course.admin.AssessmentSettings.maxProgrammingTimeLimit',
+    defaultMessage: 'Maximum programming time limit',
   },
   standardOutputsAndStandardErrors: {
     id: 'course.admin.AssessmentSettings.standardOutputsAndStandardErrors',
@@ -104,13 +104,13 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.moveTabsThenDelete',
     defaultMessage: 'Move tabs then delete',
   },
-  numberRequired: {
-    id: 'course.admin.AssessmentSettings.numberRequired',
-    defaultMessage: 'must input a number here',
+  maxTimeLimitRequired: {
+    id: 'course.admin.AssessmentSettings.maxTimeLimitRequired',
+    defaultMessage: 'Maximum programming time limit is required',
   },
-  positiveNumberRequired: {
-    id: 'course.admin.AssessmentSettings.positiveNumberRequired',
-    defaultMessage: 'must input a positive number here',
+  positiveMaxTimeLimitRequired: {
+    id: 'course.admin.AssessmentSettings.positiveMaxTimeLimitRequired',
+    defaultMessage: 'Maximum programming time limit must be a positive integer',
   },
   toTab: {
     id: 'course.admin.AssessmentSettings.toTab',

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -42,6 +42,19 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.outputsOfPublicTestCases',
     defaultMessage: 'Outputs of Public test cases',
   },
+  programmingTimeLimit: {
+    id: 'course.admin.AssessmentSettings.programmingTimeLimit',
+    defaultMessage: 'Programming Time Limit',
+  },
+  programmingTimeLimitSubtitle: {
+    id: 'course.admin.AssessmentSettings.programmingTimeLimitSubtitle',
+    defaultMessage:
+      'The time limit set for programming questions within this course',
+  },
+  programmingTimeLimitLabel: {
+    id: 'course.admin.AssessmentSettings.programmingTimeLimitLabel',
+    defaultMessage: 'Set Programming Time Limit',
+  },
   standardOutputsAndStandardErrors: {
     id: 'course.admin.AssessmentSettings.standardOutputsAndStandardErrors',
     defaultMessage: 'Standard outputs and Standard errors',

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -46,15 +46,6 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.programmingTimeoutLimit',
     defaultMessage: 'Programming Timeout Limit',
   },
-  programmingTimeoutLimitSubtitle: {
-    id: 'course.admin.AssessmentSettings.programmingTimeoutLimitSubtitle',
-    defaultMessage:
-      'The maximum time limit set for programming questions within this course',
-  },
-  programmingTimeoutLimitLabel: {
-    id: 'course.admin.AssessmentSettings.programmingTimeoutLimitLabel',
-    defaultMessage: 'Set Programming Timeout Limit',
-  },
   standardOutputsAndStandardErrors: {
     id: 'course.admin.AssessmentSettings.standardOutputsAndStandardErrors',
     defaultMessage: 'Standard outputs and Standard errors',

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -42,18 +42,18 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.outputsOfPublicTestCases',
     defaultMessage: 'Outputs of Public test cases',
   },
-  programmingTimeLimit: {
-    id: 'course.admin.AssessmentSettings.programmingTimeLimit',
-    defaultMessage: 'Programming Time Limit',
+  programmingTimeoutLimit: {
+    id: 'course.admin.AssessmentSettings.programmingTimeoutLimit',
+    defaultMessage: 'Programming Timeout Limit',
   },
-  programmingTimeLimitSubtitle: {
-    id: 'course.admin.AssessmentSettings.programmingTimeLimitSubtitle',
+  programmingTimeoutLimitSubtitle: {
+    id: 'course.admin.AssessmentSettings.programmingTimeoutLimitSubtitle',
     defaultMessage:
-      'The time limit set for programming questions within this course',
+      'The maximum time limit set for programming questions within this course',
   },
-  programmingTimeLimitLabel: {
-    id: 'course.admin.AssessmentSettings.programmingTimeLimitLabel',
-    defaultMessage: 'Set Programming Time Limit',
+  programmingTimeoutLimitLabel: {
+    id: 'course.admin.AssessmentSettings.programmingTimeoutLimitLabel',
+    defaultMessage: 'Set Programming Timeout Limit',
   },
   standardOutputsAndStandardErrors: {
     id: 'course.admin.AssessmentSettings.standardOutputsAndStandardErrors',

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -104,6 +104,14 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.moveTabsThenDelete',
     defaultMessage: 'Move tabs then delete',
   },
+  numberRequired: {
+    id: 'course.admin.AssessmentSettings.numberRequired',
+    defaultMessage: 'must input a number here',
+  },
+  positiveNumberRequired: {
+    id: 'course.admin.AssessmentSettings.positiveNumberRequired',
+    defaultMessage: 'must input a positive number here',
+  },
   toTab: {
     id: 'course.admin.AssessmentSettings.toTab',
     defaultMessage: 'to {tab}',

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
@@ -161,7 +161,7 @@ export default defineMessages({
   },
   timeLimitRangeValidationError: {
     id: 'course.assessment.question.programming.ProgrammingQuestionForm.timeLimitRangeValidationError',
-    defaultMessage: 'Time limit must be within 1 to 300.',
+    defaultMessage: 'Time limit must be within 1 to {hard_time_limit}.',
   },
   submitConfirmation: {
     id: 'course.assessment.question.programming.ProgrammingQuestionForm.submitConfirmation',

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -55,12 +55,13 @@ const propTypes = {
 };
 
 const DEFAULT_TIME_LIMIT = 10;
-const HARD_TIME_LIMIT = 300;
 
 function validation(data, pathOfKeysToData, intl) {
   const errors = [];
   const questionErrors = {};
   let hasError = false;
+
+  const HARD_TIME_LIMIT = data.get('max_timeout_limit')
 
   // Check maximum grade
   const maximumGrade = data.get('maximum_grade');
@@ -88,7 +89,9 @@ function validation(data, pathOfKeysToData, intl) {
   const timeLimit = data.get('time_limit');
   if (timeLimit && (timeLimit > HARD_TIME_LIMIT || timeLimit <= 0)) {
     questionErrors.time_limit = intl.formatMessage(
-      translations.timeLimitRangeValidationError,
+      translations.timeLimitRangeValidationError, {
+        hard_time_limit: HARD_TIME_LIMIT,
+      },
     );
     hasError = true;
   }

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -61,7 +61,7 @@ function validation(data, pathOfKeysToData, intl) {
   const questionErrors = {};
   let hasError = false;
 
-  const HARD_TIME_LIMIT = data.get('max_timeout_limit');
+  const HARD_TIME_LIMIT = data.get('max_time_limit');
 
   // Check maximum grade
   const maximumGrade = data.get('maximum_grade');

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -61,7 +61,7 @@ function validation(data, pathOfKeysToData, intl) {
   const questionErrors = {};
   let hasError = false;
 
-  const HARD_TIME_LIMIT = data.get('max_timeout_limit')
+  const HARD_TIME_LIMIT = data.get('max_timeout_limit');
 
   // Check maximum grade
   const maximumGrade = data.get('maximum_grade');
@@ -89,7 +89,8 @@ function validation(data, pathOfKeysToData, intl) {
   const timeLimit = data.get('time_limit');
   if (timeLimit && (timeLimit > HARD_TIME_LIMIT || timeLimit <= 0)) {
     questionErrors.time_limit = intl.formatMessage(
-      translations.timeLimitRangeValidationError, {
+      translations.timeLimitRangeValidationError,
+      {
         hard_time_limit: HARD_TIME_LIMIT,
       },
     );

--- a/client/app/types/course/admin/assessments.ts
+++ b/client/app/types/course/admin/assessments.ts
@@ -3,7 +3,7 @@ export interface AssessmentSettingsData {
   showStdoutAndStderr: boolean;
   allowRandomization: boolean;
   allowMrqOptionsRandomization: boolean;
-  programmingTimeLimit: number;
+  programmingTimeoutLimit: number;
   categories: AssessmentCategory[];
   canCreateCategories: boolean;
 }
@@ -61,7 +61,7 @@ export interface AssessmentSettingsPostData {
     show_stdout_and_stderr?: AssessmentSettingsData['showStdoutAndStderr'];
     allow_randomization?: AssessmentSettingsData['allowRandomization'];
     allow_mrq_options_randomization?: AssessmentSettingsData['allowMrqOptionsRandomization'];
-    programming_time_limit: AssessmentSettingsData['programmingTimeLimit'];
+    programming_timeout_limit: AssessmentSettingsData['programmingTimeoutLimit'];
     assessment_categories_attributes?: {
       id: AssessmentCategory['id'];
       title: AssessmentCategory['title'];

--- a/client/app/types/course/admin/assessments.ts
+++ b/client/app/types/course/admin/assessments.ts
@@ -3,6 +3,7 @@ export interface AssessmentSettingsData {
   showStdoutAndStderr: boolean;
   allowRandomization: boolean;
   allowMrqOptionsRandomization: boolean;
+  programmingTimeLimit: number;
   categories: AssessmentCategory[];
   canCreateCategories: boolean;
 }
@@ -60,6 +61,7 @@ export interface AssessmentSettingsPostData {
     show_stdout_and_stderr?: AssessmentSettingsData['showStdoutAndStderr'];
     allow_randomization?: AssessmentSettingsData['allowRandomization'];
     allow_mrq_options_randomization?: AssessmentSettingsData['allowMrqOptionsRandomization'];
+    programming_time_limit: AssessmentSettingsData['programmingTimeLimit'];
     assessment_categories_attributes?: {
       id: AssessmentCategory['id'];
       title: AssessmentCategory['title'];

--- a/client/app/types/course/admin/assessments.ts
+++ b/client/app/types/course/admin/assessments.ts
@@ -5,7 +5,7 @@ export interface AssessmentSettingsData {
   allowMrqOptionsRandomization: boolean;
   categories: AssessmentCategory[];
   canCreateCategories: boolean;
-  programmingTimeoutLimit?: number;
+  maxProgrammingTimeLimit?: number;
 }
 
 export interface AssessmentCategory {
@@ -61,7 +61,7 @@ export interface AssessmentSettingsPostData {
     show_stdout_and_stderr?: AssessmentSettingsData['showStdoutAndStderr'];
     allow_randomization?: AssessmentSettingsData['allowRandomization'];
     allow_mrq_options_randomization?: AssessmentSettingsData['allowMrqOptionsRandomization'];
-    programming_timeout_limit: AssessmentSettingsData['programmingTimeoutLimit'];
+    programming_max_time_limit: AssessmentSettingsData['maxProgrammingTimeLimit'];
     assessment_categories_attributes?: {
       id: AssessmentCategory['id'];
       title: AssessmentCategory['title'];

--- a/client/app/types/course/admin/assessments.ts
+++ b/client/app/types/course/admin/assessments.ts
@@ -3,9 +3,9 @@ export interface AssessmentSettingsData {
   showStdoutAndStderr: boolean;
   allowRandomization: boolean;
   allowMrqOptionsRandomization: boolean;
-  programmingTimeoutLimit: number;
   categories: AssessmentCategory[];
   canCreateCategories: boolean;
+  programmingTimeoutLimit?: number;
 }
 
 export interface AssessmentCategory {

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -1490,7 +1490,7 @@
     "description": "Label for the time limit input field."
   },
   "course.assessment.question.programming.ProgrammingQuestionForm.timeLimitRangeValidationError": {
-    "defaultMessage": "Time limit must be within 1 to 300."
+    "defaultMessage": "Time limit must be within 1 to {hard_time_limit}."
   },
   "course.assessment.question.programming.ProgrammingQuestionForm.titleFieldLabel": {
     "defaultMessage": "Title",

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -1422,7 +1422,7 @@
     "defaultMessage": "时间限制 (s)"
   },
   "course.assessment.question.programming.ProgrammingQuestionForm.timeLimitRangeValidationError": {
-    "defaultMessage": "时间限制必须在 1 到 30 之间。"
+    "defaultMessage": "时间限制必须在 1 到 {hard_time_limit} 之间。"
   },
   "course.assessment.question.programming.ProgrammingQuestionForm.titleFieldLabel": {
     "defaultMessage": "标题"

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -26,13 +26,76 @@ RSpec.describe Course::Assessment::Question::Programming do
       let(:settings1) { ActiveSupport::HashWithIndifferentAccess.new(programming_timeout_limit: 170) }
       let(:settings2) { ActiveSupport::HashWithIndifferentAccess.new(course_assessments_component: settings1) }
       let(:course) { create(:course, settings: settings2) }
-      subject { build(:course_assessment_question_programming, course: course) }
 
-      it { is_expected.to validate_numericality_of(:time_limit).allow_nil }
-      it { is_expected.to validate_numericality_of(:memory_limit).allow_nil }
-      it 'validates time_limit' do
-        expect(subject).to validate_numericality_of(:time_limit).is_greater_than(0).
-          is_less_than_or_equal_to(170)
+      let(:object1) do
+        Course::Assessment::Question::Programming.new(
+          time_limit: 171,
+          maximum_grade: 100,
+          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+          course: course
+        )
+      end
+      it 'validates time limit to be less than programming timeout limit of the course' do
+        expect(object1).to_not be_valid
+      end
+
+      let(:object2) do
+        Course::Assessment::Question::Programming.new(
+          time_limit: 'abcd',
+          maximum_grade: 100,
+          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+          course: course
+        )
+      end
+      it 'validates time limit to be an integer' do
+        expect(object2).to_not be_valid
+      end
+
+      let(:object3) do
+        Course::Assessment::Question::Programming.new(
+          time_limit: 0,
+          maximum_grade: 100,
+          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+          course: course
+        )
+      end
+      it 'validates time limit to be an integer more than 0' do
+        expect(object3).to_not be_valid
+      end
+
+      let(:object4) do
+        Course::Assessment::Question::Programming.new(
+          time_limit: 170,
+          maximum_grade: 100,
+          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+          course: course
+        )
+      end
+      it 'validates time limit to be within stipulated range (check upper bound)' do
+        expect(object4).to be_valid
+      end
+
+      let(:object5) do
+        Course::Assessment::Question::Programming.new(
+          time_limit: 1,
+          maximum_grade: 100,
+          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+          course: course
+        )
+      end
+      it 'validates time limit to be within stipulated range (check lower bound)' do
+        expect(object5).to be_valid
+      end
+
+      let(:object6) do
+        Course::Assessment::Question::Programming.new(
+          maximum_grade: 100,
+          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+          course: course
+        )
+      end
+      it 'validates time limit when it is nil' do
+        expect(object6).to be_valid
       end
     end
 

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -23,88 +23,66 @@ RSpec.describe Course::Assessment::Question::Programming do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe 'validations' do
-      let(:settings1) { ActiveSupport::HashWithIndifferentAccess.new(programming_timeout_limit: 170) }
-      let(:settings2) { ActiveSupport::HashWithIndifferentAccess.new(course_assessments_component: settings1) }
-      let(:course) { create(:course, settings: settings2) }
+      let(:programming_max_time_limit_setting) do
+        ActiveSupport::HashWithIndifferentAccess.new(programming_max_time_limit: 170)
+      end
+      let(:assessments_component_setting) do
+        ActiveSupport::HashWithIndifferentAccess.new(course_assessments_component: programming_max_time_limit_setting)
+      end
+      let(:course) { create(:course, settings: assessments_component_setting) }
+      let(:time_limit) { nil }
+      let(:question_programming) { build(:course_assessment_question_programming, time_limit: time_limit) }
 
-      context 'when the time limit is set to be higher than the programming timeout limit set in course settings' do
-        let(:object1) do
-          Course::Assessment::Question::Programming.new(
-            time_limit: 171,
-            maximum_grade: 100,
-            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            course: course
-          )
+      context 'when the time limit is set to be higher than the max programming time limit in course settings' do
+        let(:time_limit) { 171 }
+        before do
+          question_programming.max_time_limit = course.programming_max_time_limit
         end
+
         it 'is expected to be valid' do
-          expect(object1).to_not be_valid
+          expect(question_programming).to_not be_valid
         end
       end
 
       context 'when the time limit is not set to be an integer' do
-        let(:object2) do
-          Course::Assessment::Question::Programming.new(
-            time_limit: 'abcd',
-            maximum_grade: 100,
-            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            course: course
-          )
+        let(:time_limit) { 'abcd' }
+        before do
+          question_programming.max_time_limit = course.programming_max_time_limit
         end
+
         it 'is expected to be invalid' do
-          expect(object2).to_not be_valid
+          question_programming.max_time_limit = course.programming_max_time_limit
+          expect(question_programming).to_not be_valid
         end
       end
 
-      context 'when the time limit is set to be zero' do
-        let(:object3) do
-          Course::Assessment::Question::Programming.new(
-            time_limit: 0,
-            maximum_grade: 100,
-            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            course: course
-          )
-        end
+      context 'when the time limit is set to zero' do
+        let(:time_limit) { 0 }
+
         it 'is expected to be invalid' do
-          expect(object3).to_not be_valid
+          expect(question_programming).to_not be_valid
         end
       end
 
-      context 'when the time limit is set to be within the stipulated range (between 0 and upper bound)' do
-        let(:object4) do
-          Course::Assessment::Question::Programming.new(
-            time_limit: 170,
-            maximum_grade: 100,
-            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            course: course
-          )
+      context 'when the time limit is set to be within the stipulated range (between 0 and an upper bound)' do
+        let(:time_limit) { 170 }
+        before do
+          question_programming.max_time_limit = course.programming_max_time_limit
         end
+
         it 'is expected to be valid (upper bound checked)' do
-          expect(object4).to be_valid
+          expect(question_programming).to be_valid
         end
 
-        let(:object5) do
-          Course::Assessment::Question::Programming.new(
-            time_limit: 1,
-            maximum_grade: 100,
-            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            course: course
-          )
-        end
         it 'is expected to be valid (lower bound checked)' do
-          expect(object5).to be_valid
+          question_programming.time_limit = 1
+          expect(question_programming).to be_valid
         end
       end
 
-      context 'when the time limit is not set on the question' do
-        let(:object6) do
-          Course::Assessment::Question::Programming.new(
-            maximum_grade: 100,
-            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            course: course
-          )
-        end
+      context 'when the time limit is not set for the question' do
         it 'is expected to be valid' do
-          expect(object6).to be_valid
+          expect(question_programming).to be_valid
         end
       end
     end

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -23,13 +23,16 @@ RSpec.describe Course::Assessment::Question::Programming do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     describe 'validations' do
-      subject { build(:course_assessment_question_programming) }
+      let(:settings1) { ActiveSupport::HashWithIndifferentAccess.new(programming_timeout_limit: 170) }
+      let(:settings2) { ActiveSupport::HashWithIndifferentAccess.new(course_assessments_component: settings1) }
+      let(:course) { create(:course, settings: settings2) }
+      subject { build(:course_assessment_question_programming, course: course) }
 
       it { is_expected.to validate_numericality_of(:time_limit).allow_nil }
       it { is_expected.to validate_numericality_of(:memory_limit).allow_nil }
       it 'validates time_limit' do
         expect(subject).to validate_numericality_of(:time_limit).is_greater_than(0).
-          is_less_than_or_equal_to(300)
+          is_less_than_or_equal_to(170)
       end
     end
 

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -27,75 +27,85 @@ RSpec.describe Course::Assessment::Question::Programming do
       let(:settings2) { ActiveSupport::HashWithIndifferentAccess.new(course_assessments_component: settings1) }
       let(:course) { create(:course, settings: settings2) }
 
-      let(:object1) do
-        Course::Assessment::Question::Programming.new(
-          time_limit: 171,
-          maximum_grade: 100,
-          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          course: course
-        )
-      end
-      it 'validates time limit to be less than programming timeout limit of the course' do
-        expect(object1).to_not be_valid
-      end
-
-      let(:object2) do
-        Course::Assessment::Question::Programming.new(
-          time_limit: 'abcd',
-          maximum_grade: 100,
-          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          course: course
-        )
-      end
-      it 'validates time limit to be an integer' do
-        expect(object2).to_not be_valid
+      context 'when the time limit is set to be higher than the programming timeout limit set in course settings' do
+        let(:object1) do
+          Course::Assessment::Question::Programming.new(
+            time_limit: 171,
+            maximum_grade: 100,
+            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            course: course
+          )
+        end
+        it 'is expected to be valid' do
+          expect(object1).to_not be_valid
+        end
       end
 
-      let(:object3) do
-        Course::Assessment::Question::Programming.new(
-          time_limit: 0,
-          maximum_grade: 100,
-          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          course: course
-        )
-      end
-      it 'validates time limit to be an integer more than 0' do
-        expect(object3).to_not be_valid
-      end
-
-      let(:object4) do
-        Course::Assessment::Question::Programming.new(
-          time_limit: 170,
-          maximum_grade: 100,
-          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          course: course
-        )
-      end
-      it 'validates time limit to be within stipulated range (check upper bound)' do
-        expect(object4).to be_valid
+      context 'when the time limit is not set to be an integer' do
+        let(:object2) do
+          Course::Assessment::Question::Programming.new(
+            time_limit: 'abcd',
+            maximum_grade: 100,
+            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            course: course
+          )
+        end
+        it 'is expected to be invalid' do
+          expect(object2).to_not be_valid
+        end
       end
 
-      let(:object5) do
-        Course::Assessment::Question::Programming.new(
-          time_limit: 1,
-          maximum_grade: 100,
-          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          course: course
-        )
-      end
-      it 'validates time limit to be within stipulated range (check lower bound)' do
-        expect(object5).to be_valid
+      context 'when the time limit is set to be zero' do
+        let(:object3) do
+          Course::Assessment::Question::Programming.new(
+            time_limit: 0,
+            maximum_grade: 100,
+            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            course: course
+          )
+        end
+        it 'is expected to be invalid' do
+          expect(object3).to_not be_valid
+        end
       end
 
-      let(:object6) do
-        Course::Assessment::Question::Programming.new(
-          maximum_grade: 100,
-          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          course: course
-        )
+      context 'when the time limit is set to be within the stipulated range (between 0 and upper bound)' do
+        let(:object4) do
+          Course::Assessment::Question::Programming.new(
+            time_limit: 170,
+            maximum_grade: 100,
+            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            course: course
+          )
+        end
+        it 'is expected to be valid (upper bound checked)' do
+          expect(object4).to be_valid
+        end
+
+        let(:object5) do
+          Course::Assessment::Question::Programming.new(
+            time_limit: 1,
+            maximum_grade: 100,
+            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            course: course
+          )
+        end
+        it 'is expected to be valid (lower bound checked)' do
+          expect(object5).to be_valid
+        end
       end
-      it 'validates time limit when it is nil' do
-        expect(object6).to be_valid
+
+      context 'when the time limit is not set on the question' do
+        let(:object6) do
+          Course::Assessment::Question::Programming.new(
+            maximum_grade: 100,
+            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            course: course
+          )
+        end
+        it 'is expected to be valid' do
+          expect(object6).to be_valid
+        end
       end
     end
 

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
           it 'creates a new package with the correct file contents' do
             expect(Course::Assessment::ProgrammingEvaluationService).to \
               receive(:execute).and_wrap_original do |method, *args|
-              package = Course::Assessment::ProgrammingPackage.new(args[3])
+              package = Course::Assessment::ProgrammingPackage.new(args[1])
               expect(package.submission_files.values).to contain_exactly(answer_contents)
               method.call(*args)
             end

--- a/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_auto_grading_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingAutoGradingService do
           it 'creates a new package with the correct file contents' do
             expect(Course::Assessment::ProgrammingEvaluationService).to \
               receive(:execute).and_wrap_original do |method, *args|
-              package = Course::Assessment::ProgrammingPackage.new(args[1])
+              package = Course::Assessment::ProgrammingPackage.new(args[4])
               expect(package.submission_files.values).to contain_exactly(answer_contents)
               method.call(*args)
             end

--- a/spec/services/course/assessment/programming_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_evaluation_service_spec.rb
@@ -78,23 +78,18 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Assessment::ProgrammingEvaluationService }
-    let(:settings1) { ActiveSupport::HashWithIndifferentAccess.new(programming_timeout_limit: 170) }
-    let(:settings2) { ActiveSupport::HashWithIndifferentAccess.new(course_assessments_component: settings1) }
-    let(:course) { create(:course, settings: settings2) }
-    let(:question) do
-      create(
-        :course_assessment_question_programming,
-        language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-        memory_limit: 64
-      )
+    let(:question_attr) do
+      {
+        'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+        'memory_limit' => 64,
+        'time_limit' => 5,
+        'max_timeout_limit' => 30
+      }
     end
 
     it 'returns the result of evaluating' do
-      result = subject.execute(
-        course, question, 5.seconds,
-        File.join(Rails.root, 'spec', 'fixtures',
-                  'course', 'programming_question_template.zip')
-      )
+      result = subject.execute(question_attr, File.join(Rails.root, 'spec', 'fixtures', 'course',
+                                                        'programming_question_template.zip'))
       expect(result).to be_a(Course::Assessment::ProgrammingEvaluationService::Result)
     end
 
@@ -102,53 +97,85 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
       it 'raises a Timeout::Error' do
         expect do
           # Pass in a non-zero timeout as Ruby's Timeout treats 0 as infinite.
-          subject.execute(course, question, 5.seconds,
-                          File.join(Rails.root, 'spec', 'fixtures', 'course',
-                                    'programming_question_template.zip'), 0.1.seconds)
+          subject.execute(question_attr, File.join(Rails.root, 'spec', 'fixtures', 'course',
+                                                   'programming_question_template.zip'), 0.1.seconds)
         end.to raise_error(Timeout::Error)
       end
     end
 
     describe '#create_container' do
-      let(:question) do
-        create(
-          :course_assessment_question_programming,
-          language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          memory_limit: nil
-        )
+      let(:question_attr2) do
+        {
+          'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+          'memory_limit' => nil,
+          'time_limit' => nil,
+          'max_timeout_limit' => 30
+        }
       end
-      let(:time_limit) { nil }
       let(:service_instance) do
-        subject.new(course, question, time_limit, Rails.root.join('spec', 'fixtures', 'course',
-                                                                  'programming_question_template.zip'), nil)
+        subject.new(question_attr2, Rails.root.join('spec', 'fixtures', 'course',
+                                                    'programming_question_template.zip'), nil)
       end
       let(:image) { 'python:3.10' }
       let(:container) { service_instance.send(:create_container, image) }
 
       it 'prefixes the image with coursemology/evaluator-image' do
+        # when the time_limit or course is not defined here, the default time_limit is set to 30 seconds
         expect(CoursemologyDockerContainer).to \
           receive(:create).with("coursemology/evaluator-image-#{image}",
-                                hash_including(argv: ['-c170']))
+                                hash_including(argv: ['-c30']))
 
         container
       end
 
-      context 'when resource limits are specified' do
-        let(:question) do
-          create(
-            :course_assessment_question_programming,
-            language: Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            memory_limit: 16
-          )
+      context 'when the course has its programming timeout limit set' do
+        let(:question_attr3) do
+          {
+            'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            'memory_limit' => nil,
+            'time_limit' => nil,
+            'max_timeout_limit' => 170
+          }
         end
-        let(:time_limit) { 5 }
+        let(:service_instance2) do
+          subject.new(question_attr3, Rails.root.join('spec', 'fixtures', 'course',
+                                                      'programming_question_template.zip'), nil)
+        end
+        let(:image2) { 'python:3.10' }
+        let(:container2) { service_instance2.send(:create_container, image2) }
+
+        it 'prefixes the image with coursemology/evaluator-image' do
+          # when the time_limit or course is not defined here, the default time_limit is set to 30 seconds
+          expect(CoursemologyDockerContainer).to \
+            receive(:create).with("coursemology/evaluator-image-#{image2}",
+                                  hash_including(argv: ['-c170']))
+
+          container2
+        end
+      end
+
+      context 'when resource limits are specified' do
+        let(:question_attr4) do
+          {
+            'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+            'memory_limit' => 16,
+            'time_limit' => 5,
+            'max_timeout_limit' => 170
+          }
+        end
+        let(:service_instance3) do
+          subject.new(question_attr4, Rails.root.join('spec', 'fixtures', 'course',
+                                                      'programming_question_template.zip'), nil)
+        end
+        let(:image3) { 'python:3.10' }
+        let(:container3) { service_instance3.send(:create_container, image3) }
 
         it 'specifies them when creating the container' do
           expect(CoursemologyDockerContainer).to \
-            receive(:create).with("coursemology/evaluator-image-#{image}",
+            receive(:create).with("coursemology/evaluator-image-#{image3}",
                                   hash_including(argv: ['-c5', '-m16384']))
 
-          container
+          container3
         end
       end
     end

--- a/spec/services/course/assessment/programming_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_evaluation_service_spec.rb
@@ -78,18 +78,12 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
   let(:instance) { Instance.default }
   with_tenant(:instance) do
     subject { Course::Assessment::ProgrammingEvaluationService }
-    let(:question_attr) do
-      {
-        'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-        'memory_limit' => 64,
-        'time_limit' => 5,
-        'max_timeout_limit' => 30
-      }
-    end
 
     it 'returns the result of evaluating' do
-      result = subject.execute(question_attr, File.join(Rails.root, 'spec', 'fixtures', 'course',
-                                                        'programming_question_template.zip'))
+      result = subject.execute(Coursemology::Polyglot::Language::Python::Python3Point10.instance, 64,
+                               5.seconds, 30.seconds,
+                               File.join(Rails.root, 'spec', 'fixtures', 'course',
+                                         'programming_question_template.zip'))
       expect(result).to be_a(Course::Assessment::ProgrammingEvaluationService::Result)
     end
 
@@ -97,30 +91,28 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
       it 'raises a Timeout::Error' do
         expect do
           # Pass in a non-zero timeout as Ruby's Timeout treats 0 as infinite.
-          subject.execute(question_attr, File.join(Rails.root, 'spec', 'fixtures', 'course',
-                                                   'programming_question_template.zip'), 0.1.seconds)
+          subject.execute(Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+                          64, 5.seconds, 30.seconds,
+                          File.join(Rails.root, 'spec', 'fixtures', 'course',
+                                    'programming_question_template.zip'), 0.1.seconds)
         end.to raise_error(Timeout::Error)
       end
     end
 
     describe '#create_container' do
-      let(:question_attr2) do
-        {
-          'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-          'memory_limit' => nil,
-          'time_limit' => nil,
-          'max_timeout_limit' => 30
-        }
-      end
+      let(:memory_limit) { nil }
+      let(:time_limit) { nil }
       let(:service_instance) do
-        subject.new(question_attr2, Rails.root.join('spec', 'fixtures', 'course',
-                                                    'programming_question_template.zip'), nil)
+        subject.new(Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+                    memory_limit, time_limit, 30.seconds,
+                    Rails.root.join('spec', 'fixtures', 'course',
+                                    'programming_question_template.zip'), nil)
       end
       let(:image) { 'python:3.10' }
       let(:container) { service_instance.send(:create_container, image) }
 
       it 'prefixes the image with coursemology/evaluator-image' do
-        # when the time_limit or course is not defined here, the default time_limit is set to 30 seconds
+        # when the time_limit of a course is not defined, the default time_limit is set to 30 seconds
         expect(CoursemologyDockerContainer).to \
           receive(:create).with("coursemology/evaluator-image-#{image}",
                                 hash_including(argv: ['-c30']))
@@ -128,24 +120,18 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
         container
       end
 
-      context 'when the course has its programming timeout limit set' do
-        let(:question_attr3) do
-          {
-            'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            'memory_limit' => nil,
-            'time_limit' => nil,
-            'max_timeout_limit' => 170
-          }
-        end
+      context 'when the course has its maximum programming time limit set' do
         let(:service_instance2) do
-          subject.new(question_attr3, Rails.root.join('spec', 'fixtures', 'course',
-                                                      'programming_question_template.zip'), nil)
+          subject.new(Coursemology::Polyglot::Language::Python::Python3Point10.instance,
+                      nil, nil, 170.seconds,
+                      Rails.root.join('spec', 'fixtures', 'course',
+                                      'programming_question_template.zip'), nil)
         end
         let(:image2) { 'python:3.10' }
         let(:container2) { service_instance2.send(:create_container, image2) }
 
-        it 'prefixes the image with coursemology/evaluator-image' do
-          # when the time_limit or course is not defined here, the default time_limit is set to 30 seconds
+        it 'prefixes the image with the correct coursemology/evaluator-image' do
+          # when the time_limit of a course is not defined, the default time_limit is set to 30 seconds
           expect(CoursemologyDockerContainer).to \
             receive(:create).with("coursemology/evaluator-image-#{image2}",
                                   hash_including(argv: ['-c170']))
@@ -155,27 +141,14 @@ RSpec.describe Course::Assessment::ProgrammingEvaluationService do
       end
 
       context 'when resource limits are specified' do
-        let(:question_attr4) do
-          {
-            'language' => Coursemology::Polyglot::Language::Python::Python3Point10.instance,
-            'memory_limit' => 16,
-            'time_limit' => 5,
-            'max_timeout_limit' => 170
-          }
-        end
-        let(:service_instance3) do
-          subject.new(question_attr4, Rails.root.join('spec', 'fixtures', 'course',
-                                                      'programming_question_template.zip'), nil)
-        end
-        let(:image3) { 'python:3.10' }
-        let(:container3) { service_instance3.send(:create_container, image3) }
-
+        let(:memory_limit) { 16 }
+        let(:time_limit) { 5 }
         it 'specifies them when creating the container' do
           expect(CoursemologyDockerContainer).to \
-            receive(:create).with("coursemology/evaluator-image-#{image3}",
+            receive(:create).with("coursemology/evaluator-image-#{image}",
                                   hash_including(argv: ['-c5', '-m16384']))
 
-          container3
+          container
         end
       end
     end


### PR DESCRIPTION
close #5708

Main changes that has been done:
- Introducing the feature of "Programming Time Limit" inside the **Course Settings / Assessment**, which is only accessible by Administrator
- Initial setup of this Programming Time Limit is 30, which then will be able to be changed upon request to the Administrator
- Adding validation towards time_limit upon creating/editing the currently existing programming question on both frontend and backend, and also set the time_limit to be minimum of [TIME_LIMIT, PROGRAMMING_TIMEOUT_LIMIT] for programming evaluation (both codaveri and non-codaveri)
- Validation for time limit is skipped during duplication because it is possible for course assessment settings to be set to less than the time limit of the programming question's time limit, which will cause duplication to fail
- Also fix the duplication issue in which the course assessment settings from old course was not carried forward to the new course

1. Add feature Programming Time Limit
Before
<img width="1209" alt="Screenshot 2023-02-09 at 5 13 56 PM" src="https://user-images.githubusercontent.com/16359075/217989927-967d0178-ac78-41b0-b7a1-e3af3c9f12a8.png">

After
<img width="1209" alt="Screenshot 2023-02-09 at 5 13 32 PM" src="https://user-images.githubusercontent.com/16359075/217989939-1a6cf1ce-1541-462c-a290-8f93a810e865.png">

2. Validation Setters
<img width="403" alt="Screenshot 2023-02-09 at 5 16 29 PM" src="https://user-images.githubusercontent.com/16359075/217990025-1f5ff801-7beb-4919-a285-d56dccfd8a9f.png">

3. Validation on Backend
<img width="1199" alt="Screenshot 2023-02-10 at 11 04 46 AM" src="https://user-images.githubusercontent.com/16359075/217990206-c57c32f9-192f-44a8-a9ee-e1578e1ad94a.png">

