### PR TITLE
Move Mission Control to Administration sidebar, Auto-enroll course users on Cikgo with roles

### DIFF
--- a/app/controllers/components/course/stories_component.rb
+++ b/app/controllers/components/course/stories_component.rb
@@ -53,12 +53,15 @@ class Course::StoriesComponent < SimpleDelegator
       {
         key: :mission_control,
         icon: :mission_control,
+        type: :admin,
         title: I18n.t('course.stories.mission_control'),
-        weight: 5,
+        weight: 0,
         path: course_mission_control_path(current_course),
         unread: pending_threads_count
       }
     ]
+  rescue Excon::Error::Socket
+    []
   end
 
   def settings_sidebar_items

--- a/app/controllers/concerns/course/cikgo_chats_concern.rb
+++ b/app/controllers/concerns/course/cikgo_chats_concern.rb
@@ -7,17 +7,17 @@ module Course::CikgoChatsConcern
 
     user = course_user.user
     create_cikgo_user(user) if user.cikgo_user.nil?
-    Cikgo::ChatsService.find_or_create_room(course_user)
+    Cikgo::ChatsService.find_or_create_room!(course_user)
   end
 
   def get_mission_control_url(course_user)
-    Cikgo::ChatsService.mission_control(course_user)
+    Cikgo::ChatsService.mission_control!(course_user)
   end
 
   private
 
   def create_cikgo_user(user)
-    provided_user_id = Cikgo::UsersService.authenticate(user, helpers.user_image(user, url: true))
+    provided_user_id = Cikgo::UsersService.authenticate!(user, helpers.user_image(user, url: true))
     (user.cikgo_user || user.build_cikgo_user).provided_user_id = provided_user_id
     user.cikgo_user.save!
   end

--- a/app/controllers/concerns/course/cikgo_push_concern.rb
+++ b/app/controllers/concerns/course/cikgo_push_concern.rb
@@ -8,7 +8,7 @@ module Course::CikgoPushConcern
   def push_lesson_plan_items_to_remote_course
     return unless current_course.component_enabled?(Course::StoriesComponent)
 
