### PR TITLE
Heartbeat Monitoring for Exams: Beta 3

### DIFF
--- a/app/channels/course/monitoring/heartbeat_channel.rb
+++ b/app/channels/course/monitoring/heartbeat_channel.rb
@@ -85,6 +85,7 @@ class Course::Monitoring::HeartbeatChannel < Course::Channel
     Course::Monitoring::LiveMonitoringChannel.broadcast_pulse_to @monitor, @session, {
       sessionId: @session.id,
       status: @session.status,
+      misses: @session.misses,
       lastHeartbeatAt: heartbeat.generated_at,
       isValid: valid_heartbeat?(heartbeat)
     }.compact

--- a/app/channels/course/monitoring/live_monitoring_channel.rb
+++ b/app/channels/course/monitoring/live_monitoring_channel.rb
@@ -64,6 +64,7 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
       snapshot = {
         sessionId: session.id,
         status: session.status,
+        misses: session.misses,
         lastHeartbeatAt: last_heartbeat&.generated_at,
         isValid: is_valid_secret,
         userName: session.creator.name,

--- a/app/channels/course/monitoring/live_monitoring_channel.rb
+++ b/app/channels/course/monitoring/live_monitoring_channel.rb
@@ -41,7 +41,7 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
     session_id, limit = data['session_id'], data['limit'] || DEFAULT_VIEW_HEARTBEATS_LIMIT
     return unless (session = @monitor.sessions.find(session_id))
 
-    recent_heartbeats = session.heartbeats.last(limit).map do |heartbeat|
+    recent_heartbeats = (limit == -1 ? session.heartbeats : session.heartbeats.last(limit)).map do |heartbeat|
       {
         stale: heartbeat.stale,
         userAgent: heartbeat.user_agent,

--- a/app/channels/course/monitoring/live_monitoring_channel.rb
+++ b/app/channels/course/monitoring/live_monitoring_channel.rb
@@ -51,7 +51,7 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
       }.compact
     end
 
-    broadcast_viewed recent_heartbeats.reverse
+    broadcast_viewed recent_heartbeats
   end
 
   private

--- a/app/models/course/monitoring/heartbeat.rb
+++ b/app/models/course/monitoring/heartbeat.rb
@@ -9,4 +9,12 @@ class Course::Monitoring::Heartbeat < ApplicationRecord
   validates :stale, inclusion: { in: [true, false] }
 
   default_scope { order(:generated_at) }
+
+  before_save :update_session_misses
+
+  private
+
+  def update_session_misses
+    session.update_misses_after_heartbeat_saved!(self)
+  end
 end

--- a/app/models/course/monitoring/session.rb
+++ b/app/models/course/monitoring/session.rb
@@ -13,6 +13,7 @@ class Course::Monitoring::Session < ApplicationRecord
   validates :monitor_id, presence: true, uniqueness: { scope: :creator_id }
   validates :status, presence: true
   validates :creator, presence: true
+  validates :misses, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   def expired?
     created_at && (Time.zone.now - created_at > DEFAULT_MAX_SESSION_DURATION)

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -159,6 +159,7 @@ module.exports = {
       },
     ],
     'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
