### PR TITLE
Add Max Attachment Size Customisation in Text Response / File Upload Question

### DIFF
--- a/app/controllers/course/assessment/question/text_responses_controller.rb
+++ b/app/controllers/course/assessment/question/text_responses_controller.rb
@@ -7,6 +7,8 @@ class Course::Assessment::Question::TextResponsesController < Course::Assessment
                               through: :assessment, parent: false, except: [:new, :create]
   before_action :load_question_assessment, only: [:edit, :update]
 
+  DEFAULT_MAX_ATTACHMENT_SIZE = 1024
+
   def new
     if params[:file_upload] == 'true'
       @text_response_question.hide_text = true
@@ -64,7 +66,7 @@ class Course::Assessment::Question::TextResponsesController < Course::Assessment
   def text_response_question_params
     permitted_params = [
       :title, :description, :staff_only_comments, :maximum_grade, :max_attachments,
-      :hide_text, :is_comprehension, :is_attachment_required,
+      :hide_text, :is_comprehension, :is_attachment_required, :max_attachment_size,
       question_assessment: { skill_ids: [] }
     ]
     if params[:question_text_response][:is_comprehension] == 'true'

--- a/app/controllers/course/assessment/question/text_responses_controller.rb
+++ b/app/controllers/course/assessment/question/text_responses_controller.rb
@@ -7,8 +7,6 @@ class Course::Assessment::Question::TextResponsesController < Course::Assessment
                               through: :assessment, parent: false, except: [:new, :create]
   before_action :load_question_assessment, only: [:edit, :update]
 
-  DEFAULT_MAX_ATTACHMENT_SIZE = 1024
-
   def new
     if params[:file_upload] == 'true'
       @text_response_question.hide_text = true

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -2,9 +2,15 @@
 class Course::Assessment::Question::TextResponse < ApplicationRecord
   acts_as :question, class_name: Course::Assessment::Question.name
 
+  DEFAULT_MAX_ATTACHMENT_SIZE = 1024
+
   validates :max_attachments, numericality: { only_integer: true, greater_than_or_equal_to: 1,
                                               less_than_or_equal_to: 50 },
                               presence: true
+  validates :max_attachment_size, numericality: { only_integer: true, greater_than_or_equal_to: 0,
+                                                  less_than_or_equal_to: DEFAULT_MAX_ATTACHMENT_SIZE },
+                                  allow_nil: true
+  validate :max_attachment_size_defined_if_max_attachments_is_nonzero
   validate :validate_grade
 
   has_many :solutions, class_name: Course::Assessment::Question::TextResponseSolution.name,
@@ -120,5 +126,11 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
     return unless !comprehension_question? && solutions.any? { |s| s.grade > maximum_grade }
 
     errors.add(:maximum_grade, :invalid_grade)
+  end
+
+  def max_attachment_size_defined_if_max_attachments_is_nonzero
+    return unless max_attachments > 0 && !max_attachment_size?
+
+    errors.add(:max_attachment_size, :size_must_be_defined)
   end
 end

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::Question::TextResponse < ApplicationRecord
   acts_as :question, class_name: Course::Assessment::Question.name
 
-  validates :max_attachments, numericality: { only_integer: true, greater_than_or_equal_to: 0,
+  validates :max_attachments, numericality: { only_integer: true, greater_than_or_equal_to: 1,
                                               less_than_or_equal_to: 50 },
                               presence: true
   validate :validate_grade

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -2,13 +2,13 @@
 class Course::Assessment::Question::TextResponse < ApplicationRecord
   acts_as :question, class_name: Course::Assessment::Question.name
 
-  DEFAULT_MAX_ATTACHMENT_SIZE = 1024
+  DEFAULT_MAX_ATTACHMENT_SIZE_MB = 1024
 
   validates :max_attachments, numericality: { only_integer: true, greater_than_or_equal_to: 1,
                                               less_than_or_equal_to: 50 },
                               presence: true
   validates :max_attachment_size, numericality: { only_integer: true, greater_than_or_equal_to: 1,
-                                                  less_than_or_equal_to: DEFAULT_MAX_ATTACHMENT_SIZE },
+                                                  less_than_or_equal_to: DEFAULT_MAX_ATTACHMENT_SIZE_MB },
                                   presence: true
   validate :max_attachment_size_defined_if_max_attachments_is_nonzero
   validate :validate_grade

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -4,12 +4,12 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
 
   DEFAULT_MAX_ATTACHMENT_SIZE_MB = 1024
 
