### PR TITLE
Fix flaky `Signals::EmissionConcern` tests

### DIFF
--- a/app/controllers/concerns/signals/emission_concern.rb
+++ b/app/controllers/concerns/signals/emission_concern.rb
@@ -14,7 +14,7 @@ module Signals::EmissionConcern
         return unless response.successful?
 
         self.class.include(slice_class(slice_name))
-        headers[HEADER_KEY] = generate_sync&.to_json
+        headers[HEADER_KEY] = send(generate_sync_method_name(slice_name))&.to_json
       rescue NameError
         return if Rails.env.production?
 
@@ -31,5 +31,9 @@ module Signals::EmissionConcern
 
   def slice_class(slice_name)
     slice_class_name(slice_name).constantize
+  end
+
+  def generate_sync_method_name(slice_name)
+    "generate_sync_for_#{slice_name}".to_sym
   end
 end

--- a/app/controllers/concerns/signals/slices/announcements.rb
+++ b/app/controllers/concerns/signals/slices/announcements.rb
@@ -2,7 +2,7 @@
 module Signals::Slices::Announcements
   include Course::UnreadCountsConcern
 
-  def generate_sync
+  def generate_sync_for_announcements
     { announcements: unread_announcements_count }
   end
 end

--- a/app/controllers/concerns/signals/slices/assessment_submissions.rb
+++ b/app/controllers/concerns/signals/slices/assessment_submissions.rb
@@ -2,7 +2,7 @@
 module Signals::Slices::AssessmentSubmissions
   include Course::UnreadCountsConcern
 
-  def generate_sync
+  def generate_sync_for_assessment_submissions
     { assessments_submissions: pending_assessment_submissions_count }
   end
 end

--- a/app/controllers/concerns/signals/slices/comments.rb
+++ b/app/controllers/concerns/signals/slices/comments.rb
@@ -2,7 +2,7 @@
 module Signals::Slices::Comments
   include Course::UnreadCountsConcern
 
-  def generate_sync
+  def generate_sync_for_comments
     { discussion_topics: unread_comments_count }
   end
 end

--- a/app/controllers/concerns/signals/slices/enrol_requests.rb
+++ b/app/controllers/concerns/signals/slices/enrol_requests.rb
@@ -2,7 +2,7 @@
 module Signals::Slices::EnrolRequests
   include Course::UnreadCountsConcern
 
-  def generate_sync
+  def generate_sync_for_enrol_requests
     { manage_users: pending_enrol_requests_count }
   end
 end

--- a/app/controllers/concerns/signals/slices/forums.rb
+++ b/app/controllers/concerns/signals/slices/forums.rb
@@ -2,7 +2,7 @@
 module Signals::Slices::Forums
   include Course::UnreadCountsConcern
 
-  def generate_sync
+  def generate_sync_for_forums
     { forums: unread_forum_topics_count }
   end
 end

--- a/app/controllers/concerns/signals/slices/videos.rb
+++ b/app/controllers/concerns/signals/slices/videos.rb
@@ -2,7 +2,7 @@
 module Signals::Slices::Videos
   include Course::UnreadCountsConcern
 
-  def generate_sync
+  def generate_sync_for_videos
     { videos: unwatched_videos_count }
   end
 end

--- a/spec/controllers/concerns/signals/emission_concern_spec.rb
+++ b/spec/controllers/concerns/signals/emission_concern_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe Signals::EmissionConcern do
 
   module Signals::Slices::DummySlice1
     def generate_sync_for_dummy_slice1
+      access_controller_method
       (@first && @second) ? :dummy1 : raise(OutOfOrder, 'signal should be resolved after all controller callbacks')
     end
   end
 
   module Signals::Slices::DummySlice2
     def generate_sync_for_dummy_slice2
+      access_controller_method
       (@first && @second) ? :dummy2 : raise(OutOfOrder, 'signal should be resolved after all controller callbacks')
     end
   end
@@ -48,6 +50,14 @@ RSpec.describe Signals::EmissionConcern do
 
     def callback2
       @first ? (@second = true) : raise(OutOfOrder, 'callback2 should be called after callback1')
+    end
+
+    def check_if_slices_can_access_controller_method
+      @accessed_controller_method || raise(StandardError, 'slices should be able to access controller methods')
+    end
+
+    def access_controller_method
+      @accessed_controller_method = true
     end
 
     def should_emit_signal1?

--- a/spec/controllers/concerns/signals/emission_concern_spec.rb
+++ b/spec/controllers/concerns/signals/emission_concern_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Signals::EmissionConcern do
   class OutOfOrder < StandardError; end
 
   module Signals::Slices::DummySlice1
-    def generate_sync
+    def generate_sync_for_dummy_slice1
       (@first && @second) ? :dummy1 : raise(OutOfOrder, 'signal should be resolved after all controller callbacks')
     end
   end
 
   module Signals::Slices::DummySlice2
-    def generate_sync
+    def generate_sync_for_dummy_slice2
       (@first && @second) ? :dummy2 : raise(OutOfOrder, 'signal should be resolved after all controller callbacks')
     end
   end


### PR DESCRIPTION
Ruby's `include` only define the methods from the module in the target construct [if they are not already defined](https://apidock.com/ruby/Module/append_features). Since different slices define their `generate_sync` methods with the same name, if we have one controller emitting different signals, `Signals::EmissionConcern`'s attempts to include later slices will be futile because the new `generate_sync` won't be defined.

This wouldn't be a problem in production thanks to how `Signals::EmissionConcern` is written. It only `include`s the slice as it is about to be used, before calling the included `generate_sync`. Since there's only one signal emitted per action, there must only be one `generate_sync` defined per request. Rails also creates a new instance of the controller on every request.

The case is different in RSpec because while the controllers are reset, I don't believe the relationships with other constructs are fully reset, i.e., maybe they're not doing `.new` on every `it` spec. I'm not sure, but what I do know is that after a spec emits `:dummy2`, everyone will now emit `:dummy2`; essentially, `dummy_slice1`'s `generate_sync` is now overwritten. This is why we see `:dummy2` being emitted even when we're just calling `#index`, which strictly only emits `:dummy1`.

The flakiness of the specs come from the fact that RSpec tests are randomised. To replicate the errors of both problematic tests (lines 82 and 120), use the seed 61318.

## Solution

Different slices essentially must define their sync generators under different names. The easiest solution is used in this PR. We are requiring developers to put the valid slice names on the `generate_sync_for_*` method names. So now, a slice's file name, slice name, and sync generator name must follow the slice's class name.

The best solution is of course to make the `generate_sync` method automatically included with a different namespace. This is not trivial, as I have found after approx. 4 hours. It is possible, but the amount of code complexity is not worth the scale of how we're using the Signals framework for now. It'll maybe worth more to look into this approach if we start to have >5 methods for each slice.