### PR TITLE
Fix line breaks in test case outputs in Programming Question answers

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/components/common/StaticTestCase.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/common/StaticTestCase.tsx
@@ -1,7 +1,7 @@
 import { useWatch } from 'react-hook-form';
 import { Typography } from '@mui/material';
 
-import Expandable from '../../../../../../../lib/components/core/Expandable';
+import ExpandableCode from 'lib/components/core/ExpandableCode';
 
 import { TestCaseProps } from './TestCase';
 import TestCaseCell from './TestCaseCell';
@@ -13,25 +13,11 @@ const StaticTestCase = (props: TestCaseProps): JSX.Element => {
   return (
     <TestCaseRow header={props.id}>
       <TestCaseCell.Expression className="w-1/3">
-        <Expandable over={40}>
-          <Typography
-            className="h-full break-all font-mono text-[1.3rem]"
-            variant="body2"
-          >
-            {testCase.expression}
-          </Typography>
-        </Expandable>
+        <ExpandableCode>{testCase.expression}</ExpandableCode>
       </TestCaseCell.Expression>
 
       <TestCaseCell.Expected className="w-1/3">
-        <Expandable over={40}>
-          <Typography
-            className="h-full break-all font-mono text-[1.3rem]"
-            variant="body2"
-          >
-            {testCase.expected}
-          </Typography>
-        </Expandable>
+        <ExpandableCode>{testCase.expected}</ExpandableCode>
       </TestCaseCell.Expected>
 
       <TestCaseCell.Hint className="w-1/3">

--- a/client/app/bundles/course/assessment/question/programming/components/package/PackageEditor.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/package/PackageEditor.tsx
@@ -3,10 +3,10 @@ import { useFormContext } from 'react-hook-form';
 import { Typography } from '@mui/material';
 import { ProgrammingFormData } from 'types/course/assessment/question/programming';
 
+import Hint from 'lib/components/core/Hint';
 import Section from 'lib/components/core/layouts/Section';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import Hint from '../../../../../../../lib/components/core/Hint';
 import translations from '../../../../translations';
 
 export const CODE_INSERTS_ID = 'code-inserts';

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -16,7 +16,7 @@ import {
 import { green, red } from '@mui/material/colors';
 import PropTypes from 'prop-types';
 
-import Expandable from 'lib/components/core/Expandable';
+import ExpandableCode from 'lib/components/core/ExpandableCode';
 import Accordion from 'lib/components/core/layouts/Accordion';
 
 import { workflowStates } from '../../constants';
@@ -160,28 +160,16 @@ export class VisibleTestCaseView extends Component {
 
         <TableRow style={styles.testCaseRow[testCaseResult]}>
           <TableCell className="w-full pt-1">
-            <Expandable over={40}>
-              <Typography className="h-full break-all font-mono text-[1.3rem]">
-                {testCase.expression}
-              </Typography>
-            </Expandable>
+            <ExpandableCode>{testCase.expression}</ExpandableCode>
           </TableCell>
 
           <TableCell className="w-full pt-1">
-            <Expandable over={40}>
-              <Typography className="h-full break-all font-mono text-[1.3rem]">
-                {testCase.expected || ''}
-              </Typography>
-            </Expandable>
+            <ExpandableCode>{testCase.expected || ''}</ExpandableCode>
           </TableCell>
 
           {(canReadTests || showPublicTestCasesOutput) && (
             <TableCell className="w-full pt-1">
-              <Expandable over={40}>
-                <Typography className="h-full break-all font-mono text-[1.3rem]">
-                  {testCase.output || ''}
-                </Typography>
-              </Expandable>
+              <ExpandableCode>{testCase.output || ''}</ExpandableCode>
             </TableCell>
           )}
 

--- a/client/app/lib/components/core/ExpandableCode.tsx
+++ b/client/app/lib/components/core/ExpandableCode.tsx
@@ -1,0 +1,26 @@
+import { ComponentProps } from 'react';
+import { Typography } from '@mui/material';
+
+import Expandable from 'lib/components/core/Expandable';
+
+const DEFAULT_COLLAPSED_HEIGHT_PX = 40;
+
+type ExpandableProps = ComponentProps<typeof Expandable>;
+
+type ExpandableCodeProps = Omit<ExpandableProps, 'over'> & {
+  over?: ExpandableProps['over'];
+};
+
+const ExpandableCode = (props: ExpandableCodeProps): JSX.Element => {
+  const { children, over, ...expandableProps } = props;
+
+  return (
+    <Expandable {...expandableProps} over={over ?? DEFAULT_COLLAPSED_HEIGHT_PX}>
+      <Typography className="whitespace-pre-wrap h-full break-all font-mono text-[1.3rem]">
+        {children}
+      </Typography>
+    </Expandable>
+  );
+};
+
+export default ExpandableCode;


### PR DESCRIPTION
`white-space: pre-wrap;` needs to be added to the `div` containing carriage returns for the line breaks to be correctly rendered.

| Before | After |
| - | - |
| ![image](https://github.com/Coursemology/coursemology2/assets/51525686/389284ab-5178-434c-85cf-ed7ff4a32f1f) | ![image](https://github.com/Coursemology/coursemology2/assets/51525686/b3850af5-9537-424d-9e34-eb4a8f014990) |