### PR TITLE
Update Gem Self-Developed Dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,13 @@ executors:
         default: false
 
     docker:
-      - image: cimg/ruby:3.0.6-browsers
+      - image: cimg/ruby:3.1.0-browsers
         environment:
           PG_HOST: localhost
           PG_USER: ubuntu
           RAILS_ENV: test
           BUNDLE_APP_CONFIG: ~/repo/.bundle
-          DATABASE_URL: "postgres://ubuntu@localhost:5432/coursemology_test"
+          DATABASE_URL: 'postgres://ubuntu@localhost:5432/coursemology_test'
           COLLECT_COVERAGE: << parameters.collects_rails_coverage >>
 
       - image: cimg/postgres:16.1
@@ -51,8 +51,8 @@ commands:
       - restore_cache:
           name: Restore Ruby dependencies cache
           keys:
-            - v3.0.6-ruby-{{ checksum "Gemfile.lock" }}
-            - v3.0.6-ruby-
+            - v3.1.0-ruby-{{ checksum "Gemfile.lock" }}
+            - v3.1.0-ruby-
 
       - run:
           name: Install Bundler
@@ -66,7 +66,7 @@ commands:
           paths:
             - ./vendor/bundle
             - ./.bundle
-          key: v3.0.6-ruby-{{ checksum "Gemfile.lock" }}
+          key: v3.1.0-ruby-{{ checksum "Gemfile.lock" }}
 
   rehydrate_node_deps:
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'db/migrate/*'
     - 'vendor/bundle/**/*'
     - 'client/**/*'
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Bundler/OrderedGems:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+ruby '3.1.0'
+
 source 'https://rubygems.org'
 
 # For Windows devs
@@ -14,7 +16,7 @@ gem 'pg'
 gem 'rack-cors'
 
 # Instance/Course settings
-gem 'settings_on_rails'
+gem 'settings_on_rails', git: 'https://github.com/bivanalhar/settings_on_rails'
 # Manage read/unread status
 gem 'unread'
 # Extension for validating hostnames and domain names
@@ -23,14 +25,14 @@ gem 'validates_hostname'
 gem 'workflow'
 gem 'workflow-activerecord', '>= 4.1', '< 7.0'
 # Add creator_id and updater_id attributes to models
-gem 'activerecord-userstamp', git: 'https://github.com/Coursemology/activerecord-userstamp.git'
+gem 'activerecord-userstamp', git: 'https://github.com/Coursemology/activerecord-userstamp.git', branch: 'bivan/upgrade-rails-7-ruby-3'
 # Allow actions to be deferred until after a record is committed.
 gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
 gem 'calculated_attributes'
 # For multiple table inheritance
 # TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
-gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as.git'
+gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as.git', branch: 'bivan/support-rails-7-ruby-3'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Upsert action for Postgres
@@ -177,7 +179,7 @@ gem 'cancancan'
 # Some helpers for structuring CSS/JavaScript
 # Official version https://github.com/winston/rails_utils/pull/30 is no longer maintained.
 # We also want stricter sanitization.
-gem 'rails_utils', git: 'https://github.com/Coursemology/rails_utils.git'
+gem 'rails_utils', git: 'https://github.com/Coursemology/rails_utils.git', branch: 'bivan/upgrade-rails-7-ruby-3'
 
 # Using CarrierWave for file uploads
 gem 'carrierwave'

--- a/Gemfile
+++ b/Gemfile
@@ -25,14 +25,16 @@ gem 'validates_hostname'
 gem 'workflow'
 gem 'workflow-activerecord', '>= 4.1', '< 7.0'
 # Add creator_id and updater_id attributes to models
-gem 'activerecord-userstamp', git: 'https://github.com/Coursemology/activerecord-userstamp.git', branch: 'bivan/upgrade-rails-7-ruby-3'
+gem 'activerecord-userstamp', git: 'https://github.com/Coursemology/activerecord-userstamp.git',
+                              branch: 'bivan/upgrade-rails-7-ruby-3'
 # Allow actions to be deferred until after a record is committed.
 gem 'after_commit_action'
 # Allow declaring the calculated attributes of a record
 gem 'calculated_attributes'
 # For multiple table inheritance
 # TODO: Figure out breaking changes in v2 as polymorphism is not working correctly.
-gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as.git', branch: 'bivan/support-rails-7-ruby-3'
+gem 'active_record-acts_as', git: 'https://github.com/Coursemology/active_record-acts_as.git',
+                             branch: 'bivan/support-rails-7-ruby-3'
 # Organise ActiveRecord model into a tree structure
 gem 'edge'
 # Upsert action for Postgres
@@ -179,7 +181,8 @@ gem 'cancancan'
 # Some helpers for structuring CSS/JavaScript
 # Official version https://github.com/winston/rails_utils/pull/30 is no longer maintained.
 # We also want stricter sanitization.
-gem 'rails_utils', git: 'https://github.com/Coursemology/rails_utils.git', branch: 'bivan/upgrade-rails-7-ruby-3'
+gem 'rails_utils', git: 'https://github.com/Coursemology/rails_utils.git',
+                   branch: 'bivan/upgrade-rails-7-ruby-3'
 
 # Using CarrierWave for file uploads
 gem 'carrierwave'

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'pg'
 gem 'rack-cors'
 
 # Instance/Course settings
-gem 'settings_on_rails', git: 'https://github.com/bivanalhar/settings_on_rails'
+gem 'settings_on_rails'
 # Manage read/unread status
 gem 'unread'
 # Extension for validating hostnames and domain names

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,40 @@
 GIT
   remote: https://github.com/Coursemology/active_record-acts_as.git
-  revision: b853dd4aee7a218367411a3ba26fb8477ff2cda9
+  revision: f2e6845852b3eefb2afad0bdee890ba4bafa8216
+  branch: bivan/support-rails-7-ruby-3
   specs:
-    active_record-acts_as (3.0.1)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
+    active_record-acts_as (4.0.0)
+      activerecord (>= 6.0)
+      activesupport (>= 6.0)
 
 GIT
   remote: https://github.com/Coursemology/activerecord-userstamp.git
-  revision: 1170233e314466630e3a545ae3fdee16a0bb4a19
+  revision: b037b0ec260af1e0f68ebe964e9e3a9602405aa0
+  branch: bivan/upgrade-rails-7-ruby-3
   specs:
     activerecord-userstamp (3.0.5)
       rails (>= 6)
 
 GIT
   remote: https://github.com/Coursemology/rails_utils.git
-  revision: a78a20ce522e83f23725759598105ccb0d4a6d6a
+  revision: 4f9eeb311b1aaffed0d254863bbbebd96a95340a
+  branch: bivan/upgrade-rails-7-ruby-3
   specs:
-    rails_utils (4.0.0)
-      rails (>= 3.2)
+    rails_utils (6.1.0)
+      rails (>= 6)
 
 GIT
   remote: https://github.com/Coursemology/rwordnet
   revision: 54a85eed974002cb2cfb858cbcaed8e1069b5cb8
   specs:
     rwordnet (2.0.0)
+
+GIT
+  remote: https://github.com/bivanalhar/settings_on_rails
+  revision: 2ef629b94dffc019789649ebabf45d7035f66513
+  specs:
+    settings_on_rails (0.4.0)
+      rails (>= 6)
 
 GEM
   remote: https://rubygems.org/
@@ -487,8 +497,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    settings_on_rails (0.3.1)
-      activerecord (>= 3.1)
     should_not (1.1.0)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
@@ -634,7 +642,7 @@ DEPENDENCIES
   rubyzip
   rwordnet!
   sanitize (>= 4.6.3)
-  settings_on_rails
+  settings_on_rails!
   should_not
   shoulda-matchers
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,13 +29,6 @@ GIT
   specs:
     rwordnet (2.0.0)
 
