### PR TITLE
Add links to submissions on PulseGrid

### DIFF
--- a/app/channels/course/monitoring/live_monitoring_channel.rb
+++ b/app/channels/course/monitoring/live_monitoring_channel.rb
@@ -72,6 +72,7 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
         lastHeartbeatAt: last_heartbeat&.generated_at,
         isValid: is_valid_secret,
         userName: course_user.name,
+        submissionId: submission_ids_hash[session.creator_id],
         stale: last_heartbeat&.stale
       }.compact
 
@@ -117,5 +118,11 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
 
   def course_users_hash
     @course_users_hash ||= preload_course_users_hash(current_course)
+  end
+
+  def submission_ids_hash
+    @submission_ids_hash ||= @monitor.assessment.submissions.to_h do |submission|
+      [submission.creator_id, submission.id]
+    end
   end
 end

--- a/app/channels/course/monitoring/live_monitoring_channel.rb
+++ b/app/channels/course/monitoring/live_monitoring_channel.rb
@@ -27,7 +27,7 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
 
   def watch
     active_snapshots = active_sessions_snapshots
-    students = @course.students.order(:phantom, :name)
+    students = current_course.students.order(:phantom, :name)
 
     snapshots = students.to_h do |student|
       user_id = student.user_id
@@ -76,7 +76,7 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
   end
 
   def groups
-    @course.groups.ordered_by_name.includes(:group_category, :course_users).map do |group|
+    current_course.groups.ordered_by_name.includes(:group_category, :course_users).map do |group|
       {
         id: group.id,
         name: group.name,

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -79,6 +79,7 @@ const BaseActiveSessionBlob = (
         }}
         open={Boolean(snapshot.recentHeartbeats && popupData?.[0])}
         showing={snapshot.recentHeartbeats ?? []}
+        submissionId={snapshot.submissionId}
       />
     </>
   );

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
@@ -1,4 +1,5 @@
 import Draggable from 'react-draggable';
+import { useParams } from 'react-router-dom';
 import { Close } from '@mui/icons-material';
 import { IconButton, Popover, Typography } from '@mui/material';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
@@ -20,6 +21,7 @@ interface SessionDetailsPopupProps {
   anchorsOn?: HTMLElement;
   hasSecret?: boolean;
   onClickShowAllHeartbeats?: () => void;
+  submissionId?: number;
 }
 
 const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
@@ -31,6 +33,8 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
   } = props;
 
   const { t } = useTranslation();
+
+  const { courseId, assessmentId } = useParams();
 
   return (
     <Draggable handle=".handle">
@@ -63,6 +67,16 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
             })}
           </Typography>
         </header>
+
+        {props.submissionId && (
+          <Link
+            className="px-2 !mt-0 !mb-4"
+            opensInNewTab
+            to={`/courses/${courseId}/assessments/${assessmentId}/submissions/${props.submissionId}/edit`}
+          >
+            {t(translations.openSubmissionInNewTab)}
+          </Link>
+        )}
 
         <div className="flex justify-between items-center px-2">
           <Typography color="text.secondary" variant="body2">

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -1018,6 +1018,10 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.accessGrantedForThisSessionOnly',
     defaultMessage: 'Access will be granted only for this browser session.',
   },
+  openSubmissionInNewTab: {
+    id: 'course.assessment.monitoring.openSubmissionInNewTab',
+    defaultMessage: 'Open submission in new tab',
+  },
   attemptingAssessment: {
     id: 'course.assessment.submission.attemptingAssessment',
     defaultMessage: 'Creating a new submission...',

--- a/client/app/types/channels/liveMonitoring.ts
+++ b/client/app/types/channels/liveMonitoring.ts
@@ -19,6 +19,7 @@ export interface SnapshotData {
   lastHeartbeatAt: string;
   isValid: boolean;
   userName?: string;
+  submissionId?: number;
   stale?: boolean;
 }
 


### PR DESCRIPTION
This PR adds a link to open an examinee's submission from PulseGrid, suggested by @cysjonathan. There is also a fix to show the course user name instead of global user name.

<img width="378" alt="image" src="https://github.com/Coursemology/coursemology2/assets/51525686/5c261e2b-7dbe-4c23-a5b8-380a5f0915f8">
