### PR TITLE
Fix past_answers_spec cannot select toggles, `componentStack` now typing `null`

### DIFF
--- a/client/app/lib/components/core/layouts/ContextualErrorPage.tsx
+++ b/client/app/lib/components/core/layouts/ContextualErrorPage.tsx
@@ -74,7 +74,7 @@ const BareFooter = (): JSX.Element => (
   </footer>
 );
 
-const getStackMessage = (error: string, component?: string): string => {
+const getStackMessage = (error: string, component?: string | null): string => {
   let message = `Page URL:\n${window.location.href}\n`;
   message += `\nError Stack:\n${error}`;
   if (component) message += `\n\nComponent Stack:${component}`;

--- a/spec/features/course/assessment/submission/past_answers_spec.rb
+++ b/spec/features/course/assessment/submission/past_answers_spec.rb
@@ -24,13 +24,12 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
 
       scenario 'I can view my past answers' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        (0..4).each do |step_number|
-          within(%([name="step#{step_number}"])) do
-            expect(page).to have_selector('.toggle-history')
-            find('.toggle-history').click
-            expect(page).to have_selector('label', text: 'Past Answers')
-          end
-        end
+        past_answers = all('span', text: 'Past Answers')
+
+        expect do
+          past_answers.each(&:click)
+          wait_for_page
+        end.to change { all('label', text: 'Past Answers').count }.by(past_answers.count)
       end
     end
 
@@ -39,13 +38,12 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
 
       scenario "I can view my student's past answers" do
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        (0..4).each do |step_number|
-          within(%([name="step#{step_number}"])) do
-            expect(page).to have_selector('.toggle-history')
-            find('.toggle-history').click
-            expect(page).to have_selector('label', text: 'Past Answers')
-          end
-        end
+        past_answers = all('span', text: 'Past Answers')
+
+        expect do
+          past_answers.each(&:click)
+          wait_for_page
+        end.to change { all('label', text: 'Past Answers').count }.by(past_answers.count)
       end
     end
   end


### PR DESCRIPTION
past_answers_spec is directly selecting questions by their `name` attributes, which is prefixed by `step`. This `name` is passed as a prop in react-scroll's `Element` in `SubmissionEditForm`. For some reasons, the tests in CircleCI did not have this attribute. The `name`s appeared in local builds, though. Nevertheless, the test shouldn't directly target DOM properties, and this PR addresses it.

build_client was failing as of #6642. This is due to the new `null` type union added in https://github.com/DefinitelyTyped/DefinitelyTyped/commit/97dc564bb35aa0e0e4ec5ed4f5a255e7b1f81a22.