### PR TITLE
fix(personalized-timelines): standardized badge behavior

### DIFF
--- a/app/views/course/assessment/assessments/index.json.jbuilder
+++ b/app/views/course/assessment/assessments/index.json.jbuilder
@@ -5,6 +5,7 @@ submissions_hash = @assessments.to_h { |assessment| [assessment.id, assessment.s
 json.display do
   json.isStudent current_course_user&.student? || false
   json.isGamified current_course.gamified?
+  json.timelineAlgorithm current_course_user&.timeline_algorithm
   json.allowRandomization current_course.allow_randomization
   json.isAchievementsEnabled achievements_enabled
   json.isMonitoringEnabled @monitoring_component_enabled

--- a/client/app/bundles/course/achievement/pages/AchievementEdit/index.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementEdit/index.tsx
@@ -2,7 +2,6 @@ import { FC, useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { setReactHookFormError } from 'lib/helpers/react-hook-form-helper';
-import { getCourseId } from 'lib/helpers/url-helpers';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';

--- a/client/app/bundles/course/admin/pages/StoriesSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/StoriesSettings/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
-import { Alert, Typography } from '@mui/material';
+import { Alert } from '@mui/material';
 import { StoriesSettingsData } from 'types/course/admin/stories';
 
 import Section from 'lib/components/core/layouts/Section';

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
@@ -39,7 +39,11 @@ const AssessmentsTable = (props: AssessmentsTableProps): JSX.Element => {
             </Link>
           </label>
 
-          <StatusBadges for={assessment} isStudent={display.isStudent} timelineAlgorithm={display.timelineAlgorithm}/>
+          <StatusBadges
+            for={assessment}
+            isStudent={display.isStudent}
+            timelineAlgorithm={display.timelineAlgorithm}
+          />
         </div>
       ),
     },

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
@@ -39,7 +39,7 @@ const AssessmentsTable = (props: AssessmentsTableProps): JSX.Element => {
             </Link>
           </label>
 
-          <StatusBadges for={assessment} isStudent={display.isStudent} />
+          <StatusBadges for={assessment} isStudent={display.isStudent} timelineAlgorithm={display.timelineAlgorithm}/>
         </div>
       ),
     },

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/StatusBadges.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/StatusBadges.tsx
@@ -7,12 +7,12 @@ import {
 } from '@mui/icons-material';
 import { Chip, Tooltip } from '@mui/material';
 import { AssessmentListData } from 'types/course/assessment/assessments';
+import { TimelineAlgorithm } from 'types/course/personalTimes';
 
 import PersonalTimeBooleanIcons from 'lib/components/extensions/PersonalTimeBooleanIcon';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../translations';
-import { TimelineAlgorithm } from 'types/course/personalTimes';
 
 interface NonStudentStatusBadgesProps {
   for: AssessmentListData;

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/StatusBadges.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/StatusBadges.tsx
@@ -12,6 +12,7 @@ import PersonalTimeBooleanIcons from 'lib/components/extensions/PersonalTimeBool
 import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../translations';
+import { TimelineAlgorithm } from 'types/course/personalTimes';
 
 interface NonStudentStatusBadgesProps {
   for: AssessmentListData;
@@ -19,6 +20,7 @@ interface NonStudentStatusBadgesProps {
 
 interface StatusBadgesProps extends NonStudentStatusBadgesProps {
   isStudent: boolean;
+  timelineAlgorithm: TimelineAlgorithm | undefined;
 }
 
 const NonStudentStatusBadges = (
@@ -58,17 +60,12 @@ const NonStudentStatusBadges = (
           <Key className="text-3xl text-neutral-500 hover?:text-neutral-600" />
         </Tooltip>
       )}
-
-      <PersonalTimeBooleanIcons
-        affectsPersonalTimes={assessment.affectsPersonalTimes}
-        hasPersonalTimes={assessment.hasPersonalTimes}
-      />
     </>
   );
 };
 
 const StatusBadges = (props: StatusBadgesProps): JSX.Element => {
-  const { for: assessment, isStudent } = props;
+  const { for: assessment, isStudent, timelineAlgorithm } = props;
   const { t } = useTranslation();
 
   return (
@@ -85,6 +82,13 @@ const StatusBadges = (props: StatusBadgesProps): JSX.Element => {
       )}
 
       {!isStudent && <NonStudentStatusBadges for={assessment} />}
+
+      <PersonalTimeBooleanIcons
+        affectsPersonalTimes={assessment.affectsPersonalTimes}
+        hasPersonalTimes={assessment.hasPersonalTimes}
+        isStudent={isStudent}
+        timelineAlgorithm={timelineAlgorithm}
+      />
     </div>
   );
 };

--- a/client/app/bundles/course/video/components/misc/VideoBadges.tsx
+++ b/client/app/bundles/course/video/components/misc/VideoBadges.tsx
@@ -32,16 +32,9 @@ const VideoBadges = (props: Props): JSX.Element => {
       <PersonalTimeBooleanIcon
         affectsPersonalTimes={video.affectsPersonalTimes}
         hasPersonalTimes={video.hasPersonalTimes}
+        isStudent={videoMetadata.isStudent}
+        timelineAlgorithm={videoMetadata.timelineAlgorithm}
       />
-
-      {(videoMetadata.isCurrentCourseUser && !videoMetadata.isStudent) ||
-        (videoMetadata.timelineAlgorithm &&
-          videoMetadata.timelineAlgorithm !== 'fixed' && (
-            <PersonalTimeBooleanIcon
-              affectsPersonalTimes={video.affectsPersonalTimes}
-              hasPersonalTimes={video.hasPersonalTimes}
-            />
-          ))}
     </div>
   );
 };

