### PR TITLE
fix(statistics download): fix name not found for system user

### DIFF
--- a/app/services/course/assessment/submission/statistics_download_service.rb
+++ b/app/services/course/assessment/submission/statistics_download_service.rb
@@ -146,8 +146,7 @@ class Course::Assessment::Submission::StatisticsDownloadService
   def csv_grader(submission)
     if submission.grader_ids
       graders = submission.grader_ids.map do |grader_id|
-        cu = @course_users_hash[grader_id] || { name: 'System' }
-        cu.name
+        @course_users_hash[grader_id]&.name || 'System'
       end
       graders.join(', ')
     else


### PR DESCRIPTION
## Changes
- Fixed `.name` not found for `{ name: 'System' }`.