### PR TITLE
Fix test_playwright cannot install browser dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
         default: false
 
     docker:
-      - image: cimg/ruby:3.0.5-browsers
+      - image: cimg/ruby:3.0.6-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
@@ -51,8 +51,8 @@ commands:
       - restore_cache:
           name: Restore Ruby dependencies cache
           keys:
-            - v3.0.5-ruby-{{ checksum "Gemfile.lock" }}
-            - v3.0.5-ruby-
+            - v3.0.6-ruby-{{ checksum "Gemfile.lock" }}
+            - v3.0.6-ruby-
 
       - run:
           name: Install Bundler
@@ -66,7 +66,7 @@ commands:
           paths:
             - ./vendor/bundle
             - ./.bundle
-          key: v3.0.5-ruby-{{ checksum "Gemfile.lock" }}
+          key: v3.0.6-ruby-{{ checksum "Gemfile.lock" }}
 
   rehydrate_node_deps:
     steps:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: '/tests'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Coursemology is an open source gamified learning platform that enables educators
 
 ### System Requirements
 
-1. Ruby (= 3.0.5)
+1. Ruby (= 3.0.6)
 1. Ruby on Rails (= 6.0.6.1)
 1. PostgreSQL (>= 9.5)
 1. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick) - if PDF processing doesn't work for the import of scribing questions, download Ghostscript)
@@ -61,12 +61,14 @@ Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some fr
    ```
    host lvh.me
    ```
-   
 7. Open up 2 different terminals, each to run the Frontend and Backend. On the terminal for Frontend, run
+
    ```
    yarn build:development
    ```
+
    and on the terminal for Backend, run
+
    ```
    bundle exec rails s -p 5000
    ```
@@ -117,4 +119,4 @@ We are actively running [Coursemology](https://coursemology.org) and can provide
 
 ## Acknowledgments
 
-The Coursemology.org Project was made possible by a number of teaching development grants from the National University of Singapore over the years. This project is currently supported by the [AI Centre for Educational Technologies](https://www.aicet.aisingapore.org/). 
+The Coursemology.org Project was made possible by a number of teaching development grants from the National University of Singapore over the years. This project is currently supported by the [AI Centre for Educational Technologies](https://www.aicet.aisingapore.org/).

--- a/spec/libraries/coursemology_docker_container_spec.rb
+++ b/spec/libraries/coursemology_docker_container_spec.rb
@@ -131,8 +131,7 @@ RSpec.describe CoursemologyDockerContainer do
 
     it 'does not crash when report is nil' do
       copy_report(nil)
-      test_report = subject.send(:extract_test_report, CoursemologyDockerContainer::REPORT_PATH)
-      expect(test_report).to be_nil
+      expect { subject.send(:extract_test_report, CoursemologyDockerContainer::REPORT_PATH) }.not_to raise_exception
     end
 
     context 'when running the tests fails' do

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "devDependencies": {
     "@playwright/test": "^1.42.1",
-    "@types/node": "^20.4.5",
+    "@types/node": "^20.11.24",
     "nyc": "^15.1.0"
   },
   "scripts": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/Coursemology/coursemology2.git",
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.36.1",
+    "@playwright/test": "^1.42.1",
     "@types/node": "^20.4.5",
     "nyc": "^15.1.0"
   },

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -308,10 +308,12 @@
   dependencies:
     playwright "1.42.1"
 
-"@types/node@^20.4.5":
-  version "20.4.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.5.tgz#9dc0a5cb1ccce4f7a731660935ab70b9c00a5d69"
-  integrity sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==
+"@types/node@^20.11.24":
+  version "20.11.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.24.tgz#cc207511104694e84e9fb17f9a0c4c42d4517792"
+  integrity sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==
+  dependencies:
+    undici-types "~5.26.4"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1086,6 +1088,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 update-browserslist-db@^1.0.11:
   version "1.0.11"

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -301,20 +301,12 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@playwright/test@^1.36.1":
-  version "1.36.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.36.1.tgz#0b1247d279f142ac0876ce25e7daf15439d5367b"
-  integrity sha512-YK7yGWK0N3C2QInPU6iaf/L3N95dlGdbsezLya4n0ZCh3IL7VgPGxC6Gnznh9ApWdOmkJeleT2kMTcWPRZvzqg==
+"@playwright/test@^1.42.1":
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.42.1.tgz#9eff7417bcaa770e9e9a00439e078284b301f31c"
+  integrity sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==
   dependencies:
-    "@types/node" "*"
-    playwright-core "1.36.1"
-  optionalDependencies:
-    fsevents "2.3.2"
-
-"@types/node@*":
-  version "20.4.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.4.tgz#c79c7cc22c9d0e97a7944954c9e663bcbd92b0cb"
-  integrity sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==
+    playwright "1.42.1"
 
 "@types/node@^20.4.5":
   version "20.4.5"
@@ -928,10 +920,19 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.36.1:
-  version "1.36.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.36.1.tgz#f5f275d70548768ca892583519c89b237a381c77"
-  integrity sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==
+playwright-core@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.42.1.tgz#13c150b93c940a3280ab1d3fbc945bc855c9459e"
+  integrity sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==
+
+playwright@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.42.1.tgz#79c828b51fe3830211137550542426111dc8239f"
+  integrity sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==
+  dependencies:
+    playwright-core "1.42.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 process-on-spawn@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
For some reasons, CircleCI's Ubuntu 20.04.5 LTS image in cimg/ruby:3.0.5-browsers uses an expired GPG key for `https://dl.google.com/linux/chrome/deb stable InRelease`. Google is known to rotate the public GPG keys once in a while so this error appeared. I could have ignored this in apt or add a run step to update the GPG keys from Google, but I decided to just up the image to cimg/ruby:3.0.6-browsers that uses Ubuntu 22.04.2 LTS that can install the dependencies correctly.