### PR TITLE
Increase circleci resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: cimg/node:18.17.0
 
     working_directory: ~/repo
-    resource_class: large
+    resource_class: xlarge
 
   ruby_with_postgres:
     parameters:


### PR DESCRIPTION
Docker large resource class only provides 8gb of RAM which is not enough. Consider switching docker to machine for the node executor.