### PR TITLE
Add Validation for Options Count in MCQ/MRQ Questions

### DIFF
--- a/app/models/course/assessment/question/multiple_response.rb
+++ b/app/models/course/assessment/question/multiple_response.rb
@@ -4,7 +4,8 @@ class Course::Assessment::Question::MultipleResponse < ApplicationRecord
 
   enum grading_scheme: [:all_correct, :any_correct]
 
-  validate :validate_multiple_choice_has_solution, if: :multiple_choice?
+  validate :validate_has_option
+  validate :validate_multiple_choice_has_correct_solution, if: :multiple_choice?
   validates :grading_scheme, presence: true
 
   has_many :options, class_name: Course::Assessment::Question::MultipleResponseOption.name,
@@ -86,7 +87,13 @@ class Course::Assessment::Question::MultipleResponse < ApplicationRecord
 
   private
 
-  def validate_multiple_choice_has_solution
+  def validate_has_option
+    return unless options.empty?
+
+    errors.add(:options, :no_option)
+  end
+
+  def validate_multiple_choice_has_correct_solution
     return true if skip_grading
 
     errors.add(:options, :no_correct_option) if options.select(&:correct?).empty?

--- a/client/app/bundles/course/assessment/question/multiple-responses/commons/validations.ts
+++ b/client/app/bundles/course/assessment/question/multiple-responses/commons/validations.ts
@@ -42,13 +42,13 @@ const optionSchema = object({
 });
 
 const AT_LEAST_ONE_CORRECT_CHOICE_ERROR_NAME = 'at-least-one-correct-choice';
-const AT_LEAST_ONE_CHOICE_ERROR_NAME = 'at-least-one-choice';
+const AT_LEAST_ONE_RESPONSE_ERROR_NAME = 'at-least-one-response';
 
 const responsesSchema = array()
   .of(optionSchema)
   .test(
-    AT_LEAST_ONE_CHOICE_ERROR_NAME,
-    translations.mustHaveAtLeastOneChoice,
+    AT_LEAST_ONE_RESPONSE_ERROR_NAME,
+    translations.mustHaveAtLeastOneResponse,
     (options) => (options?.length ?? 0) > 0,
   );
 
