### PR TITLE
Add "Open in Mission Control" to Student Statistics page

### DIFF
--- a/app/controllers/course/stories/stories_controller.rb
+++ b/app/controllers/course/stories/stories_controller.rb
@@ -15,7 +15,8 @@ class Course::Stories::StoriesController < Course::ComponentController
   end
 
   def mission_control
-    url, @pending_threads_count = get_mission_control_url(current_course_user)
+    target_course_user = current_course.course_users.find_by(id: params[:course_user_id]) || current_course_user
+    url, @pending_threads_count = get_mission_control_url(target_course_user)
 
     render json: { redirectUrl: url }
   end

--- a/app/models/course/story.rb
+++ b/app/models/course/story.rb
@@ -4,7 +4,7 @@ class Course::Story
     def for_course_user!(course_user)
       return nil unless course_user.course.component_enabled?(Course::StoriesComponent)
 
-      Cikgo::TimelinesService.items!(course_user).map do |item|
+      Cikgo::TimelinesService.items!(course_user)&.map do |item|
         new(item, course_user)
       end
     end

--- a/app/services/cikgo/chats_service.rb
+++ b/app/services/cikgo/chats_service.rb
@@ -10,7 +10,7 @@ class Cikgo::ChatsService < Cikgo::Service
         role: cikgo_role(course_user)
       })
 
-      [result[:url], result[:openThreadsCount]]
+      [result&.[](:url), result&.[](:openThreadsCount)]
     end
 
     def mission_control!(course_user)
@@ -19,7 +19,7 @@ class Cikgo::ChatsService < Cikgo::Service
         userId: cikgo_user_id(course_user)
       })
 
-      [result[:url], result[:pendingThreadsCount]]
+      [result&.[](:url), result&.[](:pendingThreadsCount)]
     end
   end
 end

--- a/app/views/course/statistics/aggregate/all_students.json.jbuilder
+++ b/app/views/course/statistics/aggregate/all_students.json.jbuilder
@@ -47,4 +47,6 @@ json.metadata do
   json.courseVideoCount course_video_count
   json.hasGroupManagers !no_group_managers
   json.hasMyStudents has_my_students
+  json.showRedirectToMissionControl current_course.component_enabled?(Course::StoriesComponent) &&
+                                    can?(:access_mission_control, current_course)
 end

--- a/client/app/api/course/Stories.ts
+++ b/client/app/api/course/Stories.ts
@@ -7,7 +7,9 @@ export default class StoriesAPI extends BaseCourseAPI {
     return this.client.get(`/courses/${this.courseId}/learn`);
   }
 
-  missionControl(): APIResponse<JustRedirect> {
-    return this.client.get(`/courses/${this.courseId}/mission_control`);
+  missionControl(courseUserId?: string): APIResponse<JustRedirect> {
+    return this.client.get(`/courses/${this.courseId}/mission_control`, {
+      params: { course_user_id: courseUserId },
+    });
   }
 }

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/students/StudentStatisticsTable.tsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/students/StudentStatisticsTable.tsx
@@ -1,6 +1,8 @@
 import { FC, useMemo } from 'react';
 import { defineMessages } from 'react-intl';
-import { Typography } from '@mui/material';
+import { useParams } from 'react-router-dom';
+import { AssistantOutlined } from '@mui/icons-material';
+import { IconButton, Tooltip, Typography } from '@mui/material';
 
 import { GroupManager, Metadata, Student } from 'course/statistics/types';
 import { processStudent } from 'course/statistics/utils/parseStudentsResponse';
@@ -70,10 +72,14 @@ const StudentsStatisticsTable: FC<Props> = (props) => {
       showVideo,
       courseVideoCount,
       hasGroupManagers,
+      showRedirectToMissionControl,
     },
     students,
   } = props;
   const { t } = useTranslation();
+
+  const { courseId } = useParams();
+
   const formattedStudents: Student[] = students.map(processStudent);
 
   const numStudentType = useMemo(() => {
@@ -226,6 +232,25 @@ const StudentsStatisticsTable: FC<Props> = (props) => {
       csvDownloadable: true,
     });
   }
+
+  if (showRedirectToMissionControl)
+    columns.push({
+      id: 'missionControl',
+      title: '',
+      className: 'p-0',
+      cell: (student) => (
+        <Link
+          opensInNewTab
+          to={`/courses/${courseId}/mission_control?for=${student.id}`}
+        >
+          <Tooltip title="Open in Mission Control">
+            <IconButton>
+              <AssistantOutlined />
+            </IconButton>
+          </Tooltip>
+        </Link>
+      ),
+    });
 
   return (
     <>

--- a/client/app/bundles/course/statistics/types.ts
+++ b/client/app/bundles/course/statistics/types.ts
@@ -45,6 +45,7 @@ export interface Metadata {
   courseVideoCount: number;
   hasGroupManagers: boolean;
   hasMyStudents: boolean;
+  showRedirectToMissionControl: boolean;
 }
 
 export interface StudentsStatistics {

--- a/client/app/bundles/course/stories/components/CikgoErrorPage.tsx
+++ b/client/app/bundles/course/stories/components/CikgoErrorPage.tsx
@@ -10,12 +10,13 @@ import useTranslation from 'lib/hooks/useTranslation';
 const translations = defineMessages({
   errorFetching: {
     id: 'course.stories.CikgoErrorPage.errorFetching',
-    defaultMessage: 'There was a problem getting your stuff from Cikgo.',
+    defaultMessage: `Either it's supposed to be naught, or something went wrong.`,
   },
   errorFetchingDescription: {
     id: 'course.stories.CikgoErrorPage.errorFetchingDescription',
     defaultMessage:
-      '<cikgo>Cikgo</cikgo> is our partner that powers this experience. They were contactable, but did not give us any resources for this request just now Please try again later, and if this persists, <link>contact us</link>.',
+      '<cikgo>Cikgo</cikgo> is our partner that powers this experience. They were contactable, but did not give us any ' +
+      'resources for this request just now. Please try again later, and if this persists, <link>contact us</link>.',
   },
 });
 

--- a/client/app/bundles/course/stories/pages/MissionControlPage.tsx
+++ b/client/app/bundles/course/stories/pages/MissionControlPage.tsx
@@ -1,4 +1,5 @@
 import { defineMessage } from 'react-intl';
+import { useSearchParams } from 'react-router-dom';
 
 import CourseAPI from 'api/course';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
@@ -11,11 +12,14 @@ import CikgoFramePage from '../components/CikgoFramePage';
 const MissionControlPage = (): JSX.Element => {
   useSetFooter(false);
 
+  const [searchParams] = useSearchParams();
+  const courseUserId = searchParams.get('for') ?? undefined;
+
   return (
     <Preload
       render={<LoadingIndicator />}
       while={async () => {
-        const response = await CourseAPI.stories.missionControl();
+        const response = await CourseAPI.stories.missionControl(courseUserId);
         return response.data.redirectUrl;
       }}
     >


### PR DESCRIPTION
This PR adds a button in Student Statistics to open a given student's chat room in Mission Control _in a new tab_.

![image](https://github.com/Coursemology/coursemology2/assets/51525686/9ef7fbe6-ee4e-4396-b652-01195609fcaf)

>[!NOTE]
>For the sake of agility and performance, there are no pre-computations to determine if a given student has any chat rooms in Cikgo. This button is simply a convenience link that opens the Mission Control and attempts to load a given course user's chat room in Cikgo. If no chat rooms were found, Cikgo will return nothing, and you'll see `CikgoErrorPage` being rendered _expectedly_. Hence, aa2179a clarifies the intent of the page, that it could be nothing, or actually an error.