### PR TITLE
Change Filtering to use SyntaxHighlight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'friendly_id'
 gem 'html-pipeline'
 gem 'sanitize', '>= 4.6.3'
 gem 'rinku'
-gem 'html-pipeline-rouge_filter', git: 'https://github.com/Coursemology/html-pipeline-rouge_filter.git'
+gem 'rouge', '~> 3'
 gem 'ruby-oembed'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,15 +14,6 @@ GIT
       rails (>= 6)
 
 GIT
-  remote: https://github.com/Coursemology/html-pipeline-rouge_filter.git
-  revision: 4d43afb07930cbf78a8c6a6f9debd5c426ad490c
-  specs:
-    html-pipeline-rouge_filter (1.0.7)
-      activesupport
-      html-pipeline (>= 1.11)
-      rouge (>= 2.0.0, < 4)
-
-GIT
   remote: https://github.com/Coursemology/rails_utils.git
   revision: a78a20ce522e83f23725759598105ccb0d4a6d6a
   specs:
@@ -602,7 +593,6 @@ DEPENDENCIES
   fog-aws (= 3.22.0)
   friendly_id
   html-pipeline
-  html-pipeline-rouge_filter!
   http_accept_language
   i18n-tasks
   image_optim_rails
@@ -633,6 +623,7 @@ DEPENDENCIES
   rexml
   rinku
   rollbar (>= 1.5.3)
+  rouge (~> 3)
   rspec-html-matchers
   rspec-rails
   rspec-retry

--- a/app/helpers/application_html_formatters_helper.rb
+++ b/app/helpers/application_html_formatters_helper.rb
@@ -177,7 +177,7 @@ module ApplicationHTMLFormattersHelper
   end.freeze
 
   DEFAULT_PIPELINE_OPTIONS = {
-    css_class: 'codehilite',
+    scope: 'codehilite',
     replace_br: true
   }.freeze
 
@@ -185,7 +185,7 @@ module ApplicationHTMLFormattersHelper
 
   # The default pipeline, used by both text and HTML pipelines.
   DEFAULT_PIPELINE = HTML::Pipeline.new(
-    [HTML::Pipeline::AutolinkFilter, HTML::Pipeline::RougeFilter],
+    [HTML::Pipeline::AutolinkFilter, HTML::Pipeline::SyntaxHighlightFilter],
     DEFAULT_PIPELINE_OPTIONS
   )
 

--- a/app/helpers/course/discussion/topics_helper.rb
+++ b/app/helpers/course/discussion/topics_helper.rb
@@ -7,8 +7,7 @@ module Course::Discussion::TopicsHelper
   # @param [Integer] line_end The one based end line line number.
   # @return [String] A HTML fragment containing the code lines.
   def display_code_lines(file, line_start, line_end)
-    # Line added to fix alignment issue in ReadOnlyEditor adding one empty line
-    code = file.add_line.lines((line_start - 1)..(line_end - 1)).join("\n")
+    code = file.lines((line_start - 1)..(line_end - 1)).join("\n")
 
     format_code_block(code, file.answer.question.actable.language, [line_start, 1].max)
   end

--- a/app/models/course/assessment/answer/programming_file.rb
+++ b/app/models/course/assessment/answer/programming_file.rb
@@ -39,11 +39,6 @@ class Course::Assessment::Answer::ProgrammingFile < ApplicationRecord
     end
   end
 
-  def add_line
-    content.insert(0, "\r\n  ")
-    self
-  end
-
   private
 
   # Normalises the filename for use across platforms.


### PR DESCRIPTION
## Background

Based on the [RougeFilter repo](https://github.com/Coursemology/html-pipeline-rouge_filter), it's clear that the repo (and also its upstream branch) is no longer maintained and the recommendation is to use SyntaxHighlightFilter, which belongs to https://github.com/gjtorikian/html-pipeline and is still maintained (the newest version is compatible with Rails 7, which is what we need to ensure the smoothness of migrating to Rails 7 in the future).

## Additional Notes

While we move from RougeFilter to SyntaxHighlightFilter, we noticed that previously, some files have an additional newline in the beginning of the file. This was non-existent anymore with the latter filter. As a consequence, the hotfix we conducted in the past (https://github.com/Coursemology/coursemology2/pull/4618) to resolve the issue https://github.com/Coursemology/coursemology2/issues/4530 is no longer needed, as the issue becomes non-existent anymore. Therefore, this PR also revert that hotfix.

## When to merge

This PR needs to be merged after https://github.com/Coursemology/coursemology2/pull/7382 is being merged and all the annotation line numbers have been updated properly