--- a/client/app/lib/components/extensions/PersonalTimeBooleanIcon.tsx
+++ b/client/app/lib/components/extensions/PersonalTimeBooleanIcon.tsx
@@ -4,10 +4,13 @@ import { Schedule, Shuffle } from '@mui/icons-material';
 import { Tooltip, Typography } from '@mui/material';
 
 import useTranslation from 'lib/hooks/useTranslation';
+import { TimelineAlgorithm } from 'types/course/personalTimes';
 
 interface Props {
   hasPersonalTimes: boolean;
   affectsPersonalTimes: boolean;
+  isStudent: boolean;
+  timelineAlgorithm: TimelineAlgorithm | undefined;
 }
 
 const translations = defineMessages({
@@ -32,12 +35,17 @@ const translations = defineMessages({
 });
 
 const PersonalTimeBooleanIcons: FC<Props> = (props) => {
-  const { hasPersonalTimes, affectsPersonalTimes } = props;
+  const { hasPersonalTimes, affectsPersonalTimes, isStudent, timelineAlgorithm } = props;
   const { t } = useTranslation();
+
+  // If student is NOT on fixed timeline algorithm, then show, otherwise can hide
+  const isFixedStudent = isStudent && (timelineAlgorithm == 'fixed' || !timelineAlgorithm); 
+  const hasPersonalTimesCondition = hasPersonalTimes && !isFixedStudent;
+  const affectsPersonalTimesCondition = affectsPersonalTimes && !isFixedStudent;
 
   return (
     <>
-      {hasPersonalTimes && (
+      {hasPersonalTimesCondition && (
         <Tooltip
           disableInteractive
           title={
@@ -56,7 +64,7 @@ const PersonalTimeBooleanIcons: FC<Props> = (props) => {
         </Tooltip>
       )}
 
-      {affectsPersonalTimes && (
+      {affectsPersonalTimesCondition && (
         <Tooltip
           disableInteractive
           title={

--- a/client/app/lib/components/extensions/PersonalTimeBooleanIcon.tsx
+++ b/client/app/lib/components/extensions/PersonalTimeBooleanIcon.tsx
@@ -45,7 +45,7 @@ const PersonalTimeBooleanIcons: FC<Props> = (props) => {
 
   // If student is NOT on fixed timeline algorithm, then show, otherwise can hide
   const isFixedStudent =
-    isStudent && (timelineAlgorithm == 'fixed' || !timelineAlgorithm);
+    isStudent && (timelineAlgorithm === 'fixed' || !timelineAlgorithm);
   const hasPersonalTimesCondition = hasPersonalTimes && !isFixedStudent;
   const affectsPersonalTimesCondition = affectsPersonalTimes && !isFixedStudent;
 

--- a/client/app/lib/components/extensions/PersonalTimeBooleanIcon.tsx
+++ b/client/app/lib/components/extensions/PersonalTimeBooleanIcon.tsx
@@ -2,9 +2,9 @@ import { FC } from 'react';
 import { defineMessages } from 'react-intl';
 import { Schedule, Shuffle } from '@mui/icons-material';
 import { Tooltip, Typography } from '@mui/material';
+import { TimelineAlgorithm } from 'types/course/personalTimes';
 
 import useTranslation from 'lib/hooks/useTranslation';
-import { TimelineAlgorithm } from 'types/course/personalTimes';
 
 interface Props {
   hasPersonalTimes: boolean;
@@ -35,11 +35,17 @@ const translations = defineMessages({
 });
 
 const PersonalTimeBooleanIcons: FC<Props> = (props) => {
-  const { hasPersonalTimes, affectsPersonalTimes, isStudent, timelineAlgorithm } = props;
+  const {
+    hasPersonalTimes,
+    affectsPersonalTimes,
+    isStudent,
+    timelineAlgorithm,
+  } = props;
   const { t } = useTranslation();
 
   // If student is NOT on fixed timeline algorithm, then show, otherwise can hide
-  const isFixedStudent = isStudent && (timelineAlgorithm == 'fixed' || !timelineAlgorithm); 
+  const isFixedStudent =
+    isStudent && (timelineAlgorithm == 'fixed' || !timelineAlgorithm);
   const hasPersonalTimesCondition = hasPersonalTimes && !isFixedStudent;
   const affectsPersonalTimesCondition = affectsPersonalTimes && !isFixedStudent;
 

--- a/client/app/types/course/assessment/assessments.ts
+++ b/client/app/types/course/assessment/assessments.ts
@@ -1,3 +1,4 @@
+import { TimelineAlgorithm } from '../personalTimes';
 import { QuestionType } from './question';
 import type { QuestionData } from './questions';
 
@@ -52,6 +53,7 @@ export interface AssessmentsListData {
   display: {
     isStudent: boolean;
     isGamified: boolean;
+    timelineAlgorithm: TimelineAlgorithm;
     allowRandomization: boolean;
     isAchievementsEnabled: boolean;
     isMonitoringEnabled: boolean;

--- a/client/app/types/course/assessment/assessments.ts
+++ b/client/app/types/course/assessment/assessments.ts
@@ -1,4 +1,5 @@
 import { TimelineAlgorithm } from '../personalTimes';
+
 import { QuestionType } from './question';
 import type { QuestionData } from './questions';
 


### PR DESCRIPTION
## Issue

Inconsistent behavior regarding personalized timeline icons between Assessment tab and Videos tab.
In Videos tab, there are cases where icons are displayed twice:
![telegram-cloud-photo-size-5-6221992360506670707-y](https://github.com/Coursemology/coursemology2/assets/122878884/ea89f842-d11e-4a76-a533-c87586fe8421)

In Assessments, the icons were not being displayed to students, only to instructors.

## Reason

Implemented the following logic on both Assessments and Videos:
- If user is a student and NOT on fixed timeline algorithm, then show only one set of icons (if the booleans are true), otherwise can hide.
- If user is an instructor, always show icons if respective course settings are enabled.

This comes with an additive backend change to return the current user's timeline algorithm for the Assessments page.

## Outstanding Issue