### PR TITLE
Add high/low priority option for autograding of a question

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -75,7 +75,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
     params.require(:question_programming).permit(
       :title, :description, :staff_only_comments, :maximum_grade,
       :language_id, :memory_limit, :time_limit, :attempt_limit,
-      :is_codaveri, *attachment_params,
+      :is_low_priority, :is_codaveri, *attachment_params,
       question_assessment: { skill_ids: [] }
     )
   end

--- a/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
+++ b/app/jobs/course/assessment/answer/reduce_priority_auto_grading_job.rb
@@ -13,7 +13,19 @@ class Course::Assessment::Answer::ReducePriorityAutoGradingJob < ApplicationJob
   # Answers are regraded when their question is updated. This causes a large spike in the number
   # of answer auto grading jobs. To prevent active users from getting timely feedback on their
   # answers, queue these regrading jobs at a lower priority than answer grading jobs.
-  queue_as :medium_high
+  #
+  # NOTE: See Course::Assessment::Answer::AutoGradingJob for comments regarding usage of
+  # is_low_priority flag and :delayed_* queue_as below.
+  queue_as do
+    answer = arguments.first
+    question = answer.question
+
+    if question.is_low_priority
+      :delayed_medium_high
+    else
+      :medium_high
+    end
+  end
 
   protected
 

--- a/app/jobs/course/assessment/submission/auto_grading_job.rb
+++ b/app/jobs/course/assessment/submission/auto_grading_job.rb
@@ -3,6 +3,27 @@ class Course::Assessment::Submission::AutoGradingJob < ApplicationJob
   include TrackableJob
   include Rails.application.routes.url_helpers
 
+  # The Answer Auto Grading Job needs to be at a higher priority than submission auto grading jobs,
+  # because it is fired off by submission auto grading jobs. If this is at an equal or lower
+  # priority than the submission auto grading job, then it is possible that the answer auto grading
+  # jobs might never get to run, and then the submission auto grading jobs will never return.
+  #
+  # Lowering this *will* eventually cause a deadlock.
+  #
+  # NOTE: See Course::Assessment::Answer::AutoGradingJob for comments regarding usage of
+  # is_low_priority flag and :delayed_* queue_as below.
+  queue_as do
+    submission = arguments.first
+    questions = submission.questions
+    any_low_priority_qns = questions.any?(&:is_low_priority?)
+
+    if any_low_priority_qns
+      :delayed_default
+    else
+      :default
+    end
+  end
+
   protected
 
   # Performs the auto grading.

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -14,6 +14,7 @@ class Course::Assessment::Question < ApplicationRecord
                                          if: -> { actable_id? && actable_type_changed? } }
   validates :actable_id, uniqueness: { scope: [:actable_type],
                                        if: -> { actable_type? && actable_id_changed? } }
+  validates :is_low_priority, inclusion: { in: [true, false] }
 
   has_many :question_assessments, class_name: Course::QuestionAssessment.name, inverse_of: :question,
                                   dependent: :destroy

--- a/app/views/course/assessment/question/programming/_question.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_question.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.question do
   json.(@programming_question, :id, :title, :staff_only_comments, :maximum_grade,
-        :language_id, :memory_limit, :time_limit)
+        :language_id, :memory_limit, :time_limit, :is_low_priority)
   json.max_time_limit @programming_question.max_time_limit
   json.description format_ckeditor_rich_text(@programming_question.description)
   json.languages Coursemology::Polyglot::Language.all.order(:name) do |lang|

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
@@ -196,4 +196,8 @@ export default defineMessages({
       "Codaveri provides code evaluation and automated code feedback services for students' codes. \
       This feature is currently disabled. To use it, please enable this component in the course/instance setting.",
   },
+  lowestGradingPriority: {
+    id: 'course.assessment.question.programming.ProgrammingQuestionForm.lowestGradingPriority',
+    defaultMessage: 'Lowest Grading Priority',
+  },
 });

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -561,6 +561,38 @@ class ProgrammingQuestionForm extends Component {
     );
   }
 