-GIT
-  remote: https://github.com/bivanalhar/settings_on_rails
-  revision: 2ef629b94dffc019789649ebabf45d7035f66513
-  specs:
-    settings_on_rails (0.4.0)
-      rails (>= 6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -86,7 +79,7 @@ GEM
     activerecord (6.0.6.1)
       activemodel (= 6.0.6.1)
       activesupport (= 6.0.6.1)
-    activerecord-import (1.6.0)
+    activerecord-import (1.7.0)
       activerecord (>= 4.2)
     activestorage (6.0.6.1)
       actionpack (= 6.0.6.1)
@@ -101,31 +94,31 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     acts_as_tenant (1.0.1)
       rails (>= 6.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     after_commit_action (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.929.0)
-    aws-sdk-core (3.196.1)
+    aws-partitions (1.947.0)
+    aws-sdk-core (3.199.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.81.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
+    aws-sdk-kms (1.87.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.151.0)
-      aws-sdk-core (~> 3, >= 3.194.0)
+    aws-sdk-s3 (1.154.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    builder (3.2.4)
+    builder (3.3.0)
     bullet (7.1.6)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
@@ -148,17 +141,16 @@ GEM
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
-    carrierwave (2.2.6)
-      activemodel (>= 5.0.0)
-      activesupport (>= 5.0.0)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
       addressable (~> 2.6)
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
-      mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     consistency_fail (0.3.7)
     coursemology-polyglot (0.3.8)
@@ -189,7 +181,7 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
-    erubi (1.12.0)
+    erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
     excon (0.110.0)
@@ -199,7 +191,11 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
-    ffi (1.16.3)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     filename (0.1.2)
     flamegraph (0.9.5)
     fog-aws (3.22.0)
@@ -221,18 +217,18 @@ GEM
     friendly_id (5.5.1)
       activerecord (>= 4.0.0)
     fspath (3.1.2)
-    fugit (1.10.1)
-      et-orbi (~> 1, >= 1.2.7)
+    fugit (1.11.0)
+      et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
     highline (3.0.1)
-    html-pipeline (2.14.3)
-      activesupport (>= 2)
-      nokogiri (>= 1.4)
+    html-pipeline (3.2.0)
+      selma (~> 0.1)
+      zeitwerk (~> 2.5)
     htmlentities (4.3.4)
     http-accept (1.7.0)
-    http-cookie (1.0.5)
+    http-cookie (1.0.6)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
     i18n (1.14.5)
@@ -262,12 +258,12 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     image_size (3.4.0)
     in_threads (1.6.0)
-    jbuilder (2.11.5)
+    jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
     json (2.7.2)
-    jwt (2.8.1)
+    jwt (2.8.2)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -281,16 +277,17 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    keycloak (3.0.0)
-      json
-      jwt
-      rest-client
+    keycloak (3.3.0)
+      json (~> 2.6)
+      jwt (~> 2.4)
+      rest-client (~> 2.1)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -316,16 +313,15 @@ GEM
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0305)
+    mime-types-data (3.2024.0604)
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
-    mini_magick (4.12.0)
+    mini_magick (4.13.1)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.6)
-    minitest (5.23.0)
+    minitest (5.24.0)
     multi_json (1.15.0)
-    net-imap (0.4.10)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -335,20 +331,23 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.7.1)
-    nokogiri (1.16.5)
-      mini_portile2 (~> 2.8.2)
+    nio4r (2.7.3)
+    nokogiri (1.16.6-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    parallel (1.24.0)
+    parallel (1.25.1)
     parallel_tests (4.7.1)
       parallel
-    parser (3.3.1.0)
+    parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
     progress (3.6.0)
-    public_suffix (5.0.4)
+    public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -358,6 +357,8 @@ GEM
       rack (>= 2.0.0)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (6.0.6.1)
@@ -398,12 +399,13 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    recaptcha (5.16.0)
+    recaptcha (5.17.0)
     record_tag_helper (1.0.1)
       actionview (>= 5)
-    redis (4.8.1)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
     redis-actionpack (5.4.0)
       actionpack (>= 5, < 8)
       redis-rack (>= 2.1.0, < 4)
@@ -411,10 +413,10 @@ GEM
     redis-activesupport (5.3.0)
       activesupport (>= 3, < 8)
       redis-store (>= 1.3, < 2)
-    redis-client (0.22.1)
+    redis-client (0.22.2)
       connection_pool
-    redis-rack (2.1.4)
-      rack (>= 2.0.8, < 3)
+    redis-rack (3.0.0)
+      rack-session (>= 0.2.0)
       redis-store (>= 1.2, < 2)
     redis-rails (5.0.2)
       redis-actionpack (>= 5.0, < 6)
@@ -423,7 +425,7 @@ GEM
     redis-store (1.10.0)
       redis (>= 4, < 6)
     regexp_parser (2.9.2)
-    request_store (1.6.0)
+    request_store (1.7.0)
       rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
@@ -433,8 +435,8 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.1)
+      strscan
     rinku (2.0.6)
     rollbar (3.5.2)
     rouge (3.30.0)
@@ -444,13 +446,13 @@ GEM
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-html-matchers (0.10.0)
       nokogiri (~> 1)
       rspec (>= 3.0.0.a)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-rails (5.1.2)
@@ -466,7 +468,7 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.64.0)
+    rubocop (1.64.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -489,14 +491,20 @@ GEM
     ruby-vips (2.2.1)
       ffi (~> 1.12)
     rubyzip (2.3.2)
-    sanitize (6.1.0)
+    sanitize (6.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    selenium-webdriver (4.18.1)
+    selenium-webdriver (4.22.0)
       base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    selma (0.3.0-aarch64-linux)
+    selma (0.3.0-arm64-darwin)
+    selma (0.3.0-x86_64-linux)
+    settings_on_rails (0.3.1)
+      activerecord (>= 3.1)
     should_not (1.1.0)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
@@ -557,17 +565,23 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    workflow (3.0.0)
+    workflow (3.1.1)
     workflow-activerecord (6.0.1)
       activerecord (>= 6.0)
       workflow (~> 3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.36)
-    zeitwerk (2.6.14)
+    zeitwerk (2.6.16)
 
 PLATFORMS
-  ruby
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   active_record-acts_as!
@@ -642,7 +656,7 @@ DEPENDENCIES
   rubyzip
   rwordnet!
   sanitize (>= 4.6.3)
-  settings_on_rails!
+  settings_on_rails
   should_not
   shoulda-matchers
   sidekiq
@@ -659,5 +673,8 @@ DEPENDENCIES
   workflow-activerecord (>= 4.1, < 7.0)
   yard
 
+RUBY VERSION
+   ruby 3.1.0p0
+
 BUNDLED WITH
-   2.2.33
+   2.5.9

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Coursemology is an open source gamified learning platform that enables educators
 
 ### System Requirements
 
-1. Ruby (= 3.0.6)
+1. Ruby (= 3.1.0)
 2. Ruby on Rails (= 6.0.6.1)
 3. PostgreSQL (>= 9.5)
 4. ImageMagick or GraphicsMagick (For [MiniMagick](https://github.com/minimagick/minimagick) - if PDF processing doesn't work for the import of scribing questions, download Ghostscript)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,19 +1,20 @@
-default: &default
+development:
   adapter: postgresql
   pool: 5
   timeout: 5000
-
-development:
-  <<: *default
   database: coursemology
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
+  adapter: postgresql
+  pool: 5
+  timeout: 5000
   database: coursemology_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
-  <<: *default
+  adapter: postgresql
+  pool: 5
+  timeout: 5000
   database: coursemology


### PR DESCRIPTION
## Background

While attempting to upgrade to Rails 7, we noticed that some of the gems are the one developed by our own, and those have not yet been upgraded for long time and thus was not compatible with Rails 7.

## Attempt

We upgraded those gems independently from the respective repos, and then utilised those into the main Coursemology repo.

## Affected Repositories

There are 3 repositories in total in which we upgrade here:
- active_record-acts_as
- activerecord-userstamp
- rails_utils
- settings_on_rails