### PR TITLE
Heartbeat Monitoring for Exams: Beta 2

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -8,6 +8,10 @@ class ApplicationCable::Channel < ActionCable::Channel::Base
     ActionDispatch::Request.new(connection.env)
   end
 
+  def session
+    request.session
+  end
+
   def ip_address_and_user_agent
     ip_address = request.remote_ip
     user_agent = request.headers['User-Agent']

--- a/app/channels/concerns/application_cable_ability_concern.rb
+++ b/app/channels/concerns/application_cable_ability_concern.rb
@@ -7,7 +7,7 @@ module ApplicationCableAbilityConcern
   end
 
   def current_ability
-    @current_ability ||= Ability.new(current_user, current_course, current_course_user, nil, request.session)
+    @current_ability ||= Ability.new(current_user, current_course, current_course_user, nil, session)
   end
 
   def can?(*args)

--- a/app/controllers/concerns/course/assessment/monitoring_concern.rb
+++ b/app/controllers/concerns/course/assessment/monitoring_concern.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+module Course::Assessment::MonitoringConcern
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method :load_monitor, :monitor
+    alias_method :load_can_manage_monitor?, :can_manage_monitor?
+    alias_method :load_monitoring_component_enabled?, :monitoring_component_enabled?
+
+    before_action :load_monitor, only: [:edit, :show]
+    before_action :load_can_manage_monitor?, only: [:index, :edit]
+    before_action :load_monitoring_component_enabled?, only: [:index, :edit]
+
+    before_action :raise_if_no_monitor, only: [:monitoring, :unblock_monitor]
+    before_action :check_blocked_by_monitor, only: [:show]
+  end
+
+  def monitoring
+    authorize! :read, @monitor
+  end
+
+  def unblock_monitor
+    session_password = unblock_monitor_params[:password]
+
+    if monitoring_service&.unblock(session_password)
+      render json: { redirectUrl: course_assessment_path(current_course, @assessment) }
+    else
+      render json: { errors: t('course.assessment.assessments.unblock_monitor.invalid_password') }, status: :bad_request
+    end
+  end
+
+  def upsert_monitoring!
+    monitoring_service&.upsert!(monitoring_params) if can_manage_monitor?
+  end
+
+  private
+
+  def monitoring_params
+    params.require(:assessment).permit(monitoring: Course::Assessment::MonitoringService.params)[:monitoring]
+  end
+
+  def unblock_monitor_params
+    params.require(:assessment).permit(:password)
+  end
+
+  def raise_if_no_monitor
+    raise ComponentNotFoundError if monitor.nil?
+  end
+
+  def check_blocked_by_monitor
+    render 'blocked_by_monitor' if blocked_by_monitor?
+  end
+
+  def blocked_by_monitor?
+    !can_manage_monitor? && monitoring_service&.should_block?(request.user_agent)
+  end
+
+  def monitoring_service
+    return unless monitoring_component_enabled?
+
+    @monitoring_service ||= Course::Assessment::MonitoringService.new(@assessment, session)
+  end
+
+  def monitoring_component_enabled?
+    @monitoring_component_enabled ||= current_component_host[:course_monitoring_component].present?
+  end
+
+  def can_manage_monitor?
+    @can_manage_monitor ||= can?(:manage, Course::Monitoring::Monitor.new)
+  end
+
+  def monitor
+    @monitor ||= monitoring_service&.monitor
+  end
+end

--- a/app/controllers/concerns/course/assessment/submission/monitoring_concern.rb
+++ b/app/controllers/concerns/course/assessment/submission/monitoring_concern.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module Course::Assessment::Submission::MonitoringConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_blocked_by_monitor, only: [:create, :edit, :update]
+
+    after_action :stop_monitoring_session_if_submitted, only: [:update]
+  end
+
+  def should_monitor? # rubocop:disable Metrics/CyclomaticComplexity
+    monitoring_component_enabled? &&
+      current_user.id == @submission.creator_id &&
+      current_course_user&.student? &&
+      can?(:create, Course::Monitoring::Session.new(creator_id: current_user.id)) &&
+      @assessment&.monitor&.enabled?
+  end
+
+  def monitoring_service
+    return unless should_monitor? || can_update_monitoring_session?
+
+    @monitoring_service ||= Course::Assessment::Submission::MonitoringService.for(@submission, @assessment, session)
+  end
+
+  private
+
+  def monitoring_component_enabled?
+    current_component_host[:course_monitoring_component].present?
+  end
+
+  def can_update_monitoring_session?
+    can?(:update, Course::Monitoring::Session.new)
+  end
+
+  def stop_monitoring_session_if_submitted
+    monitoring_service&.stop! if @submission.submitted?
+  end
+
+  def check_blocked_by_monitor
+    render json: { newSessionUrl: course_assessment_path(current_course, @assessment) } if blocked_by_monitor?
+  end
+
+  def blocked_by_monitor?
+    should_monitor? && monitoring_service&.should_block?(request.user_agent)
+  end
+end

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -5,6 +5,8 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   before_action :load_monitor, only: [:edit, :show]
   before_action :check_can_manage_monitor, only: [:index, :edit]
   before_action :check_monitoring_component_enabled, only: [:index, :edit]
+  before_action :raise_if_no_monitor, only: [:monitoring, :unblock_monitor]
+  before_action :check_blocked_by_monitor, only: [:show]
 
   COURSE_USERS = { my_students: 'my_students',
                    my_students_w_phantom: 'my_students_w_phantom',
@@ -142,11 +144,19 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def monitoring
-    raise ComponentNotFoundError if monitor.nil?
-
     authorize! :read, @monitor
 
     @monitor_id = monitor.id
+  end
+
+  def unblock_monitor
+    session_password = unblock_monitor_params[:password]
+
+    if monitoring_service&.unblock(session_password)
+      render json: { redirectUrl: course_assessment_path(current_course, @assessment) }
+    else
+      render json: { errors: t('.invalid_password') }, status: :bad_request
+    end
   end
 
   protected
@@ -186,6 +196,10 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
 
   def monitoring_params
     params.require(:assessment).permit(monitoring: Course::Assessment::MonitoringService.params)[:monitoring]
+  end
+
+  def unblock_monitor_params
+    params.require(:assessment).permit(:password)
   end
 
   # Randomized Assessment is temporarily hidden (PR#5406)
@@ -326,12 +340,26 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
     @monitoring_component_enabled ||= current_component_host[:course_monitoring_component].present?
   end
 
+  def raise_if_no_monitor
+    raise ComponentNotFoundError if monitor.nil?
+  end
+
+  def check_blocked_by_monitor
+    render 'blocked_by_monitor' if blocked_by_monitor?
+  end
+
+  def blocked_by_monitor?
+    !can_manage_monitor? && monitoring_service&.should_block?(request.user_agent)
+  end
+
   def can_manage_monitor?
     @can_manage_monitor ||= can?(:manage, Course::Monitoring::Monitor.new) && monitoring_component_enabled?
   end
 
   def monitoring_service
-    @monitoring_service ||= Course::Assessment::MonitoringService.new(@assessment) if monitoring_component_enabled?
+    return unless monitoring_component_enabled?
+
+    @monitoring_service ||= Course::Assessment::MonitoringService.new(@assessment, session)
   end
 
   def monitor

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -46,6 +46,7 @@ module Course::Assessment::AssessmentAbility
     can :read_material, Course::Assessment::Category, course_id: course.id
     can :read_material, Course::Assessment::Tab, category: { course_id: course.id }
     can :authenticate, Course::Assessment, lesson_plan_item: { published: true, course_id: course.id }
+    can :unblock_monitor, Course::Assessment, lesson_plan_item: { published: true, course_id: course.id }
     can :requirements, Course::Assessment, lesson_plan_item: { published: true, course_id: course.id }
   end
 

--- a/app/services/course/assessment/monitoring_service.rb
+++ b/app/services/course/assessment/monitoring_service.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::MonitoringService
   class << self
     def params
-      [:enabled, :secret, :min_interval_ms, :max_interval_ms, :offset_ms]
+      [:enabled, :secret, :min_interval_ms, :max_interval_ms, :offset_ms, :blocks]
     end
   end
 

--- a/app/services/course/assessment/monitoring_service.rb
+++ b/app/services/course/assessment/monitoring_service.rb
@@ -4,10 +4,19 @@ class Course::Assessment::MonitoringService
     def params
       [:enabled, :secret, :min_interval_ms, :max_interval_ms, :offset_ms, :blocks]
     end
+
+    def unblocked_browser_session_key(assessment_id)
+      "assessment_#{assessment_id}_unblocked_by_monitor"
+    end
+
+    def unblocked?(assessment_id, browser_session)
+      browser_session[unblocked_browser_session_key(assessment_id)] == true
+    end
   end
 
-  def initialize(assessment)
+  def initialize(assessment, browser_session)
     @assessment = assessment
+    @browser_session = browser_session
   end
 
   def monitor
@@ -23,5 +32,35 @@ class Course::Assessment::MonitoringService
       @monitor = Course::Monitoring::Monitor.create!(params)
       @assessment.update!(monitor: @monitor)
     end
+  end
+
+  def should_block?(string)
+    !unblocked? && monitor&.blocks? && !monitor&.valid_secret?(string)
+  end
+
+  def unblock(session_password)
+    return true unless @assessment.session_password_protected?
+
+    if @assessment.session_password == session_password
+      set_browser_session_unblocked!
+      return true
+    end
+
+    false
+  end
+
+  private
+
+  def set_browser_session_unblocked!
+    @browser_session[unblocked_browser_session_key] = true
+  end
+
+  def unblocked?
+    Course::Assessment::MonitoringService.unblocked?(@assessment.id, @browser_session)
+  end
+
+  def unblocked_browser_session_key
+    @unblocked_browser_session_key ||=
+      Course::Assessment::MonitoringService.unblocked_browser_session_key(@assessment.id)
   end
 end

--- a/app/views/course/assessment/assessments/_assessment_list_data.json.jbuilder
+++ b/app/views/course/assessment/assessments/_assessment_list_data.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+json.id assessment.id
+json.title assessment.title
+json.tabTitle "#{category.title}: #{tab.title}"
+json.tabUrl course_assessments_path(course_id: course, category: category, tab: tab)

--- a/app/views/course/assessment/assessments/_monitoring_details.json.jbuilder
+++ b/app/views/course/assessment/assessments/_monitoring_details.json.jbuilder
@@ -5,4 +5,5 @@ json.monitoring do
   json.min_interval_ms @monitor.min_interval_ms
   json.max_interval_ms @monitor.max_interval_ms
   json.offset_ms @monitor.offset_ms
+  json.blocks @monitor.blocks
 end

--- a/app/views/course/assessment/assessments/blocked_by_monitor.json.jbuilder
+++ b/app/views/course/assessment/assessments/blocked_by_monitor.json.jbuilder
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 json.partial! 'assessment_list_data', assessment: @assessment, category: @category, tab: @tab, course: current_course
 
-json.isAuthenticated false
-json.isStartTimeBegin !assessment_not_started(@assessment_time)
-json.startAt @assessment_time.start_at
+json.blocked true

--- a/app/views/course/assessment/assessments/monitoring.json.jbuilder
+++ b/app/views/course/assessment/assessments/monitoring.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 json.courseId @course.id
-json.monitorId @monitor_id
+json.monitorId @monitor.id
 json.title @assessment.title

--- a/app/views/course/assessment/assessments/show.json.jbuilder
+++ b/app/views/course/assessment/assessments/show.json.jbuilder
@@ -10,10 +10,8 @@ can_attempt = can?(:attempt, assessment)
 can_observe = can?(:observe, assessment)
 can_manage = can?(:manage, assessment)
 
-json.id assessment.id
-json.title assessment.title
-json.tabTitle "#{@category.title}: #{@tab.title}"
-json.tabUrl course_assessments_path(course_id: current_course, category: @category, tab: @tab)
+json.partial! 'assessment_list_data', assessment: @assessment, category: @category, tab: @tab, course: current_course
+
 json.description assessment.description unless @assessment.description.blank?
 json.autograded assessment.autograded?
 json.hasTodo assessment.has_todo if can_manage

--- a/client/app/api/course/Assessment/Assessments.js
+++ b/client/app/api/course/Assessment/Assessments.js
@@ -160,6 +160,20 @@ export default class AssessmentsAPI extends BaseCourseAPI {
     );
   }
 
