### PR TITLE
Sign in with Coursemology

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,6 @@ commands:
   setup_docker_layer_cache:
     steps:
       - setup_remote_docker:
-          version: 20.10.18
           docker_layer_caching: true
 
   # Install Ghostscript so `identify` in ImageMagick works with PDF files.

--- a/Gemfile
+++ b/Gemfile
@@ -173,6 +173,9 @@ gem 'devise-multi_email'
 # Use cancancan for authorization
 gem 'cancancan'
 
+# OAuth2 provider
+gem 'doorkeeper'
+
 # Some helpers for structuring CSS/JavaScript
 # Official version https://github.com/winston/rails_utils/pull/30 is no longer maintained.
 # We also want stricter sanitization.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
     docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
+    doorkeeper (5.6.8)
+      railties (>= 5)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -588,6 +590,7 @@ DEPENDENCIES
   devise-multi_email
   devise_masquerade
   docker-api
+  doorkeeper
   dotenv-rails
   edge
   email_spec

--- a/app/controllers/concerns/application_user_concern.rb
+++ b/app/controllers/concerns/application_user_concern.rb
@@ -2,9 +2,10 @@
 module ApplicationUserConcern
   extend ActiveSupport::Concern
   include ApplicationUserMasqueradeConcern
+  include ApplicationUserOauthConcern
 
   included do
-    before_action :authenticate_user!, unless: :publicly_accessible?
+    before_action :authenticate!, unless: :publicly_accessible?
     rescue_from CanCan::AccessDenied, with: :handle_access_denied
     helper_method :url_to_user_or_course_user
   end
@@ -18,6 +19,10 @@ module ApplicationUserConcern
     return user_path(user) if user.is_a?(User)
   end
 
+  def current_user
+    @current_user ||= current_user_from_devise || current_user_from_doorkeeper
+  end
+
   protected
 
   def publicly_accessible?
@@ -26,5 +31,22 @@ module ApplicationUserConcern
 
   def handle_access_denied(exception)
     render json: { errors: exception.message }, status: :forbidden
+  end
+
+  private
+
+  # This method is more or less a copy of Devise's `authenticate_user!`. Devise responds
+  # to `:warden` throws via `Devise::FailureApp`. This way, we keep the error message and
+  # status code consistent with Devise (as at before Doorkeeper was used).
+  #
+  # https://github.com/heartcombo/devise/blob/e2242a95f3bb2e68ec0e9a064238ff7af6429545/lib/devise/controllers/helpers.rb#L153
+  # https://github.com/heartcombo/devise/blob/e2242a95f3bb2e68ec0e9a064238ff7af6429545/lib/devise/controllers/helpers.rb#L120
+  # https://github.com/wardencommunity/warden/blob/88d2f59adf5d650238c1e93072635196aea432dc/lib/warden/proxy.rb#L134
+  def authenticate!
+    throw :warden unless devise_controller? || current_user
+  end
+
+  def current_user_from_devise
+    warden.authenticate(scope: :user)
   end
 end

--- a/app/controllers/concerns/application_user_oauth_concern.rb
+++ b/app/controllers/concerns/application_user_oauth_concern.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Controllers that are accessible via OAuth must explicitly annotate itself to be accessible.
+# The easiest way is by using the `accessible_in_oauth_scopes` hook. Anywhere in the controller,
+# you can call `accessible_in_oauth_scopes` with an array of symbols that correspond to any one
+# or more of `default_scopes` or `optional_scopes` defined in `config/initializers/doorkeeper.rb`.
+#
+# accessible_in_oauth_scopes :read_everything
+# accessible_in_oauth_scopes :read_resource, only: [:index, :show]
+# accessible_in_oauth_scopes [:read_everything, :write_everything], except: [:special_action]
+#
+# The `options` that `accessible_in_oauth_scopes` accepts are the same as
+# `AbstractController::Callbacks`'s.
+#
+# If multiple annotations are present, the scopes will be merged together according to the
+# conditions that prevail at request runtime. Orders of scope do not matter.
+#
+# If custom logic is needed, you can override `accessible_in_oauth_scopes` to return an array of
+# symbols/strings of scopes that must be acceptable by the token for the request to go through.
+#
+# def accessible_in_oauth_scopes
+#   if some_condition?
+#     :read_everything
+#   elsif another_condition?
+#     [:read_some, :write_some]
+#   end
+# end
+#
+# If both `accessible_in_oauth_scopes` override and callback hook are present, the former will be
+# evaluated first. Only if the former returns falsey will the latter be take precedence.
+module ApplicationUserOauthConcern
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    private
+
+    def accessible_in_oauth_scopes(scopes, options = {})
+      prepend_before_action (lambda do
+        wrapped_scopes = Array.wrap(scopes)
+        @oauth_scopes = @oauth_scopes&.concat(wrapped_scopes) || wrapped_scopes
+      end), options
+    end
+  end
+
+  protected
+
+  def accessible_in_oauth_scopes
+  end
+
+  private
+
+  def current_user_from_doorkeeper
+    User.find(doorkeeper_token.resource_owner_id) if accessible_doorkeeper_token?
+  end
+
+  def accessible_doorkeeper_token?
+    scopes = accessible_in_oauth_scopes || @oauth_scopes
+    scopes.present? ? doorkeeper_token&.acceptable?(scopes) : false
+  end
+end

