### PR TITLE
Update course sorting in dashboard page and fix redux data staleness when switching course

### DIFF
--- a/app/controllers/course/video/videos_controller.rb
+++ b/app/controllers/course/video/videos_controller.rb
@@ -14,7 +14,6 @@ class Course::Video::VideosController < Course::Video::Controller
         preload_video_item
         @videos = @videos.
                   from_tab(current_tab).
-                  ordered_by_date_and_title.
                   includes(:statistic).
                   with_submissions_by(current_user)
 

--- a/client/app/bundles/common/DashboardPage.tsx
+++ b/client/app/bundles/common/DashboardPage.tsx
@@ -87,11 +87,6 @@ const DashboardPage = (): JSX.Element => {
   const { processedItems: filteredCourses, handleSearch } = useItems(
     courses ?? [],
     ['title'],
-    (rawCourses) =>
-      rawCourses?.slice().sort((a, b) => {
-        return moment(b.lastActiveAt).diff(moment(a.lastActiveAt));
-      }),
-    courses?.length ?? 0,
   );
 
   return (

--- a/client/app/bundles/course/reference-timelines/views/DayView/DayView.tsx
+++ b/client/app/bundles/course/reference-timelines/views/DayView/DayView.tsx
@@ -4,6 +4,7 @@ import { TimelineData } from 'types/course/referenceTimelines';
 
 import BetaChip from 'lib/components/core/BetaChip';
 import SearchField from 'lib/components/core/fields/SearchField';
+import useItems from 'lib/hooks/items/useItems';
 import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -25,7 +26,9 @@ const DayView = (): JSX.Element => {
   const calendarRef = useRef<ComponentRef<typeof DayCalendar>>(null);
   const contentsRef = useRef<HTMLDivElement>(null);
 
-  const [filterKeyword, setFilterKeyword] = useState('');
+  const { processedItems: filteredItems, handleSearch } = useItems(items, [
+    'title',
+  ]);
 
   const [hiddenTimelineIds, setHiddenTimelineIds] = useState<
     Set<TimelineData['id']>
@@ -36,14 +39,6 @@ const DayView = (): JSX.Element => {
 
     return timelines.filter((timeline) => !hiddenTimelineIds.has(timeline.id));
   }, [hiddenTimelineIds, timelines]);
-
-  const filteredItems = useMemo(() => {
-    if (!filterKeyword) return items;
-
-    return items.filter((item) =>
-      item.title.toLowerCase().includes(filterKeyword.toLowerCase().trim()),
-    );
-  }, [filterKeyword, items]);
 
   return (
     <main className="relative flex h-[calc(100vh_-_4rem)] overflow-hidden">
@@ -68,7 +63,7 @@ const DayView = (): JSX.Element => {
           </div>
 
           <SearchField
-            onChangeKeyword={setFilterKeyword}
+            onChangeKeyword={handleSearch}
             placeholder={t(translations.searchItems)}
           />
         </section>

--- a/client/app/bundles/course/video/components/tables/VideoTable.tsx
+++ b/client/app/bundles/course/video/components/tables/VideoTable.tsx
@@ -40,6 +40,8 @@ const VideoTable: FC<Props> = (props) => {
     return <Note message={intl.formatMessage(translations.noVideo)} />;
   }
 
+  videos.sort((a, b) => a.title.localeCompare(b.title));
+
   const options: TableOptions = {
     download: false,
     filter: false,

--- a/client/app/lib/components/navigation/CourseSwitcherPopupMenu.tsx
+++ b/client/app/lib/components/navigation/CourseSwitcherPopupMenu.tsx
@@ -3,7 +3,6 @@ import {
   MouseEventHandler,
   ReactNode,
   useImperativeHandle,
-  useMemo,
   useState,
 } from 'react';
 import { defineMessages } from 'react-intl';
@@ -13,6 +12,7 @@ import SearchField from 'lib/components/core/fields/SearchField';
 import PopupMenu from 'lib/components/core/PopupMenu';
 import { useAppContext } from 'lib/containers/AppContainer';
 import { getCourseId } from 'lib/helpers/url-helpers';
+import useItems from 'lib/hooks/items/useItems';
 import useTranslation from 'lib/hooks/useTranslation';
 
 const translations = defineMessages({
@@ -75,16 +75,13 @@ const CourseSwitcherPopupMenu = forwardRef<
   const isSuperAdmin = user?.role === 'administrator';
   const isInstanceAdmin = user?.instanceRole === 'administrator';
 
-  const [filterKeyword, setFilterKeyword] = useState('');
+  const {
+    processedItems: filteredCourses,
+    handleSearch,
+    searchKeyword,
+  } = useItems(courses ?? [], ['title']);
+
   const [showCourseIds, setShowCourseIds] = useState(false);
-
-  const filteredCourses = useMemo(() => {
-    if (!filterKeyword) return courses;
-
-    return courses?.filter((course) =>
-      course.title.toLowerCase().includes(filterKeyword.toLowerCase()),
-    );
-  }, [filterKeyword]);
 
   return (
     <PopupMenu
@@ -101,7 +98,7 @@ const CourseSwitcherPopupMenu = forwardRef<
               <SearchField
                 autoFocus
                 noIcon
-                onChangeKeyword={setFilterKeyword}
+                onChangeKeyword={handleSearch}
                 onKeyDown={(e): void => {
                   if (e.key === 'Alt') {
                     e.preventDefault();
@@ -140,7 +137,7 @@ const CourseSwitcherPopupMenu = forwardRef<
             {!filteredCourses?.length && (
               <PopupMenu.Text color="text.secondary">
                 {t(translations.noCoursesMatch, {
-                  keyword: filterKeyword,
+                  keyword: searchKeyword,
                 })}
               </PopupMenu.Text>
             )}

--- a/client/app/lib/hooks/items/useItems.ts
+++ b/client/app/lib/hooks/items/useItems.ts
@@ -5,6 +5,7 @@ import useSort from './useSort';
 interface UseItemsHook<T> {
   processedItems: T[];
   handleSearch: (query: string) => void;
+  searchKeyword: string;
   currentPage: number;
   totalPages: number;
   handlePageChange: (page: number) => void;
@@ -13,10 +14,13 @@ interface UseItemsHook<T> {
 const useItems = <T>(
   items: T[],
   searchKeys: (keyof T)[],
-  sortFunc: (itemsToSort: T[]) => T[],
-  itemsPerPage: number,
+  sortFunc?: (itemsToSort: T[]) => T[],
+  itemsPerPage?: number,
 ): UseItemsHook<T> => {
-  const { searchedItems, handleSearch } = useSearch(items, searchKeys);
+  const { searchedItems, handleSearch, searchKeyword } = useSearch(
+    items,
+    searchKeys,
+  );
   const { sortedItems } = useSort(searchedItems, sortFunc);
   const { paginatedItems, currentPage, totalPages, handlePageChange } =
     usePaginate(sortedItems, itemsPerPage);
@@ -29,6 +33,7 @@ const useItems = <T>(
   return {
     processedItems: paginatedItems,
     handleSearch: handleSearchAndPaginate,
+    searchKeyword,
     currentPage,
     totalPages,
     handlePageChange,

--- a/client/app/lib/hooks/items/usePaginate.ts
+++ b/client/app/lib/hooks/items/usePaginate.ts
@@ -9,7 +9,7 @@ interface UsePaginateHook<T> {
 
 const usePaginate = <T>(
   items: T[],
-  itemsPerPage: number,
+  itemsPerPage: number = items.length,
 ): UsePaginateHook<T> => {
   const totalPages = Math.ceil(items.length / itemsPerPage);
   const [currentPage, setCurrentPage] = useState(1);

--- a/client/app/lib/hooks/items/useSearch.ts
+++ b/client/app/lib/hooks/items/useSearch.ts
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 interface UseSearchHook<T> {
   searchedItems: T[];
   handleSearch: (query: string) => void;
+  searchKeyword: string;
 }
 
 const useSearch = <T>(
@@ -20,7 +21,7 @@ const useSearch = <T>(
 
         return (
           typeof value === 'string' &&
-          value.toLowerCase().includes(searchKeyword.toLowerCase())
+          value.toLowerCase().includes(searchKeyword.toLowerCase().trim())
         );
       }),
     );
@@ -31,7 +32,7 @@ const useSearch = <T>(
     setSearchKeyword(trimmedKeyword);
   };
 
-  return { searchedItems, handleSearch };
+  return { searchedItems, handleSearch, searchKeyword };
 };
 
 export default useSearch;

--- a/client/app/lib/hooks/items/useSort.ts
+++ b/client/app/lib/hooks/items/useSort.ts
@@ -4,8 +4,9 @@ interface UseSortHook<T> {
 
 const useSort = <T>(
   items: T[],
-  sortFunc: (items: T[]) => T[],
+  sortFunc?: (items: T[]) => T[],
 ): UseSortHook<T> => {
+  if (!sortFunc) return { sortedItems: items };
   const sortedItems = sortFunc(items);
   return { sortedItems };
 };

--- a/client/app/routers/AuthenticatedApp.tsx
+++ b/client/app/routers/AuthenticatedApp.tsx
@@ -139,16 +139,7 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
       loader: CourseContainer.loader,
       handle: CourseContainer.handle,
       shouldRevalidate: ({ currentParams, nextParams }): boolean => {
-        const isChangingCourse = currentParams.courseId !== nextParams.courseId;
-
-        // React Router's documentation never strictly mentioned that `shouldRevalidate`
-        // should be a pure function, but a good software engineer would probably expect
-        // it to be. Until we multi-course support in our Redux store, this is where
-        // we can detect the `courseId` is changing without janky `useEffect`. It should
-        // be safe since `resetStore` does not interfere with rendering or routing.
-        if (isChangingCourse) resetStore();
-
-        return isChangingCourse;
+        return currentParams.courseId !== nextParams.courseId;
       },
       children: [
         {

--- a/client/app/routers/router.tsx
+++ b/client/app/routers/router.tsx
@@ -1,4 +1,5 @@
 import { RouteObject } from 'react-router-dom';
+import { resetStore } from 'store';
 
 import ErrorPage from 'bundles/common/ErrorPage';
 import PrivacyPolicyPage from 'bundles/common/PrivacyPolicyPage';
@@ -16,7 +17,15 @@ const createAppRouter = (router: RouteObject[]): RouteObject[] => [
     shouldRevalidate: (props): boolean => {
       const isChangingCourse =
         props.currentParams.courseId !== props.nextParams.courseId;
-      if (isChangingCourse) return true;
+      if (isChangingCourse) {
+        // React Router's documentation never strictly mentioned that `shouldRevalidate`
+        // should be a pure function, but a good software engineer would probably expect
+        // it to be. Until we multi-course support in our Redux store, this is where
+        // we can detect the `courseId` is changing without janky `useEffect`. It should
+        // be safe since `resetStore` does not interfere with rendering or routing.
+        resetStore();
+        return true;
+      }
 
       const currentNest = props.currentUrl.pathname.split('/')[1];
       const nextNest = props.nextUrl.pathname.split('/')[1];


### PR DESCRIPTION
## Changes
- Make sorting function and pagination length to be optional in useItems.
- Refactor various code to use useItems.
- Remove course sorting based on lastActiveAt for DashboardPage.
- Reset store when changing course at root level to ensure redux store is reset when switching from `url/courses/courseId` to `url`.