### PR TITLE
UI Fixes: Missing start times in Workbin, Duplicate options in `AssessmentCondition`, Long names on sidebar

### DIFF
--- a/app/assets/stylesheets/course/layout.scss
+++ b/app/assets/stylesheets/course/layout.scss
@@ -87,12 +87,14 @@ $sidebar-margin-side: 1.5rem;
   .user {
     align-items: center;
     display: flex;
-    margin: 0.5em;
+    padding: 1rem $sidebar-margin-side;
 
     #user-sidebar {
       display: flex;
       flex-direction: column;
       flex-grow: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     #user-link-sidebar {
@@ -104,6 +106,10 @@ $sidebar-margin-side: 1.5rem;
 
     #manage-email-subscription-link-sidebar {
       font-size: 12px;
+    }
+
+    .image img {
+      max-width: inherit;
     }
 
     .image,

--- a/app/controllers/course/condition/assessments_controller.rb
+++ b/app/controllers/course/condition/assessments_controller.rb
@@ -29,8 +29,8 @@ class Course::Condition::AssessmentsController < Course::ConditionsController
   def render_available_assessments
     assessments = current_course.assessments.ordered_by_date_and_title
     existing_conditions = @conditional.specific_conditions - [@assessment_condition]
-    available_assessments = assessments - existing_conditions.map(&:dependent_object)
-    render json: available_assessments.to_h { |assessment| [assessment.id, assessment.title] }
+    @available_assessments = (assessments - existing_conditions.map(&:dependent_object)).sort_by(&:title)
+    render 'available_assessments'
   end
 
   def try_to_perform(operation_succeeded)

--- a/app/controllers/course/condition/surveys_controller.rb
+++ b/app/controllers/course/condition/surveys_controller.rb
@@ -29,8 +29,8 @@ class Course::Condition::SurveysController < Course::ConditionsController
   def render_available_surveys
     surveys = current_course.surveys
     existing_conditions = @conditional.specific_conditions - [@survey_condition]
-    available_surveys = surveys - existing_conditions.map(&:dependent_object)
-    render json: available_surveys.to_h { |survey| [survey.id, survey.title] }
+    @available_surveys = (surveys - existing_conditions.map(&:dependent_object)).sort_by(&:title)
+    render 'available_surveys'
   end
 
   def try_to_perform(operation_succeeded)

--- a/app/views/course/condition/assessments/available_assessments.json.jbuilder
+++ b/app/views/course/condition/assessments/available_assessments.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+json.ids @available_assessments.map(&:id)
+
+json.assessments do
+  @available_assessments.each do |assessment|
+    json.set! assessment.id, {
+      title: assessment.title,
+      url: course_assessment_path(current_course, assessment)
+    }
+  end
+end

--- a/app/views/course/condition/surveys/available_surveys.json.jbuilder
+++ b/app/views/course/condition/surveys/available_surveys.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+json.ids @available_surveys.map(&:id)
+
+json.surveys do
+  @available_surveys.each do |survey|
+    json.set! survey.id, {
+      title: survey.title,
+      url: course_survey_path(current_course, survey)
+    }
+  end
+end

--- a/app/views/course/material/folders/show.json.jbuilder
+++ b/app/views/course/material/folders/show.json.jbuilder
@@ -64,5 +64,4 @@ json.permissions do
   json.canCreateSubfolder can?(:new_subfolder, @folder)
   json.canUpload can?(:upload, @folder)
   json.canEdit can?(:edit, @folder)
-  json.canEditSubfolders can?(:edit, @subfolders)
 end

--- a/app/views/layouts/course.html.slim
+++ b/app/views/layouts/course.html.slim
@@ -12,7 +12,7 @@
           = link_to course_path(current_course) do
             = display_course_logo(current_course)
         - if current_course_user.present? && can?(:read, current_course)
-          div.col-xs-12.user
+          div.user
             = display_user_image(current_user)
             span#user-sidebar
               span#user-link-sidebar = link_to_user(current_course_user || current_user)

