### PR TITLE
Autograding answer attempt fix and update zombie job check

### DIFF
--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -201,7 +201,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
     return unless valid_for_grading?(answer)
 
     # Check if the last attempted answer is still being evaluated, then dont reattempt.
-    job = last_attempt_answer_submitted_job(answer) || reattempt_and_grade_answer(answer).job
+    job = last_attempt_answer_submitted_job(answer) || reattempt_and_grade_answer(answer)&.job
     if job
       render partial: 'jobs/submitted', locals: { job: job }
     else


### PR DESCRIPTION
### Issues & Solutions
- When an answer has been submitted and is being autograded, prevent re-attempt of the answer if another "submit answer" is attempted. Instead, return the job of the answer that's being queued or autograded.
- Instead of using a fixed timing to check zombie jobs, we now only check zombie jobs in sidekiq (only 5 mins after a job has been created. We assume the job has been queued if the job is created within 5 minutes and only check sidekiq queue after 5 mins to optimise performance). We then go to sidekiq to check running and enqueued jobs.