### PR TITLE
Fix programming question page regression

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -21,7 +21,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
     respond_to do |format|
       if @programming_question.save
         load_question_assessment
-        format.json { render_success_json t('.success') }
+        format.json { render_success_json t('.success'), true }
       else
         format.json { render_failure_json t('.failure') }
       end
@@ -49,7 +49,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
 
     respond_to do |format|
       if result
-        format.json { render_success_json t('.success') }
+        format.json { render_success_json t('.success'), false }
       else
         format.json { render_failure_json t('.failure') }
       end
@@ -80,8 +80,8 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
     )
   end
 
-  def render_success_json(message)
-    @response = { message: message }
+  def render_success_json(message, redirect_to_edit)
+    @response = { message: message, redirect_to_edit: redirect_to_edit }
 
     render 'edit'
   end

--- a/app/views/course/assessment/question/programming/_response.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_response.json.jbuilder
@@ -2,8 +2,13 @@
 if check_import_job?
   json.import_job_url job_path(@programming_question.import_job)
 
-  json.redirect_edit_url edit_course_assessment_question_programming_path(current_course, @assessment,
-                                                                          @programming_question)
+  if response[:redirect_to_edit]
+    json.redirect_edit do
+      json.url edit_course_assessment_question_programming_path(current_course, @assessment, @programming_question)
+      json.page_header @question_assessment.display_title
+      json.page_title "#{@question_assessment.display_title} - #{page_title}"
+    end
+  end
 end
 
 json.redirect_assessment_url course_assessment_path(current_course, @assessment)

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.intl.js
@@ -118,11 +118,6 @@ export default defineMessages({
     defaultMessage: 'Submit',
     description: 'Button for submitting the form.',
   },
-  submitButtonTooltip: {
-    id: 'course.assessment.question.programming.ProgrammingQuestionForm.submitButtonTooltip',
-    defaultMessage:
-      'Unable to update Codaveri question type as there are existing submissions',
-  },
   submitFailureMessage: {
     id: 'course.assessment.question.programming.ProgrammingQuestionForm.submitFailureMessage',
     defaultMessage: 'An error occurred, please try again.',

--- a/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
+++ b/client/app/bundles/course/assessment/question/programming/containers/ProgrammingQuestionForm/ProgrammingQuestionForm.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import { Component } from 'react';
 import { injectIntl } from 'react-intl';
-import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { HelpOutline } from '@mui/icons-material';
 import {
   Autocomplete,
@@ -683,7 +682,6 @@ class ProgrammingQuestionForm extends Component {
     const autograded = question.get('autograded');
     const isCodaveri = question.get('is_codaveri');
     const hasAutoGradings = question.get('has_auto_gradings');
-    const disableSubmit = false;
     let autogradedLabel = (
       <b>{this.props.intl.formatMessage(translations.autograded)}</b>
     );
@@ -1013,14 +1011,11 @@ class ProgrammingQuestionForm extends Component {
             }}
             open={this.props.data.get('show_submission_message')}
           />
-          <ReactTooltip id="disabled-submit-tooltip">
-            {this.props.intl.formatMessage(translations.submitButtonTooltip)}
-          </ReactTooltip>
-          <div data-tooltip-id="disabled-submit-tooltip">
+          <div>
             <Button
               className={styles.submitButton}
               color="primary"
-              disabled={this.props.data.get('is_loading') || disableSubmit}
+              disabled={this.props.data.get('is_loading')}
               endIcon={
                 this.props.data.get('is_loading') ? (
                   <LoadingIndicator bare size={20} />


### PR DESCRIPTION
## Context
When a programming question is created, a job is created to evaluate and save the programming question. However, the programming question data (i.e. test_cases, template_files, etc) could only be saved when there is no evaluation error and the job was completed. In such a case where an error occurs, the programming question form page should not be reloaded or otherwise, all the data would be gone. The backend is unable to retrieve the data as they were never saved in the first place due to the evaluation error. This behaviour should be revisited and fixed in the future.

This PR temporarily fixes the behaviour by reverting some code changes in the past that prevented the page from getting redirected after there is an import job error. How it works is that when there is a programming import job error, the page is not redirected to the edit question page (context: when there is a job error, the question has been created but the package has not been processed). Instead, the link in the browser is updated and as such, the data are not gone. There is a caveat that if the page is hard reloaded or visited in another tab or browser, the data would still be gone. 