--- a/app/controllers/user/profiles_controller.rb
+++ b/app/controllers/user/profiles_controller.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 class User::ProfilesController < ApplicationController
+  accessible_in_oauth_scopes :read, only: [:show]
+
+  def show
+  end
+
   def edit
   end
 

--- a/app/helpers/application_formatters_helper.rb
+++ b/app/helpers/application_formatters_helper.rb
@@ -23,9 +23,10 @@ module ApplicationFormattersHelper
   # Return the given user's image url.
   #
   # @param [User] user The user to display
+  # @param [Boolean] url Whether to return a URL or path
   # @return [String] A url for the image.
-  def user_image(user)
-    image_path(user.profile_photo.medium.url) if user&.profile_photo&.medium&.url
+  def user_image(user, url: false)
+    send("image_#{url ? 'url' : 'path'}", user.profile_photo.medium.url) if user&.profile_photo&.medium&.url
   end
 
   # Links to the given User.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,12 @@ class User < ApplicationRecord
   has_many :question_bundle_assignments, class_name: Course::Assessment::QuestionBundleAssignment.name,
                                          inverse_of: :user, dependent: :destroy
 
+  has_many :access_grants, class_name: Doorkeeper::AccessGrant.name, foreign_key: :resource_owner_id,
+                           dependent: :delete_all
+
+  has_many :access_tokens, class_name: Doorkeeper::AccessToken.name, foreign_key: :resource_owner_id,
+                           dependent: :delete_all
+
   accepts_nested_attributes_for :emails
 
   scope :ordered_by_name, -> { order(:name) }

--- a/app/views/user/profiles/show.json.jbuilder
+++ b/app/views/user/profiles/show.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+json.id current_user.id
+json.name current_user.name
+json.imageUrl user_image(current_user)
+json.primaryEmail current_user.email

--- a/app/views/user/profiles/show.json.jbuilder
+++ b/app/views/user/profiles/show.json.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 json.id current_user.id
 json.name current_user.name
-json.imageUrl user_image(current_user)
+json.imageUrl user_image(current_user, url: true)
 json.primaryEmail current_user.email

--- a/client/app/bundles/system/admin/admin/AdminNavigator.tsx
+++ b/client/app/bundles/system/admin/admin/AdminNavigator.tsx
@@ -1,5 +1,11 @@
 import { defineMessages } from 'react-intl';
-import { AutoStories, Campaign, Category, Group } from '@mui/icons-material';
+import {
+  AutoStories,
+  Campaign,
+  Category,
+  Group,
+  Key,
+} from '@mui/icons-material';
 
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -21,6 +27,10 @@ const translations = defineMessages({
   courses: {
     id: 'system.admin.admin.AdminNavigator.courses',
     defaultMessage: 'Courses',
+  },
+  authentications: {
+    id: 'system.admin.admin.AdminNavigator.authentications',
+    defaultMessage: 'Authentications',
   },
   systemAdminPanel: {
     id: 'system.admin.admin.AdminNavigator.systemAdminPanel',
@@ -53,6 +63,11 @@ const AdminNavigator = (): JSX.Element => {
           icon: <AutoStories />,
           title: t(translations.courses),
           path: '/admin/courses',
+        },
+        {
+          icon: <Key />,
+          title: t(translations.authentications),
+          path: '/admin/authentications',
         },
       ]}
     />

--- a/client/app/bundles/system/admin/admin/pages/AuthenticationsIndex.tsx
+++ b/client/app/bundles/system/admin/admin/pages/AuthenticationsIndex.tsx
@@ -1,0 +1,26 @@
+import { defineMessages } from 'react-intl';
+
+import Page from 'lib/components/core/layouts/Page';
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  manageOauthApplications: {
+    id: 'system.admin.admin.AuthenticationsIndex.manageOauthApplications',
+    defaultMessage: 'Manage connected OAuth 2.0 applications',
+  },
+});
+
+const AuthenticationsIndex = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Page>
+      <Link external href="/oauth/applications">
+        {t(translations.manageOauthApplications)}
+      </Link>
+    </Page>
+  );
+};
+
+export default AuthenticationsIndex;

