### PR TITLE
Fix nil errors in backend

### DIFF
--- a/app/models/concerns/user_masquerade_concern.rb
+++ b/app/models/concerns/user_masquerade_concern.rb
@@ -3,6 +3,6 @@ module UserMasqueradeConcern
   extend ActiveSupport::Concern
 
   def can_masquerade?
-    primary_email_record.confirmed?
+    primary_email_record&.confirmed?
   end
 end

--- a/app/views/course/statistics/assessments/ancestors.json.jbuilder
+++ b/app/views/course/statistics/assessments/ancestors.json.jbuilder
@@ -2,5 +2,5 @@
 json.assessments @assessments do |assessment|
   json.id assessment.id
   json.title assessment.title
-  json.courseTitle assessment.course.title
+  json.courseTitle assessment.course&.title
 end


### PR DESCRIPTION
## Issues & Solutions
- [Rollbar Issue No. 2406](https://app.rollbar.com/a/coursemology/fix/item/Coursemology2/2406) Users without primary email were found to exist (However these were all old user accounts). As such, `can_masquerade?` returns undefined method for nil class error. Added a nil guard to fix this.
- [Rollbar Issue No. 2402](https://app.rollbar.com/a/coursemology/fix/item/Coursemology2/2402) Similarly, for assessment ancestors, past courses may have been deleted. Added a nil guard to fix this.