### PR TITLE
Assessment Settings: Add programming question settings section

### DIFF
--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -119,7 +119,7 @@ const AssessmentsSettingsForm = (
                       InputProps={{
                         endAdornment: (
                           <InputAdornment position="end">
-                            {t(translations.s)}
+                            {t(translations.seconds)}
                           </InputAdornment>
                         ),
                       }}

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -1,5 +1,6 @@
 import { Emits } from 'react-emitter-factory';
 import { Controller } from 'react-hook-form';
+import { InputAdornment, Typography } from '@mui/material';
 import { AssessmentSettingsData } from 'types/course/admin/assessments';
 import * as yup from 'yup';
 
@@ -44,6 +45,38 @@ const AssessmentsSettingsForm = (
       {(control): JSX.Element => (
         <>
           <Section sticksToNavbar title={t(translations.assessmentSettings)}>
+            {/* Randomized Assessment is temporarily hidden (PR#5406) */}
+            {/* <Controller
+                control={control}
+                name="allowRandomization"
+                render={({ field, fieldState }): JSX.Element => (
+                  <FormCheckboxField
+                    disabled={props.disabled}
+                    field={field}
+                    fieldState={fieldState}
+                    label={t(translations.enableRandomisedAssessments)}
+                  />
+                )}
+              /> */}
+
+            <Controller
+              control={control}
+              name="allowMrqOptionsRandomization"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormCheckboxField
+                  disabled={props.disabled}
+                  field={field}
+                  fieldState={fieldState}
+                  label={t(translations.enableMcqChoicesRandomisations)}
+                />
+              )}
+            />
+          </Section>
+
+          <Section
+            sticksToNavbar
+            title={t(translations.programmingQuestionSettings)}
+          >
             <Subsection spaced title={t(translations.allowStudentsToView)}>
               <Controller
                 control={control}
@@ -67,39 +100,6 @@ const AssessmentsSettingsForm = (
                     field={field}
                     fieldState={fieldState}
                     label={t(translations.standardOutputsAndStandardErrors)}
-                  />
-                )}
-              />
-            </Subsection>
-
-            <Subsection
-              className="!mt-8"
-              spaced
-              title={t(translations.randomisation)}
-            >
-              {/* Randomized Assessment is temporarily hidden (PR#5406) */}
-              {/* <Controller
-                control={control}
-                name="allowRandomization"
-                render={({ field, fieldState }): JSX.Element => (
-                  <FormCheckboxField
-                    disabled={props.disabled}
-                    field={field}
-                    fieldState={fieldState}
-                    label={t(translations.enableRandomisedAssessments)}
-                  />
-                )}
-              /> */}
-
-              <Controller
-                control={control}
-                name="allowMrqOptionsRandomization"
-                render={({ field, fieldState }): JSX.Element => (
-                  <FormCheckboxField
-                    disabled={props.disabled}
-                    field={field}
-                    fieldState={fieldState}
-                    label={t(translations.enableMcqChoicesRandomisations)}
                   />
                 )}
               />

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -106,11 +106,7 @@ const AssessmentsSettingsForm = (
             </Subsection>
 
             {props.data.maxProgrammingTimeLimit && (
-              <Subsection
-                className="!mt-8"
-                spaced
-                title={t(translations.maxProgrammingTimeLimit)}
-              >
+              <div>
                 <Controller
                   control={control}
                   name="maxProgrammingTimeLimit"
@@ -120,13 +116,24 @@ const AssessmentsSettingsForm = (
                       field={field}
                       fieldState={fieldState}
                       fullWidth
+                      InputProps={{
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            {t(translations.s)}
+                          </InputAdornment>
+                        ),
+                      }}
                       label={t(translations.maxProgrammingTimeLimit)}
                       type="number"
                       variant="filled"
                     />
                   )}
                 />
-              </Subsection>
+
+                <Typography color="text.secondary" variant="body2">
+                  {t(translations.maxProgrammingTimeLimitHint)}
+                </Typography>
+              </div>
             )}
           </Section>
 

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -44,15 +44,11 @@ export default defineMessages({
   },
   maxProgrammingTimeLimit: {
     id: 'course.admin.AssessmentSettings.maxProgrammingTimeLimit',
-    defaultMessage: 'Maximum programming time limit',
+    defaultMessage: 'Maximum evaluation time limit',
   },
   standardOutputsAndStandardErrors: {
     id: 'course.admin.AssessmentSettings.standardOutputsAndStandardErrors',
     defaultMessage: 'Standard outputs and Standard errors',
-  },
-  randomisation: {
-    id: 'course.admin.AssessmentSettings.randomisation',
-    defaultMessage: 'Randomisation options',
   },
   enableRandomisedAssessments: {
     id: 'course.admin.AssessmentSettings.enableRandomisedAssessments',
@@ -60,7 +56,7 @@ export default defineMessages({
   },
   enableMcqChoicesRandomisations: {
     id: 'course.admin.AssessmentSettings.enableMcqChoicesRandomisations',
-    defaultMessage: 'Enable MCQ choices randomisations',
+    defaultMessage: 'Randomise MCQ choices',
   },
   deleteCategoryPromptAction: {
     id: 'course.admin.AssessmentSettings.deleteCategoryPromptAction',

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -156,8 +156,8 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.errorOccurredWhenDeletingTab',
     defaultMessage: 'An error occurred while deleting the tab.',
   },
-  s: {
-    id: 'course.admin.AssessmentSettings.s',
+  seconds: {
+    id: 'course.admin.AssessmentSettings.seconds',
     defaultMessage: 's',
   },
   programmingQuestionSettings: {

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/translations.ts
@@ -156,4 +156,18 @@ export default defineMessages({
     id: 'course.admin.AssessmentSettings.errorOccurredWhenDeletingTab',
     defaultMessage: 'An error occurred while deleting the tab.',
   },
+  s: {
+    id: 'course.admin.AssessmentSettings.s',
+    defaultMessage: 's',
+  },
+  programmingQuestionSettings: {
+    id: 'course.admin.AssessmentSettings.programmingQuestionSettings',
+    defaultMessage: 'Programming Question settings',
+  },
+  maxProgrammingTimeLimitHint: {
+    id: 'course.admin.AssessmentSettings.maxProgrammingTimeLimitHint',
+    defaultMessage:
+      'This will be the upper bound for the time limits of all programming questions in this course. ' +
+      'If there are programming questions with time limits greater than this, this time limit will take precedence.',
+  },
 });

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -752,7 +752,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
                           InputProps={{
                             endAdornment: (
                               <InputAdornment position="end">
-                                {t(translations.ms)}
+                                {t(translations.milliseconds)}
                               </InputAdornment>
                             ),
                           }}
@@ -778,7 +778,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
                           InputProps={{
                             endAdornment: (
                               <InputAdornment position="end">
-                                {t(translations.ms)}
+                                {t(translations.milliseconds)}
                               </InputAdornment>
                             ),
                           }}
@@ -814,7 +814,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
                       InputProps={{
                         endAdornment: (
                           <InputAdornment position="end">
-                            {t(translations.ms)}
+                            {t(translations.milliseconds)}
                           </InputAdornment>
                         ),
                       }}

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -340,8 +340,8 @@ const translations = defineMessages({
     defaultMessage:
       'Controls how long PulseGrid should wait after the frequency interval before flagging a session as late.',
   },
-  ms: {
-    id: 'course.assessment.AssessmentForm.ms',
+  milliseconds: {
+    id: 'course.assessment.AssessmentForm.milliseconds',
     defaultMessage: 'ms',
   },
   hasToBePositiveIntegerMaxOneDay: {

--- a/client/app/bundles/course/assessment/question/programming/components/sections/EvaluatorFields.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/sections/EvaluatorFields.tsx
@@ -103,7 +103,7 @@ const EvaluatorFields = (props: EvaluatorFieldsProps): JSX.Element | null => {
                   InputProps={{
                     endAdornment: (
                       <InputAdornment position="end">
-                        {t(translations.mb)}
+                        {t(translations.megabytes)}
                       </InputAdornment>
                     ),
                   }}
@@ -128,7 +128,7 @@ const EvaluatorFields = (props: EvaluatorFieldsProps): JSX.Element | null => {
                   InputProps={{
                     endAdornment: (
                       <InputAdornment position="end">
-                        {t(translations.s)}
+                        {t(translations.seconds)}
                       </InputAdornment>
                     ),
                   }}

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -1137,12 +1137,12 @@ const translations = defineMessages({
     id: 'course.assessment.question.programming.attemptLimit',
     defaultMessage: 'Attempt limit',
   },
-  s: {
-    id: 'course.assessment.question.programming.s',
+  seconds: {
+    id: 'course.assessment.question.programming.seconds',
     defaultMessage: 's',
   },
-  mb: {
-    id: 'course.assessment.question.programming.mb',
+  megabytes: {
+    id: 'course.assessment.question.programming.megabytes',
     defaultMessage: 'MB',
   },
   lowestGradingPriority: {


### PR DESCRIPTION
Adds a section for settings for programming questions in Assessment Settings. A description was provided to explain how Maximum evaluation limit works.

The Assessment settings section currently only have one visible option. The currently hidden checkbox to enable randomised assessments is supposed to be there, along with any other general options in the future.

| Before | After |
| - | - |
| ![image](https://github.com/Coursemology/coursemology2/assets/51525686/7a65ab85-f342-4726-8db1-ecf6d5e73ec3) | ![image](https://github.com/Coursemology/coursemology2/assets/51525686/7e3a4743-7cd8-4d46-a116-21181be93a9c) |
