### PR TITLE
Fix ResizeObserver not found on older browsers

### DIFF
--- a/client/app/bundles/course/container/Breadcrumbs/sliders.tsx
+++ b/client/app/bundles/course/container/Breadcrumbs/sliders.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import { ChevronLeft, ChevronRight } from '@mui/icons-material';
 import { IconButton, Slide } from '@mui/material';
+import ResizeObserver from 'utilities/ResizeObserver';
 
 interface UseSlidersHook {
   ref: RefObject<HTMLDivElement>;

--- a/client/app/lib/components/core/Expandable.tsx
+++ b/client/app/lib/components/core/Expandable.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import { defineMessages } from 'react-intl';
+import ResizeObserver from 'utilities/ResizeObserver';
 
 import Link from 'lib/components/core/Link';
 import useTranslation from 'lib/hooks/useTranslation';

--- a/client/app/utilities/ResizeObserver.ts
+++ b/client/app/utilities/ResizeObserver.ts
@@ -1,0 +1,13 @@
+import ResizeObserverPonyfill from 'resize-observer-polyfill';
+
+/**
+ * The native `ResizeObserver` class if available, otherwise the ponyfill.
+ * `@babel/preset-env` does not polyfill `ResizeObserver` because it's not an
+ * ECMAScript specification.
+ *
+ * @see https://babeljs.io/docs/babel-preset-env#corejs
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#specifications
+ */
+const ResizeObserver = window.ResizeObserver || ResizeObserverPonyfill;
+
+export default ResizeObserver;

--- a/client/package.json
+++ b/client/package.json
@@ -100,6 +100,7 @@
     "redux-immutable": "^4.0.0",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.4.2",
+    "resize-observer-polyfill": "^1.5.1",
     "rollbar": "^2.26.2",
     "webfontloader": "^1.6.28",
     "yup": "^0.32.11"


### PR DESCRIPTION
Some students couldn't sign in on SEB on macOS 12.x because they got a `ReferenceError` saying that ResizeObserver is not available in the browser.

```
ReferenceError: Can't find variable: ResizeObserver
```

SEB has two browser modes: Classic (uses the deprecated [WebView](https://developer.apple.com/documentation/webkit/webview)) and Modern (uses [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview)). The default configuration actually sets the main tab to use the Classic browser. WKWebView uses the WebKit that is shipped together with the host macOS, so its implementation will be even with the host's Safari (minus any other features behind entitlements). However, the deprecated WebView have several Web APIs that are just not even with WKWebView. In fact, the reason why SharedWorker isn't available on SEB on macOS 13 ([even if Safari 16 on macOS 13 ships with SharedWorker support](https://webkit.org/blog/13152/webkit-features-in-safari-16-0/#:~:text=of%20the%20page.-,Shared%20Workers,-WebKit%20now%20supports)) is exactly because it wasn't configured to use WKWebView in the first place. See https://github.com/SafeExamBrowser/seb-mac/issues/335.

This is why even if ResizeObserver is a relatively mature API nowadays, with supports going back to Safari 13.1 and Chrome 64, and that macOS 12 ships with Safari 15 that supports ResizeObserver, if the SEB configuration uses the Classic browser, ResizeObserver won't be available, and loading our breadcrumb and `TestCaseView` will crash the browser with a `ReferenceError`.

@babel/preset-env doesn't polyfill ResizeObserver for us because it's not an ECMAScript specification; it's a [CSS Working Group specification](https://drafts.csswg.org/resize-observer/#resize-observer-interface). @babel/preset-env only [polyfills ECMAScript proposals at Stage 3 and up](https://babeljs.io/docs/babel-preset-env#corejs). So, we need to add our own polyfill (or safely ponyfill it).

Examiners should seek to use the Modern browser on their SEB configuration. But as with what we did in #6411 at e6c85f4, we should err on the safe side and be as defensive as possible. Anyway, this isn't a problem specific to SEB. It's a feature detection issue.

## For developers

From this PR onwards, ResizeObserver should be imported from `utilities/ResizeObserver`.