### PR TITLE
Show Answer Details in Assessment Statistics Page (Part 2: Last Graded Answer (Forum Post Response, Programming))

### DIFF
--- a/app/views/course/statistics/answers/question_answer_details.json.jbuilder
+++ b/app/views/course/statistics/answers/question_answer_details.json.jbuilder
@@ -13,6 +13,7 @@ end
 
 specific_answer = @answer.specific
 json.answer do
+  json.id @answer.id
   json.grade @answer.grade
   json.questionType question.question_type
   json.partial! specific_answer, answer: specific_answer, can_grade: false

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
@@ -7,6 +7,7 @@ import { QuestionDetails } from 'types/course/statistics/assessmentStatistics';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import FileUploadDetails from './FileUploadDetails';
+import ForumPostResponseDetails from './ForumPostResponseDetails';
 import MultipleChoiceDetails from './MultipleChoiceDetails';
 import MultipleResponseDetails from './MultipleResponseDetails';
 import TextResponseDetails from './TextResponseDetails';
@@ -47,10 +48,10 @@ export const AnswerDetailsMapper = {
   FileUpload: (props: AnswerDetailsProps<'FileUpload'>): JSX.Element => (
     <FileUploadDetails {...props} />
   ),
-  // TODO: define component for Forum Post, Programming, Voice Response, Scribing
   ForumPostResponse: (
-    _props: AnswerDetailsProps<'ForumPostResponse'>,
-  ): JSX.Element => <AnswerNotImplemented />,
+    props: AnswerDetailsProps<'ForumPostResponse'>,
+  ): JSX.Element => <ForumPostResponseDetails {...props} />,
+  // TODO: define component for Programming, Voice Response, Scribing
   Programming: (_props: AnswerDetailsProps<'Programming'>): JSX.Element => (
     <AnswerNotImplemented />
   ),

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
@@ -10,6 +10,7 @@ import FileUploadDetails from './FileUploadDetails';
 import ForumPostResponseDetails from './ForumPostResponseDetails';
 import MultipleChoiceDetails from './MultipleChoiceDetails';
 import MultipleResponseDetails from './MultipleResponseDetails';
