### PR TITLE
Try CircleCI's new Re-run failed tests only (Preview)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,15 +165,8 @@ jobs:
           no_output_timeout: 10m
           command: |
             mkdir /tmp/test-results
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | \
-              circleci tests split --split-by=timings)"
-
-            bundle exec rspec \
-              --format progress \
-              --format RspecJunitFormatter \
-              --out /tmp/test-results/rspec.xml \
-              --format progress \
-              $TEST_FILES
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb"
+            echo "$TEST_FILES" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress" --verbose --split-by=timings
           environment:
             DATABASE_URL: "postgres://ubuntu@localhost:5432/coursemology_test"
 


### PR DESCRIPTION
Last year, I applied to be in line for CircleCI's new feature: [Re-run failed tests only](https://circleci.com/docs/rerun-failed-tests-only). Apparently last month I have obtained access to the preview, and am in contact with CircleCI's team about the preview.

Let's see how this goes on our repository. This feature should help with retrying flaky tests without restarting the whole failed job.