### PR TITLE
fix: savingStatus becomes undefined after unsubmit

### DIFF
--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -146,6 +146,7 @@ export function unsubmit(submissionId) {
       .then((response) => response.data)
       .then((data) => {
         dispatch({ type: actionTypes.UNSUBMIT_SUCCESS, payload: data });
+        dispatch(initiateAnswerFlagsForAnswers({ answers: data.answers }));
         dispatch(setNotification(translations.updateSuccess));
       })
       .catch((error) => {

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -410,6 +410,7 @@ const SubmissionEditForm = (props) => {
         const question = questions[id];
         const { answerId, topicId, viewHistory } = question;
         const topic = topics[topicId];
+
         return (
           <Element key={id} name={`step${index}`}>
             <Paper className="mb-5 p-6" variant="outlined">

--- a/client/app/bundles/course/assessment/submission/reducers/answerFlags/index.ts
+++ b/client/app/bundles/course/assessment/submission/reducers/answerFlags/index.ts
@@ -34,6 +34,7 @@ export const answerFlagsSlice = createSlice({
       }>,
     ) => {
       const { answers } = action.payload;
+      answerFlagsAdapter.removeAll(state.flagsByAnswerId);
       answers.forEach((answer) => {
         answerFlagsAdapter.setOne(state.flagsByAnswerId, {
           id: answer.id,

--- a/spec/features/course/assessment/submission/submissions_spec.rb
+++ b/spec/features/course/assessment/submission/submissions_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'Course: Assessment: Submissions: Submissions', js: true do
           login_as(user, scope: :user)
 
           visit edit_course_assessment_submission_path(course, mcq_assessment, attempt_submission)
+          wait_for_page
 
           click_button('Publish Grade')
           wait_for_page


### PR DESCRIPTION
### Issue
Faulty scenario happens when user unsubmit the submission and then, without refreshing the page, change the answer. What happen is that the saving indicator will not be shown to user, despite the fact that it actually saves the answer to the backend

### Root Cause
When user do the un-submitting, system basically generate the new Answer entity and use this new Answer (also with new AnswerId) to the user. This new answerId has not yet been initialised for its answerFlags and hence is not stored yet inside our Redux. On the other hand, the answerFlags still persist the old answerId's state even though this old answerId is not used anymore

Therefore, the attempt to get the answerFlags after un-submitting for the available answerId will be rendered as undefined.

### Expected
When saving, the saving indicator will be changed into Saving, and then Saved

### Fix
Upon un-submitting, redux will initialise the savingStatus for all the answers inside the submission, and purge the old one.

### MIscellanous
Other than this, we also change the saving indicator behavior a bit. When the status is saved but the answer is dirty, we do not render any saving status