### PR TITLE
Show Answer Details in Assessment Statistics Page (Part 1: Last Graded Answer (MCQ, MRQ, Text Response, File Upload))

### DIFF
--- a/app/controllers/course/statistics/answers_controller.rb
+++ b/app/controllers/course/statistics/answers_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class Course::Statistics::AnswersController < Course::Statistics::Controller
+  helper Course::Assessment::Submission::SubmissionsHelper.name.sub(/Helper$/, '')
+
+  def question_answer_details
+    @answer = Course::Assessment::Answer.find(answer_params[:id])
+    @submission = @answer.submission
+    @assessment = @submission.assessment
+  end
+
+  private
+
+  def answer_params
+    params.permit(:id)
+  end
+end

--- a/app/controllers/course/statistics/assessments_controller.rb
+++ b/app/controllers/course/statistics/assessments_controller.rb
@@ -17,7 +17,7 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
     fetch_all_ancestor_assessments
     create_question_related_hash
 
-    @assessment_autograded = @question_auto_gradable_status_hash.any? { |_, value| value }
+    @assessment_autograded = @question_hash.any? { |_, (_, _, auto_gradable)| auto_gradable }
     @student_submissions_hash = fetch_hash_for_main_assessment(submissions, @all_students)
   end
 
@@ -62,14 +62,8 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
     @question_order_hash = @assessment.question_assessments.to_h do |q|
       [q.question_id, q.weight]
     end
-    @question_maximum_grade_hash = @assessment.questions.to_h do |q|
-      [q.id, q.maximum_grade]
-    end
-    @question_auto_gradable_status_hash = @assessment.questions.to_h do |q|
-      [q.id, q.auto_gradable?]
-    end
-    @question_type_hash = @assessment.questions.to_h do |q|
-      [q.id, q.question_type]
+    @question_hash = @assessment.questions.to_h do |q|
+      [q.id, [q.maximum_grade, q.question_type, q.auto_gradable?]]
     end
   end
 end

--- a/app/controllers/course/statistics/assessments_controller.rb
+++ b/app/controllers/course/statistics/assessments_controller.rb
@@ -68,5 +68,8 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
     @question_auto_gradable_status_hash = @assessment.questions.to_h do |q|
       [q.id, q.auto_gradable?]
     end
+    @question_type_hash = @assessment.questions.to_h do |q|
+      [q.id, q.question_type]
+    end
   end
 end

--- a/app/views/course/statistics/answers/question_answer_details.json.jbuilder
+++ b/app/views/course/statistics/answers/question_answer_details.json.jbuilder
@@ -14,5 +14,6 @@ end
 specific_answer = @answer.specific
 json.answer do
   json.grade @answer.grade
+  json.questionType question.question_type
   json.partial! specific_answer, answer: specific_answer, can_grade: false
 end

--- a/app/views/course/statistics/answers/question_answer_details.json.jbuilder
+++ b/app/views/course/statistics/answers/question_answer_details.json.jbuilder
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+question = @answer.question
+
+json.question do
+  json.id question.id
+  json.title question.title
+  json.maximumGrade question.maximum_grade
+  json.description format_ckeditor_rich_text(question.description)
+  json.type question.question_type
+
+  json.partial! question, question: question.specific, can_grade: false, answer: @answer
+end
+
+specific_answer = @answer.specific
+json.answer do
+  json.grade @answer.grade
+  json.partial! specific_answer, answer: specific_answer, can_grade: false
+end

--- a/app/views/course/statistics/assessments/_answer.json.jbuilder
+++ b/app/views/course/statistics/assessments/_answer.json.jbuilder
@@ -5,8 +5,10 @@ json.grader do
 end
 
 json.answers answers.each do |answer|
+  maximum_grade, question_type, = @question_hash[answer.question_id]
+
   json.lastAttemptAnswerId answer.last_attempt_answer_id
   json.grade answer.grade
-  json.maximumGrade @question_maximum_grade_hash[answer.question_id]
-  json.questionType @question_type_hash[answer.question_id]
+  json.maximumGrade maximum_grade
+  json.questionType question_type
 end

--- a/app/views/course/statistics/assessments/_answer.json.jbuilder
+++ b/app/views/course/statistics/assessments/_answer.json.jbuilder
@@ -5,7 +5,8 @@ json.grader do
 end
 
 json.answers answers.each do |answer|
-  json.id answer.id
+  json.lastAttemptAnswerId answer.last_attempt_answer_id
   json.grade answer.grade
   json.maximumGrade @question_maximum_grade_hash[answer.question_id]
+  json.questionType @question_type_hash[answer.question_id]
 end

--- a/app/views/course/statistics/assessments/_attempt_status.json.jbuilder
+++ b/app/views/course/statistics/assessments/_attempt_status.json.jbuilder
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 json.attemptStatus answers.each do |answer|
+  json.lastAttemptAnswerId answer.last_attempt_answer_id
   json.isAutograded @question_auto_gradable_status_hash[answer.question_id]
   json.attemptCount answer.attempt_count
   json.correct answer.correct

--- a/app/views/course/statistics/assessments/_attempt_status.json.jbuilder
+++ b/app/views/course/statistics/assessments/_attempt_status.json.jbuilder
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 json.attemptStatus answers.each do |answer|
+  _, _, auto_gradable = @question_hash[answer.question_id]
+
   json.lastAttemptAnswerId answer.last_attempt_answer_id
