### PR TITLE
Add `mailto` URLs to evaluator job error message panel

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/EvaluatorErrorPanel.tsx
+++ b/client/app/bundles/course/assessment/submission/components/EvaluatorErrorPanel.tsx
@@ -1,19 +1,10 @@
 import { defineMessages } from 'react-intl';
-import { toast } from 'react-toastify';
-import { Alert, AlertProps, Typography } from '@mui/material';
+import { AlertProps } from '@mui/material';
 
-import Link from 'lib/components/core/Link';
+import ContactableErrorAlert from 'lib/components/core/layouts/ContactableErrorAlert';
 import useTranslation from 'lib/hooks/useTranslation';
 
 const translations = defineMessages({
-  contactCoursemology: {
-    id: 'course.assessment.submission.EvaluatorErrorPanel.contactCoursemology',
-    defaultMessage: 'Contact Coursemology',
-  },
-  copyEmailBodyWithErrorMessage: {
-    id: 'course.assessment.submission.EvaluatorErrorPanel.copyEmailBodyWithErrorMessage',
-    defaultMessage: 'Copy email body with error message',
-  },
   emailSubject: {
     id: 'course.assessment.submission.EvaluatorErrorPanel.emailSubject',
     defaultMessage: '[Bug Report] Evaluator Error',
@@ -26,32 +17,13 @@ const translations = defineMessages({
       `{message}{nl}{nl}` +
       `The page URL is: {url}`,
   },
-  copiedEmailBodyToClipboard: {
-    id: 'course.assessment.submission.EvaluatorErrorPanel.copiedEmailBodyToClipboard',
-    defaultMessage:
-      'Copied email body to clipboard! Contact Coursemology admin at {email}.',
-  },
-  copyingEmailBodyToClipboard: {
-    id: 'course.assessment.submission.EvaluatorErrorPanel.copyingEmailBodyToClipboard',
-    defaultMessage: 'Copying the email body to clipboard...',
-  },
-  errorCopyingEmailBodyToClipboard: {
-    id: 'course.assessment.submission.EvaluatorErrorPanel.errorCopyingEmailBodyToClipboard',
-    defaultMessage:
-      'An error occurred while copying the email body to clipboard.',
-  },
 });
 
 const SUPPORT_EMAIL = 'coursemology@gmail.com' as const;
 
-const getMailtoURL = (subject: string, body: string): string => {
-  const encodedSubject = encodeURIComponent(subject);
-  const encodedBody = encodeURIComponent(body);
-  return `mailto:${SUPPORT_EMAIL}?subject=${encodedSubject}&body=${encodedBody}`;
-};
-
 interface EvaluatorErrorPanelProps extends AlertProps {
   children: string;
+  className?: string;
 }
 
 const EvaluatorErrorPanel = (props: EvaluatorErrorPanelProps): JSX.Element => {
@@ -62,33 +34,15 @@ const EvaluatorErrorPanel = (props: EvaluatorErrorPanelProps): JSX.Element => {
   const url = window.location.href;
   const emailBody = t(translations.emailBody, { message, url, nl: '\n' });
 
-  const emailURL = getMailtoURL(t(translations.emailSubject), emailBody);
-
-  const copyEmailBodyToClipboard = (): Promise<void> =>
-    toast.promise(navigator.clipboard.writeText(emailBody), {
-      pending: t(translations.copyingEmailBodyToClipboard),
-      error: t(translations.errorCopyingEmailBodyToClipboard),
-      success: t(translations.copiedEmailBodyToClipboard, {
-        email: SUPPORT_EMAIL,
-      }),
-    });
-
   return (
-    <Alert {...props} classes={{ message: 'space-y-5' }} severity="error">
-      <Typography className="break-words" variant="body2">
-        {message}
-      </Typography>
-
-      <div className="flex flex-col space-y-3 md:flex-row md:space-x-5 md:space-y-0">
-        <Link external href={emailURL}>
-          {t(translations.contactCoursemology)}
-        </Link>
-
-        <Link onClick={copyEmailBodyToClipboard}>
-          {t(translations.copyEmailBodyWithErrorMessage)}
-        </Link>
-      </div>
-    </Alert>
+    <ContactableErrorAlert
+      className={props.className}
+      emailBody={emailBody}
+      emailSubject={t(translations.emailSubject)}
+      supportEmail={SUPPORT_EMAIL}
+    >
+      {message}
+    </ContactableErrorAlert>
   );
 };
 

--- a/client/app/bundles/course/assessment/submission/components/EvaluatorErrorPanel.tsx
+++ b/client/app/bundles/course/assessment/submission/components/EvaluatorErrorPanel.tsx
@@ -1,0 +1,95 @@
+import { defineMessages } from 'react-intl';
+import { toast } from 'react-toastify';
+import { Alert, AlertProps, Typography } from '@mui/material';
+
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  contactCoursemology: {
+    id: 'course.assessment.submission.EvaluatorErrorPanel.contactCoursemology',
+    defaultMessage: 'Contact Coursemology',
+  },
+  copyEmailBodyWithErrorMessage: {
+    id: 'course.assessment.submission.EvaluatorErrorPanel.copyEmailBodyWithErrorMessage',
+    defaultMessage: 'Copy email body with error message',
+  },
+  emailSubject: {
+    id: 'course.assessment.submission.EvaluatorErrorPanel.emailSubject',
+    defaultMessage: '[Bug Report] Evaluator Error',
+  },
+  emailBody: {
+    id: 'course.assessment.submission.EvaluatorErrorPanel.emailBody',
+    defaultMessage:
+      `Dear Coursemology Admin,{nl}{nl}` +
+      `I encountered the following error when submitting my programming question code:{nl}{nl}` +
+      `{message}{nl}{nl}` +
+      `The page URL is: {url}`,
+  },
+  copiedEmailBodyToClipboard: {
+    id: 'course.assessment.submission.EvaluatorErrorPanel.copiedEmailBodyToClipboard',
+    defaultMessage:
+      'Copied email body to clipboard! Contact Coursemology admin at {email}.',
+  },
+  copyingEmailBodyToClipboard: {
+    id: 'course.assessment.submission.EvaluatorErrorPanel.copyingEmailBodyToClipboard',
+    defaultMessage: 'Copying the email body to clipboard...',
+  },
+  errorCopyingEmailBodyToClipboard: {
+    id: 'course.assessment.submission.EvaluatorErrorPanel.errorCopyingEmailBodyToClipboard',
+    defaultMessage:
+      'An error occurred while copying the email body to clipboard.',
+  },
+});
+
+const SUPPORT_EMAIL = 'coursemology@gmail.com' as const;
+
+const getMailtoURL = (subject: string, body: string): string => {
+  const encodedSubject = encodeURIComponent(subject);
+  const encodedBody = encodeURIComponent(body);
+  return `mailto:${SUPPORT_EMAIL}?subject=${encodedSubject}&body=${encodedBody}`;
+};
+
+interface EvaluatorErrorPanelProps extends AlertProps {
+  children: string;
+}
+
+const EvaluatorErrorPanel = (props: EvaluatorErrorPanelProps): JSX.Element => {
+  const { children: message } = props;
+
+  const { t } = useTranslation();
+
+  const url = window.location.href;
+  const emailBody = t(translations.emailBody, { message, url, nl: '\n' });
+
+  const emailURL = getMailtoURL(t(translations.emailSubject), emailBody);
+
+  const copyEmailBodyToClipboard = (): Promise<void> =>
+    toast.promise(navigator.clipboard.writeText(emailBody), {
+      pending: t(translations.copyingEmailBodyToClipboard),
+      error: t(translations.errorCopyingEmailBodyToClipboard),
+      success: t(translations.copiedEmailBodyToClipboard, {
+        email: SUPPORT_EMAIL,
+      }),
+    });
+
+  return (
+    <Alert {...props} classes={{ message: 'space-y-5' }} severity="error">
+      <Typography className="break-words" variant="body2">
+        {message}
+      </Typography>
+
+      <div className="flex flex-col space-y-3 md:flex-row md:space-x-5 md:space-y-0">
+        <Link external href={emailURL}>
+          {t(translations.contactCoursemology)}
+        </Link>
+
+        <Link onClick={copyEmailBodyToClipboard}>
+          {t(translations.copyEmailBodyWithErrorMessage)}
+        </Link>
+      </div>
+    </Alert>
+  );
+};
+
+export default EvaluatorErrorPanel;

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -12,7 +12,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Paper,
   Step,
   StepButton,
   Stepper,
@@ -26,6 +25,7 @@ import ErrorText from 'lib/components/core/ErrorText';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import usePrompt from 'lib/hooks/router/usePrompt';
 
+import EvaluatorErrorPanel from '../../components/EvaluatorErrorPanel';
 import SubmissionAnswer from '../../components/SubmissionAnswer';
 import { formNames, questionTypes } from '../../constants';
 import GradingPanel from '../../containers/GradingPanel';
@@ -271,13 +271,11 @@ const SubmissionEditForm = (props) => {
 
     if (type === questionTypes.Programming && jobError) {
       return (
-        <Paper
-          style={{ padding: 10, backgroundColor: red[100], marginBottom: 20 }}
-        >
+        <EvaluatorErrorPanel className="mb-8">
           {isCodaveri
             ? intl.formatMessage(translations.codaveriAutogradeFailure)
             : jobErrorMessage}
-        </Paper>
+        </EvaluatorErrorPanel>
       );
     }
 

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -8,7 +8,6 @@ import {
   CardContent,
   CardHeader,
   CircularProgress,
-  Paper,
   Step,
   StepButton,
   StepLabel,
@@ -24,6 +23,7 @@ import ErrorText from 'lib/components/core/ErrorText';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import usePrompt from 'lib/hooks/router/usePrompt';
 
+import EvaluatorErrorPanel from '../../components/EvaluatorErrorPanel';
 import SubmissionAnswer from '../../components/SubmissionAnswer';
 import { formNames, questionTypes } from '../../constants';
 import Comments from '../../containers/Comments';
@@ -177,13 +177,11 @@ const SubmissionEditStepForm = (props) => {
 
     if (type === questionTypes.Programming && jobError) {
       return (
-        <Paper
-          style={{ padding: 10, backgroundColor: red[100], marginBottom: 20 }}
-        >
+        <EvaluatorErrorPanel className="mb-8">
           {isCodaveri
             ? intl.formatMessage(translations.codaveriAutogradeFailure)
             : jobErrorMessage}
-        </Paper>
+        </EvaluatorErrorPanel>
       );
     }
 

--- a/client/app/lib/components/core/Link.tsx
+++ b/client/app/lib/components/core/Link.tsx
@@ -1,17 +1,26 @@
 import { ComponentProps } from 'react';
+import { ArrowOutward } from '@mui/icons-material';
 import { Link as MuiLink, Typography } from '@mui/material';
 
 interface LinkProps extends ComponentProps<typeof MuiLink> {
   opensInNewTab?: boolean;
+  external?: boolean;
 }
 
 const Link = (props: LinkProps): JSX.Element => {
   const { opensInNewTab, ...linkProps } = props;
 
+  const children = (
+    <>
+      {props.children}
+      {props.external && <ArrowOutward fontSize="inherit" />}
+    </>
+  );
+
   if (!props.href && !props.onClick)
     return (
       <Typography component="span" variant={props.variant ?? 'body2'}>
-        {props.children}
+        {children}
       </Typography>
     );
 
@@ -25,7 +34,9 @@ const Link = (props: LinkProps): JSX.Element => {
         target: '_blank',
         rel: 'noopener noreferrer',
       })}
-    />
+    >
+      {children}
+    </MuiLink>
   );
 };
 

--- a/client/app/lib/components/core/layouts/ContactableErrorAlert.tsx
+++ b/client/app/lib/components/core/layouts/ContactableErrorAlert.tsx
@@ -1,0 +1,89 @@
+import { defineMessages } from 'react-intl';
+import { toast } from 'react-toastify';
+import { Alert, AlertProps, Typography } from '@mui/material';
+
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  contactCoursemology: {
+    id: 'lib.components.core.layouts.ContactableErrorAlert.contactCoursemology',
+    defaultMessage: 'Contact Coursemology',
+  },
+  copyEmailBodyWithErrorMessage: {
+    id: 'lib.components.core.layouts.ContactableErrorAlert.copyEmailBodyWithErrorMessage',
+    defaultMessage: 'Copy email body with error message',
+  },
+  copiedEmailBodyToClipboard: {
+    id: 'lib.components.core.layouts.ContactableErrorAlert.copiedEmailBodyToClipboard',
+    defaultMessage:
+      'Copied email body to clipboard! Contact Coursemology admin at {email}.',
+  },
+  copyingEmailBodyToClipboard: {
+    id: 'lib.components.core.layouts.ContactableErrorAlert.copyingEmailBodyToClipboard',
+    defaultMessage: 'Copying the email body to clipboard...',
+  },
+  errorCopyingEmailBodyToClipboard: {
+    id: 'lib.components.core.layouts.ContactableErrorAlert.errorCopyingEmailBodyToClipboard',
+    defaultMessage:
+      'An error occurred while copying the email body to clipboard.',
+  },
+});
+
+const getMailtoURL = (email: string, subject: string, body: string): string => {
+  const encodedSubject = encodeURIComponent(subject);
+  const encodedBody = encodeURIComponent(body);
+  return `mailto:${email}?subject=${encodedSubject}&body=${encodedBody}`;
+};
+
+interface ContactableErrorAlertProps extends AlertProps {
+  children: string;
+  supportEmail: string;
+  emailBody: string;
+  emailSubject: string;
+}
+
+const ContactableErrorAlert = (
+  props: ContactableErrorAlertProps,
+): JSX.Element => {
+  const {
+    children: message,
+    emailBody,
+    emailSubject,
+    supportEmail,
+    ...otherProps
+  } = props;
+
+  const { t } = useTranslation();
+
+  const emailURL = getMailtoURL(supportEmail, emailSubject, emailBody);
+
+  const copyEmailBodyToClipboard = (): Promise<void> =>
+    toast.promise(navigator.clipboard.writeText(emailBody), {
+      pending: t(translations.copyingEmailBodyToClipboard),
+      error: t(translations.errorCopyingEmailBodyToClipboard),
+      success: t(translations.copiedEmailBodyToClipboard, {
+        email: supportEmail,
+      }),
+    });
+
+  return (
+    <Alert {...otherProps} classes={{ message: 'space-y-5' }} severity="error">
+      <Typography className="break-words" variant="body2">
+        {message}
+      </Typography>
+
+      <div className="flex flex-col space-y-3 md:flex-row md:space-x-5 md:space-y-0">
+        <Link external href={emailURL}>
+          {t(translations.contactCoursemology)}
+        </Link>
+
+        <Link onClick={copyEmailBodyToClipboard}>
+          {t(translations.copyEmailBodyWithErrorMessage)}
+        </Link>
+      </div>
+    </Alert>
+  );
+};
+
+export default ContactableErrorAlert;


