### PR TITLE
fix(programming-testcase-expected): Fix erroneous newline removal for expected column in testcases

### DIFF
--- a/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/java/java_programming_test_case_report.rb
@@ -234,7 +234,8 @@ class Course::Assessment::Java::JavaProgrammingTestCaseReport <
   # @param [String] report The report XML to parse.
   # rubocop: disable Lint/MissingSuper
   def initialize(report)
-    @report = Nokogiri::XML::Document.parse(report)
+    report = report.gsub("\n", '&#10;') if report
+    @report = Nokogiri::XML::DocumentFragment.parse(report)
   end
   # rubocop: enable Lint/MissingSuper
 

--- a/lib/autoload/course/assessment/programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/programming_test_case_report.rb
@@ -246,7 +246,8 @@ class Course::Assessment::ProgrammingTestCaseReport
   #
   # @param [String] report The report XML to parse.
   def initialize(report)
-    @report = Nokogiri::XML::Document.parse(report)
+    report = report.gsub("\n", '&#10;') if report
+    @report = Nokogiri::XML::DocumentFragment.parse(report)
   end
 
   # Gets the set of test suites found in this report.


### PR DESCRIPTION
Previously the expected column text in testcases will coerce newlines into spaces. This was caused by `Nokogiri::XML::Document.parse()`.
Issued fixed by changing `Document` to `DocumentFragment`.

When testing, DocumentFragment coerces `\n` to space, while Document coerces both `\n` and `&#10;` (ASCII Line feed character)
So now we change all `\n` to `&#10;` before using `DocumentFragment` to parse.

Reference: https://github.com/flavorjones/loofah#side-note-fragments-vs-documents