### PR TITLE
Support multitenancy in the URL Link sent for Devise Related operation

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class DeviseMailer < ActionMailer::Base
+  before_action :set_mailers_url_host
+
+  def set_mailers_url_host
+    return unless Rails.env.production?
+
+    ActionMailer::Base.default_url_options[:host] = ActsAsTenant.current_tenant.host
+  end
+end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -3,8 +3,39 @@ class DeviseMailer < ActionMailer::Base
   before_action :set_mailers_url_host
 
   def set_mailers_url_host
-    return unless Rails.env.production?
+    current_tenant = ActsAsTenant.current_tenant
+    if Rails.env.production?
+      # we setup the URL for Devise related action into the tenant's host address
+      # (for example, xxx.coursemology.org)
+      ActionMailer::Base.default_url_options[:host] = current_tenant.host
+    else
+      # for development and test, we setup it to follow the following convention
+      # "{tenant}.lvh.me:8080", assuming that the URL used for testing / developing is lvh.me
+      # for development, client_port is 8080 and for test, it is 3200
+      # for more information, you might refer to config/environments/{test,development}.rb
+      ActionMailer::Base.default_url_options[:host] = setup_host_for_non_production_env(current_tenant)
+    end
+  end
 
-    ActionMailer::Base.default_url_options[:host] = ActsAsTenant.current_tenant.host
+  private
+
+  def setup_host_for_non_production_env(current_tenant)
+    if current_tenant.default?
+      default_app_host
+    else
+      tenant_host_address(current_tenant)
+    end
+  end
+
+  def default_app_host
+    return nil if Rails.env.production?
+
+    Application::Application.config.x.initial_host
+  end
+
+  def tenant_host_address(current_tenant)
+    # format return: xxx.lvh.me:8080, assuming the app is hosted in lvh.me and port is 8080
+    tenant = current_tenant.host.split('.').first
+    "#{tenant}.#{default_app_host}"
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,9 +54,13 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.x.default_app_host = 'lvh.me'
-  config.x.default_host = "#{config.x.default_app_host}:5000"
+  config.x.client_port = 8080
+  config.x.default_host = "#{config.x.default_app_host}:#{config.x.client_port}"
 
-  config.action_mailer.default_url_options = { host: "#{config.x.default_app_host}:5000" }
+  # the value should be 'lvh.me:8080'
+  config.x.initial_host = config.x.default_host
+
+  config.action_mailer.default_url_options = { host: config.x.initial_host }
 
   # Rails 6.0.5.1 security patch
   # To find out more unpermitted classes and add below then uncomment

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,9 +42,6 @@ Rails.application.configure do
   # Default from address for email
   config.action_mailer.default_options = { from: 'coursemology@example.org' }
 
-  # We will assume that we are running on localhost
-  config.action_mailer.default_url_options = { host: 'lvh.me:3200' }
-
   # Use the threaded background job adapter for replicating the production environment.
   config.active_job.queue_adapter = ActiveJob::QueueAdapters::BackgroundThreadAdapter.new
 
@@ -57,7 +54,14 @@ Rails.application.configure do
   config.x.default_host = 'lvh.me'
   config.x.client_port = 3200
   config.x.server_port = 7979
+  config.x.default_app_host = "#{config.x.default_host}:#{config.x.client_port}"
   config.x.default_user_password = 'lolololol'
+
+  # the value should be 'lvh.me:3200'
+  config.x.initial_host = config.x.default_app_host
+
+  # We will assume that we are running on xxx.lvh.me:3200, where xxx is the tenant
+  config.action_mailer.default_url_options = { host: config.x.initial_host }
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -7,6 +7,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # config.secret_key = 'b78e9024115bb66424c13b032a5588518fb468db3f771a0b39ef5fef8102826cbd095c10c'\
   #                     'e9d754daa82e847bcbb662d8f5d705b3dc1c3e074a20ecc175d6c3d'
+  config.parent_mailer = 'DeviseMailer'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
### Background

In our app, when a user:
- Sign Up
- Reset Password
- Request to Resend Confirmation Email

an automatic email with instructions is sent. These instructions typically contain a link for the user to click on to complete the next steps.

### Issue
The problem arises when user tried to do those operations from the tenant website (for example, `tenant1.coursemology.org`). 
1. The link provided on the email will direct user to the main website (`coursemology.org`) instead of the respective tenant website (`tenant1.coursemology.org`)
2. This behaviour confuses user due to the mismatch between the sites

### Root Cause

1. The process in sending the email for doing such operations was handled completely by the Devise gem
2. `default_url_options` are not being set, causing the gem to assume it as the base URL host

### Resolving the Issue

1. We add `parent_mailer` for Devise
2. Then, we setup the host for `default_url_options` towards the tenant address (in this case, it should be `tenant1.coursemology.org`)

### Additional Notes
For development and test environment in Rails, it's known that the site address is different from the production (by `2024/01/11`, the address used is `lvh.me` and the port was 8080 for development and 3200 for test). Therefore, the `default_url_options` will have its host value a bit different
- In case of development env, the link shall be `tenant1.lvh.me:8080`
- In case of test env, the link shall be `tenant1.lvh.me:3200`