### PR TITLE
Fix bug of delete button in video for the row after to be disabled

### DIFF
--- a/client/app/bundles/course/video/components/buttons/VideoManagementButtons.tsx
+++ b/client/app/bundles/course/video/components/buttons/VideoManagementButtons.tsx
@@ -51,6 +51,7 @@ const VideoManagementButtons: FC<Props> = (props) => {
             title: video.title,
           }),
         );
+        setIsDeleting(false);
         if (navigateToIndex) {
           navigate(`${getVideosURL(getCourseId())}?tab=${video.tabId}`);
         }


### PR DESCRIPTION
Details: when we proceed to delete one of the videos in the table, the delete button for the row next to it will be disabled