### PR TITLE
Signals: A framework for triggering side effects on actions

### DIFF
--- a/app/controllers/components/course/achievements_component.rb
+++ b/app/controllers/components/course/achievements_component.rb
@@ -17,8 +17,7 @@ class Course::AchievementsComponent < SimpleDelegator
         icon: :achievement,
         title: I18n.t('course.achievement.achievements.sidebar_title'),
         weight: 4,
-        path: course_achievements_path(current_course),
-        unread: 0
+        path: course_achievements_path(current_course)
       }
     ]
   end

--- a/app/controllers/components/course/announcements_component.rb
+++ b/app/controllers/components/course/announcements_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::AnnouncementsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
+  include Course::UnreadCountsConcern
 
   def self.display_name
     I18n.t('components.announcements.name')
@@ -20,7 +21,7 @@ class Course::AnnouncementsComponent < SimpleDelegator
         title: settings.title || t('course.announcements.sidebar_title'),
         weight: 1,
         path: course_announcements_path(current_course),
-        unread: unread_count
+        unread: unread_announcements_count
       }
     ]
   end
@@ -34,9 +35,5 @@ class Course::AnnouncementsComponent < SimpleDelegator
         path: course_admin_announcements_path(current_course)
       }
     ]
-  end
-
-  def unread_count
-    current_course.announcements.accessible_by(current_ability).unread_by(current_user).count
   end
 end

--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -28,8 +28,7 @@ class Course::AssessmentsComponent < SimpleDelegator
         icon: :assessment, # TODO: category.icon in db that user can select and set
         title: category.title,
         weight: 2,
-        path: course_assessments_path(current_course, category: category),
-        unread: 0
+        path: course_assessments_path(current_course, category: category)
       }
     end
   end

--- a/app/controllers/components/course/assessments_component.rb
+++ b/app/controllers/components/course/assessments_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::AssessmentsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
-  include Course::Assessment::SubmissionsHelper
+  include Course::UnreadCountsConcern
 
   def self.display_name
     I18n.t('components.assessments.name')
@@ -41,7 +41,7 @@ class Course::AssessmentsComponent < SimpleDelegator
         title: t('course.assessment.submissions.sidebar_title'),
         weight: 3,
         path: course_submissions_path(current_course),
-        unread: submission_count
+        unread: pending_assessment_submissions_count
       }
     ]
   end
@@ -70,20 +70,5 @@ class Course::AssessmentsComponent < SimpleDelegator
         path: course_admin_assessments_path(current_course)
       }
     ]
-  end
-
-  # Returns the number of pending submissions based on roles:
-  #   course_teacher_assistant: Number of submissions from students in my group
-  #   course_owner & course_manager: Number of submissions from students in my group if it's nonzero,
-  #       otherwise number of submissions from all students in the course
-  #   course_student or other users: 0
-  def submission_count
-    if current_course_user&.manager_or_owner?
-      my_students_pending_submissions_count > 0 ? my_students_pending_submissions_count : pending_submissions_count
-    elsif current_course_user&.staff?
-      my_students_pending_submissions_count
-    else
-      0
-    end
   end
 end

--- a/app/controllers/components/course/discussion/topics_component.rb
+++ b/app/controllers/components/course/discussion/topics_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::Discussion::TopicsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
-  include Course::Discussion::TopicsHelper
+  include Course::UnreadCountsConcern
 
   def self.display_name
     I18n.t('components.discussion.topics.name')
@@ -21,7 +21,7 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
         title: settings.title || t('course.discussion.topics.sidebar_title'),
         weight: 5,
         path: course_topics_path(current_course),
-        unread: unread_count
+        unread: unread_comments_count
       }
     ]
   end
@@ -35,21 +35,5 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
         path: course_admin_topics_path(current_course)
       }
     ]
-  end
-
-  def unread_count
-    if staff_with_students?
-      my_students_unread_count
-    elsif current_course_user&.teaching_staff?
-      all_staff_unread_count
-    elsif current_course_user&.student?
-      all_student_unread_count
-    else
-      0
-    end
-  end
-
-  def staff_with_students?
-    current_course_user&.staff? && !current_course_user.my_students.empty?
   end
 end

--- a/app/controllers/components/course/forums_component.rb
+++ b/app/controllers/components/course/forums_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::ForumsComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
+  include Course::UnreadCountsConcern
 
   def self.display_name
     I18n.t('components.forums.name')