--- a/client/app/bundles/course/material/folders/components/tables/TableMaterialRow.tsx
+++ b/client/app/bundles/course/material/folders/components/tables/TableMaterialRow.tsx
@@ -12,12 +12,12 @@ import WorkbinTableButtons from '../buttons/WorkbinTableButtons';
 interface Props {
   currFolderId: number;
   material: MaterialMiniEntity;
-  canEditSubfolders: boolean;
+  isCurrentCourseStudent: boolean;
   isConcrete: boolean;
 }
 
 const TableMaterialRow: FC<Props> = (props) => {
-  const { currFolderId, material, canEditSubfolders, isConcrete } = props;
+  const { currFolderId, material, isCurrentCourseStudent, isConcrete } = props;
 
   return (
     <TableRow id={`material-${material.id}`}>
@@ -66,7 +66,7 @@ const TableMaterialRow: FC<Props> = (props) => {
           <a href={material.updater.userUrl ?? '#'}>{material.updater.name}</a>
         </Stack>
       </TableCell>
-      {canEditSubfolders && (
+      {!isCurrentCourseStudent && (
         <TableCell
           style={{
             padding: 2,

--- a/client/app/bundles/course/material/folders/components/tables/TableSubfolderRow.tsx
+++ b/client/app/bundles/course/material/folders/components/tables/TableSubfolderRow.tsx
@@ -20,7 +20,6 @@ interface Props {
   currFolderId: number;
   subfolder: FolderMiniEntity;
   isCurrentCourseStudent: boolean;
-  canEditSubfolders: boolean;
   isConcrete: boolean;
 }
 
@@ -38,13 +37,7 @@ const translations = defineMessages({
 });
 
 const TableSubfolderRow: FC<Props> = (props) => {
-  const {
-    currFolderId,
-    subfolder,
-    isCurrentCourseStudent,
-    canEditSubfolders,
-    isConcrete,
-  } = props;
+  const { currFolderId, subfolder, isCurrentCourseStudent, isConcrete } = props;
   const { t } = useTranslation();
 
   return (
@@ -103,7 +96,7 @@ const TableSubfolderRow: FC<Props> = (props) => {
       >
         {formatFullDateTime(subfolder.updatedAt)}
       </TableCell>
-      {subfolder.permissions.canEdit ? (
+      {!isCurrentCourseStudent && (
         <TableCell
           style={{
             padding: 2,
@@ -121,21 +114,6 @@ const TableSubfolderRow: FC<Props> = (props) => {
             <div>{formatFullDateTime(subfolder.startAt)}</div>
           </Stack>
         </TableCell>
-      ) : (
-        canEditSubfolders && (
-          <TableCell
-            style={{
-              padding: 2,
-              width: '240px',
-              maxWidth: '240px',
-              minWidth: '60px',
-            }}
-          >
-            <Stack alignItems="center" direction="row" spacing={0.5}>
-              <div>-</div>
-            </Stack>
-          </TableCell>
-        )
       )}
       <TableCell
         style={{

--- a/client/app/bundles/course/material/folders/components/tables/WorkbinTable.tsx
+++ b/client/app/bundles/course/material/folders/components/tables/WorkbinTable.tsx
@@ -25,7 +25,6 @@ interface Props extends WrappedComponentProps {
   currFolderId: number;
   subfolders: FolderMiniEntity[];
   materials: MaterialMiniEntity[];
-  canEditSubfolders: boolean;
   isCurrentCourseStudent: boolean;
   isConcrete: boolean;
 }
@@ -35,7 +34,6 @@ const WorkbinTable: FC<Props> = (props) => {
     currFolderId,
     subfolders,
     materials,
-    canEditSubfolders,
     isCurrentCourseStudent,
     isConcrete,
   } = props;
@@ -137,7 +135,7 @@ const WorkbinTable: FC<Props> = (props) => {
           <TableCell style={{ padding: 2 }}>
             {columnHeaderWithSort('Last Modified')}
           </TableCell>
-          {canEditSubfolders && (
+          {!isCurrentCourseStudent && (
             <TableCell style={{ padding: 2 }}>
               {columnHeaderWithSort('Start At')}
             </TableCell>
@@ -150,7 +148,6 @@ const WorkbinTable: FC<Props> = (props) => {
           return (
             <TableSubfolderRow
               key={`subfolder-${subfolder.id}`}
-              canEditSubfolders={canEditSubfolders}
               currFolderId={currFolderId}
               isConcrete={isConcrete}
               isCurrentCourseStudent={isCurrentCourseStudent}
@@ -162,9 +159,9 @@ const WorkbinTable: FC<Props> = (props) => {
           return (
             <TableMaterialRow
               key={`material-${material.id}`}
-              canEditSubfolders={canEditSubfolders}
               currFolderId={currFolderId}
               isConcrete={isConcrete}
+              isCurrentCourseStudent={isCurrentCourseStudent}
               material={material}
             />
           );

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -169,7 +169,6 @@ const FolderShow: FC = () => {
       />
       <WorkbinTable
         key={currFolderInfo.id}
-        canEditSubfolders={permissions.canEditSubfolders}
         currFolderId={currFolderInfo.id}
         isConcrete={currFolderInfo.isConcrete}
         isCurrentCourseStudent={permissions.isCurrentCourseStudent}

--- a/client/app/bundles/course/material/folders/reducers.ts
+++ b/client/app/bundles/course/material/folders/reducers.ts
@@ -34,7 +34,6 @@ const initialState: FoldersState = {
     canCreateSubfolder: false,
     canUpload: false,
     canEdit: false,
-    canEditSubfolders: false,
   },
 };
 

--- a/client/app/lib/components/extensions/conditions/translations.ts
+++ b/client/app/lib/components/extensions/conditions/translations.ts
@@ -96,4 +96,8 @@ export default defineMessages({
     id: 'lib.components.extensions.conditions.errorOccurredWhenUpdatingCondition',
     defaultMessage: 'An error occurred while updating this condition.',
   },
+  details: {
+    id: 'lib.components.extensions.conditions.details',
+    defaultMessage: 'Details',
+  },
 });

--- a/client/app/types/course/conditions.ts
+++ b/client/app/types/course/conditions.ts
@@ -45,7 +45,10 @@ export interface AvailableAssessments {
   >;
 }
 
-export type AvailableSurveys = Record<string, string>;
+export interface AvailableSurveys {
+  ids: SurveyConditionData['id'][];
+  surveys: Record<SurveyConditionData['id'], { title: string; url: string }>;
+}
 
 export type AvailableAchievements = Record<
   string,

--- a/client/app/types/course/conditions.ts
+++ b/client/app/types/course/conditions.ts
@@ -37,7 +37,13 @@ export interface SurveyConditionData extends ConditionData {
   surveyId?: number;
 }
 
-export type AvailableAssessments = Record<string, string>;
+export interface AvailableAssessments {
+  ids: AssessmentConditionData['id'][];
+  assessments: Record<
+    AssessmentConditionData['id'],
+    { title: string; url: string }
+  >;
+}
 
 export type AvailableSurveys = Record<string, string>;
 

--- a/client/app/types/course/material/folders.ts
+++ b/client/app/types/course/material/folders.ts
@@ -12,7 +12,6 @@ export type FolderPermissions = Permissions<
   | 'canCreateSubfolder'
   | 'canUpload'
   | 'canEdit'
-  | 'canEditSubfolders'
 >;
 
 export type SubfolderPermissions = Permissions<

--- a/spec/features/course/achievement_condition_management_spec.rb
+++ b/spec/features/course/achievement_condition_management_spec.rb
@@ -92,14 +92,14 @@ RSpec.feature 'Course: Achievements', js: true do
 
         hover_then_click edit_button
         assessment_field = find_field('Assessment')
-        expect(assessment_field.value).to eq(valid_assessment_as_condition.title)
+        expect(assessment_field.value).to include(valid_assessment_as_condition.title)
         assessment_field.click
         find('li', text: assessment_to_change_to.title).click
         click_button 'Update condition'
 
         expect_toastify('Your changes have been saved.')
         hover_then_click condition_row.first('button', visible: false)
-        expect(find_field('Assessment').value).to eq(assessment_to_change_to.title)
+        expect(find_field('Assessment').value).to include(assessment_to_change_to.title)
         find('button.prompt-cancel-btn').click
 
         # Delete achievement condition

--- a/spec/features/course/achievement_condition_management_spec.rb
+++ b/spec/features/course/achievement_condition_management_spec.rb
@@ -173,14 +173,14 @@ RSpec.feature 'Course: Achievements', js: true do
 
         hover_then_click edit_button
         survey_field = find_field('Survey')
-        expect(survey_field.value).to eq(valid_survey_as_condition.title)
+        expect(survey_field.value).to include(valid_survey_as_condition.title)
         survey_field.click
         find('li', text: survey_to_change_to.title).click
         click_button 'Update condition'
 
         expect_toastify('Your changes have been saved.')
         hover_then_click condition_row.first('button', visible: false)
-        expect(find_field('Survey').value).to eq(survey_to_change_to.title)
+        expect(find_field('Survey').value).to include(survey_to_change_to.title)
         find('button.prompt-cancel-btn').click
 
         # Delete survey condition

--- a/spec/features/course/assessment_condition_management_spec.rb
+++ b/spec/features/course/assessment_condition_management_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Course: Assessments', js: true do
 
         expect_toastify('Your changes have been saved.')
         hover_then_click condition_row.first('button', visible: false)
-        expect(find_field('Assessment').value).to eq(assessment_to_change_to.title)
+        expect(find_field('Assessment').value).to include(assessment_to_change_to.title)
       end
 
       scenario 'I can delete a assessment condition' do


### PR DESCRIPTION
| Bug | Problem | Solution |
| - | - | - |
| Missing start times for folders linked to assessments in the Workbin | For some reasons, the condition for rendering the start time for a subfolder is the ability to edit it. Since linked folders are not editable at all regardless of course user role, their start times are never rendered. `canEditSubfolders` was also used, but this is `false` for both staff and student. | Since there is already `isCurrentCourseStudent`, it is used instead as the condition to render all subfolders' start times. |
| Duplicate options appear in the `Autocomplete` when typing keywords in `AssessmentCondition` and `SurveyCondition` | The `Autocomplete`s were using assessments'/surveys' `title` to render options, hence their DOM nodes' `key`s. Since it is possible to have multiple assessments/surveys with the same name, this caused React to render duplicates of these options at every render (keystroke). | Manually render the option component and use the assessments'/surveys' `id` as `key`. To prevent confusion, the `id`s are also rendered as `Chip`s. |
| Long names overflows and squishes the profile image in the sidebar | Bootstrap's annoying column utility and missing `text-overflow` and `overflow: hidden` in the `a` for user name. | Add the missing CSS attributes and remove Bootstrap's annoying column utility. |
