### PR TITLE
Fix unread counts not updating when switching courses

### DIFF
--- a/client/app/api/Base.ts
+++ b/client/app/api/Base.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 
-import { syncSignals } from 'lib/hooks/session';
+import { syncSignals } from 'lib/hooks/unread';
 
 import {
   isInvalidCSRFTokenResponse,

--- a/client/app/bundles/common/store.ts
+++ b/client/app/bundles/common/store.ts
@@ -20,14 +20,12 @@ export interface SessionState {
   authenticated: boolean;
   locale: string;
   timeZone: string;
-  unread: Record<string, number>;
 }
 
 const initialState: SessionState = {
   authenticated: false,
   locale: DEFAULT_LOCALE,
   timeZone: DEFAULT_TIME_ZONE,
-  unread: {},
 };
 
 export const sessionStore = createSlice({
@@ -43,9 +41,6 @@ export const sessionStore = createSlice({
     ) => {
       state.locale = action.payload.locale ?? DEFAULT_LOCALE;
       state.timeZone = action.payload.timeZone ?? DEFAULT_TIME_ZONE;
-    },
-    updateUnread: (state, action: PayloadAction<Record<string, number>>) => {
-      Object.assign(state.unread, action.payload);
     },
   },
 });

--- a/client/app/bundles/course/container/CourseContainer.tsx
+++ b/client/app/bundles/course/container/CourseContainer.tsx
@@ -13,7 +13,7 @@ import CourseAPI from 'api/course';
 import PopupNotifier from 'course/user-notification/PopupNotifier';
 import Footer from 'lib/components/core/layouts/Footer';
 import { DataHandle, useDynamicNest } from 'lib/hooks/router/dynamicNest';
-import { syncSignals } from 'lib/hooks/session';
+import { syncSignals } from 'lib/hooks/unread';
 
 import Breadcrumbs from './Breadcrumbs';
 import Sidebar from './Sidebar';

--- a/client/app/bundles/course/container/Sidebar/SidebarItem.tsx
+++ b/client/app/bundles/course/container/Sidebar/SidebarItem.tsx
@@ -5,7 +5,7 @@ import { Badge, Typography } from '@mui/material';
 import { SidebarItemData } from 'types/course/courses';
 
 import { defensivelyGetIcon } from 'lib/constants/icons';
-import { useUnreadCountForItem } from 'lib/hooks/session';
+import { useUnreadCountForItem } from 'lib/hooks/unread';
 import useTranslation from 'lib/hooks/useTranslation';
 
 interface SidebarItemProps {

--- a/client/app/bundles/course/container/unread.ts
+++ b/client/app/bundles/course/container/unread.ts
@@ -1,0 +1,19 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export type UnreadState = Record<string, number>;
+
+const initialState: UnreadState = {};
+
+const unreadStore = createSlice({
+  name: 'unread',
+  initialState,
+  reducers: {
+    updateUnread: (state, action: PayloadAction<Record<string, number>>) => {
+      Object.assign(state, action.payload);
+    },
+  },
+});
+
+export const { updateUnread } = unreadStore.actions;
+
+export default unreadStore.reducer;

--- a/client/app/lib/hooks/session.ts
+++ b/client/app/lib/hooks/session.ts
@@ -1,10 +1,5 @@
 import { createSelector, Dispatch } from '@reduxjs/toolkit';
-import {
-  AppState,
-  dispatch as imperativeDispatch,
-  Selector,
-  store,
-} from 'store';
+import { AppState, dispatch as imperativeDispatch, store } from 'store';
 
 import { actions, SessionState } from 'bundles/common/store';
 
@@ -22,13 +17,7 @@ const selectI18nConfig = createSelector(selectSessionStore, (session) => ({
   timeZone: session.timeZone,
 }));
 
-const selectUnreadCountForItem = (key: string): Selector<number | undefined> =>
-  createSelector(selectSessionStore, (session) => session.unread[key]);
-
 export const useAuthState = (): boolean => useAppSelector(selectAuthState);
-
-export const useUnreadCountForItem = (key: string): number | undefined =>
-  useAppSelector(selectUnreadCountForItem(key));
 
 interface UseAuthenticatorHook {
   authenticate: () => void;
@@ -81,8 +70,4 @@ export const setI18nConfig = (config: Partial<I18nConfig>): void => {
     return;
 
   imperativeDispatch(actions.setI18nConfig(config));
-};
-
-export const syncSignals = (signals: Record<string, number>): void => {
-  imperativeDispatch(actions.updateUnread(signals));
 };

--- a/client/app/lib/hooks/unread.ts
+++ b/client/app/lib/hooks/unread.ts
@@ -1,0 +1,23 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { AppState, dispatch as imperativeDispatch, Selector } from 'store';
+
+import { updateUnread } from 'course/container/unread';
+
+import { useAppSelector } from './store';
+
+const selectUnreadCountForItem = (key: string): Selector<number | undefined> =>
+  createSelector(
+    (state: AppState) => state.unread,
+    (unread) => unread[key],
+  );
+
+export const useUnreadCountForItem = (key: string): number | undefined =>
+  useAppSelector(selectUnreadCountForItem(key));
+
+/**
+ * When the time comes that the Signals framework is used for more than unread counts,
+ * consider moving this function to some `signals.ts` file and make it general-purpose.
+ */
+export const syncSignals = (signals: Record<string, number>): void => {
+  imperativeDispatch(updateUnread(signals));
+};

--- a/client/app/store.ts
+++ b/client/app/store.ts
@@ -21,6 +21,7 @@ import scribingQuestionReducer from './bundles/course/assessment/question/scribi
 import skillsReducer from './bundles/course/assessment/skills/store';
 import assessmentsReducer from './bundles/course/assessment/store';
 import submissionsReducer from './bundles/course/assessment/submissions/store';
+import unreadReducer from './bundles/course/container/unread';
 import coursesReducer from './bundles/course/courses/store';
 import commentsReducer from './bundles/course/discussion/topics/store';
 import duplicationsReducer from './bundles/course/duplication/store';
@@ -78,6 +79,7 @@ const rootReducer = combineReducers({
   users: usersReducer,
   userEmailSubscriptions: userEmailSubscriptionsReducer,
   videos: videosReducer,
+  unread: unreadReducer,
 
   // The following reducers are of outside of a course.
   admin: adminReducer,


### PR DESCRIPTION
Follows #6450 up.

Unread counts are unique to each course, and so must not be nested under the site-wide `session` store. Since the `session` store doesn't get purged when switching courses, the unread counts from the previous course persists.