### PR TITLE
Change evaluator timeout to be >= time_limit

### DIFF
--- a/app/services/course/assessment/programming_evaluation_service.rb
+++ b/app/services/course/assessment/programming_evaluation_service.rb
@@ -2,7 +2,7 @@
 # Sets up a programming evaluation, queues it for execution by evaluators, then returns the results.
 class Course::Assessment::ProgrammingEvaluationService
   # The default timeout for the job to finish.
-  DEFAULT_TIMEOUT = 5.minutes
+  DEFAULT_TIMEOUT = 300.seconds
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
 
   # The ratio to multiply the memory limits from our evaluation to the container by.
@@ -105,7 +105,7 @@ class Course::Assessment::ProgrammingEvaluationService
     @memory_limit = memory_limit || MEMORY_LIMIT
     @time_limit = time_limit ? [time_limit, max_time_limit].min : max_time_limit
     @package = package
-    @timeout = timeout || DEFAULT_TIMEOUT
+    @timeout = timeout || [DEFAULT_TIMEOUT.to_i, @time_limit.to_i].max
   end
 
   def create_container(image)


### PR DESCRIPTION
Fixes #5877 

Evaluation has two params: `time_limit` and `timeout`

> `time_limit` The time limit for the evaluation, in seconds. (computation time)

> `timeout` The duration to elapse before timing out. When the operation times out, a +Timeout::TimeoutError+ is raised. This is different from the time limit in that the time limit affects only the run time of the evaluation. The timeout includes waiting for an evaluator, setting up the environment etc.

When timeout is not specified, it falls back to the default timeout of 5.minutes   
`DEFAULT_TIMEOUT = 5.minutes`  

`timeout` should always be >= `time_limit`, so the PR fixes that.