### PR TITLE
Compute Exp in Fetching Submission

### DIFF
--- a/client/app/bundles/course/assessment/submission/reducers/grading.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading.js
@@ -104,13 +104,15 @@ export default function (state = initialState, action) {
       return {
         ...state,
         questions: questionWithGrades,
-        exp: computeExp(
-          questionWithGrades,
-          maxGrade,
-          basePoints,
-          expMultiplier,
-          bonusAwarded,
-        ),
+        exp:
+          action.payload.submission.pointsAwarded ??
+          computeExp(
+            questionWithGrades,
+            maxGrade,
+            basePoints,
+            expMultiplier,
+            bonusAwarded,
+          ),
         basePoints,
         maximumGrade: maxGrade,
       };


### PR DESCRIPTION
Current behavior: everytime submission is fetched, we compute the exp points regardless of whether the user has already been awarded the EXP points for that submission or not. This creates the confusion as, for example, grader has overwritten the exp points after the submission is published, then the exp points' change will not be reflected upon fetching submission

After behavior: when fetching the submission, we firstly check if the EXP points has been awarded to the user. If yes, we display this number to user. Otherwise, we do pre-computation for EXP using the existing formula (computeExp)