### PR TITLE
Add oEmbed support for CKEditor media embeds 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'html-pipeline'
 gem 'sanitize', '>= 4.6.3'
 gem 'rinku'
 gem 'html-pipeline-rouge_filter', git: 'https://github.com/ekowidianto/html-pipeline-rouge_filter.git'
+gem 'ruby-oembed'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder'
 # Slim as the templating language

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,6 +482,7 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
+    ruby-oembed (0.16.1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
@@ -638,6 +639,7 @@ DEPENDENCIES
   rspec-retry
   rspec_junit_formatter
   rubocop-rails
+  ruby-oembed
   rubyzip
   rwordnet!
   sanitize (>= 4.6.3)

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -6,22 +6,25 @@ module ApplicationHTMLFormattersHelper
 
   # Replaces the Rails sanitizer with the one configured with HTML Pipeline.
   def sanitize(text, _options = {})
-    format_with_pipeline(HTMLSanitizerPipeline, text)
+    pipeline = HTML::Pipeline.new([HTML::Pipeline::SanitizationFilter], { whitelist: SANITIZATION_FILTER_WHITELIST })
+    format_with_pipeline(pipeline, text)
   end
 
   # Sanitises and formats the given user-input string. The string is assumed to contain HTML markup.
+  # Conversions may happen, depending on the transformers registered in the pipeline.
   #
   # @param [String] text The text to display
   # @return [String]
   def format_html(text)
-    format_with_pipeline(DefaultHTMLPipeline, text)
+    format_with_pipeline(DEFAULT_HTML_CONVERTING_PIPELINE, text)
   end
 
   def format_ckeditor_rich_text(text)
-    text_with_updated_code_tag = remove_internal_adjacent_code_tags(text)
-    DefaultHTMLPipeline.to_document("<div>#{text_with_updated_code_tag}</div>").
-      child.inner_html.html_safe.
-      gsub(/<table>/, '<table class="table table-bordered">') # Add lines to tables
+    process_ckeditor_rich_text_with_pipeline(DEFAULT_HTML_CONVERTING_PIPELINE, text)
+  end
+
+  def sanitize_ckeditor_rich_text(text)
+    process_ckeditor_rich_text_with_pipeline(DEFAULT_HTML_PIPELINE, text)
   end
 
   # Syntax highlights and adds lines numbers to the given code fragment.
@@ -62,24 +65,22 @@ module ApplicationHTMLFormattersHelper
       content_tag(:code) { code }
     end
 
-    pipeline = HTML::Pipeline.new(DefaultPipeline.filters +
-                                  [PreformattedTextLineSplitFilter],
-                                  DefaultCodePipelineOptions)
+    pipeline = HTML::Pipeline.new(DEFAULT_PIPELINE.filters + [PreformattedTextLineSplitFilter],
+                                  DEFAULT_CODE_PIPELINE_OPTIONS)
+
     format_with_pipeline(pipeline, code)
   end
 
+  def self.build_html_pipeline(custom_options)
+    pipeline = HTML::Pipeline.new([HTML::Pipeline::SanitizationFilter], custom_options)
+    options = DEFAULT_PIPELINE_OPTIONS.merge(custom_options)
+
+    HTML::Pipeline.new(pipeline.filters + DEFAULT_PIPELINE.filters, options)
+  end
+
+  private_class_method :build_html_pipeline
+
   private
-
-  DEFAULT_PIPELINE_OPTIONS = {
-    css_class: 'codehilite',
-    replace_br: true
-  }.freeze
-
-  # The default pipeline, used by both text and HTML pipelines.
-  DefaultPipeline = HTML::Pipeline.new([
-                                         HTML::Pipeline::AutolinkFilter,
-                                         HTML::Pipeline::RougeFilter
-                                       ], DEFAULT_PIPELINE_OPTIONS)
 
   # List of video hosting site URLs to allow
   VIDEO_URL_WHITELIST = Regexp.union(
@@ -91,9 +92,20 @@ module ApplicationHTMLFormattersHelper
     /\A(?:https?:)?\/\/(?:www\.)?(?:geo.)?dailymotion\.com\//,
     /\A(?:https?:)?\/\/(?:www\.)?dai\.ly\//,
     /\A(?:https?:)?\/\/(?:www\.)?youku\.com\//
-  )
+  ).freeze
 
   OEMBED_WHITELIST_TRANSFORMER = lambda do |env|
