### PR TITLE
Fix TAs get blocked by monitor when accessing assessment details

### DIFF
--- a/app/controllers/concerns/course/assessment/monitoring_concern.rb
+++ b/app/controllers/concerns/course/assessment/monitoring_concern.rb
@@ -52,7 +52,7 @@ module Course::Assessment::MonitoringConcern
   end
 
   def blocked_by_monitor?
-    !can_manage_monitor? && monitoring_service&.should_block?(request.user_agent)
+    cannot?(:read, monitor) && monitoring_service&.should_block?(request.user_agent)
   end
 
   def monitoring_service


### PR DESCRIPTION
When assessment blocking is enabled by the monitor, TAs get blocked too because `blocked_by_monitor?` is checking the wrong permission. It should check `:read`, not `:manage`.