### PR TITLE
Breadcrumbs for some Components need to follow its settings name

### DIFF
--- a/client/app/bundles/course/announcements/handles.ts
+++ b/client/app/bundles/course/announcements/handles.ts
@@ -1,0 +1,26 @@
+import { defineMessages } from 'react-intl';
+
+import CourseAPI from 'api/course';
+import { CrumbPath, DataHandle } from 'lib/hooks/router/dynamicNest';
+
+const translations = defineMessages({
+  header: {
+    id: 'course.announcements.AnnouncementsIndex.header',
+    defaultMessage: 'Announcements',
+  },
+});
+
+export const announcementsHandle: DataHandle = (match) => {
+  const courseId = match.params.courseId;
+
+  return {
+    getData: async (): Promise<CrumbPath> => {
+      const { data } = await CourseAPI.announcements.index();
+
+      return {
+        activePath: `/courses/${courseId}/announcements`,
+        content: { title: data.announcementTitle || translations.header },
+      };
+    },
+  };
+};

--- a/client/app/bundles/course/announcements/pages/AnnouncementsIndex/index.tsx
+++ b/client/app/bundles/course/announcements/pages/AnnouncementsIndex/index.tsx
@@ -98,6 +98,4 @@ const AnnouncementsIndex = (): JSX.Element => {
   );
 };
 
-const handle = translations.header;
-
-export default Object.assign(AnnouncementsIndex, { handle });
+export default AnnouncementsIndex;

--- a/client/app/bundles/course/discussion/topics/handles.ts
+++ b/client/app/bundles/course/discussion/topics/handles.ts
@@ -1,0 +1,26 @@
+import { defineMessages } from 'react-intl';
+
+import CourseAPI from 'api/course';
+import { CrumbPath, DataHandle } from 'lib/hooks/router/dynamicNest';
+
+const translations = defineMessages({
+  header: {
+    id: 'course.discussion.topics.CommentIndex.comments',
+    defaultMessage: 'Comments',
+  },
+});
+
+export const commentHandle: DataHandle = (match) => {
+  const courseId = match.params.courseId;
+
+  return {
+    getData: async (): Promise<CrumbPath> => {
+      const { data } = await CourseAPI.comments.index();
+
+      return {
+        activePath: `/courses/${courseId}/comments`,
+        content: { title: data.settings.title || translations.header },
+      };
+    },
+  };
+};

--- a/client/app/bundles/course/discussion/topics/pages/CommentIndex/index.tsx
+++ b/client/app/bundles/course/discussion/topics/pages/CommentIndex/index.tsx
@@ -218,6 +218,4 @@ const CommentIndex: FC<Props> = (props) => {
   );
 };
 
-const handle = translations.comments;
-
-export default Object.assign(injectIntl(CommentIndex), { handle });
+export default injectIntl(CommentIndex);

--- a/client/app/bundles/course/forum/handles.ts
+++ b/client/app/bundles/course/forum/handles.ts
@@ -1,7 +1,16 @@
-import CourseAPI from 'api/course';
-import { DataHandle } from 'lib/hooks/router/dynamicNest';
+import { defineMessages } from 'react-intl';
 
