### PR TITLE
Render Cikgo sidebar items asynchronously

### DIFF
--- a/app/controllers/components/course/stories_component.rb
+++ b/app/controllers/components/course/stories_component.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Course::StoriesComponent < SimpleDelegator
   include Course::ControllerComponentHost::Component
-  include Course::CikgoChatsConcern
 
   def self.display_name
     I18n.t('components.stories.name')
@@ -27,27 +26,19 @@ class Course::StoriesComponent < SimpleDelegator
   end
 
   def student_sidebar_items
-    _, open_threads_count = find_or_create_room(current_course_user)
-
     [
       {
         key: :learn,
         icon: :learn,
         title: settings.title || I18n.t('course.stories.learn'),
         weight: 0,
-        path: course_learn_path(current_course),
-        unread: open_threads_count
+        path: course_learn_path(current_course)
       }
     ]
-  rescue Excon::Error::Socket
-    []
   end
 
   def staff_sidebar_items
     return [] unless can?(:access_mission_control, current_course)
-
-    remote_url, pending_threads_count = get_mission_control_url(current_course_user)
-    return [] unless remote_url.present?
 
     [
       {
@@ -56,12 +47,9 @@ class Course::StoriesComponent < SimpleDelegator
         type: :admin,
         title: I18n.t('course.stories.mission_control'),
         weight: 1,
-        path: course_mission_control_path(current_course),
-        unread: pending_threads_count
+        path: course_mission_control_path(current_course)
       }
     ]
-  rescue Excon::Error::Socket
-    []
   end
 
   def settings_sidebar_items

--- a/app/controllers/course/stories/stories_controller.rb
+++ b/app/controllers/course/stories/stories_controller.rb
@@ -4,6 +4,7 @@ class Course::Stories::StoriesController < Course::ComponentController
   include Course::CikgoChatsConcern
 
   signals :cikgo_open_threads_count, after: [:learn]
+  signals :cikgo_mission_control, after: [:mission_control]
 
   before_action :check_course_user_and_push_key
   before_action -> { authorize!(:access_mission_control, current_course) }, only: [:mission_control]

--- a/app/services/cikgo/service.rb
+++ b/app/services/cikgo/service.rb
@@ -4,6 +4,7 @@ class Cikgo::Service
     private
 
     CIKGO_OAUTH_APPLICATION_NAME = 'Cikgo'
+    DEFAULT_REQUEST_TIMEOUT_SECONDS = 5
 
     def connection(method, path, options = {})
       endpoint, api_key = config
@@ -12,6 +13,7 @@ class Cikgo::Service
         "#{endpoint}/#{path}",
         headers: { Authorization: "Bearer #{api_key}" },
         method: method,
+        timeout: DEFAULT_REQUEST_TIMEOUT_SECONDS,
         **options,
         body: options[:body]&.to_json
       )

--- a/client/app/bundles/course/container/CourseContainer.tsx
+++ b/client/app/bundles/course/container/CourseContainer.tsx
@@ -4,6 +4,7 @@ import { MenuOutlined } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { CourseLayoutData } from 'types/course/courses';
 
+import CikgoSidebarItems from 'course/stories/components/CikgoSidebarItems';
 import PopupNotifier from 'course/user-notification/PopupNotifier';
 import Footer from 'lib/components/core/layouts/Footer';
 import { DataHandle, useDynamicNest } from 'lib/hooks/router/dynamicNest';
@@ -60,6 +61,8 @@ const CourseContainer = (): JSX.Element => {
       </div>
 
       <PopupNotifier />
+
+      <CikgoSidebarItems sidebarData={data} />
     </main>
   );
 };

--- a/client/app/bundles/course/stories/components/CikgoSidebarItems.tsx
+++ b/client/app/bundles/course/stories/components/CikgoSidebarItems.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { CourseLayoutData } from 'types/course/courses';
+
+import CourseAPI from 'api/course';
+
+interface CikgoSidebarItemsProps {
+  sidebarData: CourseLayoutData;
+}
+
+/**
+ * This component independently fetches the unread counts for "Learn" and
+ * "Mission Control" sidebar items. It exists because Cikgo's servers may not always
+ * respond in time, and blocking `/sidebar` requests while waiting for Cikgo's
+ * servers' response will slow Coursemology's page loads down.
+ *
+ * The promises in this component will fail silently to prevent any side effects
+ * when rendering its parent component, e.g., `CourseContainer`. Failed requests
+ * can be inspected under _Network_ in the browser's developer tools.
+ */
+const CikgoSidebarItems = ({ sidebarData }: CikgoSidebarItemsProps): null => {
+  const { courseId } = useParams();
+
+  const shouldLoadLearn = useMemo(
+    () => sidebarData.sidebar?.some((item) => item.key === 'learn'),
+    [sidebarData.sidebar],
+  );
+
+  const shouldLoadMissionControl = useMemo(
+    () =>
+      sidebarData.adminSidebar?.some((item) => item.key === 'mission_control'),
+    [sidebarData.adminSidebar],
+  );
+
+  useEffect(() => {
+    if (!shouldLoadLearn) return;
+
+    CourseAPI.stories.learn().catch(() => {});
+  }, [courseId, shouldLoadLearn]);
+
+  useEffect(() => {
+    if (!shouldLoadMissionControl) return;
+
+    CourseAPI.stories.missionControl().catch(() => {});
+  }, [courseId, shouldLoadMissionControl]);
+
+  return null;
+};
+
+export default CikgoSidebarItems;


### PR DESCRIPTION
This PR adds makes the unread counts of "Learn" and "Mission Control" sidebar items render asynchronously. GET `/sidebar` will no longer make calls to Cikgo before responding. Instead, it will just respond with the appropriate sidebar items without unread counts.

Once the client receives GET `/sidebar`'s response, it will then decide to dispatch asynchronous calls to fetch the unread counts of "Learn" and/or "Mission Control" sidebar items.

This change is introduced to prevent the loading of pages of courses integrated with Cikgo from slowing down if Cikgo's servers are experiencing heavy loads.

Note that one Rails process responds to one request. If that one request is stuck awaiting a response from Cikgo, then other requests queued on this process will have to wait too. Hence, a default timeout is added to all requests to Cikgo's public APIs to prevent this from happening badly. Technically, this shouldn't be a major concern in production since Puma should spawn multiple Rails processes to respond to multiple requests (though I can't be bothered to prove this). So, `CikgoSidebarItems`'s requests shouldn't block other requests necessary for loading a page. But, I added this just in case, and for correctness' sake.