### PR TITLE
Answers on screen not reflected upon submitting

### DIFF
--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/ErrorHelper.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/ErrorHelper.tsx
@@ -25,7 +25,7 @@ export const errorResolver = (
       }
     });
     return {
-      values: {},
+      values: data,
       errors: allErrors,
     };
   };


### PR DESCRIPTION
## Issue

When students attempted the assessment, the unsaved answers on the screen won't be reflected after the submission is finalised. Even though this unsaved answers case are not that likely to occur (since we utilised autosave), but the autosave is only activated when user is idle for 1 second (we used debouncing)

During that 1 second, should user finalise the submission (basically finalising it before the autosaving takes place), the answer will be left unsaved and thus won't be reflected after the finalising is finished (only the last saved answer will be there)

## Reason

Upon inspection, it's revealed that the final version of the answer (what's on the screen) was not being sent to BE and thus BE assumes nothing changes from FE when attempting to finalise the submission. What should have happened was that FE should send the final version of the answers, on what's displayed on screen to reflect user's final answer, to BE for it to save to the system.

<img width="568" alt="Screenshot 2024-04-16 at 10 12 49 AM" src="https://github.com/Coursemology/coursemology2/assets/16359075/3a4e3f2a-52bf-45a9-9918-11b0e0f60804">

The main problem lies in the `errorResolver`, in which before submitting, this resolver changes the values to null. This mistake is resolved by maintaining the data being evaluated for validation to be sent to BE

## Outstanding Issue

With this PR, actually there is still an outstanding issue left unsolved within this PR, which is that the debouncing of the answer saving won't be triggered if we switch to another question in the Step Form (clicking on another bubble indicating another question). This will be resolved in the another PR that follow this one