-const getForumTitle = async (forumId: string): Promise<string> => {
+import CourseAPI from 'api/course';
+import { CrumbPath, DataHandle } from 'lib/hooks/router/dynamicNest';
+
+const translations = defineMessages({
+  header: {
+    id: 'course.forum.ForumsIndex.header',
+    defaultMessage: 'Forums',
+  },
+});
+
+const getForumName = async (forumId: string): Promise<string> => {
   const response = await CourseAPI.forum.forums.fetch(forumId);
   return response.data.forum.name;
 };
@@ -15,10 +24,28 @@ const getTopicTitle = async (
 };
 
 export const forumHandle: DataHandle = (match) => {
+  const courseId = match.params.courseId;
+
+  return {
+    getData: async (): Promise<CrumbPath> => {
+      const { data } = await CourseAPI.forum.forums.index();
+
+      return {
+        activePath: `/courses/${courseId}/forums`,
+        content: {
+          title: data.forumTitle || translations.header,
+          url: `forums`,
+        },
+      };
+    },
+  };
+};
+
+export const forumNameHandle: DataHandle = (match) => {
   const forumId = match.params?.forumId;
   if (!forumId) throw new Error(`Invalid forum id: ${forumId}`);
 
-  return { getData: () => getForumTitle(forumId) };
+  return { getData: () => getForumName(forumId) };
 };
 
 export const forumTopicHandle: DataHandle = (match) => {

--- a/client/app/bundles/course/forum/pages/ForumsIndex/index.tsx
+++ b/client/app/bundles/course/forum/pages/ForumsIndex/index.tsx
@@ -114,6 +114,4 @@ const ForumsIndex: FC = () => {
   );
 };
 
-const handle = translations.header;
-
-export default Object.assign(ForumsIndex, { handle });
+export default ForumsIndex;

--- a/client/app/bundles/course/leaderboard/handles.ts
+++ b/client/app/bundles/course/leaderboard/handles.ts
@@ -1,0 +1,26 @@
+import { defineMessages } from 'react-intl';
+
+import CourseAPI from 'api/course';
+import { CrumbPath, DataHandle } from 'lib/hooks/router/dynamicNest';
+
+const translations = defineMessages({
+  header: {
+    id: 'course.leaderboard.LeaderboardIndex.leaderboard',
+    defaultMessage: 'Leaderboard',
+  },
+});
+
+export const leaderboardHandle: DataHandle = (match) => {
+  const courseId = match.params.courseId;
+
+  return {
+    getData: async (): Promise<CrumbPath> => {
+      const { data } = await CourseAPI.leaderboard.index();
+
+      return {
+        activePath: `/courses/${courseId}/leaderboard`,
+        content: { title: data.leaderboardTitle || translations.header },
+      };
+    },
+  };
+};

--- a/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
+++ b/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
@@ -211,6 +211,4 @@ const LeaderboardIndex: FC<Props> = (props) => {
   );
 };
 
-const handle = translations.leaderboard;
-
-export default Object.assign(injectIntl(LeaderboardIndex), { handle });
+export default injectIntl(LeaderboardIndex);

--- a/client/app/routers/AuthenticatedApp.tsx
+++ b/client/app/routers/AuthenticatedApp.tsx
@@ -109,6 +109,7 @@ import ConfirmEmailPage from 'bundles/users/pages/ConfirmEmailPage';
 import UserShow from 'bundles/users/pages/UserShow';
 import { achievementHandle } from 'course/achievement/handles';
 import StoriesSettings from 'course/admin/pages/StoriesSettings';
+import { announcementsHandle } from 'course/announcements/handles';
 import assessmentAttemptLoader from 'course/assessment/attemptLoader';
 import {
   assessmentHandle,
@@ -117,7 +118,13 @@ import {
 } from 'course/assessment/handles';
 import QuestionFormOutlet from 'course/assessment/question/components/QuestionFormOutlet';
 import { CourseContainer } from 'course/container';
-import { forumHandle, forumTopicHandle } from 'course/forum/handles';
+import { commentHandle } from 'course/discussion/topics/handles';
+import {
+  forumHandle,
+  forumNameHandle,
+  forumTopicHandle,
+} from 'course/forum/handles';
+import { leaderboardHandle } from 'course/leaderboard/handles';
 import { folderHandle } from 'course/material/folders/handles';
 import materialLoader from 'course/material/materialLoader';
 import { videoWatchHistoryHandle } from 'course/statistics/handles';
@@ -180,17 +187,17 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
         },
         {
           path: 'announcements',
-          handle: AnnouncementsIndex.handle,
+          handle: announcementsHandle,
           element: <AnnouncementsIndex />,
         },
         {
           path: 'comments',
-          handle: CommentIndex.handle,
+          handle: commentHandle,
           element: <CommentIndex />,
         },
         {
           path: 'leaderboard',
-          handle: LeaderboardIndex.handle,
+          handle: leaderboardHandle,
           element: <LeaderboardIndex />,
         },
         {
@@ -518,7 +525,7 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
         },
         {
           path: 'forums',
-          handle: ForumsIndex.handle,
+          handle: forumHandle,
           children: [
             {
               index: true,
@@ -526,7 +533,7 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
             },
             {
               path: ':forumId',
-              handle: forumHandle,
+              handle: forumNameHandle,
               children: [
                 {
                   index: true,


### PR DESCRIPTION
- announcements
- leaderboards
- forums
- comments

(for videos and materials, the breadcrumb title has been handled)

This PR should be merged to master after https://github.com/Coursemology/coursemology2/pull/7429 to ensure consistency