### PR TITLE
Make Capybara tests work with new Chrome versions 115 and up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,6 @@ group :test do
   # Capybara for feature testing
   gem 'capybara'
   gem 'capybara-selenium'
-  gem 'webdrivers'
 
   gem 'aws-sdk-s3'
   # Make screen shots in tests, helps with the debugging of JavaScript tests.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,6 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
-    childprocess (4.1.0)
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
     concurrent-ruby (1.2.2)
@@ -491,8 +490,7 @@ GEM
     sanitize (6.0.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    selenium-webdriver (4.5.0)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -558,10 +556,6 @@ GEM
       activesupport (>= 3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -661,7 +655,6 @@ DEPENDENCIES
   tzinfo-data
   unread
   validates_hostname
-  webdrivers
   workflow
   workflow-activerecord (>= 4.1, < 7.0)
   yard


### PR DESCRIPTION
Overrides #6319.

This PR allows our Capybara tests to run on Chrome version 115 and later. [Chrome 115 introduces Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) and changes how ChromeDriver is deployed together with Chrome versions. Previously if Chrome 115 is installed, Capybara tests won't run.

We're doing away with the `webdrivers` gem and upgrading `selenium-webdriver` to 4.11.0, as [advised by the author](https://github.com/titusfortner/webdrivers#update-future-of-this-project).