### PR TITLE
Fix inconsistent grade input behaviours on Safari and Chrome

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -139,7 +139,7 @@ class VisibleGradingPanel extends Component {
     const questionGrading = this.props.grading.questions[question.id];
     const questionGrade =
       questionGrading && questionGrading.grade !== null
-        ? questionGrading.grade
+        ? parseFloat(questionGrading.grade) || ''
         : '';
     const grader = questionGrading && questionGrading.grader;
 

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -41,7 +41,7 @@ class VisibleGradingPanel extends Component {
   static calculateTotalGrade(grades) {
     return Object.values(grades)
       .filter((grade) => grade !== null)
-      .reduce((acc, b) => acc + b.grade, 0);
+      .reduce((acc, b) => acc + (parseFloat(b.grade) || 0), 0);
   }
 
   static renderCourseUserLink(courseUser) {


### PR DESCRIPTION
Closes #5111.

Since `type="number"` is removed from the input, the steps (numeric up/down buttons) are no longer available. To compensate, it was re-implemented that pressing the arrow up and down keys will still increase and decrease the grade by 1.