### PR TITLE
Redirect /role_requests to SignIn Page when User is Unauthenticated

### DIFF
--- a/client/app/routers/redirects.tsx
+++ b/client/app/routers/redirects.tsx
@@ -33,5 +33,6 @@ export const protectedRoutes: RouteObject = {
     { path: 'announcements' },
     { path: 'users/:userId' },
     { path: 'user/*' },
+    { path: 'role_requests' },
   ],
 };


### PR DESCRIPTION
## Issue

When user is unauthenticated, entering the URL of `xxx.coursemology.org/role_requests` redirect user to `404 Not Found Error` page.

## Expected Behaviour

Entering such URL should redirect user to the sign-in page instead of spewing `404 Not Found Error`

## Root Cause

Since user's state is unauthenticated, every path entered will be checked inside `UnauthenticatedApp` routers. Initially the path `role_requests` is not available there, and hence the `404 Not Found Error` page.

## Resolving the Issue

Include the path `/role_requests` there, through including it in the variable `protectedRoutes`. Therefore, when user tried to access the path `/role_requests`, they will be automatically redirected to sign in page. Finally, after the sign-in is done, user will be able to access this path.