### PR TITLE
Trigger Saving Answer when Toggling to Other Question in Submission

### DIFF
--- a/client/app/bundles/course/assessment/submission/actions/answers/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/answers/index.js
@@ -166,7 +166,6 @@ export function saveAnswer(answerData, answerId, currentTime, resetField) {
 export function saveAllAnswers(rawAnswers, resetField) {
   const currentTime = Date.now();
 
-  // const payload = { submission: { answers, is_save_draft: true } };
   return (dispatch) => {
     Object.values(rawAnswers).forEach((rawAnswer) =>
       dispatch(saveAnswer(rawAnswer, rawAnswer.id, currentTime, resetField)),

--- a/client/app/bundles/course/assessment/submission/actions/answers/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/answers/index.js
@@ -7,7 +7,10 @@ import pollJob from 'lib/helpers/jobHelpers';
 
 import actionTypes from '../../constants';
 import { updateAnswerFlagSavingStatus } from '../../reducers/answerFlags';
-import { getClientVersionForAnswerId } from '../../selectors/answers';
+import {
+  getClientVersionForAnswerId,
+  getSavingStatusForAnswerId,
+} from '../../selectors/answers';
 import translations from '../../translations';
 import { convertAnswerDataToInitialValue } from '../../utils/answers';
 import { buildErrorMessage, formatAnswer } from '../utils';
@@ -17,13 +20,11 @@ const JOB_POLL_DELAY_MS = 500;
 export const STALE_ANSWER_ERR = 'stale_answer';
 
 export const dispatchUpdateAnswerFlagSavingStatus =
-  (answerId, savingStatus, isStaleAnswer = false) =>
-  (dispatch) =>
+  (answerId, savingStatus) => (dispatch) =>
     dispatch(
       updateAnswerFlagSavingStatus({
         answer: { id: answerId },
         savingStatus,
-        isStaleAnswer,
       }),
     );
 
@@ -114,6 +115,11 @@ export function saveAnswer(answerData, answerId, currentTime, resetField) {
       getClientVersionForAnswerId(getState(), answerId) > currentTime;
     if (isAnswerStale) return {};
 
+    const currentSavingStatus = getSavingStatusForAnswerId(
+      getState(),
+      answerId,
+    );
+
     dispatch({
       type: actionTypes.SAVE_ANSWER_REQUEST,
       payload: { answer: { id: answerId, clientVersion: currentTime } },
@@ -152,11 +158,13 @@ export function saveAnswer(answerData, answerId, currentTime, resetField) {
           payload: { answerId },
         });
         const isStaleAnswer = buildErrorMessage(e).includes(STALE_ANSWER_ERR);
+        if (isStaleAnswer) {
+          resetField(`${answerId}`, { defaultValue: answerData });
+        }
         dispatch(
           dispatchUpdateAnswerFlagSavingStatus(
             answerId,
-            SAVING_STATUS.Failed,
-            isStaleAnswer,
+            isStaleAnswer ? currentSavingStatus : SAVING_STATUS.Failed,
           ),
         );
       });

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -188,6 +188,13 @@ const SubmissionEditForm = (props) => {
     };
   });
 
+  const getCurrentlySavingAnswerId = () => {
+    const id = questionIds[stepIndex];
+    const question = questions[id];
+
+    return question.answerId;
+  };
+
   const renderAutogradeSubmissionButton = () => {
     if (graderView && submitted) {
       return (
@@ -618,44 +625,51 @@ const SubmissionEditForm = (props) => {
     </div>
   );
 
-  const renderSteppedQuestions = () => (
-    <Stepper
-      activeStep={stepIndex}
-      connector={<div />}
-      nonLinear
-      style={{ justifyContent: 'center', flexWrap: 'wrap', padding: 10 }}
-    >
-      {questionIds.map((id, index) => {
-        let stepButtonColor = '';
-        const isCurrentQuestion = index === stepIndex;
-        stepButtonColor = isCurrentQuestion ? blue[800] : blue[400];
-        return (
-          <Step key={id} sx={{ width: 55, height: 50 }}>
-            <StepButton
-              icon={
-                <SvgIcon htmlColor={stepButtonColor}>
-                  <circle cx="12" cy="12" r="12" />
-                  <text
-                    fill="#fff"
-                    fontSize="12"
-                    textAnchor="middle"
-                    x="12"
-                    y="16"
-                  >
-                    {index + 1}
-                  </text>
-                </SvgIcon>
-              }
-              onClick={() => {
-                setStepIndex(index);
-              }}
-              style={styles.stepButton}
-            />
-          </Step>
-        );
-      })}
-    </Stepper>
-  );
+  const renderSteppedQuestions = () => {
+    const answerId = getCurrentlySavingAnswerId();
+
+    return (
+      <Stepper
+        activeStep={stepIndex}
+        connector={<div />}
+        nonLinear
+        style={{ justifyContent: 'center', flexWrap: 'wrap', padding: 10 }}
+      >
+        {questionIds.map((id, index) => {
+          let stepButtonColor = '';
+          const isCurrentQuestion = index === stepIndex;
+          stepButtonColor = isCurrentQuestion ? blue[800] : blue[400];
+          return (
+            <Step key={id} sx={{ width: 55, height: 50 }}>
+              <StepButton
+                icon={
+                  <SvgIcon htmlColor={stepButtonColor}>
+                    <circle cx="12" cy="12" r="12" />
+                    <text
+                      fill="#fff"
+                      fontSize="12"
+                      textAnchor="middle"
+                      x="12"
+                      y="16"
+                    >
+                      {index + 1}
+                    </text>
+                  </SvgIcon>
+                }
+                onClick={() => {
+                  handleSubmit((data) =>
+                    onSaveDraft({ answerId: data[answerId] }, resetField),
+                  )();
+                  setStepIndex(index);
+                }}
+                style={styles.stepButton}
+              />
+            </Step>
+          );
+        })}
+      </Stepper>
+    );
+  };
 
   const renderSteppedQuestionsContent = () => {
     const questionId = questionIds[stepIndex];

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -184,13 +184,30 @@ const SubmissionEditStepForm = (props) => {
     };
   });
 
+  const getCurrentlySavingAnswerId = () => {
+    const id = questionIds[stepIndex];
+    const question = questions[id];
+
+    return question.answerId;
+  };
+
   const handleNext = () => {
+    const answerId = getCurrentlySavingAnswerId();
+
+    handleSubmit((data) => {
+      onSaveDraft({ answerId: data[answerId] }, resetField);
+    })();
     setMaxStep(Math.max(maxStep, stepIndex + 1));
     setStepIndex(stepIndex + 1);
   };
 
   const handleStepClick = (index) => {
+    const answerId = getCurrentlySavingAnswerId();
+
     if (published || skippable || graderView || index <= maxStep) {
+      handleSubmit((data) => {
+        onSaveDraft({ answerId: data[answerId] }, resetField);
+      })();
       setStepIndex(index);
     }
   };

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditStepForm.jsx
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
 import ConfirmationDialog from 'lib/components/core/dialogs/ConfirmationDialog';
 import ErrorText from 'lib/components/core/ErrorText';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import { SAVING_STATUS } from 'lib/constants/sharedConstants';
 import usePrompt from 'lib/hooks/router/usePrompt';
 
 import SubmissionAnswer from '../../components/answers';
@@ -86,6 +87,7 @@ const SubmissionEditStepForm = (props) => {
   const {
     assessment,
     attachments,
+    answerFlags,
     allConsideredCorrect,
     allowPartialSubmission,
     attempting,
@@ -141,7 +143,7 @@ const SubmissionEditStepForm = (props) => {
     handleSubmit,
     reset,
     resetField,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, dirtyFields },
   } = methods;
   usePrompt(isDirty);
 
@@ -193,21 +195,32 @@ const SubmissionEditStepForm = (props) => {
 
   const handleNext = () => {
     const answerId = getCurrentlySavingAnswerId();
+    const isAnswerUnsaved =
+      answerFlags[answerId].savingStatus !== SAVING_STATUS.Saved;
+    const isAnswerDirty = !!dirtyFields[answerId];
 
-    handleSubmit((data) => {
-      onSaveDraft({ answerId: data[answerId] }, resetField);
-    })();
+    if (isAnswerUnsaved && isAnswerDirty) {
+      handleSubmit((data) => {
+        onSaveDraft({ answerId: data[answerId] }, resetField);
+      })();
+    }
+
     setMaxStep(Math.max(maxStep, stepIndex + 1));
     setStepIndex(stepIndex + 1);
   };
 
   const handleStepClick = (index) => {
     const answerId = getCurrentlySavingAnswerId();
+    const isAnswerUnsaved =
+      answerFlags[answerId].savingStatus !== SAVING_STATUS.Saved;
+    const isAnswerDirty = !!dirtyFields[answerId];
 
     if (published || skippable || graderView || index <= maxStep) {
-      handleSubmit((data) => {
-        onSaveDraft({ answerId: data[answerId] }, resetField);
-      })();
+      if (isAnswerUnsaved && isAnswerDirty) {
+        handleSubmit((data) => {
+          onSaveDraft({ answerId: data[answerId] }, resetField);
+        })();
+      }
       setStepIndex(index);
     }
   };
@@ -766,6 +779,7 @@ SubmissionEditStepForm.propTypes = {
   assessment: PropTypes.object,
   attachments: PropTypes.arrayOf(attachmentShape),
   submissionTimeLimitAt: PropTypes.number,
+  answerFlags: PropTypes.object,
   graderView: PropTypes.bool.isRequired,
   maxStep: PropTypes.number.isRequired,
   step: PropTypes.number,
@@ -808,6 +822,8 @@ function mapStateToProps(state) {
     assessment: state.assessments.submission.assessment,
     attachments: state.assessments.submission.attachments,
     liveFeedback: state.assessments.submission.liveFeedback,
+    answerFlags:
+      state.assessments.submission.answerFlags.flagsByAnswerId.entities,
   };
 }
 

--- a/client/app/bundles/course/assessment/submission/reducers/answerFlags/index.ts
+++ b/client/app/bundles/course/assessment/submission/reducers/answerFlags/index.ts
@@ -58,11 +58,8 @@ export const answerFlagsSlice = createSlice({
       action: PayloadAction<{
         answer: { id: number | string };
         savingStatus: AnswerFlagData['savingStatus'];
-        isStaleAnswer?: boolean;
       }>,
     ) => {
-      if (action.payload.isStaleAnswer) return;
-
       answerFlagsAdapter.updateOne(state.flagsByAnswerId, {
         id: action.payload.answer.id,
         changes: {

--- a/client/app/bundles/course/assessment/submission/selectors/answers.ts
+++ b/client/app/bundles/course/assessment/submission/selectors/answers.ts
@@ -1,7 +1,16 @@
+import { Dictionary } from '@reduxjs/toolkit';
 import { AppState } from 'store';
+
+import { SAVING_STATUS } from 'lib/constants/sharedConstants';
+
+import { AnswerFlagData } from '../reducers/answerFlags';
 
 const getLocalState = (state: AppState): Record<number | string, number> => {
   return state.assessments.submission.answers.clientVersionByAnswerId;
+};
+
+const getSavingStatus = (state: AppState): Dictionary<AnswerFlagData> => {
+  return state.assessments.submission.answerFlags.flagsByAnswerId.entities;
 };
 
 export const getClientVersionForAnswerId = (
@@ -9,4 +18,11 @@ export const getClientVersionForAnswerId = (
   answerId: number,
 ): number => {
   return getLocalState(state)[answerId];
+};
+
+export const getSavingStatusForAnswerId = (
+  state: AppState,
+  answerId: number,
+): keyof typeof SAVING_STATUS => {
+  return getSavingStatus(state)[answerId]?.savingStatus ?? SAVING_STATUS.None;
 };


### PR DESCRIPTION
## Issue
Continuation of https://github.com/Coursemology/coursemology2/pull/7278, this issue is happens when the autosave is not yet triggered while the user has already switched to another question in stepped-format assessment. As such, the autosave won't be triggered and the answer is lost when the page is refreshed or the user navigates to another page.

## Solution
Under normal circumstances, there is a prompt showing up to user when there's unsaved answers. However, it would be better to trigger the saving when the user navigates to another question. Here, we trigger the autosaving when the user clicks another bubble/step to navigate to another question

https://github.com/Coursemology/coursemology2/assets/16359075/b9f126f2-8d88-46de-9927-5a17a0503bc7

