### PR TITLE
Add course_name to codaveri api

### DIFF
--- a/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
@@ -21,19 +21,20 @@ class Course::Assessment::Answer::ProgrammingCodaveriAutoGradingService < \
   def evaluate_answer(answer)
     question = answer.question.actable
     assessment = answer.submission.assessment
-    evaluation_result = evaluate_package(question, answer)
+    evaluation_result = evaluate_package(assessment.course.title, question, answer)
     build_result(question, evaluation_result,
                  graded_test_case_types: assessment.graded_test_case_types)
   end
 
   # Evaluates the package to obtain the set of tests.
   #
+  # @param [string] course_title Title of the course.
   # @param [Course::Assessment::Question::Programming] question The programming question being
   #   graded.
   # @param [Course::Assessment::Answer::Programming] answer The answer specified by the student.
   # @return [Course::Assessment::ProgrammingCodaveriEvaluationService::Result]
-  def evaluate_package(question, answer)
-    Course::Assessment::ProgrammingCodaveriEvaluationService.execute(question, answer)
+  def evaluate_package(course_title, question, answer)
+    Course::Assessment::ProgrammingCodaveriEvaluationService.execute(course_title, question, answer)
   end
 
   # Builds the result of the auto grading from the codevari evaluation result.

--- a/app/services/course/assessment/answer/programming_codaveri_feedback_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_feedback_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::ProgrammingCodaveriFeedbackService
   def initialize(assessment, question, answer)
+    @course = assessment.course
     @assessment = assessment
     @question = question
     @answer = answer
@@ -10,7 +11,8 @@ class Course::Assessment::Answer::ProgrammingCodaveriFeedbackService
                        user_id: answer.submission.creator_id.to_s,
                        language_version: { language: '', version: '' },
                        files_student: [],
-                       problem_id: '' }
+                       problem_id: '',
+                       course_name: @course.title }
   end
 
   def run_codaveri_feedback_service
@@ -35,7 +37,7 @@ class Course::Assessment::Answer::ProgrammingCodaveriFeedbackService
     @answer_object[:language_version][:language] = @question.polyglot_language_name
     @answer_object[:language_version][:version] = @question.polyglot_language_version
 
-    @answer_object[:is_only_itsp] = true if @assessment.course.codaveri_itsp_enabled?
+    @answer_object[:is_only_itsp] = true if @course.codaveri_itsp_enabled?
 
     @answer_files.each do |file|
       file_template = default_codaveri_student_file_template

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -68,14 +68,15 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
   class << self
     # Executes the provided answer.
     #
+    # @param [string] course_title Title of the course.
     # @param [Course::Assessment::Question::Programming] question The programming question being
     #   graded.
     # @param [Course::Assessment::Answer::Programming] answer The answer specified by the student.
     # @return [Course::Assessment::ProgrammingCodaveriEvaluationService::Result]
     #
     # @raise [Timeout::Error] When the operation times out.
-    def execute(question, answer, timeout = nil)
-      new(question, answer, timeout).execute
+    def execute(course_title, question, answer, timeout = nil)
+      new(course_title, question, answer, timeout).execute
     end
   end
 
@@ -90,7 +91,7 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
 
   private
 
-  def initialize(question, answer, timeout)
+  def initialize(course_title, question, answer, timeout)
     @question = question
     @answer = answer
     @language = question.language
@@ -101,7 +102,8 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService
     @answer_object = { api_version: 'latest',
                        language_version: { language: '', version: '' },
                        files: [],
-                       problem_id: '' }
+                       problem_id: '',
+                       course_name: course_title }
 
     @codaveri_evaluation_results = nil
   end

--- a/spec/services/course/assessment/answer/programming_codaveri_feedback_service_spec.rb
+++ b/spec/services/course/assessment/answer/programming_codaveri_feedback_service_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingCodaveriFeedbackService do
           expect(test_payload_object[:language_version]).to eq(actual_payload_object[:language_version])
           expect(test_payload_object[:files_student]).to eq(actual_payload_object[:files_student])
           expect(test_payload_object[:problem_id]).to eq(actual_payload_object[:problem_id])
+          expect(test_payload_object[:course_name]).to eq(course.title)
         end
       end
 

--- a/spec/services/course/assessment/programming_codaveri_evaluation_service_spec.rb
+++ b/spec/services/course/assessment/programming_codaveri_evaluation_service_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Course::Assessment::ProgrammingCodaveriEvaluationService do
     end
 
     it 'returns the result of evaluating' do
-      result = subject.execute(question, answer.actable)
+      result = subject.execute(course.title, question, answer.actable)
       expect(result).to be_a(Course::Assessment::ProgrammingCodaveriEvaluationService::Result)
     end
 
@@ -74,14 +74,14 @@ RSpec.describe Course::Assessment::ProgrammingCodaveriEvaluationService do
       it 'raises a Timeout::Error' do
         expect do
           # Pass in a non-zero timeout as Ruby's Timeout treats 0 as infinite.
-          subject.execute(question, answer.actable, 0.0000000000001.seconds)
+          subject.execute(course.title, question, answer.actable, 0.0000000000001.seconds)
         end.to raise_error(Timeout::Error)
       end
     end
 
     describe '#construct_grading_object' do
       let(:service_instance) do
-        subject.new(question, answer.actable, 1)
+        subject.new(course.title, question, answer.actable, 1)
       end
       it 'constructs API payload correctly' do
         test_payload_object = service_instance.send(:construct_grading_object)
@@ -95,6 +95,7 @@ RSpec.describe Course::Assessment::ProgrammingCodaveriEvaluationService do
         expect(test_payload_object[:language_version]).to eq(actual_payload_object[:language_version])
         expect(test_payload_object[:files]).to eq(actual_payload_object[:files])
         expect(test_payload_object[:problem_id]).to eq(actual_payload_object[:problem_id])
+        expect(test_payload_object[:course_name]).to eq(course.title)
       end
     end
   end


### PR DESCRIPTION
As per Codaveri team's request, `course_name` is added as an additional API payload request to Codaveri's feedback and evaluation APIs.