### PR TITLE
Fix misaligned cursor after bold texts in Ace Editor

### DIFF
--- a/client/app/bundles/course/assessment/question/programming/components/common/EditorAccordion.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/common/EditorAccordion.tsx
@@ -1,10 +1,9 @@
 import { ComponentProps } from 'react';
 
+import EditorField from 'lib/components/core/fields/EditorField';
 import Accordion from 'lib/components/core/layouts/Accordion';
 
-import Editor from './Editor';
-
-interface EditorAccordionProps extends ComponentProps<typeof Editor> {
+interface EditorAccordionProps extends ComponentProps<typeof EditorField> {
   title: string;
   disabled?: boolean;
   subtitle?: string;
@@ -15,7 +14,7 @@ const EditorAccordion = (props: EditorAccordionProps): JSX.Element => {
 
   return (
     <Accordion disabled={props.disabled} subtitle={subtitle} title={title}>
-      <Editor {...editorProps} />
+      <EditorField {...editorProps} />
     </Accordion>
   );
 };

--- a/client/app/bundles/course/assessment/question/programming/components/common/JavaTestCase.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/common/JavaTestCase.tsx
@@ -13,11 +13,11 @@ import {
   ProgrammingFormData,
 } from 'types/course/assessment/question/programming';
 
+import EditorField from 'lib/components/core/fields/EditorField';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../../../translations';
 
-import Editor from './Editor';
 import ExpressionField from './ExpressionField';
 import { TestCaseProps } from './TestCase';
 import TestCaseCell from './TestCaseCell';
@@ -129,7 +129,7 @@ const JavaTestCase = (props: TestCaseProps): JSX.Element => {
                 control={props.control}
                 name={`${props.name}.inlineCode` as JavaTestCaseFieldPath}
                 render={({ field }): JSX.Element => (
-                  <Editor
+                  <EditorField
                     disabled={props.disabled}
                     height="7rem"
                     language="java"

--- a/client/app/bundles/course/assessment/submission/components/Editor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Editor.jsx
@@ -1,7 +1,7 @@
 import { Controller, useFormContext } from 'react-hook-form';
 import PropTypes from 'prop-types';
 
-import AceEditorField from 'lib/components/form/fields/AceEditorField';
+import FormEditorField from 'lib/components/form/fields/EditorField';
 
 import { fileShape } from '../propTypes';
 
@@ -18,7 +18,7 @@ const Editor = (props) => {
         control={control}
         name={fieldName}
         render={({ field }) => (
-          <AceEditorField
+          <FormEditorField
             editorProps={{ $blockScrolling: true }}
             field={{
               ...field,

--- a/client/app/bundles/course/assessment/submission/components/Editor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Editor.jsx
@@ -19,7 +19,6 @@ const Editor = (props) => {
         name={fieldName}
         render={({ field }) => (
           <FormEditorField
-            editorProps={{ $blockScrolling: true }}
             field={{
               ...field,
               onChange: (event) => {
@@ -28,14 +27,11 @@ const Editor = (props) => {
               },
             }}
             filename={file.filename}
+            language={language}
             maxLines={25}
             minLines={25}
-            mode={language}
             readOnly={false}
-            setOptions={{ useSoftTabs: true }}
             style={{ marginBottom: 10 }}
-            theme="github"
-            width="100%"
           />
         )}
       />

--- a/client/app/lib/components/core/fields/EditorField.tsx
+++ b/client/app/lib/components/core/fields/EditorField.tsx
@@ -11,6 +11,22 @@ interface EditorProps extends ComponentProps<typeof AceEditor> {
   disabled?: boolean;
 }
 
+/**
+ * Font family for our Ace Editor, in descending order of priority.
+ *
+ * For some reasons, Monaco bold (font-weight: 700) renders narrower text widths in
+ * Safari, causing the cursor after the bolded texts to be misaligned. The fonts here are
+ * what Ace Editor renders by default, minus 'Monaco', which was first in line.
+ */
+const DEFAULT_FONT_FAMILY = [
+  'Menlo',
+  'Ubuntu Mono',
+  'Consolas',
+  'Source Code Pro',
+  'source-code-pro',
+  'monospace',
+].join(',');
+
 const EditorField = (props: EditorProps): JSX.Element => {
   const { language, value, disabled, onChange, ...otherProps } = props;
 
@@ -33,6 +49,7 @@ const EditorField = (props: EditorProps): JSX.Element => {
         useSoftTabs: true,
         readOnly: disabled,
         useWorker: false,
+        fontFamily: DEFAULT_FONT_FAMILY,
       }}
     />
   );

--- a/client/app/lib/components/core/fields/EditorField.tsx
+++ b/client/app/lib/components/core/fields/EditorField.tsx
@@ -11,7 +11,7 @@ interface EditorProps extends ComponentProps<typeof AceEditor> {
   disabled?: boolean;
 }
 
-const Editor = (props: EditorProps): JSX.Element => {
+const EditorField = (props: EditorProps): JSX.Element => {
   const { language, value, disabled, onChange, ...otherProps } = props;
 
   return (
@@ -24,7 +24,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       value={value}
       width="100%"
       {...otherProps}
-      editorProps={{ ...otherProps.editorProps, $blockScrolling: true }}
+      editorProps={{
+        ...otherProps.editorProps,
+        $blockScrolling: true,
+      }}
       setOptions={{
         ...otherProps.setOptions,
         useSoftTabs: true,
@@ -35,4 +38,4 @@ const Editor = (props: EditorProps): JSX.Element => {
   );
 };
 
-export default Editor;
+export default EditorField;

--- a/client/app/lib/components/form/fields/EditorField.jsx
+++ b/client/app/lib/components/form/fields/EditorField.jsx
@@ -1,5 +1,6 @@
-import AceEditor from 'react-ace';
 import PropTypes from 'prop-types';
+
+import EditorField from 'lib/components/core/fields/EditorField';
 
 const FormEditorField = (props) => {
   const {
@@ -8,7 +9,7 @@ const FormEditorField = (props) => {
   } = props;
 
   return (
-    <AceEditor name={name} onChange={onChange} value={value} {...custom} />
+    <EditorField name={name} onChange={onChange} value={value} {...custom} />
   );
 };
 

--- a/client/app/lib/components/form/fields/EditorField.jsx
+++ b/client/app/lib/components/form/fields/EditorField.jsx
@@ -1,7 +1,7 @@
 import AceEditor from 'react-ace';
 import PropTypes from 'prop-types';
 
-const AceEditorField = (props) => {
+const FormEditorField = (props) => {
   const {
     field: { name, onChange, value },
     ...custom
@@ -12,8 +12,8 @@ const AceEditorField = (props) => {
   );
 };
 
-AceEditorField.propTypes = {
+FormEditorField.propTypes = {
   field: PropTypes.object.isRequired,
 };
 
-export default AceEditorField;
+export default FormEditorField;


### PR DESCRIPTION
Reported by @markusyeo.

<details>
<summary>See bug in action</summary>

Safe Exam Browser 3.3.1 on macOS Sonoma 14.0

https://github.com/Coursemology/coursemology2/assets/51525686/d223dad1-844f-4b40-b172-180cd3ef33b4
</details>

For some reasons, Monaco on Safari produces bold texts that have logical widths in the DOM smaller than what is seen, resulting in the cursor after the bold texts to be under-offset. In this example, a `<div>` was added with `Hello` text on Monaco, 12px, 700 font weight, and the same erratic rendering is also seen, _outside of Ace Editor's parent_. It is likely that this has nothing to do with Ace Editor at all.

![image](https://github.com/Coursemology/coursemology2/assets/51525686/884d66f8-39f4-441d-85c7-2d341a43402f)

## Solution

We just prevent Ace Editor from using Monaco ever. Menlo is always available on macOS, and is thus safe to be used as an alternative. This change also ensures renders on other browsers and operating systems won't be affected.

This PR also refactors the programming submission form to use the same Ace Editor component as the programming question form. This makes sure Coursemology's configurations of Ace Editor stays the same throughout the entire site.

| Font | Result |
| - | - |
| Monaco | ![image](https://github.com/Coursemology/coursemology2/assets/51525686/da204aea-8ab8-4b51-bec3-e6ffc51ed43d) |
| Menlo | ![image](https://github.com/Coursemology/coursemology2/assets/51525686/41575a68-1eda-4045-aabe-0fec43aecba5) |
