### PR TITLE
Allow versioning of draft answer into past answers

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -188,7 +188,8 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
     base_params = [:title, :description, :base_exp, :time_bonus_exp, :start_at, :end_at, :tab_id,
                    :bonus_end_at, :published, :autograded, :show_mcq_mrq_solution, :show_private,
                    :show_evaluation, :use_public, :use_private, :use_evaluation, :has_personal_times,
-                   :affects_personal_times, :block_student_viewing_after_submitted, :has_todo]
+                   :affects_personal_times, :block_student_viewing_after_submitted, :has_todo,
+                   :allow_record_draft_answer]
     base_params += if autograded?
                      [:skippable, :allow_partial_submission, :show_mcq_answer]
                    else

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -126,6 +126,10 @@ class Course::Assessment::Answer < ApplicationRecord
     actable.generate_feedback
   end
 
+  def draft_answer?
+    attempting? && !current_answer?
+  end
+
   protected
 
   def finalise

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -60,6 +60,7 @@ class Course::Assessment::Answer < ApplicationRecord
 
   default_scope { order(:created_at) }
 
+  scope :with_attempting_state, -> { where(workflow_state: :attempting) }
   scope :without_attempting_state, -> { where.not(workflow_state: :attempting) }
   scope :non_current_answers, -> { where(current_answer: false) }
   scope :current_answers, -> { where(current_answer: true) }

--- a/app/models/course/assessment/submission_question.rb
+++ b/app/models/course/assessment/submission_question.rb
@@ -45,8 +45,12 @@ class Course::Assessment::SubmissionQuestion < ApplicationRecord
 
   # Loads the past answers of a specific question
   def past_answers(answers_to_load)
-    answers.unscope(:order).order(created_at: :desc).
-      where('workflow_state != ?', 'attempting').first(answers_to_load)
+    answers.
+      unscope(:order).
+      order(created_at: :desc).
+      where('workflow_state != ? '\
+            'OR (workflow_state = ? AND current_answer IS false)', 'attempting', 'attempting').
+      first(answers_to_load)
   end
 
   private

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -169,10 +169,10 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
   end
 
   def attempt_draft_answer(answer)
-    reattempt_answer(answer, finalise: false) if should_attempt_draft_answer(answer)
+    reattempt_answer(answer, finalise: false) if should_attempt_draft_answer?(answer)
   end
 
-  def should_attempt_draft_answer(answer)
+  def should_attempt_draft_answer?(answer)
     is_save_draft = update_submission_additional_params[:is_save_draft].to_s.downcase == 'true'
     is_programming = answer.actable_type == Course::Assessment::Answer::Programming.name
     assessment_save_draft_answer = @assessment.allow_record_draft_answer

--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -102,6 +102,7 @@ json.explanation do
   end
 end
 
+json.isDraftAnswer answer.draft_answer?
 json.attemptsLeft answer.attempting_times_left if question.attempt_limit
 
 if answer.codaveri_feedback_job_id && question.is_codaveri

--- a/app/views/course/assessment/assessments/edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/edit.json.jbuilder
@@ -4,7 +4,8 @@ json.attributes do
             :time_bonus_exp, :published, :autograded, :show_mcq_mrq_solution, :show_private, :show_evaluation,
             :skippable, :tabbed_view, :view_password, :session_password, :delayed_grade_publication, :tab_id,
             :use_public, :use_private, :use_evaluation, :allow_partial_submission, :has_personal_times,
-            :affects_personal_times, :show_mcq_answer, :block_student_viewing_after_submitted, :has_todo)
+            :affects_personal_times, :show_mcq_answer, :block_student_viewing_after_submitted, :has_todo,
+            :allow_record_draft_answer)
 
   # TODO: [PR#5491] Edit Assessment only changes time in the Default Timeline
   json.start_at @assessment.start_at&.iso8601

--- a/app/views/course/assessment/assessments/show.json.jbuilder
+++ b/app/views/course/assessment/assessments/show.json.jbuilder
@@ -97,6 +97,7 @@ if can_attempt && assessment.folder.materials.exists?
 end
 
 if can_observe
+  json.allowRecordDraftAnswer assessment.allow_record_draft_answer
   json.showMcqMrqSolution assessment.show_mcq_mrq_solution
   json.gradedTestCases display_graded_test_types(assessment)
 

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -26,7 +26,7 @@ import useTranslation from 'lib/hooks/useTranslation';
 import FileManager from '../FileManager';
 
 import { fetchTabs } from './actions';