-    Cikgo::ResourcesService.push_repository(
+    Cikgo::ResourcesService.push_repository!(
       current_course,
       course_url(current_course),
       pushable_lesson_plan_items.filter_map do |item|

--- a/app/controllers/concerns/course/cikgo_push_concern.rb
+++ b/app/controllers/concerns/course/cikgo_push_concern.rb
@@ -6,6 +6,8 @@ module Course::CikgoPushConcern
   private
 
   def push_lesson_plan_items_to_remote_course
+    return unless current_course.component_enabled?(Course::StoriesComponent)
+
     Cikgo::ResourcesService.push_repository(
       current_course,
       course_url(current_course),

--- a/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/learning_rate_concern.rb
@@ -2,6 +2,8 @@
 module Course::LessonPlan::LearningRateConcern
   extend ActiveSupport::Concern
 
+  include Course::LessonPlan::StoriesConcern
+
   # Returns { lesson_plan_item_id => submitted_time or nil }.
   # If the lesson plan item is a key in this hash then we consider the item "submitted" regardless of whether we have a
   # submission time for it.
@@ -127,10 +129,6 @@ module Course::LessonPlan::LearningRateConcern
       select { |x| x.submissions.present? }.
       to_h { |x| [x.lesson_plan_item.id, nil] }
     )
-  end
-
-  def stories_for(course_user)
-    @stories_for ||= Course::Story.for_course_user(course_user) || []
   end
 
   def merge_course_stories(hash, course_user)

--- a/app/controllers/concerns/course/lesson_plan/stories_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/stories_concern.rb
@@ -11,12 +11,18 @@ module Course::LessonPlan::StoriesConcern
 
     Cikgo::TimelinesService.delete_times!(course_user, future_story_ids)
   rescue StandardError => e
+    Rails.logger.error("Cikgo: Cannot delete personal times for story IDs #{future_story_ids}: #{e}")
     raise e unless Rails.env.production?
   end
 
   private
 
   def stories_for(course_user)
-    @stories_for ||= Course::Story.for_course_user(course_user) || []
+    @stories_for ||= Course::Story.for_course_user!(course_user) || []
+  rescue StandardError => e
+    Rails.logger.error("Cannot fetch stories for course user #{course_user.id}: #{e}")
+    raise e unless Rails.env.production?
+
+    []
   end
 end

--- a/app/controllers/concerns/course/lesson_plan/stories_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/stories_concern.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Course::LessonPlan::StoriesConcern
+  extend ActiveSupport::Concern
+
+  def delete_all_future_stories_personal_times(course_user)
+    future_story_ids = stories_for(course_user).filter_map do |story|
+      story.id if story.personal_time_for(course_user) && story.submitted_at.blank?
+    end
+
+    return if future_story_ids.blank?
+
+    Cikgo::TimelinesService.delete_times(course_user, future_story_ids)
+  rescue StandardError => e
+    raise e unless Rails.env.production?
+  end
+
+  private
+
+  def stories_for(course_user)
+    @stories_for ||= Course::Story.for_course_user(course_user) || []
+  end
+end

--- a/app/controllers/concerns/course/lesson_plan/stories_concern.rb
+++ b/app/controllers/concerns/course/lesson_plan/stories_concern.rb
@@ -9,7 +9,7 @@ module Course::LessonPlan::StoriesConcern
 
     return if future_story_ids.blank?
 
-    Cikgo::TimelinesService.delete_times(course_user, future_story_ids)
+    Cikgo::TimelinesService.delete_times!(course_user, future_story_ids)
   rescue StandardError => e
     raise e unless Rails.env.production?
   end

--- a/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
+++ b/app/controllers/concerns/course/lesson_plan/strategies/fixed_personalization_strategy.rb
@@ -20,5 +20,7 @@ class Course::LessonPlan::Strategies::FixedPersonalizationStrategy <
   def execute(course_user, precompute_data, _items_to_shift)
     course_user.personal_times.where(fixed: false).
       where.not(lesson_plan_item_id: precompute_data.keys).delete_all
+
+    delete_all_future_stories_personal_times(course_user)
   end
 end

--- a/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
@@ -17,7 +17,7 @@ module Course::Assessment::Submission::CikgoTaskCompletionConcern
   delegate :edit_course_assessment_submission_url, to: 'Rails.application.routes.url_helpers'
 
   def publish_task_completion
-    Cikgo::ResourcesService.mark_task(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: submission_url })
+    Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: submission_url })
   end
 
   def status

--- a/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
@@ -18,6 +18,9 @@ module Course::Assessment::Submission::CikgoTaskCompletionConcern
 
   def publish_task_completion
     Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: submission_url })
+  rescue StandardError => e
+    Rails.logger.error("Cikgo: Cannot publish task completion for submission #{id}: #{e}")
+    raise e unless Rails.env.production?
   end
 
   def status

--- a/app/models/concerns/course/lesson_plan/item/cikgo_push_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item/cikgo_push_concern.rb
@@ -43,7 +43,7 @@ module Course::LessonPlan::Item::CikgoPushConcern
   def push(method)
     return unless pushable?(actable) && course.component_enabled?(Course::StoriesComponent)
 
-    Cikgo::ResourcesService.push_resources(course, [{ method: method, id: id.to_s }.merge(send("#{method}_payload"))])
+    Cikgo::ResourcesService.push_resources!(course, [{ method: method, id: id.to_s }.merge(send("#{method}_payload"))])
   rescue StandardError
     Rails.env.production? ? return : raise
   end

--- a/app/models/concerns/course/lesson_plan/item/cikgo_push_concern.rb
+++ b/app/models/concerns/course/lesson_plan/item/cikgo_push_concern.rb
@@ -44,7 +44,8 @@ module Course::LessonPlan::Item::CikgoPushConcern
     return unless pushable?(actable) && course.component_enabled?(Course::StoriesComponent)
 
     Cikgo::ResourcesService.push_resources!(course, [{ method: method, id: id.to_s }.merge(send("#{method}_payload"))])
-  rescue StandardError
+  rescue StandardError => e
+    Rails.logger.error("Cikgo: Cannot push lesson plan item #{id}: #{e}")
     Rails.env.production? ? return : raise
   end
 end

