### PR TITLE
Fix submission nil answer

### DIFF
--- a/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
+++ b/app/models/concerns/course/assessment/submission/workflow_event_concern.rb
@@ -16,9 +16,10 @@ module Course::Assessment::Submission::WorkflowEventConcern
     self.submitted_at = Time.zone.now
     save!
 
+    answers.reload # Reload answers after saving
     finalise_current_answers
 
-    answers.reload
+    answers.reload # Reload answers after finalising
     assign_zero_experience_points
 
     # Trigger timeline recomputation

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -155,7 +155,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
             logger.error("Failed to update answer #{answer.errors.inspect}")
             raise ActiveRecord::Rollback
           end
-          attempt_draft_answer(answer)
+          attempt_draft_answer(answer) if answer
         end
       end
 


### PR DESCRIPTION
### Issues
- After saving a submission with answers nested attribute, `answers` need to be reloaded to get the latest saved answers.
- Only attempt draft answer if answer is not nil