### PR TITLE
Fix 500 when submitting an assessment, has, affects personal times, that's last in a course

### DIFF
--- a/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
@@ -82,6 +82,13 @@ module Course::LessonPlan::LearningRateConcern
     [min_remaining_time / reference_remaining_time, max_remaining_time / reference_remaining_time]
   end
 
+  def lesson_plan_items_with_sorted_times_for(course_user)
+    course_user.course.lesson_plan_items.published.
+      with_reference_times_for(course_user).
+      with_personal_times_for(course_user).
+      sort_by { |item| item.time_for(course_user).start_at }
+  end
+
   private
 
   # Merges course assessment submissions into the given hash, with the following format:

--- a/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
@@ -74,6 +74,8 @@ module Course::LessonPlan::LearningRateConcern
     return [min_learning_rate, max_learning_rate] if last_submitted_item.nil?
 
     reference_remaining_time = items.last.start_at - last_submitted_item.reference_time_for(course_user).start_at
+    reference_remaining_time += 1e-99 # Prevent division by zero.
+
     min_remaining_time = course_start + (min_learning_rate * (course_end - course_start)) -
                          last_submitted_item.time_for(course_user).start_at
     max_remaining_time = course_start + (max_learning_rate * (course_end - course_start)) -

--- a/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
@@ -38,8 +38,10 @@ class Course::LessonPlan::Strategies::BasePersonalizationStrategy
       effective_min, effective_max = compute_learning_rate_effective_limits(course_user, items, submitted_items,
                                                                             self.class::MIN_LEARNING_RATE,
                                                                             self.class::MAX_LEARNING_RATE)
