### PR TITLE
Fix Behavior of Deleting User Belonging to More than 1 Instance

### DIFF
--- a/app/controllers/system/admin/users_controller.rb
+++ b/app/controllers/system/admin/users_controller.rb
@@ -24,6 +24,13 @@ class System::Admin::UsersController < System::Admin::Controller
   end
 
   def destroy
+    # in deleting user, we also need to subsequently delete all of its associated instance users, and everything
+    # that needs to be destroyed as a result. Since the relation between instance_user and its corresponding
+    # user is dictated by acts_as_tenant, doing the destroy operation will automatically scope the instance_user
+    # to be only those inside the current tenant, and hence unexpected error will occur.
+
+    # hence, we need to remove the scope for this so that the deletion of users will also delete all of its
+    # associated instance_users.
     ActsAsTenant.without_tenant do
       if @user.destroy
         head :ok

--- a/app/controllers/system/admin/users_controller.rb
+++ b/app/controllers/system/admin/users_controller.rb
@@ -24,10 +24,12 @@ class System::Admin::UsersController < System::Admin::Controller
   end
 
   def destroy
-    if @user.destroy
-      head :ok
-    else
-      render json: { errors: @user.errors.full_messages.to_sentence }, status: :bad_request
+    ActsAsTenant.without_tenant do
+      if @user.destroy
+        head :ok
+      else
+        render json: { errors: @user.errors.full_messages.to_sentence }, status: :bad_request
+      end
     end
   end
 