@@ -20,7 +21,7 @@ class Course::ForumsComponent < SimpleDelegator
         title: settings.title || t('course.forum.forums.sidebar_title'),
         weight: 10,
         path: course_forums_path(current_course),
-        unread: unread_count
+        unread: unread_forum_topics_count
       }
     ]
   end
@@ -34,9 +35,5 @@ class Course::ForumsComponent < SimpleDelegator
         path: course_admin_forums_path(current_course)
       }
     ]
-  end
-
-  def unread_count
-    Course::Forum::Topic.from_course(current_course).accessible_by(current_ability).unread_by(current_user).count
   end
 end

--- a/app/controllers/components/course/materials_component.rb
+++ b/app/controllers/components/course/materials_component.rb
@@ -19,8 +19,7 @@ class Course::MaterialsComponent < SimpleDelegator
         icon: :material,
         title: settings.title || t('course.material.sidebar_title'),
         weight: 9,
-        path: course_material_folder_path(current_course, current_course.root_folder),
-        unread: 0
+        path: course_material_folder_path(current_course, current_course.root_folder)
       }
     ]
   end

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::UsersComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
+  include Course::UnreadCountsConcern
 
   def self.can_be_disabled_for_course?
     false
@@ -50,7 +51,7 @@ class Course::UsersComponent < SimpleDelegator
           else
             personal_times_course_users_path(current_course)
           end,
-        unread: can_manage_users ? current_course.enrol_requests.pending.count : 0
+        unread: pending_enrol_requests_count
       }
     ]
   end

--- a/app/controllers/components/course/videos_component.rb
+++ b/app/controllers/components/course/videos_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::VideosComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
+  include Course::UnreadCountsConcern
 
   def self.display_name
     I18n.t('components.video.name')
@@ -28,7 +29,7 @@ class Course::VideosComponent < SimpleDelegator
         title: settings.title || t('course.video.videos.sidebar_title'),
         weight: 12,
         path: course_videos_path(current_course, tab: current_course.default_video_tab),
-        unread: unread_count
+        unread: unwatched_videos_count
       }
     ]
   end
@@ -42,16 +43,5 @@ class Course::VideosComponent < SimpleDelegator
         path: course_admin_videos_path(current_course)
       }
     ]
-  end
-
-  def unread_count
-    return 0 unless current_course_user&.student?
-
-    Course::Video.
-      from_course(current_course).
-      unwatched_by(current_user).
-      published.
-      active.
-      count
   end
 end

--- a/app/controllers/concerns/course/unread_counts_concern.rb
+++ b/app/controllers/concerns/course/unread_counts_concern.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+module Course::UnreadCountsConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  def unread_announcements_count
+    current_course.announcements.accessible_by(current_ability).unread_by(current_user).count
+  end
+
+  def unread_forum_topics_count
+    Course::Forum::Topic.from_course(current_course).accessible_by(current_ability).unread_by(current_user).count
+  end
+
+  def unwatched_videos_count
+    return 0 unless current_course_user&.student?
+
+    Course::Video.from_course(current_course).unwatched_by(current_user).published.active.count
+  end
+
+  def pending_enrol_requests_count
+    return 0 unless can?(:manage, CourseUser.new(course: current_course))
+
+    current_course.enrol_requests.pending.count
+  end
+
+  # Returns the number of pending submissions based on the `CourseUser` role.
+  # - `:teacher_assistant`: submissions from students in my group,
+  # - `:owner`, `:manager`: submissions from students in my group if it's not `0`, otherwise, from all students,
+  # - `:student` or other users: `0`.
+  def pending_assessment_submissions_count
+    self.class.include Course::Assessment::SubmissionsHelper
+
+    if current_course_user&.manager_or_owner?
+      (my_students_pending_submissions_count > 0) ? my_students_pending_submissions_count : pending_submissions_count
+    elsif current_course_user&.staff?
+      my_students_pending_submissions_count
+    else
+      0
+    end
+  end
+
+  def unread_comments_count # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    self.class.include Course::Discussion::TopicsHelper
+
+    is_staff_with_students = current_course_user&.staff? && !current_course_user.my_students.empty?
+
+    if is_staff_with_students
+      my_students_unread_count
+    elsif current_course_user&.teaching_staff?
+      all_staff_unread_count
+    elsif current_course_user&.student?
+      all_student_unread_count
+    else
+      0
+    end
+  end
+end

