### PR TITLE
Various minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some fr
    ```sh
    $ cp env .env; cp client/env client/.env
    ```
+   You may need to add specific API keys (such as the [GOOGLE_RECAPTCHA_SITE_KEY](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do)) to the .env files for testing specific features.
 
 8. Open up 2 different terminals, each to run the Frontend and Backend. On the terminal for Frontend, run
 

--- a/client/app/bundles/course/achievement/components/buttons/AchievementManagementButtons.tsx
+++ b/client/app/bundles/course/achievement/components/buttons/AchievementManagementButtons.tsx
@@ -82,6 +82,7 @@ const AchievementManagementButtons: FC<Props> = (props) => {
             <AchievementEdit
               achievementId={achievement.id}
               onClose={(): void => setIsEditing(false)}
+              onSubmit={(): void => setIsEditing(false)}
               open={isEditing}
             />
           )}

--- a/client/app/bundles/course/achievement/components/forms/AchievementForm.tsx
+++ b/client/app/bundles/course/achievement/components/forms/AchievementForm.tsx
@@ -79,6 +79,14 @@ const AchievementForm: FC<Props> = (props) => {
   } = props;
   const { t } = useTranslation();
 
+  // known issues:
+
+  // - users cannot click "update" after adding / removing conditions without other changes
+  // - if user cancels after adding / removing conditions, conditions will change,
+  //   but achievement row doesn't update until page refresh or edit menu reopened
+
+  // TODO: work should be done to unify data from ConditionsManager with main form,
+  // which will solve both issues
   return (
     <FormDialog
       editing={editing}

--- a/client/app/bundles/course/achievement/operations.ts
+++ b/client/app/bundles/course/achievement/operations.ts
@@ -77,9 +77,14 @@ export function createAchievement(data: AchievementFormData): Operation<
 export function updateAchievement(
   achievementId: number,
   data: AchievementFormData,
-): Operation<AxiosResponse<unknown, unknown>> {
+): Operation {
   const attributes = formatAttributes(data);
-  return async () => CourseAPI.achievements.update(achievementId, attributes);
+  return async (dispatch) =>
+    CourseAPI.achievements
+      .update(achievementId, attributes)
+      .then((response) => {
+        dispatch(actions.saveAchievement(response.data.achievement));
+      });
 }
 
 export function deleteAchievement(achievementId: number): Operation {

--- a/client/app/bundles/course/achievement/pages/AchievementEdit/index.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementEdit/index.tsx
@@ -15,6 +15,7 @@ interface Props {
   achievementId: number;
   open: boolean;
   onClose: () => void;
+  onSubmit: () => void;
 }
 
 const translations = defineMessages({
@@ -33,7 +34,7 @@ const translations = defineMessages({
 });
 
 const AchievementEdit: FC<Props> = (props) => {
-  const { achievementId, open, onClose } = props;
+  const { achievementId, open, onClose, onSubmit } = props;
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const achievement = useAppSelector((state) =>
@@ -48,13 +49,11 @@ const AchievementEdit: FC<Props> = (props) => {
     return null;
   }
 
-  const onSubmit = (data, setError): Promise<void> =>
+  const onSubmitWrapped = (data, setError): Promise<void> =>
     dispatch(updateAchievement(data.id, data))
       .then(() => {
         toast.success(t(translations.updateSuccess));
-        setTimeout(() => {
-          window.location.href = `/courses/${getCourseId()}/achievements`;
-        }, 500);
+        onSubmit();
       })
       .catch((error) => {
         toast.error(t(translations.updateFailure));
@@ -81,7 +80,7 @@ const AchievementEdit: FC<Props> = (props) => {
       editing
       initialValues={initialValues}
       onClose={onClose}
-      onSubmit={onSubmit}
+      onSubmit={onSubmitWrapped}
       open={open}
       title={t(translations.editAchievement)}
     />

--- a/client/app/bundles/course/assessment/submission/components/answers/index.tsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/index.tsx
@@ -168,7 +168,7 @@ const SubmissionAnswer = <T extends keyof typeof QuestionType>(
       ))}
 
       <Typography className="mt-2" variant="body1">
-        {question.questionTitle}
+        {question.questionTitle ?? ''}
       </Typography>
 
       <Typography

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -41,12 +41,6 @@ const styles = {
 };
 
 class VisibleGradingPanel extends Component {
-  static calculateTotalGrade(grades) {
-    return Object.values(grades)
-      .filter((grade) => grade !== null)
-      .reduce((acc, b) => acc + (parseFloat(b.grade) || 0), 0);
-  }
-
   static renderCourseUserLink(courseUser) {
     const courseId = getCourseId();
     if (courseUser && courseUser.id) {
@@ -320,14 +314,9 @@ class VisibleGradingPanel extends Component {
   }
 
   renderTotalGrade() {
-    const {
-      grading: { questions },
-      submission: { maximumGrade },
-    } = this.props;
+    const { submission } = this.props;
     return (
-      <div>{`${VisibleGradingPanel.calculateTotalGrade(
-        questions,
-      )} / ${maximumGrade}`}</div>
+      <div>{`${submission.grade ?? '--'} / ${submission.maximumGrade}`}</div>
     );
   }
 

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -163,7 +163,7 @@ class VisibleGradingPanel extends Component {
     return (
       <TableRow key={question.id}>
         <TableCell colSpan={2} style={styles.headerColumn}>
-          {`${question.questionNumber}: ${question.questionTitle}`}
+          {`${question.questionNumber}: ${question.questionTitle ?? ''}`}
         </TableCell>
         {showGrader ? (
           <TableCell style={styles.headerColumn}>{graderInfo}</TableCell>

--- a/spec/features/course/achievement_management_spec.rb
+++ b/spec/features/course/achievement_management_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature 'Course: Achievements', js: true do
 
         # Edit the achievement
         find('.btn-submit').click
-        expect(page).not_to have_selector('h2', text: 'Edit Achievement')
-        expect(current_path).to eq(course_achievements_path(course))
+        expect(page).to have_selector('h2', text: 'Edit Achievement')
+        expect(current_path).to eq(course_achievement_path(course, achievement_created))
         expect(page).to have_text(new_achievement[:title])
       end
 


### PR DESCRIPTION
## Issue

1. When an instructor edits an achievement, previously a full refresh of the page was triggered to update the corresponding achievement table entry. This is changed to update the entry in place to be less cumbersome.
2. Fixed questions whose title is `NULL` in database displaying "Question N: null".
3. Fixed rounding error when displaying total grade of assessment (e.g. 3.99999999997 / 4.0)


## Reason

1. The null strings were being forwarded as is, added [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) `??` to FE to convert nulls into empty strings
2. Total grade was being computed manually from sum of individual questions' grades, now it uses submission level value from BE directly


## Outstanding Issue

 - users cannot click "update" after adding / removing conditions without other changes
 - if user cancels after adding / removing conditions, conditions will change, but achievement row doesn't update until page refresh or edit menu reopened

Work should be done to unify data from ConditionsManager with main form, which will solve both issues.