--- a/app/models/concerns/course/survey/response/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/survey/response/cikgo_task_completion_concern.rb
@@ -15,7 +15,7 @@ module Course::Survey::Response::CikgoTaskCompletionConcern
   delegate :edit_course_survey_response_url, to: 'Rails.application.routes.url_helpers'
 
   def publish_task_completion
-    Cikgo::ResourcesService.mark_task(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: response_url })
+    Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: response_url })
   end
 
   def status

--- a/app/models/concerns/course/survey/response/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/survey/response/cikgo_task_completion_concern.rb
@@ -16,6 +16,9 @@ module Course::Survey::Response::CikgoTaskCompletionConcern
 
   def publish_task_completion
     Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: response_url })
+  rescue StandardError => e
+    Rails.logger.error("Cikgo: Cannot publish task completion for survey response #{id}: #{e}")
+    raise e unless Rails.env.production?
   end
 
   def status

--- a/app/models/concerns/course/survey/response/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/survey/response/cikgo_task_completion_concern.rb
@@ -6,8 +6,8 @@ module Course::Survey::Response::CikgoTaskCompletionConcern
     # TODO: Combine to `after_save` with `previously_new_record? || saved_change_to_submitted_at?`
     # once up to Rails 6.1+. `previously_new_record?` is only available from Rails 6.1+.
     # See https://apidock.com/rails/v6.1.3.1/ActiveRecord/Persistence/previously_new_record%3F
-    after_create :publish_task_completion
-    after_update :publish_task_completion, if: :saved_change_to_submitted_at?
+    after_create :publish_task_completion, if: :should_publish_task_completion?
+    after_update :publish_task_completion, if: -> { should_publish_task_completion? && saved_change_to_submitted_at? }
   end
 
   private
@@ -15,21 +15,24 @@ module Course::Survey::Response::CikgoTaskCompletionConcern
   delegate :edit_course_survey_response_url, to: 'Rails.application.routes.url_helpers'
 
   def publish_task_completion
-    return unless creator_id_on_cikgo
+    Cikgo::ResourcesService.mark_task(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: response_url })
+  end
 
-    lesson_plan_item = survey.acting_as
-    status = submitted? ? :completed : :ongoing
+  def status
+    submitted? ? :completed : :ongoing
+  end
 
-    Cikgo::ResourcesService.mark_task(status, lesson_plan_item, {
-      user_id: creator_id_on_cikgo,
-      url: edit_course_survey_response_url(
-        lesson_plan_item.course_id,
-        survey_id,
-        id,
-        host: lesson_plan_item.course.instance.host,
-        protocol: :https
-      )
-    })
+  def response_url
+    edit_course_survey_response_url(lesson_plan_item.course_id, survey_id, id,
+                                    host: lesson_plan_item.course.instance.host, protocol: :https)
+  end
+
+  def should_publish_task_completion?
+    lesson_plan_item.course.component_enabled?(Course::StoriesComponent) && creator_id_on_cikgo.present?
+  end
+
+  def lesson_plan_item
+    @lesson_plan_item ||= survey.acting_as
   end
 
   def creator_id_on_cikgo

--- a/app/models/concerns/course/video/submission/statistic/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/video/submission/statistic/cikgo_task_completion_concern.rb
@@ -14,6 +14,9 @@ module Course::Video::Submission::Statistic::CikgoTaskCompletionConcern
 
   def publish_task_completion
     Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: submission_url })
+  rescue StandardError => e
+    Rails.logger.error("Cikgo: Cannot publish task completion for video submission #{submission_id}: #{e}")
+    raise e unless Rails.env.production?
   end
 
   def status

--- a/app/models/concerns/course/video/submission/statistic/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/video/submission/statistic/cikgo_task_completion_concern.rb
@@ -13,7 +13,7 @@ module Course::Video::Submission::Statistic::CikgoTaskCompletionConcern
   delegate :edit_course_video_submission_url, to: 'Rails.application.routes.url_helpers'
 
   def publish_task_completion
-    Cikgo::ResourcesService.mark_task(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: submission_url })
+    Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, { user_id: creator_id_on_cikgo, url: submission_url })
   end
 
   def status