--- a/app/controllers/concerns/course/users_controller_management_concern.rb
+++ b/app/controllers/concerns/course/users_controller_management_concern.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 module Course::UsersControllerManagementConcern
-  include Course::LessonPlan::PersonalizationConcern
-
   extend ActiveSupport::Concern
+
+  include Course::LessonPlan::PersonalizationConcern
+  include Signals::EmissionConcern
 
   included do
     before_action :authorize_show!, only: [:students, :staff, :requests, :invitations]
     before_action :authorize_edit!, only: [:update, :destroy, :upgrade_to_staff, :assign_timeline]
+
+    signals :enrol_requests, after: [:students]
   end
 
   def update

--- a/app/controllers/concerns/signals/emission_concern.rb
+++ b/app/controllers/concerns/signals/emission_concern.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Signals::EmissionConcern
+  extend ActiveSupport::Concern
+
+  include ActiveSupport::Callbacks
+
+  HEADER_KEY = 'Signals-Sync'
+
+  module ClassMethods
+    private
+
+    def signals(slice_name, options = {})
+      prepend_after_action (lambda do
+        return unless response.successful?
+
+        self.class.include(slice_class(slice_name))
+        headers[HEADER_KEY] = generate_sync&.to_json
+      rescue NameError
+        return if Rails.env.production?
+
+        raise NameError, "Slice :#{slice_name} not defined, expected #{slice_class_name(slice_name)}"
+      end), only: options[:after], except: options[:except], if: options[:if]
+    end
+  end
+
+  private
+
+  def slice_class_name(slice_name)
+    "Signals::Slices::#{slice_name.to_s.camelize}"
+  end
+
+  def slice_class(slice_name)
+    slice_class_name(slice_name).constantize
+  end
+end

--- a/app/controllers/concerns/signals/slices/announcements.rb
+++ b/app/controllers/concerns/signals/slices/announcements.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Signals::Slices::Announcements
+  include Course::UnreadCountsConcern
+
+  def generate_sync
+    { announcements: unread_announcements_count }
+  end
+end

--- a/app/controllers/concerns/signals/slices/assessment_submissions.rb
+++ b/app/controllers/concerns/signals/slices/assessment_submissions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Signals::Slices::AssessmentSubmissions
+  include Course::UnreadCountsConcern
+
+  def generate_sync
+    { assessments_submissions: pending_assessment_submissions_count }
+  end
+end

--- a/app/controllers/concerns/signals/slices/comments.rb
+++ b/app/controllers/concerns/signals/slices/comments.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Signals::Slices::Comments
+  include Course::UnreadCountsConcern
+
+  def generate_sync
+    { discussion_topics: unread_comments_count }
+  end
+end

--- a/app/controllers/concerns/signals/slices/enrol_requests.rb
+++ b/app/controllers/concerns/signals/slices/enrol_requests.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Signals::Slices::EnrolRequests
+  include Course::UnreadCountsConcern
+
+  def generate_sync
+    { manage_users: pending_enrol_requests_count }
+  end
+end

--- a/app/controllers/concerns/signals/slices/forums.rb
+++ b/app/controllers/concerns/signals/slices/forums.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Signals::Slices::Forums
+  include Course::UnreadCountsConcern
+
+  def generate_sync
+    { forums: unread_forum_topics_count }
+  end
+end

--- a/app/controllers/concerns/signals/slices/videos.rb
+++ b/app/controllers/concerns/signals/slices/videos.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Signals::Slices::Videos
+  include Course::UnreadCountsConcern
+
+  def generate_sync
+    { videos: unwatched_videos_count }
+  end
+end

--- a/app/controllers/course/announcements_controller.rb
+++ b/app/controllers/course/announcements_controller.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 class Course::AnnouncementsController < Course::ComponentController
   include Course::UsersHelper
+  include Signals::EmissionConcern
 
   load_and_authorize_resource :announcement, through: :course, class: Course::Announcement.name
 
   after_action :mark_announcements_as_read, only: [:index]
+
+  signals :announcements, after: [:index, :destroy]
 
   def index
     respond_to do |format|

--- a/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
+++ b/app/controllers/course/assessment/submission/answer/programming/annotations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Course::Assessment::Submission::Answer::Programming::AnnotationsController < \
   Course::Assessment::Submission::Answer::Programming::Controller
