### PR TITLE
Allow Course Manager, Owner, Observer to duplicate entire course even if they are Normal users in Instances

### DIFF
--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -20,7 +20,7 @@ class Course::DuplicationsController < Course::ComponentController
     return if instance_params == current_tenant.id
 
     destination_tenant = Instance.find(instance_params)
-    
+
     authorize!(:duplicate_across_instances, destination_tenant)
   end
 

--- a/app/controllers/course/duplications_controller.rb
+++ b/app/controllers/course/duplications_controller.rb
@@ -20,8 +20,7 @@ class Course::DuplicationsController < Course::ComponentController
     return if instance_params == current_tenant.id
 
     destination_tenant = Instance.find(instance_params)
-
-    authorize!(:duplicate_across_instances, current_tenant)
+    
     authorize!(:duplicate_across_instances, destination_tenant)
   end
 

--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -19,7 +19,9 @@ class Course::ObjectDuplicationsController < Course::ComponentController
   protected
 
   def authorize_duplication
-    authorize!(:duplicate_from, current_course)
+    unless can?(:duplicate_from, current_course) || can?(:duplicate_across_instances, current_tenant)
+      raise CanCan::AccessDenied
+    end
   end
 
   private

--- a/app/controllers/course/object_duplications_controller.rb
+++ b/app/controllers/course/object_duplications_controller.rb
@@ -19,9 +19,7 @@ class Course::ObjectDuplicationsController < Course::ComponentController
   protected
 
   def authorize_duplication
-    unless can?(:duplicate_from, current_course) || can?(:duplicate_across_instances, current_tenant)
-      raise CanCan::AccessDenied
-    end
+    authorize!(:duplicate_from, current_course)
   end
 
   private

--- a/spec/controllers/course/duplications_controller_spec.rb
+++ b/spec/controllers/course/duplications_controller_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe Course::DuplicationsController, type: :controller do
   let(:instance) { Instance.default }
   let(:destination_instance) { create(:instance) }
+  let(:destination_instance_admin) { create(:instance_user, :instructor, instance: destination_instance).user }
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
@@ -23,6 +24,21 @@ RSpec.describe Course::DuplicationsController, type: :controller do
         before { sign_in(instance_admin_course_user) }
 
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when course manager in a course which is instance normal wants to duplicate to other instance' do
+        let(:instance_normal_user) do
+          ActsAsTenant.without_tenant do
+            create(:instance_user, user: destination_instance_admin, instance: instance).user
+          end
+        end
+        let!(:instance_course_manager) { create(:course_manager, user: instance_normal_user, course: course).user }
+        before { sign_in(instance_course_manager) }
+
+        it 'expects the duplication to be successful' do
+          subject
+          expect(response).to be_successful
+        end
       end
 
       context 'when admin user wants to duplicate course to another instance' do


### PR DESCRIPTION
## Issue

Previously, course manager / owner can only duplicate objects from their course to other courses. While for duplicating the entire course, this manager needs to request being instance instructor or instance administrator. This creates the confusion as the said manager can actually access the page while not being given privilege for the entire operation inside that. Related to #7289

## Features

Now, we allow the course manager, course owner, and course observer to be able to duplicate their entire course to other instance, with the notes that this person needs to be the instance admin or instance instructor on the destination instance.

## Some features being kept

To access the duplication page, user needs to be either manager, owner, or observer of that course, regardless of their status in Coursemology (be it system admin, instance instructor or instance administrator)