### PR TITLE
Remove filename coercion logic

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
@@ -151,7 +151,7 @@ const ProgrammingFiles = ({
     }
   };
 
-  const renderFeedbackCard = (feedbackItem) => {
+  const renderFeedbackCard = (filename, feedbackItem) => {
     let cardStyle = styles.card;
     if (feedbackItem.state === 'resolved') {
       cardStyle = { ...styles.card, ...styles.cardResolved };
@@ -199,7 +199,7 @@ const ProgrammingFiles = ({
               type: actionTypes.LIVE_FEEDBACK_ITEM_MARK_RESOLVED,
               payload: {
                 questionId,
-                path: 'main.py',
+                path: filename,
                 lineId: feedbackItem.id,
               },
             });
@@ -223,7 +223,7 @@ const ProgrammingFiles = ({
               type: actionTypes.LIVE_FEEDBACK_ITEM_MARK_DISMISSED,
               payload: {
                 questionId,
-                path: 'main.py',
+                path: filename,
                 lineId: feedbackItem.id,
               },
             });
@@ -246,7 +246,7 @@ const ProgrammingFiles = ({
               type: actionTypes.LIVE_FEEDBACK_ITEM_DELETE,
               payload: {
                 questionId,
-                path: 'main.py',
+                path: filename,
                 lineId: feedbackItem.id,
               },
             });
@@ -282,7 +282,7 @@ const ProgrammingFiles = ({
     );
   };
 
-  const renderFeedbackDrawer = (keyString, annotations) => (
+  const renderFeedbackDrawer = (keyString, annotations, filename) => (
     <Drawer
       anchor="right"
       ModalProps={{
@@ -294,7 +294,11 @@ const ProgrammingFiles = ({
       PaperProps={{ style: styles.drawerPaper }}
       variant="persistent"
     >
-      <div>{annotations.map(renderFeedbackCard)}</div>
+      <div>
+        {annotations.map((feedbackItem) =>
+          renderFeedbackCard(filename, feedbackItem),
+        )}
+      </div>
     </Drawer>
   );
 
@@ -311,14 +315,7 @@ const ProgrammingFiles = ({
       highlightedContent: field.highlightedContent,
     };
 
-    let annotations = feedbackFiles[field.filename] ?? [];
-    // TODO: remove special casing around Codaveri name coercion issue
-    if (
-      index === 0 &&
-      !controlledProgrammingFields.some((elem) => elem.filename === 'main.py')
-    ) {
-      annotations = feedbackFiles['main.py'] ?? [];
-    }
+    const annotations = feedbackFiles[field.filename] ?? [];
     const keyString = `editor-container-${index}`;
     const shouldRenderDrawer = annotations.length > 0;
 
@@ -337,7 +334,8 @@ const ProgrammingFiles = ({
             saveAnswerAndUpdateClientVersion={saveAnswerAndUpdateClientVersion}
           />
         </Box>
-        {shouldRenderDrawer && renderFeedbackDrawer(keyString, annotations)}
+        {shouldRenderDrawer &&
+          renderFeedbackDrawer(keyString, annotations, field.filename)}
       </div>
     );
   });

--- a/spec/jobs/course/assessment/answer/programming_codaveri_feedback_job_spec.rb
+++ b/spec/jobs/course/assessment/answer/programming_codaveri_feedback_job_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingCodaveriFeedbackJob do
 
         codaveri_feedback = post.codaveri_feedback
         expect(codaveri_feedback.codaveri_feedback_id).to eq(
-          '6311a0548c57aae93d260927:main.py:63141b108c57aae93d260a00'
+          '6311a0548c57aae93d260927:template.py:63141b108c57aae93d260a00'
         )
         expect(codaveri_feedback.status).to eq('pending_review')
         expect(codaveri_feedback.original_feedback).to eq('This is a test feedback')
@@ -145,7 +145,7 @@ RSpec.describe Course::Assessment::Answer::ProgrammingCodaveriFeedbackJob do
 
         codaveri_feedback = post.codaveri_feedback
         expect(codaveri_feedback.codaveri_feedback_id).to eq(
-          '6311a0548c57aae93d260927:main.py:63141b108c57aae93d260a00'
+          '6311a0548c57aae93d260927:template.py:63141b108c57aae93d260a00'
         )
         expect(codaveri_feedback.status).to eq('pending_review')
         expect(codaveri_feedback.original_feedback).to eq('This is a test feedback')

--- a/spec/support/stubs/codaveri/feedback_api_stubs.rb
+++ b/spec/support/stubs/codaveri/feedback_api_stubs.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 module Codaveri::FeedbackApiStubs
-  # TODO: update this fixture when name coercion logic is removed
   FEEDBACK_SUCCESS_FINAL_RESULT = {
     status: 200,
     body: {
@@ -9,10 +8,10 @@ module Codaveri::FeedbackApiStubs
       data: {
         feedbackFiles: [
           {
-            path: 'main.py',
+            path: 'template.py',
             feedbackLines: [
               {
-                id: '6311a0548c57aae93d260927:main.py:63141b108c57aae93d260a00',
+                id: '6311a0548c57aae93d260927:template.py:63141b108c57aae93d260a00',
                 linenum: 5,
                 feedback: 'This is a test feedback',
                 category: 'syntax',


### PR DESCRIPTION
In the initial integration with Codaveri, there was an issue where feedback for filenames other than "main.py" was not being generated correctly.

This issue has been fixed, so this PR removes the workarounds we implemented for that issue.

The removed workarounds never affected question creation payloads, so no updates of production records are needed.