### PR TITLE
Fix `datePickers.datetimepicker()` error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -205,7 +205,7 @@ gem 'themes_on_rails', '>= 0.3.1', git: 'https://github.com/raymondtangsc/themes
 
 # Forms made easy for Rails
 gem 'simple_form'
-gem 'simple_form-bootstrap', git: 'https://github.com/raymondtangsc/simple_form-bootstrap'
+gem 'simple_form-bootstrap', git: 'https://github.com/purfectliterature/simple_form-bootstrap'
 # Dynamic nested forms
 gem 'cocoon'
 gem 'bootstrap_tokenfield_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,16 +37,8 @@ GIT
     rwordnet (2.0.0)
 
 GIT
-  remote: https://github.com/raymondtangsc/rails_utils.git
-  revision: 5c8c0caacf08985ae14c5d007529a09d5f284da0
-  branch: full-sanitize-flash
-  specs:
-    rails_utils (4.0.0)
-      rails (>= 3.2)
-
-GIT
-  remote: https://github.com/raymondtangsc/simple_form-bootstrap
-  revision: aa17b3362bf32b73a2cd8aa708d656b7e26ad275
+  remote: https://github.com/purfectliterature/simple_form-bootstrap
+  revision: 2c61978f8d40f8053deb3f748dafbdd5c9de5864
   specs:
     simple_form-bootstrap (1.6.0)
       actionpack (>= 4.1)
@@ -54,6 +46,14 @@ GIT
       bootstrap-sass (~> 3)
       railties (>= 4.1)
       simple_form (>= 3.1.0)
+
+GIT
+  remote: https://github.com/raymondtangsc/rails_utils.git
+  revision: 5c8c0caacf08985ae14c5d007529a09d5f284da0
+  branch: full-sanitize-flash
+  specs:
+    rails_utils (4.0.0)
+      rails (>= 3.2)
 
 GIT
   remote: https://github.com/raymondtangsc/themes_on_rails


### PR DESCRIPTION
Fixes that annoying error. This error is thrown by the `simple_form-bootstrap` gem because it couldn't find Bootstrap's `datetimepicker` that is supposed to be exposed by `bootstrap3-datetimepicker-rails`, which we don't install. It tries to initialise the date/time picker with `datePickers.datetimepicker()`, but ultimately fails. The patch was made to initialise the picker and other optional components _defensively_.

Patch was made in a remote repository: https://github.com/purfectliterature/simple_form-bootstrap/commit/2c61978f8d40f8053deb3f748dafbdd5c9de5864.