### PR TITLE
Fix closing reminder token not updated when a new `end_at` is in the past

### DIFF
--- a/app/models/concerns/course/closing_reminder_concern.rb
+++ b/app/models/concerns/course/closing_reminder_concern.rb
@@ -16,10 +16,12 @@ module Course::ClosingReminderConcern
   end
 
   def create_closing_reminders_at(new_end_at)
-    return if new_end_at <= Time.zone.now
-
     # Use current time as token to prevent duplicate notification.
+    # Always regenerate the closing reminder token, regardless of whether a new
+    # `Course::ClosingReminderJob` is created, to invalidate all previous jobs.
     self.closing_reminder_token = Time.zone.now.to_f.round(5)
+
+    return if new_end_at <= Time.zone.now
 
     # Send notification one day before the closing date
     closing_reminder_job_class.set(wait_until: new_end_at - 1.day).

--- a/spec/jobs/course/assessment/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/closing_reminder_job_spec.rb
@@ -8,17 +8,20 @@ RSpec.describe Course::Assessment::ClosingReminderJob do
 
     context 'when end_at of the assessment is changed' do
       it 'creates a closing reminder job' do
+        old_closing_reminder_token = assessment.closing_reminder_token
         assessment.end_at = 1.day.from_now
 
         expect { assessment.save }.to have_enqueued_job(Course::Assessment::ClosingReminderJob)
+        expect(assessment.closing_reminder_token).not_to eq(old_closing_reminder_token)
       end
 
       context 'when end_at is a past time' do
-        it 'does not do anything' do
+        it 'does not create a closing reminder job, but updates the token' do
+          old_closing_reminder_token = assessment.closing_reminder_token
           assessment.end_at = 1.day.ago
 
-          expect { assessment.save }.
-            not_to have_enqueued_job(Course::Assessment::ClosingReminderJob)
+          expect { assessment.save }.not_to have_enqueued_job(Course::Assessment::ClosingReminderJob)
+          expect(assessment.closing_reminder_token).not_to eq(old_closing_reminder_token)
         end
       end
     end

--- a/spec/models/course/reference_time_spec.rb
+++ b/spec/models/course/reference_time_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe Course::ReferenceTime, type: :model do
               have_enqueued_job(Course::Assessment::ClosingReminderJob).
               with { |_, token| expect(token).not_to eq(old_closing_reminder_token) }
             )
+
+            expect(assessment.reload.closing_reminder_token).not_to eq(old_closing_reminder_token)
           end
         end
 


### PR DESCRIPTION
Follows #6005 up.