### PR TITLE
Fix submission session auth race condition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ gem 'rexml'
 # Page profiler
 gem 'rack-mini-profiler'
 
+gem 'redis-rails'
+
 group :development do
   # Spring speeds up development by keeping your application running in the background.
   # Read more: https://github.com/rails/spring
@@ -141,10 +143,6 @@ end
 
 group :production, :ci do
   gem 'aws-sdk-s3'
-end
-
-group :production, :development do
-  gem 'redis-rails'
 end
 
 group :production do

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -51,7 +51,7 @@ class Course::Assessment::Submission::SubmissionsController < \
       success = @assessment.create_new_submission(@submission, current_user)
       raise ActiveRecord::Rollback unless success
 
-      authentication_service.save_token_to_session(@submission.session_id)
+      authentication_service.save_token_to_redis(@submission.session_id)
       log_service.log_submission_access(request) if @assessment.session_password_protected?
       monitoring_service&.create_new_session_if_not_exist! if should_monitor?
 

--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -48,7 +48,7 @@ class Course::Material::MaterialsController < Course::Material::Controller
       success = @assessment.create_new_submission(@submission, current_user)
 
       if success
-        authentication_service.save_token_to_session(@submission.session_id)
+        authentication_service.save_token_to_redis(@submission.session_id)
         log_service.log_submission_access(request) if @assessment.session_password_protected?
         @submission.create_new_answers
       end

--- a/app/services/course/assessment/authentication_service.rb
+++ b/app/services/course/assessment/authentication_service.rb
@@ -29,7 +29,8 @@ class Course::Assessment::AuthenticationService
 
   # Generates a new authentication token and stores it in current session.
   def set_session_token!
-    @session[session_key] = password_token
+    token_expiry_seconds = 86_400
+    REDIS.set(session_key, password_token, ex: token_expiry_seconds)
   end
 
   # Check whether current session is the same session that created the submission or not.
@@ -38,7 +39,7 @@ class Course::Assessment::AuthenticationService
   def authenticated?
     return true unless @session
 
-    @session[session_key] == password_token
+    REDIS.get(session_key) == password_token
   end
 
   private
@@ -48,6 +49,6 @@ class Course::Assessment::AuthenticationService
   end
 
   def session_key
-    "assessment_#{@assessment.id}_access_token"
+    "session_#{@session.id}_assessment_#{@assessment.id}_access_token"
   end
 end

--- a/app/services/course/assessment/session_log_service.rb
+++ b/app/services/course/assessment/session_log_service.rb
@@ -25,10 +25,10 @@ class Course::Assessment::SessionLogService
   private
 
   def current_authentication_token
-    @session[session_key]
+    REDIS.get(session_key)
   end
 
   def session_key
-    "assessment_#{@assessment.id}_authentication_token"
+    "session_#{@session.id}_assessment_#{@assessment.id}_submission_#{@submission.id}_authentication_token"
   end
 end

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTable.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTable.jsx
@@ -15,6 +15,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Typography,
 } from '@mui/material';
 import { pink, red } from '@mui/material/colors';
 import PropTypes from 'prop-types';
@@ -279,7 +280,9 @@ export default class SubmissionsTable extends Component {
     ];
     return tooltipIds.map((tooltipId, index) => (
       <Tooltip key={tooltipId} id={tooltipId}>
-        <FormattedMessage {...formattedMessages[index]} />
+        <Typography variant="caption">
+          <FormattedMessage {...formattedMessages[index]} />
+        </Typography>
       </Tooltip>
     ));
   };

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionsIndex/SubmissionsTableRow.jsx
@@ -1,6 +1,5 @@
 import { memo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
 import { Warning } from '@mui/icons-material';
 import Delete from '@mui/icons-material/Delete';
 import History from '@mui/icons-material/History';
@@ -77,8 +76,6 @@ const SubmissionsTableRow = (props) => {
     unsubmitConfirmation: false,
     deleteConfirmation: false,
   });