--- a/client/app/routers/AuthenticatedApp.tsx
+++ b/client/app/routers/AuthenticatedApp.tsx
@@ -92,6 +92,7 @@ import VideoSubmissionsIndex from 'bundles/course/video/submission/pages/VideoSu
 import UserVideoSubmissionsIndex from 'bundles/course/video-submissions/pages/UserVideoSubmissionsIndex';
 import AdminNavigator from 'bundles/system/admin/admin/AdminNavigator';
 import AnnouncementIndex from 'bundles/system/admin/admin/pages/AnnouncementsIndex';
+import AuthenticationsIndex from 'bundles/system/admin/admin/pages/AuthenticationsIndex';
 import CourseIndex from 'bundles/system/admin/admin/pages/CoursesIndex';
 import InstancesIndex from 'bundles/system/admin/admin/pages/InstancesIndex';
 import UserIndex from 'bundles/system/admin/admin/pages/UsersIndex';
@@ -723,6 +724,10 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
             {
               path: 'courses',
               element: <CourseIndex />,
+            },
+            {
+              path: 'authentications',
+              element: <AuthenticationsIndex />,
             },
           ],
         },

--- a/client/webpack.dev.js
+++ b/client/webpack.dev.js
@@ -17,6 +17,8 @@ const bypassProxyIf = [
   (request) => request.url.startsWith('/downloads'),
   (request) => request.url.startsWith('/uploads'),
   (request) => request.url.startsWith('/attachments'),
+  (request) => request.url.startsWith('/oauth'),
+  (request) => request.url.startsWith('/assets/doorkeeper'),
 ];
 
 module.exports = merge(common, {

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,466 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  orm :active_record
+
+  base_controller ApplicationController.name
+
+  default_scopes :read
+  optional_scopes :write
+  enforce_configured_scopes
+
+  resource_owner_authenticator do
+    current_user || warden.authenticate!(scope: :user)
+  end
+
+  admin_authenticator do
+    if current_user
+      head :forbidden unless current_user.administrator?
+    else
+      head :not_found
+    end
+  end
+
+  # skip_authorization do |_resource_owner, _client|
+  #   # TODO: Whitelist Genie (working title) here
+  #   # client.superapp? or resource_owner.admin?
+  #   true
+  # end
+
+  use_refresh_token
+  enforce_content_type # application/x-www-form-urlencoded
+
+  # You can use your own model classes if you need to extend (or even override) default
+  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+  #
+  # Be default Doorkeeper ActiveRecord ORM uses it's own classes:
+  #
+  # access_token_class "Doorkeeper::AccessToken"
+  # access_grant_class "Doorkeeper::AccessGrant"
+  # application_class "Doorkeeper::Application"
+  #
+  # Don't forget to include Doorkeeper ORM mixins into your custom models:
+  #
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+  #
+  # For example:
+  #
+  # access_token_class "MyAccessToken"
+  #
+  # class MyAccessToken < ApplicationRecord
+  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+  #
+  #   self.table_name = "hey_i_wanna_my_name"
+  #
+  #   def destroy_me!
+  #     destroy
+  #   end
+  # end
+
+  # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
+  # By default this option is disabled.
+  #
+  # Make sure you properly setup you database and have all the required columns (run
+  # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
+  # migrations).
+  #
+  # If this option enabled, Doorkeeper will store not only Resource Owner primary key
+  # value, but also it's type (class name). See "Polymorphic Associations" section of
+  # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
+  #
+  # [NOTE] If you apply this option on already existing project don't forget to manually
+  # update `resource_owner_type` column in the database and fix migration template as it will
+  # set NOT NULL constraint for Access Grants table.
+  #
+  # use_polymorphic_resource_owner
+
+  # Authorization Code expiration time (default: 10 minutes).
+  #
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default: 2 hours).
+  # If you want to disable expiration, set this to `nil`.
+  #
+  # access_token_expires_in 2.hours
+
+  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
+  # non-expiring access token (which is not recommended) then you need to return
+  # Float::INFINITY from this block.
+  #
+  # `context` has the following properties available:
+  #
+  #   * `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  #   * `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  #   * `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #   * `resource_owner` - authorized resource owner instance (if present)
+  #
+  # custom_access_token_expires_in do |context|
+  #   context.client.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+  #
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # Reuse access token for the same resource owner within an application (disabled by default).
+  #
+  # This option protects your application from creating new tokens before old **valid** one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is enabled Doorkeeper
+  # doesn't update existing token expiration time, it will create a new token instead if no active matching
+  # token found for the application, resources owner and/or set of scopes.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
+  reuse_access_token
+
+  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+  # token using `matching_token_for` Access Token API that searches for valid records
+  # in batches in order not to pollute the memory with all the database records. By default
+  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+  # depending on your needs and server capabilities.
+  #
+  # token_lookup_batch_size 10_000
+
+  # Set a limit for token_reuse if using reuse_access_token option
+  #
+  # This option limits token_reusability to some extent.
+  # If not set then access_token will be reused unless it expires.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+  #
+  # This option should be a percentage(i.e. (0,100])
+  #
+  # token_reuse_limit 100
+
+  # Only allow one valid access token obtained via client credentials
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # When enabling this option, make sure that you do not expect multiple processes
+  # using the same credentials at the same time (e.g. web servers spanning
+  # multiple machines and/or processes).
+  #
+  # revoke_previous_client_credentials_token
+
+  # Hash access and refresh tokens before persisting them.
+  # This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without adding 'fallback: :plain'.
+  #
+  # hash_token_secrets
+  # By default, token secrets will be hashed using the
+  # +Doorkeeper::Hashing::SHA256+ strategy.
+  #
+  # If you wish to use another hashing implementation, you can override
+  # this strategy as follows:
+  #
+  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+  #
+  # Keep in mind that changing the hashing function will invalidate all existing
+  # secrets, if there are any.
+
+  # Hash application secrets before persisting them.
+  #
+  # hash_application_secrets
+  #
+  # By default, applications will be hashed
+  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+  #
+  # If you wish to use bcrypt for application secret hashing, uncomment
+  # this line instead:
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled.
+  #
+  # This can be done by adding 'fallback: plain', e.g. :
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt', fallback: :plain
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+  # a registered application
+  # NOTE: you must also run the rails g doorkeeper:application_owner generator
+  # to provide the necessary support
+  #
+  # enable_application_owner confirmation: false
+
+  # Allows to restrict only certain scopes for grant_type.
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # Callable objects such as proc, lambda, block or any object that responds to
+  # #call can be used in order to allow conditional checks (to allow non-SSL
+  # redirects to localhost for example).
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+  #
+  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is allowed by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  #
+  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+  # Password Credentials. The option is on by default and checks configured grant
+  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+  # column for `oauth_applications` database table.
+  #
+  # You can completely disable this feature with:
+  #
+  # allow_blank_redirect_uri false
+  #
+  # Or you can define your custom check:
+  #
+  # allow_blank_redirect_uri do |grant_flows, client|
+  #   client.superapp?
+  # end
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself (i.e. rescue exceptions),
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
+  #
+  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors :raise
+  #
+  # If you want to redirect back to the client application in accordance with
+  # https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1, you can set
+  # +handle_auth_errors+ to :redirect
+  #
+  # handle_auth_errors :redirect
+
+  # Customize token introspection response.
+  # Allows to add your own fields to default one that are required by the OAuth spec
+  # for the introspection response. It could be `sub`, `aud` and so on.
+  # This configuration option can be a proc, lambda or any Ruby object responds
+  # to `.call` method and result of it's invocation must be a Hash.
+  #
+  # custom_introspection_response do |token, context|
+  #   {
+  #     "sub": "Z5O3upPC88QrAjx00dis",
+  #     "aud": "https://protected.example.net/resource",
+  #     "username": User.find(token.resource_owner_id).username
+  #   }
+  # end
+  #
+  # or
+  #
+  # custom_introspection_response CustomIntrospectionResponder
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
+  #
+  # grant_flows %w[authorization_code client_credentials]
+
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
+  # If you need arbitrary Resource Owner-Client authorization you can enable this option
+  # and implement the check your need. Config option must respond to #call and return
+  # true in case resource owner authorized for the specific application or false in other
+  # cases.
+  #
+  # By default all Resource Owners are authorized to any Client (application).
+  #
+  # authorize_resource_owner_for_client do |client, resource_owner|
+  #   resource_owner.admin? || client.owners_allowlist.include?(resource_owner)
+  # end
+
+  # Allows additional data fields to be sent while granting access to an application,
+  # and for this additional data to be included in subsequently generated access tokens.
+  # The 'authorizations/new' page will need to be overridden to include this additional data
+  # in the request params when granting access. The access grant and access token models
+  # will both need to respond to these additional data fields, and have a database column
+  # to store them in.
+  #
+  # Example:
+  # You have a multi-tenanted platform and want to be able to grant access to a specific
+  # tenant, rather than all the tenants a user has access to. You can use this config
+  # option to specify that a ':tenant_id' will be passed when authorizing. This tenant_id
+  # will be included in the access tokens. When a request is made with one of these access
+  # tokens, you can check that the requested data belongs to the specified tenant.
+  #
+  # Default value is an empty Array: []
+  # custom_access_token_attributes [:tenant_id]
+
+  # Hook into the strategies' request & response life-cycle in case your
+  # application needs advanced customization or logging:
+  #
+  # before_successful_strategy_response do |request|
+  #   puts "BEFORE HOOK FIRED! #{request}"
+  # end
+  #
+  # after_successful_strategy_response do |request, response|
+  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+  # end
+
+  # Hook into Authorization flow in order to implement Single Sign Out
+  # or add any other functionality. Inside the block you have an access
+  # to `controller` (authorizations controller instance) and `context`
+  # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
+  # or auth objects with issued token based on hook type (before or after).
+  #
+  # before_successful_authorization do |controller, context|
+  #   Rails.logger.info(controller.request.params.inspect)
+  #
+  #   Rails.logger.info(context.pre_auth.inspect)
+  # end
+  #
+  # after_successful_authorization do |controller, context|
+  #   controller.session[:logout_urls] <<
+  #     Doorkeeper::Application
+  #       .find_by(controller.request.params.slice(:redirect_uri))
+  #       .logout_uri
+  #
+  #   Rails.logger.info(context.auth.inspect)
+  #   Rails.logger.info(context.issued_token)
+  # end
+
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
+  #
+  # realm "Doorkeeper"
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,152 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+              forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
+        redirect_uri: 'Use one line per URI'
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require redirect URI."
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+        confidential: 'Confidential?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Yes'
+          'no': 'No'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'UID'
+        secret: 'Secret'
+        secret_hashed: 'Secret hashed'
+        scopes: 'Scopes'
+        confidential: 'Confidential'
+        callback_urls: 'Callback urls'
+        actions: 'Actions'
+        not_defined: 'Not defined'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to'
+      show:
+        title: 'Authorization code'
+      form_post:
+        title: 'Submit this form'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pre-authorization'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
+        invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        invalid_code_challenge_method: 'The code challenge method must be plain or S256.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+        unsupported_response_mode: 'The authorization server does not support this response mode.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
       post 'send_confirmation', on: :member
     end
 
-    resource :profile, only: [:edit, :update] do
+    resource :profile, only: [:show, :edit, :update] do
       get 'time_zones'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  use_doorkeeper
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20231215074458_create_doorkeeper_tables.rb
+++ b/db/migrate/20231215074458_create_doorkeeper_tables.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      t.string  :secret,  null: false
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.boolean :confidential, null: false, default: true
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.string   :scopes,            null: false, default: ''
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key :oauth_access_grants, :oauth_applications, column: :application_id
+
+    create_table :oauth_access_tokens do |t|
+      t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application,    null: false
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.string   :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+    add_index :oauth_access_tokens, :refresh_token, unique: true
+    add_foreign_key :oauth_access_tokens, :oauth_applications, column: :application_id
+
+    add_foreign_key :oauth_access_grants, :users, column: :resource_owner_id
+    add_foreign_key :oauth_access_tokens, :users, column: :resource_owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_07_114521) do
+ActiveRecord::Schema.define(version: 2023_12_15_074458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1326,6 +1326,48 @@ ActiveRecord::Schema.define(version: 2023_11_07_114521) do
     t.datetime "updated_at"
   end
 
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.bigint "resource_owner_id", null: false
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.bigint "resource_owner_id"
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
+    t.string "scopes"
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.string "previous_refresh_token", default: "", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.boolean "confidential", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
   create_table "polyglot_languages", id: :serial, force: :cascade do |t|
     t.string "type", limit: 255, null: false
     t.string "name", limit: 255, null: false
@@ -1615,6 +1657,10 @@ ActiveRecord::Schema.define(version: 2023_11_07_114521) do
   add_foreign_key "instance_user_role_requests", "users", name: "fk_instance_user_role_requests_user_id"
   add_foreign_key "instance_users", "instances", name: "fk_instance_users_instance_id"
   add_foreign_key "instance_users", "users", name: "fk_instance_users_user_id"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "polyglot_languages", "polyglot_languages", column: "parent_id", name: "fk_polyglot_languages_parent_id"
   add_foreign_key "user_emails", "users", name: "fk_user_emails_user_id"
   add_foreign_key "user_identities", "users", name: "fk_user_identities_user_id"


### PR DESCRIPTION
Needed for Cikgo (formerly Genie) deployment since it only authenticates via OAuth 2.0 with Coursemology.

## Summary

This PR enables Coursemology to be an OAuth 2.0 server. The compliance is handled by [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper). `use_doorkeeper` in `routes.rb` adds the [default Doorkeeper routes](https://doorkeeper.gitbook.io/guides/ruby-on-rails/routes), but the ones that we'd care the most are as follows.

| Endpoint | Used for |
| - | - |
| `/oauth/authorize` | The confirmation page for authorising access to third-party apps. |
| `/oauth/applications` | The control panel to control apps that can Sign in with Coursemology. This is where client IDs and secrets are issued. |
| `/oauth/authorized_applications` | For individual users to manage OAuth 2.0 accesses that they've authorised. |

We are just using Doorkeeper's built-in UI components (powered by Bootstrap) for now, since we're going to replace this with the upcoming authentication server.

A new tab in the System Admin Panel has been added to access `/oauth/applications`. As of now, there's not really any need for users to revoke access, so while `/oauth/authorized_applications` is accessible directly, I did not make any UI elements to access it.

>[!IMPORTANT]
>Rewrite rules for `/oauth/*` and `/assets/doorkeeper/*` were added to `webpack.dev.js`. The same rules must be added to our NGINX configuration.

## Changes to authentication flow

Since now a session can be authenticated by Devise and/or Doorkeeper, we can no longer use `authenticate_user!` in `ApplicationUserConcern`.

Doorkeeper also has a similar callback, `doorkeeper_authorize!`, that is supposed to be called `before_action`. So, ideally one should do,

```rb
before_action :authenticate_user!
before_action :doorkeeper_authorize!
```

This won't work because both methods immediately cancel the current response if any one fails. A quick inspection of `authenticate_user!` in Devise's source code reveals that it just returns `warden.authenticate!`, which returns the `current_user` if exists, and just `throw :warden` which Devise catches generally, and we catch it and respond with 401. Therefore, we can no longer use their built-in callbacks and must reconcile the authentication state ourselves __in one step__.

`current_user` was overwritten to be able to work with Doorkeeper-authorised users. In particular, from its definition, we prioritise the Devise-authorised user in case the session is authorised by both contexts. A new callback `authenticate!` was then created to mimic what `authenticate_user!` does.

## Resource accesses in OAuth contexts

Sign in with Coursemology was implemented in a way such that resource accesses are opt-in. By default, nothing is accessible in OAuth contexts. A hook, `accessible_in_oauth_scopes`, was created to incrementally expose certain endpoints in OAuth contexts. Full documentation was written in `ApplicationUserOauthConcern`.

Currently, we expose GET `/user/profile` since OAuth servers generally provide some information about the authenticated user to the OAuth clients.