### PR TITLE
fix(js array method): replace `at` method due to backward incompatibility with safari 14

### DIFF
--- a/client/app/lib/containers/CourselessContainer.tsx
+++ b/client/app/lib/containers/CourselessContainer.tsx
@@ -13,10 +13,12 @@ import BrandingHead from '../components/navigation/BrandingHead';
 import { useAppContext } from './AppContainer';
 
 const getLastCrumbTitle = (crumbs: CrumbData[]): CrumbTitle | null => {
-  const content = crumbs.at(-1)?.content;
+  const content = crumbs[crumbs.length - 1]?.content;
   if (!content) return null;
 
-  const actualContent = Array.isArray(content) ? content.at(-1) : content;
+  const actualContent = Array.isArray(content)
+    ? content[content.length - 1]
+    : content;
   if (!actualContent) return null;
 
   return actualContent.title;


### PR DESCRIPTION
May consider polyfilling `Array.at` when there's more usage in the future.