-
-  const navigate = useNavigate();
 
   const getGradeString = () => {
     if (submission.workflowState === workflowStates.Unstarted) return null;
@@ -172,16 +169,12 @@ const SubmissionsTableRow = (props) => {
       return null;
 
     return (
-      <span className="submission-access-logs" data-tooltip-id="access-logs">
-        <IconButton
-          onClick={() =>
-            navigate(
-              getSubmissionLogsURL(courseId, assessmentId, submission.id),
-            )
-          }
-          size="large"
-          style={styles.button}
-        >
+      <Link
+        className="submission-access-logs"
+        data-tooltip-id="access-logs"
+        to={getSubmissionLogsURL(courseId, assessmentId, submission.id)}
+      >
+        <IconButton size="large" style={styles.button}>
           <History
             htmlColor={
               palette.submissionIcon.history[
@@ -190,7 +183,7 @@ const SubmissionsTableRow = (props) => {
             }
           />
         </IconButton>
-      </span>
+      </Link>
     );
   };
 

--- a/client/app/lib/components/core/BarChart.jsx
+++ b/client/app/lib/components/core/BarChart.jsx
@@ -1,4 +1,5 @@
 import { Tooltip } from 'react-tooltip';
+import { Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 
 const styles = {
@@ -31,9 +32,13 @@ const BarChart = (props) => (
           data-tooltip-id={segment.color}
           style={segmentStyle}
         >
-          {segment.count > 0 ? segment.count : null}
+          {segment.count > 0 ? (
+            <Typography variant="caption">{segment.count}</Typography>
+          ) : null}
 
-          <Tooltip id={segment.color}>{segment.label}</Tooltip>
+          <Typography variant="caption">
+            <Tooltip id={segment.color}>{segment.label}</Tooltip>
+          </Typography>
         </div>
       );
     })}

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+redis_host = ENV['REDIS_HOST']
+redis_port = 6379
+redis_password = ENV['REDIS_PASS']
+
+REDIS = Redis.new(host: redis_host, port: redis_port, password: redis_password, db: 0)

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -97,13 +97,13 @@ RSpec.describe Course::Assessment do
           create(:assessment, :published_with_all_question_types, :view_password, course: course)
         end
         let(:authenticated_session) do
-          session = {}
+          session = OpenStruct.new(id: '1234')
           service = Course::Assessment::AuthenticationService.new(assessment, session)
           service.authenticate(assessment.view_password)
           session
         end
         let(:unauthenticated_session) do
-          session = {}
+          session = OpenStruct.new(id: '1234')
           service = Course::Assessment::AuthenticationService.new(assessment, session)
           service.authenticate('WRONG PASSWORD')
           session


### PR DESCRIPTION
Previously, assessment session token is stored in the session store. This causes problem since there could be a race condition when multiple different APIs are called for the same user (same session). Rails would [overwrite](https://github.com/redis-store/redis-rack/blob/e737008b6d6979c4bd8c74b39a6002fcf2d93a79/lib/rack/session/redis.rb#L47C61-L47C61) the content of the session store for a particular session when a request ends.

As such, the session key, which has been initially added to the session store, is then not persisted subsequently due to the race condition. For example, there are 2 simultaneous API requests: Request A (getting latest announcement that has nothing to do with assessment session key) and Request B (attempting a submission that will create an assessment session key in exam mode). Request A and B arrive at time t = 0 and t = 1 respectively, but request B and A are completed at time t=3 and t=4 respectively. So even though the session key has been added to the session store in Request B, since request A ends later and does not rehydrate the content after request B has been completed, the session store from request A overwrites the existing content of the session store.

```
      0   1   2   3   4 (seconds)
t     |---|---|---|---|
A   S |---------------> S
B       S |-------> S'

S = session, S' = modified session
```

To fix this, instead of storing the key in session store, it is now stored in redis store in order to avoid unnecessary overwriting due to unrelated actions.