+  include Signals::EmissionConcern
+
   load_resource :actable, class: Course::Assessment::Answer::Programming.name,
                           singleton: true, through: :answer
   before_action :set_programming_answer
@@ -11,6 +13,8 @@ class Course::Assessment::Submission::Answer::Programming::AnnotationsController
                              through: :file
 
   include Course::Discussion::PostsConcern
+
+  signals :comments, after: [:create, :destroy]
 
   def create
     result = @annotation.class.transaction do

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -2,6 +2,7 @@
 class Course::Assessment::Submission::SubmissionsController < \
   Course::Assessment::Submission::Controller
   include Course::Assessment::Submission::SubmissionsControllerServiceConcern
+  include Signals::EmissionConcern
 
   before_action :authorize_assessment!, only: :create
   skip_authorize_resource :submission, only: [:edit, :update, :auto_grade]
@@ -15,6 +16,9 @@ class Course::Assessment::Submission::SubmissionsController < \
   before_action :load_or_create_submission_questions, only: [:edit, :update]
 
   after_action :stop_monitoring_session_if_submitted, only: [:update]
+
+  signals :assessment_submissions, after: [:unsubmit, :delete]
+  signals :assessment_submissions, after: [:update], if: -> { @submission.saved_change_to_workflow_state? }
 
   delegate_to_service(:update)
   delegate_to_service(:submit_answer)

--- a/app/controllers/course/assessment/submission_question/comments_controller.rb
+++ b/app/controllers/course/assessment/submission_question/comments_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 class Course::Assessment::SubmissionQuestion::CommentsController < Course::Assessment::SubmissionQuestion::Controller
   include Course::Discussion::PostsConcern
+  include Signals::EmissionConcern
+
+  signals :comments, after: [:create]
 
   def create
     result = @submission_question.class.transaction do

--- a/app/controllers/course/assessment/submissions_controller.rb
+++ b/app/controllers/course/assessment/submissions_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 class Course::Assessment::SubmissionsController < Course::ComponentController
+  include Signals::EmissionConcern
+
   before_action :load_submissions
   before_action :load_category
-  before_action :load_group_managers, only: [:pending, :index]
+  before_action :load_group_managers, only: [:index, :pending]
+
+  signals :assessment_submissions, after: [:index, :pending]
 
   def index
     respond_to do |format|

--- a/app/controllers/course/discussion/posts_controller.rb
+++ b/app/controllers/course/discussion/posts_controller.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 class Course::Discussion::PostsController < Course::ComponentController
+  include Signals::EmissionConcern
+
   before_action :load_topic
   authorize_resource :specific_topic
 
   helper Course::Discussion::TopicsHelper.name.sub(/Helper$/, '')
   include Course::Discussion::PostsConcern
+
+  signals :comments, after: [:create, :destroy]
 
   def create
     result = @post.transaction do

--- a/app/controllers/course/discussion/topics_controller.rb
+++ b/app/controllers/course/discussion/topics_controller.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 class Course::Discussion::TopicsController < Course::ComponentController
   include Course::UsersHelper
+  include Signals::EmissionConcern
 
   load_and_authorize_resource :discussion_topic, through: :course, instance_name: :topic,
                                                  class: Course::Discussion::Topic.name,
                                                  parent: false
+
+  signals :comments, after: [:index, :toggle_pending, :mark_as_read]
 
   def index
   end

--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 class Course::EnrolRequestsController < Course::ComponentController
+  include Signals::EmissionConcern
+
   skip_authorize_resource :course, only: [:create, :destroy]
   load_and_authorize_resource :enrol_request, through: :course, class: Course::EnrolRequest.name
+
+  signals :enrol_requests, after: [:index, :approve, :reject]
 
   def index
     @enrol_requests = @enrol_requests.includes(:confirmer, user: :emails)

--- a/app/controllers/course/forum/forums_controller.rb
+++ b/app/controllers/course/forum/forums_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 class Course::Forum::ForumsController < Course::Forum::Controller
   include Course::UsersHelper
+  include Signals::EmissionConcern
+
   load_resource :forum, class: Course::Forum.name, through: :course, only: [:index, :new, :create]
+
+  signals :forums, after: [:mark_all_as_read, :mark_as_read]
 
   def index
     respond_to do |format|

