### PR TITLE
Update Annotation Lines for Programming Question

### DIFF
--- a/lib/tasks/db/update_annotation_line.rake
+++ b/lib/tasks/db/update_annotation_line.rake
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+namespace :db do
+  task update_annotation_line: :environment do
+    Rails.application.eager_load!
+
+    require 'action_view'
+    require 'action_view/helpers'
+
+    helper = HelperContext.new
+
+    start_date_input, end_date_input = ENV['START_DATE'], ENV['END_DATE']
+    unless start_date_input && end_date_input
+      puts 'Please provide START_DATE and END_DATE to execute this script'
+      exit
+    end
+
+    start_date = Date.parse(start_date_input)
+    end_date = Date.parse(end_date_input)
+
+    if start_date > end_date
+      puts 'START_DATE should be earlier than END_DATE'
+      exit
+    end
+
+    start_time = Time.now
+
+    ActsAsTenant.without_tenant do
+      conn = ActiveRecord::Base.connection
+      annotations_with_file_content = conn.exec_query(<<-SQL)
+        SELECT annotations.*, files.content, questions.actable_id
+        FROM course_assessment_answer_programming_file_annotations AS annotations
+        JOIN course_assessment_answer_programming_files AS files
+          ON annotations.file_id = files.id
+        JOIN course_assessment_answers AS answers
+          ON files.answer_id = answers.actable_id
+          AND answers.actable_type = 'Course::Assessment::Answer::Programming'
+          AND CAST(answers.created_at AS DATE) BETWEEN '#{start_date}' AND '#{end_date}'
+        JOIN course_assessment_questions AS questions
+          ON answers.question_id = questions.id
+      SQL
+
+      end_time = Time.now
+      puts "Extract all annotations with file content = #{end_time - start_time} seconds"
+
+      annotations_grouped = annotations_with_file_content.group_by do |row|
+        [row['content'], row['actable_id'], row['file_id']]
+      end
+
+      start_time = Time.now
+
+      annotations_grouped.map do |key, values|
+        content, actable_id, file_id = key
+        programming_question = Course::Assessment::Question::Programming.find(actable_id)
+        language = programming_question.language
+
+        lines = values.map { |value| value['line'] }
+        highlighted_code = helper.highlight_code_block(content, language)
+
+        if !annotations_present_on_line_one_and_two(lines) && lines_are_added(highlighted_code)
+          decrement_annotation_line_number(file_id)
+        end
+      end
+
+      end_time = Time.now
+      puts "Update annotation lines = #{end_time - start_time} seconds"
+    end
+  end
+end
+
+# in our previous HTML Pipeline (using RougeFilter and PreformattedLineSplitFilter), some of the codes
+# are unintentionally added 1 line on the FE while displaying, and all such files have the criteria
+# that the processed code is always started with <div class=highlight codehilite-*>\n<
+def lines_are_added(highlighted_code)
+  pattern = /\A<div class=.*>\n<span/
+  highlighted_code.match?(pattern)
+end
+
+# we do not want to decrease the line number if line 1 and line 2 was having the annotation in that file
+def annotations_present_on_line_one_and_two(lines)
+  lines.include?(1) && lines.include?(2)
+end
+
+def decrement_annotation_line_number(file_id)
+  annotations = Course::Assessment::Answer::ProgrammingFileAnnotation.where(file_id: file_id)
+
+  annotations.find_each do |annotation|
+    line_number = annotation.line
+
+    annotation.update(line: line_number - 1) unless line_number == 1
+  end
+end
+
+class HelperContext
+  require Rails.root.join('app/helpers/application_html_formatters_helper')
+
+  include ApplicationHTMLFormattersHelper
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::OutputSafetyHelper
+  include ERB::Util
+
+  attr_accessor :output_buffer
+
+  def initialize
+    @output_buffer = ActiveSupport::SafeBuffer.new
+  end
+end


### PR DESCRIPTION
## Background

In an attempt to change the HTML Pipeline formatting from RougeFilter to SyntaxHighlightFilter (the one that's continuously being updated and managed), we found out that previously, almost all the programming files were being displayed with one extra newline at the beginning of the file. 

When we tried to move to the latter filter, that newline is gone but then since annotations are tied to the line number, those annotations are being misplaced by one line. Therefore, this PR is attempting to fix those already existing annotations back to its improper place.

## Some Exception

During the updating, we found out that some users actually put the annotations on such files on line 1. Should we shift that annotation upward, it will become at line 0 and thus the annotation comment won't even be displayed (since line 0 does not exist). Therefore, we decided that we should only update the annotation line on lines other than line 1.

Another case being put is when user puts the annotation on both line 1 and 2. Due to the previous action, the annotation on line 2 will be moved to line 1, and since there are multiple annotations on line 1 now, the display will not be what is expected. After further investigation, it's found out that the occasions of annotations on both line 1 and 2 within the same file is very uncommon, usually user who do that only do the annotation on both lines and also that those annotations are not actually specific towards those 2 lines. Therefore, we decided for such files, we do not update the annotation line numbers.

## How to Execute

Upon further investigation, it was revealed that the addition of that one extra newline begins when we add the helper `PreformattedTextLineSplitFilter` in which, together with `RougeFilter`, creates the issue of that one extra newline. This addition happened at 2nd August 2017, and after looking through the submissions before and after that date (which has annotations), we concluded that the case of that extra newline being added was happenning from 2nd August 2017.

Therefore, we might need to execute the rakefile for the annotations being created from 2nd August 2017 until now. We have tested locally on the execution time, and it turns out that for the range of 6 months (starting from 2021-07-01 to 2022-01-01), the execution time was almost 3 minutes. Therefore, to ensure that the other services are still running properly and not blocked by this, it might be preferable to have the time duration to be set 1 month.

The template of the execution code should be as follows **(target range should be 2017-08-02 until now)**

`RUBYOPT="-W0" bundle exec rake db:update_annotation_line START_DATE='2017-08-02' END_DATE='2017-09-01'`

the first environment settings, `RUBYOPT`, is merely to ignore the warnings that are basically non-essential for our use case. It is recommended for the early dates to have the interval being generous (can be 3-6 months) while the later dates should be made a bit stricter (1 or 2 months) so that we can finish updating the entry as soon as possible while not getting our online service got clogged by this