### PR TITLE
Fix staff cannot see video statistics

### DIFF
--- a/app/models/components/course/videos_ability_component.rb
+++ b/app/models/components/course/videos_ability_component.rb
@@ -75,16 +75,17 @@ module Course::VideosAbilityComponent
   end
 
   def define_staff_video_permissions
-    allow_staff_read_and_attempt_all_video
-    allow_staff_read_and_analzye_all_video_submission
+    allow_staff_read_analyze_and_attempt_all_video
+    allow_staff_read_and_analyze_all_video_submission
   end
 
-  def allow_staff_read_and_attempt_all_video
+  def allow_staff_read_analyze_and_attempt_all_video
     can :read, Course::Video, lesson_plan_course_hash
+    can :analyze, Course::Video, lesson_plan_course_hash
     can :attempt, Course::Video, lesson_plan_course_hash
   end
 
-  def allow_staff_read_and_analzye_all_video_submission
+  def allow_staff_read_and_analyze_all_video_submission
     can :read, Course::Video::Submission, video_course_hash
     can :analyze, Course::Video::Submission, video_course_hash
   end

--- a/app/views/course/video/videos/index.json.jbuilder
+++ b/app/views/course/video/videos/index.json.jbuilder
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
-
-can_analyze = can?(:analyze, @videos)
-
 json.videoTabs @video_tabs do |video_tab|
   json.id video_tab.id
   json.title video_tab.title
 end
 
 json.videos @videos do |video|
-  json.partial! 'video_list_data', video: video, can_analyze: can_analyze, submission: video.submissions.first&.id
+  json.partial! 'video_list_data', video: video, can_analyze: @can_analyze, submission: video.submissions.first&.id
 end
 
 json.metadata do
@@ -21,6 +18,6 @@ json.metadata do
 end
 
 json.permissions do
-  json.canAnalyze can_analyze
-  json.canManage can?(:manage, Course::Video.new(course: current_course))
+  json.canAnalyze @can_analyze
+  json.canManage @can_manage
 end


### PR DESCRIPTION
- `:analyze` ability for `Course::Video` was never defined.
- CanCanCan cannot authorise ability for an array or collection proxy.