--- a/app/models/course/story.rb
+++ b/app/models/course/story.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Course::Story
   class << self
-    def for_course_user(course_user)
+    def for_course_user!(course_user)
       return nil unless course_user.course.component_enabled?(Course::StoriesComponent)
 
       Cikgo::TimelinesService.items!(course_user).map do |item|
@@ -20,6 +20,9 @@ class Course::Story
 
     def save
       Cikgo::TimelinesService.update_time!(course_user, @story_id, start_at)
+    rescue StandardError => e
+      Rails.logger.error("Cikgo: Cannot update personal time for story ID #{@story_id}: #{e}")
+      raise e unless Rails.env.production?
     end
 
     alias_method :save!, :save

--- a/app/models/course/story.rb
+++ b/app/models/course/story.rb
@@ -4,7 +4,7 @@ class Course::Story
     def for_course_user(course_user)
       return nil unless course_user.course.component_enabled?(Course::StoriesComponent)
 
-      Cikgo::TimelinesService.items(course_user).map do |item|
+      Cikgo::TimelinesService.items!(course_user).map do |item|
         new(item, course_user)
       end
     end
@@ -19,7 +19,7 @@ class Course::Story
     end
 
     def save
-      Cikgo::TimelinesService.update_time(course_user, @story_id, start_at)
+      Cikgo::TimelinesService.update_time!(course_user, @story_id, start_at)
     end
 
     alias_method :save!, :save

--- a/app/models/course/story.rb
+++ b/app/models/course/story.rb
@@ -65,7 +65,10 @@ class Course::Story
     true
   end
 
+  # Since stories on Cikgo have no end times, they effectively do not affect personal times,
+  # i.e., `compute_learning_rate_ema` filters them out. Setting this to `false` reduces the
+  # number of items that the personalisation strategies have to iterate.
   def affects_personal_times?
-    true
+    false
   end
 end

--- a/app/services/cikgo/chats_service.rb
+++ b/app/services/cikgo/chats_service.rb
@@ -3,7 +3,7 @@ class Cikgo::ChatsService < Cikgo::Service
   class << self
     include Cikgo::CourseConcern
 
-    def find_or_create_room(course_user)
+    def find_or_create_room!(course_user)
       result = connection(:post, 'chats', body: {
         pushKey: push_key(course_user.course),
         userId: cikgo_user_id(course_user),
@@ -13,7 +13,7 @@ class Cikgo::ChatsService < Cikgo::Service
       [result[:url], result[:openThreadsCount]]
     end
 
-    def mission_control(course_user)
+    def mission_control!(course_user)
       result = connection(:post, 'chats/manage', body: {
         pushKey: push_key(course_user.course),
         userId: cikgo_user_id(course_user)

--- a/app/services/cikgo/chats_service.rb
+++ b/app/services/cikgo/chats_service.rb
@@ -6,7 +6,8 @@ class Cikgo::ChatsService < Cikgo::Service
     def find_or_create_room(course_user)
       result = connection(:post, 'chats', body: {
         pushKey: push_key(course_user.course),
-        userId: cikgo_user_id(course_user)
+        userId: cikgo_user_id(course_user),
+        role: cikgo_role(course_user)
       })
 
       [result[:url], result[:openThreadsCount]]

--- a/app/services/cikgo/resources_service.rb
+++ b/app/services/cikgo/resources_service.rb
@@ -10,7 +10,7 @@ class Cikgo::ResourcesService < Cikgo::Service
       { status: :error }
     end
 
-    def push_repository(course, url, resources)
+    def push_repository!(course, url, resources)
       course_push_key = push_key(course)
       return unless course_push_key
 
@@ -25,7 +25,7 @@ class Cikgo::ResourcesService < Cikgo::Service
       })
     end
 
-    def push_resources(course, resources)
+    def push_resources!(course, resources)
       course_push_key = push_key(course)
       return unless course_push_key
 
@@ -35,7 +35,7 @@ class Cikgo::ResourcesService < Cikgo::Service
       })
     end
 