+  renderSwitchField(label, field, value, disabled) {
+    return (
+      <>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={value}
+              color="primary"
+              id={ProgrammingQuestionForm.getInputId(field)}
+              name={ProgrammingQuestionForm.getInputName(field)}
+              onChange={(e) => {
+                this.handleChange(field, e.target.checked);
+              }}
+            />
+          }
+          disabled={this.props.data.get('is_loading') || disabled}
+          label={label}
+        />
+        {/** For some reason, FormData(this.form) is unable to retrieve the data from <Switch />
+         * component above. As such, hidden input field is used to store the form data.
+         */}
+        <input
+          id={ProgrammingQuestionForm.getInputId(field)}
+          name={ProgrammingQuestionForm.getInputName(field)}
+          readOnly={this.props.data.get('is_loading') || disabled}
+          type="hidden"
+          value={value}
+        />
+      </>
+    );
+  }
+
   renderSwitcher(showEditOnline, canSwitch) {
     if (!canSwitch) {
       return null;
@@ -788,104 +820,70 @@ class ProgrammingQuestionForm extends Component {
               </div>
             </Stack>
 
-            <div className={styles.autogradeToggle}>
+            <div>
               {this.props.data.getIn([
                 'question',
                 'display_autograded_toggle',
-              ]) ? (
-                <>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={autograded}
-                        color="primary"
-                        onChange={(e) => {
-                          if (hasAutoGradings) return;
-                          this.handleChange('autograded', e.target.checked);
-                        }}
-                      />
-                    }
-                    disabled={
-                      this.props.data.get('is_loading') || hasAutoGradings
-                    }
-                    label={autogradedLabel}
-                    name={ProgrammingQuestionForm.getInputName('autograded')}
-                  />
-                  <input
-                    id={ProgrammingQuestionForm.getInputId('autograded')}
-                    name={ProgrammingQuestionForm.getInputName('autograded')}
-                    readOnly={
-                      this.props.data.get('is_loading') || hasAutoGradings
-                    }
-                    style={{ display: 'none' }}
-                    type="hidden"
-                    value={autograded}
-                  />
-                </>
-              ) : null}
+              ]) &&
+                this.renderSwitchField(
+                  autogradedLabel,
+                  'autograded',
+                  autograded,
+                  hasAutoGradings,
+                )}
+
               {showIsCodaveri && (
-                <>
-                  <RadioGroup
-                    disabled={this.props.data.get('is_loading')}
-                    name={ProgrammingQuestionForm.getInputName('is_codaveri')}
-                    onChange={(e_, mode) => {
-                      this.handleChange('is_codaveri', mode === 'true');
-                    }}
-                    value={isCodaveri}
-                  >
-                    <div>
-                      {this.props.intl.formatMessage(
-                        translations.chooseEvaluator,
-                      )}
-                    </div>
-                    <FormControlLabel
-                      key={0}
-                      control={<Radio style={{ padding: 0, marginLeft: 10 }} />}
-                      label={
-                        <b>
-                          {this.props.intl.formatMessage(
-                            translations.defaultEvaluator,
-                          )}
-                        </b>
-                      }
-                      value={false}
-                    />
-                    <FormControlLabel
-                      key={1}
-                      control={<Radio style={{ padding: 0, marginLeft: 10 }} />}
-                      disabled={!enableCodaveri}
-                      label={
-                        <Tooltip
-                          title={this.props.intl.formatMessage(
-                            enableCodaveri
-                              ? translations.codaveriTooltip
-                              : translations.disableCodaveriTooltip,
-                          )}
-                        >
-                          <div
-                            style={{ alignItems: 'center', display: 'flex' }}
-                          >
-                            <b>
-                              {this.props.intl.formatMessage(
-                                translations.codaveriEvaluator,
-                              )}
-                            </b>
-                            <HelpOutline fontSize="small" />
-                          </div>
-                        </Tooltip>
-                      }
-                      value
-                    />
-                  </RadioGroup>
-                  <input
-                    id={ProgrammingQuestionForm.getInputId('is_codaveri')}
-                    name={ProgrammingQuestionForm.getInputName('is_codaveri')}
-                    readOnly={this.props.data.get('is_loading')}
-                    style={{ display: 'none' }}
-                    type="hidden"
-                    value={isCodaveri}
+                <RadioGroup
+                  disabled={this.props.data.get('is_loading')}
+                  id={ProgrammingQuestionForm.getInputId('is_codaveri')}
+                  name={ProgrammingQuestionForm.getInputName('is_codaveri')}
+                  onChange={(e_, mode) => {
+                    this.handleChange('is_codaveri', mode === 'true');
+                  }}
+                  value={isCodaveri}
+                >
+                  <div>
+                    {this.props.intl.formatMessage(
+                      translations.chooseEvaluator,
+                    )}
+                  </div>
+                  <FormControlLabel
+                    key={0}
+                    control={<Radio style={{ padding: 0, marginLeft: 10 }} />}
+                    label={
+                      <b>
+                        {this.props.intl.formatMessage(
+                          translations.defaultEvaluator,
+                        )}
+                      </b>
+                    }
+                    value={false}
                   />
-                </>
+                  <FormControlLabel
+                    key={1}
+                    control={<Radio style={{ padding: 0, marginLeft: 10 }} />}
+                    disabled={!enableCodaveri}
+                    label={
+                      <Tooltip
+                        title={this.props.intl.formatMessage(
+                          enableCodaveri
+                            ? translations.codaveriTooltip
+                            : translations.disableCodaveriTooltip,
+                        )}
+                      >
+                        <div style={{ alignItems: 'center', display: 'flex' }}>
+                          <b>
+                            {this.props.intl.formatMessage(
+                              translations.codaveriEvaluator,
+                            )}
+                          </b>
+                          <HelpOutline fontSize="small" />
+                        </div>
+                      </Tooltip>
+                    }
+                    value
+                  />
+                </RadioGroup>
               )}
             </div>
             <Grid