@@ -94,7 +94,7 @@ export const validateOptions = async (
       const { path, type: name, message } = error;
 
       if (
-        name === AT_LEAST_ONE_CHOICE_ERROR_NAME ||
+        name === AT_LEAST_ONE_RESPONSE_ERROR_NAME ||
         name === AT_LEAST_ONE_CORRECT_CHOICE_ERROR_NAME
       ) {
         errors.error = message;

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -728,6 +728,10 @@ const translations = defineMessages({
     id: 'course.assessment.question.multipleResponses.mustSpecifyChoice',
     defaultMessage: 'You must specify a valid choice title.',
   },
+  mustHaveAtLeastOneChoice: {
+    id: 'course.assessment.question.multipleResponses.mustHaveAtLeastOneChoice',
+    defaultMessage: 'You must specify at least one choice.',
+  },
   mustSpecifyAtLeastOneCorrectChoice: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyAtLeastOneCorrectChoice',
     defaultMessage: 'You must specify at least one correct choice.',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -728,9 +728,9 @@ const translations = defineMessages({
     id: 'course.assessment.question.multipleResponses.mustSpecifyChoice',
     defaultMessage: 'You must specify a valid choice title.',
   },
-  mustHaveAtLeastOneChoice: {
-    id: 'course.assessment.question.multipleResponses.mustHaveAtLeastOneChoice',
-    defaultMessage: 'You must specify at least one choice.',
+  mustHaveAtLeastOneResponse: {
+    id: 'course.assessment.question.multipleResponses.mustHaveAtLeastOneResponse',
+    defaultMessage: 'You must specify at least one response.',
   },
   mustSpecifyAtLeastOneCorrectChoice: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyAtLeastOneCorrectChoice',

--- a/config/locales/en/activerecord/course/assessment/question/multiple_response.yml
+++ b/config/locales/en/activerecord/course/assessment/question/multiple_response.yml
@@ -5,4 +5,5 @@ en:
         course/assessment/question/multiple_response:
           attributes:
             options:
-              no_correct_option: 'must contain at least one correct option.'
+              no_option: "must contain at least one option"
+              no_correct_option: "must contain at least one correct option."

--- a/config/locales/en/activerecord/course/assessment/question/multiple_response.yml
+++ b/config/locales/en/activerecord/course/assessment/question/multiple_response.yml
@@ -5,5 +5,5 @@ en:
         course/assessment/question/multiple_response:
           attributes:
             options:
-              no_option: "must contain at least one option"
-              no_correct_option: "must contain at least one correct option."
+              no_option: 'must contain at least one option.'
+              no_correct_option: 'must contain at least one correct option.'

--- a/config/locales/zh/activerecord/course/assessment/question/multiple_response.yml
+++ b/config/locales/zh/activerecord/course/assessment/question/multiple_response.yml
@@ -5,4 +5,5 @@ zh:
         course/assessment/question/multiple_response:
           attributes:
             options:
+              no_option: '至少要包含一个选项。'
               no_correct_option: '至少要包含一个正确选项。'

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management', j
         visit edit_path
 
         find_all('button[aria-label="Delete choice"]').each(&:click)
+        expect(page).to have_button('Save Changes')
         click_button 'Save changes'
         wait_for_page
 

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -118,12 +118,12 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management', j
       end
 
       scenario 'I can edit a question, change MRQ to MCQ and back to MRQ, and delete an option' do
-        mrq = create(:course_assessment_question_multiple_response, assessment: assessment,
-                                                                    options: [])
+        mrq = create(:course_assessment_question_multiple_response, assessment: assessment)
         options = [
           attributes_for(:course_assessment_question_multiple_response_option, :wrong),
           attributes_for(:course_assessment_question_multiple_response_option, :correct)
         ]
+        initial_options_count = mrq.options.count
         visit course_assessment_path(course, assessment)
 
         edit_path = edit_course_assessment_question_multiple_response_path(course, assessment, mrq)
@@ -158,7 +158,7 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management', j
         wait_for_page
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
-        expect(mrq.reload.options.count).to eq(options.count)
+        expect(mrq.reload.options.count).to eq(initial_options_count + options.count)
 
         # Switching in edit page
         # Switch MRQ to MCQ

--- a/spec/features/course/assessment/question/multiple_response_management_spec.rb
+++ b/spec/features/course/assessment/question/multiple_response_management_spec.rb
@@ -190,12 +190,51 @@ RSpec.describe 'Course: Assessments: Questions: Multiple Response Management', j
         visit edit_path
 
         find_all('button[aria-label="Delete choice"]').each(&:click)
-        expect(page).to have_button('Save Changes')
+        expect(page).to have_button('Save changes')
+        click_button 'Save changes'
+
+        expect(page).to have_text('You must specify at least one correct choice.')
+
+        find_all('button[aria-label="Undo delete choice"]').last.click
+        expect(page).to have_button('Save changes')
         click_button 'Save changes'
         wait_for_page
 
         expect(current_path).to eq(course_assessment_path(course, assessment))
-        expect(mrq.reload.options.count).to eq(0)
+        expect(mrq.reload.options.count).to eq(1)
+      end
+
+      scenario 'I cannot delete all answers in mrq question' do
+        mrq = create(:course_assessment_question_multiple_response, assessment: assessment)
+
+        visit course_assessment_path(course, assessment)
+
+        edit_path = edit_course_assessment_question_multiple_response_path(course, assessment, mrq)
+        find_link(nil, href: edit_path).click
+
+        maximum_grade = 999.9
+        fill_in 'maximumGrade', with: maximum_grade
+        click_button 'Save changes'
+
+        wait_for_page
+        expect(current_path).to eq(course_assessment_path(course, assessment))
+        expect(mrq.reload.maximum_grade).to eq(maximum_grade)
+
+        visit edit_path
+
+        find_all('button[aria-label="Delete response"]').each(&:click)
+        expect(page).to have_button('Save changes')
+        click_button 'Save changes'
+
+        expect(page).to have_text('You must specify at least one response.')
+
+        find_all('button[aria-label="Undo delete response"]').last.click
+        expect(page).to have_button('Save changes')
+        click_button 'Save changes'
+        wait_for_page
+
+        expect(current_path).to eq(course_assessment_path(course, assessment))
+        expect(mrq.reload.options.count).to eq(1)
       end
 
       scenario 'I can delete a question' do

--- a/spec/models/course/assessment/question/multiple_response_spec.rb
+++ b/spec/models/course/assessment/question/multiple_response_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe Course::Assessment::Question::MultipleResponse do
 
   let(:instance) { Instance.default }
   with_tenant(:instance) do
+    describe '#create' do
+      let(:course) { create(:course) }
+      let(:assessment) { create(:assessment, course: course) }
+
+      context 'when creating the mcq/mrq with no options' do
+        it 'is invalid due to absence of options' do
+          question = build(:course_assessment_question_multiple_response, assessment: assessment, options: [])
+
+          expect(question).not_to be_valid
+        end
+      end
+    end
+
     describe '#auto_gradable?' do
       subject { create(:course_assessment_question_multiple_response) }
       it 'returns true' do

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -64,7 +64,7 @@ module TrackableJob::SpecHelpers
 
   # Wait for page/react lifecycle to finish loading/end
   def wait_for_page
-    sleep 1.7
+    sleep 2.5
   end
 
   # Wait for autosave to be completed


### PR DESCRIPTION
## Background

Closes https://github.com/Coursemology/coursemology2/issues/7127

Previously, we didn't have the validation on the number of options that will exist inside the MCQ/MRQ questions upon creating/editing. As a result, we might be able to create an MRQ question with no options. This is undesirable since intuitively, each MCQ/MRQ questions should have at least one option.

## Resolving the Issue

Adding the validation for both MCQ and MRQ questions, to ensure that at least one options will still be in the question.