### PR TITLE
Fix sign in page redirection

### DIFF
--- a/client/app/bundles/users/pages/SignInPage.tsx
+++ b/client/app/bundles/users/pages/SignInPage.tsx
@@ -54,7 +54,9 @@ const SignInPage = (): JSX.Element => {
 
       if (error.response?.status === 401) {
         setErrored(true);
-        toast.error(t(translations.invalidEmailOrPassword));
+        toast.error(
+          error.response?.data?.error || t(translations.invalidEmailOrPassword),
+        );
       }
     } finally {
       setSubmitting(false);

--- a/client/app/lib/hooks/router/redirect.tsx
+++ b/client/app/lib/hooks/router/redirect.tsx
@@ -50,11 +50,13 @@ const useNextURL = (): { nextURL: string | null; expired: boolean } => {
 /**
  * Redirects to the sign in page with the current URL as the next URL. To be used
  * in scopes outside React and/or React Router, e.g., Axios interceptors.
+ * Do not redirect to the same /users/sign_in url.
  *
  * @param expired Whether this redirect is caused by an expired session.
  */
 export const redirectToSignIn = (expired?: boolean): void => {
-  window.location.href = getAuthenticatableURL(getCurrentURL(), expired);
+  if (!window.location.pathname.startsWith('/users/sign_in'))
+    window.location.href = getAuthenticatableURL(getCurrentURL(), expired);
 };
 
 export const redirectToForbidden = (): void => {


### PR DESCRIPTION
Closes #6351 

Rails devise gem uses 401 error code too liberally. As such, wrong email or password is returned as 401 unauthorized (and who knows what else). When the page is already at `users/sign_in` dont redirect the page again. Also, show error returned from the BE in SignInPage as the error could be due to unconfirmed email, etc.