-import translations from './translations.intl';
+import translations from './translations';
 import { AssessmentFormProps, connector } from './types';
 import useFormValidation from './useFormValidation';
 
@@ -498,6 +498,18 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
         sticksToNavbar={editing}
         title={t(translations.answersAndTestCases)}
       >
+        <Controller
+          control={control}
+          name="allow_record_draft_answer"
+          render={({ field, fieldState }): JSX.Element => (
+            <FormCheckboxField
+              disabled={disabled}
+              field={field}
+              fieldState={fieldState}
+              label={t(translations.allowRecordDraftAnswer)}
+            />
+          )}
+        />
         <Controller
           control={control}
           name="skippable"

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -143,6 +143,10 @@ const translations = defineMessages({
     id: 'course.assessment.AssessmentForm.calculateGradeWith',
     defaultMessage: 'Calculate grade and EXP with',
   },
+  allowRecordDraftAnswer: {
+    id: 'course.assessment.AssessmentForm.allowRecordDraftAnswer',
+    defaultMessage: 'Allow versioning of draft programming answer',
+  },
   skippable: {
     id: 'course.assessment.AssessmentForm.skippable',
     defaultMessage: 'Allow to skip steps',

--- a/client/app/bundles/course/assessment/components/AssessmentForm/useFormValidation.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/useFormValidation.tsx
@@ -16,7 +16,7 @@ import * as yup from 'yup';
 
 import ft from 'lib/translations/form';
 
-import t from './translations.intl';
+import t from './translations';
 
 const validationSchema = yup.object({
   title: yup.string().required(ft.required),
@@ -46,6 +46,7 @@ const validationSchema = yup.object({
   has_todo: yup.bool(),
   autograded: yup.bool(),
   block_student_viewing_after_submitted: yup.bool(),
+  allow_record_draft_answer: yup.bool(),
   skippable: yup.bool(),
   allow_partial_submission: yup.bool(),
   show_mcq_answer: yup.bool(),

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/__test__/index.test.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/__test__/index.test.tsx
@@ -26,6 +26,7 @@ const INITIAL_VALUES = {
   has_todo: false,
   allow_partial_submission: false,
   block_student_viewing_after_submitted: false,
+  allow_record_draft_answer: false,
   delayed_grade_publication: false,
   password_protected: false,
   view_password: null,

--- a/client/app/bundles/course/assessment/pages/AssessmentShow/AssessmentDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentShow/AssessmentDetails.tsx
@@ -77,6 +77,16 @@ const AssessmentDetails = (props: AssessmentDetailsProps): JSX.Element => {
           <>
             <TableRow>
               <TableCell variant="head">
+                {t(translations.allowRecordDraftAnswer)}
+              </TableCell>
+
+              <TableCell>
+                {assessment.allowRecordDraftAnswer ? '✅' : '❌'}
+              </TableCell>
+            </TableRow>
+
+            <TableRow>
+              <TableCell variant="head">
                 {t(translations.showMcqMrqSolution)}
               </TableCell>
 

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/NewAssessmentFormButton.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/NewAssessmentFormButton.jsx
@@ -119,6 +119,7 @@ class NewAssessmentFormButton extends Component {
       has_todo: true,
       autograded: false,
       block_student_viewing_after_submitted: false,
+      allow_record_draft_answer: false,
       skippable: false,
       allow_partial_submission: false,
       show_mcq_answer: true,

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -148,7 +148,7 @@ export function autogradeSubmission(id) {
 
 export function saveDraft(submissionId, rawAnswers) {
   const answers = formatAnswers(rawAnswers);
-  const payload = { submission: { answers } };
+  const payload = { submission: { answers, is_save_draft: true } };
   return (dispatch) => {
     dispatch({ type: actionTypes.SAVE_DRAFT_REQUEST });
 

--- a/client/app/bundles/course/assessment/submission/components/pastAnswers/PastProgrammingAnswer.jsx
+++ b/client/app/bundles/course/assessment/submission/components/pastAnswers/PastProgrammingAnswer.jsx
@@ -19,7 +19,11 @@ export default class PastProgrammingAnswer extends Component {
             question,
           }}
         />
-        <TestCaseView answerId={answer.id} viewHistory />
+        <TestCaseView
+          answerId={answer.id}
+          isDraftAnswer={answer.isDraftAnswer}
+          viewHistory
+        />
       </div>
     );
   }
@@ -41,7 +45,11 @@ export default class PastProgrammingAnswer extends Component {
           content={content}
           fileId={file.id}
         />
-        <TestCaseView answerId={answer.id} viewHistory />
+        <TestCaseView
+          answerId={answer.id}
+          isDraftAnswer={answer.isDraftAnswer}
+          viewHistory
+        />
       </div>
     );
   }

--- a/client/app/bundles/course/assessment/submission/containers/PastAnswers.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/PastAnswers.jsx
@@ -72,6 +72,9 @@ class PastAnswers extends Component {
       return (
         <MenuItem key={index} value={answer}>
           {formatLongDateTime(answer.createdAt)}
+          {answer.isDraftAnswer && (
+            <>&nbsp;{intl.formatMessage(translations.draftAnswer)}</>
+          )}
         </MenuItem>
       );
     };
@@ -99,7 +102,10 @@ class PastAnswers extends Component {
     return (
       <div key={answer.id}>
         <h4>
-          {intl.formatMessage(translations.submittedAt)}: {date}
+          {answer.isDraftAnswer
+            ? intl.formatMessage(translations.savedAt)
+            : intl.formatMessage(translations.submittedAt)}
+          : {date}
         </h4>
         {this.getAnswersHistory(question, answer)}
         <hr style={styles.horizontalRule} />

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -249,7 +249,7 @@ export class VisibleTestCaseView extends Component {
     );
   }
 
-  renderTestCases(testCases, testCaseType, warn) {
+  renderTestCases(testCases, testCaseType, warn, isDraftAnswer) {
     const {
       collapsible,
       testCases: { canReadTests },
@@ -268,7 +268,7 @@ export class VisibleTestCaseView extends Component {
       return val;
     }, true);
     let headerStyle = { ...styles.panelSummary };
-    if (collapsible) {
+    if (collapsible && !isDraftAnswer) {
       headerStyle = {
         ...headerStyle,
         backgroundColor: passedTestCases ? green[100] : red[100],
@@ -323,6 +323,7 @@ export class VisibleTestCaseView extends Component {
       testCases,
       collapsible,
       showStdoutAndStderr,
+      isDraftAnswer,
     } = this.props;
     if (!testCases) {
       return null;
@@ -354,18 +355,25 @@ export class VisibleTestCaseView extends Component {
         <h3>
           <FormattedMessage {...translations.testCases} />
         </h3>
-        {this.renderTestCases(testCases.public_test, 'publicTestCases', false)}
+        {this.renderTestCases(
+          testCases.public_test,
+          'publicTestCases',
+          false,
+          isDraftAnswer,
+        )}
         {showPrivateTest &&
           this.renderTestCases(
             testCases.private_test,
             'privateTestCases',
             !showPrivateTestToStudents,
+            isDraftAnswer,
           )}
         {showEvaluationTest &&
           this.renderTestCases(
             testCases.evaluation_test,
             'evaluationTestCases',
             !showEvaluationTestToStudents,
+            isDraftAnswer,
           )}
         {showOutputStreams &&
           !collapsible &&
@@ -406,10 +414,11 @@ VisibleTestCaseView.propTypes = {
     stdout: PropTypes.string,
     stderr: PropTypes.string,
   }),
+  isDraftAnswer: PropTypes.bool,
 };
 
 function mapStateToProps(state, ownProps) {
-  const { questionId, answerId, viewHistory } = ownProps;
+  const { questionId, answerId, viewHistory, isDraftAnswer } = ownProps;
   let testCases;
   let isAutograding;
   if (viewHistory) {
@@ -430,6 +439,7 @@ function mapStateToProps(state, ownProps) {
     collapsible: viewHistory,
     isAutograding,
     testCases,
+    isDraftAnswer,
   };
 }
 

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -85,6 +85,7 @@ export const answerShape = PropTypes.shape({
   file: PropTypes.object,
   files: PropTypes.arrayOf(fileShape),
   option_ids: PropTypes.arrayOf(PropTypes.number),
+  isDraftAnswer: PropTypes.bool,
   createdAt: PropTypes.string,
 });
 

--- a/client/app/bundles/course/assessment/submission/reducers/history/answers.js
+++ b/client/app/bundles/course/assessment/submission/reducers/history/answers.js
@@ -10,6 +10,7 @@ export default function (state = {}, action) {
             ...obj,
             [answer.id]: {
               ...answer.fields,
+              isDraftAnswer: answer.isDraftAnswer,
               createdAt: answer.createdAt,
             },
           }),
@@ -24,6 +25,7 @@ export default function (state = {}, action) {
           ...state,
           [latestAnswer.id]: {
             ...latestAnswer.fields,
+            isDraftAnswer: latestAnswer.isDraftAnswer,
             createdAt: latestAnswer.createdAt,
           },
         };

--- a/client/app/bundles/course/assessment/submission/translations.js
+++ b/client/app/bundles/course/assessment/submission/translations.js
@@ -126,6 +126,10 @@ const translations = defineMessages({
     id: 'course.assessment.submission.attemptedAt',
     defaultMessage: 'Attempted At',
   },
+  savedAt: {
+    id: 'course.assessment.submission.savedAt',
+    defaultMessage: 'Saved At',
+  },
   submittedAt: {
     id: 'course.assessment.submission.submittedAt',
     defaultMessage: 'Submitted At',
@@ -412,6 +416,10 @@ const translations = defineMessages({
   getPastAnswersFailure: {
     id: 'course.assessment.submission.getPastAnswersFailure',
     defaultMessage: 'Failed to load past answers',
+  },
+  draftAnswer: {
+    id: 'course.assessment.submission.draftAnswer',
+    defaultMessage: ' - Draft',
   },
   statistics: {
     id: 'course.assessment.submission.statistics',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -184,6 +184,10 @@ const translations = defineMessages({
     id: 'course.assessment.show.baseExp',
     defaultMessage: 'Base EXP',
   },
+  allowRecordDraftAnswer: {
+    id: 'course.assessment.show.allowRecordDraftAnswer',
+    defaultMessage: 'Allow versioning of draft programming answer',
+  },
   showMcqMrqSolution: {
     id: 'course.assessment.show.showMcqMrqSolution',
     defaultMessage: 'Show MCQ/MRQ solutions',

--- a/client/app/types/course/assessment/assessments.ts
+++ b/client/app/types/course/assessment/assessments.ts
@@ -121,6 +121,7 @@ export interface AssessmentData extends AssessmentActionsData {
     url?: string;
   }[];
 
+  allowRecordDraftAnswer?: boolean;
   showMcqMrqSolution?: boolean;
   gradedTestCases?: string;
   skippable?: boolean;

--- a/db/migrate/20230410121228_add_allow_record_draft_answer_to_assessments.rb
+++ b/db/migrate/20230410121228_add_allow_record_draft_answer_to_assessments.rb
@@ -1,4 +1,4 @@
-class UpdateAssessmentTable < ActiveRecord::Migration[6.0]
+class AddAllowRecordDraftAnswerToAssessments < ActiveRecord::Migration[6.0]
   def change
     add_column :course_assessments, :allow_record_draft_answer, :boolean, default: false
   end

--- a/db/migrate/20230410121228_update_assessment_table.rb
+++ b/db/migrate/20230410121228_update_assessment_table.rb
@@ -1,0 +1,5 @@
+class UpdateAssessmentTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_assessments, :allow_record_draft_answer, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_06_063949) do
+ActiveRecord::Schema.define(version: 2023_04_10_121228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -471,6 +471,7 @@ ActiveRecord::Schema.define(version: 2023_04_06_063949) do
     t.boolean "block_student_viewing_after_submitted", default: false
     t.integer "satisfiability_type", default: 0
     t.bigint "monitor_id"
+    t.boolean "allow_record_draft_answer", default: false
     t.index ["creator_id"], name: "fk__course_assessments_creator_id"
     t.index ["monitor_id"], name: "index_course_assessments_on_monitor_id"
     t.index ["tab_id"], name: "fk__course_assessments_tab_id"


### PR DESCRIPTION
Changes:
- Refactored methods in `workflow_event_concern ` to prevent getting _SLAPped_.
- Add setting in assessment to enable/disable versioning of draft programming answer. 

![image](https://user-images.githubusercontent.com/42570513/224206661-718b6826-f930-4b00-89b4-902491fe164a.png)