--- a/client/app/bundles/system/admin/admin/components/buttons/UsersButtons.tsx
+++ b/client/app/bundles/system/admin/admin/components/buttons/UsersButtons.tsx
@@ -28,12 +28,12 @@ const translations = defineMessages({
   },
   deletionConfirmTitle: {
     id: 'system.admin.admin.UsersButton.deletionConfirmTitle',
-    defaultMessage: 'Deleting {role} {name} ({email})?',
+    defaultMessage: 'Deleting {role} {name} ({email})',
   },
   deletionPromptContent: {
     id: 'system.admin.admin.UsersButton.deletionPromptContent',
     defaultMessage:
-      'After deleting this user, all the associated instance users in the following instances will be deleted',
+      'After deleting this user, all associated instance users in the following instances will be deleted.',
   },
   associatedInstances: {
     id: 'system.admin.admin.UsersButton.associatedInstances',

--- a/client/app/bundles/system/admin/admin/components/buttons/UsersButtons.tsx
+++ b/client/app/bundles/system/admin/admin/components/buttons/UsersButtons.tsx
@@ -5,9 +5,11 @@ import { UserMiniEntity } from 'types/users';
 
 import DeleteButton from 'lib/components/core/buttons/DeleteButton';
 import MasqueradeButton from 'lib/components/core/buttons/MasqueradeButton';
+import { PromptText } from 'lib/components/core/dialogs/Prompt';
 import { USER_ROLES } from 'lib/constants/sharedConstants';
 import { useAppDispatch } from 'lib/hooks/store';
 import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import { deleteUser } from '../../operations';
 
@@ -24,9 +26,22 @@ const translations = defineMessages({
     id: 'system.admin.admin.UsersButton.deletionFailure',
     defaultMessage: 'Failed to delete user - {error}',
   },
+  deletionConfirmTitle: {
+    id: 'system.admin.admin.UsersButton.deletionConfirmTitle',
+    defaultMessage: 'Deleting {role} {name} ({email})?',
+  },
+  deletionPromptContent: {
+    id: 'system.admin.admin.UsersButton.deletionPromptContent',
+    defaultMessage:
+      'After deleting this user, all the associated instance users in the following instances will be deleted',
+  },
+  associatedInstances: {
+    id: 'system.admin.admin.UsersButton.associatedInstances',
+    defaultMessage: '{index}. {instanceName}',
+  },
   deletionConfirm: {
     id: 'system.admin.admin.UsersButton.deletionConfirm',
-    defaultMessage: 'Are you sure you wish to delete {role} {name} ({email})?',
+    defaultMessage: 'Are you sure?',
   },
   deleteTooltip: {
     id: 'system.admin.admin.UsersButton.deleteTooltip',
@@ -38,6 +53,7 @@ const UserManagementButtons: FC<Props> = (props) => {
   const { intl, user } = props;
   const dispatch = useAppDispatch();
   const [isDeleting, setIsDeleting] = useState(false);
+  const { t } = useTranslation();
 
   const onDelete = (): Promise<void> => {
     setIsDeleting(true);
@@ -63,16 +79,31 @@ const UserManagementButtons: FC<Props> = (props) => {
     <div key={`buttons-${user.id}`} className="whitespace-nowrap">
       <DeleteButton
         className={`user-delete-${user.id} p-0`}
-        confirmMessage={intl.formatMessage(translations.deletionConfirm, {
+        disabled={isDeleting}
+        loading={isDeleting}
+        onClick={onDelete}
+        title={t(translations.deletionConfirmTitle, {
           role: USER_ROLES[user.role],
           name: user.name,
           email: user.email,
         })}
-        disabled={isDeleting}
-        loading={isDeleting}
-        onClick={onDelete}
-        tooltip={intl.formatMessage(translations.deleteTooltip)}
-      />
+        tooltip={t(translations.deleteTooltip)}
+      >
+        {user.instances.length > 1 && (
+          <>
+            <PromptText>{t(translations.deletionPromptContent)}</PromptText>
+            {user.instances.map((instance, index) => (
+              <PromptText key={`instance-${instance.host}`}>
+                {t(translations.associatedInstances, {
+                  index: index + 1,
+                  instanceName: instance.name,
+                })}
+              </PromptText>
+            ))}
+          </>
+        )}
+        <PromptText>{t(translations.deletionConfirm)}</PromptText>
+      </DeleteButton>
       <MasqueradeButton
         canMasquerade={Boolean(user.canMasquerade)}
         className={`user-masquerade-${user.id} ml-4 p-0`}


### PR DESCRIPTION
## Background

Previously, an attempt to delete a user from System Admin that belongs to more than one instance will immediately create an error. The deletion will run just fine if user does not belong to more than one instance

## Root of Issue
The relation between InstanceUser and Instance is set up using `acts_as_tenant` gem, which basically adds the scope of `instance_id` whenever we attempt to search for `InstanceUser` object. This behavior is actually logical since we want to isolate the result of the search for `InstanceUser` so that it's confined within the current instance the user is operating

However, for deletion, it will create the problem as in deleting user, it will subsequently try deleting all associated instance users but upon searching, they will only get the result (and hence delete) of instance user within the current instance. Therefore, all the other instance user objects associated with this user will be orphaned and this is prohibited by our system.

## Resolving the Issue
Deleting user should be possible even if this user has multiple associated instance users, which is also to subsequently deleted those instance users belonging to this deleted user.

Furthermore, due to the risk in deleting lots of instance users merely from deleting this one user, the prompt content from attempting to delete the user is also changed, as follows:

Deleting user that is only associated with 1 instance:
<img width="636" alt="Screenshot 2024-02-29 at 10 21 18 AM" src="https://github.com/Coursemology/coursemology2/assets/16359075/065003c3-b2f5-4d1c-a3bb-f0c06f565ede">

Deleting user associated with more than 1 instances:
<img width="636" alt="Screenshot 2024-02-29 at 10 21 30 AM" src="https://github.com/Coursemology/coursemology2/assets/16359075/e83a90bd-e743-4b66-83a7-e6a536aae483">

## Further Issue
Deleting user that is still referenced by other table (either through creator_id, confirmer_id, or anything else) will still fail. This is a separate issue that will be resolved in the other PR