### PR TITLE
fix(notifications): phantom student submission emails

### DIFF
--- a/app/models/concerns/course/assessment/submission/notification_concern.rb
+++ b/app/models/concerns/course/assessment/submission/notification_concern.rb
@@ -25,7 +25,7 @@ module Course::Assessment::Submission::NotificationConcern
     # a new submission to be graded since it was submitted by the course staff anyway.
     return unless creator == updater
     return if assessment.autograded?
-    return unless course_user.real_student?
+    return unless course_user.student?
 
     Course::AssessmentNotifier.assessment_submitted(creator, course_user, self)
   end


### PR DESCRIPTION
## Issue

When phantom student finalises a submission, there is no email sent to course manager / group manager.

## Reason

There is logic introduced by [this commit](https://github.com/Coursemology/coursemology2/commit/744d98684c015312f33a70323390d6e5a81e89ef#diff-7dc96453a867f60e6950f18fd12a117a6c5f31701914991c3d1de16ed5932b05L21) which makes it so that notifications are only sent for real students' submissions.

In the currently existing Email Notification Settings, this is the setting that controls notifications for student submission. We choose to interpret the option as whether to send notifications to ***phantom / regular managers***, instead of whether to send notifications for phantom / regular students.
<img width="831" alt="Screenshot 2024-05-27 at 14 47 59" src="https://github.com/Coursemology/coursemology2/assets/122878884/80640d15-2623-443a-a78a-92aa9e671742">


To test the updated behavior, the following scenario was set: there is a group with regular student (`spooky`), phantom student (`send`), regular manager (`skeletons`), and phantom manager (`spine`)

<img width="761" alt="Screenshot 2024-05-28 at 14 02 17" src="https://github.com/Coursemology/coursemology2/assets/122878884/770d0fa2-fbf8-4d50-bef4-d4f3e632a4b0">

In the first case (bottom 4 emails), both notification settings were enabled and both students submitted an assessment. It can be seen that both managers received the email notifications, and the ones related to phantom students are clearly labeled as such.

In the second case (top email), only regular managers were set to be notified, so only the regular manager received the notification for a student submission.

<img width="1183" alt="Screenshot 2024-05-28 at 14 26 10" src="https://github.com/Coursemology/coursemology2/assets/122878884/cf06fe7a-7d75-42f0-9184-5b81cc483187">