-  validates :max_attachments, numericality: { only_integer: true, greater_than_or_equal_to: 1,
+  validates :max_attachments, numericality: { only_integer: true, greater_than_or_equal_to: 0,
                                               less_than_or_equal_to: 50 },
                               presence: true
   validates :max_attachment_size, numericality: { only_integer: true, greater_than_or_equal_to: 1,
                                                   less_than_or_equal_to: DEFAULT_MAX_ATTACHMENT_SIZE_MB },
-                                  presence: true
+                                  allow_nil: true
   validate :max_attachment_size_defined_if_max_attachments_is_nonzero
   validate :validate_grade
 

--- a/app/models/course/assessment/question/text_response.rb
+++ b/app/models/course/assessment/question/text_response.rb
@@ -7,9 +7,9 @@ class Course::Assessment::Question::TextResponse < ApplicationRecord
   validates :max_attachments, numericality: { only_integer: true, greater_than_or_equal_to: 1,
                                               less_than_or_equal_to: 50 },
                               presence: true
-  validates :max_attachment_size, numericality: { only_integer: true, greater_than_or_equal_to: 0,
+  validates :max_attachment_size, numericality: { only_integer: true, greater_than_or_equal_to: 1,
                                                   less_than_or_equal_to: DEFAULT_MAX_ATTACHMENT_SIZE },
-                                  allow_nil: true
+                                  presence: true
   validate :max_attachment_size_defined_if_max_attachments_is_nonzero
   validate :validate_grade
 

--- a/app/views/course/assessment/question/text_responses/_form.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/_form.json.jbuilder
@@ -3,5 +3,7 @@ json.partial! 'course/assessment/question/skills', course: course
 
 json.questionType question.question_type_sym
 json.isAssessmentAutograded assessment.autograded?
+json.defaultMaxAttachmentSize question.default_max_attachment_size
+json.defaultMaxAttachments question.default_max_attachments
 
 json.partial! 'solution_details', question: question unless question.file_upload_question?

--- a/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
-default_max_attachment_size = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE
+default_max_attachment_size_mb = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE_MB
 
 case question.question_type_sym
 when :file_upload
   json.maxAttachments question.max_attachments
-  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size
+  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size_mb
   json.isAttachmentRequired question.is_attachment_required
 
 when :text_response
   json.maxAttachments question.max_attachments
-  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size if question.max_attachments > 0
+  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size_mb if question.max_attachments > 0
   json.isAttachmentRequired question.is_attachment_required
 
   if can_grade && question.auto_gradable?

--- a/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
+default_max_attachment_size = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE
 
 case question.question_type_sym
 when :file_upload
   json.maxAttachments question.max_attachments
+  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size
   json.isAttachmentRequired question.is_attachment_required
 
 when :text_response
   json.maxAttachments question.max_attachments
+  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size if question.max_attachments > 0
   json.isAttachmentRequired question.is_attachment_required
 
   if can_grade && question.auto_gradable?

--- a/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/_text_response.json.jbuilder
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 json.autogradable question.auto_gradable?
-default_max_attachment_size_mb = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE_MB
 
 case question.question_type_sym
 when :file_upload
   json.maxAttachments question.max_attachments
-  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size_mb
+  json.maxAttachmentSize question.computed_max_attachment_size
   json.isAttachmentRequired question.is_attachment_required
 
 when :text_response
   json.maxAttachments question.max_attachments
-  json.maxAttachmentSize question.max_attachment_size || default_max_attachment_size_mb if question.max_attachments > 0
+  json.maxAttachmentSize question.computed_max_attachment_size if question.max_attachments > 0
   json.isAttachmentRequired question.is_attachment_required
 
   if can_grade && question.auto_gradable?

--- a/app/views/course/assessment/question/text_responses/edit.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/edit.json.jbuilder
@@ -2,7 +2,7 @@
 question = @text_response_question
 question_assessment = @question_assessment
 assessment = @assessment
-default_max_attachment_size = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE
+default_max_attachment_size_mb = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE_MB
 
 json.partial! 'form', locals: {
   course: current_course,
@@ -16,7 +16,7 @@ json.question do
     question_assessment: question_assessment
   }
   json.maxAttachments @text_response_question.max_attachments
-  json.maxAttachmentSize @text_response_question.max_attachment_size || default_max_attachment_size if @text_response_question.max_attachments > 0
+  json.maxAttachmentSize @text_response_question.max_attachment_size || default_max_attachment_size_mb if @text_response_question.max_attachments > 0
   json.isAttachmentRequired @text_response_question.is_attachment_required
   json.hideText @text_response_question.hide_text
 end

--- a/app/views/course/assessment/question/text_responses/edit.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/edit.json.jbuilder
@@ -2,7 +2,6 @@
 question = @text_response_question
 question_assessment = @question_assessment
 assessment = @assessment
-default_max_attachment_size_mb = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE_MB
 
 json.partial! 'form', locals: {
   course: current_course,
@@ -18,7 +17,7 @@ json.question do
   json.maxAttachments @text_response_question.max_attachments
 
   if @text_response_question.max_attachments > 0
-    json.maxAttachmentSize @text_response_question.max_attachment_size || default_max_attachment_size_mb
+    json.maxAttachmentSize @text_response_question.computed_max_attachment_size
   end
 
   json.isAttachmentRequired @text_response_question.is_attachment_required

--- a/app/views/course/assessment/question/text_responses/edit.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/edit.json.jbuilder
@@ -2,6 +2,7 @@
 question = @text_response_question
 question_assessment = @question_assessment
 assessment = @assessment
+default_max_attachment_size = Course::Assessment::Question::TextResponse::DEFAULT_MAX_ATTACHMENT_SIZE
 
 json.partial! 'form', locals: {
   course: current_course,
@@ -15,6 +16,7 @@ json.question do
     question_assessment: question_assessment
   }
   json.maxAttachments @text_response_question.max_attachments
+  json.maxAttachmentSize @text_response_question.max_attachment_size || default_max_attachment_size if @text_response_question.max_attachments > 0
   json.isAttachmentRequired @text_response_question.is_attachment_required
   json.hideText @text_response_question.hide_text
 end

--- a/app/views/course/assessment/question/text_responses/edit.json.jbuilder
+++ b/app/views/course/assessment/question/text_responses/edit.json.jbuilder
@@ -16,7 +16,11 @@ json.question do
     question_assessment: question_assessment
   }
   json.maxAttachments @text_response_question.max_attachments
-  json.maxAttachmentSize @text_response_question.max_attachment_size || default_max_attachment_size_mb if @text_response_question.max_attachments > 0
+
+  if @text_response_question.max_attachments > 0
+    json.maxAttachmentSize @text_response_question.max_attachment_size || default_max_attachment_size_mb
+  end
+
   json.isAttachmentRequired @text_response_question.is_attachment_required
   json.hideText @text_response_question.hide_text
 end

--- a/client/app/bundles/course/assessment/question/text-responses/NewTextResponsePage.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/NewTextResponsePage.tsx
@@ -21,12 +21,14 @@ import TextResponseForm, {
 import { create, fetchNewFileUpload, fetchNewTextResponse } from './operations';
 
 const INITIAL_MAX_ATTACHMENTS = 3;
+const INITIAL_MAX_ATTACHMENT_SIZE = 10;
 
 const NEW_TEXT_RESPONSE_VALUE = {
   ...commonQuestionFieldsInitialValues,
   hideText: false,
   attachmentType: AttachmentType.NO_ATTACHMENT,
   maxAttachments: INITIAL_MAX_ATTACHMENTS,
+  maxAttachmentSize: INITIAL_MAX_ATTACHMENT_SIZE,
   isAttachmentRequired: false,
 };
 
@@ -35,6 +37,7 @@ const NEW_FILE_UPLOAD_RESPONSE_VALUE = {
   hideText: true,
   attachmentType: AttachmentType.SINGLE_FILE_ATTACHMENT,
   maxAttachments: INITIAL_MAX_ATTACHMENTS,
+  maxAttachmentSize: INITIAL_MAX_ATTACHMENT_SIZE,
   isAttachmentRequired: true,
 };
 

--- a/client/app/bundles/course/assessment/question/text-responses/NewTextResponsePage.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/NewTextResponsePage.tsx
@@ -35,7 +35,7 @@ const NEW_TEXT_RESPONSE_VALUE = {
 const NEW_FILE_UPLOAD_RESPONSE_VALUE = {
   ...commonQuestionFieldsInitialValues,
   hideText: true,
-  attachmentType: AttachmentType.SINGLE_FILE_ATTACHMENT,
+  attachmentType: AttachmentType.SINGLE_ATTACHMENT,
   maxAttachments: INITIAL_MAX_ATTACHMENTS,
   maxAttachmentSize: INITIAL_MAX_ATTACHMENT_SIZE,
   isAttachmentRequired: true,

--- a/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
+++ b/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
@@ -19,7 +19,7 @@ export const questionSchema = commonQuestionFieldsValidation.shape({
     )
     .required(translations.attachmentSettingRequired),
   maxAttachments: number().when('attachmentType', {
-    is: AttachmentType.MULTIPLE_FILE_ATTACHMENTS,
+    is: AttachmentType.MULTIPLE_ATTACHMENT,
     then: number()
       .required()
       .min(1, translations.mustSpecifyPositiveMaxAttachment)

--- a/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
+++ b/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
@@ -29,7 +29,18 @@ export const questionSchema = commonQuestionFieldsValidation.shape({
       )
       .typeError(translations.mustSpecifyMaxAttachment),
   }),
-  maxAttachmentSize: number().min(0).max(MAX_ATTACHMENT_SIZE_UPPER_LIMIT),
+  maxAttachmentSize: number().when('attachmentType', {
+    is: AttachmentType.NO_ATTACHMENT,
+    then: number(),
+    otherwise: number()
+      .required()
+      .min(1, translations.mustSpecifyPositiveMaxAttachmentSize)
+      .max(
+        MAX_ATTACHMENT_SIZE_UPPER_LIMIT,
+        translations.mustBeLessThanMaxAttachmentSize,
+      )
+      .typeError(translations.mustSpecifyMaxAttachmentSize),
+  }),
   isAttachmentRequired: bool(),
 });
 

--- a/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
+++ b/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
@@ -9,6 +9,7 @@ import getIndexAndKeyPath from '../../commons/utils';
 import { commonQuestionFieldsValidation } from '../../components/CommonQuestionFields';
 
 const MAX_ATTACHMENT_UPPER_LIMIT = 50;
+const MAX_ATTACHMENT_SIZE_UPPER_LIMIT = 1024;
 
 export const questionSchema = commonQuestionFieldsValidation.shape({
   attachmentType: string()
@@ -28,6 +29,7 @@ export const questionSchema = commonQuestionFieldsValidation.shape({
       )
       .typeError(translations.mustSpecifyMaxAttachment),
   }),
+  maxAttachmentSize: number().min(0).max(MAX_ATTACHMENT_SIZE_UPPER_LIMIT),
   isAttachmentRequired: bool(),
 });
 

--- a/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
@@ -1,5 +1,5 @@
 import { Controller, useFormContext } from 'react-hook-form';
-import { RadioGroup } from '@mui/material';
+import { InputAdornment, RadioGroup } from '@mui/material';
 import {
   AttachmentType,
   TextResponseQuestionFormData,
@@ -81,6 +81,13 @@ const FileUploadManager = (props: Props): JSX.Element => {
                   disableMargins
                   field={field}
                   fieldState={fieldState}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        {t(translations.megabytes)}
+                      </InputAdornment>
+                    ),
+                  }}
                   label={t(translations.maxAttachmentSize)}
                   variant="filled"
                 />

--- a/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
@@ -55,20 +55,39 @@ const FileUploadManager = (props: Props): JSX.Element => {
       />
 
       {watch('attachmentType') !== AttachmentType.NO_ATTACHMENT && (
-        <div className="mt-5">
-          <Controller
-            control={control}
-            name="isAttachmentRequired"
-            render={({ field, fieldState }): JSX.Element => (
-              <FormCheckboxField
-                disabled={disabled}
-                field={field}
-                fieldState={fieldState}
-                label={t(translations.isAttachmentRequired)}
-              />
-            )}
-          />
-        </div>
+        <>
+          <div className="mt-5">
+            <Controller
+              control={control}
+              name="isAttachmentRequired"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormCheckboxField
+                  disabled={disabled}
+                  field={field}
+                  fieldState={fieldState}
+                  label={t(translations.isAttachmentRequired)}
+                />
+              )}
+            />
+          </div>
+          <div className="mt-5">
+            <Controller
+              control={control}
+              name="maxAttachmentSize"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormTextField
+                  className="w-1/2"
+                  disabled={disabled}
+                  disableMargins
+                  field={field}
+                  fieldState={fieldState}
+                  label={t(translations.maxAttachmentSize)}
+                  variant="filled"
+                />
+              )}
+            />
+          </div>
+        </>
       )}
 
       {watch('attachmentType') === AttachmentType.MULTIPLE_FILE_ATTACHMENTS && (

--- a/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
@@ -109,7 +109,7 @@ const FileUploadManager = (props: Props): JSX.Element => {
                 disableMargins
                 field={field}
                 fieldState={fieldState}
-                label={t(translations.maxAttachment)}
+                label={t(translations.maxAttachments)}
                 variant="filled"
               />
             )}

--- a/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
@@ -41,14 +41,14 @@ const FileUploadManager = (props: Props): JSX.Element => {
             <RadioButton
               description={t(translations.singleFileAttachmentDescription)}
               disabled={disabled}
-              label={t(translations.singleFileAttachment)}
-              value="single_file_attachment"
+              label={t(translations.singleAttachment)}
+              value="single_attachment"
             />
             <RadioButton
               description={t(translations.multipleFileAttachmentDescription)}
               disabled={disabled}
-              label={t(translations.multipleFileAttachment)}
-              value="multiple_file_attachments"
+              label={t(translations.multipleAttachment)}
+              value="multiple_attachment"
             />
           </RadioGroup>
         )}