+    'no-continue': 'off',
   },
   globals: {
     window: true,

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -310,9 +310,8 @@ const translations = defineMessages({
   secretHint: {
     id: 'course.assessment.AssessmentForm.secretHint',
     defaultMessage:
-      'If provided, Coursemology can automatically flag a connection as valid in <pulsegrid>PulseGrid</pulsegrid> if the ' +
-      "examinee's User Agent (UA) contains this secret. Otherwise, connections will be flagged only by heartbeat intervals. " +
-      'This string is case-sensitive.',
+      "If provided, the <pulsegrid>PulseGrid</pulsegrid> automatically checks if the examinee's browser's User Agent (UA) " +
+      'contains this secret, and marks connections that do not as invalid. This string is case-sensitive.',
   },
   minInterval: {
     id: 'course.assessment.AssessmentForm.minInterval',

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -342,14 +342,14 @@ const translations = defineMessages({
   },
   blocksAccessesFromInvalidSUS: {
     id: 'course.assessment.AssessmentForm.blocksAccessesFromInvalidSUS',
-    defaultMessage: 'Block accesses from browsers with invalid SUS',
+    defaultMessage: 'Block accesses from browsers with invalid UA',
   },
   blocksAccessesFromInvalidSUSHint: {
     id: 'course.assessment.AssessmentForm.blocksAccessesFromInvalidSUSHint',
     defaultMessage:
-      'If enabled, examinees using browsers with invalid SUS will be blocked from accessing this assessment. ' +
-      'Instructors can override access with the session unlock password. Heartbeats from an overridden browser ' +
-      'session will be flagged as valid in the PulseGrid.',
+      'If enabled, examinees using browsers with invalid UA (does not contain the specified SUS below) will be blocked ' +
+      'from accessing this assessment. Instructors can override access with the session unlock password. Heartbeats ' +
+      'from an overridden browser session will be flagged as valid in the PulseGrid.',
   },
   needSUSAndSessionUnlockPassword: {
     id: 'course.assessment.AssessmentForm.needSUSAndSessionUnlockPassword',

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
@@ -39,10 +39,10 @@ const PulseGrid = (props: PulseGridProps): JSX.Element => {
       setGroups(data.groups);
       setHasSecret(data.monitor.hasSecret);
       monitoring.initialize(data.monitor, data.snapshots);
-      monitoring.notifyConnectedAt(Date.now());
+      monitoring.notifyConnected();
     },
     disconnected: () => {
-      monitoring.notifyDisconnectedAt(Date.now());
+      monitoring.notifyDisconnected();
     },
     pulse: ({ userId, snapshot }) => {
       monitoring.refresh(userId, snapshot);

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
@@ -71,10 +71,7 @@ const PulseGrid = (props: PulseGridProps): JSX.Element => {
 
         <SessionBlobLegend hasSecret={hasSecret} />
 
-        <SessionsGrid
-          for={userIds}
-          onClickSession={channel.getRecentHeartbeats}
-        />
+        <SessionsGrid for={userIds} getHeartbeats={channel.getHeartbeats} />
       </aside>
 
       <aside className="flex w-[30rem] flex-col space-y-5">

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -88,10 +88,7 @@ const ListeningSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => {
 };
 
 const ExpiredSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => (
-  <BaseActiveSessionBlob
-    {...props}
-    className="border border-solid border-neutral-200 bg-neutral-100"
-  />
+  <BaseActiveSessionBlob {...props} className="bg-neutral-200" />
 );
 
 const StoppedSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => (

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -94,7 +94,7 @@ const ExpiredSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => (
 const StoppedSessionBlob = (props: ActiveSessionBlobProps): JSX.Element => (
   <BaseActiveSessionBlob
     {...props}
-    className="bg-neutral-200 flex items-center justify-center"
+    className="bg-sky-200 flex items-center justify-center"
   >
     <Remove color="disabled" fontSize="small" />
   </BaseActiveSessionBlob>

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -20,7 +20,7 @@ export const PRESENCE_COLORS: Record<Presence, string> = {
 export interface ActiveSessionBlobProps {
   of: Snapshot;
   for: number;
-  onClick?: (sessionId: number) => void;
+  getHeartbeats?: (sessionId: number, limit?: number) => void;
 }
 
 interface BaseActiveSessionBlobProps extends ActiveSessionBlobProps {
@@ -47,7 +47,7 @@ const BaseActiveSessionBlob = (
         of={snapshot}
         onClick={(e): void => {
           monitoring.select(userId);
-          props.onClick?.(snapshot.sessionId);
+          props.getHeartbeats?.(snapshot.sessionId);
           setPopupData([e.currentTarget, new Date().toISOString()]);
         }}
       >

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -1,5 +1,6 @@
 import { ElementType, ReactNode, useState } from 'react';
 import { Remove } from '@mui/icons-material';
+import { Badge } from '@mui/material';
 import { Snapshot } from 'types/channels/liveMonitoring';
 
 import { useAppSelector } from 'lib/hooks/store';
@@ -21,6 +22,7 @@ export const PRESENCE_COLORS: Record<Presence, string> = {
 export interface ActiveSessionBlobProps {
   of: Snapshot;
   for: number;
+  warns?: boolean;
   getHeartbeats?: (sessionId: number, limit?: number) => void;
 }
 
@@ -43,17 +45,24 @@ const BaseActiveSessionBlob = (
 
   return (
     <>
-      <SessionBlob
-        className={props.className}
-        of={snapshot}
-        onClick={(e): void => {
-          monitoring.select(userId);
-          props.getHeartbeats?.(snapshot.sessionId);
-          setPopupData([e.currentTarget, new Date().toISOString()]);
-        }}
+      <Badge
+        badgeContent={props.warns ? undefined : 0}
+        color="error"
+        overlap="circular"
+        variant="dot"
       >
-        {props.children}
-      </SessionBlob>
+        <SessionBlob
+          className={props.className}
+          of={snapshot}
+          onClick={(e): void => {
+            monitoring.select(userId);
+            props.getHeartbeats?.(snapshot.sessionId);
+            setPopupData([e.currentTarget, new Date().toISOString()]);
+          }}
+        >
+          {props.children}
+        </SessionBlob>
+      </Badge>
 
       <SessionDetailsPopup
         anchorsOn={popupData?.[0]}

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -59,6 +59,10 @@ const BaseActiveSessionBlob = (
         for={snapshot.userName ?? ''}
         generatedAt={popupData?.[1]}
         hasSecret={hasSecret}
+        onClickShowAllHeartbeats={(): void => {
+          props.getHeartbeats?.(snapshot.sessionId, -1);
+          setPopupData((data) => [data?.[0], new Date().toISOString()]);
+        }}
         onClose={(): void => {
           setPopupData((data) => [undefined, data?.[1]]);
           monitoring.deselect();

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -5,8 +5,9 @@ import { Snapshot } from 'types/channels/liveMonitoring';
 import { useAppSelector } from 'lib/hooks/store';
 
 import useMonitoring from '../hooks/useMonitoring';
-import usePresence, { Presence } from '../hooks/usePresence';
+import usePresence from '../hooks/usePresence';
 import { select } from '../selectors';
+import { Presence } from '../utils';
 
 import SessionBlob from './SessionBlob';
 import SessionDetailsPopup from './SessionDetailsPopup';

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
@@ -45,12 +45,14 @@ const HeartbeatDetailCard = (props: HeartbeatDetailCardProps): JSX.Element => {
               />
             </Tooltip>
           ) : (
-            <Chip
-              className="text-neutral-800 border-neutral-800"
-              label={t(translations.live)}
-              size="small"
-              variant="outlined"
-            />
+            <Tooltip title={t(translations.liveHint)}>
+              <Chip
+                className="text-neutral-800 border-neutral-800 cursor-pointer select-none"
+                label={t(translations.live)}
+                size="small"
+                variant="outlined"
+              />
+            </Tooltip>
           )}
         </span>
 

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
@@ -1,4 +1,4 @@
-import { Chip, Typography } from '@mui/material';
+import { Chip, Tooltip, Typography } from '@mui/material';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
 import useTranslation from 'lib/hooks/useTranslation';
@@ -36,12 +36,14 @@ const HeartbeatDetailCard = (props: HeartbeatDetailCardProps): JSX.Element => {
           </Typography>
 
           {heartbeat.stale ? (
-            <Chip
-              className="text-neutral-400 border-neutral-400"
-              label={t(translations.stale)}
-              size="small"
-              variant="outlined"
-            />
+            <Tooltip title={t(translations.staleHint)}>
+              <Chip
+                className="text-neutral-400 border-neutral-400 cursor-pointer select-none"
+                label={t(translations.stale)}
+                size="small"
+                variant="outlined"
+              />
+            </Tooltip>
           ) : (
             <Chip
               className="text-neutral-800 border-neutral-800"

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
@@ -12,6 +12,7 @@ interface HeartbeatDetailCardProps {
   of: HeartbeatDetail;
   hasSecret?: boolean;
   className?: string;
+  delta?: number;
 }
 
 const HeartbeatDetailCard = (props: HeartbeatDetailCardProps): JSX.Element => {
@@ -56,9 +57,15 @@ const HeartbeatDetailCard = (props: HeartbeatDetailCardProps): JSX.Element => {
           )}
         </span>
 
-        <Typography variant="caption">
-          {moment(heartbeat.generatedAt).fromNow()}
-        </Typography>
+        {props.delta !== undefined && (
+          <Typography variant="caption">
+            {props.delta > 0
+              ? t(translations.deltaFromPreviousHeartbeat, {
+                  ms: props.delta.toLocaleString(),
+                })
+              : t(translations.firstReceivedHeartbeat)}
+          </Typography>
+        )}
       </section>
 
       <section className="space-y-2">

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
@@ -1,19 +1,9 @@
-import { useMemo, useState } from 'react';
-import { Line } from 'react-chartjs-2';
-import { Color } from 'chart.js';
+import { useState } from 'react';
 import moment from 'moment';
-import palette from 'theme/palette';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
-import useTranslation from 'lib/hooks/useTranslation';
-
-import translations from '../../../translations';
-
 import HeartbeatDetailCard from './HeartbeatDetailCard';
-
-const VALID_HEARTBEAT_COLOR = palette.success.main;
-const INVALID_HEARTBEAT_COLOR = palette.error.main;
-const SELECTED_HEARTBEAT_BORDER_COLOR = 'rgb(59 130 246 / 0.5)';
+import HeartbeatsTimelineChart from './HeartbeatsTimelineChart';
 
 interface HeartbeatsTimelineProps {
   in: HeartbeatDetail[];
@@ -23,85 +13,19 @@ interface HeartbeatsTimelineProps {
 const HeartbeatsTimeline = (props: HeartbeatsTimelineProps): JSX.Element => {
   const { in: heartbeats } = props;
 
-  const { t } = useTranslation();
-
-  const [hoveredIndex, setHoveredIndex] = useState<number>(0);
-
-  const heartbeatsChartData = useMemo(
-    () =>
-      heartbeats.map((heartbeat) => ({
-        ...heartbeat,
-        generatedAt: moment(heartbeat.generatedAt).valueOf(),
-        stale: heartbeat.stale ? t(translations.stale) : t(translations.live),
-      })),
-    [heartbeats],
+  const [hoveredIndex, setHoveredIndex] = useState<number>(
+    Math.max(0, heartbeats.length - 1),
   );
 
   return (
     <>
-      <div className="h-[10rem]">
-        <Line
-          data={{
-            datasets: [
-              {
-                data: heartbeatsChartData,
-                pointBackgroundColor: (context): Color => {
-                  const heartbeat = context.raw as HeartbeatDetail;
+      <HeartbeatsTimelineChart
+        hoveredIndex={hoveredIndex}
+        in={heartbeats}
+        onHover={setHoveredIndex}
+      />
 
-                  return heartbeat.isValid
-                    ? VALID_HEARTBEAT_COLOR
-                    : INVALID_HEARTBEAT_COLOR;
-                },
-                pointRadius: 5,
-                pointHoverRadius: 5,
-                pointBorderWidth: 5,
-                pointHoverBorderWidth: 5,
-                pointBorderColor: (context): Color =>
-                  context.dataIndex === hoveredIndex
-                    ? SELECTED_HEARTBEAT_BORDER_COLOR
-                    : 'transparent',
-                fill: true,
-              },
-            ],
-          }}
-          options={{
-            parsing: {
-              yAxisKey: 'stale',
-              xAxisKey: 'generatedAt',
-            },
-            onHover: (event, elements): void => {
-              if (event.type !== 'mousemove' || !elements.length) return;
-
-              const element = elements[0];
-              setHoveredIndex(element.index);
-            },
-            scales: {
-              x: {
-                type: 'time',
-                time: {
-                  unit: 'second',
-                  stepSize: 10,
-                  displayFormats: {
-                    second: 'HH:mm:ss',
-                  },
-                },
-              },
-              y: {
-                type: 'category',
-                labels: [t(translations.live), t(translations.stale), ''],
-              },
-            },
-            plugins: {
-              legend: { display: false },
-              tooltip: { enabled: false },
-            },
-            maintainAspectRatio: false,
-            animation: false,
-          }}
-        />
-      </div>
-
-      {hoveredIndex !== undefined && (
+      {heartbeats[hoveredIndex] && (
         <HeartbeatDetailCard
           className="ring-2 ring-offset-0"
           hasSecret={props.hasSecret}

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
@@ -10,6 +10,27 @@ interface HeartbeatsTimelineProps {
   hasSecret?: boolean;
 }
 
+/**
+ * Returns the number of milliseconds between the heartbeat at the given index
+ * and the one before it.
+ *
+ * @param heartbeats The list of heartbeats, sorted in chronological order.
+ */
+const getHeartbeatDelta = (
+  heartbeats: HeartbeatDetail[],
+  index: number,
+): number | undefined => {
+  if (index === 0) return 0;
+
+  const heartbeat = heartbeats[index];
+  const previousHeartbeat = heartbeats[index - 1];
+  if (!heartbeat || !previousHeartbeat) return undefined;
+
+  return moment(heartbeats[index]?.generatedAt).diff(
+    heartbeats[index - 1]?.generatedAt,
+  );
+};
+
 const HeartbeatsTimeline = (props: HeartbeatsTimelineProps): JSX.Element => {
   const { in: heartbeats } = props;
 
@@ -28,6 +49,7 @@ const HeartbeatsTimeline = (props: HeartbeatsTimelineProps): JSX.Element => {
       {heartbeats[hoveredIndex] && (
         <HeartbeatDetailCard
           className="ring-2 ring-offset-0"
+          delta={getHeartbeatDelta(heartbeats, hoveredIndex)}
           hasSecret={props.hasSecret}
           of={heartbeats[hoveredIndex]}
         />

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimelineChart.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimelineChart.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { Line } from 'react-chartjs-2';
+import { PinchOutlined } from '@mui/icons-material';
+import { Button, Typography } from '@mui/material';
 import {
   Chart as ChartJS,
   ChartData,
@@ -7,6 +9,7 @@ import {
   Color,
   PointStyle,
 } from 'chart.js';
+import zoomPlugin from 'chartjs-plugin-zoom';
 import moment from 'moment';
 import palette from 'theme/palette';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
@@ -26,6 +29,8 @@ const SELECTED_HEARTBEAT_BORDER_COLOR = 'rgba(59, 130, 246, 0.5)';
 const ALIVE_PERIOD_COLOR = 'rgba(69, 184, 128, 0.2)';
 const LATE_PERIOD_COLOR = palette.warning.main;
 const MISSING_PERIOD_COLOR = palette.error.main;
+
+ChartJS.register(zoomPlugin);
 
 interface HeartbeatsTimelineChartProps {
   in: HeartbeatDetail[];
@@ -157,6 +162,19 @@ const HeartbeatsTimelineChart = (
       plugins: {
         legend: { display: false },
         tooltip: { displayColors: false, callbacks: { label: () => '' } },
+        zoom: {
+          pan: {
+            enabled: true,
+            mode: 'x',
+            scaleMode: 'x',
+          },
+          zoom: {
+            wheel: { enabled: true },
+            pinch: { enabled: true },
+            mode: 'x',
+            scaleMode: 'x',
+          },
+        },
       },
       animation: false,
       maintainAspectRatio: false,
@@ -171,6 +189,20 @@ const HeartbeatsTimelineChart = (
     <div className="flex flex-col space-y-2 h-full overflow-hidden">
       <div className="w-full min-h-[15rem] h-full relative">
         <Line ref={ref} data={data} options={options} />
+      </div>
+
+      <div className="flex justify-between">
+        <div className="flex space-x-2 items-center text-neutral-400">
+          <PinchOutlined fontSize="small" />
+
+          <Typography className="mt-0.5" color="inherit" variant="caption">
+            {t(translations.zoomPanHint)}
+          </Typography>
+        </div>
+
+        <Button onClick={(): void => ref.current?.resetZoom()} size="small">
+          {t(translations.resetZoom)}
+        </Button>
       </div>
     </div>
   );

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimelineChart.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimelineChart.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useRef } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  ChartData,
+  ChartOptions,
+  Color,
+  PointStyle,
+} from 'chart.js';
+import moment from 'moment';
+import palette from 'theme/palette';
+import { HeartbeatDetail } from 'types/channels/liveMonitoring';
+
+import { useAppSelector } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from '../../../translations';
+import { select } from '../selectors';
+import { ChartPoint, getPresenceBuckets } from '../utils';
+
+const VALID_HEARTBEAT_COLOR = palette.success.main;
+const INVALID_HEARTBEAT_COLOR = palette.error.main;
+const VALID_STALE_HEARTBEAT_COLOR = 'rgba(69, 184, 128, 0.3)';
+const INVALID_STALE_HEARTBEAT_COLOR = 'rgba(255, 82, 99, 0.3)';
+const SELECTED_HEARTBEAT_BORDER_COLOR = 'rgba(59, 130, 246, 0.5)';
+const ALIVE_PERIOD_COLOR = 'rgba(69, 184, 128, 0.2)';
+const LATE_PERIOD_COLOR = palette.warning.main;
+const MISSING_PERIOD_COLOR = palette.error.main;
+
+interface HeartbeatsTimelineChartProps {
+  in: HeartbeatDetail[];
+  onHover?: (index: number) => void;
+  hoveredIndex?: number;
+}
+
+const HeartbeatsTimelineChart = (
+  props: HeartbeatsTimelineChartProps,
+): JSX.Element => {
+  const { in: heartbeats } = props;
+
+  const { t } = useTranslation();
+
+  const { maxIntervalMs, offsetMs } = useAppSelector(select('monitor'));
+
+  const heartbeatsChartPoints = useMemo(
+    () =>
+      heartbeats.map((heartbeat) => ({
+        timestamp: moment(heartbeat.generatedAt).valueOf(),
+        liveness: 1,
+      })),
+    [heartbeats],
+  );
+
+  const [alives, lates, missings] = useMemo(
+    () =>
+      getPresenceBuckets(
+        heartbeatsChartPoints.filter((_, index) => !heartbeats[index].stale),
+        maxIntervalMs,
+        offsetMs,
+      ),
+    [heartbeats, maxIntervalMs, offsetMs],
+  );
+
+  const data: ChartData<'line', ChartPoint[]> = {
+    datasets: [
+      {
+        data: heartbeatsChartPoints,
+        pointBorderColor: (context): Color => {
+          if (context.dataIndex === props.hoveredIndex)
+            return SELECTED_HEARTBEAT_BORDER_COLOR;
+
+          const heartbeat = heartbeats[context.dataIndex];
+          if (!heartbeat) return 'transparent';
+
+          if (heartbeat.isValid && heartbeat.stale)
+            return VALID_STALE_HEARTBEAT_COLOR;
+
+          if (!heartbeat.isValid && heartbeat.stale)
+            return INVALID_STALE_HEARTBEAT_COLOR;
+
+          if (heartbeat.isValid && !heartbeat.stale)
+            return VALID_HEARTBEAT_COLOR;
+
+          return INVALID_HEARTBEAT_COLOR;
+        },
+        pointRadius: 5,
+        pointHoverRadius: 5,
+        pointBorderWidth: 2,
+        pointHoverBorderWidth: 3,
+        pointStyle: (context): PointStyle => {
+          const heartbeat = heartbeats[context.dataIndex];
+          return heartbeat?.isValid ? 'circle' : 'crossRot';
+        },
+      },
+      {
+        data: alives,
+        fill: true,
+        backgroundColor: ALIVE_PERIOD_COLOR,
+        pointRadius: 0,
+        pointHoverRadius: 0,
+        hoverBackgroundColor: VALID_HEARTBEAT_COLOR,
+      },
+      {
+        data: lates,
+        fill: true,
+        backgroundColor: LATE_PERIOD_COLOR,
+        pointRadius: 2,
+        pointHoverRadius: 5,
+      },
+      {
+        data: missings,
+        fill: true,
+        backgroundColor: MISSING_PERIOD_COLOR,
+        pointRadius: 2,
+        pointHoverRadius: 5,
+      },
+    ],
+  };
+
+  /**
+   * `options` is memoized to prevent the zoom and pan states from resetting on every render.
+   * Generally, there's no reason why `options` will need to dynamically change.
+   * @see https://github.com/chartjs/chartjs-plugin-zoom/discussions/589
+   */
+  const options: ChartOptions<'line'> = useMemo(
+    () => ({
+      parsing: {
+        xAxisKey: 'timestamp',
+        yAxisKey: 'liveness',
+      },
+      onHover: (event, elements): void => {
+        if (event.type !== 'mousemove' || !elements.length) return;
+
+        const element = elements[0];
+        if (element.datasetIndex !== 0) return;
+
+        props.onHover?.(element.index);
+      },
+      scales: {
+        x: {
+          type: 'time',
+          time: {
+            minUnit: 'second',
+            stepSize: 10,
+            displayFormats: { second: 'HH:mm:ss' },
+          },
+          ticks: { major: { enabled: true } },
+        },
+        y: {
+          type: 'linear',
+          min: 0,
+          max: 1.2,
+          title: { display: true, text: t(translations.liveness) },
+          ticks: { display: false },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: { displayColors: false, callbacks: { label: () => '' } },
+      },
+      animation: false,
+      maintainAspectRatio: false,
+      responsive: true,
+    }),
+    [],
+  );
+
+  const ref = useRef<ChartJS<'line', ChartPoint[]>>(null);
+
+  return (
+    <div className="flex flex-col space-y-2 h-full overflow-hidden">
+      <div className="w-full min-h-[15rem] h-full relative">
+        <Line ref={ref} data={data} options={options} />
+      </div>
+    </div>
+  );
+};
+
+export default HeartbeatsTimelineChart;

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/Session.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/Session.tsx
@@ -28,6 +28,7 @@ const Session = (props: SessionProps): JSX.Element => {
       for={userId}
       getHeartbeats={props.getHeartbeats}
       of={snapshot}
+      warns={snapshot.misses > 0}
     />
   );
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/Session.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/Session.tsx
@@ -7,7 +7,7 @@ import SessionBlob from './SessionBlob';
 
 interface SessionProps {
   for: number;
-  onClick?: (sessionId: number) => void;
+  getHeartbeats?: (sessionId: number, limit?: number) => void;
 }
 
 const Session = (props: SessionProps): JSX.Element => {
@@ -24,7 +24,11 @@ const Session = (props: SessionProps): JSX.Element => {
     );
 
   return (
-    <ActiveSessionBlob for={userId} of={snapshot} onClick={props.onClick} />
+    <ActiveSessionBlob
+      for={userId}
+      getHeartbeats={props.getHeartbeats}
+      of={snapshot}
+    />
   );
 };
 

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
@@ -29,7 +29,7 @@ const SessionBlobLegend = (props: SessionBlobLegendProps): JSX.Element => {
           </div>
 
           <div className="flex space-x-2">
-            <SessionBlob className="border border-solid border-neutral-200 bg-neutral-100" />
+            <SessionBlob className="bg-neutral-200" />
 
             <Typography className="mt-1" variant="body2">
               {t(translations.expiredSession)}

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
@@ -37,7 +37,7 @@ const SessionBlobLegend = (props: SessionBlobLegendProps): JSX.Element => {
           </div>
 
           <div className="flex space-x-2">
-            <SessionBlob className="bg-neutral-200 flex items-center justify-center">
+            <SessionBlob className="bg-sky-200 flex items-center justify-center">
               <Remove color="disabled" fontSize="small" />
             </SessionBlob>
 

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
@@ -38,7 +38,7 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
         anchorEl={anchorElement}
         classes={{
           paper:
-            'px-4 pb-4 @container w-[36rem] shadow-xl border border-solid border-neutral-200 space-y-4 resize',
+            'flex flex-col px-4 pb-4 @container w-[36rem] shadow-xl border border-solid border-neutral-200 space-y-4 resize',
         }}
         elevation={0}
         onClose={props.onClose}

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
@@ -3,6 +3,7 @@ import { Close } from '@mui/icons-material';
 import { IconButton, Popover, Typography } from '@mui/material';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
+import Link from 'lib/components/core/Link';
 import useTranslation from 'lib/hooks/useTranslation';
 import { formatPreciseDateTime } from 'lib/moment';
 
@@ -18,6 +19,7 @@ interface SessionDetailsPopupProps {
   generatedAt?: string;
   anchorsOn?: HTMLElement;
   hasSecret?: boolean;
+  onClickShowAllHeartbeats?: () => void;
 }
 
 const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
@@ -43,7 +45,7 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
         open={props.open}
         transformOrigin={{ vertical: 'center', horizontal: 'center' }}
       >
-        <header className="handle sticky top-0 -mx-4 mb-4 cursor-move border-0 border-b border-solid border-neutral-200 bg-white p-4">
+        <header className="handle sticky top-0 -mx-4 mb-4 cursor-move border-only-b-neutral-200 bg-white p-4">
           <IconButton
             className="float-right ml-5"
             edge="end"
@@ -62,15 +64,17 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
           </Typography>
         </header>
 
-        <Typography
-          className="!-mb-1 !mt-7 ml-2"
-          color="text.secondary"
-          variant="body2"
-        >
-          {t(translations.detailsOfNHeartbeats, {
-            n: heartbeats.length,
-          })}
-        </Typography>
+        <div className="flex justify-between items-center px-2">
+          <Typography color="text.secondary" variant="body2">
+            {t(translations.detailsOfNHeartbeats, {
+              n: heartbeats.length,
+            })}
+          </Typography>
+
+          <Link onClick={props.onClickShowAllHeartbeats}>
+            {t(translations.loadAllHeartbeats)}
+          </Link>
+        </div>
 
         <HeartbeatsTimeline hasSecret={props.hasSecret} in={heartbeats} />
       </Popover>

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionsGrid.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionsGrid.tsx
@@ -5,16 +5,16 @@ import Session from './Session';
 
 interface SessionsGridProps {
   for?: number[];
-  onClickSession?: (sessionId: number) => void;
+  getHeartbeats?: (sessionId: number, limit?: number) => void;
 }
 
 const SessionsGrid = (props: SessionsGridProps): JSX.Element => {
-  const { for: userIds, onClickSession } = props;
+  const { for: userIds, getHeartbeats } = props;
 
   return (
     <section className="-m-1 flex h-fit w-full flex-wrap">
       {userIds?.map((userId) => (
-        <Session key={userId} for={userId} onClick={onClickSession} />
+        <Session key={userId} for={userId} getHeartbeats={getHeartbeats} />
       ))}
     </section>
   );

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/liveMonitoringChannel.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/liveMonitoringChannel.ts
@@ -9,7 +9,7 @@ const LIVE_MONITORING_CHANNEL_NAME =
   'Course::Monitoring::LiveMonitoringChannel' as const;
 
 export interface LiveMonitoringChannel {
-  getRecentHeartbeats: (sessionId: number) => void;
+  getHeartbeats: (sessionId: number, limit?: number) => void;
   unsubscribe: () => void;
 }
 
@@ -53,8 +53,8 @@ const subscribe = (
   );
 
   return {
-    getRecentHeartbeats: (sessionId) =>
-      channel.perform('view', { session_id: sessionId }),
+    getHeartbeats: (sessionId, limit?) =>
+      channel.perform('view', { session_id: sessionId, limit }),
 
     unsubscribe: (): void => {
       channel.unsubscribe();

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/useLiveMonitoringChannel.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/useLiveMonitoringChannel.ts
@@ -33,11 +33,11 @@ const useLiveMonitoringChannel = (
     };
   }, [courseId, monitorId]);
 
-  const getRecentHeartbeats = useCallback((sessionId: number): void => {
-    channelRef.current?.getRecentHeartbeats(sessionId);
-  }, []);
-
-  return { getRecentHeartbeats };
+  return {
+    getHeartbeats: useCallback((sessionId, limit?) => {
+      channelRef.current?.getHeartbeats(sessionId, limit);
+    }, []),
+  };
 };
 
 export default useLiveMonitoringChannel;

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/useMonitoring.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/useMonitoring.ts
@@ -13,8 +13,8 @@ import translations from '../../../translations';
 
 interface UseMonitoringHook {
   initialize: (monitor: MonitoringMonitorData, snapshots: Snapshots) => void;
-  notifyConnectedAt: (timestamp: number) => void;
-  notifyDisconnectedAt: (timestamp: number) => void;
+  notifyConnected: () => void;
+  notifyDisconnected: () => void;
   notifyMissingAt: (timestamp: number, userId: number, name: string) => void;
   notifyAliveAt: (timestamp: number, userId: number, name: string) => void;
   refresh: (userId: number, data: Partial<Snapshot>) => void;
@@ -51,27 +51,11 @@ const useMonitoring = (): UseMonitoringHook => {
     filter: (userIds): void => {
       dispatch(actions.filter(userIds));
     },
-    notifyConnectedAt: (timestamp): void => {
+    notifyConnected: (): void => {
       dispatch(actions.setConnected(true));
-
-      dispatch(
-        actions.pushHistory({
-          message: t(translations.connectedToLiveMonitoringChannel),
-          type: 'info',
-          timestamp,
-        }),
-      );
     },
-    notifyDisconnectedAt: (timestamp): void => {
+    notifyDisconnected: (): void => {
       dispatch(actions.setConnected(false));
-
-      dispatch(
-        actions.pushHistory({
-          message: t(translations.disconnectedFromLiveMonitoringChannel),
-          type: 'info',
-          timestamp,
-        }),
-      );
     },
     notifyMissingAt: (timestamp, userId, name): void => {
       dispatch(

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/utils.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/utils.ts
@@ -1,0 +1,140 @@
+import moment from 'moment';
+
+export type Presence = 'alive' | 'late' | 'missing';
+
+/**
+ * Returns the `Presence` value between two timestamps. If `endTime` is omitted, it
+ * returns the `Presence` value between `startTime` and now.
+ */
+export const getPresenceBetween = (
+  maxIntervalMs: number,
+  offsetMs: number,
+  startTime: string | number,
+  endTime?: string | number,
+): Presence => {
+  const start = moment(startTime);
+  const end = endTime ? moment(endTime) : moment();
+
+  if (!start.isValid()) throw new Error(`Encountered time value: ${startTime}`);
+  if (!end.isValid()) throw new Error(`Encountered time value: ${endTime}`);
+
+  const differenceMs = end.diff(start, 'milliseconds');
+
+  if (differenceMs <= maxIntervalMs) return 'alive';
+  if (differenceMs <= maxIntervalMs + offsetMs) return 'late';
+
+  return 'missing';
+};
+
+export interface ChartPoint {
+  timestamp: number | null;
+
+  /**
+   * A number from 0 to 1 that denotes how late a heartbeat is. Alive heartbeats
+   * always have a liveness of 1. Missing heartbeats have a liveness of 0. The late
+   * heartbeats' liveness is the ratio of the duration since last `maxIntervalMs` to
+   * `offsetMs`. See `getPresenceBuckets` for more details.
+   */
+  liveness: number | null;
+}
+
+export type NonNullableChartPoint = {
+  [Property in keyof ChartPoint]: NonNullable<ChartPoint[Property]>;
+};
+
+type ChartPointWithPresence = ChartPoint & { presence: Presence };
+
+const nullPoint: ChartPoint = { timestamp: null, liveness: null };
+
+const getBuckets = (points: ChartPointWithPresence[]): ChartPoint[][] => {
+  const buckets: Record<Presence, ChartPoint[]> = {
+    alive: [],
+    late: [],
+    missing: [],
+  };
+
+  points.forEach((point) => {
+    buckets[point.presence].push({
+      timestamp: point.timestamp,
+      liveness: point.liveness,
+    });
+
+    (['alive', 'late', 'missing'] satisfies Presence[]).forEach((key) => {
+      if (key === point.presence) return;
+
+      buckets[key].push(nullPoint);
+    });
+  });
+
+  return [buckets.alive, buckets.late, buckets.missing];
+};
+
+/**
+ * Returns a function that creates and pushes a `ChartPoint` to the given `points`.
+ * If `presence` is different from the `presence` of the last `ChartPoint`, it adds
+ * another `ChartPoint` with the same `timestamp` but previous `presence` to
+ * close the range of the previous `presence`, i.e., "terminating" it.
+ */
+const getTerminatingPusherFor =
+  (points: ChartPointWithPresence[]) =>
+  (presence: Presence, timestamp: number, liveness: number): void => {
+    const lastPoint = points.at(-1);
+
+    if (lastPoint && lastPoint.presence !== presence)
+      points.push({
+        presence,
+        timestamp: lastPoint.timestamp,
+        liveness: presence === 'missing' ? 0 : 1,
+      });
+
+    points.push({ presence, timestamp, liveness });
+  };
+
+/**
+ * Returns points that show the time periods of all `Presence` values from the
+ * given `heartbeats`. Points are returned as `ChartPoint`s and are bucketed into
+ * arrays for each `Presence` value.
+ *
+ * @param heartbeats The list of heartbeat points, sorted in chronological order.
+ * @returns A triplet of `ChartPoint[]` for alive, late, and missing time periods.
+ */
+export const getPresenceBuckets = (
+  heartbeats: NonNullableChartPoint[],
+  maxIntervalMs: number,
+  offsetMs: number,
+): ChartPoint[][] => {
+  if (heartbeats.length === 0) return [[], [], []];
+
+  const points: ChartPointWithPresence[] = [];
+  const push = getTerminatingPusherFor(points);
+
+  push('alive', heartbeats[0].timestamp, 1);
+
+  for (let i = 1; i < heartbeats.length; i++) {
+    const { timestamp: last } = heartbeats[i - 1];
+    const { timestamp: current } = heartbeats[i];
+
+    const presence = getPresenceBetween(maxIntervalMs, offsetMs, last, current);
+
+    if (presence === 'missing' || presence === 'late') {
+      const lateTime = moment(last).add(maxIntervalMs);
+      push('alive', lateTime.valueOf(), 1);
+    }
+
+    if (presence === 'missing') {
+      const missingTime = moment(last).add(maxIntervalMs + offsetMs);
+      push('late', missingTime.valueOf(), 0);
+    }
+
+    let liveness = presence === 'alive' ? 1 : 0;
+
+    if (presence === 'late') {
+      const lateDurationMs = moment(current).diff(last) - maxIntervalMs;
+      liveness = 1 - lateDurationMs / offsetMs;
+    }
+
+    push(presence, current, liveness);
+  }
+
+  return getBuckets(points);
+};

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -904,6 +904,10 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.live',
     defaultMessage: 'Live',
   },
+  liveHint: {
+    id: 'course.assessment.monitoring.liveHint',
+    defaultMessage: 'This heartbeat was immediately received by the server.',
+  },
   ipAddress: {
     id: 'course.assessment.monitoring.ipAddress',
     defaultMessage: 'IP Address',
@@ -970,11 +974,11 @@ const translations = defineMessages({
   },
   validHeartbeat: {
     id: 'course.assessment.monitoring.validHeartbeat',
-    defaultMessage: 'Contains SUS',
+    defaultMessage: 'Valid UA',
   },
   invalidHeartbeat: {
     id: 'course.assessment.monitoring.invalidHeartbeat',
-    defaultMessage: 'Does not contain SUS',
+    defaultMessage: 'Invalid UA',
   },
   invalidBrowser: {
     id: 'course.assessment.monitoring.invalidBrowser',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -894,6 +894,12 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.stale',
     defaultMessage: 'Stale',
   },
+  staleHint: {
+    id: 'course.assessment.monitoring.staleHint',
+    defaultMessage:
+      "This heartbeat wasn't immediately received by the server because the examinee's browser was temporarily " +
+      'unreachable. It was cached in the browser, and sent to the server when the browser was reachable again.',
+  },
   live: {
     id: 'course.assessment.monitoring.live',
     defaultMessage: 'Live',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -916,14 +916,6 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.detailsOfNHeartbeats',
     defaultMessage: 'Last {n} heartbeats',
   },
-  connectedToLiveMonitoringChannel: {
-    id: 'course.assessment.monitoring.connectedToLiveMonitoringChannel',
-    defaultMessage: 'Connected to the live monitoring channel',
-  },
-  disconnectedFromLiveMonitoringChannel: {
-    id: 'course.assessment.monitoring.disconnectedFromLiveMonitoringChannel',
-    defaultMessage: 'Disconnected from the live monitoring channel',
-  },
   userHeartbeatNotReceivedInTime: {
     id: 'course.assessment.monitoring.userHeartbeatNotReceivedInTime',
     defaultMessage: "{name}'s heartbeat wasn't received in time.",

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -916,6 +916,10 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.detailsOfNHeartbeats',
     defaultMessage: 'Last {n} heartbeats',
   },
+  liveness: {
+    id: 'course.assessment.monitoring.liveness',
+    defaultMessage: 'Liveness',
+  },
   loadAllHeartbeats: {
     id: 'course.assessment.monitoring.loadAllHeartbeats',
     defaultMessage: 'Load all',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -916,6 +916,10 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.detailsOfNHeartbeats',
     defaultMessage: 'Last {n} heartbeats',
   },
+  loadAllHeartbeats: {
+    id: 'course.assessment.monitoring.loadAllHeartbeats',
+    defaultMessage: 'Load all',
+  },
   userHeartbeatNotReceivedInTime: {
     id: 'course.assessment.monitoring.userHeartbeatNotReceivedInTime',
     defaultMessage: "{name}'s heartbeat wasn't received in time.",

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -916,6 +916,14 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.detailsOfNHeartbeats',
     defaultMessage: 'Last {n} heartbeats',
   },
+  deltaFromPreviousHeartbeat: {
+    id: 'course.assessment.monitoring.deltaFromPreviousHeartbeat',
+    defaultMessage: '{ms} ms from previous heartbeat',
+  },
+  firstReceivedHeartbeat: {
+    id: 'course.assessment.monitoring.firstReceivedHeartbeat',
+    defaultMessage: 'First received heartbeat',
+  },
   liveness: {
     id: 'course.assessment.monitoring.liveness',
     defaultMessage: 'Liveness',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -920,6 +920,14 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.liveness',
     defaultMessage: 'Liveness',
   },
+  resetZoom: {
+    id: 'course.assessment.monitoring.resetZoom',
+    defaultMessage: 'Reset zoom',
+  },
+  zoomPanHint: {
+    id: 'course.assessment.monitoring.zoomPanHint',
+    defaultMessage: 'Pinch or scroll to zoom. Drag to pan.',
+  },
   loadAllHeartbeats: {
     id: 'course.assessment.monitoring.loadAllHeartbeats',
     defaultMessage: 'Load all',

--- a/client/app/types/channels/liveMonitoring.ts
+++ b/client/app/types/channels/liveMonitoring.ts
@@ -15,6 +15,7 @@ export interface HeartbeatDetail {
 export interface SnapshotData {
   sessionId: number;
   status: 'expired' | 'listening' | 'stopped';
+  misses: number;
   lastHeartbeatAt: string;
   isValid: boolean;
   userName?: string;

--- a/client/app/workers/withHeartbeatWorker.tsx
+++ b/client/app/workers/withHeartbeatWorker.tsx
@@ -43,7 +43,6 @@ const withHeartbeatWorker = <P extends WrappedComponentProps>(
       window.addEventListener('beforeunload', terminateWorker);
 
       return () => {
-        terminateWorker();
         window.removeEventListener('beforeunload', terminateWorker);
       };
     }, [sessionId]);

--- a/db/migrate/20231026165911_add_misses_to_monitoring.rb
+++ b/db/migrate/20231026165911_add_misses_to_monitoring.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddMissesToMonitoring < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_monitoring_sessions, :misses, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_17_055234) do
+ActiveRecord::Schema.define(version: 2023_10_26_165911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -866,6 +866,7 @@ ActiveRecord::Schema.define(version: 2023_10_17_055234) do
     t.bigint "creator_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "misses", default: 0, null: false
     t.index ["creator_id"], name: "fk__course_monitoring_sessions_creator_id"
     t.index ["monitor_id"], name: "index_course_monitoring_sessions_on_monitor_id"
   end

--- a/spec/factories/course_monitoring_heartbeats.rb
+++ b/spec/factories/course_monitoring_heartbeats.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     stale { false }
 
     trait :stale do
-      is_stale { true }
+      stale { true }
     end
   end
 end

--- a/spec/models/course/monitoring/heartbeat_spec.rb
+++ b/spec/models/course/monitoring/heartbeat_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Course::Monitoring::Heartbeat, type: :model do
   let!(:instance) { Instance.default }
   with_tenant(:instance) do
     let(:heartbeat) { create(:course_monitoring_heartbeat) }
+    let(:session) { heartbeat.session }
+    let(:monitor) { session.monitor }
 
     it { should belong_to(:session).inverse_of(:heartbeats).without_validating_presence }
     it { should validate_presence_of(:session) }
@@ -19,6 +21,71 @@ RSpec.describe Course::Monitoring::Heartbeat, type: :model do
           subject.assign_attributes(ip_address: 'invalid')
           expect(subject).not_to be_valid
           expect(subject.errors[:ip_address]).to be_present
+        end
+      end
+    end
+
+    describe '#update_session_misses' do
+      let(:generated_time) { heartbeat.generated_at + (delta / 1000).seconds }
+
+      subject { build(:course_monitoring_heartbeat, session: session, generated_at: generated_time) }
+
+      context 'when a heartbeat is overly late' do
+        let(:delta) { monitor.max_interval_ms + monitor.offset_ms + 2.seconds.in_milliseconds }
+
+        context 'when its save succeeds' do
+          it 'increases the session misses by 1' do
+            expect { subject.save }.
+              to change { heartbeat.session.heartbeats.count }.by(1).
+              and change { heartbeat.session.misses }.by(1)
+          end
+        end
+
+        context 'when its save fails' do
+          before { allow(subject).to receive(:valid?).and_return(false) }
+
+          it 'does not change the session misses' do
+            expect { subject.save }.
+              to change { heartbeat.session.heartbeats.count }.by(0).
+              and change { heartbeat.session.misses }.by(0)
+          end
+        end
+      end
+
+      context 'when a late heartbeat is saved' do
+        let(:delta) { monitor.max_interval_ms + (monitor.offset_ms / 2) }
+
+        it 'does not change the session misses' do
+          expect { subject.save }.
+            to change { heartbeat.session.heartbeats.count }.by(1).
+            and change { heartbeat.session.misses }.by(0)
+        end
+      end
+
+      context 'when a timely heartbeat is saved' do
+        let(:delta) { monitor.max_interval_ms / 2 }
+
+        it 'does not change the session misses' do
+          expect { subject.save }.
+            to change { heartbeat.session.heartbeats.count }.by(1).
+            and change { heartbeat.session.misses }.by(0)
+        end
+      end
+
+      context 'when the last heartbeat is timely but stale' do
+        let!(:stale_heartbeat) do
+          five_seconds_after = heartbeat.generated_at + ((monitor.max_interval_ms - 1000) / 1000).seconds
+          create(:course_monitoring_heartbeat, :stale, session: session, generated_at: five_seconds_after)
+        end
+
+        let(:delta) { monitor.max_interval_ms + monitor.offset_ms + 2.seconds.in_milliseconds }
+
+        # `heartbeat` <--5 seconds--> `stale_heartbeat` <--5 seconds--> `subject`
+        # max_interval_ms: 6 seconds, offset_ms: 2 seconds
+        it 'increases the session misses by 1' do
+          expect { subject.save }.
+            to change { heartbeat.session.heartbeats.count }.by(1).
+            and change { heartbeat.session.misses }.by(1)
         end
       end
     end


### PR DESCRIPTION
This PR introduces a new coloured liveness chart that shows the punctuality of an examinee's session. It essentially shows a trend of the colour (presence) changes in the PulseGrid for a given session. The green colour for alive presence is used at an opacity of 20% to highlight the late presence periods.

>[!NOTE]
Liveness is a value between 0 and 1 that measures the punctuality of a session at a given timestamp (x-axis). Alive presence will replenish the liveness to 1. Late presence will result in a liveness of ratio of the duration since last `maxIntervalMs` to `offsetMs`. Missing presence will not replenish the liveness, i.e., remains at 0. Note that liveness is only calculated with live heartbeats. See `getPresenceBuckets` in `AssessmentMonitoring/utils.ts` for more details.

To prevent confusion between red/green/yellow as presence values and red/green as UA validity, green O and red X are used to indicate UA validity of a heartbeat. Stale heartbeats will be slightly translucent at an opacity of 30%.

The chart also now supports zooming and panning.

<img width="704" alt="image" src="https://github.com/Coursemology/coursemology2/assets/51525686/03054076-bbad-4069-a25b-8786728dbe70">

## Other notable changes
- The chart now resizes with the `SessionDetailsPopup`.
- The relative time of a heartbeat in `HeartbeatDetailsCard` is now replaced with the number of milliseconds delta from the previous heartbeat.
- "Contains SUS" and "Does not contain SUS" are now replaced with "Valid UA" and "Invalid UA".
- `SessionDetailsPopup` can now load all heartbeats for a session.
- A `Session` that ~~just changed to alive from missing~~ has at least one missing periods will now display a small circular badge ~~that disappears after clicking~~.
- Stopped but not expired `Session`s are now blue in colour.
- Add tooltip explanations for Live and Stale chips in `HeartbeatDetailsCard`.
- Remove the annoying connected/disconnected notifications in the recent activities panel.
- The heartbeat worker now stays alive even if the student navigates away from the submission page.