### PR TITLE
Fix various submission answer bugs reported in rollbar

### DIFF
--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -151,6 +151,7 @@ class Course::Assessment::Answer < ApplicationRecord
   def validate_session_and_client_version # rubocop:disable Metrics/CyclomaticComplexity
     return if last_session_id.nil? || client_version.nil?
     return if last_session_id_changed? || !client_version_changed?
+    return if client_version_change[0].nil?
     return if client_version_change[1] >= client_version_change[0]
 
     errors.add(:answer, 'stale_answer')

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -215,7 +215,7 @@ class Course::Assessment::Submission < ApplicationRecord
   end
 
   def submission_view_blocked?(course_user)
-    !attempting? && !published? && assessment.block_student_viewing_after_submitted? && course_user.student?
+    !attempting? && !published? && assessment.block_student_viewing_after_submitted? && course_user&.student?
   end
 
   def questions

--- a/app/services/course/assessment/submission/update_service.rb
+++ b/app/services/course/assessment/submission/update_service.rb
@@ -102,7 +102,7 @@ class Course::Assessment::Submission::UpdateService < SimpleDelegator
     @submission.class.transaction do
       unless unsubmit? || unmark?
         update_answers_params&.each do |answer_params|
-          next if answer_params[:id].blank?
+          next if !answer_params.is_a?(ActionController::Parameters) || answer_params[:id].blank?
 
           answer = @submission.answers.includes(:actable).find { |a| a.id == answer_params[:id].to_i }
 


### PR DESCRIPTION
- check if initial client version is nil for submission answer validation
- course_user may be nil when checking submission_view_blokced? if unenrolled coursemology admin accesses the page
- check if answer params is of parameters type