### PR TITLE
Fix `Module::DelegationError` when duplicating `Course::LessonPlan::Item`s with `end_at`

### DIFF
--- a/app/models/course/reference_time.rb
+++ b/app/models/course/reference_time.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::ReferenceTime < ApplicationRecord
+  include DuplicationStateTrackingConcern
+
   belongs_to :reference_timeline, class_name: Course::ReferenceTimeline.name, inverse_of: :reference_times
   belongs_to :lesson_plan_item, class_name: Course::LessonPlan::Item.name, inverse_of: :reference_times
 
@@ -23,6 +25,8 @@ class Course::ReferenceTime < ApplicationRecord
     self.start_at = duplicator.time_shift(other.start_at)
     self.bonus_end_at = duplicator.time_shift(other.bonus_end_at) if other.bonus_end_at
     self.end_at = duplicator.time_shift(other.end_at) if other.end_at
+
+    set_duplication_flag
   end
 
   private
@@ -39,6 +43,26 @@ class Course::ReferenceTime < ApplicationRecord
 
   def reset_closing_reminders
     actable = lesson_plan_item.actable
+
+    # When `duplicating?`, `end_at` change is emitted from the associated `Course::LessonPlan::Item`.
+    # If the `Course::LessonPlan::Item` includes `Course::ClosingReminderConcern`, `end_at_changed?`
+    # will be true on `before_save`, so the closing reminder token and job will be reset there. So,
+    # there is no need for reference time to trigger the reset at all.
+    #
+    # Furthermore, when `duplicating?`, a `Course::LessonPlan::Item`'s default reference time MUST be
+    # saved first for the `delegate`s to work. Otherwise, `end_at`, `end_at_changed?`, and other
+    # delegated reference time-related attributes in `Course::LessonPlan::Item` will raise a
+    # `Module::DelegationError` exception, akin to a cyclic dependency (but not exactly). In fact, we
+    # are doing it in this method; see `actable&.end_at` below.
+    #
+    # Therefore, we skip the reset here when `duplicating?` and let the `Course::LessonPlan::Item`
+    # trigger the closing reminder reset. Rather, it's not a reset, but create (since it's for a new
+    # duplicated record).
+    #
+    # Note that this isn't a problem when a new `Course::LessonPlan::Item` is created normally (not
+    # via duplication), thanks to `after_initialize :set_default_reference_time, if: :new_record?` in
+    # `Course::LessonPlan::Item`.
+    return if duplicating?
 
     # This check prevents `create_closing_reminders_at` from creating another `*ClosingReminderJob` if
     # `end_at` was changed from the `actable` (that includes `Course::ClosingReminderConcern`).


### PR DESCRIPTION
Related to #6005.

## Problem description
When duplicating a course, `Module::DelegationError` is raised when `Course::LessonPlan::Item` actables with `end_at` are duplicated.

## Diagnosis
The actable with the (default) reference time can be successfully initialised by `duplicator.duplicate(item)`. The error is thrown when this duplicate is `save!`d.

When `save!`d, the reference time will also be `save!`d. The `before_save :reset_closing_reminders` introduced in #6005 will be triggered. It will then attempt to access `actable&.end_at`. However, the `actable` is yet to be saved, and it's pending this reference time to be saved first. Since a `Course::LessonPlan::Item` `delegate`s `:end_at` to `default_reference_time` (this reference time), at that time, it is not yet available, i.e., `actable.default_reference_time` is `nil`. Therefore, `Module::DelegationError` is raised.

## Solution
We can skip `Course::ReferenceTime`'s invocation to `reset_closing_reminders` when duplicating, thus avoiding the problematic premature `actable&.end_at` invocation.

Note that `Course::ReferenceTime`'s `reset_closing_reminders` callback is there only to reset closing reminders _if the `end_at` change is emitted without going through the actable_, e.g., changed from the Timeline Designer.

Since during duplication we know for a fact that `end_at` change is emitted from the actable, we can skip `reset_closing_reminders` in `Course::ReferenceTime`, and let the `reset_closing_reminders` in the actable's `Course::ClosingReminderConcern` (if `include`d) to handle the creation of closing reminders for the newly duplicated actable. Essentially, we are allowing the reference time to be saved first, so that there are no cyclic dependency-like symptoms happening.

Note that this is safe since at this point (during `before_save`) we already know that our model is valid, i.e., `duplicator.duplicate(item).valid?` is `true`.