-  json.isAutograded @question_auto_gradable_status_hash[answer.question_id]
+  json.isAutograded auto_gradable
   json.attemptCount answer.attempt_count
   json.correct answer.correct
 end

--- a/client/app/api/course/Statistics/AnswerStatistics.ts
+++ b/client/app/api/course/Statistics/AnswerStatistics.ts
@@ -1,0 +1,18 @@
+import { QuestionType } from 'types/course/assessment/question';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import { APIResponse } from 'api/types';
+
+import BaseCourseAPI from '../Base';
+
+export default class AnswerStatisticsAPI extends BaseCourseAPI {
+  get #urlPrefix(): string {
+    return `/courses/${this.courseId}/statistics/answer`;
+  }
+
+  fetchQuestionAnswerDetails(
+    answerId: number,
+  ): APIResponse<QuestionAnswerDetails<keyof typeof QuestionType>> {
+    return this.client.get(`${this.#urlPrefix}/${answerId}`);
+  }
+}

--- a/client/app/api/course/Statistics/index.ts
+++ b/client/app/api/course/Statistics/index.ts
@@ -1,9 +1,11 @@
+import AnswerStatisticsAPI from './AnswerStatistics';
 import AssessmentStatisticsAPI from './AssessmentStatistics';
 import CourseStatisticsAPI from './CourseStatistics';
 import UserStatisticsAPI from './UserStatistics';
 
 const StatisticsAPI = {
   assessment: new AssessmentStatisticsAPI(),
+  answer: new AnswerStatisticsAPI(),
   course: new CourseStatisticsAPI(),
   user: new UserStatisticsAPI(),
 };

--- a/client/app/bundles/course/assessment/operations/statistics.ts
+++ b/client/app/bundles/course/assessment/operations/statistics.ts
@@ -1,6 +1,10 @@
 import { AxiosError } from 'axios';
 import { dispatch } from 'store';
-import { AncestorAssessmentStats } from 'types/course/statistics/assessmentStatistics';
+import { QuestionType } from 'types/course/assessment/question';
+import {
+  AncestorAssessmentStats,
+  QuestionAnswerDetails,
+} from 'types/course/statistics/assessmentStatistics';
 
 import CourseAPI from 'api/course';
 