-    def mark_task(status, lesson_plan_item, data)
+    def mark_task!(status, lesson_plan_item, data)
       connection(:patch, 'tasks', body: {
         resourceId: lesson_plan_item.id.to_s,
         repositoryId: repository_id(lesson_plan_item.course_id),

--- a/app/services/cikgo/service.rb
+++ b/app/services/cikgo/service.rb
@@ -6,9 +6,11 @@ class Cikgo::Service
     CIKGO_OAUTH_APPLICATION_NAME = 'Cikgo'
 
     def connection(method, path, options = {})
+      endpoint, api_key = config
+
       connection = Excon.new(
-        "#{ENV.fetch('CIKGO_ENDPOINT')}/#{path}",
-        headers: { Authorization: "Bearer #{ENV.fetch('CIKGO_API_KEY')}" },
+        "#{endpoint}/#{path}",
+        headers: { Authorization: "Bearer #{api_key}" },
         method: method,
         **options,
         body: options[:body]&.to_json
@@ -22,6 +24,15 @@ class Cikgo::Service
       JSON.parse(json, symbolize_names: true)
     rescue JSON::ParserError
       nil
+    end
+
+    def config
+      endpoint = ENV.fetch('CIKGO_ENDPOINT')
+      api_key = ENV.fetch('CIKGO_API_KEY')
+
+      [endpoint, api_key]
+    rescue StandardError => e
+      raise e unless Rails.env.production?
     end
   end
 end

--- a/app/services/cikgo/timelines_service.rb
+++ b/app/services/cikgo/timelines_service.rb
@@ -20,5 +20,13 @@ class Cikgo::TimelinesService < Cikgo::Service
         }]
       })
     end
+
+    def delete_times(course_user, story_ids)
+      connection(:delete, 'timelines', body: {
+        pushKey: push_key(course_user.course),
+        userId: cikgo_user_id(course_user),
+        storyIds: story_ids
+      })
+    end
   end
 end

--- a/app/services/cikgo/timelines_service.rb
+++ b/app/services/cikgo/timelines_service.rb
@@ -3,14 +3,14 @@ class Cikgo::TimelinesService < Cikgo::Service
   class << self
     include Cikgo::CourseConcern
 
-    def items(course_user)
+    def items!(course_user)
       connection(:get, 'timelines', query: {
         pushKey: push_key(course_user.course),
         userId: cikgo_user_id(course_user)
       })
     end
 
-    def update_time(course_user, story_id, start_at)
+    def update_time!(course_user, story_id, start_at)
       connection(:patch, 'timelines', body: {
         pushKey: push_key(course_user.course),
         userId: cikgo_user_id(course_user),
@@ -21,7 +21,7 @@ class Cikgo::TimelinesService < Cikgo::Service
       })
     end
 
-    def delete_times(course_user, story_ids)
+    def delete_times!(course_user, story_ids)
       connection(:delete, 'timelines', body: {
         pushKey: push_key(course_user.course),
         userId: cikgo_user_id(course_user),

--- a/app/services/cikgo/users_service.rb
+++ b/app/services/cikgo/users_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Cikgo::UsersService < Cikgo::Service
   class << self
-    def authenticate(user, image)
+    def authenticate!(user, image)
       access_token = find_or_create_oauth_tokens_for(user)
 
       response = connection(:post, 'auth', body: {

--- a/app/services/concerns/cikgo/course_concern.rb
+++ b/app/services/concerns/cikgo/course_concern.rb
@@ -8,6 +8,17 @@ module Cikgo::CourseConcern
     course_user.user.cikgo_user&.provided_user_id
   end
 
+  # Maps Coursemology's `CourseUser` role to Cikgo's course user role.
+  # :manager, :owner               -> 'owner'
+  # :teaching_assistant, :observer -> 'instructor'
+  # :student                       -> 'student'
+  def cikgo_role(course_user)
+    return 'owner' if course_user.manager_or_owner?
+    return 'instructor' if course_user.staff?
+
+    'student'
+  end
+
   def push_key(course)
     stories_settings = course.settings.course_stories_component
     return unless stories_settings


### PR DESCRIPTION
This PR also adds support for deleting personal times on Cikgo if the personalised timeline strategy is reverted to Fixed, and adds safe callbacks that do not block actions on production and instead log errors, if any.