### PR TITLE
Update README for Keycloak Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some fr
    $ bundle exec rake db:setup
    ```
 
+6. We are using [Keycloak](https://www.keycloak.org/) as our Identity and Access Management (IAM) solution. Before proceeding to the next step, please navigate to `./authentication` folder, follow the instruction provided over the [README](https://github.com/Coursemology/coursemology2/blob/master/authentication/README.md), and then ensure that the Docker for Coursemology Authentication is running and that you are able to access the Keycloak site as mentioned in the very last step of that instruction
+
 7. Initialize .env files for Frontend and Backend
+
    ```sh
    $ cp env .env; cp client/env client/.env
    ```
+
    You may need to add specific API keys (such as the [GOOGLE_RECAPTCHA_SITE_KEY](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do)) to the .env files for testing specific features.
 
 8. Open up 3 different terminals. On the terminal for Frontend in the `client` directory, run
@@ -71,21 +75,27 @@ Coursemology uses [Ruby on Rails](http://rubyonrails.org/). In addition, some fr
    yarn build:development
    ```
 
-   , on the terminal for authentication service in the `authentication` directory, run
+   on the terminal for authentication service in the `authentication` directory, if you have not yet started Keycloak, run
 
    ```
    docker compose up
    ```
 
-   , and on the terminal for Backend, run
+   or
 
    ```
-   bundle exec rails s
+   docker-compose up
    ```
 
-7. Access the App by visiting `http://localhost:8080`
+   and on the terminal for Backend, run
 
-8. You're all set! Simply login with the default username and password:
+   ```
+   bundle exec rails s -p 3000
+   ```
+
+9. Access the App by visiting `http://localhost:8080`
+
+10. You're all set! Simply login with the default username and password:
 
 > Email: `test@example.org`
 >

--- a/authentication/README.md
+++ b/authentication/README.md
@@ -4,15 +4,53 @@ We are now using [Keycloak](https://www.keycloak.org/) as our Identity and Acces
 
 ## Installation Guide
 
-1. Make sure you have docker installed.
-2. Go to /authentication and run
+1. Make sure you have docker and also docker-compose installed.
+2. Run the following command
+
    ```
    docker build -t coursemology_auth .
    ```
-3. Create and/or update .env file using template from env file in /auth, /client and root directories.
-4. Create an empty coursemology_keycloak database in postgresql
+
+3. Run the following command to initialize `.env` files over here
+
+   ```
+   cp env .env
+   ```
+
+4. Create an empty coursemology_keycloak database in postgresql by running the following command
+
+   ```
+   psql -c "CREATE DATABASE coursemology_keycloak;" -d postgres
+   ```
+
 5. From a terminal, enter the following command to start Keycloak:
+
    ```
    docker compose up
    ```
+
+   If the above does not work (happened sometimes), you can instead opt to run the following command:
+
+   ```
+   docker-compose up
+   ```
+
 6. The authentication pages can be accessed via `http://localhost:8443/admin`
+
+## Further Guide
+
+To ensure the smoothness in signing-in to Coursemology, you must ensure that the configuration for `KEYCLOAK_BE_CLIENT_SECRET` inside `.env` matches with the settings inside Keycloak. To do so, you can simply do the following instructions:
+
+1. Sign-in to authentication pages by inputting the following credentials:
+
+> Username: `admin` (whatever defined in KEYCLOAK_ADMIN inside ./.env)
+>
+> Password: `password` (whatever defined in KEYCLOAK_ADMIN_PASSWORD inside ./.env)
+
+2. Navigate to coursemology realm by choosing Coursemology in the top-left dropdown box, or simply access Coursemology [realm](http://localhost:8443/admin/master/console/#/coursemology)
+
+3. Navigate to Client, then click on the Client ID in which name is `coursemology-backend`
+
+4. Over there, navigate to Credentials and you will see the Client Secret. If whatever is defined there does not match with the Client Secret defined in your environment setup, simply copy-paste the client secret inside the page (you can possibly regenerate it if you want), then copy-paste it to `KEYCLOAK_BE_CLIENT_SECRET` inside `../.env`
+
+5. Finally, your Keycloak setup for Coursemology is finished and you are safe to proceed to the next step inside the Coursemology setup guide.


### PR DESCRIPTION
To better assist developer in setup, we add more clarity in doing Keycloak setup and ensure it's properly set before signing in to Coursemology