### PR TITLE
Highlight tab characters in interactive editor

### DIFF
--- a/client/app/lib/components/core/fields/AceEditor.css
+++ b/client/app/lib/components/core/fields/AceEditor.css
@@ -1,0 +1,7 @@
+.ace_invisible {
+    opacity: 0;
+}
+
+.ace_invisible.ace_invisible_tab {
+    opacity: 1;
+}

--- a/client/app/lib/components/core/fields/EditorField.tsx
+++ b/client/app/lib/components/core/fields/EditorField.tsx
@@ -4,6 +4,8 @@ import { LanguageMode } from 'types/course/assessment/question/programming';
 
 import 'ace-builds/src-noconflict/theme-github';
 
+import './AceEditor.css';
+
 interface EditorProps extends ComponentProps<typeof AceEditor> {
   language: LanguageMode;
   value?: string;
@@ -52,6 +54,7 @@ const EditorField = forwardRef(
           readOnly: disabled,
           useWorker: false,
           fontFamily: DEFAULT_FONT_FAMILY,
+          showInvisibles: true,
         }}
       />
     );

--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -112,6 +112,7 @@ module.exports = {
             'node_modules/react-tooltip/dist/react-tooltip.min.css',
           ),
           resolve(__dirname, 'app/lib/components/core/fields/CKEditor.css'),
+          resolve(__dirname, 'app/lib/components/core/fields/AceEditor.css'),
         ],
       },
       {


### PR DESCRIPTION
Previously, when user copy-pastes Tab (`\t`) characters into the editor, it doesn't show it as distinct from normal whitespace characters.

Note that pressing the Tab key on the keyboard will add spaces instead, since the `useSoftTabs` option is already configured.

<img width="1218" alt="Screenshot 2024-07-31 at 12 44 41" src="https://github.com/user-attachments/assets/46895275-446e-4d7e-9acf-42f8bfd2c5b9">
