### PR TITLE
Fix `json.correct` for programming questions for students with failing evaluation tests

### DIFF
--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -103,7 +103,7 @@ json.explanation do
 
     passed_evaluation_tests = failed_test_cases_by_type['evaluation_test'].blank?
 
-    json.correct attempt&.auto_grading && attempt&.correct && (can_grade && passed_evaluation_tests)
+    json.correct attempt&.auto_grading && attempt&.correct && (can_grade ? passed_evaluation_tests : true)
     json.explanations explanations
   end
 end


### PR DESCRIPTION
Correction for comment raised in https://github.com/Coursemology/coursemology2/pull/6437#discussion_r1318069225.