-      learning_rate_ema = [self.class::HARD_MIN_LEARNING_RATE, effective_min,
-                           [learning_rate_ema, effective_max].min].max
+
+      effective_min = [effective_min, self.class::HARD_MIN_LEARNING_RATE].max
+      effective_max = [effective_max, self.class::HARD_MIN_LEARNING_RATE].max
+      learning_rate_ema = learning_rate_ema.clamp(effective_min, effective_max)
     end
 
     { submitted_items: submitted_items, items: items, learning_rate_ema: learning_rate_ema,

--- a/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/base_personalization_strategy.rb
@@ -29,11 +29,7 @@ class Course::LessonPlan::Strategies::BasePersonalizationStrategy
   # @return [Hash] Precomputed data to aid execution.
   def precompute_data(course_user) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     submitted_items = lesson_plan_items_submission_time_hash(course_user)
-    items = course_user.course.lesson_plan_items.published.
-            with_reference_times_for(course_user).
-            with_personal_times_for(course_user).
-            to_a
-    items = items.sort_by { |x| x.time_for(course_user).start_at }
+    items = lesson_plan_items_with_sorted_times_for(course_user)
     items_affecting_personal_times = items.select(&:affects_personal_times?)
     learning_rate_ema = compute_learning_rate_ema(
       course_user, items_affecting_personal_times, submitted_items, self.class::LEARNING_RATE_ALPHA

--- a/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
@@ -23,8 +23,9 @@ class Course::LessonPlan::Strategies::OtotPersonalizationStrategy <
       effective_min, effective_max = compute_learning_rate_effective_limits(course_user, items, submitted_items,
                                                                             strategy::MIN_LEARNING_RATE,
                                                                             strategy::MAX_LEARNING_RATE)
-      bounded_learning_rate_ema = [strategy::HARD_MIN_LEARNING_RATE, effective_min,
-                                   [learning_rate_ema, effective_max].min].max
+      effective_min = [effective_min, strategy::HARD_MIN_LEARNING_RATE].max
+      effective_max = [effective_max, strategy::HARD_MIN_LEARNING_RATE].max
+      bounded_learning_rate_ema = learning_rate_ema.clamp(effective_min, effective_max)
     end
 
     { submitted_items: submitted_items, items: items, learning_rate_ema: bounded_learning_rate_ema,

--- a/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb
@@ -9,11 +9,7 @@ class Course::LessonPlan::Strategies::OtotPersonalizationStrategy <
   # @return [Hash] Precomputed data to aid execution.
   def precompute_data(course_user) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     submitted_items = lesson_plan_items_submission_time_hash(course_user)
-    items = course_user.course.lesson_plan_items.published.
-            with_reference_times_for(course_user).
-            with_personal_times_for(course_user).
-            to_a
-    items = items.sort_by { |x| x.time_for(course_user).start_at }
+    items = lesson_plan_items_with_sorted_times_for(course_user)
     items_affecting_personal_times = items.select(&:affects_personal_times?)
     learning_rate_ema = compute_learning_rate_ema(
       course_user, items_affecting_personal_times, submitted_items, self.class::LEARNING_RATE_ALPHA


### PR DESCRIPTION
This PR fixes a float error that got thrown by any of the personalised timelines strategies' `precompute_data` when a student submits an assessment (has and affects personal times) with the latest default `start_at` in a course. This error essentially makes it impossible to finalise the submission of said assessment.

```
ArgumentError (comparison of Float with 0.5559384903083443 failed):
  
app/controllers/concerns/course/lesson_plan/strategies/otot_personalization_strategy.rb:28:in `precompute_data'
app/controllers/concerns/course/lesson_plan/personalization_concern.rb:36:in `update_personalized_timeline_for_user'
app/controllers/course/personal_times_controller.rb:50:in `recompute'
app/controllers/concerns/application_user_time_zone_concern.rb:13:in `set_time_zone'
```

This hasn't really been caught because in most courses with personalised timelines, they always have last assessments that do not have and affect personal times, e.g., exams, make-up exams, reflections, etc.

To reproduce this bug, 
1. go to any course, 
2. create an assessment with `start_at` that's the last in the course but has passed from now,
3. enable "Has personal times" and "Affects personal times" in Edit Assessment,
4. masquerade as a student in that course,
5. attempt and submit that assessment,
6. observe the HTTP 500 error and above's `ArgumentError` in `precompute_data`.

## How this error happened?

`precompute_data` has the following lines. Fixed, FOMO, and Stragglers use the same `precompute_data` from `BasePersonalizationStrategy`, while OTOT defines its own `precompute_data` similarly as the following.

```rb
effective_min, effective_max = compute_learning_rate_effective_limits(course_user, items, submitted_items,
                                                                        self.class::MIN_LEARNING_RATE,
                                                                        self.class::MAX_LEARNING_RATE)
learning_rate_ema = [self.class::HARD_MIN_LEARNING_RATE, effective_min,
                        [learning_rate_ema, effective_max].min].max

```

And this is the definition of `compute_learning_rate_effective_limits`.

```rb
def compute_learning_rate_effective_limits(course_user, items, submitted_items, min_learning_rate, max_learning_rate) # rubocop:disable Metrics/AbcSize
  course_start = items.first.start_at
  course_end = items.last.start_at
  last_submitted_item = items.reverse_each.lazy.
                        # TODO: Look into whether there's a need to filter on affects_personal_times?
                        select { |item| item.affects_personal_times? && item.id.in?(submitted_items.keys) }.
                        first
  return [min_learning_rate, max_learning_rate] if last_submitted_item.nil?

  reference_remaining_time = items.last.start_at - last_submitted_item.reference_time_for(course_user).start_at

  min_remaining_time = course_start + (min_learning_rate * (course_end - course_start)) -
                        last_submitted_item.time_for(course_user).start_at
  max_remaining_time = course_start + (max_learning_rate * (course_end - course_start)) -
                        last_submitted_item.time_for(course_user).start_at

  [min_remaining_time / reference_remaining_time, max_remaining_time / reference_remaining_time]
end
```

If a student submits an assessment, has and affects personal times, with the latest `start_at` in a course, we see that this assessment will be both `items.last` and `last_submitted_item`. As such, `reference_remaining_time` and `max_remaining_time` become `0.0`. This causes the return tuple of `compute_learning_rate_effective_limits` to be `[-Infinity, NaN]`.

>[!NOTE]
>I must emphasise the subtlety that `reference_remaining_time` is `0.0` (float) instead of `0` (integer). In Ruby, dividing by `0` will throw a `ZeroDivisionError`, as expected, but dividing by `0.0` gives `Infinity` or `-Infinity`, depending on the sign of the numerator.

As such in `precompute_data`, we get `effective_min` and `effective_max` to be `-Infinity` and `NaN`, respectively. According to the Yardoc of `compute_learning_rate_effective_limits`, `-Infinity` is expected, but `NaN` is obviously not. This causes `[learning_rate_ema, effective_max].min` to throw the `ArgumentError`.

## Solution

We make sure `reference_remaining_time` never gets to actually zero by adding it with a ridiculously small number `1e-99` that is semantically insignificant to the variable; essentially creating an asymptote. This ensures that we don't get `NaN` that we can't work with.

We also clamp `effective_min` and `effective_max` to `HARD_MIN_LEARNING_RATE` to ensure that the learning rate will never go over `effective_max` and causing a `ValidationError` specified by `learning_rate_record.rb:8`.