### PR TITLE
Allow Instance Admin and Instance Instructor to Duplicate Courses across Instances

### DIFF
--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -17,10 +17,12 @@ class Course::DuplicationsController < Course::ComponentController
 
   def authorize_duplication
     authorize!(:duplicate_from, current_course)
-    return unless instance_params != current_tenant.id
+    return if instance_params == current_tenant.id
+
+    destination_tenant = Instance.find(instance_params)
 
     authorize!(:duplicate_across_instances, current_tenant)
-    authorize!(:duplicate_across_instances, Instance.find(instance_params))
+    authorize!(:duplicate_across_instances, destination_tenant)
   end
 
   private

--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -17,7 +17,10 @@ class Course::DuplicationsController < Course::ComponentController
 
   def authorize_duplication
     authorize!(:duplicate_from, current_course)
-    authorize!(:duplicate_to_other_instances, current_tenant) if instance_params != current_tenant.id
+    return unless instance_params != current_tenant.id
+
+    authorize!(:duplicate_across_instances, current_tenant)
+    authorize!(:duplicate_across_instances, Instance.find(instance_params))
   end
 
   private

--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -85,8 +85,13 @@ class Course::ObjectDuplicationsController < Course::ComponentController
   end
 
   def load_destination_instances_data
-    @destination_instances = if can?(:duplicate_to_other_instances, current_tenant)
-                               Instance.all
+    @destination_instances = if can?(:duplicate_across_instances, current_tenant)
+                               instance_ids = InstanceUser.unscope(where: :instance_id).
+                                              where(user_id: current_user.id,
+                                                    role: [InstanceUser.roles[:instructor],
+                                                           InstanceUser.roles[:administrator]]).
+                                              pluck(:instance_id)
+                               Instance.where(id: instance_ids)
                              else
                                Instance.where(id: current_tenant.id)
                              end

--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -91,7 +91,7 @@ class Course::ObjectDuplicationsController < Course::ComponentController
                                                     role: [InstanceUser.roles[:instructor],
                                                            InstanceUser.roles[:administrator]]).
                                               pluck(:instance_id)
-                               Instance.where(id: instance_ids)
+                               current_user.administrator? ? Instance.all : Instance.where(id: instance_ids)
                              else
                                Instance.where(id: current_tenant.id)
                              end

--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -85,13 +85,15 @@ class Course::ObjectDuplicationsController < Course::ComponentController
   end
 
   def load_destination_instances_data
-    @destination_instances = if can?(:duplicate_across_instances, current_tenant)
+    @destination_instances = if current_user.administrator?
+                               Instance.all
+                             elsif can?(:duplicate_across_instances, current_tenant)
                                instance_ids = InstanceUser.unscope(where: :instance_id).
                                               where(user_id: current_user.id,
                                                     role: [InstanceUser.roles[:instructor],
                                                            InstanceUser.roles[:administrator]]).
                                               pluck(:instance_id)
-                               current_user.administrator? ? Instance.all : Instance.where(id: instance_ids)
+                               Instance.where(id: instance_ids)
                              else
                                Instance.where(id: current_tenant.id)
                              end

--- a/app/models/components/course/duplication_ability_component.rb
+++ b/app/models/components/course/duplication_ability_component.rb
@@ -4,7 +4,9 @@ module Course::DuplicationAbilityComponent
 
   def define_permissions
     disallow_superusers_duplicate_via_frontend if user
-    disallow_users_to_duplicate_cross_instances unless user&.administrator?
+    allow_administrator_to_duplicate_cross_instances if user&.administrator?
+    allow_instance_admin_to_duplicate_cross_instances
+    allow_instance_instructor_to_duplicate_cross_instances
 
     if course_user
       allow_managers_duplicate_to_course if course_user.manager_or_owner?
@@ -24,8 +26,20 @@ module Course::DuplicationAbilityComponent
     cannot :duplicate_from, Course
   end
 
-  def disallow_users_to_duplicate_cross_instances
-    cannot :duplicate_to_other_instances, Instance
+  def allow_administrator_to_duplicate_cross_instances
+    can :duplicate_across_instances, Instance
+  end
+
+  def allow_instance_admin_to_duplicate_cross_instances
+    can :duplicate_across_instances, Instance do |instance|
+      instance.instance_users.administrator.exists?(user_id: user.id)
+    end
+  end
+
+  def allow_instance_instructor_to_duplicate_cross_instances
+    can :duplicate_across_instances, Instance do |instance|
+      instance.instance_users.instructor.exists?(user_id: user.id)
+    end
   end
 
   def allow_managers_duplicate_to_course

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -28,8 +28,7 @@ json.destinationInstances @destination_instances do |instance|
 end
 
 json.metadata do
-  json.canDuplicateToAnotherInstance can?(:duplicate_across_instances, current_tenant) &&
-                                     @destination_instances.length > 1
+  json.canDuplicateToAnotherInstance can?(:duplicate_across_instances, current_tenant)
   json.currentInstanceId current_tenant.id
 end
 

--- a/app/views/course/object_duplications/new.json.jbuilder
+++ b/app/views/course/object_duplications/new.json.jbuilder
@@ -28,7 +28,8 @@ json.destinationInstances @destination_instances do |instance|
 end
 
 json.metadata do
-  json.canDuplicateToAnotherInstance can?(:duplicate_to_other_instances, current_tenant)
+  json.canDuplicateToAnotherInstance can?(:duplicate_across_instances, current_tenant) &&
+                                     @destination_instances.length > 1
   json.currentInstanceId current_tenant.id
 end
 

