### PR TITLE
Fix first lines of read-only codes have scrollbars on submission edit page

### DIFF
--- a/client/app/theme/syntax-highlighting.css
+++ b/client/app/theme/syntax-highlighting.css
@@ -33,6 +33,6 @@ table.codehilite.table {
   border-spacing: 0;
 }
 
-div.highlight {
+div.highlight:not(code .highlight) {
   overflow: scroll;
 }


### PR DESCRIPTION
The inactive scrollbars (on Linux, Windows, and macOS with persistent scrollbars) push content up and makes the first line unreadable. The `overflow: scroll` was added to `div.highlight` because it was the parent of the code's `table` in Edit Programming Question form. Apparently, it shows also in the first lines of read-only code tables because `highlight` is the default CSS class specified by the [html-pipeline-rouge_filter](https://github.com/ekowidianto/html-pipeline-rouge_filter) gem.

This commit is a band-aid fix, but the proper fix aims to either:
- not format codes in the server, or 
- harmonise the formatters between Comments, Edit Programming Question form, and submission edit pages.