### PR TITLE
Fix Issue: Prefilled Grade Reverted to 0 when Published

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -300,7 +300,7 @@ class Course::Assessment::Submission::SubmissionsController < \
   def check_zombie_jobs # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     return unless @submission.attempting? || @submission.submitted?
 
-    submitted_answers = @submission.answers.select(&:submitted?)
+    submitted_answers = @submission.answers.where(workflow_state: 'submitted')
     return if submitted_answers.empty?
 
     dead_answers = submitted_answers.select do |a|


### PR DESCRIPTION
**Main Issue**

When grader is grading the submission and doesn't input some of the grades because those have already been pre-filled with maximum grade and directly click Publish Grade, those grades saved as 0

**Root Cause**

Upon investigation, we found out that we did checking for zombie jobs before we did the update (Publish Grade), and in here we call the function `@submission.answers.select(&:submitted)`. This causes the system to recognise `@submission.answers` as having been fully loaded and hence upon calling this instance, they won't reload from the DB. This renders the answers value inside `@submission` not up-to-date, and thus even after we attempted the update for the grades, it won't be reflected here.

This lead to the call for `@submission.update` to have `answers` value not up-to-date. Since we did Publish Grade, the state is changed from submitted to published, thus invoking the call for function `publish_answers` in which for every answers inside `@submission`, they will re-update the grade, grader, and graded_at. Since at this point, the grade is not up-to-date, it's still recorded as `nil` and thus it becomes zero.

**How to Solve the Issue**

We seek for the alternatives towards `@submission.answers.select(&:submitted)` which doesn't make `@submission.answers` to be fully loaded into the cache. Upon some little research, we found the alternatives of using `where` instead of `select` to address the issue that we have

**Other Additional Notes**

In order to prevent this issue to resurface, we decided also to add one test-case which simulate this issue, and making sure we will be able to detect the issue early on should it happen again.