### PR TITLE
Fix closing reminder token not saved when not updated before saving

### DIFF
--- a/app/models/course/reference_time.rb
+++ b/app/models/course/reference_time.rb
@@ -12,7 +12,7 @@ class Course::ReferenceTime < ApplicationRecord
 
   before_destroy :prevent_destroy_if_in_default_timeline, prepend: true
 
-  after_save :reset_closing_reminders, if: :saved_change_to_end_at?
+  before_save :reset_closing_reminders, if: :end_at_changed?
 
   # TODO(#3448): Consider creating personal times if new_record?
   after_commit :update_personal_times, on: :update
@@ -46,6 +46,7 @@ class Course::ReferenceTime < ApplicationRecord
     return unless !actable_end_at_already_updated && actable.respond_to?(:create_closing_reminders_at)
 
     actable.create_closing_reminders_at(end_at)
+    actable.save!
   end
 
   def lesson_plan_item_in_same_course

--- a/spec/jobs/course/assessment/closing_reminder_job_spec.rb
+++ b/spec/jobs/course/assessment/closing_reminder_job_spec.rb
@@ -7,21 +7,40 @@ RSpec.describe Course::Assessment::ClosingReminderJob do
     let(:assessment) { create(:assessment) }
 
     context 'when end_at of the assessment is changed' do
-      it 'creates a closing reminder job' do
-        old_closing_reminder_token = assessment.closing_reminder_token
-        assessment.end_at = 1.day.from_now
+      context 'when end_at is a time in the future' do
+        it 'creates a closing reminder job' do
+          old_closing_reminder_token = assessment.closing_reminder_token
+          new_end_at = 1.day.from_now
+          assessment.end_at = 1.day.from_now
 
-        expect { assessment.save }.to have_enqueued_job(Course::Assessment::ClosingReminderJob)
-        expect(assessment.closing_reminder_token).not_to eq(old_closing_reminder_token)
+          expect { assessment.save }.to have_enqueued_job(Course::Assessment::ClosingReminderJob).exactly(:once)
+          expect(assessment.reload.end_at.to_i).to eq(new_end_at.to_i)
+          expect(assessment.reload.closing_reminder_token).not_to eq(old_closing_reminder_token)
+        end
       end
 
       context 'when end_at is a past time' do
         it 'does not create a closing reminder job, but updates the token' do
           old_closing_reminder_token = assessment.closing_reminder_token
-          assessment.end_at = 1.day.ago
+          new_end_at = 1.day.ago
+          assessment.end_at = new_end_at
 
           expect { assessment.save }.not_to have_enqueued_job(Course::Assessment::ClosingReminderJob)
-          expect(assessment.closing_reminder_token).not_to eq(old_closing_reminder_token)
+          expect(assessment.reload.end_at.to_i).to eq(new_end_at.to_i)
+          expect(assessment.reload.closing_reminder_token).not_to eq(old_closing_reminder_token)
+        end
+      end
+
+      context 'when end_at becomes nil' do
+        let(:future_assessment) { create(:assessment, end_at: 1.day.from_now) }
+
+        it 'does not create a closing reminder job, but updates the token' do
+          old_closing_reminder_token = future_assessment.closing_reminder_token
+          future_assessment.end_at = nil
+
+          expect { future_assessment.save }.not_to have_enqueued_job(Course::Assessment::ClosingReminderJob)
+          expect(future_assessment.reload.end_at).to eq(nil)
+          expect(future_assessment.reload.closing_reminder_token).not_to eq(old_closing_reminder_token)
         end
       end
     end


### PR DESCRIPTION
Also added tests to ensure that changes from Lesson Plan Item actables and reference times committed the updated closing reminder token to the database.