### PR TITLE
Fix user invite

### DIFF
--- a/app/controllers/course/user_invitations_controller.rb
+++ b/app/controllers/course/user_invitations_controller.rb
@@ -128,7 +128,7 @@ class Course::UserInvitationsController < Course::ComponentController
   #
   # @return [Course::UserInvitationService]
   def invitation_service
-    @invitation_service ||= Course::UserInvitationService.new(current_course_user)
+    @invitation_service ||= Course::UserInvitationService.new(current_course_user, current_user, current_course)
   end
 
   # Propagate errors from the parameters depending on the type of the parameters.

--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -68,9 +68,8 @@ module Course::UserInvitationService::ParseInvitationConcern
   # @param [Array<Hash>] users
   # @return [Array<Hash>] users
   def restrict_invitee_role(users)
-    return users unless @current_course_user.role == 'teaching_assistant'
-
-    users.each { |invitee| invitee[:role] = :student }
+    users.each { |invitee| invitee[:role] = :student } if @current_course_user&.role == 'teaching_assistant'
+    users
   end
 
   # Invites the users from the form submission, which reflects the actual model associations.

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -8,12 +8,14 @@ class Course::UserInvitationService
 
   # Constructor for the user invitation service object.
   #
-  # @param [CourseUser] current_course_user The course user performing this action.
-  def initialize(current_course_user)
+  # @param [CourseUser|nil] current_course_user The course user performing this action.
+  # @param [User] current_user The user performing this action.
+  # @param [Course] current_course The user performing this action for which course.
+  def initialize(current_course_user, current_user, current_course)
     @current_course_user = current_course_user
-    @current_user = current_course_user.user
-    @current_course = current_course_user.course
-    @current_instance = @current_course.instance
+    @current_user = current_user
+    @current_course = current_course
+    @current_instance = current_course.instance
   end
 
   # Invites users to the given course.

--- a/client/app/bundles/course/user-invitations/components/forms/IndividualInviteForm.tsx
+++ b/client/app/bundles/course/user-invitations/components/forms/IndividualInviteForm.tsx
@@ -69,7 +69,6 @@ const IndividualInviteForm: FC<Props> = (props) => {
     handleSubmit,
     watch,
     reset,
-    formState,
     formState: { errors },
   } = useForm<IndividualInvites>({
     defaultValues: initialValues,
@@ -103,17 +102,11 @@ const IndividualInviteForm: FC<Props> = (props) => {
     }
   }, [invitationsFields.length === 0]);
 
-  // It's recommended to reset in useEffect as execution order matters
-  useEffect(() => {
-    if (formState.isSubmitSuccessful) {
-      reset(initialValues);
-    }
-  }, [formState, reset]);
-
   const onSubmit = (data: InvitationsPostData): Promise<void> => {
     setIsLoading(true);
     return dispatch(inviteUsersFromForm(data))
       .then((response) => {
+        reset(initialValues);
         openResultDialog(response);
       })
       .catch(() => {

--- a/spec/controllers/course/user_invitations_controller_spec.rb
+++ b/spec/controllers/course/user_invitations_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Course::UserInvitationsController, type: :controller do
 
         context 'when the invitations do not get created successfully' do
           before do
-            stubbed_invitation_service = Course::UserInvitationService.new(course_lecturer)
+            stubbed_invitation_service = Course::UserInvitationService.new(course_lecturer, user, course)
             stubbed_invitation_service.define_singleton_method(:invite) do |*|
               false
             end

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe Course::UserInvitationService, type: :service do
     let(:course_user) { create(:course_manager, course: course) }
     let(:user) { course_user.user }
     let(:stubbed_user_invitation_service) do
-      Course::UserInvitationService.new(course_user).tap do |result|
+      Course::UserInvitationService.new(course_user, user, course).tap do |result|
         result.define_singleton_method(:invite_users) do |users|
           users
         end
       end
     end
-    subject { Course::UserInvitationService.new(course_user) }
+    subject { Course::UserInvitationService.new(course_user, user, course) }
 
     let(:existing_roles) { Course::UserInvitation.roles.keys.sample(3).map(&:to_sym) }
     let(:existing_timeline_algorithms) { Course::UserInvitation.timeline_algorithms.keys.sample(3).map(&:to_sym) }


### PR DESCRIPTION
When an admin invites someone to a course the admin is not registered as a course user, the admin should still be able to invite them.