@@ -961,6 +959,19 @@ class ProgrammingQuestionForm extends Component {
                     )}
                   </div>
                 ) : null}
+              </Grid>
+              <Grid item xs={1}>
+                {autograded &&
+                  this.renderSwitchField(
+                    <b>
+                      {this.props.intl.formatMessage(
+                        translations.lowestGradingPriority,
+                      )}
+                    </b>,
+                    'is_low_priority',
+                    question.get('is_low_priority'),
+                    false,
+                  )}
               </Grid>
             </Grid>
           </Stack>

--- a/client/app/bundles/course/assessment/question/programming/reducers/programmingQuestionReducer.jsx
+++ b/client/app/bundles/course/assessment/question/programming/reducers/programmingQuestionReducer.jsx
@@ -24,6 +24,7 @@ export const initialState = fromJS({
     skills: [],
     memory_limit: null,
     time_limit: null,
+    is_low_priority: false,
     autograded: false,
     display_autograded_toggle: false,
     autograded_assessment: false,

--- a/db/migrate/20230404030133_add_auto_grading_queue_to_question.rb
+++ b/db/migrate/20230404030133_add_auto_grading_queue_to_question.rb
@@ -1,0 +1,5 @@
+class AddAutoGradingQueueToQuestion < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_assessment_questions, :is_low_priority, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_15_054448) do
+ActiveRecord::Schema.define(version: 2023_04_04_030133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -356,6 +356,7 @@ ActiveRecord::Schema.define(version: 2023_01_15_054448) do
     t.integer "updater_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_low_priority", default: false
     t.index ["actable_type", "actable_id"], name: "index_course_assessment_questions_actable", unique: true
     t.index ["creator_id"], name: "fk__course_assessment_questions_creator_id"
     t.index ["updater_id"], name: "fk__course_assessment_questions_updater_id"

--- a/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/auto_grading_job_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Course::Assessment::Answer::AutoGradingJob do
         have_enqueued_job(subject).exactly(:once).on_queue('highest')
     end
 
+    context 'When a question is set as lower priority' do
+      before do
+        question.update!(is_low_priority: true)
+        answer.reload
+      end
+
+      it 'can be queued with delayed_ queue' do
+        expect { subject.perform_later(answer) }.to \
+          have_enqueued_job(subject).exactly(:once).on_queue('delayed_highest')
+      end
+    end
+
     context 'when the assessment is non-autograded' do
       it 'evaluates answers and does not update the exp' do
         initial_points = submission.points_awarded

--- a/spec/jobs/course/assessment/answer/reduce_priority_auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/reduce_priority_auto_grading_job_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Course::Assessment::Answer::ReducePriorityAutoGradingJob do
         have_enqueued_job(subject).exactly(:once).on_queue('medium_high')
     end
 
+    context 'When a question is not of highest grading priority' do
+      before do
+        question.update!(is_low_priority: true)
+        answer.reload
+      end
+
+      it 'can be queued with delayed_ queue' do
+        expect { subject.perform_later(answer) }.to \
+          have_enqueued_job(subject).exactly(:once).on_queue('delayed_medium_high')
+      end
+    end
+
     context 'when the initial wrong answer is re-evaluated' do
       before do
         submission.update!(awarder: User.system)

--- a/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
+++ b/spec/jobs/course/assessment/submission/auto_grading_job_spec.rb
@@ -17,7 +17,18 @@ RSpec.describe Course::Assessment::Submission::AutoGradingJob do
 
     it 'can be queued' do
       expect { subject.perform_later(submission) }.to \
-        have_enqueued_job(subject).exactly(:once)
+        have_enqueued_job(subject).exactly(:once).on_queue('default')
+    end
+
+    context 'When a question is not of highest grading priority' do
+      before do
+        question.update!(is_low_priority: true)
+      end
+
+      it 'can be queued with delayed_ queue' do
+        expect { subject.perform_later(submission) }.to \
+          have_enqueued_job(subject).exactly(:once).on_queue('delayed_default')
+      end
     end
 
     with_active_job_queue_adapter(:background_thread) do


### PR DESCRIPTION
## Context
In the latest use case of programming autograding, we have started to allow users to adjust for higher time limit (5 - 10 minutes) for programming answer evaluation (mainly for exam purpose). In production, lets say there are N workers with N autograding job (`highest` queue) that are running. This will block other jobs (ie email, answer autograding that requires much less time to execute, downloading, etc) from being executed and clog the job pipeline for other normal users.

## Solution (Temporary-ish)
As the exam period is near, a temporary solution is currently proposed. First, `is_high_priority` attribute is added to the question table. Since only programming autograding is currently run by worker, the flag is only added to the programming question form. When a programming question is not of "high_priority", all answers autograding of the question will be pushed to "lower" priorities. To allow such behaviour, queues with `delayed_` prefix are introduced. There are 3 new `delayed_` queues, namely `delayed_highest`, `delayed_medium_high` and `delayed_default`.

Currently, the sequence of the queue is `highest, medium_high, default, mailers, rollbar, duplication, lowest`. This needs to be changed to `highest, medium_high, default, mailers, rollbar, duplication, lowest, delayed_highest, delayed_medium_high, delayed_default`. Basically, adding the 3 new queues to the last of the existing queue sequence.

In production, lets say there are 4 workers, 3 will run the queues including the`delayed_` queues and the last server would exclude the `delayed_` queues. This is to allow other jobs to be completed while the much slower jobs sent to `delayed_` queues are being worked on.
 
The need to create these `delayed_` queues, instead of just dumping all slow answer autograding to `lowest` queue is due to the following reasons:
- There is a queue dependency between answer autograding job and submission autograding job. As highlighted in the inline document inside `Course::Assessment::Answer::AutoGradingJob`, `the answer auto grading job needs to be at a higher priority than submission auto grading jobs, because the answer autograding job is also fired off by submission auto grading jobs. If this is at an equal or lower priority than the submission auto grading job, then it is possible that the answer auto grading jobs might never get to run, and then the submission auto grading jobs will never return`. As such, there needs to be a lower priority queue for submission (that contains questions with low priority grading) autograding when compared to the answer autograding of the low priority question.
- There are other types of jobs in the `lowest` queue such as download of csv, statistics, etc and these jobs should not be clogged as well.

With that all being said, for a question with lower grading priority (and submission with such question), the queue is mapped below:
-  `Course::Assessment::Answer::AutoGradingJob`: `highest` -> `delayed_highest`
- `Course::Assessment::Answer::ReducePriorityAutoGradingJob`: `high_medium` -> `delayed_high_medium`
- `Course::Assessment::Submission::AutoGradingJob`: `default` -> `delayed_default`

## Future work
Jobs should be picked up by workers of specific domain/role with single responsibility (ie a worker only autogrades and not sending out email). <---- Microservices~

## Screenshot of the priority setting in the programming question form 
![image](https://user-images.githubusercontent.com/42570513/230074934-6d557c3f-3865-4c38-bf60-1288b14e2133.png)
