### PR TITLE
Truncate Name of Identifier in each Testcase in Programming Questions

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -205,6 +205,10 @@ export class VisibleTestCaseView extends Component {
     } = this.props;
     const { showPublicTestCasesOutput } = this.props;
 
+    const nameRegex = /\/?(\w+)$/;
+    const idMatch = testCase.identifier.match(nameRegex);
+    const truncatedIdentifier = idMatch ? idMatch[1] : '';
+
     let testCaseResult = 'unattempted';
     let testCaseIcon;
     if (testCase.passed !== undefined) {
@@ -223,7 +227,7 @@ export class VisibleTestCaseView extends Component {
         key={testCase.identifier}
         style={styles.testCaseRow[testCaseResult]}
       >
-        {canReadTests && tableRowColumnFor(testCase.identifier)}
+        {canReadTests && tableRowColumnFor(truncatedIdentifier)}
         {tableRowColumnFor(
           <ExpandableText style={outputStyle} text={testCase.expression} />,
         )}


### PR DESCRIPTION
What's been done:
- Identifying that all the entities' identifier has redundant naming that makes the column too long and so the other columns (which are more important) are rendered shorter
- The redundancy lies in the prefix of the testCase's name, which is always {someCat}/{someCat}/{realName}
- We only need the realName over here, thus omitting the other characters

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="1211" alt="Screenshot 2023-04-11 at 6 39 05 PM" src="https://user-images.githubusercontent.com/16359075/231137161-f33a5b1b-afbf-4c9c-8ea1-c82e8a8d465c.png">
</td>
<td>
<img width="1211" alt="Screenshot 2023-04-11 at 6 37 10 PM" src="https://user-images.githubusercontent.com/16359075/231137226-804dc8bb-1b03-44ff-9849-0f20af5023af.png">
</td>
</tr>
</table>