### PR TITLE
Re-add course user email in profile page

### DIFF
--- a/client/app/bundles/course/users/components/misc/UserProfileCard.tsx
+++ b/client/app/bundles/course/users/components/misc/UserProfileCard.tsx
@@ -109,6 +109,7 @@ const UserProfileCard: FC<Props> = ({ user, intl }) => {
             <Typography>
               <strong>{COURSE_USER_ROLES[user.role]}</strong>
             </Typography>
+            <Typography>{user.email}</Typography>
             {renderUserStats()}
           </Grid>
         </Grid>


### PR DESCRIPTION
In a previous commit, the email was accidentally removed when manage user subscription button was moved to the sidebar. In this PR, the course user email is re-added to the profile page.