### PR TITLE
Material Last Updater refers to the File Updater

### DIFF
--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -10,12 +10,12 @@ class Course::Material::MaterialsController < Course::Material::Controller
 
   def update
     if @material.update(material_params)
-      course_user = @material.updater.course_users.find_by(course: current_course)
-      user = course_user || @material.updater
+      course_user = @material.attachment.updater.course_users.find_by(course: current_course)
+      user = course_user || @material.attachment.updater
       render json: { id: @material.id,
                      name: @material.name,
                      description: @material.description,
-                     updatedAt: @material.updated_at,
+                     updatedAt: @material.attachment.updated_at,
                      updater: { id: user.id, name: user.name,
                                 userUrl: url_to_user_or_course_user(current_course, user) } },
              status: :ok

--- a/app/views/course/material/folders/show.json.jbuilder
+++ b/app/views/course/material/folders/show.json.jbuilder
@@ -34,12 +34,11 @@ json.materials @folder.materials.includes(:updater) do |material|
   json.name material.name
   json.description format_ckeditor_rich_text(material.description)
   json.materialUrl url_to_material(current_course, @folder, material)
-  json.updatedAt material.updated_at
+  json.updatedAt material.attachment.updated_at
 
-  updater = material.updater
   json.updater do
-    course_user = updater.course_users.find_by(course: current_course)
-    user = course_user || updater
+    course_user = material.attachment.updater.course_users.find_by(course: current_course)
+    user = course_user || material.attachment.updater
     json.id user.id
     json.name user.name
     json.userUrl url_to_user_or_course_user(current_course, user)


### PR DESCRIPTION
Issue

Previously, we resort to the updater and the last updated_at inside `Course::Material` to be displayed in the page. This creates the discrepancy since when user did not change any name and description of the file itself (the modification of `File` is handled separately in `AttachmentReference`), the information regarding `updated_at` is not displayed properly

Fix Attempt

Displaying `updater` and `updated_at` based on what is reflected inside the table `attachment_reference` instead of `course_materials`