### PR TITLE
Reset weights on Administration sidebar section

### DIFF
--- a/app/controllers/components/course/multiple_reference_timelines_component.rb
+++ b/app/controllers/components/course/multiple_reference_timelines_component.rb
@@ -18,7 +18,7 @@ class Course::MultipleReferenceTimelinesComponent < SimpleDelegator
         key: :reference_timelines,
         icon: :timelines,
         type: :admin,
-        weight: 8,
+        weight: 9,
         title: t('layouts.multiple_reference_timelines.timeline_designer'),
         path: course_reference_timelines_path(current_course)
       }

--- a/app/controllers/components/course/settings_component.rb
+++ b/app/controllers/components/course/settings_component.rb
@@ -26,7 +26,7 @@ class Course::SettingsComponent < SimpleDelegator
         icon: :settings,
         title: t('layouts.course_admin.title'),
         type: :admin,
-        weight: 9,
+        weight: 100,
         path: course_admin_path(current_course)
       }
     ]

--- a/app/controllers/components/course/statistics_component.rb
+++ b/app/controllers/components/course/statistics_component.rb
@@ -15,7 +15,7 @@ class Course::StatisticsComponent < SimpleDelegator
         icon: :statistics,
         title: t('course.statistics.header'),
         type: :admin,
-        weight: 2,
+        weight: 3,
         path: course_statistics_students_path(current_course)
       }
     ]

--- a/app/controllers/components/course/stories_component.rb
+++ b/app/controllers/components/course/stories_component.rb
@@ -55,7 +55,7 @@ class Course::StoriesComponent < SimpleDelegator
         icon: :mission_control,
         type: :admin,
         title: I18n.t('course.stories.mission_control'),
-        weight: 0,
+        weight: 1,
         path: course_mission_control_path(current_course),
         unread: pending_threads_count
       }

--- a/app/controllers/components/course/users_component.rb
+++ b/app/controllers/components/course/users_component.rb
@@ -44,7 +44,7 @@ class Course::UsersComponent < SimpleDelegator
         icon: :manageUsers,
         title: t('layouts.course_users.title'),
         type: :admin,
-        weight: 1,
+        weight: 2,
         path:
           if can_manage_users
             course_users_students_path(current_course)


### PR DESCRIPTION
The weights on the Administration sidebar section is messed up. For some reasons, Mission Control gets last place _in some courses_ even though it has `weight: 0`. Other sidebar items also have clashing weights.

![image](https://github.com/Coursemology/coursemology2/assets/51525686/dd4ff77e-f6a4-4b01-bb4a-152e488b4ccd)

This PR resets the weights of the items on the Administration sidebar section as follows.
1. Mission Control
2. Manage Users
3. Statistics
4. Experience Points
5. Duplicate Data
6. Levels
7. Groups
8. Skills
9. Timeline Designer
10. Course Settings

Course Settings gets `weight: 100` to ensure it always floats to the end of the section.