+    node, node_name = env[:node], env[:node_name]
+
+    return if env[:is_whitelisted] || !node.element?
+
+    return unless node_name == 'oembed'
+    return unless node['url']&.match VIDEO_URL_WHITELIST
+
+    { node_whitelist: [node] }
+  end.freeze
+
+  OEMBED_WHITELIST_CONVERTER = lambda do |env|
     node, node_name = env[:node], env[:node_name]
 
     return if env[:is_whitelisted] || !node.element?
@@ -107,7 +119,7 @@ module ApplicationHTMLFormattersHelper
     node.add_next_sibling(new_node)
 
     { node_whitelist: [node] }
-  end
+  end.freeze
 
   # Transformer to whitelist iframes containing embedded video content
   VIDEO_WHITELIST_TRANSFORMER = lambda do |env|
@@ -124,7 +136,7 @@ module ApplicationHTMLFormattersHelper
                          })
 
     { node_whitelist: [node] }
-  end
+  end.freeze
 
   # - Allow whitelisting of base64 encoded images for HTML text.
   # TODO: Remove 'data' from whitelisted protocols once we disable Base64 encoding
@@ -142,7 +154,7 @@ module ApplicationHTMLFormattersHelper
                          css: { properties: ['height', 'width'] })
 
     { node_whitelist: [node] }
-  end
+  end.freeze
 
   # SanitizationFilter Custom Options
   # See https://github.com/gjtorikian/html-pipeline#2-how-do-i-customize-an-allowlist-for-sanitizationfilters
@@ -160,29 +172,39 @@ module ApplicationHTMLFormattersHelper
       'margin-bottom', 'margin-left', 'margin-right', 'margin-top', 'text-align',
       'width', 'list-style-type'
     ] }
-    list[:transformers] |= [OEMBED_WHITELIST_TRANSFORMER, VIDEO_WHITELIST_TRANSFORMER, IMAGE_WHITELIST_TRANSFORMER]
+    list[:transformers] |= [VIDEO_WHITELIST_TRANSFORMER, IMAGE_WHITELIST_TRANSFORMER].freeze
     list
-  end
+  end.freeze
 
