### PR TITLE
Fix Autofill Grade Issues

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -308,7 +308,10 @@ class VisibleGradingPanel extends Component {
                 )
               : null}
             {shouldRenderGrading
-              ? tableRow('gradedAt', formatLongDateTime(gradedAt))
+              ? tableRow(
+                  'gradedAt',
+                  gradedAt ? formatLongDateTime(gradedAt) : null,
+                )
               : null}
           </TableBody>
         </Table>

--- a/client/app/bundles/course/assessment/submission/reducers/grading.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading.js
@@ -15,7 +15,9 @@ const computeExp = (
   expMultiplier,
   bonusAwarded = 0,
 ) => {
-  const totalGrade = sum(Object.values(questions).map((q) => q.grade));
+  const totalGrade = sum(
+    Object.values(questions).map((q) => parseInt(q.grade, 10)),
+  );
   return Math.round(
     (totalGrade / maximumGrade) * (basePoints + bonusAwarded) * expMultiplier,
   );

--- a/client/app/bundles/course/assessment/submission/reducers/grading.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading.js
@@ -100,17 +100,34 @@ export default function (state = initialState, action) {
     case actions.MARK_SUCCESS:
     case actions.UNMARK_SUCCESS:
     case actions.PUBLISH_SUCCESS: {
+      const { expMultiplier } = state;
+      const basePoints = action.payload.submission.basePoints;
+      const bonusAwarded = action.bonusAwarded;
+
+      const questionWithGrades =
+        action.type === actions.FETCH_SUBMISSION_SUCCESS
+          ? extractPrefillableGrades(action.payload)
+          : extractGrades(action.payload.answers);
+
+      const maxGrade = sum(
+        Object.values(action.payload.questions).map((q) => q.maximumGrade),
+      );
+
       return {
         ...state,
-        questions:
+        questions: questionWithGrades,
+        exp:
           action.type === actions.FETCH_SUBMISSION_SUCCESS
-            ? extractPrefillableGrades(action.payload)
-            : extractGrades(action.payload.answers),
-        exp: action.payload.submission.pointsAwarded,
-        basePoints: action.payload.submission.basePoints,
-        maximumGrade: sum(
-          Object.values(action.payload.questions).map((q) => q.maximumGrade),
-        ),
+            ? computeExp(
+                questionWithGrades,
+                maxGrade,
+                basePoints,
+                expMultiplier,
+                bonusAwarded,
+              )
+            : action.payload.submission.pointsAwarded,
+        basePoints,
+        maximumGrade: maxGrade,
       };
     }
     case actions.UPDATE_GRADING: {

--- a/client/app/bundles/course/assessment/submission/reducers/grading.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading.js
@@ -92,23 +92,11 @@ const extractPrefillableGrades = (payload) => {
 
 export default function (state = initialState, action) {
   switch (action.type) {
-    case actions.FETCH_SUBMISSION_SUCCESS:
-    case actions.SAVE_DRAFT_SUCCESS:
-    case actions.FINALISE_SUCCESS:
-    case actions.UNSUBMIT_SUCCESS:
-    case actions.SAVE_GRADE_SUCCESS:
-    case actions.MARK_SUCCESS:
-    case actions.UNMARK_SUCCESS:
-    case actions.PUBLISH_SUCCESS: {
+    case actions.FETCH_SUBMISSION_SUCCESS: {
       const { expMultiplier } = state;
       const basePoints = action.payload.submission.basePoints;
       const bonusAwarded = action.bonusAwarded;
-
-      const questionWithGrades =
-        action.type === actions.FETCH_SUBMISSION_SUCCESS
-          ? extractPrefillableGrades(action.payload)
-          : extractGrades(action.payload.answers);
-
+      const questionWithGrades = extractPrefillableGrades(action.payload);
       const maxGrade = sum(
         Object.values(action.payload.questions).map((q) => q.maximumGrade),
       );
@@ -116,16 +104,34 @@ export default function (state = initialState, action) {
       return {
         ...state,
         questions: questionWithGrades,
-        exp:
-          action.type === actions.FETCH_SUBMISSION_SUCCESS
-            ? computeExp(
-                questionWithGrades,
-                maxGrade,
-                basePoints,
-                expMultiplier,
-                bonusAwarded,
-              )
-            : action.payload.submission.pointsAwarded,
+        exp: computeExp(
+          questionWithGrades,
+          maxGrade,
+          basePoints,
+          expMultiplier,
+          bonusAwarded,
+        ),
+        basePoints,
+        maximumGrade: maxGrade,
+      };
+    }
+    case actions.SAVE_DRAFT_SUCCESS:
+    case actions.FINALISE_SUCCESS:
+    case actions.UNSUBMIT_SUCCESS:
+    case actions.SAVE_GRADE_SUCCESS:
+    case actions.MARK_SUCCESS:
+    case actions.UNMARK_SUCCESS:
+    case actions.PUBLISH_SUCCESS: {
+      const basePoints = action.payload.submission.basePoints;
+      const questionWithGrades = extractGrades(action.payload.answers);
+      const maxGrade = sum(
+        Object.values(action.payload.questions).map((q) => q.maximumGrade),
+      );
+
+      return {
+        ...state,
+        questions: questionWithGrades,
+        exp: action.payload.submission.pointsAwarded,
         basePoints,
         maximumGrade: maxGrade,
       };


### PR DESCRIPTION
Notable fixes:

1) The auto-filled experience points while the grade is being filled by the instructor showed unusual values. The example is the following one. The experience point is supposed to be filled in with some pre-computed number within the maximum experience points possible, but instead it shows the number way above that
<img width="1497" alt="Screenshot 2023-09-12 at 1 37 35 PM" src="https://github.com/Coursemology/coursemology2/assets/16359075/e609ddea-9617-4f65-86ee-fb119b2b7fca">

Root Cause: the first time the grade is inputted by user, that grade is of type string and only when user click out (onBlur) then it is converted to integer. This leads to the weird behaviour while calculating the totalGrade (as it's now the sum among grades, in which some are integer and some are string)
**Fix: convert all grades into integer before calculating the totalGrade**

2) Experience points not being prefilled even though some of the grades are prefilled.
<img width="1497" alt="Screenshot 2023-09-12 at 1 43 26 PM" src="https://github.com/Coursemology/coursemology2/assets/16359075/35078044-2981-45b9-95c5-14bead640f04">

Root Cause: Experience points is only auto-filled when the grade is manually inputted by the user. When the grade is pre-filled by the system, the past behaviour is that it only pre-filled the grade but did not trigger the call for computing the experience points based on those grades
**Fix: If some of the grades are potentially auto-graded, then we invoke the call for pre-compute (and subsequently pre-fill) the experience points.**

The resulting state (this following picture is upon initial rendering, when user entered the Submission Edit Form the first time):
<img width="1497" alt="Screenshot 2023-09-12 at 1 46 42 PM" src="https://github.com/Coursemology/coursemology2/assets/16359075/8c82e9a3-770e-4634-a336-9ee0800a676a">

3) Graded At row is filled in even when the grading is not finished
Root cause: the function used for formatting the value gradedAt into dateTime will automatically display the current time if the mentioned value is undefined
**Fix: display the value only when gradedAt is defined (i.e. when the grade has been published)**