+import ProgrammingAnswerDetails from './ProgrammingAnswerDetails';
 import TextResponseDetails from './TextResponseDetails';
 
 const translations = defineMessages({
@@ -51,10 +52,10 @@ export const AnswerDetailsMapper = {
   ForumPostResponse: (
     props: AnswerDetailsProps<'ForumPostResponse'>,
   ): JSX.Element => <ForumPostResponseDetails {...props} />,
-  // TODO: define component for Programming, Voice Response, Scribing
-  Programming: (_props: AnswerDetailsProps<'Programming'>): JSX.Element => (
-    <AnswerNotImplemented />
+  Programming: (props: AnswerDetailsProps<'Programming'>): JSX.Element => (
+    <ProgrammingAnswerDetails {...props} />
   ),
+  // TODO: define component for Voice Response, Scribing
   VoiceResponse: (_props: AnswerDetailsProps<'VoiceResponse'>): JSX.Element => (
     <AnswerNotImplemented />
   ),

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/ParentPostPack.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/ParentPostPack.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Typography } from '@mui/material';
+import { PostPack } from 'types/course/assessment/submission/answer/forumPostResponse';
+
+import Labels from 'course/assessment/submission/components/answers/ForumPostResponse/Labels';
+
+import PostContent from './PostContent';
+
+const translations = defineMessages({
+  postMadeInResponseTo: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ParentPost.postMadeInResponseTo',
+    defaultMessage: 'Post made in response to:',
+  },
+});
+
+interface Props {
+  post: PostPack;
+}
+
+const ParentPostPack: FC<Props> = (props) => {
+  const { post } = props;
+
+  return (
+    <div className="m-4">
+      <Typography className="mb-5" color="text.secondary" variant="body2">
+        <FormattedMessage {...translations.postMadeInResponseTo} />
+      </Typography>
+      <Labels post={post} />
+      <PostContent isExpandable post={post} />
+    </div>
+  );
+};
+
+export default ParentPostPack;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostContent.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostContent.tsx
@@ -1,0 +1,83 @@
+import { FC, useLayoutEffect, useRef, useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import {
+  Avatar,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  Typography,
+} from '@mui/material';
+import { PostPack } from 'types/course/assessment/submission/answer/forumPostResponse';
+
+import { formatLongDateTime } from 'lib/moment';
+
+interface Props {
+  post: PostPack;
+  isExpandable?: boolean;
+}
+
+const MAX_POST_HEIGHT = 60;
+
+export const translations = defineMessages({
+  showMore: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ForumPost.showMore',
+    defaultMessage: 'SHOW MORE',
+  },
+  showLess: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ForumPost.showLess',
+    defaultMessage: 'SHOW LESS',
+  },
+});
+
+const PostContent: FC<Props> = (props) => {
+  const { post, isExpandable } = props;
+  const [renderedHeight, setRenderedHeight] = useState(0);
+
+  const contentIsExpandable = isExpandable && renderedHeight > MAX_POST_HEIGHT;
+  const [isExpanded, setIsExpanded] = useState(!isExpandable);
+
+  const postRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (postRef.current) {
+      setRenderedHeight(postRef.current.clientHeight);
+    }
+  }, [post]);
+
+  return (
+    <div ref={postRef}>
+      <Card className="forum-post shadow-none border-0">
+        <CardHeader
+          avatar={<Avatar src={post.avatar} />}
+          subheader={formatLongDateTime(post.updatedAt)}
+          title={post.userName}
+        />
+        <Divider />
+        <CardContent>
+          <Typography
+            className={`overflow-hidden ${!isExpanded && contentIsExpandable ? `h-20` : 'h-auto'}`}
+            dangerouslySetInnerHTML={{ __html: post.text }}
+            variant="body2"
+          />
+          {contentIsExpandable && (
+            <Button
+              className="forum-post-expand-button mt-2"
+              color="primary"
+              onClick={() => setIsExpanded(!isExpanded)}
+            >
+              {isExpanded ? (
+                <FormattedMessage {...translations.showLess} />
+              ) : (
+                <FormattedMessage {...translations.showMore} />
+              )}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PostContent;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostPack.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostPack.tsx
@@ -1,0 +1,103 @@
+import { FC, useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { ChevronRight, ExpandMore } from '@mui/icons-material';
+import { Typography } from '@mui/material';
+import { SelectedPostPack } from 'types/course/assessment/submission/answer/forumPostResponse';
+
+import Labels from 'course/assessment/submission/components/answers/ForumPostResponse/Labels';
+import Link from 'lib/components/core/Link';
+import { getForumTopicURL, getForumURL } from 'lib/helpers/url-builders';
+import { getCourseId } from 'lib/helpers/url-helpers';
+
+import ParentPostPack from './ParentPostPack';
+import PostContent from './PostContent';
+
+const translations = defineMessages({
+  topicDeleted: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.SelectedPostCard.topicDeleted',
+    defaultMessage: 'Post made under a topic that was subsequently deleted.',
+  },
+  postMadeUnder: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.SelectedPostCard.postMadeUnder',
+    defaultMessage: 'Post made under {topicUrl} in {forumUrl}',
+  },
+});
+
+interface Props {
+  postPack: SelectedPostPack;
+}
+
+const MAX_NAME_LENGTH = 30;
+
+const generateLink = (url: string, name: string): JSX.Element => {
+  const renderedName =
+    name.length > MAX_NAME_LENGTH
+      ? `${name.slice(0, MAX_NAME_LENGTH)}...`
+      : name;
+  return (
+    <Link opensInNewTab to={url}>
+      {renderedName}
+    </Link>
+  );
+};
+
+const PostPack: FC<Props> = (props) => {
+  const { postPack } = props;
+  const courseId = getCourseId();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const ForumPostLabel = (): JSX.Element => {
+    const { forum, topic } = postPack;
+    return (
+      <div className="flex items-center">
+        {isExpanded ? (
+          <ExpandMore fontSize="small" />
+        ) : (
+          <ChevronRight fontSize="small" />
+        )}
+        <Typography variant="body2">
+          {topic.isDeleted ? (
+            <FormattedMessage {...translations.topicDeleted} />
+          ) : (
+            <FormattedMessage
+              values={{
+                topicUrl: generateLink(
+                  getForumTopicURL(courseId, forum.id, topic.id),
+                  topic.title,
+                ),
+                forumUrl: generateLink(
+                  getForumURL(courseId, forum.id),
+                  forum.name,
+                ),
+              }}
+              {...translations.postMadeUnder}
+            />
+          )}
+        </Typography>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      key={`forum-post-pack-${postPack.forum.id}-${postPack.topic.id}`}
+      className="mb-12 shadow-md rounded-md overflow-hidden"
+    >
+      <div
+        className="p-4 bg-green-50 cursor-pointer flex justify-between items-center"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <ForumPostLabel />
+      </div>
+      {isExpanded && (
+        <>
+          <Labels post={postPack.corePost} />
+          <PostContent post={postPack.corePost} />
+          {postPack.parentPost && <ParentPostPack post={postPack.parentPost} />}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PostPack;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseDetails.tsx
@@ -1,0 +1,40 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Typography } from '@mui/material';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import PostPack from './ForumPostResponseComponent/PostPack';
+
+const translations = defineMessages({
+  submittedInstructions: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ForumPostSelect.submittedInstructions',
+    defaultMessage:
+      '{numPosts, plural, =0 {No posts were} one {# post was} other {# posts were}} submitted.',
+  },
+});
+
+const ForumPostResponseDetails = (
+  props: QuestionAnswerDetails<'ForumPostResponse'>,
+): JSX.Element => {
+  const { answer } = props;
+  const postPacks = answer.fields.selected_post_packs;
+
+  return (
+    <>
+      <Typography className="mb-5 mt-5" color="text.secondary" variant="body2">
+        <FormattedMessage
+          values={{ numPosts: postPacks.length }}
+          {...translations.submittedInstructions}
+        />
+      </Typography>
+      {postPacks.length > 0 &&
+        postPacks.map((postPack) => (
+          <PostPack
+            key={`post-pack-${postPack.forum.id}-${postPack.topic.id}`}
+            postPack={postPack}
+          />
+        ))}
+    </>
+  );
+};
+
+export default ForumPostResponseDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingAnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingAnswerDetails.tsx
@@ -1,0 +1,30 @@
+import { Annotation } from 'types/course/statistics/answer';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import CodaveriFeedbackStatus from './ProgrammingComponent/CodaveriFeedbackStatus';
+import FileContent from './ProgrammingComponent/FileContent';
+import TestCases from './ProgrammingComponent/TestCases';
+
+const ProgrammingAnswerDetails = (
+  props: QuestionAnswerDetails<'Programming'>,
+): JSX.Element => {
+  const { answer } = props;
+  const annotations = answer.latestAnswer?.annotations ?? ([] as Annotation[]);
+
+  return (
+    <>
+      {answer.fields.files_attributes.map((file) => (
+        <FileContent
+          key={`file-${file.id}-answer-${answer.id}`}
+          annotations={annotations}
+          answerId={answer.id}
+          file={file}
+        />
+      ))}
+      <TestCases testCase={answer.testCases} />
+      <CodaveriFeedbackStatus status={answer.codaveriFeedback} />
+    </>
+  );
+};
+
+export default ProgrammingAnswerDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/CodaveriFeedbackStatus.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/CodaveriFeedbackStatus.tsx
@@ -1,0 +1,72 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Paper, Typography } from '@mui/material';
+import { CodaveriFeedback } from 'types/course/statistics/answer';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  codaveriFeedbackStatus: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.codaveriFeedbackStatus',
+    defaultMessage: 'Codaveri Feedback Status',
+  },
+  loadingFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.loadingFeedbackGeneration',
+    defaultMessage: 'Generating Feedback. Please wait...',
+  },
+  successfulFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.successfulFeedbackGeneration',
+    defaultMessage: 'Feedback has been successfully generated.',
+  },
+  failedFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.failedFeedbackGeneration',
+    defaultMessage: 'Failed to generate feedback. Please try again later.',
+  },
+});
+
+const codaveriJobDisplay = {
+  submitted: {
+    feedbackBgColor: 'bg-orange-100',
+    feedbackDescription: translations.loadingFeedbackGeneration,
+  },
+  completed: {
+    feedbackBgColor: 'bg-green-100',
+    feedbackDescription: translations.successfulFeedbackGeneration,
+  },
+  errored: {
+    feedbackBgColor: 'bg-red-100',
+    feedbackDescription: translations.failedFeedbackGeneration,
+  },
+};
+
+interface Props {
+  status?: CodaveriFeedback;
+}
+
+const CodaveriFeedbackStatus: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const { status } = props;
+
+  if (!status) {
+    return null;
+  }
+
+  const { feedbackBgColor, feedbackDescription } =
+    codaveriJobDisplay[status.jobStatus];
+
+  return (
+    <Paper className="mb-8">
+      <Typography
+        className={`${feedbackBgColor} table-cell p-8 font-bold`}
+        variant="body2"
+      >
+        {t(translations.codaveriFeedbackStatus)}
+      </Typography>
+      <Typography className="table-cell pl-5" variant="body2">
+        {t(feedbackDescription)}
+      </Typography>
+    </Paper>
+  );
+};
+
+export default CodaveriFeedbackStatus;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
@@ -30,6 +30,7 @@ const FileContent: FC<Props> = (props) => {
       annotations={fileAnnotation?.topics ?? ([] as AnnotationTopic[])}
       answerId={answerId}
       file={file}
+      isUpdatingAnnotationAllowed={false}
     />
   ) : (
     <>

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Warning } from '@mui/icons-material';
+import { Paper, Typography } from '@mui/material';
+import { ProgrammingContent } from 'types/course/assessment/submission/answer/programming';
+import { Annotation, AnnotationTopic } from 'types/course/statistics/answer';
+
+import ProgrammingFileDownloadLink from 'course/assessment/submission/components/answers/Programming/ProgrammingFileDownloadLink';
+import ReadOnlyEditor from 'course/assessment/submission/components/ReadOnlyEditor';
+
+const translations = defineMessages({
+  sizeTooBig: {
+    id: 'course.assessment.submission.answers.Programming.ProgrammingFile.sizeTooBig',
+    defaultMessage: 'The file is too big and cannot be displayed.',
+  },
+});
+
+interface Props {
+  answerId: number;
+  annotations: Annotation[];
+  file: ProgrammingContent;
+}
+
+const FileContent: FC<Props> = (props) => {
+  const { answerId, annotations, file } = props;
+  const fileAnnotation = annotations.find((a) => a.fileId === file.id);
+
+  return file.highlightedContent ? (
+    <ReadOnlyEditor
+      annotations={fileAnnotation?.topics ?? ([] as AnnotationTopic[])}
+      answerId={answerId}
+      file={file}
+    />
+  ) : (
+    <>
+      <ProgrammingFileDownloadLink file={file} />
+      <Paper className="flex items-center bg-yellow-100 p-2">
+        <Warning />
+        <Typography variant="body2">
+          <FormattedMessage {...translations.sizeTooBig} />
+        </Typography>
+      </Paper>
+    </>
+  );
+};
+
+export default FileContent;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCaseRow.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCaseRow.tsx
@@ -1,0 +1,69 @@
+import { FC, Fragment } from 'react';
+import { Clear, Done } from '@mui/icons-material';
+import { TableCell, TableRow, Typography } from '@mui/material';
+import { TestCaseResult } from 'types/course/assessment/submission/answer/programming';
+
+import ExpandableCode from 'lib/components/core/ExpandableCode';
+
+interface Props {
+  result: TestCaseResult;
+}
+
+const TestCaseClassName = {
+  unattempted: '',
+  correct: 'bg-green-50',
+  wrong: 'bg-red-50',
+};
+
+const TestCaseRow: FC<Props> = (props) => {
+  const { result } = props;
+
+  const nameRegex = /\/?(\w+)$/;
+  const idMatch = result.identifier?.match(nameRegex);
+  const truncatedIdentifier = idMatch ? idMatch[1] : '';
+
+  let testCaseResult = 'unattempted';
+  let testCaseIcon;
+  if (result.passed !== undefined) {
+    testCaseResult = result.passed ? 'correct' : 'wrong';
+    testCaseIcon = result.passed ? (
+      <Done color="success" />
+    ) : (
+      <Clear color="error" />
+    );
+  }
+
+  return (
+    <Fragment key={result.identifier}>
+      <TableRow className={TestCaseClassName[testCaseResult]}>
+        <TableCell className="h-fit border-none pb-0 leading-none" colSpan={5}>
+          <Typography
+            className="break-all"
+            color="text.secondary"
+            variant="caption"
+          >
+            {truncatedIdentifier}
+          </Typography>
+        </TableCell>
+      </TableRow>
+
+      <TableRow className={TestCaseClassName[testCaseResult]}>
+        <TableCell className="w-full pt-1">
+          <ExpandableCode>{result.expression}</ExpandableCode>
+        </TableCell>
+
+        <TableCell className="w-full pt-1">
+          <ExpandableCode>{result.expected || ''}</ExpandableCode>
+        </TableCell>
+
+        <TableCell className="w-full pt-1">
+          <ExpandableCode>{result.output || ''}</ExpandableCode>
+        </TableCell>
+
+        <TableCell>{testCaseIcon}</TableCell>
+      </TableRow>
+    </Fragment>
+  );
+};
+
+export default TestCaseRow;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCases.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCases.tsx
@@ -1,0 +1,175 @@
+import { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Done } from '@mui/icons-material';
+import {
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { TestCaseResult } from 'types/course/assessment/submission/answer/programming';
+import { TestCase } from 'types/course/statistics/answer';
+
+import Accordion from 'lib/components/core/layouts/Accordion';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import TestCaseRow from './TestCaseRow';
+
+const translations = defineMessages({
+  expression: {
+    id: 'course.assessment.submission.TestCaseView.experession',
+    defaultMessage: 'Expression',
+  },
+  expected: {
+    id: 'course.assessment.submission.TestCaseView.expected',
+    defaultMessage: 'Expected',
+  },
+  output: {
+    id: 'course.assessment.submission.TestCaseView.output',
+    defaultMessage: 'Output',
+  },
+  allPassed: {
+    id: 'course.assessment.submission.TestCaseView.allPassed',
+    defaultMessage: 'All passed',
+  },
+  publicTestCases: {
+    id: 'course.assessment.submission.TestCaseView.publicTestCases',
+    defaultMessage: 'Public Test Cases',
+  },
+  privateTestCases: {
+    id: 'course.assessment.submission.TestCaseView.privateTestCases',
+    defaultMessage: 'Private Test Cases',
+  },
+  evaluationTestCases: {
+    id: 'course.assessment.submission.TestCaseView.evaluationTestCases',
+    defaultMessage: 'Evaluation Test Cases',
+  },
+  standardOutput: {
+    id: 'course.assessment.submission.TestCaseView.standardOutput',
+    defaultMessage: 'Standard Output',
+  },
+  standardError: {
+    id: 'course.assessment.submission.TestCaseView.standardError',
+    defaultMessage: 'Standard Error',
+  },
+  noOutputs: {
+    id: 'course.assessment.submission.TestCaseView.noOutputs',
+    defaultMessage: 'No outputs',
+  },
+});
+
+interface Props {
+  testCase: TestCase;
+}
+
+const TestCaseComponent = (
+  testCaseResults: TestCaseResult[],
+  testCaseType: string,
+): JSX.Element => {
+  const { t } = useTranslation();
+  const passedTestCases = testCaseResults.reduce(
+    (passed, testCase) => passed && testCase?.passed,
+    true,
+  );
+
+  return (
+    <Accordion
+      className={passedTestCases ? 'border-success' : ''}
+      defaultExpanded={false}
+      disableGutters
+      icon={
+        passedTestCases && (
+          <Chip
+            color="success"
+            icon={<Done />}
+            label={t(translations.allPassed)}
+            size="small"
+            variant="outlined"
+          />
+        )
+      }
+      id={testCaseType}
+      title={t(translations[testCaseType])}
+    >
+      <Table className="table-fixed">
+        <TableHead>
+          <TableRow>
+            <TableCell className="w-full">
+              <FormattedMessage {...translations.expression} />
+            </TableCell>
+
+            <TableCell className="w-full">
+              <FormattedMessage {...translations.expected} />
+            </TableCell>
+
+            <TableCell className="w-full">
+              <FormattedMessage {...translations.output} />
+            </TableCell>
+
+            <TableCell className="w-24" />
+          </TableRow>
+        </TableHead>
+
+        <TableBody>
+          {testCaseResults.map((result) => (
+            <TestCaseRow key={result.identifier} result={result} />
+          ))}
+        </TableBody>
+      </Table>
+    </Accordion>
+  );
+};
+
+const OutputStream = (
+  outputStreamType: 'standardOutput' | 'standardError',
+  output?: string,
+): JSX.Element => {
+  const { t } = useTranslation();
+  return (
+    <Accordion
+      defaultExpanded={false}
+      disabled={!output}
+      disableGutters
+      icon={
+        !output && (
+          <Chip
+            label={<FormattedMessage {...translations.noOutputs} />}
+            size="small"
+            variant="outlined"
+          />
+        )
+      }
+      id={outputStreamType}
+      title={t(translations[outputStreamType])}
+    >
+      <pre className="w-full">{output}</pre>
+    </Accordion>
+  );
+};
+
+const TestCases: FC<Props> = (props) => {
+  const { testCase } = props;
+
+  return (
+    <div className="my-5 space-y-5">
+      {testCase.public_test &&
+        testCase.public_test.length > 0 &&
+        TestCaseComponent(testCase.public_test, 'publicTestCases')}
+
+      {testCase.private_test &&
+        testCase.private_test.length > 0 &&
+        TestCaseComponent(testCase.private_test, 'privateTestCases')}
+
+      {testCase.evaluation_test &&
+        testCase.evaluation_test.length > 0 &&
+        TestCaseComponent(testCase.evaluation_test, 'evaluationTestCases')}
+
+      {OutputStream('standardOutput', testCase.stdout)}
+      {OutputStream('standardError', testCase.stderr)}
+    </div>
+  );
+};
+
+export default TestCases;

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/NarrowEditor.jsx
@@ -74,6 +74,7 @@ const LineNumberColumn = (props) => {
     collapseComment,
     annotations,
     editorWidth,
+    isUpdatingAnnotationAllowed,
   } = props;
 
   const annotation = annotations.find((a) => a.line === lineNumber);
@@ -110,22 +111,35 @@ const LineNumberColumn = (props) => {
 
   return (
     <>
-      <div
-        onClick={() => toggleComment(lineNumber)}
-        onMouseOut={() => setLineHovered(0)}
-        onMouseOver={() => setLineHovered(lineNumber)}
-        style={
-          annotation
-            ? styles.editorLineNumberWithComments
-            : styles.editorLineNumber
-        }
-      >
-        <div>{lineNumber}</div>
-        <AddCommentIcon
-          hovered={lineHovered === lineNumber}
-          onClick={() => expandComment(lineNumber)}
-        />
-      </div>
+      {isUpdatingAnnotationAllowed ? (
+        <div
+          onClick={() => toggleComment(lineNumber)}
+          onMouseOut={() => setLineHovered(0)}
+          onMouseOver={() => setLineHovered(lineNumber)}
+          style={
+            annotation
+              ? styles.editorLineNumberWithComments
+              : styles.editorLineNumber
+          }
+        >
+          <div>{lineNumber}</div>
+          <AddCommentIcon
+            hovered={lineHovered === lineNumber}
+            onClick={() => expandComment(lineNumber)}
+          />
+        </div>
+      ) : (
+        <div
+          style={
+            annotation
+              ? styles.editorLineNumberWithComments
+              : styles.editorLineNumber
+          }
+        >
+          <div>{lineNumber}</div>
+        </div>
+      )}
+
       {renderComments()}
     </>
   );
@@ -144,6 +158,7 @@ LineNumberColumn.propTypes = {
   answerId: PropTypes.number.isRequired,
   fileId: PropTypes.number.isRequired,
   annotations: PropTypes.arrayOf(annotationShape),
+  isUpdatingAnnotationAllowed: PropTypes.bool.isRequired,
 };
 
 const NarrowEditor = (props) => {
@@ -191,6 +206,7 @@ const NarrowEditor = (props) => {
       collapseComment={collapseComment}
       editorWidth={editorWidth}
       expandComment={expandComment}
+      isUpdatingAnnotationAllowed={props.isUpdatingAnnotationAllowed}
       lineHovered={lineHovered}
       lineNumber={lineNumber}
       setLineHovered={setLineHovered}
@@ -251,6 +267,7 @@ NarrowEditor.propTypes = {
   answerId: PropTypes.number.isRequired,
   fileId: PropTypes.number.isRequired,
   annotations: PropTypes.arrayOf(annotationShape),
+  isUpdatingAnnotationAllowed: PropTypes.bool.isRequired,
   content: PropTypes.arrayOf(PropTypes.string).isRequired,
   expandLine: PropTypes.func,
   collapseLine: PropTypes.func,

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/WideEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/WideEditor.jsx
@@ -143,7 +143,7 @@ export default class WideEditor extends Component {
 
   renderLineNumberColumn(lineNumber) {
     const { lineHovered } = this.state;
-    const { annotations } = this.props;
+    const { annotations, isUpdatingAnnotationAllowed } = this.props;
     const annotation = annotations.find((a) => a.line === lineNumber);
 
     return (
@@ -158,10 +158,12 @@ export default class WideEditor extends Component {
         }
       >
         {lineNumber}
-        <AddCommentIcon
-          hovered={lineHovered === lineNumber}
-          onClick={() => this.expandComment(lineNumber)}
-        />
+        {isUpdatingAnnotationAllowed && (
+          <AddCommentIcon
+            hovered={lineHovered === lineNumber}
+            onClick={() => this.expandComment(lineNumber)}
+          />
+        )}
       </div>
     );
   }
@@ -189,6 +191,7 @@ WideEditor.propTypes = {
   expandLine: PropTypes.func,
   collapseLine: PropTypes.func,
   toggleLine: PropTypes.func,
+  isUpdatingAnnotationAllowed: PropTypes.bool.isRequired,
 };
 
 WideEditor.defaultProps = {

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
@@ -185,13 +185,15 @@ class ReadOnlyEditor extends Component {
 
   render() {
     const { expanded } = this.state;
-    const { answerId, annotations, file } = this.props;
+    const { answerId, annotations, file, isUpdatingAnnotationAllowed } =
+      this.props;
     const editorProps = {
       expanded,
       answerId,
       fileId: file.id,
       annotations,
       content: file.highlightedContent.split('\n'),
+      isUpdatingAnnotationAllowed,
       expandLine: (lineNumber) => this.setExpandedLine(lineNumber),
       collapseLine: (lineNumber) => this.setCollapsedLine(lineNumber),
       toggleLine: (lineNumber) => this.toggleCommentLine(lineNumber),
@@ -215,6 +217,7 @@ ReadOnlyEditor.propTypes = {
   annotations: PropTypes.arrayOf(annotationShape),
   answerId: PropTypes.number.isRequired,
   file: fileShape.isRequired,
+  isUpdatingAnnotationAllowed: PropTypes.bool.isRequired,
   intl: PropTypes.object.isRequired,
 };
 

--- a/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
@@ -30,6 +30,7 @@ class ReadOnlyEditorContainer extends Component {
           annotations={Object.values(annotations)}
           answerId={answerId}
           file={file}
+          isUpdatingAnnotationAllowed
         />
       );
     }

--- a/client/app/types/course/statistics/answer.ts
+++ b/client/app/types/course/statistics/answer.ts
@@ -19,6 +19,7 @@ import {
 import { VoiceResponseFieldData } from '../assessment/submission/answer/voiceResponse';
 
 interface AnswerCommonDetails<T extends keyof typeof QuestionType> {
+  id: number;
   grade: number;
   questionType: T;
 }
@@ -43,6 +44,33 @@ export interface MrqAnswerDetails
   latestAnswer?: MrqAnswerDetails;
 }
 
+export interface AnnotationTopic {
+  id: number;
+  postIds: number[];
+  line: string;
+}
+
+export interface Annotation {
+  fileId: number;
+  topics: AnnotationTopic[];
+}
+
+export interface TestCase {
+  canReadTests: boolean;
+  public_test?: TestCaseResult[];
+  private_test?: TestCaseResult[];
+  evaluation_test?: TestCaseResult[];
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface CodaveriFeedback {
+  jobId: string;
+  jobStatus: keyof typeof JobStatus;
+  jobUrl?: string;
+  errorMessage?: string;
+}
+
 export interface ProgrammingAnswerDetails
   extends AnswerCommonDetails<'Programming'> {
   fields: ProgrammingFieldData;
@@ -51,33 +79,14 @@ export interface ProgrammingAnswerDetails
     explanation: string[];
     failureType: TestCaseType;
   };
-  testCases: {
-    canReadTests: boolean;
-    public_test?: TestCaseResult[];
-    private_test?: TestCaseResult[];
-    evaluation_test?: TestCaseResult[];
-    stdout?: string;
-    stderr?: string;
-  };
+  testCases: TestCase;
   attemptsLeft?: number;
   autograding?: JobStatusResponse & {
     path?: string;
   };
-  codaveriFeedback?: {
-    jobId: string;
-    jobStatus: keyof typeof JobStatus;
-    jobUrl?: string;
-    errorMessage?: string;
-  };
+  codaveriFeedback?: CodaveriFeedback;
   latestAnswer?: ProgrammingAnswerDetails & {
-    annotations: {
-      fileId: number;
-      topics: {
-        id: number;
-        postIds: number[];
-        line: string;
-      }[];
-    };
+    annotations: Annotation[];
   };
 }
 


### PR DESCRIPTION
## Background

This is the continuation of the previous PR https://github.com/Coursemology/coursemology2/pull/7130 that completes that mentioned PR by having the implementation for answer display for Forum Post Response and Programming

This PR is related with the issue https://github.com/Coursemology/coursemology2/issues/4567

## Layout

Forum Post Response
<img width="639" alt="Screenshot 2024-08-01 at 5 12 53 PM" src="https://github.com/user-attachments/assets/7513ec49-5746-4bc5-b483-8805ad1a2af7">

Programming
<img width="639" alt="Screenshot 2024-08-01 at 5 14 44 PM" src="https://github.com/user-attachments/assets/cfd90aaa-2d39-429c-814c-ed107e70a420">

## TO-DO List

- [x] Get all past answers (other attempts made by students other than the last graded one) and display the most recent 10 answers into the Answer Details component (https://github.com/Coursemology/coursemology2/pull/7135)
- [x] Define new page consisting of all the past answers list (possibly creating new API for this as well) (https://github.com/Coursemology/coursemology2/pull/7135)