--- a/app/controllers/course/forum/topics_controller.rb
+++ b/app/controllers/course/forum/topics_controller.rb
@@ -4,11 +4,14 @@ class Course::Forum::TopicsController < Course::Forum::ComponentController
   include Course::Forum::TopicControllerHidingConcern
   include Course::Forum::TopicControllerLockingConcern
   include Course::Forum::TopicControllerSubscriptionConcern
+  include Signals::EmissionConcern
 
   before_action :load_topic, except: [:create]
   load_resource :topic, class: Course::Forum::Topic.name, through: :forum, only: [:create]
   authorize_resource :topic, class: Course::Forum::Topic.name, except: [:set_resolved]
   after_action :mark_posts_read, only: [:show]
+
+  signals :forums, after: [:show]
 
   def show
     respond_to do |format|

--- a/app/controllers/course/video/submission/submissions_controller.rb
+++ b/app/controllers/course/video/submission/submissions_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 class Course::Video::Submission::SubmissionsController < Course::Video::Submission::Controller
+  include Signals::EmissionConcern
+
   before_action :authorize_attempt_video!, only: :create
   before_action :authorize_analyze_video!, only: [:index, :show]
   skip_authorize_resource :submission, only: :edit
+
+  signals :videos, after: [:create]
 
   def index
     respond_to do |format|