@@ -32,6 +36,15 @@ export const fetchAncestorStatistics = async (
 ): Promise<AncestorAssessmentStats> => {
   const response =
     await CourseAPI.statistics.assessment.fetchAncestorStatistics(ancestorId);
+
+  return response.data;
+};
+
+export const fetchQuestionAnswerDetails = async (
+  answerId: number,
+): Promise<QuestionAnswerDetails<keyof typeof QuestionType>> => {
+  const response =
+    await CourseAPI.statistics.answer.fetchQuestionAnswerDetails(answerId);
 
   return response.data;
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
@@ -1,0 +1,81 @@
+import { defineMessages } from 'react-intl';
+import { Card, CardContent } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+import { AnswerDetailsMap } from 'types/course/statistics/answer';
+import { QuestionDetails } from 'types/course/statistics/assessmentStatistics';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+import FileUploadDetails from './FileUploadDetails';
+import MultipleChoiceDetails from './MultipleChoiceDetails';
+import MultipleResponseDetails from './MultipleResponseDetails';
+import TextResponseDetails from './TextResponseDetails';
+
+const translations = defineMessages({
+  rendererNotImplemented: {
+    id: 'course.assessment.submission.Answer.rendererNotImplemented',
+    defaultMessage:
+      'The display for this question type has not been implemented yet.',
+  },
+});
+
+interface AnswerDetailsProps<T extends keyof typeof QuestionType> {
+  question: QuestionDetails<T>;
+  answer: AnswerDetailsMap[T];
+}
+
+const AnswerNotImplemented = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="bg-yellow-100">
+      <CardContent>{t(translations.rendererNotImplemented)}</CardContent>
+    </Card>
+  );
+};
+
+export const AnswerDetailsMapper = {
+  MultipleChoice: (
+    props: AnswerDetailsProps<'MultipleChoice'>,
+  ): JSX.Element => <MultipleChoiceDetails {...props} />,
+  MultipleResponse: (
+    props: AnswerDetailsProps<'MultipleResponse'>,
+  ): JSX.Element => <MultipleResponseDetails {...props} />,
+  TextResponse: (props: AnswerDetailsProps<'TextResponse'>): JSX.Element => (
+    <TextResponseDetails {...props} />
+  ),
+  FileUpload: (props: AnswerDetailsProps<'FileUpload'>): JSX.Element => (
+    <FileUploadDetails {...props} />
+  ),
+  // TODO: define component for Forum Post, Programming, Voice Response, Scribing
+  ForumPostResponse: (
+    _props: AnswerDetailsProps<'ForumPostResponse'>,
+  ): JSX.Element => <AnswerNotImplemented />,
+  Programming: (_props: AnswerDetailsProps<'Programming'>): JSX.Element => (
+    <AnswerNotImplemented />
+  ),
+  VoiceResponse: (_props: AnswerDetailsProps<'VoiceResponse'>): JSX.Element => (
+    <AnswerNotImplemented />
+  ),
+  Scribing: (_props: AnswerDetailsProps<'Scribing'>): JSX.Element => (
+    <AnswerNotImplemented />
+  ),
+  Comprehension: (_props: AnswerDetailsProps<'Comprehension'>): JSX.Element => (
+    <AnswerNotImplemented />
+  ),
+};
+
+const AnswerDetails = <T extends keyof typeof QuestionType>(
+  props: AnswerDetailsProps<T>,
+): JSX.Element => {
+  const Component = AnswerDetailsMapper[props.answer.questionType];
+
+  // "Any" type is used here as the props are dynamically generated
+  // depending on the different answer type and typescript
+  // does not support union typing for the elements.
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return Component({ ...props } as any);
+};
+
+export default AnswerDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AttachmentDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AttachmentDetails.tsx
@@ -1,0 +1,60 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Chip, Typography } from '@mui/material';
+
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  attachments: {
+    id: string;
+    name: string;
+  }[];
+}
+
+const translations = defineMessages({
+  uploadedFiles: {
+    id: 'course.assessment.submission.UploadedFileView.uploadedFiles',
+    defaultMessage: 'Uploaded Files',
+  },
+  noFiles: {
+    id: 'course.assessment.submission.UploadedFileView.noFiles',
+    defaultMessage: 'No files uploaded.',
+  },
+});
+
+const AttachmentDetails: FC<Props> = (props) => {
+  const { attachments } = props;
+  const { t } = useTranslation();
+
+  const AttachmentComponent = (): JSX.Element => (
+    <div className="mt-4">
+      {attachments.map((attachment) => (
+        <Chip
+          key={attachment.id}
+          clickable
+          label={
+            <Link href={`/attachments/${attachment.id}`}>
+              {attachment.name}
+            </Link>
+          }
+        />
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="mt-4">
+      <Typography variant="h6">{t(translations.uploadedFiles)}</Typography>
+      {attachments.length > 0 ? (
+        <AttachmentComponent />
+      ) : (
+        <Typography color="text.secondary" variant="body2">
+          {t(translations.noFiles)}
+        </Typography>
+      )}
+    </div>
+  );
+};
+
+export default AttachmentDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/FileUploadDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/FileUploadDetails.tsx
@@ -1,0 +1,17 @@
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import AttachmentDetails from './AttachmentDetails';
+
+const FileUploadDetails = (
+  props: QuestionAnswerDetails<'FileUpload'>,
+): JSX.Element => {
+  const { answer } = props;
+
+  return (
+    <div className="w-full mt-4 mb-4">
+      <AttachmentDetails attachments={answer.attachments} />
+    </div>
+  );
+};
+
+export default FileUploadDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleChoiceDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleChoiceDetails.tsx
@@ -1,0 +1,43 @@
+import { FormControlLabel, Radio, Typography } from '@mui/material';
+import { green } from '@mui/material/colors';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+const MultipleChoiceDetails = (
+  props: QuestionAnswerDetails<'MultipleChoice'>,
+): JSX.Element => {
+  const { question, answer } = props;
+  return (
+    <>
+      {question.options.map((option) => (
+        <FormControlLabel
+          key={option.id}
+          checked={
+            answer.fields.option_ids.length > 0 &&
+            answer.fields.option_ids.includes(option.id)
+          }
+          className="w-full"
+          control={<Radio />}
+          disabled
+          label={
+            <b>
+              <Typography
+                dangerouslySetInnerHTML={{ __html: option.option.trim() }}
+                style={
+                  option.correct
+                    ? {
+                        backgroundColor: green[50],
+                        verticalAlign: 'middle',
+                      }
+                    : { verticalAlign: 'middle' }
+                }
+                variant="body2"
+              />
+            </b>
+          }
+        />
+      ))}
+    </>
+  );
+};
+
+export default MultipleChoiceDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleResponseDetails.tsx
@@ -1,0 +1,45 @@
+import { Checkbox, FormControlLabel, Typography } from '@mui/material';
+import { green } from '@mui/material/colors';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+const MultipleResponseDetails = (
+  props: QuestionAnswerDetails<'MultipleResponse'>,
+): JSX.Element => {
+  const { question, answer } = props;
+  return (
+    <>
+      {question.options.map((option) => {
+        return (
+          <FormControlLabel
+            key={option.id}
+            checked={
+              answer.fields.option_ids.length > 0 &&
+              answer.fields.option_ids.indexOf(option.id) !== -1
+            }
+            className="w-full"
+            control={<Checkbox />}
+            disabled
+            label={
+              <b>
+                <Typography
+                  dangerouslySetInnerHTML={{ __html: option.option.trim() }}
+                  style={
+                    option.correct
+                      ? {
+                          backgroundColor: green[50],
+                          verticalAlign: 'middle',
+                        }
+                      : { verticalAlign: 'middle' }
+                  }
+                  variant="body2"
+                />
+              </b>
+            }
+          />
+        );
+      })}
+    </>
+  );
+};
+
+export default MultipleResponseDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/TextResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/TextResponseDetails.tsx
@@ -1,0 +1,26 @@
+import { Typography } from '@mui/material';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import AttachmentDetails from './AttachmentDetails';
+
+const TextResponseDetails = (
+  props: QuestionAnswerDetails<'TextResponse'>,
+): JSX.Element => {
+  const { question, answer } = props;
+
+  return (
+    <>
+      <Typography
+        dangerouslySetInnerHTML={{ __html: answer.fields.answer_text }}
+        variant="body2"
+      />
+      {question.maxAttachments > 0 && (
+        <div className="w-full mt-4 mb-4">
+          <AttachmentDetails attachments={answer.attachments} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TextResponseDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay.tsx
@@ -1,0 +1,82 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Chip, Typography } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import { fetchQuestionAnswerDetails } from 'course/assessment/operations/statistics';
+import Accordion from 'lib/components/core/layouts/Accordion';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import { getClassNameForMarkCell } from './classNameUtils';
+
+const translations = defineMessages({
+  questionTitle: {
+    id: 'course.assessment.statistics.questionTitle',
+    defaultMessage: 'Question {index}',
+  },
+  gradeDisplay: {
+    id: 'course.assessment.statistics.gradeDisplay',
+    defaultMessage: 'Grade: {grade} / {maxGrade}',
+  },
+});
+
+interface Props {
+  curAnswerId: number;
+  index: number;
+}
+
+const AnswerDisplay: FC<Props> = (props) => {
+  const { curAnswerId, index } = props;
+  const { t } = useTranslation();
+
+  const fetchQuestionAndCurrentAnswerDetails = (): Promise<
+    QuestionAnswerDetails<keyof typeof QuestionType>
+  > => {
+    return fetchQuestionAnswerDetails(curAnswerId);
+  };
+
+  return (
+    <Preload
+      render={<LoadingIndicator />}
+      while={fetchQuestionAndCurrentAnswerDetails}
+    >
+      {(data): JSX.Element => {
+        const gradeCellColor = getClassNameForMarkCell(
+          data.answer.grade,
+          data.question.maximumGrade,
+        );
+        return (
+          <>
+            <Accordion
+              defaultExpanded={false}
+              title={t(translations.questionTitle, { index })}
+            >
+              <div className="ml-4 mt-4">
+                <Typography variant="body1">{data.question.title}</Typography>
+                <Typography
+                  dangerouslySetInnerHTML={{
+                    __html: data.question.description,
+                  }}
+                  variant="body2"
+                />
+              </div>
+            </Accordion>
+            <Chip
+              className={`w-100 mt-3 ${gradeCellColor}`}
+              label={t(translations.gradeDisplay, {
+                grade: data.answer.grade,
+                maxGrade: data.question.maximumGrade,
+              })}
+              variant="filled"
+            />
+          </>
+        );
+      }}
+    </Preload>
+  );
+};
+
+export default AnswerDisplay;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay.tsx
@@ -10,6 +10,7 @@ import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import Preload from 'lib/components/wrappers/Preload';
 import useTranslation from 'lib/hooks/useTranslation';
 
+import AnswerDetails from './AnswerDetails/AnswerDetails';
 import { getClassNameForMarkCell } from './classNameUtils';
 
 const translations = defineMessages({
@@ -64,6 +65,7 @@ const AnswerDisplay: FC<Props> = (props) => {
                 />
               </div>
             </Accordion>
+            <AnswerDetails answer={data.answer} question={data.question} />
             <Chip
               className={`w-100 mt-3 ${gradeCellColor}`}
               label={t(translations.gradeDisplay, {

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -73,6 +73,10 @@ const translations = defineMessages({
     id: 'course.assessment.statistics.filename',
     defaultMessage: 'Question-level Attempt Statistics for {assessment}',
   },
+  close: {
+    id: 'course.assessment.statistics.close',
+    defaultMessage: 'Close',
+  },
 });
 
 interface Props {
@@ -303,6 +307,7 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
         toolbar={{ show: true }}
       />
       <Prompt
+        cancelLabel={t(translations.close)}
         onClose={(): void => setOpenPastAnswers(false)}
         open={openPastAnswers}
         title={answerInfo.studentName}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -121,7 +121,7 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
   const renderNonNullAttemptCountCell = (attempt: AttemptInfo): ReactNode => {
     const className = getClassNameForAttemptCountCell(attempt);
     return (
-      <div className={className}>
+      <div className={`cursor-pointer ${className}`}>
         <Box>{attempt.attemptCount}</Box>
       </div>
     );

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -141,7 +141,7 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
           setOpenPastAnswers(true);
           setAnswerInfo({
             index: index + 1,
-            answerId: datum.answers![index].currentAnswerId,
+            answerId: datum.answers![index].lastAttemptAnswerId,
             studentName: datum.courseUser.name,
           });
         }}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -68,6 +68,10 @@ const translations = defineMessages({
     id: 'course.assessment.statistics.filename',
     defaultMessage: 'Question-level Marks Statistics for {assessment}',
   },
+  close: {
+    id: 'course.assessment.statistics.close',
+    defaultMessage: 'Close',
+  },
 });
 
 interface Props {
@@ -335,6 +339,7 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
         toolbar={{ show: true }}
       />
       <Prompt
+        cancelLabel={t(translations.close)}
         onClose={(): void => setOpenAnswer(false)}
         open={openAnswer}
         title={answerDisplayInfo.studentName}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -89,7 +89,7 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
 
   const statistics = useAppSelector(getAssessmentStatistics);
   const [openAnswer, setOpenAnswer] = useState(false);
-  const [answerInfo, setAnswerInfo] = useState({
+  const [answerDisplayInfo, setAnswerDisplayInfo] = useState({
     index: 0,
     answerId: 0,
     studentName: '',
@@ -130,9 +130,9 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
         className={`cursor-pointer ${className}`}
         onClick={(): void => {
           setOpenAnswer(true);
-          setAnswerInfo({
+          setAnswerDisplayInfo({
             index: index + 1,
-            answerId: datum.answers![index].currentAnswerId,
+            answerId: datum.answers![index].lastAttemptAnswerId,
             studentName: datum.courseUser.name,
           });
         }}
@@ -337,11 +337,11 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
       <Prompt
         onClose={(): void => setOpenAnswer(false)}
         open={openAnswer}
-        title={answerInfo.studentName}
+        title={answerDisplayInfo.studentName}
       >
         <AnswerDisplay
-          curAnswerId={answerInfo.answerId}
-          index={answerInfo.index}
+          curAnswerId={answerDisplayInfo.answerId}
+          index={answerDisplayInfo.index}
         />
       </Prompt>
     </>

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -113,13 +113,16 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
 
   // the case where the grade is null is handled separately inside the column
   // (refer to the definition of answerColumns below)
-  const renderNonNullGradeCell = (
+  const renderAnswerGradeCell = (
+    currentAnswerId: number | null,
     grade: number,
     maxGrade: number,
   ): ReactNode => {
     const className = getClassNameForMarkCell(grade, maxGrade);
     return (
-      <div className={className}>
+      <div
+        className={currentAnswerId ? `cursor-pointer ${className}` : className}
+      >
         <Box>{grade.toFixed(1)}</Box>
       </div>
     );
@@ -151,8 +154,9 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
         },
         title: t(translations.questionIndex, { index: index + 1 }),
         cell: (datum): ReactNode => {
-          return typeof datum.answers?.[index]?.grade === 'number'
-            ? renderNonNullGradeCell(
+          return typeof datum.answers?.[index].grade === 'number'
+            ? renderAnswerGradeCell(
+                datum.answers?.[index]?.currentAnswerId,
                 datum.answers?.[index]?.grade,
                 datum.answers?.[index]?.maximumGrade,
               )
@@ -237,7 +241,8 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
       sortable: true,
       cell: (datum): ReactNode =>
         datum.totalGrade
-          ? renderNonNullGradeCell(
+          ? renderAnswerGradeCell(
+              null,
               datum.totalGrade ?? null,
               assessment!.maximumGrade,
             )

--- a/client/app/bundles/course/assessment/submission/components/answers/TextResponse/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/TextResponse/index.jsx
@@ -128,8 +128,8 @@ TextResponse.propTypes = {
   answerId: PropTypes.number.isRequired,
   graderView: PropTypes.bool.isRequired,
   handleUploadTextResponseFiles: PropTypes.func.isRequired,
-  question: questionShape.isRequired,
   numAttachments: PropTypes.number,
+  question: questionShape.isRequired,
   readOnly: PropTypes.bool.isRequired,
   saveAnswerAndUpdateClientVersion: PropTypes.func.isRequired,
 };

--- a/client/app/types/course/assessment/submission/answer/forumPostResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/forumPostResponse.ts
@@ -6,7 +6,7 @@ import {
   AnswerFieldBaseEntity,
 } from './answer';
 
-interface PostPack {
+export interface PostPack {
   id: number;
   text: string;
   creatorId: number;
@@ -19,19 +19,21 @@ interface PostPack {
 
 // BE Data Type
 
-interface ForumPostResponseFieldData extends AnswerFieldBaseData {
+export interface SelectedPostPack {
+  forum: { id: string; name: string };
+  topic: { id: number; title: string; isDeleted: boolean };
+  corePost: PostPack;
+  parentPost?: PostPack;
+}
+
+export interface ForumPostResponseFieldData extends AnswerFieldBaseData {
   answer_text: string;
+  selected_post_packs: SelectedPostPack[];
 }
 
 export interface ForumPostResponseAnswerData extends AnswerBaseData {
   questionType: QuestionType.ForumPostResponse;
   fields: ForumPostResponseFieldData;
-  selected_post_packs: {
-    forum: { id: string; name: string };
-    topic: { id: number; title: string; isDeleted: boolean };
-    corePost: PostPack;
-    parentPost?: PostPack;
-  };
   explanation: {
     correct: boolean | null;
     explanations: string[];

--- a/client/app/types/course/assessment/submission/answer/multipleResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/multipleResponse.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface MultipleResponseFieldData extends AnswerFieldBaseData {
+export interface MultipleResponseFieldData extends AnswerFieldBaseData {
   option_ids: number[];
 }
 
@@ -22,7 +22,7 @@ export interface MultipleResponseAnswerData extends AnswerBaseData {
   latestAnswer?: MultipleResponseAnswerData;
 }
 
-interface MultipleChoiceFieldData extends AnswerFieldBaseData {
+export interface MultipleChoiceFieldData extends AnswerFieldBaseData {
   option_ids: number[];
 }
 

--- a/client/app/types/course/assessment/submission/answer/programming.ts
+++ b/client/app/types/course/assessment/submission/answer/programming.ts
@@ -15,9 +15,9 @@ export interface ProgrammingContent {
   highlightedContent: string | null;
 }
 
-type TestCaseType = 'public_test' | 'private_test' | 'evaluation_test';
+export type TestCaseType = 'public_test' | 'private_test' | 'evaluation_test';
 
-interface TestCaseResult {
+export interface TestCaseResult {
   identifier?: string;
   expression: string;
   expected: string;
@@ -27,7 +27,7 @@ interface TestCaseResult {
 
 // BE Data Type
 
-interface ProgrammingFieldData extends AnswerFieldBaseData {
+export interface ProgrammingFieldData extends AnswerFieldBaseData {
   files_attributes: ProgrammingContent[];
 }
 

--- a/client/app/types/course/assessment/submission/answer/scribing.ts
+++ b/client/app/types/course/assessment/submission/answer/scribing.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface ScribingFieldData extends AnswerFieldBaseData {}
+export interface ScribingFieldData extends AnswerFieldBaseData {}
 
 export interface ScribingAnswerData extends AnswerBaseData {
   questionType: QuestionType.Scribing;

--- a/client/app/types/course/assessment/submission/answer/textResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/textResponse.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface TextResponseFieldData extends AnswerFieldBaseData {
+export interface TextResponseFieldData extends AnswerFieldBaseData {
   answer_text: string;
 }
 
@@ -23,7 +23,7 @@ export interface TextResponseAnswerData extends AnswerBaseData {
   latestAnswer?: TextResponseAnswerData;
 }
 
-interface FileUploadFieldData extends AnswerFieldBaseData {}
+export interface FileUploadFieldData extends AnswerFieldBaseData {}
 
 export interface FileUploadAnswerData extends AnswerBaseData {
   questionType: QuestionType.FileUpload;

--- a/client/app/types/course/assessment/submission/answer/voiceResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/voiceResponse.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface VoiceResponseFieldData extends AnswerFieldBaseData {
+export interface VoiceResponseFieldData extends AnswerFieldBaseData {
   file: { url: string | null; name: string };
 }
 

--- a/client/app/types/course/assessment/submission/question/types.ts
+++ b/client/app/types/course/assessment/submission/question/types.ts
@@ -66,7 +66,7 @@ interface ForumPostResponseQuestionData {
   maxPosts: boolean;
 }
 
-interface SpecificQuestionDataMap {
+export interface SpecificQuestionDataMap {
   MultipleChoice: MultipleResponseQuestionData;
   MultipleResponse: MultipleResponseQuestionData;
   Programming: ProgrammingQuestionData;

--- a/client/app/types/course/statistics/answer.ts
+++ b/client/app/types/course/statistics/answer.ts
@@ -1,0 +1,151 @@
+import { JobStatus, JobStatusResponse } from 'types/jobs';
+
+import { QuestionType } from '../assessment/question';
+import { ForumPostResponseFieldData } from '../assessment/submission/answer/forumPostResponse';
+import {
+  MultipleChoiceFieldData,
+  MultipleResponseFieldData,
+} from '../assessment/submission/answer/multipleResponse';
+import {
+  ProgrammingFieldData,
+  TestCaseResult,
+  TestCaseType,
+} from '../assessment/submission/answer/programming';
+import { ScribingFieldData } from '../assessment/submission/answer/scribing';
+import {
+  FileUploadFieldData,
+  TextResponseFieldData,
+} from '../assessment/submission/answer/textResponse';
+import { VoiceResponseFieldData } from '../assessment/submission/answer/voiceResponse';
+
+interface AnswerCommonDetails<T extends keyof typeof QuestionType> {
+  grade: number;
+  questionType: T;
+}
+
+export interface McqAnswerDetails
+  extends AnswerCommonDetails<'MultipleChoice'> {
+  fields: MultipleChoiceFieldData;
+  explanation: {
+    correct?: boolean | null;
+    explanations?: string[];
+  };
+  latestAnswer?: McqAnswerDetails;
+}
+
+export interface MrqAnswerDetails
+  extends AnswerCommonDetails<'MultipleResponse'> {
+  fields: MultipleResponseFieldData;
+  explanation: {
+    correct?: boolean | null;
+    explanations?: string[];
+  };
+  latestAnswer?: MrqAnswerDetails;
+}
+
+export interface ProgrammingAnswerDetails
+  extends AnswerCommonDetails<'Programming'> {
+  fields: ProgrammingFieldData;
+  explanation: {
+    correct?: boolean;
+    explanation: string[];
+    failureType: TestCaseType;
+  };
+  testCases: {
+    canReadTests: boolean;
+    public_test?: TestCaseResult[];
+    private_test?: TestCaseResult[];
+    evaluation_test?: TestCaseResult[];
+    stdout?: string;
+    stderr?: string;
+  };
+  attemptsLeft?: number;
+  autograding?: JobStatusResponse & {
+    path?: string;
+  };
+  codaveriFeedback?: {
+    jobId: string;
+    jobStatus: keyof typeof JobStatus;
+    jobUrl?: string;
+    errorMessage?: string;
+  };
+  latestAnswer?: ProgrammingAnswerDetails & {
+    annotations: {
+      fileId: number;
+      topics: {
+        id: number;
+        postIds: number[];
+        line: string;
+      }[];
+    };
+  };
+}
+
+export interface TextResponseAnswerDetails
+  extends AnswerCommonDetails<'TextResponse'> {
+  fields: TextResponseFieldData;
+  attachments: { id: string; name: string }[];
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+  latestAnswer?: TextResponseAnswerDetails;
+}
+
+export interface FileUploadAnswerDetails
+  extends AnswerCommonDetails<'FileUpload'> {
+  fields: FileUploadFieldData;
+  attachments: { id: string; name: string }[];
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+  latestAnswer?: FileUploadAnswerDetails;
+}
+
+export interface ComprehensionAnswerDetails
+  extends AnswerCommonDetails<'Comprehension'> {}
+
+export interface ScribingAnswerDetails extends AnswerCommonDetails<'Scribing'> {
+  fields: ScribingFieldData;
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+  scribing_answer: {
+    image_url: string;
+    user_id: number;
+    answer_id: number;
+    scribbles: { content: string; creator_name: string; creator_id: number }[];
+  };
+}
+
+export interface VoiceResponseAnswerDetails
+  extends AnswerCommonDetails<'VoiceResponse'> {
+  fields: VoiceResponseFieldData;
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+}
+
+export interface ForumPostResponseAnswerDetails
+  extends AnswerCommonDetails<'ForumPostResponse'> {
+  fields: ForumPostResponseFieldData;
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+}
+
+export interface AnswerDetailsMap {
+  MultipleChoice: McqAnswerDetails;
+  MultipleResponse: MrqAnswerDetails;
+  Programming: ProgrammingAnswerDetails;
+  TextResponse: TextResponseAnswerDetails;
+  FileUpload: FileUploadAnswerDetails;
+  Comprehension: ComprehensionAnswerDetails;
+  Scribing: ScribingAnswerDetails;
+  VoiceResponse: VoiceResponseAnswerDetails;
+  ForumPostResponse: ForumPostResponseAnswerDetails;
+}

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -1,4 +1,8 @@
+import { QuestionType } from '../assessment/question';
+import { SpecificQuestionDataMap } from '../assessment/submission/question/types';
 import { WorkflowState } from '../assessment/submission/submission';
+
+import { AnswerDetailsMap } from './answer';
 
 interface AssessmentInfo {
   id: number;
@@ -27,11 +31,13 @@ export interface StudentInfo extends UserInfo {
 }
 
 interface AnswerInfo {
+  currentAnswerId: number;
   grade: number;
   maximumGrade: number;
 }
 
 export interface AttemptInfo {
+  currentAnswerId: number;
   isAutograded: boolean;
   attemptCount: number;
   correct: boolean | null;
@@ -77,3 +83,19 @@ export interface AncestorAssessmentStats {
 }
 
 export interface AssessmentStatisticsState extends MainAssessmentStats {}
+
+interface QuestionBasicDetails<T extends keyof typeof QuestionType> {
+  id: number;
+  title: string;
+  description: string;
+  type: T;
+  maximumGrade: number;
+}
+
+export type QuestionDetails<T extends keyof typeof QuestionType> =
+  QuestionBasicDetails<T> & SpecificQuestionDataMap[T];
+
+export interface QuestionAnswerDetails<T extends keyof typeof QuestionType> {
+  question: QuestionDetails<T>;
+  answer: AnswerDetailsMap[T];
+}

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -30,7 +30,7 @@ export interface StudentInfo extends UserInfo {
   role: 'student';
 }
 
-interface AnswerInfo {
+export interface AnswerInfo {
   currentAnswerId: number;
   grade: number;
   maximumGrade: number;

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -31,13 +31,13 @@ export interface StudentInfo extends UserInfo {
 }
 
 export interface AnswerInfo {
-  currentAnswerId: number;
+  lastAttemptAnswerId: number;
   grade: number;
   maximumGrade: number;
 }
 
 export interface AttemptInfo {
-  currentAnswerId: number;
+  lastAttemptAnswerId: number;
   isAutograded: boolean;
   attemptCount: number;
   correct: boolean | null;

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -2504,13 +2504,13 @@
   "course.assessment.submission.ImportedFileView.uploadedFiles": {
     "defaultMessage": "Uploaded Files:"
   },
-  "course.assessment.submission.SubmissionAnswer.missingAnswer": {
+  "course.assessment.submission.Answer.missingAnswer": {
     "defaultMessage": "There is no answer submitted for this question - this might be caused by the addition of this question after the submission is submitted."
   },
-  "course.assessment.submission.SubmissionAnswer.noPastAnswers": {
+  "course.assessment.submission.answers.AnswerHeader.noPastAnswers": {
     "defaultMessage": "No past answers."
   },
-  "course.assessment.submission.SubmissionAnswer.rendererNotImplemented": {
+  "course.assessment.submission.Answer.rendererNotImplemented": {
     "defaultMessage": "The display for this question type has not been implemented yet."
   },
   "course.assessment.submission.SubmissionAnswer.viewPastAnswers": {

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -2444,13 +2444,13 @@
   "course.assessment.submission.ImportedFileView.uploadedFiles": {
     "defaultMessage": "上传的文件："
   },
-  "course.assessment.submission.SubmissionAnswer.missingAnswer": {
+  "course.assessment.submission.Answer.missingAnswer": {
     "defaultMessage": "此问题没有已提交的答案——可能是因为提交之后又添加了新问题。"
   },
-  "course.assessment.submission.SubmissionAnswer.noPastAnswers": {
+  "course.assessment.submission.answers.AnswerHeader.noPastAnswers": {
     "defaultMessage": "没有过去的答案。"
   },
-  "course.assessment.submission.SubmissionAnswer.rendererNotImplemented": {
+  "course.assessment.submission.Answer.rendererNotImplemented": {
     "defaultMessage": "此问题类型的显示尚未实现。"
   },
   "course.assessment.submission.SubmissionAnswer.viewPastAnswers": {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -428,13 +428,14 @@ Rails.application.routes.draw do
 
       namespace :statistics do
         get '/' => 'statistics#index'
+        get 'answer/:id' => 'answers#question_answer_details'
+        get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
+        get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
         get 'course/progression' => 'aggregate#course_progression'
         get 'course/performance' => 'aggregate#course_performance'
         get 'students' => 'aggregate#all_students'
         get 'staff' => 'aggregate#all_staff'
         get 'user/:user_id/learning_rate_records' => 'users#learning_rate_records'
-        get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
-        get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
       end
 
       scope module: :video do

--- a/spec/controllers/course/statistics/answers_controller_spec.rb
+++ b/spec/controllers/course/statistics/answers_controller_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Statistics::AnswersController, type: :controller do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course, :enrollable) }
+    let(:course_user) { create(:course_user, course: course) }
+    let(:assessment) do
+      create(:assessment, :published_with_mrq_question, course: course, start_at: 1.day.from_now)
+    end
+    let(:submission) { create(:submission, :graded, assessment: assessment, creator: course_user.user) }
+    let(:answer) { submission.answers.first }
+
+    describe '#question_answer_details' do
+      render_views
+      subject { get :question_answer_details, format: :json, params: { course_id: course, id: answer.id } }
+
+      context 'when the Normal User get the question answer details for the statistics' do
+        let(:user) { create(:user) }
+        before { controller_sign_in(controller, user) }
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the Course Student get the question answer details for the statistics' do
+        let(:user) { create(:course_student, course: course).user }
+        before { controller_sign_in(controller, user) }
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the Course Manager get the question answer details for the statistics' do
+        let(:user) { create(:course_manager, course: course).user }
+        before { controller_sign_in(controller, user) }
+
+        it 'returns OK with right question id and answer grade being displayed' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          expect(json_result['question']['id']).to eq(answer.question.id)
+          expect(json_result['answer']['grade'].to_f).to eq(answer.grade)
+        end
+      end
+
+      context 'when the administrator get the question answer details for the statistics' do
+        let(:administrator) { create(:administrator) }
+        before { controller_sign_in(controller, administrator) }
+
+        it 'returns OK with right question id and answer grade being displayed' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          expect(json_result['question']['id']).to eq(answer.question.id)
+          expect(json_result['answer']['grade'].to_f).to eq(answer.grade)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Background

This is the continuation of the previous PR https://github.com/Coursemology/coursemology2/pull/7077 and https://github.com/Coursemology/coursemology2/pull/7084 that adds feature allowing teacher to see the details of the answer when clicking on the grade box in the Assessment Statistics Page

This PR is related with the issue https://github.com/Coursemology/coursemology2/issues/4567

## Feature Details

The display of the answer is as follows:
<img width="639" alt="Screenshot 2024-08-01 at 5 09 38 PM" src="https://github.com/user-attachments/assets/887aa069-eb9d-4a6b-a16b-756a479919f8">

How to navigate:
- In either Marks per Question Table or Attempt Count Table (available inside the Assessment Statistics Page), you might click on any grade/attempt-count box.
- The answer details pop-up box will be shown immediately after.

Some consideration in the feature implementation:
- Question is included in the Details as a reference for the teacher to make them easier to look into the question details while looking at the Answer.
- Since our focus here is the details inside the answer, we made Question to be collapsible, with not expanded as the default.
- We define the new component instead of redirecting the user to the Submission Page so that user can stay on the statistics page while examining the Answer

## TO-DO Lists

- [x] Define component for Forum Post Response and Programming Answer (higher priority) (https://github.com/Coursemology/coursemology2/pull/7131)
- [x] Get all past answers (other attempts made by students other than the last graded one) and display the most recent 10 answers into the Answer Details component (https://github.com/Coursemology/coursemology2/pull/7135)
- [x] Define new page consisting of all the past answers list (possibly creating new API for this as well) (https://github.com/Coursemology/coursemology2/pull/7135)

## Future Improvement

- Define component for Voice Response and Scribing (at this point, not urgent to do)

## Additional Notes

The codecov here noted some of the changes in BE not covered in the tests in RSpec. However, this will be later covered in the PR https://github.com/Coursemology/coursemology2/pull/7135