+  /**
+   * Overrides access for an assessment if blocked by the monitoring component.
+   *
+   * @param {number} assessmentId
+   * @param {string} password
+   * @returns {import('api/types').APIResponse<import('api/types').JustRedirect>}
+   */
+  unblockMonitor(assessmentId, password) {
+    return this.client.post(
+      `${this.#urlPrefix}/${assessmentId}/unblock_monitor`,
+      { assessment: { password } },
+    );
+  }
+
   get #urlPrefix() {
     return `/courses/${this.courseId}/assessments`;
   }

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -114,7 +114,9 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
         name="session_protected"
         render={({ field, fieldState }): JSX.Element => (
           <FormCheckboxField
-            description={t(translations.sessionProtectionHint)}
+            description={t(translations.sessionProtectionHint, {
+              b: (chunk) => <strong>{chunk}</strong>,
+            })}
             disabled={autograded || disabled}
             field={field}
             fieldState={fieldState}
@@ -124,28 +126,22 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
       />
 
       {sessionProtected && (
-        <>
-          <Controller
-            control={control}
-            name="session_password"
-            render={({ field, fieldState }): JSX.Element => (
-              <FormTextField
-                disabled={disabled}
-                field={field}
-                fieldState={fieldState}
-                fullWidth
-                label={t(translations.sessionPassword)}
-                required
-                type="password"
-                variant="filled"
-              />
-            )}
-          />
-
-          <Typography className="!mt-0" color="text.secondary" variant="body2">
-            {t(translations.sessionPasswordHint)}
-          </Typography>
-        </>
+        <Controller
+          control={control}
+          name="session_password"
+          render={({ field, fieldState }): JSX.Element => (
+            <FormTextField
+              disabled={disabled}
+              field={field}
+              fieldState={fieldState}
+              fullWidth
+              label={t(translations.sessionPassword)}
+              required
+              type="password"
+              variant="filled"
+            />
+          )}
+        />
       )}
     </>
   );

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -67,6 +67,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
   const sessionProtected = watch('session_protected');
 
   const monitoring = watch('monitoring.enabled');
+  const hasMonitoringSecret = watch('monitoring.secret');
 
   // Load all tabs if data is loaded, otherwise fall back to current assessment tab.
   const loadedTabs = tabs ?? watch('tabs');
@@ -675,6 +676,32 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
         />
 
         {!autograded && passwordProtected && renderPasswordFields()}
+
+        {passwordProtected && monitoring && (
+          <Controller
+            control={control}
+            name="monitoring.blocks"
+            render={({ field, fieldState }): JSX.Element => (
+              <FormCheckboxField
+                description={t(translations.blocksAccessesFromInvalidSUSHint)}
+                disabled={
+                  !canManageMonitor ||
+                  !sessionProtected ||
+                  !hasMonitoringSecret ||
+                  disabled
+                }
+                disabledHint={
+                  !sessionProtected || !hasMonitoringSecret
+                    ? t(translations.needSUSAndSessionUnlockPassword)
+                    : undefined
+                }
+                field={field}
+                fieldState={fieldState}
+                label={t(translations.blocksAccessesFromInvalidSUS)}
+              />
+            )}
+          />
+        )}
 
         {passwordProtected && monitoringEnabled && (
           <Controller

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -344,6 +344,22 @@ const translations = defineMessages({
     id: 'course.assessment.AssessmentForm.milliseconds',
     defaultMessage: 'ms',
   },
+  blocksAccessesFromInvalidSUS: {
+    id: 'course.assessment.AssessmentForm.blocksAccessesFromInvalidSUS',
+    defaultMessage: 'Block accesses from browsers with invalid SUS',
+  },
+  blocksAccessesFromInvalidSUSHint: {
+    id: 'course.assessment.AssessmentForm.blocksAccessesFromInvalidSUSHint',
+    defaultMessage:
+      'If enabled, examinees using browsers with invalid SUS will be blocked from accessing this assessment. ' +
+      'Instructors can override access with the session unlock password. Heartbeats from an overridden browser ' +
+      'session will be flagged as valid in the PulseGrid.',
+  },
+  needSUSAndSessionUnlockPassword: {
+    id: 'course.assessment.AssessmentForm.needSUSAndSessionUnlockPassword',
+    defaultMessage:
+      'You need to specify a SUS and session unlock password to enable this.',
+  },
   hasToBePositiveIntegerMaxOneDay: {
     id: 'course.assessment.AssessmentForm.hasToBePositiveInteger',
     defaultMessage: 'Has to be a positive integer less than 86,400,000 ms',

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -206,8 +206,8 @@ const translations = defineMessages({
   sessionProtectionHint: {
     id: 'course.assessment.AssessmentForm.sessionProtectionHint',
     defaultMessage:
-      'If enabled, students can only access their attempt once. \
-      Further access will require the session unlock password.',
+      'If enabled, students can only access their attempt once. Further access will require ' +
+      'the session unlock password. Ideally, <b>do NOT give this password to students</b>.',
   },
   viewPasswordHint: {
     id: 'course.assessment.AssessmentForm.viewPasswordHint',
@@ -217,10 +217,6 @@ const translations = defineMessages({
   viewPassword: {
     id: 'course.assessment.AssessmentForm.viewPassword',
     defaultMessage: 'Assessment password',
-  },
-  sessionPasswordHint: {
-    id: 'course.assessment.AssessmentForm.sessionPasswordHint',
-    defaultMessage: 'Ideally, do NOT give this password to students.',
   },
   sessionPassword: {
     id: 'course.assessment.AssessmentForm.sessionPassword',

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -315,7 +315,8 @@ const translations = defineMessages({
     id: 'course.assessment.AssessmentForm.secretHint',
     defaultMessage:
       'If provided, Coursemology can automatically flag a connection as valid in <pulsegrid>PulseGrid</pulsegrid> if the ' +
-      "examinee's User Agent (UA) contains this secret. Otherwise, connections will be flagged only by heartbeat intervals.",
+      "examinee's User Agent (UA) contains this secret. Otherwise, connections will be flagged only by heartbeat intervals. " +
+      'This string is case-sensitive.',
   },
   minInterval: {
     id: 'course.assessment.AssessmentForm.minInterval',

--- a/client/app/bundles/course/assessment/components/AssessmentForm/useFormValidation.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/useFormValidation.tsx
@@ -121,6 +121,7 @@ const validationSchema = yup.object({
         .typeError(ft.required)
         .required(ft.required),
     }),
+    blocks: yup.bool(),
   }),
 });
 
@@ -144,7 +145,14 @@ const useFormValidation = (
     handleSubmit: (onValid, onInvalid): SubmitHandler<FieldValues> => {
       const postProcessor = (rawData): SubmitHandler<FieldValues> => {
         if (!rawData.session_protected) rawData.session_password = null;
+
         delete rawData.session_protected;
+
+        if (
+          (!rawData.session_password || !rawData.monitoring?.secret) &&
+          rawData.monitoring?.blocks !== undefined
+        )
+          rawData.monitoring.blocks = false;
 
         if (!rawData.password_protected && rawData.monitoring !== undefined)
           rawData.monitoring.enabled = false;
@@ -153,6 +161,7 @@ const useFormValidation = (
           delete rawData.monitoring.min_interval_ms;
           delete rawData.monitoring.max_interval_ms;
           delete rawData.monitoring.offset_ms;
+          delete rawData.monitoring.blocks;
         }
 
         return onValid(rawData);

--- a/client/app/bundles/course/assessment/constants.js
+++ b/client/app/bundles/course/assessment/constants.js
@@ -33,6 +33,7 @@ export const DEFAULT_MONITORING_OPTIONS = {
   min_interval_ms: 20000,
   max_interval_ms: 30000,
   offset_ms: 3000,
+  blocks: false,
 };
 
 export default actionTypes;

--- a/client/app/bundles/course/assessment/operations.ts
+++ b/client/app/bundles/course/assessment/operations.ts
@@ -2,12 +2,11 @@
 import { AxiosError } from 'axios';
 import { Operation } from 'store';
 import {
-  AssessmentData,
   AssessmentDeleteResult,
   AssessmentsListData,
   AssessmentUnlockRequirements,
+  FetchAssessmentData,
   QuestionOrderPostData,
-  UnauthenticatedAssessmentData,
 } from 'types/course/assessment/assessments';
 import { MonitoringRequestData } from 'types/course/assessment/monitoring';
 import { McqMrqListData } from 'types/course/assessment/question/multiple-responses';
@@ -41,7 +40,7 @@ export const fetchAssessments = async (
 
 export const fetchAssessment = async (
   id: number,
-): Promise<AssessmentData | UnauthenticatedAssessmentData> => {
+): Promise<FetchAssessmentData> => {
   const response = await CourseAPI.assessment.assessments.fetch(id);
   return response.data;
 };
@@ -88,6 +87,23 @@ export const authenticateAssessment = async (
       adaptedData,
     );
     return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError) throw error.response?.data?.errors;
+    throw error;
+  }
+};
+
+export const unblockAssessment = async (
+  assessmentId: number,
+  password: string,
+): Promise<string> => {
+  try {
+    const response = await CourseAPI.assessment.assessments.unblockMonitor(
+      assessmentId,
+      password,
+    );
+
+    return response.data.redirectUrl;
   } catch (error) {
     if (error instanceof AxiosError) throw error.response?.data?.errors;
     throw error;

--- a/client/app/bundles/course/assessment/pages/AssessmentBlockedByMonitorPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentBlockedByMonitorPage.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Dangerous } from '@mui/icons-material';
+import { LoadingButton } from '@mui/lab';
+import { Typography } from '@mui/material';
+import { BlockedByMonitorAssessmentData } from 'types/course/assessment/assessments';
+
+import TextField from 'lib/components/core/fields/TextField';
+import Page from 'lib/components/core/layouts/Page';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import { unblockAssessment } from '../operations';
+import translations from '../translations';
+
+interface AssessmentBlockedByMonitorPageProps {
+  for: BlockedByMonitorAssessmentData;
+}
+
+const AssessmentBlockedByMonitorPage = (
+  props: AssessmentBlockedByMonitorPageProps,
+): JSX.Element => {
+  const { for: assessment } = props;
+
+  const { t } = useTranslation();
+
+  const [sessionPassword, setSessionPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  const navigate = useNavigate();
+
+  const handleOverrideAccess = (): void => {
+    if (!sessionPassword) return;
+
+    setErrored(false);
+    setSubmitting(true);
+
+    unblockAssessment(assessment.id, sessionPassword)
+      .then(() => navigate(0))
+      .catch((error) => {
+        toast.error(error ?? 'oopsie');
+        setErrored(true);
+        setSubmitting(false);
+      });
+  };
+
+  return (
+    <Page className="h-full m-auto flex flex-col items-center justify-center text-center">
+      <Dangerous className="text-[6rem]" color="error" />
+
+      <Typography className="mt-5" variant="h6">
+        {t(translations.invalidBrowser)}
+      </Typography>
+
+      <Typography
+        className="max-w-3xl mt-2"
+        color="text.secondary"
+        variant="body2"
+      >
+        {t(translations.invalidBrowserSubtitle)}
+      </Typography>
+
+      <section className="mt-10 w-full max-w-lg flex flex-col space-y-5">
+        <TextField
+          autoFocus
+          className={errored ? 'animate-shake' : undefined}
+          disabled={submitting}
+          error={errored}
+          fullWidth
+          label={t(translations.sessionUnlockPassword)}
+          name="email"
+          onChange={(e): void => setSessionPassword(e.target.value)}
+          onPressEnter={handleOverrideAccess}
+          trims
+          type="password"
+          value={sessionPassword}
+          variant="filled"
+        />
+
+        <LoadingButton
+          disabled={!sessionPassword}
+          loading={submitting}
+          onClick={handleOverrideAccess}
+          variant="contained"
+        >
+          {t(translations.overrideAccess)}
+        </LoadingButton>
+
+        <Typography color="text.secondary" variant="caption">
+          {t(translations.accessGrantedForThisSessionOnly)}
+        </Typography>
+      </section>
+    </Page>
+  );
+};
+
+export default AssessmentBlockedByMonitorPage;

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
@@ -5,6 +5,7 @@ import { MonitoringRequestData } from 'types/course/assessment/monitoring';
 
 import BetaChip from 'lib/components/core/BetaChip';
 import ErrorCard from 'lib/components/core/ErrorCard';
+import Page from 'lib/components/core/layouts/Page';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../translations';
@@ -59,7 +60,7 @@ const PulseGrid = (props: PulseGridProps): JSX.Element => {
     );
 
   return (
-    <main className="flex h-full space-x-4">
+    <Page className="flex h-full space-x-4 pt-0">
       <aside className="w-full space-y-5">
         <div className="flex items-center space-x-4">
           <Typography variant="h6">{t(translations.pulsegrid)}</Typography>
@@ -80,7 +81,7 @@ const PulseGrid = (props: PulseGridProps): JSX.Element => {
         <ConnectionStatus title={title} />
         <ActivityCenter />
       </aside>
-    </main>
+    </Page>
   );
 };
 

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -1,0 +1,121 @@
+import { ElementType, ReactNode, useState } from 'react';
+import { Remove } from '@mui/icons-material';
+import { Snapshot } from 'types/channels/liveMonitoring';
+
+import { useAppSelector } from 'lib/hooks/store';
+
+import useMonitoring from '../hooks/useMonitoring';
+import usePresence, { Presence } from '../hooks/usePresence';
+import { select } from '../selectors';
+
+import SessionBlob from './SessionBlob';
+import SessionDetailsPopup from './SessionDetailsPopup';
+
+export const PRESENCE_COLORS: Record<Presence, string> = {
+  alive: 'bg-green-400',
+  late: 'bg-amber-400',
+  missing: 'bg-red-500',
+};
+
+export interface ActiveSessionBlobProps {
+  of: Snapshot;
+  for: number;
+  onClick?: (sessionId: number) => void;
+}
+
+interface BaseActiveSessionBlobProps extends ActiveSessionBlobProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+const BaseActiveSessionBlob = (
+  props: BaseActiveSessionBlobProps,
+): JSX.Element => {
+  const { of: snapshot, for: userId } = props;
+
+  const { hasSecret } = useAppSelector(select('monitor'));
+
+  const monitoring = useMonitoring();
+
+  const [popupData, setPopupData] =
+    useState<[HTMLElement | undefined, string | undefined]>();
+
+  return (
+    <>
+      <SessionBlob
+        className={props.className}
+        of={snapshot}
+        onClick={(e): void => {
+          monitoring.select(userId);
+          props.onClick?.(snapshot.sessionId);
+          setPopupData([e.currentTarget, new Date().toISOString()]);
+        }}
+      >
+        {props.children}
+      </SessionBlob>
+
+      <SessionDetailsPopup
+        anchorsOn={popupData?.[0]}
+        for={snapshot.userName ?? ''}
+        generatedAt={popupData?.[1]}
+        hasSecret={hasSecret}
+        onClose={(): void => {
+          setPopupData((data) => [undefined, data?.[1]]);
+          monitoring.deselect();
+        }}
+        open={Boolean(snapshot.recentHeartbeats && popupData?.[0])}
+        showing={snapshot.recentHeartbeats ?? []}
+      />
+    </>
+  );
+};
+
+const ListeningSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => {
+  const { of: snapshot, for: userId } = props;
+
+  const monitoring = useMonitoring();
+
+  const presence = usePresence(snapshot, {
+    onMissing: (timestamp) =>
+      monitoring.notifyMissingAt(timestamp, userId, snapshot.userName ?? ''),
+    onAlive: (timestamp) =>
+      monitoring.notifyAliveAt(timestamp, userId, snapshot.userName ?? ''),
+  });
+
+  return (
+    <BaseActiveSessionBlob {...props} className={PRESENCE_COLORS[presence]} />
+  );
+};
+
+const ExpiredSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => (
+  <BaseActiveSessionBlob
+    {...props}
+    className="border border-solid border-neutral-200 bg-neutral-100"
+  />
+);
+
+const StoppedSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => (
+  <BaseActiveSessionBlob
+    {...props}
+    className="bg-neutral-200 flex items-center justify-center"
+  >
+    <Remove color="disabled" fontSize="small" />
+  </BaseActiveSessionBlob>
+);
+
+const blobs: Record<Snapshot['status'], ElementType<ActiveSessionBlobProps>> = {
+  listening: ListeningSessionBlob,
+  expired: ExpiredSessionBlob,
+  stopped: StoppedSessionBlob,
+};
+
+const ActiveSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => {
+  const { of: snapshot } = props;
+
+  const Blob = blobs[snapshot.status];
+  if (!Blob) throw new Error(`Unknown status: ${snapshot.status}`);
+
+  return <Blob {...props} />;
+};
+
+export default ActiveSessionBlob;

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
@@ -1,0 +1,75 @@
+import { Chip, Typography } from '@mui/material';
+import { HeartbeatDetail } from 'types/channels/liveMonitoring';
+
+import useTranslation from 'lib/hooks/useTranslation';
+import moment, { formatPreciseDateTime } from 'lib/moment';
+
+import translations from '../../../translations';
+
+import UserAgentDetail from './UserAgentDetail';
+
+interface HeartbeatDetailCardProps {
+  of: HeartbeatDetail;
+  hasSecret?: boolean;
+  className?: string;
+}
+
+const HeartbeatDetailCard = (props: HeartbeatDetailCardProps): JSX.Element => {
+  const { of: heartbeat } = props;
+
+  const { t } = useTranslation();
+
+  return (
+    <section
+      className={`space-y-4 rounded-lg bg-neutral-100 p-4 ${
+        props.className ?? ''
+      }`}
+    >
+      <section>
+        <Typography color="text.secondary" variant="caption">
+          {t(translations.generatedAt)}
+        </Typography>
+
+        <span className="flex space-x-2 items-center">
+          <Typography variant="body2">
+            {formatPreciseDateTime(heartbeat.generatedAt)}
+          </Typography>
+
+          {heartbeat.stale ? (
+            <Chip
+              className="text-neutral-400 border-neutral-400"
+              label={t(translations.stale)}
+              size="small"
+              variant="outlined"
+            />
+          ) : (
+            <Chip
+              className="text-neutral-800 border-neutral-800"
+              label={t(translations.live)}
+              size="small"
+              variant="outlined"
+            />
+          )}
+        </span>
+
+        <Typography variant="caption">
+          {moment(heartbeat.generatedAt).fromNow()}
+        </Typography>
+      </section>
+
+      <section className="space-y-2">
+        <Typography color="text.secondary" variant="caption">
+          {t(translations.userAgent)}
+        </Typography>
+
+        <UserAgentDetail
+          of={heartbeat.userAgent}
+          valid={heartbeat.isValid}
+          validate={props.hasSecret}
+        />
+      </section>
+    </section>
+  );
+};
+
+export default HeartbeatDetailCard;

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import { Color } from 'chart.js';
+import moment from 'moment';
+import palette from 'theme/palette';
+import { HeartbeatDetail } from 'types/channels/liveMonitoring';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from '../../../translations';
+
+import HeartbeatDetailCard from './HeartbeatDetailCard';
+
+const VALID_HEARTBEAT_COLOR = palette.success.main;
+const INVALID_HEARTBEAT_COLOR = palette.error.main;
+const SELECTED_HEARTBEAT_BORDER_COLOR = 'rgb(59 130 246 / 0.5)';
+
+interface HeartbeatsTimelineProps {
+  in: HeartbeatDetail[];
+  hasSecret?: boolean;
+}
+
+const HeartbeatsTimeline = (props: HeartbeatsTimelineProps): JSX.Element => {
+  const { in: heartbeats } = props;
+
+  const { t } = useTranslation();
+
+  const [hoveredIndex, setHoveredIndex] = useState<number>(0);
+
+  const heartbeatsChartData = useMemo(
+    () =>
+      heartbeats.map((heartbeat) => ({
+        ...heartbeat,
+        generatedAt: moment(heartbeat.generatedAt).valueOf(),
+        stale: heartbeat.stale ? t(translations.stale) : t(translations.live),
+      })),
+    [heartbeats],
+  );
+
+  return (
+    <>
+      <div className="h-[10rem]">
+        <Line
+          data={{
+            datasets: [
+              {
+                data: heartbeatsChartData,
+                pointBackgroundColor: (context): Color => {
+                  const heartbeat = context.raw as HeartbeatDetail;
+
+                  return heartbeat.isValid
+                    ? VALID_HEARTBEAT_COLOR
+                    : INVALID_HEARTBEAT_COLOR;
+                },
+                pointRadius: 5,
+                pointHoverRadius: 5,
+                pointBorderWidth: 5,
+                pointHoverBorderWidth: 5,
+                pointBorderColor: (context): Color =>
+                  context.dataIndex === hoveredIndex
+                    ? SELECTED_HEARTBEAT_BORDER_COLOR
+                    : 'transparent',
+                fill: true,
+              },
+            ],
+          }}
+          options={{
+            parsing: {
+              yAxisKey: 'stale',
+              xAxisKey: 'generatedAt',
+            },
+            onHover: (event, elements): void => {
+              if (event.type !== 'mousemove' || !elements.length) return;
+
+              const element = elements[0];
+              setHoveredIndex(element.index);
+            },
+            scales: {
+              x: {
+                type: 'time',
+                time: {
+                  unit: 'second',
+                  stepSize: 10,
+                  displayFormats: {
+                    second: 'HH:mm:ss',
+                  },
+                },
+              },
+              y: {
+                type: 'category',
+                labels: [t(translations.live), t(translations.stale), ''],
+              },
+            },
+            plugins: {
+              legend: { display: false },
+              tooltip: { enabled: false },
+            },
+            maintainAspectRatio: false,
+            animation: false,
+          }}
+        />
+      </div>
+
+      {hoveredIndex !== undefined && (
+        <HeartbeatDetailCard
+          className="ring-2 ring-offset-0"
+          hasSecret={props.hasSecret}
+          of={heartbeats[hoveredIndex]}
+        />
+      )}
+    </>
+  );
+};
+
+export default HeartbeatsTimeline;

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/Session.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/Session.tsx
@@ -1,89 +1,30 @@
-import { useState } from 'react';
-import { Snapshot } from 'types/channels/liveMonitoring';
-
 import { useAppSelector } from 'lib/hooks/store';
 
-import useMonitoring from '../hooks/useMonitoring';
-import usePresence, { Presence } from '../hooks/usePresence';
-import { select, selectSnapshot } from '../selectors';
+import { selectSnapshot } from '../selectors';
 
+import ActiveSessionBlob from './ActiveSessionBlob';
 import SessionBlob from './SessionBlob';
-import SessionDetailsPopup from './SessionDetailsPopup';
 
 interface SessionProps {
   for: number;
   onClick?: (sessionId: number) => void;
 }
 
-interface ActiveSessionProps extends SessionProps {
-  of: Snapshot;
-}
-
-export const PRESENCE_COLORS: Record<Presence, string> = {
-  alive: 'bg-green-400',
-  late: 'bg-amber-400',
-  missing: 'bg-red-500',
-};
-
-const ActiveSession = (props: ActiveSessionProps): JSX.Element => {
-  const { of: snapshot, for: userId } = props;
-
-  const { hasSecret } = useAppSelector(select('monitor'));
-
-  const monitoring = useMonitoring();
-
-  const presence = usePresence(snapshot, {
-    onMissing: (timestamp) =>
-      monitoring.notifyMissingAt(timestamp, userId, snapshot.userName ?? ''),
-    onAlive: (timestamp) =>
-      monitoring.notifyAliveAt(timestamp, userId, snapshot.userName ?? ''),
-  });
-
-  const [popupData, setPopupData] =
-    useState<[HTMLElement | undefined, string | undefined]>();
-
-  return (
-    <>
-      <SessionBlob
-        className={PRESENCE_COLORS[presence]}
-        for={snapshot}
-        onClick={(e): void => {
-          monitoring.select(userId);
-          props.onClick?.(snapshot.sessionId);
-          setPopupData([e.currentTarget, new Date().toISOString()]);
-        }}
-      />
-
-      <SessionDetailsPopup
-        anchorsOn={popupData?.[0]}
-        for={snapshot.userName ?? ''}
-        generatedAt={popupData?.[1]}
-        hasSecret={hasSecret}
-        onClose={(): void => {
-          setPopupData((data) => [undefined, data?.[1]]);
-          monitoring.deselect();
-        }}
-        open={Boolean(snapshot.recentHeartbeats && popupData?.[0])}
-        showing={snapshot.recentHeartbeats ?? []}
-      />
-    </>
-  );
-};
-
-const isActiveSession = (snapshot: Snapshot): boolean =>
-  Boolean(snapshot.sessionId) &&
-  snapshot.status === 'listening' &&
-  Boolean(snapshot.lastHeartbeatAt);
-
 const Session = (props: SessionProps): JSX.Element => {
   const { for: userId } = props;
 
   const snapshot = useAppSelector(selectSnapshot(userId));
 
-  return isActiveSession(snapshot) ? (
-    <ActiveSession {...props} of={snapshot} />
-  ) : (
-    <SessionBlob className="bg-neutral-100" for={snapshot} />
+  if (!snapshot.sessionId)
+    return (
+      <SessionBlob
+        className="border border-solid border-neutral-200/50"
+        of={snapshot}
+      />
+    );
+
+  return (
+    <ActiveSessionBlob for={userId} of={snapshot} onClick={props.onClick} />
   );
 };
 

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlob.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps, ReactNode } from 'react';
-import { Tooltip } from '@mui/material';
+import { Fade, Tooltip } from '@mui/material';
 import { Snapshot } from 'types/channels/liveMonitoring';
 
 interface SessionBlobProps extends ComponentProps<'div'> {
@@ -23,7 +23,14 @@ const SessionBlob = (props: SessionBlobProps): JSX.Element => {
   if (!snapshot) return blob;
 
   return (
-    <Tooltip arrow disableInteractive title={snapshot.userName}>
+    <Tooltip
+      arrow
+      disableInteractive
+      enterDelay={0}
+      title={snapshot.userName}
+      TransitionComponent={Fade}
+      TransitionProps={{ timeout: 0 }}
+    >
       {blob}
     </Tooltip>
   );

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlob.tsx
@@ -1,14 +1,15 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, ReactNode } from 'react';
 import { Tooltip } from '@mui/material';
 import { Snapshot } from 'types/channels/liveMonitoring';
 
 interface SessionBlobProps extends ComponentProps<'div'> {
-  for?: Snapshot;
+  of?: Snapshot;
   className?: string;
+  children?: ReactNode;
 }
 
 const SessionBlob = (props: SessionBlobProps): JSX.Element => {
-  const { for: snapshot, ...divProps } = props;
+  const { of: snapshot, ...divProps } = props;
 
   const blob = (
     <div

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
@@ -5,7 +5,7 @@ import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../../translations';
 
-import { PRESENCE_COLORS } from './Session';
+import { PRESENCE_COLORS } from './ActiveSessionBlob';
 import SessionBlob from './SessionBlob';
 
 interface SessionBlobLegendProps {

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Remove } from '@mui/icons-material';
 import { Tooltip, Typography } from '@mui/material';
 
 import useTranslation from 'lib/hooks/useTranslation';
@@ -20,9 +21,28 @@ const SessionBlobLegend = (props: SessionBlobLegendProps): JSX.Element => {
       title={
         <div className="flex flex-col space-y-4">
           <div className="flex space-x-2">
-            <SessionBlob className="bg-neutral-100" />
+            <SessionBlob className="border border-solid border-neutral-200/50" />
+
             <Typography className="mt-1" variant="body2">
               {t(translations.noActiveSessions)}
+            </Typography>
+          </div>
+
+          <div className="flex space-x-2">
+            <SessionBlob className="border border-solid border-neutral-200 bg-neutral-100" />
+
+            <Typography className="mt-1" variant="body2">
+              {t(translations.expiredSession)}
+            </Typography>
+          </div>
+
+          <div className="flex space-x-2">
+            <SessionBlob className="bg-neutral-200 flex items-center justify-center">
+              <Remove color="disabled" fontSize="small" />
+            </SessionBlob>
+
+            <Typography className="mt-1" variant="body2">
+              {t(translations.stoppedSession)}
             </Typography>
           </div>
 

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
@@ -1,11 +1,10 @@
 import Draggable from 'react-draggable';
 import { Close } from '@mui/icons-material';
-import { Chip, IconButton, Popover, Typography } from '@mui/material';
+import { IconButton, Popover, Typography } from '@mui/material';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
-import Table from 'lib/components/table';
 import useTranslation from 'lib/hooks/useTranslation';
-import { formatPreciseDateTime, formatPreciseTime } from 'lib/moment';
+import { formatPreciseDateTime } from 'lib/moment';
 
 import translations from '../../../translations';
 
@@ -21,40 +20,6 @@ interface SessionDetailsPopupProps {
   anchorsOn?: HTMLElement;
   hasSecret?: boolean;
 }
-
-interface BlankableProps {
-  of?: string;
-  className?: string;
-}
-
-interface ValidableProps extends BlankableProps {
-  valid?: boolean;
-}
-
-const Blankable = ({ of: value, className }: BlankableProps): JSX.Element => {
-  const { t } = useTranslation();
-
-  return value !== undefined ? (
-    <Typography className={className} variant="body2">
-      {value}
-    </Typography>
-  ) : (
-    <Typography
-      className={`italic ${className ?? ''}`}
-      color="text.disabled"
-      variant="body2"
-    >
-      {t(translations.blankField)}
-    </Typography>
-  );
-};
-
-const Validable = ({ valid, ...props }: ValidableProps): JSX.Element => (
-  <div className="flex space-x-2">
-    {valid ? <CheckCircle color="success" /> : <Cancel color="error" />}
-    <Blankable {...props} className="mt-0.5" />
-  </div>
-);
 
 const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
   const {
@@ -121,58 +86,6 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
         </Typography>
 
         <HeartbeatsTimeline hasSecret={props.hasSecret} in={heartbeats} />
-
-        <Table
-          columns={[
-            {
-              of: 'generatedAt',
-              title: t(translations.generatedAt),
-              cell: ({ generatedAt }) => formatPreciseTime(generatedAt),
-              className: '@lg:sticky @lg:left-0 @lg:bg-neutral-100 z-10',
-            },
-            {
-              of: 'stale',
-              title: t(translations.type),
-              cell: ({ stale }) =>
-                stale ? (
-                  <Chip
-                    color="info"
-                    label={t(translations.stale)}
-                    size="small"
-                    variant="outlined"
-                  />
-                ) : (
-                  <Chip
-                    color="success"
-                    label={t(translations.live)}
-                    size="small"
-                    variant="outlined"
-                  />
-                ),
-            },
-            {
-              of: 'userAgent',
-              title: t(translations.userAgent),
-              cell: ({ userAgent }) =>
-                props.hasSecret ? (
-                  <Validable
-                    of={lastHeartbeat?.userAgent}
-                    valid={lastHeartbeat?.isValid}
-                  />
-                ) : (
-                  <Blankable of={userAgent} />
-                ),
-              className: 'whitespace-nowrap',
-            },
-            {
-              of: 'ipAddress',
-              title: t(translations.ipAddress),
-              cell: ({ ipAddress }) => <Blankable of={ipAddress} />,
-            },
-          ]}
-          data={heartbeats}
-          getRowId={(heartbeat): string => heartbeat.generatedAt?.toString()}
-        />
       </Popover>
     </Draggable>
   );

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
@@ -1,5 +1,5 @@
 import Draggable from 'react-draggable';
-import { Cancel, CheckCircle, Close } from '@mui/icons-material';
+import { Close } from '@mui/icons-material';
 import { Chip, IconButton, Popover, Typography } from '@mui/material';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
@@ -8,6 +8,9 @@ import useTranslation from 'lib/hooks/useTranslation';
 import { formatPreciseDateTime, formatPreciseTime } from 'lib/moment';
 
 import translations from '../../../translations';
+
+import HeartbeatDetailCard from './HeartbeatDetailCard';
+import HeartbeatsTimeline from './HeartbeatsTimeline';
 
 interface SessionDetailsPopupProps {
   for: string;
@@ -105,32 +108,7 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
           {t(translations.lastHeartbeat)}
         </Typography>
 
-        <section className="space-y-4 rounded-lg bg-neutral-100 p-4">
-          <section>
-            <Typography color="text.secondary" variant="caption">
-              {t(translations.generatedAt)}
-            </Typography>
-
-            <Typography variant="body2">
-              {formatPreciseDateTime(lastHeartbeat?.generatedAt)}
-            </Typography>
-          </section>
-
-          <section>
-            <Typography color="text.secondary" variant="caption">
-              {t(translations.userAgent)}
-            </Typography>
-
-            {props.hasSecret ? (
-              <Validable
-                of={lastHeartbeat?.userAgent}
-                valid={lastHeartbeat?.isValid}
-              />
-            ) : (
-              <Blankable of={lastHeartbeat?.userAgent} />
-            )}
-          </section>
-        </section>
+        <HeartbeatDetailCard hasSecret={props.hasSecret} of={lastHeartbeat} />
 
         <Typography
           className="!-mb-1 !mt-7 ml-2"
@@ -141,6 +119,8 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
             n: heartbeats.length,
           })}
         </Typography>
+
+        <HeartbeatsTimeline hasSecret={props.hasSecret} in={heartbeats} />
 
         <Table
           columns={[

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
@@ -8,7 +8,6 @@ import { formatPreciseDateTime } from 'lib/moment';
 
 import translations from '../../../translations';
 
-import HeartbeatDetailCard from './HeartbeatDetailCard';
 import HeartbeatsTimeline from './HeartbeatsTimeline';
 
 interface SessionDetailsPopupProps {
@@ -28,8 +27,6 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
     showing: heartbeats,
     generatedAt: time,
   } = props;
-
-  const lastHeartbeat = heartbeats[0];
 
   const { t } = useTranslation();
 
@@ -64,16 +61,6 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
             })}
           </Typography>
         </header>
-
-        <Typography
-          className="!-mb-1 ml-2"
-          color="text.secondary"
-          variant="body2"
-        >
-          {t(translations.lastHeartbeat)}
-        </Typography>
-
-        <HeartbeatDetailCard hasSecret={props.hasSecret} of={lastHeartbeat} />
 
         <Typography
           className="!-mb-1 !mt-7 ml-2"

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/UserAgentDetail.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/UserAgentDetail.tsx
@@ -1,0 +1,94 @@
+import { Apple, Cancel, CheckCircle, WindowSharp } from '@mui/icons-material';
+import { Chip, Typography } from '@mui/material';
+
+import useTranslation, {
+  Descriptor,
+  MessageTranslator,
+} from 'lib/hooks/useTranslation';
+import commonTranslations from 'lib/translations';
+
+import translations from '../../../translations';
+
+interface UserAgentDetailProps {
+  of?: string;
+  className?: string;
+  validate?: boolean;
+  valid?: boolean;
+}
+
+const platforms = {
+  windows: {
+    icon: <WindowSharp className="text-[#2A78D4]" />,
+    label: commonTranslations.windows,
+  },
+  macos: {
+    icon: <Apple />,
+    label: commonTranslations.macos,
+  },
+} satisfies Record<string, { icon: JSX.Element; label: Descriptor }>;
+
+const getPlatformChipFromUserAgent = (
+  userAgent: string,
+  t: MessageTranslator,
+): JSX.Element | null => {
+  let platform: keyof typeof platforms | undefined;
+
+  if (userAgent.includes('Windows')) {
+    platform = 'windows';
+  } else if (userAgent.includes('Mac')) {
+    platform = 'macos';
+  }
+
+  if (!platform) return null;
+
+  const { icon, label } = platforms[platform];
+
+  return <Chip icon={icon} label={t(label)} size="small" variant="outlined" />;
+};
+
+const UserAgentDetail = (props: UserAgentDetailProps): JSX.Element => {
+  const { of: userAgent, className } = props;
+
+  const { t } = useTranslation();
+
+  if (userAgent === undefined)
+    return (
+      <Typography
+        className={`italic ${className ?? ''}`}
+        color="text.disabled"
+        variant="body2"
+      >
+        {t(translations.blankField)}
+      </Typography>
+    );
+
+  const platformChip = getPlatformChipFromUserAgent(userAgent, t);
+
+  return (
+    <section className="flex flex-col space-y-2">
+      <div className="flex space-x-2 items-center">
+        {props.validate && (
+          <Chip
+            color={props.valid ? 'success' : 'error'}
+            icon={props.valid ? <CheckCircle /> : <Cancel />}
+            label={
+              props.valid
+                ? t(translations.validHeartbeat)
+                : t(translations.invalidHeartbeat)
+            }
+            size="small"
+            variant="outlined"
+          />
+        )}
+
+        {platformChip}
+      </div>
+
+      <Typography className={className} variant="body2">
+        {userAgent}
+      </Typography>
+    </section>
+  );
+};
+
+export default UserAgentDetail;

--- a/client/app/bundles/course/assessment/pages/AssessmentShow/index.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentShow/index.tsx
@@ -1,7 +1,8 @@
 import { useParams } from 'react-router-dom';
 import {
-  AssessmentData,
-  UnauthenticatedAssessmentData,
+  FetchAssessmentData,
+  isBlockedByMonitorAssessmentData,
+  isUnauthenticatedAssessmentData,
 } from 'types/course/assessment/assessments';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
@@ -9,28 +10,27 @@ import Preload from 'lib/components/wrappers/Preload';
 
 import { fetchAssessment } from '../../operations';
 import AssessmentAuthenticate from '../AssessmentAuthenticate';
+import AssessmentBlockedByMonitorPage from '../AssessmentBlockedByMonitorPage';
 
 import AssessmentShowPage from './AssessmentShowPage';
-
-const isUnauthenticatedData = (
-  data: unknown,
-): data is UnauthenticatedAssessmentData =>
-  (data as UnauthenticatedAssessmentData)?.isAuthenticated !== undefined;
 
 const AssessmentShow = (): JSX.Element => {
   const params = useParams();
   const id = parseInt(params?.assessmentId ?? '', 10) || undefined;
   if (!id) throw new Error(`AssessmentShow was loaded with ID: ${id}.`);
 
-  const fetchAssessmentWithId = (): Promise<
-    AssessmentData | UnauthenticatedAssessmentData
-  > => fetchAssessment(id);
+  const fetchAssessmentWithId = (): Promise<FetchAssessmentData> =>
+    fetchAssessment(id);
 
   return (
     <Preload render={<LoadingIndicator />} while={fetchAssessmentWithId}>
       {(data): JSX.Element => {
-        if (isUnauthenticatedData(data))
+        if (isUnauthenticatedAssessmentData(data))
           return <AssessmentAuthenticate for={data} />;
+
+        if (isBlockedByMonitorAssessmentData(data))
+          return <AssessmentBlockedByMonitorPage for={data} />;
+
         return <AssessmentShowPage for={data} />;
       }}
     </Preload>

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -933,7 +933,17 @@ const translations = defineMessages({
   },
   noActiveSessions: {
     id: 'course.assessment.monitoring.noActiveSessions',
-    defaultMessage: 'No active sessions.',
+    defaultMessage: 'No active sessions. No attempts have been made.',
+  },
+  expiredSession: {
+    id: 'course.assessment.monitoring.expiredSession',
+    defaultMessage:
+      'Expired session. It has been at least 24 hours since the submission was made.',
+  },
+  stoppedSession: {
+    id: 'course.assessment.monitoring.stoppedSession',
+    defaultMessage:
+      'Stopped session. Student may have finalised their submission.',
   },
   alivePresenceHint: {
     id: 'course.assessment.monitoring.alivePresenceHint',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -908,7 +908,7 @@ const translations = defineMessages({
   },
   detailsOfNHeartbeats: {
     id: 'course.assessment.monitoring.detailsOfNHeartbeats',
-    defaultMessage: 'Details of the last {n} heartbeats',
+    defaultMessage: 'Last {n} heartbeats',
   },
   connectedToLiveMonitoringChannel: {
     id: 'course.assessment.monitoring.connectedToLiveMonitoringChannel',
@@ -955,6 +955,14 @@ const translations = defineMessages({
   missingPresenceHint: {
     id: 'course.assessment.monitoring.missingPresenceHint',
     defaultMessage: "Next heartbeat hasn't been received in time.",
+  },
+  validHeartbeat: {
+    id: 'course.assessment.monitoring.validHeartbeat',
+    defaultMessage: 'Contains SUS',
+  },
+  invalidHeartbeat: {
+    id: 'course.assessment.monitoring.invalidHeartbeat',
+    defaultMessage: 'Does not contain SUS',
   },
   attemptingAssessment: {
     id: 'course.assessment.submission.attemptingAssessment',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -878,10 +878,6 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.summaryCorrectAsAt',
     defaultMessage: 'Summary correct as at {time}',
   },
-  lastHeartbeat: {
-    id: 'course.assessment.monitoring.lastHeartbeat',
-    defaultMessage: 'Last heartbeat',
-  },
   generatedAt: {
     id: 'course.assessment.monitoring.generatedAt',
     defaultMessage: 'Generated at',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -960,6 +960,28 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.invalidHeartbeat',
     defaultMessage: 'Does not contain SUS',
   },
+  invalidBrowser: {
+    id: 'course.assessment.monitoring.invalidBrowser',
+    defaultMessage: 'Invalid browser configuration',
+  },
+  invalidBrowserSubtitle: {
+    id: 'course.assessment.monitoring.invalidBrowserSubtitle',
+    defaultMessage:
+      'Access to this assessment is not allowed with your current browser and/or its configuration. ' +
+      'Contact your instructor for assistance.',
+  },
+  sessionUnlockPassword: {
+    id: 'course.assessment.monitoring.sessionUnlockPassword',
+    defaultMessage: 'Session unlock password',
+  },
+  overrideAccess: {
+    id: 'course.assessment.monitoring.overrideAccess',
+    defaultMessage: 'Override access',
+  },
+  accessGrantedForThisSessionOnly: {
+    id: 'course.assessment.monitoring.accessGrantedForThisSessionOnly',
+    defaultMessage: 'Access will be granted only for this browser session.',
+  },
   attemptingAssessment: {
     id: 'course.assessment.submission.attemptingAssessment',
     defaultMessage: 'Creating a new submission...',

--- a/client/app/lib/translations/index.ts
+++ b/client/app/lib/translations/index.ts
@@ -21,6 +21,14 @@ const translations = defineMessages({
     id: 'lib.translations.experimental',
     defaultMessage: 'Experimental',
   },
+  windows: {
+    id: 'lib.translations.windows',
+    defaultMessage: 'Windows',
+  },
+  macos: {
+    id: 'lib.translations.macos',
+    defaultMessage: 'macOS',
+  },
 });
 
 export default translations;

--- a/client/app/types/course/assessment/assessments.ts
+++ b/client/app/types/course/assessment/assessments.ts
@@ -148,6 +148,19 @@ export interface UnauthenticatedAssessmentData {
   startAt: string;
 }
 
+export interface BlockedByMonitorAssessmentData {
+  id: number;
+  title: string;
+  tabTitle: string;
+  tabUrl: string;
+  blocked: true;
+}
+
+export type FetchAssessmentData =
+  | AssessmentData
+  | UnauthenticatedAssessmentData
+  | BlockedByMonitorAssessmentData;
+
 export interface AssessmentDeleteResult {
   redirect: string;
 }
@@ -163,5 +176,16 @@ export interface AssessmentAuthenticationFormData {
 }
 
 export const isAuthenticatedAssessmentData = (
-  data: AssessmentData | UnauthenticatedAssessmentData,
-): data is AssessmentData => (data as AssessmentData).permissions !== undefined;
+  data: FetchAssessmentData,
+): data is AssessmentData =>
+  (data as AssessmentData)?.permissions !== undefined;
+
+export const isUnauthenticatedAssessmentData = (
+  data: FetchAssessmentData,
+): data is UnauthenticatedAssessmentData =>
+  (data as UnauthenticatedAssessmentData)?.isAuthenticated !== undefined;
+
+export const isBlockedByMonitorAssessmentData = (
+  data: FetchAssessmentData,
+): data is BlockedByMonitorAssessmentData =>
+  (data as BlockedByMonitorAssessmentData)?.blocked === true;

--- a/client/app/workers/constructors.ts
+++ b/client/app/workers/constructors.ts
@@ -1,0 +1,48 @@
+import { HeartbeatWorker } from './types';
+
+const workerConstructors = {
+  dedicated: (): HeartbeatWorker => {
+    const worker = new Worker(
+      new URL('workers/heartbeat.worker.ts', import.meta.url),
+    );
+
+    return {
+      postMessage: (message) => worker.postMessage(message),
+      terminate: (): void => {
+        worker.postMessage({ type: 'disconnect' });
+        worker.terminate();
+      },
+    };
+  },
+  shared: (): HeartbeatWorker => {
+    const worker = new SharedWorker(
+      new URL('workers/heartbeat.sharedworker.ts', import.meta.url),
+    );
+
+    worker.port.start();
+
+    return {
+      postMessage: (message) => worker.port.postMessage(message),
+      terminate: (): void => {
+        worker.port.postMessage({ type: 'disconnect' });
+        worker.port.close();
+      },
+    };
+  },
+} satisfies Record<string, () => HeartbeatWorker>;
+
+type WorkerType = keyof typeof workerConstructors;
+
+export const getWorkerType = (): WorkerType | null => {
+  if (globalThis.SharedWorker) return 'shared';
+  if (globalThis.Worker) return 'dedicated';
+
+  return null;
+};
+
+export const setUpWorker = (type: WorkerType): HeartbeatWorker => {
+  const constructor = workerConstructors[type];
+  if (!constructor) throw new Error(`No constructor for ${type}!`);
+
+  return workerConstructors[type]();
+};

--- a/client/app/workers/heartbeat.sharedworker.ts
+++ b/client/app/workers/heartbeat.sharedworker.ts
@@ -1,0 +1,18 @@
+import createListeners from './listeners';
+
+onconnect = ({ ports }: MessageEvent): void => {
+  const port = ports[0];
+
+  const listeners = createListeners({
+    close: () => port.close(),
+  });
+
+  port.addEventListener('message', ({ data }: MessageEvent) => {
+    const listener = listeners[data.type];
+    if (!listener) throw new Error(`No listener for ${data.type}!`);
+
+    listener(data.payload);
+  });
+
+  port.start();
+};

--- a/client/app/workers/heartbeat.worker.ts
+++ b/client/app/workers/heartbeat.worker.ts
@@ -1,66 +1,12 @@
-import { getWebSocketURL } from 'utilities/socket';
+import createListeners from './listeners';
 
-import subscribe, { HeartbeatChannel } from './heartbeatChannel';
-import setUpDatabase, { MonitoringDBActions } from './monitoringDatabase';
-
-interface StartPayload {
-  sessionId: number;
-  courseId: number;
-}
-
-interface HeartbeatWorkerListener {
-  start: (payload: StartPayload) => void;
-  disconnect: () => void;
-}
-
-let channel: HeartbeatChannel;
-let storage: MonitoringDBActions | null;
-let interval: NodeJS.Timer;
-
-const resetInterval = (callback: () => void, timeout: number): void => {
-  if (interval) clearInterval(interval);
-  interval = setInterval(callback, timeout);
-};
-
-const terminateWorker = async (): Promise<void> => {
-  clearInterval(interval);
-  channel.unsubscribe();
-  await storage?.destroy();
-  globalThis.close();
-};
-
-const listenersThrough = (port: MessagePort): HeartbeatWorkerListener => ({
-  start: async (payload): Promise<void> => {
-    const { sessionId, courseId } = payload;
-    storage ??= await setUpDatabase();
-
-    channel ??= subscribe(getWebSocketURL(), sessionId, courseId, {
-      resetInterval,
-      onPulse: storage?.cacheHeartbeat,
-      onPulsed: (timestamp: number) => {
-        storage?.updateLastSuccessfulPulse(timestamp);
-        storage?.removeHeartbeat(timestamp);
-      },
-      getFlushData: storage?.getHeartbeats,
-      onFlushed: storage?.removeHeartbeats,
-      onTerminate: terminateWorker,
-    });
-  },
-
-  disconnect: () => port.close(),
+const listeners = createListeners({
+  close: () => globalThis.close(),
 });
 
-onconnect = ({ ports }: MessageEvent): void => {
-  const port = ports[0];
+onmessage = ({ data }: MessageEvent): void => {
+  const listener = listeners[data.type];
+  if (!listener) throw new Error(`No listener for ${data.type}!`);
 
-  const listeners = listenersThrough(port);
-
-  port.addEventListener('message', ({ data }: MessageEvent) => {
-    const listener = listeners[data.type];
-    if (!listener) throw new Error(`No listener for ${data.type}!`);
-
-    listener(data.payload);
-  });
-
-  port.start();
+  listener(data.payload);
 };

--- a/client/app/workers/listeners.ts
+++ b/client/app/workers/listeners.ts
@@ -1,0 +1,49 @@
+import { getWebSocketURL } from 'utilities/socket';
+
+import subscribe, { HeartbeatChannel } from './heartbeatChannel';
+import setUpDatabase, { MonitoringDBActions } from './monitoringDatabase';
+import type {
+  HeartbeatWorkerListener,
+  HeartbeatWorkerListenerHost,
+} from './types';
+
+let channel: HeartbeatChannel;
+let storage: MonitoringDBActions | null;
+let interval: NodeJS.Timer;
+
+const resetInterval = (callback: () => void, timeout: number): void => {
+  if (interval) clearInterval(interval);
+  interval = setInterval(callback, timeout);
+};
+
+const terminateWorker = async (): Promise<void> => {
+  clearInterval(interval);
+  channel.unsubscribe();
+  await storage?.destroy();
+  globalThis.close();
+};
+
+const createListeners = (
+  host: HeartbeatWorkerListenerHost,
+): HeartbeatWorkerListener => ({
+  start: async (payload): Promise<void> => {
+    const { sessionId, courseId } = payload;
+    storage ??= await setUpDatabase();
+
+    channel ??= subscribe(getWebSocketURL(), sessionId, courseId, {
+      resetInterval,
+      onPulse: storage?.cacheHeartbeat,
+      onPulsed: (timestamp: number) => {
+        storage?.updateLastSuccessfulPulse(timestamp);
+        storage?.removeHeartbeat(timestamp);
+      },
+      getFlushData: storage?.getHeartbeats,
+      onFlushed: storage?.removeHeartbeats,
+      onTerminate: terminateWorker,
+    });
+  },
+
+  disconnect: () => host.close(),
+});
+
+export default createListeners;

--- a/client/app/workers/types.ts
+++ b/client/app/workers/types.ts
@@ -1,0 +1,25 @@
+interface StartPayload {
+  sessionId: number;
+  courseId: number;
+}
+
+export interface HeartbeatWorkerListener {
+  start: (payload: StartPayload) => void;
+  disconnect: () => void;
+}
+
+export interface HeartbeatWorkerListenerHost {
+  close: () => void;
+}
+
+interface HeartbeatWorkerMessage<T extends keyof HeartbeatWorkerListener> {
+  type: T;
+  payload?: Parameters<HeartbeatWorkerListener[T]>[0];
+}
+
+export interface HeartbeatWorker {
+  postMessage: <T extends keyof HeartbeatWorkerListener>(
+    message: HeartbeatWorkerMessage<T>,
+  ) => void;
+  terminate: () => void;
+}

--- a/config/locales/en/activerecord/course/monitoring/monitor.yml
+++ b/config/locales/en/activerecord/course/monitoring/monitor.yml
@@ -6,3 +6,5 @@ en:
           attributes:
             max_interval_ms:
               greater_than_min_interval: "must be greater than min interval"
+            blocks:
+              must_have_secret_and_session_protection: "must have secret and session protection enabled"

--- a/config/locales/en/course/assessment/assessments.yml
+++ b/config/locales/en/course/assessment/assessments.yml
@@ -23,3 +23,5 @@ en:
           question_bundles: "Bundles"
           question_bundle_questions: "Bundle Questions"
           question_bundle_assignments: "Bundle Assignments"
+        unblock_monitor:
+          invalid_password: "The password you entered was invalid. Please try again."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,7 @@ Rails.application.routes.draw do
           post 'reorder', on: :member
           post 'authenticate', on: :member
           post 'remind', on: :member
+          post 'unblock_monitor', on: :member
           get :requirements, on: :member
           get :statistics, on: :member
           get :monitoring, on: :member

--- a/db/migrate/20231017055234_add_blocks_to_monitoring.rb
+++ b/db/migrate/20231017055234_add_blocks_to_monitoring.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddBlocksToMonitoring < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_monitoring_monitors, :blocks, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_04_095037) do
+ActiveRecord::Schema.define(version: 2023_10_17_055234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -857,6 +857,7 @@ ActiveRecord::Schema.define(version: 2023_09_04_095037) do
     t.integer "offset_ms", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "blocks", default: false, null: false
   end
 
   create_table "course_monitoring_sessions", force: :cascade do |t|

--- a/spec/factories/course_monitoring_monitors.rb
+++ b/spec/factories/course_monitoring_monitors.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :course_monitoring_monitor, class: Course::Monitoring::Monitor.name do
+    assessment
+
     enabled { true }
     min_interval_ms { Course::Monitoring::Monitor::DEFAULT_MIN_INTERVAL_MS }
     max_interval_ms { Course::Monitoring::Monitor::DEFAULT_MIN_INTERVAL_MS * 2 }

--- a/spec/factories/course_monitoring_monitors.rb
+++ b/spec/factories/course_monitoring_monitors.rb
@@ -15,5 +15,10 @@ FactoryBot.define do
     trait :with_secret do
       sequence(:secret) { |n| "secret_#{n}" }
     end
+
+    trait :blocks do
+      with_secret
+      blocks { true }
+    end
   end
 end

--- a/spec/models/course/monitoring/monitor_spec.rb
+++ b/spec/models/course/monitoring/monitor_spec.rb
@@ -35,6 +35,37 @@ RSpec.describe Course::Monitoring::Monitor, type: :model do
           expect(subject.errors[:max_interval_ms]).to be_present
         end
       end
+
+      context 'when secret is not set' do
+        it 'cannot block' do
+          subject.assign_attributes(secret: nil, blocks: true)
+          expect(subject).not_to be_valid
+          expect(subject.errors[:blocks]).to be_present
+        end
+      end
+
+      context 'when session protection is disabled' do
+        before { subject.assessment.update!(session_password: nil) }
+
+        it 'cannot block' do
+          subject.assign_attributes(blocks: true)
+          expect(subject).not_to be_valid
+          expect(subject.errors[:blocks]).to be_present
+        end
+      end
+
+      context 'when secret is set and session protection is enabled' do
+        before do
+          subject.update!(secret: SecureRandom.hex)
+          subject.assessment.update!(session_password: SecureRandom.hex)
+        end
+
+        it 'can block' do
+          subject.assign_attributes(blocks: true)
+          expect(subject).to be_valid
+          expect(subject.errors[:blocks]).not_to be_present
+        end
+      end
     end
 
     describe '#valid_secret?' do

--- a/spec/services/course/assessment/monitoring_service_spec.rb
+++ b/spec/services/course/assessment/monitoring_service_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::MonitoringService, type: :service do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:assessment, course: course) }
+
+    let(:base_user_agent) { 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)' }
+    let(:browser_session) { {} }
+
+    subject { described_class.new(assessment, browser_session) }
+
+    context 'when the assessment has no monitor' do
+      it 'does not retrieve a monitor' do
+        expect(subject.monitor).to eq(nil)
+      end
+
+      it 'creates a monitor with valid params' do
+        params = {
+          enabled: true,
+          secret: SecureRandom.hex,
+          min_interval_ms: 3000,
+          max_interval_ms: 3100,
+          offset_ms: 2000
+        }
+
+        expect { subject.upsert!(params) }.to change { subject.monitor }.from(nil)
+      end
+
+      it 'never blocks' do
+        expect(subject.should_block?(SecureRandom.hex)).to be_falsey
+      end
+    end
+
+    context 'when the assessment has a monitor' do
+      let!(:monitor) { create(:course_monitoring_monitor, assessment: assessment) }
+
+      it 'retrieves the monitor' do
+        expect(subject.monitor).to eq(monitor)
+      end
+
+      it 'updates the monitor with valid params' do
+        params = {
+          enabled: !monitor.enabled,
+          secret: SecureRandom.hex,
+          min_interval_ms: monitor.min_interval_ms + 3000,
+          max_interval_ms: monitor.max_interval_ms + 3100,
+          offset_ms: monitor.offset_ms + 2000
+        }
+
+        expect { subject.upsert!(params) }.
+          to change { subject.monitor.enabled }.to(params[:enabled]).
+          and change { subject.monitor.secret }.to(params[:secret]).
+          and change { subject.monitor.min_interval_ms }.to(params[:min_interval_ms]).
+          and change { subject.monitor.max_interval_ms }.to(params[:max_interval_ms]).
+          and change { subject.monitor.offset_ms }.to(params[:offset_ms])
+
+        expect(subject.monitor.id).to eq(monitor.id)
+      end
+
+      context 'when the monitor blocks' do
+        let(:valid_user_agent) { "#{base_user_agent} #{monitor.secret}" }
+        let(:invalid_user_agent) { "#{base_user_agent} #{SecureRandom.hex}" }
+
+        before do
+          assessment.update!(session_password: SecureRandom.hex)
+          monitor.update!(secret: SecureRandom.hex, blocks: true)
+        end
+
+        it 'blocks when the user agent is invalid' do
+          expect(subject.should_block?(invalid_user_agent)).to be_truthy
+        end
+
+        it 'does not block when the user agent is valid' do
+          expect(subject.should_block?(valid_user_agent)).to be_falsey
+        end
+
+        it 'does not block when the user agent is invalid but the browser session is unblocked' do
+          browser_session[described_class.unblocked_browser_session_key(assessment.id)] = true
+
+          expect(subject.should_block?(invalid_user_agent)).to be_falsey
+        end
+
+        it 'can unblock a browser with an invalid user agent' do
+          invalid_user_agent = "#{base_user_agent} #{SecureRandom.hex}"
+
+          expect { subject.unblock(assessment.session_password) }.
+            to change { subject.should_block?(invalid_user_agent) }.from(true).to(false).
+            and change { browser_session }.from({})
+        end
+      end
+
+      context 'when the monitor does not block' do
+        it 'cannot be set to block if the assessment is not session-protected' do
+          monitor.update!(secret: SecureRandom.hex)
+          assessment.update!(session_password: nil)
+
+          expect { subject.upsert!(blocks: true) }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+
+        it 'cannot be set to block if the monitor does not have a secret' do
+          monitor.update!(secret: nil)
+          assessment.update!(session_password: SecureRandom.hex)
+
+          expect { subject.upsert!(blocks: true) }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+
+        it 'can be set to block if the assessment is session-protected and the monitor has a secret' do
+          monitor.update!(secret: SecureRandom.hex)
+          assessment.update!(session_password: SecureRandom.hex)
+
+          expect { subject.upsert!(blocks: true) }.to change { subject.monitor.blocks }.from(false).to(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/course/assessment/submission/monitoring_service_spec.rb
+++ b/spec/services/course/assessment/submission/monitoring_service_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Submission::MonitoringService, type: :service do
+  let(:instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+    let(:assessment) { create(:assessment, course: course) }
+    let(:submission) { create(:submission, assessment: assessment) }
+
+    let(:base_user_agent) { 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)' }
+    let(:browser_session) { {} }
+
+    subject { described_class.for(submission, assessment, browser_session) }
+
+    context 'when the assessment has no monitor' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the assessment has a monitor' do
+      let!(:monitor) { create(:course_monitoring_monitor, assessment: assessment) }
+
+      it 'retrieves the submission session' do
+        expect(subject.session).to eq(monitor.sessions.first)
+      end
+
+      describe '#listening?' do
+        it 'returns true when the monitor is enabled' do
+          expect(subject.listening?).to be_truthy
+        end
+
+        it 'returns false when the monitor is disabled' do
+          monitor.update!(enabled: false)
+
+          expect(subject.listening?).to be_falsey
+        end
+      end
+
+      describe '#stop!' do
+        it 'stops the session' do
+          expect(Course::Monitoring::HeartbeatChannel).to receive(:broadcast_terminate).once
+          expect(Course::Monitoring::LiveMonitoringChannel).to receive(:broadcast_terminate).once
+
+          expect { subject.stop! }.
+            to change { subject.session.stopped? }.from(false).to(true).
+            and change { subject.session.listening? }.from(true).to(false).
+            and change { subject.listening? }.from(true).to(false)
+        end
+      end
+
+      describe '#continue_listening!' do
+        it 'sets the session to continue listening' do
+          subject.session.update!(status: :stopped)
+
+          expect { subject.continue_listening! }.
+            to change { subject.session.stopped? }.from(true).to(false).
+            and change { subject.session.listening? }.from(false).to(true).
+            and change { subject.listening? }.from(false).to(true)
+        end
+      end
+
+      describe '#should_block?' do
+        let(:valid_user_agent) { "#{base_user_agent} #{monitor.secret}" }
+        let(:invalid_user_agent) { "#{base_user_agent} #{SecureRandom.hex}" }
+
+        before { monitor.update!(secret: SecureRandom.hex) }
+
+        context 'when the monitor blocks' do
+          before do
+            assessment.update!(session_password: SecureRandom.hex)
+            monitor.update!(blocks: true)
+          end
+
+          it 'blocks when the user agent is invalid' do
+            expect(subject.should_block?(invalid_user_agent)).to be_truthy
+          end
+
+          it 'does not block when the user agent is valid' do
+            expect(subject.should_block?(valid_user_agent)).to be_falsey
+          end
+
+          it 'does not block when the user agent is invalid but the browser session is unblocked' do
+            Course::Assessment::MonitoringService.new(assessment, browser_session).unblock(assessment.session_password)
+
+            expect(subject.should_block?(invalid_user_agent)).to be_falsey
+          end
+        end
+
+        context 'when the monitor does not block' do
+          before { monitor.update!(blocks: false) }
+
+          it 'does not block when the user agent is invalid' do
+            expect(subject.should_block?(invalid_user_agent)).to be_falsey
+          end
+
+          it 'does not block when the user agent is valid' do
+            expect(subject.should_block?(valid_user_agent)).to be_falsey
+          end
+        end
+      end
+
+      describe 'static methods' do
+        it 'can set the session to continue listening' do
+          subject.session.update!(status: :stopped)
+
+          expect { described_class.continue_listening_from(assessment, [submission.creator.id]) }.
+            to change { subject.session.reload.stopped? }.from(true).to(false).
+            and change { subject.session.reload.listening? }.from(false).to(true).
+            and change { subject.listening? }.from(false).to(true)
+        end
+
+        it 'can destroy the sessions' do
+          subject.create_new_session_if_not_exist!
+
+          expect { described_class.destroy_all_by(assessment, [submission.creator.id]) }.
+            to change { monitor.sessions.count }.by(-1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add heartbeat worker support for SEB on macOS
- Add heartbeat timeline chart in `SessionDetailsPopup`
- Remove heartbeats table in `SessionDetailsPopup`
- Add OS logo to user agent in `SessionDetailsPopup`
- Add heartbeat relative time in `SessionDetailsPopup`
- Add feature to block accesses from browsers with invalid SUS
- Differentiate the `SessionBlob`s between active (listening, stopped, expired) and idle sessions