### PR TITLE
Fix cancel and submit are disabled on initial multiple group creation

### DIFF
--- a/client/app/bundles/course/group/forms/GroupCreationForm.jsx
+++ b/client/app/bundles/course/group/forms/GroupCreationForm.jsx
@@ -144,7 +144,11 @@ const GroupCreationForm = (props) => {
   );
 
   useEffect(() => {
-    if (!isSingle && numToCreate === conflictingNames.length) {
+    if (
+      !isSingle &&
+      numToCreate > 0 &&
+      numToCreate === conflictingNames.length
+    ) {
       dispatch({ type: actionTypes.SET_IS_DISABLED_TRUE });
     } else {
       dispatch({ type: actionTypes.SET_IS_DISABLED_FALSE });


### PR DESCRIPTION
Details : when you need to create the multiple groups using our feature "Multiple", the button cancel and submit are disabled  if you did not input anything, and no error message will occur.

Cause : the condition of (`!isSingle && numToCreate === conflictingNames.length`) causes this, since upon initiation of that form, `numToCreate` is initially 0 and `conflictingNames` is initially [].