### PR TITLE
Fix inconsistencies in assessment exam monitoring settings

### DIFF
--- a/app/controllers/concerns/course/assessment/monitoring_concern.rb
+++ b/app/controllers/concerns/course/assessment/monitoring_concern.rb
@@ -30,7 +30,9 @@ module Course::Assessment::MonitoringConcern
   end
 
   def upsert_monitoring!
-    monitoring_service&.upsert!(monitoring_params) if can_manage_monitor?
+    monitoring_service&.upsert!(monitoring_params.merge({
+      enabled: @assessment.view_password_protected? ? monitoring_params[:enabled] : false
+    }))
   end
 
   private

--- a/app/controllers/concerns/course/assessment/monitoring_concern.rb
+++ b/app/controllers/concerns/course/assessment/monitoring_concern.rb
@@ -31,7 +31,8 @@ module Course::Assessment::MonitoringConcern
 
   def upsert_monitoring!
     monitoring_service&.upsert!(monitoring_params.merge({
-      enabled: @assessment.view_password_protected? ? monitoring_params[:enabled] : false
+      enabled: @assessment.view_password_protected? ? monitoring_params[:enabled] : false,
+      blocks: should_disable_block? ? false : monitoring_params[:blocks]
     }))
   end
 
@@ -73,5 +74,9 @@ module Course::Assessment::MonitoringConcern
 
   def monitor
     @monitor ||= monitoring_service&.monitor
+  end
+
+  def should_disable_block?
+    !@assessment.session_password_protected? || monitor.secret.blank?
   end
 end

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -69,8 +69,8 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
     # @assessment.update_randomization(randomization_params)
 
     ActiveRecord::Base.transaction do
-      upsert_monitoring! if @assessment.view_password_protected?
       @assessment.update!(assessment_params)
+      upsert_monitoring! if can_manage_monitor?
 
       head :ok
     end

--- a/app/models/course/monitoring/monitor.rb
+++ b/app/models/course/monitoring/monitor.rb
@@ -12,6 +12,7 @@ class Course::Monitoring::Monitor < ApplicationRecord
   validates :blocks, inclusion: { in: [true, false] }
 
   validate :max_interval_greater_than_min
+  validate :can_enable_only_when_password_protected
   validate :can_block_only_when_has_secret_and_session_protected
 
   def valid_secret?(string)
@@ -24,6 +25,12 @@ class Course::Monitoring::Monitor < ApplicationRecord
     return unless max_interval_ms.present? && min_interval_ms.present?
 
     errors.add(:max_interval_ms, :greater_than_min_interval) unless max_interval_ms > min_interval_ms
+  end
+
+  def can_enable_only_when_password_protected
+    return unless enabled? && !assessment.view_password_protected?
+
+    errors.add(:enabled, :must_be_password_protected)
   end
 
   def can_block_only_when_has_secret_and_session_protected

--- a/config/locales/en/activerecord/course/monitoring/monitor.yml
+++ b/config/locales/en/activerecord/course/monitoring/monitor.yml
@@ -4,6 +4,8 @@ en:
       models:
         course/monitoring/monitor:
           attributes:
+            enabled:
+              must_be_password_protected: "assessment must be password protected to enable"
             max_interval_ms:
               greater_than_min_interval: "must be greater than min interval"
             blocks:

--- a/spec/factories/course_monitoring_monitors.rb
+++ b/spec/factories/course_monitoring_monitors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :course_monitoring_monitor, class: Course::Monitoring::Monitor.name do
-    assessment
+    association :assessment, :view_password
 
     enabled { true }
     min_interval_ms { Course::Monitoring::Monitor::DEFAULT_MIN_INTERVAL_MS }

--- a/spec/models/course/monitoring/monitor_spec.rb
+++ b/spec/models/course/monitoring/monitor_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe Course::Monitoring::Monitor, type: :model do
           expect(subject.errors[:blocks]).not_to be_present
         end
       end
+
+      context 'when the assessment is not password-protected' do
+        before { subject.assessment.update!(view_password: nil) }
+
+        it 'cannot be enabled' do
+          subject.assign_attributes(enabled: true)
+          expect(subject).not_to be_valid
+          expect(subject.errors[:enabled]).to be_present
+        end
+      end
     end
 
     describe '#valid_secret?' do

--- a/spec/services/course/assessment/monitoring_service_spec.rb
+++ b/spec/services/course/assessment/monitoring_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment::MonitoringService, type: :service do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:assessment, course: course) }
+    let(:assessment) { create(:assessment, :view_password, course: course) }
 
     let(:base_user_agent) { 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)' }
     let(:browser_session) { {} }

--- a/spec/services/course/assessment/monitoring_service_spec.rb
+++ b/spec/services/course/assessment/monitoring_service_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Course::Assessment::MonitoringService, type: :service do
           secret: SecureRandom.hex,
           min_interval_ms: 3000,
           max_interval_ms: 3100,
-          offset_ms: 2000
+          offset_ms: 2000,
+          assessment: assessment
         }
 
         expect { subject.upsert!(params) }.to change { subject.monitor }.from(nil)

--- a/spec/services/course/assessment/submission/monitoring_service_spec.rb
+++ b/spec/services/course/assessment/submission/monitoring_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course::Assessment::Submission::MonitoringService, type: :service
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:assessment) { create(:assessment, course: course) }
+    let(:assessment) { create(:assessment, :view_password, course: course) }
     let(:submission) { create(:submission, assessment: assessment) }
 
     let(:base_user_agent) { 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)' }


### PR DESCRIPTION
For a non-password-protected assessment, when both password-protection and exam monitoring are enabled in one PATCH request, exam monitoring is still disabled. This is because `upsert_monitoring!` was called only when `@assessment.view_password_protected?` _before_ `@assessment` is `update!`d. This means when `@assessment.monitor` is upserted, `@assessment` is still not password-protected. We should only `upsert_monitoring!` after `@assessment` is properly `update!`d.

A validation was added to ensure that exam monitoring can only be enabled when an assessment is password-protected. Technically, there's no reason why this should be the case. But since this feature is specifically used for exams, and the assessment edit page removes the exam monitoring settings if password-protection is disabled, a back-end validation should be added to support this behaviour. If in the future we decide to discretise password-protection and exam monitoring, we can just remove this validation.

Some codes were added in `assessment/monitoring_concern.rb` to gracefully disable exam monitoring and blocking when the conditions aren't met.