### PR DESCRIPTION
I noticed that recently, reporters of the evaluator job errors might have forgotten to include their question URL, or sent an image instead of the error message, making it hard for us to copy/paste and debug their issue. It also makes our debugging slower since we have to send another email to ask them for the URL.

## Notable changes
- Add _Contact Coursemology_ `mailto` URL that will automatically draft a new email to coursemology(at)gmail.com*, with the appropriate subject, and URL + error message in the body.
- Add _Copy email body with error message_ that will write the same email body to the clipboard in case they don't have a default email client installed.
- Fix the text wrapping when the error message is too long.
- Use `Alert` so the error message looks nice.

[*actual email address was obfuscated.](https://www.quora.com/Why-do-some-people-write-out-the-at-in-their-email-addresses-on-websites-and-not-write#:~:text=It's%20a%20technic%20designed%20to%20obfuscate%20email%20addresses%20to%20prevent%20easy%20collection.&text=I've%20also%20seen%20it,%5D%20domain%20%5Bdot%5D%20com.)

| Before | After |
| - | - |
| ![image](https://github.com/Coursemology/coursemology2/assets/51525686/81111556-0d44-44ec-8b6c-59ea7bced5a8) | ![image](https://github.com/Coursemology/coursemology2/assets/51525686/6a31414e-e8b1-4cf1-b8a0-ec025f921266) |

![image](https://github.com/Coursemology/coursemology2/assets/51525686/c3605aa4-c88a-4251-9854-92f795351098)