--- a/client/app/api/course/Forum/Forums.ts
+++ b/client/app/api/course/Forum/Forums.ts
@@ -71,7 +71,7 @@ export default class ForumsAPI extends BaseCourseAPI {
   }
 
   /**
-   * Mark all topics as read in a forum.
+   * Mark all topics as read in all forums.
    */
   markAllAsRead(): APIResponse {
     return this.client.patch(`${this.#urlPrefix}/mark_all_as_read`);

--- a/client/app/bundles/common/store.ts
+++ b/client/app/bundles/common/store.ts
@@ -20,12 +20,14 @@ export interface SessionState {
   authenticated: boolean;
   locale: string;
   timeZone: string;
+  unread: Record<string, number>;
 }
 
 const initialState: SessionState = {
   authenticated: false,
   locale: DEFAULT_LOCALE,
   timeZone: DEFAULT_TIME_ZONE,
+  unread: {},
 };
 
 export const sessionStore = createSlice({
@@ -41,6 +43,9 @@ export const sessionStore = createSlice({
     ) => {
       state.locale = action.payload.locale ?? DEFAULT_LOCALE;
       state.timeZone = action.payload.timeZone ?? DEFAULT_TIME_ZONE;
+    },
+    updateUnread: (state, action: PayloadAction<Record<string, number>>) => {
+      Object.assign(state.unread, action.payload);
     },
   },
 });

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/selectors.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { AppState } from 'store';
+import { AppState, Selector } from 'store';
 import { Snapshot } from 'types/channels/liveMonitoring';
 
 import { MonitoringState } from './types';
@@ -7,7 +7,6 @@ import { MonitoringState } from './types';
 const selectMonitoringStore = (state: AppState): MonitoringState =>
   state.assessments.monitoring;
 
-type Selector<T> = (state: AppState) => T;
 type UniversalSelectorFrom<S> = <K extends keyof S>(key: K) => Selector<S[K]>;
 
 export const select: UniversalSelectorFrom<MonitoringState> = (key) =>

--- a/client/app/bundles/course/container/Sidebar/SidebarItem.tsx
+++ b/client/app/bundles/course/container/Sidebar/SidebarItem.tsx
@@ -5,6 +5,7 @@ import { Badge, Typography } from '@mui/material';
 import { SidebarItemData } from 'types/course/courses';
 
 import { defensivelyGetIcon } from 'lib/constants/icons';
+import { useUnreadCountForItem } from 'lib/hooks/session';
 import useTranslation from 'lib/hooks/useTranslation';
 
 interface SidebarItemProps {
@@ -34,6 +35,8 @@ const SidebarItem = (props: SidebarItemProps): JSX.Element => {
     ref.current?.scrollIntoView({ behavior: 'auto', block: 'nearest' });
   }, [isActive]);
 
+  const unreadCount = useUnreadCountForItem(item.key);
+
   return (
     <Link
       ref={ref}
@@ -50,7 +53,7 @@ const SidebarItem = (props: SidebarItemProps): JSX.Element => {
         }`}
         role="button"
       >
-        <Badge badgeContent={item.unread?.toString()} color="primary" max={999}>
+        <Badge badgeContent={unreadCount} color="primary" max={999}>
           <Icon />
         </Badge>
 

--- a/client/app/lib/hooks/session.ts
+++ b/client/app/lib/hooks/session.ts
@@ -1,5 +1,10 @@
 import { createSelector, Dispatch } from '@reduxjs/toolkit';
-import { AppState, dispatch as imperativeDispatch, store } from 'store';
+import {
+  AppState,
+  dispatch as imperativeDispatch,
+  Selector,
+  store,
+} from 'store';
 
 import { actions, SessionState } from 'bundles/common/store';
 
@@ -17,7 +22,13 @@ const selectI18nConfig = createSelector(selectSessionStore, (session) => ({
   timeZone: session.timeZone,
 }));
 
+const selectUnreadCountForItem = (key: string): Selector<number | undefined> =>
+  createSelector(selectSessionStore, (session) => session.unread[key]);
+
 export const useAuthState = (): boolean => useAppSelector(selectAuthState);
+
+export const useUnreadCountForItem = (key: string): number | undefined =>
+  useAppSelector(selectUnreadCountForItem(key));
 
 interface UseAuthenticatorHook {
   authenticate: () => void;

--- a/client/app/lib/hooks/session.ts
+++ b/client/app/lib/hooks/session.ts
@@ -82,3 +82,7 @@ export const setI18nConfig = (config: Partial<I18nConfig>): void => {
 
   imperativeDispatch(actions.setI18nConfig(config));
 };
+
+export const syncSignals = (signals: Record<string, number>): void => {
+  imperativeDispatch(actions.updateUnread(signals));
+};

--- a/client/app/store.ts
+++ b/client/app/store.ts
@@ -118,6 +118,8 @@ export type AppDispatch = ThunkDispatch<
   AnyAction
 >;
 
+export type Selector<T> = (state: AppState) => T;
+
 export type Operation<R = void> = ThunkAction<
   Promise<R>,
   AppState,

--- a/spec/controllers/concerns/signals/emission_concern_spec.rb
+++ b/spec/controllers/concerns/signals/emission_concern_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Signals::EmissionConcern do
+  HEADER_KEY = Signals::EmissionConcern::HEADER_KEY
+
+  class OutOfOrder < StandardError; end
+
+  module Signals::Slices::DummySlice1
+    def generate_sync
+      (@first && @second) ? :dummy1 : raise(OutOfOrder, 'signal should be resolved after all controller callbacks')
+    end
+  end
+
+  module Signals::Slices::DummySlice2
+    def generate_sync
+      (@first && @second) ? :dummy2 : raise(OutOfOrder, 'signal should be resolved after all controller callbacks')
+    end
+  end
+
+  controller(ActionController::Base) do
+    include Signals::EmissionConcern
+
+    after_action :callback2
+    after_action :callback1
+
+    signals :dummy_slice1, after: [:index, :show], if: :should_emit_signal1?
+    signals :dummy_slice1, after: [:update]
+    signals :dummy_slice2, after: [:edit]
+
+    def index; end
+
+    def new; end
+
+    def edit; end
+
+    def update; end
+
+    def show
+      head :bad_request
+    end
+
+    private
+
+    def callback1
+      @first = true
+    end
+
+    def callback2
+      @first ? (@second = true) : raise(OutOfOrder, 'callback2 should be called after callback1')
+    end
+
+    def should_emit_signal1?
+      true
+    end
+  end
+
+  before do
+    routes.draw do
+      get 'index' => 'anonymous#index'
+      get 'show' => 'anonymous#show'
+      get 'new' => 'anonymous#new'
+      get 'edit' => 'anonymous#edit'
+      get 'update' => 'anonymous#update'
+    end
+  end
+
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    context 'if request succeeds' do
+      it 'emits signal if action is attached' do
+        get :index, as: :json
+
+        expect(response).to be_successful
+        expect(response.headers).to include(HEADER_KEY)
+        expect(JSON.parse(response.headers[HEADER_KEY])).to eq('dummy1')
+      end
+
+      it 'does not emit signal if action is not attached' do
+        get :new, as: :json
+
+        expect(response).to be_successful
+        expect(response.headers).not_to include(HEADER_KEY)
+      end
+
+      it 'does not emit signal if condition is false' do
+        allow(controller).to receive(:should_emit_signal1?).and_return(false)
+
+        get :index, as: :json
+
+        expect(response).to be_successful
+        expect(response.headers).not_to include(HEADER_KEY)
+      end
+
+      it 'emit different signals for different actions' do
+        response1 = get :index, as: :json
+
+        expect(response1).to be_successful
+        expect(response1.headers).to include(HEADER_KEY)
+        expect(JSON.parse(response1.headers[HEADER_KEY])).to eq('dummy1')
+
+        response2 = get :edit, as: :json
+
+        expect(response2).to be_successful
+        expect(response2.headers).to include(HEADER_KEY)
+        expect(JSON.parse(response2.headers[HEADER_KEY])).to eq('dummy2')
+      end
+
+      it 'emits the same signal depending on configuration' do
+        allow(controller).to receive(:should_emit_signal1?).and_return(false)
+
+        response1 = get :update, as: :json
+
+        expect(response1).to be_successful
+        expect(response1.headers).to include(HEADER_KEY)
+        expect(JSON.parse(response1.headers[HEADER_KEY])).to eq('dummy1')
+
+        response2 = get :index, as: :json
+
+        expect(response2).to be_successful
+        expect(response2.headers).not_to include(HEADER_KEY)
+      end
+    end
+
+    context 'if request fails' do
+      it 'does not emit signal if request fails' do
+        get :show, as: :json
+
+        expect(response).not_to be_successful
+        expect(response.headers).not_to include(HEADER_KEY)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Signals is a framework for triggering side effects on some actions, without actually touching the codes for said actions. This patterns make side effects reusable across different actions, extensible, and decoupled of any actions.

An action can emit signals with the `signals` callback. The signal emitted ideally represent a slice of the syncable signals state. Think of slice as similarly as [Redux slices](https://redux-toolkit.js.org/usage/usage-guide#creating-slices-of-state).

>[!NOTE]
Fundamentally, signals are NOT data. Signals are indications given by an operation that signifies an occurrence. For now, since the Signals framework is being used to update unread counts, `syncSignals` and `Signals::EmissionConcern` are written in a way to succinctly support this feature. They can, and must, be extended in the future should the use cases diverge.

## The Signals API
Slices are defined as `include`able modules in `signals/slices` that defines a `generate_sync` method that returns a hash that will be appended in the sync header in the response.

```ruby
# signals/slices/severe_destruction.rb
module Signals::Slices::SevereDestruction
  def generate_sync
    { is_destroyed: some.active_record.query.here }
  end
end
```

This slice can then be included in the next sync when certain actions signals it. To emit a signal, include `Signals::EmissionConcern` and add the `signals` callback in the controller (or concerns/helpers that are eventually included in the controller).

```ruby
class Some::Controller < ApplicationController
  include Signals::EmissionConcern

  signals :severe_destruction, after: [:destroy], if: :some_conditions_if_needed?

  def destroy
    ...
end
```

- Just like models and controllers, the symbol that follows `signals` must be resolvable to an existing slice.
- The `after`, `except`, and `if` options are optional. 
- `if` can also receive an anonymous function.
- The orders of `Signals::EmissionConcern` inclusion and `signals` callback attachment _don't matter_. Signals will only be emitted _after every other `after_action`s, if any_.
- Slices are evaluated in the scope of the emitting controller. So, you can safely use `current_course`, `current_user`, `current_ability`, and everything else provided by the superclass/inclusions/extensions of the emitting controller.

>[!IMPORTANT]
Just like React components, the more controller-specific methods/helpers/variables you use in a slice, the less reusable it is.

## Syncs
A sync is the streaming of signals from a server to its client(s). Syncs will only happen on successful responses, i.e., HTTP 2XX and 3XX. When attached with mutating actions (e.g., `create`s, `update`s), this behaviour essentially nets syncs happening _when there are successful mutations_. This way, most, if not all syncs only happen when changes are expected.

For now, syncs are done NOT in real-time, and by attaching sync states in the `Signals-Sync` response headers. The base Axios client will parse the sync state values and act upon them. For now, it simply merges the unread counts to the session Redux store.

## Specificity and future extensions
Note that _for now_, the Signals framework is written to support (1) updating unread counts on the sidebar (2) by attaching syncable states to response headers as a stringified JSON. However, the public-facing APIs are written to support general uses. This way, as we find more use cases for Signals, we can safely extend the internal implementations in the future, and keep the rest of the consumer codes the same.