### PR TITLE
Fix 403 when TAs try to access Edit Assessment page

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -154,12 +154,18 @@ module Course::Assessment::AssessmentAbility
   end
 
   def define_teaching_staff_assessment_permissions
+    allow_teaching_staff_read_tab_and_categories
     allow_teaching_staff_manage_assessments
     allow_teaching_staff_grade_assessment_submissions
     allow_teaching_staff_manage_assessment_annotations
     disallow_teaching_staff_publish_assessment_submission_grades
     disallow_teaching_staff_force_submit_assessment_submissions
     disallow_teaching_staff_delete_assessment_submissions
+  end
+
+  def allow_teaching_staff_read_tab_and_categories
+    can :read, Course::Assessment::Tab, category: { course_id: course.id }
+    can :read, Course::Assessment::Category, course_id: course.id
   end
 
   def allow_teaching_staff_manage_assessments

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -172,6 +172,8 @@ RSpec.describe Course::Assessment do
       # Course Tabs and Categories
       it { is_expected.not_to be_able_to(:manage, tab) }
       it { is_expected.not_to be_able_to(:manage, category) }
+      it { is_expected.to be_able_to(:read, tab) }
+      it { is_expected.to be_able_to(:read, category) }
 
       # Course Assessments
       it { is_expected.to be_able_to(:manage, unpublished_assessment) }


### PR DESCRIPTION
TAs will 403 when trying to access the Edit Assessment page because the GET to `/courses/2095/categories` is 403. This PR sets the ability to read assessment categories and tabs for TAs.