### PR TITLE
Upgrade ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
         default: false
 
     docker:
-      - image: cimg/ruby:3.0.6-browsers
+      - image: cimg/ruby:3.1.4-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
@@ -51,8 +51,8 @@ commands:
       - restore_cache:
           name: Restore Ruby dependencies cache
           keys:
-            - v3.0.6-ruby-{{ checksum "Gemfile.lock" }}
-            - v3.0.6-ruby-
+            - v3.1.4-ruby-{{ checksum "Gemfile.lock" }}
+            - v3.1.4-ruby-
 
       - run:
           name: Install Bundler
@@ -66,7 +66,7 @@ commands:
           paths:
             - ./vendor/bundle
             - ./.bundle
-          key: v3.0.6-ruby-{{ checksum "Gemfile.lock" }}
+          key: v3.1.4-ruby-{{ checksum "Gemfile.lock" }}
 
   rehydrate_node_deps:
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
+ruby '3.1.4'
+
 # For Windows devs
 gem 'tzinfo-data', platforms: [:mswin, :mswin64]
 
@@ -117,6 +119,7 @@ group :development, :test do
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
+  gem 'debug'
 
   # Code Coverage reporters
   gem 'simplecov'
@@ -208,3 +211,15 @@ gem 'rails-html-sanitizer', '>= 1.0.4'
 
 gem 'mimemagic', '0.4.3'
 gem 'ffi', '>= 1.14.2'
+
+# net-smtp has been removed from the default gems in ruby 3.1.
+# As Action Mailbox depends on net/smtp temporarily add to your gemfile until the mail gem includes it as a dependancy.
+gem 'net-smtp'
+gem 'net-ftp'
+gem 'net-imap'
+gem 'net-pop'
+gem 'matrix'
+gem 'prime'
+
+# Ruby 3.1 uses Psych 4.0.0 makes Psych.load refuse to load untrusted data. This is only fixed in rails 7.0.2.4
+gem 'psych', '< 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,9 @@ GEM
       activesupport (>= 4.2)
     crass (1.0.6)
     date (3.3.4)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -231,6 +234,7 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    forwardable (1.3.3)
     friendly_id (5.5.1)
       activerecord (>= 4.0.0)
     fspath (3.1.2)
@@ -273,6 +277,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     image_size (3.4.0)
     in_threads (1.6.0)
+    io-console (0.7.2)
+    irb (1.12.0)
+      rdoc
+      reline (>= 0.4.2)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -330,6 +338,9 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.22.3)
     multi_json (1.15.0)
+    net-ftp (0.3.4)
+      net-protocol
+      time
     net-imap (0.4.10)
       date
       net-protocol
@@ -351,7 +362,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    prime (0.1.2)
+      forwardable
+      singleton
     progress (3.6.0)
+    psych (3.3.4)
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
@@ -404,6 +419,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rdoc (6.3.4.1)
     recaptcha (5.16.0)
     record_tag_helper (1.0.1)
       actionview (>= 5)
@@ -427,6 +443,8 @@ GEM
     redis-store (1.10.0)
       redis (>= 4, < 6)
     regexp_parser (2.9.0)
+    reline (0.5.0)
+      io-console (~> 0.5)
     request_store (1.6.0)
       rack (>= 1.4)
     responders (3.1.1)
@@ -515,6 +533,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    singleton (0.2.0)
     slim (5.2.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
@@ -539,6 +558,8 @@ GEM
     thor (1.3.1)
     thread_safe (0.3.6)
     tilt (2.3.0)
+    time (0.3.0)
+      date
     timeout (0.4.1)
     traceroute (0.8.1)
       rails (>= 3.0.0)
@@ -588,6 +609,7 @@ DEPENDENCIES
   codecov
   consistency_fail
   coursemology-polyglot
+  debug
   devise (= 4.9.3)
   devise-multi_email
   devise_masquerade
@@ -614,11 +636,18 @@ DEPENDENCIES
   lograge-sql
   lol_dba
   loofah (>= 2.2.1)
+  matrix
   mimemagic (= 0.4.3)
   mini_magick
+  net-ftp
+  net-imap
+  net-pop
+  net-smtp
   nokogiri (>= 1.8.1)
   parallel_tests
   pg
+  prime
+  psych (< 4.0.0)
   puma
   rack-cors
   rack-mini-profiler
@@ -658,6 +687,9 @@ DEPENDENCIES
   workflow
   workflow-activerecord (>= 4.1, < 7.0)
   yard
+
+RUBY VERSION
+   ruby 3.1.4p223
 
 BUNDLED WITH
    2.2.33

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Coursemology is an open source gamified learning platform that enables educators
 
 ### System Requirements
 
-1. Ruby (= 3.0.6)
+1. Ruby (= 3.1.4)
 1. Ruby on Rails (= 6.0.6.1)
 1. PostgreSQL (>= 9.5)
 1. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick) - if PDF processing doesn't work for the import of scribing questions, download Ghostscript)


### PR DESCRIPTION
Ruby upgrade is stopped at 3.1 as there's an incompatibility issue between rails 6 and ruby 3.2. Refer to the issues below
- https://stackoverflow.com/questions/76262079/ruby-on-rails-update-triggered-argumenterror-in-mailer-functions
- https://stackoverflow.com/questions/75423891/getting-wrong-number-of-arguments-calling-a-function-with-keyword-arguments-with

We can continue to upgrade to Ruby > 3.2 after upgrading rails > 7.0.1

References:
- https://rubyreferences.github.io/rubychanges/3.1.html
- https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/