### PR TITLE
Comment Setting Title should be Updated when Title is Updated

### DIFF
--- a/app/controllers/components/course/discussion/topics_component.rb
+++ b/app/controllers/components/course/discussion/topics_component.rb
@@ -29,7 +29,7 @@ class Course::Discussion::TopicsComponent < SimpleDelegator
   def settings_sidebar_items
     [
       {
-        title: t('course.discussion.topics.sidebar_title'),
+        title: settings.title || t('course.discussion.topics.sidebar_title'),
         type: :settings,
         weight: 7,
         path: course_admin_topics_path(current_course)

--- a/app/controllers/components/course/materials_component.rb
+++ b/app/controllers/components/course/materials_component.rb
@@ -27,7 +27,7 @@ class Course::MaterialsComponent < SimpleDelegator
   def settings_sidebar_items
     [
       {
-        title: t('course.material.sidebar_title'),
+        title: settings.title || t('course.material.sidebar_title'),
         type: :settings,
         weight: 10,
         path: course_admin_materials_path(current_course)


### PR DESCRIPTION
## Background

In Course Settings, we have the flexibility to change the title of the sidebar for Announcement, Comment, Leaderboard, and Video. For Comment, however, even if we edit the title and do the savings, the sidebar title for the Comment will still persist as Comment, and not the one we're changing into. The details are shown in the below picture

<img width="806" alt="Screenshot 2024-07-10 at 5 33 08 PM" src="https://github.com/Coursemology/coursemology2/assets/16359075/7579dc53-241c-4df5-aec6-633cc5dd2af1">

## Expected Behavior

After editing the title for Comment and saving, the Comment title inside the Sidebar Setting chips should be updated immediately, as shown below
 
<img width="806" alt="Screenshot 2024-07-10 at 5 37 45 PM" src="https://github.com/Coursemology/coursemology2/assets/16359075/168a8e5d-9eeb-4299-9227-c537235b5f6e">
