### PR TITLE
feat: allow manager or owner of course to submit answer

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -246,4 +246,8 @@ module Course::Assessment::AssessmentAbility
     can :delete_all_submissions, Course::Assessment, assessment_course_hash
     can :delete_submission, Course::Assessment::Submission, assessment: assessment_course_hash
   end
+
+  def allow_manager_update_assessment_submissions
+    can [:submit_answer], Course::Assessment::Submission, assessment: assessment_course_hash
+  end
 end


### PR DESCRIPTION
Previously, only site admins were allowed to run students' code (legacy policy) — [[reference PR](https://github.com/Coursemology/coursemology2/pull/2354/files)].
After discussion, we decide to align on the policy to only grant Owners and Managers ability to run students' code.
We choose to omit rights to TeachingAssistants in order to limit risk exposure.
There may be a large number of TAs in any course, and there is the risk of TAs submitting/modifying students' work.

The existence of distinct Manager and TA roles allow us role-based control over code running/submitting, so this new policy maximizes this potential.
If TAs require modifying students' code, they should then request assistance from Managers / Owners.