### PR TITLE
Update temporary file download workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ group :test do
   gem 'capybara'
   gem 'capybara-selenium'
 
-  gem 'aws-sdk-s3'
   # Make screen shots in tests, helps with the debugging of JavaScript tests.
   gem 'capybara-screenshot'
 end
@@ -134,6 +133,10 @@ end
 group :production, :test do
   # Puma will be our app server
   gem 'puma'
+end
+
+group :production, :ci do
+  gem 'aws-sdk-s3'
 end
 
 group :production, :development do

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+if Rails.env.production?
+  require 'aws-sdk-s3'
+
+  Aws.config.update({
+    region: ENV['AWS_REGION'],
+    credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
+  })
+
+  S3_BUCKET = Aws::S3::Resource.new.bucket(ENV['AWS_BUCKET'])
+end

--- a/db/migrate/20230904095037_change_jobs_column_type.rb
+++ b/db/migrate/20230904095037_change_jobs_column_type.rb
@@ -1,0 +1,5 @@
+class ChangeJobsColumnType < ActiveRecord::Migration[6.0]
+  def change
+    change_column :jobs, :redirect_to, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_17_051641) do
+ActiveRecord::Schema.define(version: 2023_09_04_095037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1316,7 +1316,7 @@ ActiveRecord::Schema.define(version: 2023_04_17_051641) do
 
   create_table "jobs", id: :uuid, default: nil, force: :cascade do |t|
     t.integer "status", default: 0, null: false
-    t.string "redirect_to", limit: 255
+    t.text "redirect_to"
     t.json "error"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/lib/autoload/trackable_job.rb
+++ b/lib/autoload/trackable_job.rb
@@ -21,7 +21,6 @@ module TrackableJob
     validates :redirect_to, absence: true, if: :submitted?
     validates :error, absence: true, unless: :errored?
     validates :status, presence: true
-    validates :redirect_to, length: { maximum: 255 }, allow_nil: true
 
     private
 


### PR DESCRIPTION
Instead of temporarily store file download request in the public folder and using SSHFS to connect the downloads folder to NGINX, worker and apps, we now store the files in S3 instead. 

## Changes
- Change `redirect_to` column type in jobs table to text and remove length restriction.
- Enable temporary download file uploading to S3.