--- a/client/app/bundles/course/duplication/pages/Duplication/DestinationCourseSelector/InstanceDropdown.tsx
+++ b/client/app/bundles/course/duplication/pages/Duplication/DestinationCourseSelector/InstanceDropdown.tsx
@@ -29,7 +29,11 @@ const InstanceDropdown: FC<InstanceDropdownProps> = (props) => {
   return (
     <Autocomplete
       {...field}
-      disabled={disabled || !metadata.canDuplicateToAnotherInstance}
+      disabled={
+        disabled ||
+        !metadata.canDuplicateToAnotherInstance ||
+        instances.length > 1
+      }
       fullWidth
       getOptionLabel={(instanceId): string => instances[instanceId]?.name ?? ''}
       onChange={(_, instanceId): void =>

--- a/spec/controllers/course/duplications_controller_spec.rb
+++ b/spec/controllers/course/duplications_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::DuplicationsController, type: :controller do
+  let(:instance) { Instance.default }
+  let(:destination_instance) { create(:instance) }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+
+    describe '#create' do
+      subject do
+        post :create, format: :json, params: {
+          course_id: course.id, duplication: {
+            destination_instance_id: destination_instance.id, new_title: 'abcd', new_start_at: Time.now
+          }
+        }
+      end
+
+      context 'when instance admin of only one instance wants to duplicate course to another instance' do
+        let(:instance_admin_user) { create(:instance_administrator).user }
+        let(:instance_admin_course_user) { create(:course_manager, user: instance_admin_user, course: course).user }
+        before { sign_in(instance_admin_course_user) }
+
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when admin user wants to duplicate course to another instance' do
+        let(:admin) { create(:administrator) }
+        let(:admin_course_user) { create(:course_manager, user: admin, course: course).user }
+        before { sign_in(admin_course_user) }
+
+        it 'expects the duplication to be successful' do
+          subject
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+end

--- a/spec/models/duplication_ability_spec.rb
+++ b/spec/models/duplication_ability_spec.rb
@@ -12,14 +12,21 @@ RSpec.describe Course, type: :model do
       let(:user) { create(:user, :administrator) }
       let(:course_user) { nil }
 
-      it { is_expected.to be_able_to(:duplicate_to_other_instances, instance) }
+      it { is_expected.to be_able_to(:duplicate_across_instances, instance) }
     end
 
     context 'when the user is an instance administrator but not an admin' do
       let(:user) { create(:instance_administrator).user }
       let(:course_user) { nil }
 
-      it { is_expected.not_to be_able_to(:duplicate_to_other_instances, instance) }
+      it { is_expected.to be_able_to(:duplicate_across_instances, instance) }
+    end
+
+    context 'when the user is an instance instructor but not an admin' do
+      let(:user) { create(:instance_user, :instructor).user }
+      let(:course_user) { nil }
+
+      it { is_expected.to be_able_to(:duplicate_across_instances, instance) }
     end
 
     context 'when the user is a Normal User' do
@@ -28,7 +35,7 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.not_to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }
-      it { is_expected.not_to be_able_to(:duplicate_to_other_instances, instance) }
+      it { is_expected.not_to be_able_to(:duplicate_across_instances, instance) }
     end
 
     context 'when the user is a Course Student' do
@@ -37,7 +44,7 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.not_to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }
-      it { is_expected.not_to be_able_to(:duplicate_to_other_instances, instance) }
+      it { is_expected.not_to be_able_to(:duplicate_across_instances, instance) }
     end
 
     context 'when the user is a Course Teaching Assistant' do
@@ -46,7 +53,7 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.not_to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }
-      it { is_expected.not_to be_able_to(:duplicate_to_other_instances, instance) }
+      it { is_expected.not_to be_able_to(:duplicate_across_instances, instance) }
     end
 
     context 'when the user is a Course Manager' do
@@ -55,7 +62,7 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.to be_able_to(:duplicate_from, course) }
       it { is_expected.to be_able_to(:duplicate_to, course) }
-      it { is_expected.not_to be_able_to(:duplicate_to_other_instances, instance) }
+      it { is_expected.not_to be_able_to(:duplicate_across_instances, instance) }
     end
 
     context 'when the user is a Course Observer' do
@@ -64,7 +71,7 @@ RSpec.describe Course, type: :model do
 
       it { is_expected.to be_able_to(:duplicate_from, course) }
       it { is_expected.not_to be_able_to(:duplicate_to, course) }
-      it { is_expected.not_to be_able_to(:duplicate_to_other_instances, instance) }
+      it { is_expected.not_to be_able_to(:duplicate_across_instances, instance) }
     end
   end
 end


### PR DESCRIPTION
## Background

Previously, only administrator of Coursemology can do the duplication of course between instances, while other people having privileges in duplicating the course can only do that within the instance they're in.

## Objective

In this PR, we decided to allow the instance instructor as well as instance admin to duplicate courses within their instance. The rulings that we apply are as follows:
- In the source instance, the user doing the duplication should be either instance instructor or instance admin
- The same should go for the destination instance

## Result

As shown below, if user is at least instance instructor in the instance Default and Raffles Institution, those 2 options will be available in the Duplication Page, in the Destination Instance section
<img width="1527" alt="Screenshot 2024-02-07 at 1 22 20 AM" src="https://github.com/Coursemology/coursemology2/assets/16359075/6fcdc766-0439-4884-a5ce-8bd688d9616a">

On the other hand, if a user is only the instance admin/instructor in one instance (and either instance normal or none in other instances), then the option for Destination Instance will be fixed and user will not be able to modify it
<img width="1527" alt="Screenshot 2024-02-07 at 1 23 40 AM" src="https://github.com/Coursemology/coursemology2/assets/16359075/c9b8cfe4-ab0c-4497-8939-c4e43a21cef4">