-  # The HTML sanitizer options to use.
-  HTML_SANITIZER_OPTIONS = {
-    whitelist: SANITIZATION_FILTER_WHITELIST
+  DEFAULT_PIPELINE_OPTIONS = {
+    css_class: 'codehilite',
+    replace_br: true
   }.freeze
 
-  # The HTML sanitizer to use.
-  HTMLSanitizerPipeline = HTML::Pipeline.new([HTML::Pipeline::SanitizationFilter],
-                                             HTML_SANITIZER_OPTIONS)
+  DEFAULT_CODE_PIPELINE_OPTIONS = DEFAULT_PIPELINE_OPTIONS.merge(css_table_class: 'table').freeze
 
-  # The default HTML pipeline options.
-  DefaultHTMLPipelineOptions = DEFAULT_PIPELINE_OPTIONS.merge(HTML_SANITIZER_OPTIONS).freeze
+  # The default pipeline, used by both text and HTML pipelines.
+  DEFAULT_PIPELINE = HTML::Pipeline.new(
+    [HTML::Pipeline::AutolinkFilter, HTML::Pipeline::RougeFilter],
+    DEFAULT_PIPELINE_OPTIONS
+  )
 
-  # The default HTML pipeline.
-  DefaultHTMLPipeline = HTML::Pipeline.new(HTMLSanitizerPipeline.filters +
-                                           DefaultPipeline.filters,
-                                           DefaultHTMLPipelineOptions)
+  # The default HTML pipeline that sanitises an HTML.
+  DEFAULT_HTML_PIPELINE = begin
+    whitelist = SANITIZATION_FILTER_WHITELIST.deep_dup
+    whitelist[:transformers].prepend OEMBED_WHITELIST_TRANSFORMER
 
-  # The Code formatter options to use.
-  DefaultCodePipelineOptions = DEFAULT_PIPELINE_OPTIONS.merge(css_table_class: 'table').freeze
+    build_html_pipeline({ whitelist: whitelist })
+  end
+
+  # The default HTML pipeline that sanitises AND converts certain HTML markups for display/formatting purposes.
+  # This pipeline is generally NOT used for saving to the database.
+  DEFAULT_HTML_CONVERTING_PIPELINE = begin
+    whitelist = SANITIZATION_FILTER_WHITELIST.deep_dup
+    whitelist[:transformers].prepend OEMBED_WHITELIST_CONVERTER
+
+    build_html_pipeline({ whitelist: whitelist })
+  end
 
   # Test if the given code exceeds the size or line limit.
   def code_size_exceeds_limit?(code)
@@ -201,6 +223,12 @@ module ApplicationHTMLFormattersHelper
     format_with_pipeline(default_code_pipeline(start_line), code)
   end
 
+  def process_ckeditor_rich_text_with_pipeline(pipeline, text)
+    text_with_updated_code_tag = remove_internal_adjacent_code_tags(text)
+    format_with_pipeline(pipeline, text_with_updated_code_tag).
+      gsub(/<table>/, '<table class="table table-bordered">') # Add lines to tables
+  end
+
   # Filters the given text through the given pipeline.
   #
   # This inserts a dummy root node to conform with html-pipeline needing a root element.
@@ -217,9 +245,8 @@ module ApplicationHTMLFormattersHelper
   # @param [Integer] starting_line_number The line number of the first line, default is 1.
   # @return [HTML::Pipeline]
   def default_code_pipeline(starting_line_number = 1)
-    HTML::Pipeline.new(DefaultPipeline.filters +
-                         [PreformattedTextLineNumbersFilter],
-                       DefaultCodePipelineOptions.merge(line_start: starting_line_number))
+    HTML::Pipeline.new(DEFAULT_PIPELINE.filters + [PreformattedTextLineNumbersFilter],
+                       DEFAULT_CODE_PIPELINE_OPTIONS.merge(line_start: starting_line_number))
   end
 
   # Removes adjacent code tags inside pre tag

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -18,7 +18,8 @@ module ApplicationHTMLFormattersHelper
     /\A(?:https?:)?\/\/(?:www\.)?(?:player.)?vimeo\.com\//,
     /\A(?:https?:)?\/\/(?:www\.)?vine\.co\//,
     /\A(?:https?:)?\/\/(?:www\.)?instagram\.com\//,
-    /\A(?:https?:)?\/\/(?:www\.)?dailymotion\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?(?:geo.)?dailymotion\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?dai\.ly\//,
     /\A(?:https?:)?\/\/(?:www\.)?youku\.com\//
   )
 

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHTMLFormattersHelper
 
   # List of video hosting site URLs to allow
   VIDEO_URL_WHITELIST = Regexp.union(
-    /\A(?:https?:)?\/\/(?:www\.)?youtube\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?(?:m.)?youtube\.com\//,
     /\A(?:https?:)?\/\/(?:www\.)?youtu.be\//,
     /\A(?:https?:)?\/\/(?:www\.)?vimeo\.com\//,
     /\A(?:https?:)?\/\/(?:www\.)?vine\.co\//,

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHTMLFormattersHelper
   VIDEO_URL_WHITELIST = Regexp.union(
     /\A(?:https?:)?\/\/(?:www\.)?(?:m.)?youtube\.com\//,
     /\A(?:https?:)?\/\/(?:www\.)?youtu.be\//,
-    /\A(?:https?:)?\/\/(?:www\.)?vimeo\.com\//,
+    /\A(?:https?:)?\/\/(?:www\.)?(?:player.)?vimeo\.com\//,
     /\A(?:https?:)?\/\/(?:www\.)?vine\.co\//,
     /\A(?:https?:)?\/\/(?:www\.)?instagram\.com\//,
     /\A(?:https?:)?\/\/(?:www\.)?dailymotion\.com\//,

--- a/app/models/concerns/course/sanitize_description_concern.rb
+++ b/app/models/concerns/course/sanitize_description_concern.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # This concern helps sanitize items with description fields, in case a malicious user bypasses
-# the sanitization provided by the WYSIWHG editor.
+# the sanitization provided by the WYSIWYG editor.
 module Course::SanitizeDescriptionConcern
   extend ActiveSupport::Concern
 
@@ -12,6 +12,6 @@ module Course::SanitizeDescriptionConcern
   private
 
   def sanitize_description
-    self.description = ApplicationController.helpers.format_ckeditor_rich_text(description)
+    self.description = ApplicationController.helpers.sanitize_ckeditor_rich_text(description)
   end
 end

--- a/app/models/course/achievement.rb
+++ b/app/models/course/achievement.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 class Course::Achievement < ApplicationRecord
+  include Course::SanitizeDescriptionConcern
+
   acts_as_conditional
   mount_uploader :badge, ImageUploader
   has_many_attachments on: :description
 
   after_initialize :set_defaults, if: :new_record?
-  before_save :sanitize_text
 
   validates :title, length: { maximum: 255 }, presence: true
   validates :weight, numericality: { only_integer: true }, presence: true
@@ -75,9 +76,5 @@ class Course::Achievement < ApplicationRecord
 
   def duplicate_badge(other)
     self.badge = nil if other.badge_url && !badge.duplicate_from(other.badge)
-  end
-
-  def sanitize_text
-    self.description = ApplicationController.helpers.format_ckeditor_rich_text(description)
   end
 end

--- a/app/models/course/announcement.rb
+++ b/app/models/course/announcement.rb
@@ -20,6 +20,6 @@ class Course::Announcement < ApplicationRecord
   belongs_to :course, inverse_of: :announcements
 
   def sanitize_text
-    self.content = ApplicationController.helpers.format_ckeditor_rich_text(content)
+    self.content = ApplicationController.helpers.sanitize_ckeditor_rich_text(content)
   end
 end

--- a/app/models/course/assessment/question/text_response_solution.rb
+++ b/app/models/course/assessment/question/text_response_solution.rb
@@ -28,6 +28,6 @@ class Course::Assessment::Question::TextResponseSolution < ApplicationRecord
   end
 
   def sanitize_explanation
-    self.explanation = ApplicationController.helpers.format_ckeditor_rich_text(explanation)
+    self.explanation = ApplicationController.helpers.sanitize_ckeditor_rich_text(explanation)
   end
 end

--- a/app/models/course/discussion/post.rb
+++ b/app/models/course/discussion/post.rb
@@ -168,6 +168,6 @@ class Course::Discussion::Post < ApplicationRecord
   end
 
   def sanitize_text
-    self.text = ApplicationController.helpers.format_ckeditor_rich_text(text)
+    self.text = ApplicationController.helpers.sanitize_ckeditor_rich_text(text)
   end
 end

--- a/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
+++ b/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
@@ -2,7 +2,7 @@
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id
-  json.answer_text answer.answer_text
+  json.answer_text format_ckeditor_rich_text(answer.answer_text)
   json.partial! 'course/assessment/submission/answer/forum_post_response/posts/post_packs',
                 selected_posts: answer.compute_post_packs
 end

--- a/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
@@ -4,7 +4,7 @@ json.fields do
   json.id answer.acting_as.id
   question = answer.question.specific
   json.files nil # required for react-hook-form initial values
-  json.answer_text answer.answer_text unless question.hide_text
+  json.answer_text format_ckeditor_rich_text(answer.answer_text) unless question.hide_text
 end
 
 json.attachments answer.attachments do |attachment|

--- a/app/views/course/forum/posts/_post_list_data.json.jbuilder
+++ b/app/views/course/forum/posts/_post_list_data.json.jbuilder
@@ -4,7 +4,7 @@ json.id post.id
 json.topicId topic.id
 json.parentId post.parent_id
 json.postUrl course_forum_topic_post_path(current_course, forum, topic, post)
-json.text post.text
+json.text format_ckeditor_rich_text(post.text)
 json.createdAt post.created_at
 json.isAnswer post.answer
 json.isUnread post.unread?(current_user)

--- a/app/views/course/question_assessments/_question_assessment.json.jbuilder
+++ b/app/views/course/question_assessments/_question_assessment.json.jbuilder
@@ -10,7 +10,7 @@ json.defaultTitle question_assessment.default_title(question_number)
 json.title question.title
 json.unautogradable !question.auto_gradable? && assessment.autograded?
 json.type question_assessment.question.question_type
-json.description question.description unless question.description.blank?
+json.description format_ckeditor_rich_text(question.description) unless question.description.blank?
 
 if can?(:manage, assessment)
   json.editUrl url_for([:edit, current_course, assessment, question.specific])

--- a/client/app/bundles/course/assessment/submission/components/answers/TextResponse.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/TextResponse.jsx
@@ -1,4 +1,5 @@
 import { Controller, useFormContext } from 'react-hook-form';
+import { Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 
 import FormRichTextField from 'lib/components/form/fields/RichTextField';
@@ -18,7 +19,10 @@ const TextResponse = (props) => {
       control={control}
       name={`${answerId}.answer_text`}
       render={({ field }) => (
-        <div dangerouslySetInnerHTML={{ __html: field.value }} />
+        <Typography
+          dangerouslySetInnerHTML={{ __html: field.value }}
+          variant="body2"
+        />
       )}
     />
   );

--- a/client/app/bundles/system/admin/admin/pages/AnnouncementsIndex.tsx
+++ b/client/app/bundles/system/admin/admin/pages/AnnouncementsIndex.tsx
@@ -55,11 +55,9 @@ const AnnouncementsIndex: FC<Props> = (props) => {
   return (
     <Page>
       <Button
-        key="new-announcement-button"
+        className="float-right"
         id="new-announcement-button"
-        onClick={(): void => {
-          setIsOpen(true);
-        }}
+        onClick={(): void => setIsOpen(true)}
         variant="outlined"
       >
         {intl.formatMessage(translations.newAnnouncement)}

--- a/client/app/bundles/system/admin/instance/instance/pages/InstanceAnnouncementsIndex.tsx
+++ b/client/app/bundles/system/admin/instance/instance/pages/InstanceAnnouncementsIndex.tsx
@@ -65,7 +65,7 @@ const InstanceAnnouncementsIndex: FC<Props> = (props) => {
     <Page>
       {announcementPermission && (
         <Button
-          key="new-announcement-button"
+          className="float-right"
           id="new-announcement-button"
           onClick={(): void => setIsOpen(true)}
           variant="outlined"

--- a/client/app/lib/components/core/fields/CKEditorRichText.tsx
+++ b/client/app/lib/components/core/fields/CKEditorRichText.tsx
@@ -131,6 +131,16 @@ const CKEditorRichText = forwardRef((props: Props, ref) => {
               },
             },
             placeholder,
+            mediaEmbed: {
+              removeProviders: [
+                'spotify',
+                'instagram',
+                'twitter',
+                'googleMaps',
+                'flickr',
+                'facebook',
+              ],
+            },
           }}
           data={value}
           disabled={disabled}

--- a/client/app/theme/index.css
+++ b/client/app/theme/index.css
@@ -44,6 +44,15 @@
   [role='button'] {
     @apply cursor-pointer;
   }
+
+  /* For embed videos */
+  figure.media {
+    @apply m-0 relative aspect-video max-w-3xl;
+  }
+
+  figure.media > iframe {
+    @apply w-full h-full absolute;
+  }
 }
 
 @layer utilities {

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+require 'oembed'
+
+OEmbed::Providers.register_all
+

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -3,3 +3,13 @@ require 'oembed'
 
 OEmbed::Providers.register_all
 
+# HTML iframe points to https://geo.dailymotion.com/*. Ensure this is whitelisted in the sanitizer.
+# https://developers.dailymotion.com/news/player-api/embed-dailymotion-video-oembed/
+DailymotionProvider = OEmbed::Provider.new('https://www.dailymotion.com/services/oembed')
+DailymotionProvider << 'http://*.dailymotion.com/video/*'
+DailymotionProvider << 'https://*.dailymotion.com/video/*'
+DailymotionProvider << 'http://*.dai.ly/*'
+DailymotionProvider << 'https://*.dai.ly/*'
+
+# ruby-oembed's Dailymotion provider is from Embedly and requires an API key, so we make our own.
+OEmbed::Providers.register(DailymotionProvider)

--- a/spec/helpers/application_formatters_helper_spec.rb
+++ b/spec/helpers/application_formatters_helper_spec.rb
@@ -120,6 +120,81 @@ RSpec.describe ApplicationFormattersHelper do
           expect(helper.format_html(html)).to be_empty
         end
       end
+
+      context 'when oembed tags are present' do
+        it 'transforms embedded content from youtube' do
+          html = <<-HTML
+            <oembed url="https://www.youtube.com/watch?v=jNQXAC9IVRw"></oembed>
+            <oembed url="https://youtube.com/watch?v=jNQXAC9IVRw"></oembed>
+            <oembed url="https://m.youtube.com/watch?v=jNQXAC9IVRw"></oembed>
+            <oembed url="https://youtu.be/jNQXAC9IVRw"></oembed>
+            <oembed url="http://www.youtube.com/watch?v=jNQXAC9IVRw"></oembed>
+            <oembed url="http://youtube.com/watch?v=jNQXAC9IVRw"></oembed>
+            <oembed url="http://m.youtube.com/watch?v=jNQXAC9IVRw"></oembed>
+            <oembed url="http://youtu.be/jNQXAC9IVRw"></oembed>
+          HTML
+
+          embed_count = html.scan('<oembed').size
+          result = helper.format_html(html)
+
+          expect(result.scan('<iframe').size).to eq(embed_count)
+          expect(result.scan('src="https://www.youtube.com/embed/jNQXAC9IVRw').size).to eq(embed_count)
+        end
+
+        it 'transforms embedded content from dailymotion' do
+          html = <<-HTML
+            <oembed url="https://www.dailymotion.com/video/x3k7o56"></oembed>
+            <oembed url="https://dailymotion.com/video/x3k7o56"></oembed>
+            <oembed url="https://dai.ly/x3k7o56"></oembed>
+            <oembed url="http://www.dailymotion.com/video/x3k7o56"></oembed>
+            <oembed url="http://dailymotion.com/video/x3k7o56"></oembed>
+            <oembed url="http://dai.ly/x3k7o56"></oembed>
+          HTML
+
+          embed_count = html.scan('<oembed').size
+          result = helper.format_html(html)
+
+          expect(result.scan('<iframe').size).to eq(embed_count)
+          expect(result.scan('src="https://geo.dailymotion.com/player.html?video=x3k7o56').size).to eq(embed_count)
+        end
+
+        it 'transforms embedded content from vimeo' do
+          html = <<-HTML
+            <oembed url="https://vimeo.com/channels/staffpicks/852794606"></oembed>
+            <oembed url="https://vimeo.com/852794606"></oembed>
+            <oembed url="https://www.vimeo.com/channels/staffpicks/852794606"></oembed>
+            <oembed url="https://www.vimeo.com/852794606"></oembed>
+            <oembed url="http://vimeo.com/channels/staffpicks/852794606"></oembed>
+            <oembed url="http://vimeo.com/852794606"></oembed>
+            <oembed url="http://www.vimeo.com/channels/staffpicks/852794606"></oembed>
+            <oembed url="http://www.vimeo.com/852794606"></oembed>
+          HTML
+
+          embed_count = html.scan('<oembed').size
+          result = helper.format_html(html)
+
+          expect(result.scan('<iframe').size).to eq(embed_count)
+          expect(result.scan('src="https://player.vimeo.com/video/852794606').size).to eq(embed_count)
+        end
+
+        it 'removes forbidden embedded content' do
+          html = <<-HTML
+            <oembed url="//beta.coursemology.org"></oembed>
+            <oembed url="//www.youtubeXcom.com"></oembed>
+            <oembed url="//wwwXinstagram.com"></oembed>
+            <oembed url="//vine.com"></oembed>
+            <oembed url="//dailymotion.co"></oembed>
+            <oembed url="//vimeo.org"></oembed>
+          HTML
+
+          expect(helper.format_html(html).squish).to be_empty
+        end
+
+        it 'removes oembed tags without url attribute' do
+          html = '<oembed></oembed>'
+          expect(helper.format_html(html)).to be_empty
+        end
+      end
     end
 
     describe '#format_code_block' do


### PR DESCRIPTION
The CKEditor media embed plug-in added in #5929 adds media embeds as [semantic outputs](https://ckeditor.com/docs/ckeditor5/latest/features/media-embed.html#displaying-embedded-media-on-your-website). This means that after `getData()`, embeds are rendered as `<oembed>` tags (not `<iframe>`s). Since `<oembed>` is not a standard HTML element, it doesn't display anything in the browser, leading to users being confused why embeds seen in the CKEditor preview are not displaying correctly once saved/submitted and shown as read-only.

This PR adds support for oEmbed transformations for YouTube, Dailymotion, and Vimeo as defined in `VIDEO_URL_WHITELIST`. `CKEditorRichText` is also set to only allow previews for these 3 sites to ensure consistency between preview and read-only (submitted) views.

Tested on Safari 17.0, Firefox 115.0.3, and Chrome 115.0.5790.170. Pages in question were comments, announcements, forum posts, assessment descriptions, and text response answers.

## About oEmbed
[oEmbed is an open format for allowing an embedded representations of contents on third-party sites](https://oembed.com/).

`<oembed>` tags added by CKEditor is meant to be transformed into `<iframe>`s manually by the developer. CKEditor recommends using [iframely](https://iframely.com/) or [Embedly](https://embed.ly/), but they are paid. The best way to transform these tags are in the back-end server, and so the [ruby-oembed](https://github.com/ruby-oembed/ruby-oembed) gem is used.

>[!NOTE]
>The [ruby-oembed](https://github.com/ruby-oembed/ruby-oembed) gem's repository stated that it is unmaintained as of 2022, but the commit history seems recent. It's a pretty good gem. I don't think this is an issue because oEmbed transformations are pretty standard, and the APIs rarely change. Even if they do change, we can easily override it in `initializers/oembed.rb`. If push comes to shove, we can adopt their code and tweak it ourselves. oEmbed transformations are not that complicated. 

## Injection method
We add the transformed `<iframe>` node instead of replacing the `<oembed>` because there are some pages that feed the formatted HTML back into CKEditor for editing. This is actually suboptimal, because raw data and display data should never be confused with each other. The result is that when the media embed is first added in CKEditor and saved, the `<iframe>` is shown on the read-only view (say announcement). When it is edited, CKEditor no longer sees the `<oembed>` tag it can preview and edit, but instead sees and removes the `<iframe>`. After the next `onChange`, the `<iframe>` is completely removed and the user had lost their embed. This is why one should never confuse raw and display data.

Thus, in the interest of minimal changes, we add the transformed `<iframe>` node instead of replacing the `<oembed>` tag. When in DOM, the browser ignores `<oembed>` and displays `<iframe>`. When in CKEditor, it ignores and eventually removes the `<iframe>`, but allows editing the `<oembed>`.

## Screenshot

![image](https://github.com/Coursemology/coursemology2/assets/51525686/3ae92f13-d286-4bcb-b4bd-224eef75b03d)