@@ -90,7 +90,7 @@ const FileUploadManager = (props: Props): JSX.Element => {
         </>
       )}
 
-      {watch('attachmentType') === AttachmentType.MULTIPLE_FILE_ATTACHMENTS && (
+      {watch('attachmentType') === AttachmentType.MULTIPLE_ATTACHMENT && (
         <div className="mt-5">
           <Controller
             control={control}
@@ -103,7 +103,6 @@ const FileUploadManager = (props: Props): JSX.Element => {
                 field={field}
                 fieldState={fieldState}
                 label={t(translations.maxAttachment)}
-                type="number"
                 variant="filled"
               />
             )}

--- a/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
@@ -17,6 +17,7 @@ import { questionSchema, validateSolutions } from '../commons/validations';
 import {
   getAttachmentTypeFromMaxAttachment,
   getMaxAttachmentFromAttachmentType,
+  getMaxAttachmentSize,
 } from '../utils';
 
 import FileUploadManager from './FileUploadManager';
@@ -83,6 +84,7 @@ const TextResponseForm = <T extends 'new' | 'edit'>(
             ? false
             : question.isAttachmentRequired,
         maxAttachments: getMaxAttachmentFromAttachmentType(question),
+        maxAttachmentSize: getMaxAttachmentSize(question),
       },
       solutions,
     };

--- a/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
@@ -104,7 +104,11 @@ const TextResponseForm = <T extends 'new' | 'edit'>(
       headsUp
       initialValues={formattedData.question!}
       onSubmit={handleSubmit}
-      validates={questionSchema}
+      validates={questionSchema(
+        t,
+        data.defaultMaxAttachmentSize!,
+        data.defaultMaxAttachments!,
+      )}
     >
       {(control): JSX.Element => (
         <>

--- a/client/app/bundles/course/assessment/question/text-responses/operations.ts
+++ b/client/app/bundles/course/assessment/question/text-responses/operations.ts
@@ -39,6 +39,7 @@ const adaptPostData = (data: TextResponseData): TextResponsePostData => ({
     staff_only_comments: data.question.staffOnlyComments,
     maximum_grade: data.question.maximumGrade,
     max_attachments: data.question.maxAttachments,
+    max_attachment_size: data.question.maxAttachmentSize,
     is_attachment_required: data.question.isAttachmentRequired,
     hide_text: data.question.hideText,
     question_assessment: { skill_ids: data.question.skillIds },

--- a/client/app/bundles/course/assessment/question/text-responses/utils.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/utils.tsx
@@ -4,17 +4,17 @@ import {
 } from 'types/course/assessment/question/text-responses';
 
 export const getAttachmentTypeFromMaxAttachment = (
-  maxAttachment: number | undefined,
+  maxAttachments: number | undefined,
 ): AttachmentType => {
-  if (!maxAttachment || maxAttachment === 0) {
+  if (!maxAttachments || maxAttachments === 0) {
     return AttachmentType.NO_ATTACHMENT;
   }
 
-  if (maxAttachment === 1) {
-    return AttachmentType.SINGLE_FILE_ATTACHMENT;
+  if (maxAttachments === 1) {
+    return AttachmentType.SINGLE_ATTACHMENT;
   }
 
-  return AttachmentType.MULTIPLE_FILE_ATTACHMENTS;
+  return AttachmentType.MULTIPLE_ATTACHMENT;
 };
 
 export const getMaxAttachmentFromAttachmentType = (
@@ -24,7 +24,7 @@ export const getMaxAttachmentFromAttachmentType = (
     return 0;
   }
 
-  if (question.attachmentType === AttachmentType.SINGLE_FILE_ATTACHMENT) {
+  if (question.attachmentType === AttachmentType.SINGLE_ATTACHMENT) {
     return 1;
   }
 

--- a/client/app/bundles/course/assessment/question/text-responses/utils.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/utils.tsx
@@ -30,3 +30,13 @@ export const getMaxAttachmentFromAttachmentType = (
 
   return question.maxAttachments;
 };
+
+export const getMaxAttachmentSize = (
+  question: TextResponseQuestionFormData,
+): number | null => {
+  if (question.attachmentType === AttachmentType.NO_ATTACHMENT) {
+    return null;
+  }
+
+  return question.maxAttachmentSize;
+};

--- a/client/app/bundles/course/assessment/submission/components/DropzoneErrorComponent.tsx
+++ b/client/app/bundles/course/assessment/submission/components/DropzoneErrorComponent.tsx
@@ -15,7 +15,7 @@ const translations = defineMessages({
   fileTooLargeErrorMessage: {
     id: 'course.assessment.submission.FileInput.fileTooLargeErrorMessage',
     defaultMessage:
-      'The following files have size larger than allowed ({maxAttachmentSize} MiB)',
+      'The following files have size larger than allowed ({maxAttachmentSize} MB)',
   },
   fileName: {
     id: 'course.assessment.submission.FileInput.fileName',

--- a/client/app/bundles/course/assessment/submission/components/DropzoneErrorComponent.tsx
+++ b/client/app/bundles/course/assessment/submission/components/DropzoneErrorComponent.tsx
@@ -30,7 +30,6 @@ export const ErrorCodes = {
 
 interface TooManyFilesPrompt {
   maxAttachmentsAllowed: number;
-  needBottomMargin: boolean;
   numAttachments: number;
   numFiles: number;
 }
@@ -38,10 +37,9 @@ interface TooManyFilesPrompt {
 export const TooManyFilesErrorPromptContent: FC<TooManyFilesPrompt> = (
   props,
 ) => {
-  const { maxAttachmentsAllowed, needBottomMargin, numAttachments, numFiles } =
-    props;
+  const { maxAttachmentsAllowed, numAttachments, numFiles } = props;
   return (
-    <PromptText className={`${needBottomMargin ? 'mb-4' : ''}`}>
+    <PromptText>
       <FormattedMessage
         {...translations.tooManyFilesErrorMessage}
         values={{

--- a/client/app/bundles/course/assessment/submission/components/DropzoneErrorComponent.tsx
+++ b/client/app/bundles/course/assessment/submission/components/DropzoneErrorComponent.tsx
@@ -1,0 +1,84 @@
+import { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { PromptText } from 'lib/components/core/dialogs/Prompt';
+
+const translations = defineMessages({
+  tooManyFilesErrorMessage: {
+    id: 'course.assessment.submission.FileInput.tooManyFilesErrorMessage',
+    defaultMessage:
+      'You have attempted to upload {numFiles} files, but ONLY {maxAttachmentsAllowed} \
+      {maxAttachmentsAllowed, plural, one {file} other {files}} can be uploaded \
+      {numAttachments, plural, =0 {} one {since 1 file has been uploaded before} \
+      other {since {numAttachments} files has been uploaded before}}',
+  },
+  fileTooLargeErrorMessage: {
+    id: 'course.assessment.submission.FileInput.fileTooLargeErrorMessage',
+    defaultMessage:
+      'The following files have size larger than allowed ({maxAttachmentSize} MiB)',
+  },
+  fileName: {
+    id: 'course.assessment.submission.FileInput.fileName',
+    defaultMessage: '{index}. {name}',
+  },
+});
+
+export const ErrorCodes = {
+  FileTooLarge: 'file-too-large',
+  TooManyFiles: 'too-many-files',
+};
+
+interface TooManyFilesPrompt {
+  maxAttachmentsAllowed: number;
+  needBottomMargin: boolean;
+  numAttachments: number;
+  numFiles: number;
+}
+
+export const TooManyFilesErrorPromptContent: FC<TooManyFilesPrompt> = (
+  props,
+) => {
+  const { maxAttachmentsAllowed, needBottomMargin, numAttachments, numFiles } =
+    props;
+  return (
+    <PromptText className={`${needBottomMargin ? 'mb-4' : ''}`}>
+      <FormattedMessage
+        {...translations.tooManyFilesErrorMessage}
+        values={{
+          maxAttachmentsAllowed,
+          numFiles,
+          numAttachments,
+        }}
+      />
+    </PromptText>
+  );
+};
+
+interface FileTooLargePrompt {
+  maxAttachmentSize: number;
+  tooLargeFiles: string[];
+}
+
+export const FileTooLargeErrorPromptContent: FC<FileTooLargePrompt> = (
+  props,
+) => {
+  const { maxAttachmentSize, tooLargeFiles } = props;
+  return (
+    <>
+      <PromptText>
+        <FormattedMessage
+          {...translations.fileTooLargeErrorMessage}
+          values={{ maxAttachmentSize }}
+        />
+      </PromptText>
+      {tooLargeFiles.map((name, index) => (
+        <PromptText key={name} className="ml-6">
+          <FormattedMessage
+            {...translations.fileName}
+            values={{ index: index + 1, name }}
+          />
+        </PromptText>
+      ))}
+    </>
+  );
+};

--- a/client/app/bundles/course/assessment/submission/components/FileInput.jsx
+++ b/client/app/bundles/course/assessment/submission/components/FileInput.jsx
@@ -54,7 +54,10 @@ const styles = {
 const isFileTooLarge = (file) =>
   file.errors.some((error) => error.code === ErrorCodes.FileTooLarge);
 
-const initialErrorState = { 'file-too-large': [], 'too-many-files': 0 };
+const initialErrorState = {
+  [ErrorCodes.FileTooLarge]: [],
+  [ErrorCodes.TooManyFiles]: 0,
+};
 
 class FileInput extends Component {
   constructor(props) {
@@ -159,6 +162,8 @@ class FileInput extends Component {
       <div>
         <Dropzone
           disabled={disabled}
+          // 0 means no limit to the maxFiles
+          // ref: https://github.com/react-dropzone/react-dropzone/blob/master/examples/maxFiles/README.md
           maxFiles={maxAttachmentsAllowed ?? 0}
           maxSize={maxAttachmentSize * MEGABYTES_TO_BYTES}
           multiple={isMultipleAttachmentsAllowed}
@@ -187,20 +192,21 @@ class FileInput extends Component {
           open={this.errorExists()}
           title={<FormattedMessage {...translations.fileUploadErrorTitle} />}
         >
-          {errors[ErrorCodes.TooManyFiles] > 0 && (
-            <TooManyFilesErrorPromptContent
-              maxAttachmentsAllowed={maxAttachmentsAllowed}
-              needBottomMargin={errors[ErrorCodes.FileTooLarge].length > 0}
-              numAttachments={numAttachments}
-              numFiles={errors[ErrorCodes.TooManyFiles]}
-            />
-          )}
-          {errors[ErrorCodes.FileTooLarge].length > 0 && (
-            <FileTooLargeErrorPromptContent
-              maxAttachmentSize={maxAttachmentSize}
-              tooLargeFiles={errors[ErrorCodes.FileTooLarge]}
-            />
-          )}
+          <div className="space-y-4">
+            {errors[ErrorCodes.TooManyFiles] > 0 && (
+              <TooManyFilesErrorPromptContent
+                maxAttachmentsAllowed={maxAttachmentsAllowed}
+                numAttachments={numAttachments}
+                numFiles={errors[ErrorCodes.TooManyFiles]}
+              />
+            )}
+            {errors[ErrorCodes.FileTooLarge].length > 0 && (
+              <FileTooLargeErrorPromptContent
+                maxAttachmentSize={maxAttachmentSize}
+                tooLargeFiles={errors[ErrorCodes.FileTooLarge]}
+              />
+            )}
+          </div>
         </Prompt>
 
         {error || ''}

--- a/client/app/bundles/course/assessment/submission/components/answers/FileUpload/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/FileUpload/index.jsx
@@ -21,7 +21,7 @@ const FileUpload = ({
     getIsSavingAnswer(state, answerId),
   );
   const disableField = readOnly || isSaving;
-  const { maxAttachments, isAttachmentRequired } = question;
+  const { maxAttachments, isAttachmentRequired, maxAttachmentSize } = question;
   const isMultipleAttachmentsAllowed = maxAttachments - numAttachments > 1;
   const isFileUploadStillAllowed = maxAttachments > numAttachments;
 
@@ -33,6 +33,7 @@ const FileUpload = ({
           disabled={disableField || !isFileUploadStillAllowed}
           isMultipleAttachmentsAllowed={isMultipleAttachmentsAllowed}
           maxAttachmentsAllowed={maxAttachments - numAttachments}
+          maxAttachmentSize={maxAttachmentSize}
           name={`${answerId}.files`}
           numAttachments={numAttachments}
           onChangeCallback={() => handleUploadTextResponseFiles(answerId)}

--- a/client/app/bundles/course/assessment/submission/components/answers/TextResponse/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/TextResponse/index.jsx
@@ -28,7 +28,7 @@ const TextResponse = (props) => {
     getIsSavingAnswer(state, answerId),
   );
   const disableField = readOnly || isSaving;
-  const { maxAttachments, isAttachmentRequired } = question;
+  const { maxAttachments, isAttachmentRequired, maxAttachmentSize } = question;
   const allowUpload = maxAttachments !== 0;
 
   const readOnlyAnswer = (
@@ -109,6 +109,7 @@ const TextResponse = (props) => {
           disabled={disableField || !isFileUploadStillAllowed}
           isMultipleAttachmentsAllowed={isMultipleAttachmentsAllowed}
           maxAttachmentsAllowed={maxAttachments - numAttachments}
+          maxAttachmentSize={maxAttachmentSize}
           name={`${answerId}.files`}
           numAttachments={numAttachments}
           onChangeCallback={() => handleUploadTextResponseFiles(answerId)}

--- a/client/app/bundles/course/assessment/submission/components/answers/utils.tsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/utils.tsx
@@ -9,7 +9,7 @@ const translations = defineMessages({
   limitedNumberOfFileUploadAllowed: {
     id: 'course.assessment.submission.FileInput.onlyOneFileUploadAllowed',
     defaultMessage:
-      '*You can only upload AT MOST {maxAttachment} file for this question',
+      '*You can only upload AT MOST {maxAttachments} file for this question',
   },
   exactlyOneFileUploadAllowed: {
     id: 'course.assessment.submission.FileInput.exactlyOneFileUploadAllowed',

--- a/client/app/bundles/course/assessment/submission/constants.js
+++ b/client/app/bundles/course/assessment/submission/constants.js
@@ -14,6 +14,8 @@ export const questionTypes = mirrorCreator([
   'ForumPostResponse',
 ]);
 
+export const MEGABYTES_TO_BYTES = 1024 * 1024;
+
 export const workflowStates = {
   Unstarted: 'unstarted',
   Attempting: 'attempting',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -454,8 +454,8 @@ const translations = defineMessages({
     id: 'course.assessment.question.textResponses.isAttachmentRequired',
     defaultMessage: 'Require file upload for this question',
   },
-  maxAttachment: {
-    id: 'course.assessment.question.textResponses.maxAttachment',
+  maxAttachments: {
+    id: 'course.assessment.question.textResponses.maxAttachments',
     defaultMessage: 'Max Number of Attachments',
   },
   maxAttachmentSize: {
@@ -789,11 +789,11 @@ const translations = defineMessages({
   },
   mustBeLessThanMaxAttachments: {
     id: 'course.assessment.question.multipleResponses.mustBeLessThanMaxAttachments',
-    defaultMessage: 'Must be at most 50.',
+    defaultMessage: 'Must be at most {defaultMax}.',
   },
   mustBeLessThanMaxAttachmentSize: {
     id: 'course.assessment.question.multipleResponses.mustBeLessThanMaxAttachmentSize',
-    defaultMessage: 'Must be at most 1024MB.',
+    defaultMessage: 'Must be at most {defaultMax}MB.',
   },
   mustSpecifyResponse: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyResponse',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -434,7 +434,7 @@ const translations = defineMessages({
     id: 'course.assessment.question.textResponses.noAttachmentDescription',
     defaultMessage: 'They will not be able to upload any attachment.',
   },
-  singleFileAttachment: {
+  singleAttachment: {
     id: 'course.assessment.question.textResponses.singleFileAttachment',
     defaultMessage: 'Single Attachment',
   },
@@ -442,8 +442,8 @@ const translations = defineMessages({
     id: 'course.assessment.question.textResponses.singleFileAttachmentDescription',
     defaultMessage: 'They can only upload one attachment.',
   },
-  multipleFileAttachment: {
-    id: 'course.assessment.question.textResponses.multipleFileAttachment',
+  multipleAttachment: {
+    id: 'course.assessment.question.textResponses.multipleAttachments',
     defaultMessage: 'Multiple Attachments',
   },
   multipleFileAttachmentDescription: {
@@ -764,12 +764,12 @@ const translations = defineMessages({
   mustSpecifyMaxAttachment: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyMaxAttachment',
     defaultMessage:
-      'You must specify a valid, positive maximum attachment number to be set.',
+      'You must specify a valid, positive maximum attachment number.',
   },
   mustSpecifyMaxAttachmentSize: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyMaxAttachmentSize',
     defaultMessage:
-      'You must specify a valid, positive maximum attachment size to be set.',
+      'You must specify a valid, positive maximum attachment size.',
   },
   mustSpecifyPositiveMaximumGrade: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyPositiveMaximumGrade',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -458,6 +458,10 @@ const translations = defineMessages({
     id: 'course.assessment.question.textResponses.maxAttachment',
     defaultMessage: 'Max Number of Attachments',
   },
+  maxAttachmentSize: {
+    id: 'course.assessment.question.textResponses.maxAttachmentSize',
+    defaultMessage: 'Max Attachment Size (in MB)',
+  },
   comprehension: {
     id: 'course.assessment.show.comprehension',
     defaultMessage: 'Comprehension',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -766,6 +766,11 @@ const translations = defineMessages({
     defaultMessage:
       'You must specify a valid, positive maximum attachment number to be set.',
   },
+  mustSpecifyMaxAttachmentSize: {
+    id: 'course.assessment.question.multipleResponses.mustSpecifyMaxAttachmentSize',
+    defaultMessage:
+      'You must specify a valid, positive maximum attachment size to be set.',
+  },
   mustSpecifyPositiveMaximumGrade: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyPositiveMaximumGrade',
     defaultMessage: 'Maximum grade has to be non-negative.',
@@ -774,6 +779,10 @@ const translations = defineMessages({
     id: 'course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachment',
     defaultMessage: 'Maximum Number of Attachments has to be positive.',
   },
+  mustSpecifyPositiveMaxAttachmentSize: {
+    id: 'course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachmentSize',
+    defaultMessage: 'Max Attachment Size has to be positive.',
+  },
   mustBeLessThanMaxMaximumGrade: {
     id: 'course.assessment.question.multipleResponses.mustBeLessThanMaxMaximumGrade',
     defaultMessage: 'Must be less than 1000.',
@@ -781,6 +790,10 @@ const translations = defineMessages({
   mustBeLessThanMaxAttachments: {
     id: 'course.assessment.question.multipleResponses.mustBeLessThanMaxAttachments',
     defaultMessage: 'Must be at most 50.',
+  },
+  mustBeLessThanMaxAttachmentSize: {
+    id: 'course.assessment.question.multipleResponses.mustBeLessThanMaxAttachmentSize',
+    defaultMessage: 'Must be at most 1024MB.',
   },
   mustSpecifyResponse: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyResponse',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -460,7 +460,7 @@ const translations = defineMessages({
   },
   maxAttachmentSize: {
     id: 'course.assessment.question.textResponses.maxAttachmentSize',
-    defaultMessage: 'Max Attachment Size (in MB)',
+    defaultMessage: 'Max Size per Attachment',
   },
   comprehension: {
     id: 'course.assessment.show.comprehension',
@@ -781,7 +781,7 @@ const translations = defineMessages({
   },
   mustSpecifyPositiveMaxAttachmentSize: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachmentSize',
-    defaultMessage: 'Max Attachment Size has to be positive.',
+    defaultMessage: 'Max Size has to be positive.',
   },
   mustBeLessThanMaxMaximumGrade: {
     id: 'course.assessment.question.multipleResponses.mustBeLessThanMaxMaximumGrade',

--- a/client/app/types/course/assessment/question/text-responses.ts
+++ b/client/app/types/course/assessment/question/text-responses.ts
@@ -15,8 +15,8 @@ export interface SolutionEntity extends SolutionData {
 
 export enum AttachmentType {
   NO_ATTACHMENT = 'no_attachment',
-  SINGLE_FILE_ATTACHMENT = 'single_file_attachment',
-  MULTIPLE_FILE_ATTACHMENTS = 'multiple_file_attachments',
+  SINGLE_ATTACHMENT = 'single_attachment',
+  MULTIPLE_ATTACHMENT = 'multiple_attachment',
 }
 
 export interface TextResponseQuestionFormData extends QuestionFormData {

--- a/client/app/types/course/assessment/question/text-responses.ts
+++ b/client/app/types/course/assessment/question/text-responses.ts
@@ -22,6 +22,7 @@ export enum AttachmentType {
 export interface TextResponseQuestionFormData extends QuestionFormData {
   attachmentType: AttachmentType;
   maxAttachments: number;
+  maxAttachmentSize: number | null;
   isAttachmentRequired: boolean;
   hideText: boolean;
 }
@@ -45,6 +46,7 @@ export interface TextResponsePostData {
     staff_only_comments?: TextResponseFormDataQuestion['staffOnlyComments'];
     maximum_grade: TextResponseFormDataQuestion['maximumGrade'];
     max_attachments: TextResponseFormDataQuestion['maxAttachments'];
+    max_attachment_size: TextResponseFormDataQuestion['maxAttachmentSize'];
     is_attachment_required: TextResponseFormDataQuestion['isAttachmentRequired'];
     hide_text: TextResponseFormDataQuestion['hideText'];
     question_assessment?: {

--- a/client/app/types/course/assessment/question/text-responses.ts
+++ b/client/app/types/course/assessment/question/text-responses.ts
@@ -31,6 +31,8 @@ export interface TextResponseData<T extends 'new' | 'edit' = 'edit'> {
   solutions?: SolutionEntity[] | null | OptionalIfNew<T>;
   questionType: 'file_upload' | 'text_response';
   isAssessmentAutograded: boolean;
+  defaultMaxAttachmentSize?: number;
+  defaultMaxAttachments?: number;
   question: TextResponseQuestionFormData | OptionalIfNew<T>;
 }
 

--- a/client/app/types/course/assessment/submission/question/types.ts
+++ b/client/app/types/course/assessment/submission/question/types.ts
@@ -22,9 +22,13 @@ interface ProgrammingQuestionData {
 
 interface TextResponseParentQuestionData {}
 
-interface TextResponseQuestionData extends TextResponseParentQuestionData {
+interface TextResponseAttachmentData extends TextResponseParentQuestionData {
   maxAttachments: number;
+  maxAttachmentSize: number | null;
   isAttachmentRequired: boolean;
+}
+
+interface TextResponseQuestionData extends TextResponseAttachmentData {
   solutions?: {
     id: number;
     solutionType: 'exact_match' | 'keyword';
@@ -33,10 +37,7 @@ interface TextResponseQuestionData extends TextResponseParentQuestionData {
   };
 }
 
-interface FileUploadQuestionData extends TextResponseParentQuestionData {
-  maxAttachments: number;
-  isAttachmentRequired: boolean;
-}
+interface FileUploadQuestionData extends TextResponseAttachmentData {}
 
 interface ComprehensionQuestionData extends TextResponseParentQuestionData {
   groups?: {

--- a/config/locales/en/activerecord/course/assessment/question/text_response.yml
+++ b/config/locales/en/activerecord/course/assessment/question/text_response.yml
@@ -3,12 +3,14 @@ en:
     attributes:
       models:
         course/assessment/question/text_response:
-          text_response: 'Text Response Question'
-          file_upload: 'File Upload Question'
-          comprehension: 'Comprehension Question'
+          text_response: "Text Response Question"
+          file_upload: "File Upload Question"
+          comprehension: "Comprehension Question"
     errors:
       models:
         course/assessment/question/text_response:
           attributes:
             maximum_grade:
-              invalid_grade: 'must be no less than the grade of any solution'
+              invalid_grade: "must be no less than the grade of any solution"
+            max_attachment_size:
+              size_must_be_defined: "max attachment size must be defined if max attachments is nonzero"

--- a/db/migrate/20240312101723_add_max_size_to_attachment.rb
+++ b/db/migrate/20240312101723_add_max_size_to_attachment.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddMaxSizeToAttachment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_assessment_question_text_responses, :max_attachment_size, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -343,6 +343,7 @@ ActiveRecord::Schema.define(version: 2024_02_26_104135) do
     t.boolean "is_comprehension", default: false
     t.boolean "is_attachment_required", default: false, null: false
     t.integer "max_attachments", default: 0, null: false
+    t.integer "max_attachment_size"
   end
 
   create_table "course_assessment_question_voice_responses", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_26_104135) do
+ActiveRecord::Schema.define(version: 2024_03_12_104135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/course_assessment_question_text_responses.rb
+++ b/spec/factories/course_assessment_question_text_responses.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
           class: Course::Assessment::Question::TextResponse,
           parent: :course_assessment_question do
     max_attachments { 0 }
+    max_attachment_size { 1024 }
     is_attachment_required { false }
     hide_text { false }
     is_comprehension { false }

--- a/spec/models/course/assessment/question/text_response_spec.rb
+++ b/spec/models/course/assessment/question/text_response_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe Course::Assessment::Question::TextResponse, type: :model do
       end
     end
 
+    describe '#max_attachment_size' do
+      context 'when the input max_attachment_size is null and max_attachments is nonzero' do
+        subject { create(:course_assessment_question_text_response, max_attachments: 1, max_attachment_size: nil) }
+
+        it 'will return error' do
+          expect { subject }.to raise_error
+        end
+      end
+    end
+
     describe '#attempt' do
       let(:course) { create(:course) }
       let(:student_user) { create(:course_student, course: course).user }


### PR DESCRIPTION
## Feature

On top of https://github.com/Coursemology/coursemology2/pull/7137, we also add the ability for user to customise the maximum size per attachment (for now, we set it to at least 1 and at most 1024 (which is equal to 1GB))
<img width="1033" alt="Screenshot 2024-03-13 at 2 53 56 PM" src="https://github.com/Coursemology/coursemology2/assets/16359075/b4238d6f-8320-49b1-892f-f9185432f946">
