### PR TITLE
Add live feedback storage and statistics

### DIFF
--- a/app/controllers/concerns/course/statistics/live_feedback_concern.rb
+++ b/app/controllers/concerns/course/statistics/live_feedback_concern.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+module Course::Statistics::LiveFeedbackConcern
+  private
+
+  def find_submitter_course_user(submission)
+    submission.creator.course_users.find { |u| u.course_id == @assessment.course_id }
+  end
+
+  def find_live_feedback_course_user(live_feedback)
+    live_feedback.creator.course_users.find { |u| u.course_id == @assessment.course_id }
+  end
+
+  def initialize_feedback_count
+    Array.new(@question_order_hash.size, 0)
+  end
+
+  def find_user_assessment_live_feedback(submitter_course_user, assessment_live_feedbacks)
+    assessment_live_feedbacks.select do |live_feedback|
+      find_live_feedback_course_user(live_feedback) == submitter_course_user
+    end
+  end
+
+  def update_feedback_count(feedback_count, user_assessment_live_feedback)
+    user_assessment_live_feedback.each do |feedback|
+      index = @ordered_questions.index(feedback.question_id)
+      feedback.code.each do |code|
+        unless code.comments.empty?
+          feedback_count[index] += 1
+          break
+        end
+      end
+    end
+  end
+
+  def initialize_student_hash(students)
+    students.to_h { |student| [student, nil] }
+  end
+
+  def fetch_hash_for_live_feedback_assessment(submissions, assessment_live_feedbacks)
+    students = @all_students
+    student_hash = initialize_student_hash(students)
+
+    populate_hash(submissions, student_hash, assessment_live_feedbacks)
+    student_hash
+  end
+
+  def populate_hash(submissions, student_hash, assessment_live_feedbacks)
+    submissions.each do |submission|
+      submitter_course_user = find_submitter_course_user(submission)
+      next unless submitter_course_user&.student?
+
+      feedback_count = initialize_feedback_count
+
+      user_assessment_live_feedback = find_user_assessment_live_feedback(submitter_course_user,
+                                                                         assessment_live_feedbacks)
+
+      update_feedback_count(feedback_count, user_assessment_live_feedback)
+
+      student_hash[submitter_course_user] = [submission, feedback_count]
+    end
+  end
+end

--- a/app/controllers/course/assessment/submission/live_feedback_controller.rb
+++ b/app/controllers/course/assessment/submission/live_feedback_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Course::Assessment::Submission::LiveFeedbackController <
+  Course::Assessment::Submission::Controller
+  def save_live_feedback
+    live_feedback = Course::Assessment::LiveFeedback.find_by(id: params[:live_feedback_id])
+    return head :bad_request if live_feedback.nil?
+
+    feedback_files = params[:feedback_files]
+    feedback_files.each do |file|
+      filename = file[:path]
+      file[:feedbackLines].each do |feedback_line|
+        Course::Assessment::LiveFeedbackComment.create(
+          code_id: live_feedback.code.find_by(filename: filename).id,
+          line_number: feedback_line[:linenum],
+          comment: feedback_line[:feedback]
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course::Assessment::Submission::SubmissionsController <
+class Course::Assessment::Submission::SubmissionsController < # rubocop:disable Metrics/ClassLength
   Course::Assessment::Submission::Controller
   include Course::Assessment::Submission::SubmissionsControllerServiceConcern
   include Signals::EmissionConcern

--- a/app/controllers/course/statistics/assessments_controller.rb
+++ b/app/controllers/course/statistics/assessments_controller.rb
@@ -7,6 +7,7 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
   def main_statistics
     @assessment = Course::Assessment.where(id: assessment_params[:id]).
                   calculated(:maximum_grade, :question_count).
+                  includes(programming_questions: [:language]).
                   preload(course: :course_users).first
     submissions = Course::Assessment::Submission.where(assessment_id: assessment_params[:id]).
                   calculated(:grade, :grader_ids).

--- a/app/controllers/course/statistics/assessments_controller.rb
+++ b/app/controllers/course/statistics/assessments_controller.rb
@@ -43,7 +43,8 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
                   preload(course: :course_users).first
     submissions = Course::Assessment::Submission.where(assessment_id: assessment_params[:id]).
                   preload(creator: :course_users)
-    assessment_live_feedbacks = Course::Assessment::LiveFeedback.where(assessment_id: assessment_params[:id])
+    assessment_live_feedbacks = Course::Assessment::LiveFeedback.where(assessment_id: assessment_params[:id]).
+                                preload(:creator, creator: :course_users, code: :comments)
 
     @course_users_hash = preload_course_users_hash(@assessment.course)
 

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -72,6 +72,8 @@ class Course::Assessment < ApplicationRecord
                                          inverse_of: :assessment, dependent: :destroy
   has_one :duplication_traceable, class_name: 'DuplicationTraceable::Assessment',
                                   inverse_of: :assessment, dependent: :destroy
+  has_many :live_feedbacks, class_name: 'Course::Assessment::LiveFeedback',
+                            inverse_of: :assessment, dependent: :destroy
 
   validate :tab_in_same_course
   validate :selected_test_type_for_grading

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -75,7 +75,8 @@ module Course::Assessment::AssessmentAbility
   def allow_create_assessment_submission
     can :create, Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
-    can [:update, :generate_live_feedback], Course::Assessment::Submission, assessment_submission_attempting_hash(user)
+    can [:update, :generate_live_feedback, :save_live_feedback], Course::Assessment::Submission,
+        assessment_submission_attempting_hash(user)
   end
 
   def allow_update_own_assessment_answer

--- a/app/models/course/assessment/live_feedback.rb
+++ b/app/models/course/assessment/live_feedback.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedback < ApplicationRecord
+  belongs_to :assessment, class_name: 'Course::Assessment', foreign_key: 'assessment_id', inverse_of: :live_feedbacks
+  belongs_to :question, class_name: 'Course::Assessment::Question', foreign_key: 'question_id',
+                        inverse_of: :live_feedbacks
+  has_many :code, class_name: 'Course::Assessment::LiveFeedbackCode', foreign_key: 'feedback_id',
+                  inverse_of: :feedback, dependent: :destroy
+
+  validates :assessment, presence: true
+  validates :question, presence: true
+  validates :creator, presence: true
+
+  def self.create_with_codes(assessment_id, question_id, user, feedback_id, files)
+    live_feedback = new(
+      assessment_id: assessment_id,
+      question_id: question_id,
+      creator: user,
+      feedback_id: feedback_id
+    )
+
+    if live_feedback.save
+      files.each do |file|
+        live_feedback_code = Course::Assessment::LiveFeedbackCode.new(
+          feedback_id: live_feedback.id,
+          filename: file.filename,
+          content: file.content
+        )
+        unless live_feedback_code.save
+          Rails.logger.error "Failed to save live_feedback_code: #{live_feedback_code.errors.full_messages.join(', ')}"
+        end
+      end
+      live_feedback
+    else
+      Rails.logger.error "Failed to save live_feedback: #{live_feedback.errors.full_messages.join(', ')}"
+      nil
+    end
+  end
+end

--- a/app/models/course/assessment/live_feedback_code.rb
+++ b/app/models/course/assessment/live_feedback_code.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedbackCode < ApplicationRecord
+  self.table_name = 'course_assessment_live_feedback_code'
+  belongs_to :feedback, class_name: 'Course::Assessment::LiveFeedback', foreign_key: 'feedback_id', inverse_of: :code
+  has_many :comments, class_name: 'Course::Assessment::LiveFeedbackComment', foreign_key: 'code_id',
+                      dependent: :destroy, inverse_of: :code
+
+  validates :filename, presence: true
+  validates :content, presence: true
+end

--- a/app/models/course/assessment/live_feedback_comment.rb
+++ b/app/models/course/assessment/live_feedback_comment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedbackComment < ApplicationRecord
+  belongs_to :code, class_name: 'Course::Assessment::LiveFeedbackCode', foreign_key: 'code_id', inverse_of: :comments
+
+  validates :line_number, presence: true
+  validates :comment, presence: true
+end

--- a/app/models/course/assessment/question.rb
+++ b/app/models/course/assessment/question.rb
@@ -25,6 +25,8 @@ class Course::Assessment::Question < ApplicationRecord
   has_many :question_bundle_questions, class_name: 'Course::Assessment::QuestionBundleQuestion',
                                        foreign_key: :question_id, dependent: :destroy, inverse_of: :question
   has_many :question_bundles, through: :question_bundle_questions, class_name: 'Course::Assessment::QuestionBundle'
+  has_many :live_feedbacks, class_name: 'Course::Assessment::LiveFeedback',
+                            dependent: :destroy, inverse_of: :question
 
   delegate :to_partial_path, to: :actable
   delegate :question_type, to: :actable
@@ -38,7 +40,7 @@ class Course::Assessment::Question < ApplicationRecord
   #
   # @return [Boolean] True if the question supports auto grading.
   def auto_gradable?
-    actable.present? && actable.self_respond_to?(:auto_gradable?) ? actable.auto_gradable? : false
+    (actable.present? && actable.self_respond_to?(:auto_gradable?)) ? actable.auto_gradable? : false
   end
 
   # Gets an instance of the auto grader suitable for use with this question.

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -263,8 +263,8 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
 
     # TODO: Move this validation logic to frontend, to prevent user from submitting in the first place.
     if !CodaveriAsyncApiService.language_valid_for_codaveri?(language)
-      errors.add(:base, 'Language type must be Python 3 and above to activate either codaveri '\
-                        'evaluator or get help')
+      errors.add(:base, 'Language type must be Python 3 and above to activate either codaveri ' \
+                        'evaluator or live feedback')
     elsif !question_assessments.empty? &&
           !question_assessments.first.assessment.course.component_enabled?(Course::CodaveriComponent)
       errors.add(:base,

--- a/app/services/course/assessment/answer/programming_codaveri_async_feedback_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_async_feedback_service.rb
@@ -69,15 +69,13 @@ class Course::Assessment::Answer::ProgrammingCodaveriAsyncFeedbackService # rubo
   # @param [Course::Assessment::Answer] answer The answer to be graded.
   # @return [Course::Assessment::Answer] The graded answer. Note that this answer is not persisted
   #   yet.
-  def construct_feedback_object # rubocop:disable Metrics/AbcSize
+  def construct_feedback_object
     return unless @question.codaveri_id
 
     @answer_object[:problemId] = @question.codaveri_id
 
     @answer_object[:languageVersion][:language] = @question.polyglot_language_name
     @answer_object[:languageVersion][:version] = @question.polyglot_language_version
-
-    # @answer_object[:is_only_itsp] = true if @course.codaveri_itsp_enabled?
 
     @answer_files.each do |file|
       file_template = default_codaveri_student_file_template

--- a/app/views/course/statistics/assessments/_live_feedback_history_details.json.jbuilder
+++ b/app/views/course/statistics/assessments/_live_feedback_history_details.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+json.files @live_feedback_details_hash[live_feedback_id].each do |live_feedback_details|
+  json.id live_feedback_details[:code][:id]
+  json.filename live_feedback_details[:code][:filename]
+  json.content live_feedback_details[:code][:content]
+  json.language @question.specific.language[:name]
+  json.comments live_feedback_details[:comments].map do |comment|
+    json.lineNumber comment[:line_number]
+    json.comment comment[:comment]
+  end
+end

--- a/app/views/course/statistics/assessments/live_feedback_history.json.jbuilder
+++ b/app/views/course/statistics/assessments/live_feedback_history.json.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+json.liveFeedbackHistory do
+  json.array! @live_feedbacks.map do |live_feedback|
+    json.id live_feedback.id
+    json.createdAt live_feedback.created_at&.iso8601
+    json.partial! 'live_feedback_history_details', live_feedback_id: live_feedback.id
+  end
+end
+
+json.question do
+  json.id @question.id
+  json.title @question.title
+  json.description format_ckeditor_rich_text(@question.description)
+end

--- a/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
+++ b/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
@@ -10,5 +10,7 @@ json.array! @student_live_feedback_hash.each do |course_user, (submission, live_
   json.groups @group_names_hash[course_user.id] do |name|
     json.name name
   end
+
   json.liveFeedbackCount live_feedback_count
+  json.questionIds(@question_order_hash.keys.sort_by { |key| @question_order_hash[key] })
 end

--- a/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
+++ b/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+json.array! @student_live_feedback_hash.each do |course_user, (submission, live_feedback_count)|
+  json.partial! 'course_user', course_user: course_user
+  if submission.nil?
+    json.workflowState 'unstarted'
+  else
+    json.workflowState submission.workflow_state
+  end
+
+  json.groups @group_names_hash[course_user.id] do |name|
+    json.name name
+  end
+  json.liveFeedbackCount live_feedback_count
+end

--- a/app/views/course/statistics/assessments/main_statistics.json.jbuilder
+++ b/app/views/course/statistics/assessments/main_statistics.json.jbuilder
@@ -3,6 +3,7 @@ json.assessment do
   json.partial! 'assessment', assessment: @assessment, course: current_course
   json.isAutograded @assessment_autograded
   json.questionCount @assessment.question_count
+  json.liveFeedbackEnabled @assessment.programming_questions.any?(&:live_feedback_enabled)
 end
 
 json.submissions @student_submissions_hash.each do |course_user, (submission, answers, end_at)|

--- a/client/app/api/course/Assessment/Submissions.js
+++ b/client/app/api/course/Assessment/Submissions.js
@@ -138,6 +138,13 @@ export default class SubmissionsAPI extends BaseAssessmentAPI {
     });
   }
 
+  saveLiveFeedback(liveFeedbackId, feedbackFiles) {
+    return this.client.post(`${this.#urlPrefix}/save_live_feedback`, {
+      live_feedback_id: liveFeedbackId,
+      feedback_files: feedbackFiles,
+    });
+  }
+
   createProgrammingAnnotation(submissionId, answerId, fileId, params) {
     const url = `${this.#urlPrefix}/${submissionId}/answers/${answerId}/programming/files/${fileId}/annotations`;
     return this.client.post(url, params);

--- a/client/app/api/course/Statistics/AssessmentStatistics.ts
+++ b/client/app/api/course/Statistics/AssessmentStatistics.ts
@@ -1,3 +1,4 @@
+import { LiveFeedbackHistoryState } from 'types/course/assessment/submission/liveFeedback';
 import {
   AncestorAssessmentStats,
   AssessmentLiveFeedbackStatistics,
@@ -40,6 +41,17 @@ export default class AssessmentStatisticsAPI extends BaseCourseAPI {
   ): APIResponse<AssessmentLiveFeedbackStatistics[]> {
     return this.client.get(
       `${this.#urlPrefix}/${assessmentId}/live_feedback_statistics`,
+    );
+  }
+
+  fetchLiveFeedbackHistory(
+    assessmentId: string | number,
+    questionId: string | number,
+    courseUserId: string | number,
+  ): APIResponse<LiveFeedbackHistoryState> {
+    return this.client.get(
+      `${this.#urlPrefix}/${assessmentId}/live_feedback_history`,
+      { params: { question_id: questionId, course_user_id: courseUserId } },
     );
   }
 }

--- a/client/app/api/course/Statistics/AssessmentStatistics.ts
+++ b/client/app/api/course/Statistics/AssessmentStatistics.ts
@@ -1,5 +1,6 @@
 import {
   AncestorAssessmentStats,
+  AssessmentLiveFeedbackStatistics,
   MainAssessmentStats,
 } from 'types/course/statistics/assessmentStatistics';
 
@@ -31,6 +32,14 @@ export default class AssessmentStatisticsAPI extends BaseCourseAPI {
   ): APIResponse<MainAssessmentStats> {
     return this.client.get(
       `${this.#urlPrefix}/${assessmentId}/main_statistics`,
+    );
+  }
+
+  fetchLiveFeedbackStatistics(
+    assessmentId: number,
+  ): APIResponse<AssessmentLiveFeedbackStatistics[]> {
+    return this.client.get(
+      `${this.#urlPrefix}/${assessmentId}/live_feedback_statistics`,
     );
   }
 }

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/translations.ts
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/translations.ts
@@ -85,7 +85,8 @@ export default defineMessages({
   },
   errorOccurredWhenUpdatingLiveFeedbackSettings: {
     id: 'course.admin.CodaveriSettings.errorOccurredWhenUpdatingLiveFeedbackSettings',
-    defaultMessage: 'An error occurred while updating the get help settings.',
+    defaultMessage:
+      'An error occurred while updating the live feedback settings.',
   },
   enableDisableButton: {
     id: 'course.admin.CodaveriSettings.enableDisableButton',
@@ -100,7 +101,7 @@ export default defineMessages({
   enableDisableLiveFeedback: {
     id: 'course.admin.CodaveriSettings.enableDisableLiveFeedback',
     defaultMessage:
-      '{enabled, select, true {Enable } other {Disable }} Get Help for {questionCount} \
+      '{enabled, select, true {Enable } other {Disable }} live feedback for {questionCount} \
       programming questions in {title}?',
   },
   enableDisableEvaluatorDescription: {
@@ -116,7 +117,7 @@ export default defineMessages({
   successfulUpdateAllLiveFeedbackEnabled: {
     id: 'course.admin.CodaveriSettings.successfulUpdateAllLiveFeedbackEnabled',
     defaultMessage:
-      'Sucessfully {liveFeedbackEnabled, select, true {enabled} other {disabled}} get help for all questions',
+      'Sucessfully {liveFeedbackEnabled, select, true {enabled} other {disabled}} live feedback for all questions',
   },
   evaluatorUpdateSuccess: {
     id: 'course.admin.CodaveriSettings.evaluatorUpdateSuccess',
@@ -125,7 +126,7 @@ export default defineMessages({
   liveFeedbackEnabledUpdateSuccess: {
     id: 'course.admin.CodaveriSettings.liveFeedbackEnabledUpdateSuccess',
     defaultMessage:
-      'Get Help for {question} is now {liveFeedbackEnabled, select, true {enabled} other {disabled}}',
+      'Live feedback for {question} is now {liveFeedbackEnabled, select, true {enabled} other {disabled}}',
   },
   expandAll: {
     id: 'course.admin.CodaveriSettings.expandAll',

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -31,13 +31,14 @@ const translations = defineMessages({
   },
   toggleLiveFeedbackDescription: {
     id: 'course.assessment.AssessmentForm.toggleLiveFeedbackDescription',
-    defaultMessage: 'Enable Get Help feature for all programming questions',
+    defaultMessage:
+      'Enable live feedback feature for all programming questions',
   },
   noProgrammingQuestion: {
     id: 'course.assessment.AssessmentForm.noProgrammingQuestion',
     defaultMessage:
       'You need to add at least one programming question that can be \
-      supported by Codaveri to allow enabling Get Help for this Assessment',
+      supported by Codaveri to allow enabling live feedback for this Assessment',
   },
   timeLimit: {
     id: 'course.assessment.AssessmentForm.timeLimit',

--- a/client/app/bundles/course/assessment/operations/liveFeedback.ts
+++ b/client/app/bundles/course/assessment/operations/liveFeedback.ts
@@ -1,0 +1,32 @@
+import { AxiosError } from 'axios';
+import { dispatch } from 'store';
+
+import CourseAPI from 'api/course';
+
+import { liveFeedbackActions as actions } from '../reducers/liveFeedback';
+
+export const fetchLiveFeedbackHistory = async (
+  assessmentId: number,
+  questionId: number,
+  courseUserId: number,
+): Promise<void> => {
+  try {
+    const response =
+      await CourseAPI.statistics.assessment.fetchLiveFeedbackHistory(
+        assessmentId,
+        questionId,
+        courseUserId,
+      );
+
+    const data = response.data;
+    dispatch(
+      actions.initialize({
+        liveFeedbackHistory: data.liveFeedbackHistory,
+        question: data.question,
+      }),
+    );
+  } catch (error) {
+    if (error instanceof AxiosError) throw error.response?.data?.errors;
+    throw error;
+  }
+};

--- a/client/app/bundles/course/assessment/operations/statistics.ts
+++ b/client/app/bundles/course/assessment/operations/statistics.ts
@@ -3,6 +3,7 @@ import { dispatch } from 'store';
 import { QuestionType } from 'types/course/assessment/question';
 import {
   AncestorAssessmentStats,
+  AssessmentLiveFeedbackStatistics,
   QuestionAllAnswerDisplayDetails,
   QuestionAnswerDetails,
 } from 'types/course/statistics/assessmentStatistics';
@@ -56,5 +57,15 @@ export const fetchAllAnswers = async (
   const response =
     await CourseAPI.statistics.allAnswer.fetchAllAnswers(submissionQuestionId);
 
+  return response.data;
+};
+
+export const fetchLiveFeedbackStatistics = async (
+  assessmentId: number,
+): Promise<AssessmentLiveFeedbackStatistics[]> => {
+  const response =
+    await CourseAPI.statistics.assessment.fetchLiveFeedbackStatistics(
+      assessmentId,
+    );
   return response.data;
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react';
 import { defineMessages } from 'react-intl';
-import { Slider, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { QuestionType } from 'types/course/assessment/question';
 import {
   AllAnswerDetails,
@@ -9,6 +9,7 @@ import {
 
 import Accordion from 'lib/components/core/layouts/Accordion';
 import Link from 'lib/components/core/Link';
+import CustomSlider from 'lib/components/extensions/CustomSlider';
 import useTranslation from 'lib/hooks/useTranslation';
 import { formatLongDateTime } from 'lib/moment';
 
@@ -91,7 +92,7 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
       </Accordion>
       {answerSubmittedTimes.length > 1 && (
         <div className="w-[calc(100%_-_17rem)] mx-auto">
-          <Slider
+          <CustomSlider
             defaultValue={currentAnswerMarker.value}
             marks={answerSubmittedTimes}
             max={currentAnswerMarker.value}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AssessmentStatisticsPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AssessmentStatisticsPage.tsx
@@ -17,6 +17,7 @@ import MainGradesChart from './GradeDistribution/MainGradesChart';
 import MainSubmissionChart from './SubmissionStatus/MainSubmissionChart';
 import MainSubmissionTimeAndGradeStatistics from './SubmissionTimeAndGradeStatistics/MainSubmissionTimeAndGradeStatistics';
 import DuplicationHistoryStatistics from './DuplicationHistoryStatistics';
+import LiveFeedbackStatistics from './LiveFeedbackStatistics';
 import { getAssessmentStatistics } from './selectors';
 import StudentAttemptCountTable from './StudentAttemptCountTable';
 import StudentMarksPerQuestionTable from './StudentMarksPerQuestionTable';
@@ -41,6 +42,10 @@ const translations = defineMessages({
   duplicationHistory: {
     id: 'course.assessment.statistics.duplicationHistory',
     defaultMessage: 'Duplication History',
+  },
+  liveFeedback: {
+    id: 'course.assessment.statistics.liveFeedback',
+    defaultMessage: 'Live Feedback',
   },
   marksPerQuestion: {
     id: 'course.assessment.statistics.marksPerQuestion',
@@ -75,6 +80,7 @@ const tabMapping = (includePhantom: boolean): Record<string, JSX.Element> => {
       <MainSubmissionTimeAndGradeStatistics includePhantom={includePhantom} />
     ),
     duplicationHistory: <DuplicationHistoryStatistics />,
+    liveHelp: <LiveFeedbackStatistics includePhantom={includePhantom} />,
   };
 };
 
@@ -154,6 +160,14 @@ const AssessmentStatisticsPage: FC = () => {
               label={t(translations.duplicationHistory)}
               value="duplicationHistory"
             />
+            {statistics.assessment?.liveFeedbackEnabled && (
+              <Tab
+                className="min-h-12"
+                id="liveHelp"
+                label={t(translations.liveHelp)}
+                value="liveHelp"
+              />
+            )}
           </Tabs>
         </Box>
 

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AssessmentStatisticsPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AssessmentStatisticsPage.tsx
@@ -80,7 +80,7 @@ const tabMapping = (includePhantom: boolean): Record<string, JSX.Element> => {
       <MainSubmissionTimeAndGradeStatistics includePhantom={includePhantom} />
     ),
     duplicationHistory: <DuplicationHistoryStatistics />,
-    liveHelp: <LiveFeedbackStatistics includePhantom={includePhantom} />,
+    liveFeedback: <LiveFeedbackStatistics includePhantom={includePhantom} />,
   };
 };
 
@@ -163,9 +163,9 @@ const AssessmentStatisticsPage: FC = () => {
             {statistics.assessment?.liveFeedbackEnabled && (
               <Tab
                 className="min-h-12"
-                id="liveHelp"
-                label={t(translations.liveHelp)}
-                value="liveHelp"
+                id="liveFeedback"
+                label={t(translations.liveFeedback)}
+                value="liveFeedback"
               />
             )}
           </Tabs>

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
@@ -1,0 +1,109 @@
+import { FC, useRef, useState } from 'react';
+import ReactAce from 'react-ace';
+import { defineMessages } from 'react-intl';
+import { Box, Card, CardContent, Drawer, Typography } from '@mui/material';
+import { LiveFeedbackCodeAndComments } from 'types/course/assessment/submission/liveFeedback';
+
+import { parseLanguages } from 'course/assessment/submission/utils';
+import EditorField from 'lib/components/core/fields/EditorField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  liveFeedbackName: {
+    id: 'course.assessment.liveFeedback.comments',
+    defaultMessage: 'Live Feedback',
+  },
+  comments: {
+    id: 'course.assessment.liveFeedback.comments',
+    defaultMessage: 'Comments',
+  },
+  lineHeader: {
+    id: 'course.assessment.liveFeedback.lineHeader',
+    defaultMessage: 'Line {lineNumber}',
+  },
+});
+
+interface Props {
+  file: LiveFeedbackCodeAndComments;
+}
+
+const LiveFeedbackDetails: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const { file } = props;
+
+  const startingLineNum = Math.min(
+    ...file.comments.map((comment) => comment.lineNumber),
+  );
+
+  const [selectedLine, setSelectedLine] = useState<number>(startingLineNum);
+  const editorRef = useRef<ReactAce | null>(null);
+
+  const handleCursorChange = (selection): void => {
+    const currentLine = selection.getCursor().row + 1; // Ace editor uses 0-index, so add 1
+    setSelectedLine(currentLine);
+  };
+
+  const handleCommentClick = (lineNumber: number): void => {
+    setSelectedLine(lineNumber);
+    if (editorRef.current) {
+      editorRef.current.editor.focus();
+      editorRef.current.editor.gotoLine(lineNumber, 0, true);
+    }
+  };
+
+  return (
+    <div className="relative" id={`file-${file.id}`}>
+      <Box marginRight="315px">
+        <EditorField
+          ref={editorRef}
+          cursorStart={startingLineNum - 1}
+          disabled
+          focus
+          // This height matches the prompt height exactly so there is no awkward scroll bar
+          // and the prompt does not expand weirdly when description is opened
+          height="44rem"
+          language={parseLanguages[file.language]}
+          onCursorChange={handleCursorChange}
+          value={file.content}
+        />
+      </Box>
+      <Drawer
+        anchor="right"
+        open
+        PaperProps={{
+          className: 'absolute w-[31.5rem] border-0 bg-transparent',
+        }}
+        variant="persistent"
+      >
+        <div className="p-2">
+          {file.comments.map((comment) => (
+            <Card
+              key={`file-${file.id}-comment-${comment.lineNumber}`}
+              className={`mb-1 border border-solid border-gray-400 rounded-lg shadow-none cursor-pointer ${
+                selectedLine === comment.lineNumber ? 'bg-yellow-100' : ''
+              }`}
+              onClick={() => {
+                handleCommentClick(comment.lineNumber);
+              }}
+            >
+              <Typography
+                className="ml-1"
+                fontWeight="bold"
+                variant="subtitle1"
+              >
+                {t(translations.lineHeader, {
+                  lineNumber: comment.lineNumber,
+                })}
+              </Typography>
+              <CardContent className="px-1 pt-0 last:pb-1">
+                <Typography variant="body2">{comment.comment}</Typography>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </Drawer>
+    </div>
+  );
+};
+
+export default LiveFeedbackDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
@@ -47,7 +47,7 @@ const LiveFeedbackDetails: FC<Props> = (props) => {
           focus
           // This height matches the prompt height exactly so there is no awkward scroll bar
           // and the prompt does not expand weirdly when description is opened
-          height="44rem"
+          height="43.6rem"
           language={parseLanguages[file.language]}
           onCursorChange={handleCursorChange}
           value={file.content}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
@@ -1,6 +1,5 @@
 import { FC, useRef, useState } from 'react';
 import ReactAce from 'react-ace';
-import { defineMessages } from 'react-intl';
 import { Box, Card, CardContent, Drawer, Typography } from '@mui/material';
 import { LiveFeedbackCodeAndComments } from 'types/course/assessment/submission/liveFeedback';
 
@@ -8,20 +7,7 @@ import { parseLanguages } from 'course/assessment/submission/utils';
 import EditorField from 'lib/components/core/fields/EditorField';
 import useTranslation from 'lib/hooks/useTranslation';
 
-const translations = defineMessages({
-  liveFeedbackName: {
-    id: 'course.assessment.liveFeedback.comments',
-    defaultMessage: 'Live Feedback',
-  },
-  comments: {
-    id: 'course.assessment.liveFeedback.comments',
-    defaultMessage: 'Comments',
-  },
-  lineHeader: {
-    id: 'course.assessment.liveFeedback.lineHeader',
-    defaultMessage: 'Line {lineNumber}',
-  },
-});
+import translations from '../translations';
 
 interface Props {
   file: LiveFeedbackCodeAndComments;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
@@ -1,0 +1,112 @@
+import { FC, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Slider, Typography } from '@mui/material';
+
+import Accordion from 'lib/components/core/layouts/Accordion';
+import { useAppSelector } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
+import { formatLongDateTime } from 'lib/moment';
+
+import {
+  getLiveFeedbackHistory,
+  getLiveFeedbadkQuestionInfo,
+} from '../selectors';
+
+import LiveFeedbackDetails from './LiveFeedbackDetails';
+
+const translations = defineMessages({
+  questionTitle: {
+    id: 'course.assessment.liveFeedback.questionTitle',
+    defaultMessage: 'Question {index}',
+  },
+  feedbackTimingTitle: {
+    id: 'course.assessment.liveFeedback.feedbackTimingTitle',
+    defaultMessage: 'Used at: {usedAt}',
+  },
+});
+
+interface Props {
+  questionNumber: number;
+}
+
+const LiveFeedbackHistoryPage: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const { questionNumber } = props;
+  const allLiveFeedbackHistory = useAppSelector(getLiveFeedbackHistory);
+  const nonEmptyLiveFeedbackHistory = allLiveFeedbackHistory.filter(
+    (liveFeedbackHistory) => {
+      // Remove live feedbacks that have no comments
+      return liveFeedbackHistory.files.some((file) => file.comments.length > 0);
+    },
+  );
+  const question = useAppSelector(getLiveFeedbadkQuestionInfo);
+
+  const [displayedIndex, setDisplayedIndex] = useState(
+    nonEmptyLiveFeedbackHistory.length - 1,
+  );
+  const sliderMarks = nonEmptyLiveFeedbackHistory.map(
+    (liveFeedbackHistory, idx) => {
+      return {
+        value: idx,
+        label:
+          idx === 0 || idx === nonEmptyLiveFeedbackHistory.length - 1
+            ? formatLongDateTime(liveFeedbackHistory.createdAt)
+            : '',
+      };
+    },
+  );
+
+  return (
+    <>
+      <div className="pb-2">
+        <Accordion
+          defaultExpanded={false}
+          disableGutters
+          title={t(translations.questionTitle, {
+            index: questionNumber,
+          })}
+        >
+          <div className="ml-4 mt-4">
+            <Typography variant="body1">{question.title}</Typography>
+            <Typography
+              dangerouslySetInnerHTML={{
+                __html: question.description,
+              }}
+              variant="body2"
+            />
+          </div>
+        </Accordion>
+      </div>
+
+      {nonEmptyLiveFeedbackHistory.length > 1 && (
+        <div className="w-[calc(100%_-_17rem)] mx-auto">
+          <Slider
+            defaultValue={nonEmptyLiveFeedbackHistory.length - 1}
+            marks={sliderMarks}
+            max={nonEmptyLiveFeedbackHistory.length - 1}
+            min={0}
+            onChange={(_, value) => {
+              setDisplayedIndex(Array.isArray(value) ? value[0] : value);
+            }}
+            step={null}
+            valueLabelDisplay="off"
+          />
+        </div>
+      )}
+
+      <Typography className="py-2" variant="h6">
+        {t(translations.feedbackTimingTitle, {
+          usedAt: formatLongDateTime(
+            nonEmptyLiveFeedbackHistory[displayedIndex].createdAt,
+          ),
+        })}
+      </Typography>
+
+      {nonEmptyLiveFeedbackHistory[displayedIndex].files.map((file) => (
+        <LiveFeedbackDetails key={file.id} file={file} />
+      ))}
+    </>
+  );
+};
+
+export default LiveFeedbackHistoryPage;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
@@ -1,5 +1,4 @@
 import { FC, useState } from 'react';
-import { defineMessages } from 'react-intl';
 import { Slider, Typography } from '@mui/material';
 
 import Accordion from 'lib/components/core/layouts/Accordion';
@@ -11,19 +10,9 @@ import {
   getLiveFeedbackHistory,
   getLiveFeedbadkQuestionInfo,
 } from '../selectors';
+import translations from '../translations';
 
 import LiveFeedbackDetails from './LiveFeedbackDetails';
-
-const translations = defineMessages({
-  questionTitle: {
-    id: 'course.assessment.liveFeedback.questionTitle',
-    defaultMessage: 'Question {index}',
-  },
-  feedbackTimingTitle: {
-    id: 'course.assessment.liveFeedback.feedbackTimingTitle',
-    defaultMessage: 'Used at: {usedAt}',
-  },
-});
 
 interface Props {
   questionNumber: number;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
@@ -1,7 +1,8 @@
 import { FC, useState } from 'react';
-import { Slider, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 
 import Accordion from 'lib/components/core/layouts/Accordion';
+import CustomSlider from 'lib/components/extensions/CustomSlider';
 import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 import { formatLongDateTime } from 'lib/moment';
@@ -36,7 +37,7 @@ const LiveFeedbackHistoryPage: FC<Props> = (props) => {
   const sliderMarks = nonEmptyLiveFeedbackHistory.map(
     (liveFeedbackHistory, idx) => {
       return {
-        value: idx,
+        value: idx + 1,
         label:
           idx === 0 || idx === nonEmptyLiveFeedbackHistory.length - 1
             ? formatLongDateTime(liveFeedbackHistory.createdAt)
@@ -69,16 +70,18 @@ const LiveFeedbackHistoryPage: FC<Props> = (props) => {
 
       {nonEmptyLiveFeedbackHistory.length > 1 && (
         <div className="w-[calc(100%_-_17rem)] mx-auto">
-          <Slider
-            defaultValue={nonEmptyLiveFeedbackHistory.length - 1}
+          <CustomSlider
+            defaultValue={nonEmptyLiveFeedbackHistory.length}
             marks={sliderMarks}
-            max={nonEmptyLiveFeedbackHistory.length - 1}
-            min={0}
+            max={nonEmptyLiveFeedbackHistory.length}
+            min={1}
             onChange={(_, value) => {
-              setDisplayedIndex(Array.isArray(value) ? value[0] : value);
+              setDisplayedIndex(
+                Array.isArray(value) ? value[0] - 1 : value - 1,
+              );
             }}
             step={null}
-            valueLabelDisplay="off"
+            valueLabelDisplay="auto"
           />
         </div>
       )}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/index.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/index.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { fetchLiveFeedbackHistory } from 'course/assessment/operations/liveFeedback';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+
+import LiveFeedbackHistoryPage from './LiveFeedbackHistoryPage';
+
+interface Props {
+  questionNumber: number;
+  questionId: number;
+  courseUserId: number;
+}
+
+const LiveFeedbackHistoryIndex: FC<Props> = (props): JSX.Element => {
+  const { questionNumber, questionId, courseUserId } = props;
+  const { assessmentId } = useParams();
+  const parsedAssessmentId = parseInt(assessmentId!, 10);
+
+  const fetchLiveFeedbackHistoryDetails = (): Promise<void> =>
+    fetchLiveFeedbackHistory(parsedAssessmentId, questionId, courseUserId);
+
+  return (
+    <Preload
+      render={<LoadingIndicator />}
+      while={fetchLiveFeedbackHistoryDetails}
+    >
+      {(): JSX.Element => (
+        <LiveFeedbackHistoryPage questionNumber={questionNumber} />
+      )}
+    </Preload>
+  );
+};
+
+export default LiveFeedbackHistoryIndex;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatistics.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatistics.tsx
@@ -1,0 +1,44 @@
+import { FC, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { AssessmentLiveFeedbackStatistics } from 'types/course/statistics/assessmentStatistics';
+
+import { fetchLiveFeedbackStatistics } from 'course/assessment/operations/statistics';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+
+import LiveFeedbackStatisticsTable from './LiveFeedbackStatisticsTable';
+
+interface Props {
+  includePhantom: boolean;
+}
+
+const LiveFeedbackStatistics: FC<Props> = (props) => {
+  const { assessmentId } = useParams();
+  const parsedAssessmentId = parseInt(assessmentId!, 10);
+  const { includePhantom } = props;
+
+  const [liveFeedbackStatistics, setLiveFeedbackStatistics] = useState<
+    AssessmentLiveFeedbackStatistics[]
+  >([]);
+
+  const fetchAndSetLiveFeedbackStatistics = (): Promise<void> =>
+    fetchLiveFeedbackStatistics(parsedAssessmentId).then(
+      setLiveFeedbackStatistics,
+    );
+
+  return (
+    <Preload
+      render={<LoadingIndicator />}
+      while={fetchAndSetLiveFeedbackStatistics}
+    >
+      {(): JSX.Element => (
+        <LiveFeedbackStatisticsTable
+          includePhantom={includePhantom}
+          liveFeedbackStatistics={liveFeedbackStatistics}
+        />
+      )}
+    </Preload>
+  );
+};
+
+export default LiveFeedbackStatistics;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
@@ -1,0 +1,288 @@
+import { FC, ReactNode, useEffect, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
+import { Box, Chip, Typography } from '@mui/material';
+import palette from 'theme/palette';
+import { AssessmentLiveFeedbackStatistics } from 'types/course/statistics/assessmentStatistics';
+
+import { workflowStates } from 'course/assessment/submission/constants';
+import Link from 'lib/components/core/Link';
+import GhostIcon from 'lib/components/icons/GhostIcon';
+import Table, { ColumnTemplate } from 'lib/components/table';
+import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { useAppSelector } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import { getClassnameForLiveFeedbackCell } from './classNameUtils';
+import { getAssessmentStatistics } from './selectors';
+import { getJointGroupsName, translateStatus } from './utils';
+
+const translations = defineMessages({
+  name: {
+    id: 'course.assessment.statistics.name',
+    defaultMessage: 'Name',
+  },
+  group: {
+    id: 'course.assessment.statistics.group',
+    defaultMessage: 'Group',
+  },
+  workflowState: {
+    id: 'course.assessment.statistics.workflowState',
+    defaultMessage: 'Status',
+  },
+  questionIndex: {
+    id: 'course.assessment.statistics.questionIndex',
+    defaultMessage: 'Q{index}',
+  },
+  totalFeedbackCount: {
+    id: 'course.assessment.statistics.totalFeedbackCount',
+    defaultMessage: 'Total',
+  },
+  searchText: {
+    id: 'course.assessment.statistics.searchText',
+    defaultMessage: 'Search by Name or Groups',
+  },
+  filename: {
+    id: 'course.assessment.statistics.filename',
+    defaultMessage: 'Question-level Live Feedback Statistics for {assessment}',
+  },
+  legendLowerUsage: {
+    id: 'course.assessment.statistics.legendLowerUsage',
+    defaultMessage: 'Lower Usage',
+  },
+  legendHigherusage: {
+    id: 'course.assessment.statistics.legendHigherusage',
+    defaultMessage: 'Higher Usage',
+  },
+});
+
+interface Props {
+  includePhantom: boolean;
+  liveFeedbackStatistics: AssessmentLiveFeedbackStatistics[];
+}
+
+const LiveFeedbackStatisticsTable: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const { courseId } = useParams();
+  const { includePhantom, liveFeedbackStatistics } = props;
+
+  const statistics = useAppSelector(getAssessmentStatistics);
+  const assessment = statistics.assessment;
+
+  const [parsedStatistics, setParsedStatistics] = useState<
+    AssessmentLiveFeedbackStatistics[]
+  >([]);
+  const [upperQuartileFeedbackCount, setUpperQuartileFeedbackCount] =
+    useState<number>(0);
+
+  useEffect(() => {
+    const feedbackCounts = liveFeedbackStatistics
+      .flatMap((s) => s.liveFeedbackCount ?? [])
+      .map((c) => c ?? 0)
+      .filter((c) => c !== 0)
+      .sort((a, b) => a - b);
+    const upperQuartilePercentileIndex = Math.floor(
+      0.75 * (feedbackCounts.length - 1),
+    );
+    const upperQuartilePercentileValue =
+      feedbackCounts[upperQuartilePercentileIndex];
+    setUpperQuartileFeedbackCount(upperQuartilePercentileValue);
+
+    const filteredStats = includePhantom
+      ? liveFeedbackStatistics
+      : liveFeedbackStatistics.filter((s) => !s.courseUser.isPhantom);
+
+    filteredStats.forEach((stat) => {
+      stat.totalFeedbackCount =
+        stat.liveFeedbackCount?.reduce((sum, count) => sum + (count || 0), 0) ??
+        0;
+    });
+
+    setParsedStatistics(
+      filteredStats.sort((a, b) => {
+        const phantomDiff =
+          Number(a.courseUser.isPhantom) - Number(b.courseUser.isPhantom);
+        if (phantomDiff !== 0) return phantomDiff;
+
+        const feedbackDiff =
+          (b.totalFeedbackCount ?? 0) - (a.totalFeedbackCount ?? 0);
+        if (feedbackDiff !== 0) return feedbackDiff;
+
+        return a.courseUser.name.localeCompare(b.courseUser.name);
+      }),
+    );
+  }, [liveFeedbackStatistics, includePhantom]);
+
+  // the case where the live feedback count is null is handled separately inside the column
+  // (refer to the definition of statColumns below)
+  const renderNonNullAttemptCountCell = (count: number): ReactNode => {
+    const classname = getClassnameForLiveFeedbackCell(
+      count,
+      upperQuartileFeedbackCount,
+    );
+    return (
+      <div className={classname}>
+        <Box>{count}</Box>
+      </div>
+    );
+  };
+
+  const statColumns: ColumnTemplate<AssessmentLiveFeedbackStatistics>[] =
+    Array.from({ length: assessment?.questionCount ?? 0 }, (_, index) => {
+      return {
+        searchProps: {
+          getValue: (datum) =>
+            datum.liveFeedbackCount?.[index]?.toString() ?? '',
+        },
+        title: t(translations.questionIndex, { index: index + 1 }),
+        cell: (datum): ReactNode => {
+          return typeof datum.liveFeedbackCount?.[index] === 'number'
+            ? renderNonNullAttemptCountCell(datum.liveFeedbackCount?.[index])
+            : null;
+        },
+        sortable: true,
+        csvDownloadable: true,
+        className: 'text-right',
+        sortProps: {
+          sort: (a, b): number => {
+            const aValue =
+              a.liveFeedbackCount?.[index] ?? Number.MIN_SAFE_INTEGER;
+            const bValue =
+              b.liveFeedbackCount?.[index] ?? Number.MIN_SAFE_INTEGER;
+
+            return aValue - bValue;
+          },
+        },
+      };
+    });
+
+  const columns: ColumnTemplate<AssessmentLiveFeedbackStatistics>[] = [
+    {
+      searchProps: {
+        getValue: (datum) => datum.courseUser.name,
+      },
+      title: t(translations.name),
+      sortable: true,
+      searchable: true,
+      cell: (datum) => (
+        <div className="flex grow items-center">
+          <Link to={`/courses/${courseId}/users/${datum.courseUser.id}`}>
+            {datum.courseUser.name}
+          </Link>
+          {datum.courseUser.isPhantom && (
+            <GhostIcon className="ml-2" fontSize="small" />
+          )}
+        </div>
+      ),
+      csvDownloadable: true,
+    },
+    {
+      of: 'groups',
+      title: t(translations.group),
+      sortable: true,
+      searchable: true,
+      searchProps: {
+        getValue: (datum) => getJointGroupsName(datum.groups),
+      },
+      cell: (datum) => getJointGroupsName(datum.groups),
+      csvDownloadable: true,
+    },
+    {
+      of: 'workflowState',
+      title: t(translations.workflowState),
+      sortable: true,
+      cell: (datum) => (
+        <Chip
+          className="w-100"
+          label={translateStatus(
+            datum.workflowState ?? workflowStates.Unstarted,
+          )}
+          style={{
+            backgroundColor:
+              palette.submissionStatus[
+                datum.workflowState ?? workflowStates.Unstarted
+              ],
+          }}
+          variant="filled"
+        />
+      ),
+      className: 'center',
+    },
+    ...statColumns,
+    {
+      searchProps: {
+        getValue: (datum) =>
+          datum.liveFeedbackCount
+            ? datum.liveFeedbackCount
+                .reduce((sum, count) => sum + (count || 0), 0)
+                .toString()
+            : '',
+      },
+      title: t(translations.totalFeedbackCount),
+      cell: (datum): ReactNode => {
+        const totalFeedbackCount = datum.liveFeedbackCount
+          ? datum.liveFeedbackCount.reduce(
+              (sum, count) => sum + (count || 0),
+              0,
+            )
+          : null;
+        return (
+          <div className="p-[1rem]">
+            <Box>{totalFeedbackCount}</Box>
+          </div>
+        );
+      },
+      sortable: true,
+      csvDownloadable: true,
+      className: 'text-right',
+      sortProps: {
+        sort: (a, b): number => {
+          const totalA = a.totalFeedbackCount ?? 0;
+          const totalB = b.totalFeedbackCount ?? 0;
+          return totalA - totalB;
+        },
+      },
+    },
+  ];
+
+  return (
+    <>
+      <div className="flex items-center">
+        <Typography variant="caption">
+          {t(translations.legendLowerUsage)}
+        </Typography>
+        {
+          // The gradient color bar
+          <div className="h-5 w-1/4 mx-2 bg-gradient-to-r from-red-100 to-red-500" />
+        }
+        <Typography variant="caption">
+          {t(translations.legendHigherusage)}
+        </Typography>
+      </div>
+
+      <Table
+        columns={columns}
+        csvDownload={{
+          filename: t(translations.filename, {
+            assessment: assessment?.title ?? '',
+          }),
+        }}
+        data={parsedStatistics}
+        getRowClassName={(datum): string =>
+          `data_${datum.courseUser.id} bg-slot-1 hover?:bg-slot-2 slot-1-white slot-2-neutral-100`
+        }
+        getRowEqualityData={(datum): AssessmentLiveFeedbackStatistics => datum}
+        getRowId={(datum): string => datum.courseUser.id.toString()}
+        indexing={{ indices: true }}
+        pagination={{
+          rowsPerPage: [DEFAULT_TABLE_ROWS_PER_PAGE],
+          showAllRows: true,
+        }}
+        search={{ searchPlaceholder: t(translations.searchText) }}
+        toolbar={{ show: true }}
+      />
+    </>
+  );
+};
+
+export default LiveFeedbackStatisticsTable;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
@@ -1,5 +1,4 @@
 import { FC, ReactNode, useEffect, useState } from 'react';
-import { defineMessages } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { Box, Chip, Typography } from '@mui/material';
 import palette from 'theme/palette';
@@ -17,54 +16,8 @@ import useTranslation from 'lib/hooks/useTranslation';
 import { getClassnameForLiveFeedbackCell } from './classNameUtils';
 import LiveFeedbackHistoryIndex from './LiveFeedbackHistory';
 import { getAssessmentStatistics } from './selectors';
+import translations from './translations';
 import { getJointGroupsName, translateStatus } from './utils';
-
-const translations = defineMessages({
-  name: {
-    id: 'course.assessment.statistics.name',
-    defaultMessage: 'Name',
-  },
-  group: {
-    id: 'course.assessment.statistics.group',
-    defaultMessage: 'Group',
-  },
-  workflowState: {
-    id: 'course.assessment.statistics.workflowState',
-    defaultMessage: 'Status',
-  },
-  questionIndex: {
-    id: 'course.assessment.statistics.questionIndex',
-    defaultMessage: 'Q{index}',
-  },
-  totalFeedbackCount: {
-    id: 'course.assessment.statistics.totalFeedbackCount',
-    defaultMessage: 'Total',
-  },
-  searchText: {
-    id: 'course.assessment.statistics.searchText',
-    defaultMessage: 'Search by Name or Groups',
-  },
-  filename: {
-    id: 'course.assessment.statistics.filename',
-    defaultMessage: 'Question-level Live Feedback Statistics for {assessment}',
-  },
-  closePrompt: {
-    id: 'course.assessment.statistics.closePrompt',
-    defaultMessage: 'Close',
-  },
-  liveFeedbackHistoryPromptTitle: {
-    id: 'course.assessment.statistics.liveFeedbackHistoryPromptTitle',
-    defaultMessage: 'Live Feedback History',
-  },
-  legendLowerUsage: {
-    id: 'course.assessment.statistics.legendLowerUsage',
-    defaultMessage: 'Lower Usage',
-  },
-  legendHigherusage: {
-    id: 'course.assessment.statistics.legendHigherusage',
-    defaultMessage: 'Higher Usage',
-  },
-});
 
 interface Props {
   includePhantom: boolean;
@@ -254,7 +207,7 @@ const LiveFeedbackStatisticsTable: FC<Props> = (props) => {
                 .toString()
             : '',
       },
-      title: t(translations.totalFeedbackCount),
+      title: t(translations.total),
       cell: (datum): ReactNode => {
         const totalFeedbackCount = datum.liveFeedbackCount
           ? datum.liveFeedbackCount.reduce(
@@ -299,7 +252,7 @@ const LiveFeedbackStatisticsTable: FC<Props> = (props) => {
       <Table
         columns={columns}
         csvDownload={{
-          filename: t(translations.filename, {
+          filename: t(translations.liveFeedbackFilename, {
             assessment: assessment?.title ?? '',
           }),
         }}
@@ -314,7 +267,7 @@ const LiveFeedbackStatisticsTable: FC<Props> = (props) => {
           rowsPerPage: [DEFAULT_TABLE_ROWS_PER_PAGE],
           showAllRows: true,
         }}
-        search={{ searchPlaceholder: t(translations.searchText) }}
+        search={{ searchPlaceholder: t(translations.nameGroupsSearchText) }}
         toolbar={{ show: true }}
       />
       <Prompt

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -20,6 +20,7 @@ import useTranslation from 'lib/hooks/useTranslation';
 import AllAttemptsIndex from './AnswerDisplay/AllAttempts';
 import { getClassNameForAttemptCountCell } from './classNameUtils';
 import { getAssessmentStatistics } from './selectors';
+import { getJointGroupsName, translateStatus } from './utils';
 
 const translations = defineMessages({
   onlyForAutogradableAssessment: {
@@ -80,14 +81,6 @@ const translations = defineMessages({
 interface Props {
   includePhantom: boolean;
 }
-
-const statusTranslations = {
-  attempting: 'Attempting',
-  submitted: 'Submitted',
-  graded: 'Graded, unpublished',
-  published: 'Graded',
-  unstarted: 'Not Started',
-};
 
 const StudentAttemptCountTable: FC<Props> = (props) => {
   const { t } = useTranslation();
@@ -180,14 +173,6 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
     },
   );
 
-  const jointGroupsName = (datum: MainSubmissionInfo): string =>
-    datum.groups
-      ? datum.groups
-          .map((g) => g.name)
-          .sort()
-          .join(', ')
-      : '';
-
   const columns: ColumnTemplate<MainSubmissionInfo>[] = [
     {
       searchProps: {
@@ -214,9 +199,9 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
       sortable: true,
       searchable: true,
       searchProps: {
-        getValue: (datum) => jointGroupsName(datum),
+        getValue: (datum) => getJointGroupsName(datum.groups),
       },
-      cell: (datum) => jointGroupsName(datum),
+      cell: (datum) => getJointGroupsName(datum.groups),
       csvDownloadable: true,
     },
     {
@@ -230,11 +215,9 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
         >
           <Chip
             className={`text-blue-800 ${palette.submissionStatusClassName[datum.workflowState ?? workflowStates.Unstarted]} w-full`}
-            label={
-              statusTranslations[
-                datum.workflowState ?? workflowStates.Unstarted
-              ]
-            }
+            label={translateStatus(
+              datum.workflowState ?? workflowStates.Unstarted,
+            )}
             variant="filled"
           />
         </Link>

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -1,5 +1,4 @@
 import { FC, ReactNode, useState } from 'react';
-import { defineMessages } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { Box, Chip } from '@mui/material';
 import palette from 'theme/palette';
@@ -20,63 +19,8 @@ import useTranslation from 'lib/hooks/useTranslation';
 import AllAttemptsIndex from './AnswerDisplay/AllAttempts';
 import { getClassNameForAttemptCountCell } from './classNameUtils';
 import { getAssessmentStatistics } from './selectors';
+import translations from './translations';
 import { getJointGroupsName, translateStatus } from './utils';
-
-const translations = defineMessages({
-  onlyForAutogradableAssessment: {
-    id: 'course.assessment.statistics.onlyForAutogradableAssessment',
-    defaultMessage:
-      'This table is only displayed for Assessment with at least one Autograded Questions',
-  },
-  greenCellLegend: {
-    id: 'course.assessment.statistics.greenCellLegend',
-    defaultMessage: 'Correct',
-  },
-  redCellLegend: {
-    id: 'course.assessment.statistics.redCellLegend',
-    defaultMessage: 'Incorrect',
-  },
-  grayCellLegend: {
-    id: 'course.assessment.statistics.grayCellLegend',
-    defaultMessage: 'Undecided (question is Non-autogradable)',
-  },
-  name: {
-    id: 'course.assessment.statistics.name',
-    defaultMessage: 'Name',
-  },
-  group: {
-    id: 'course.assessment.statistics.group',
-    defaultMessage: 'Group',
-  },
-  searchText: {
-    id: 'course.assessment.statistics.searchText',
-    defaultMessage: 'Search by Name or Groups',
-  },
-  answers: {
-    id: 'course.assessment.statistics.answers',
-    defaultMessage: 'Answers',
-  },
-  questionIndex: {
-    id: 'course.assessment.statistics.questionIndex',
-    defaultMessage: 'Q{index}',
-  },
-  noSubmission: {
-    id: 'course.assessment.statistics.noSubmission',
-    defaultMessage: 'No Submission yet',
-  },
-  workflowState: {
-    id: 'course.assessment.statistics.workflowState',
-    defaultMessage: 'Status',
-  },
-  filename: {
-    id: 'course.assessment.statistics.filename',
-    defaultMessage: 'Question-level Attempt Statistics for {assessment}',
-  },
-  close: {
-    id: 'course.assessment.statistics.close',
-    defaultMessage: 'Close',
-  },
-});
 
 interface Props {
   includePhantom: boolean;
@@ -234,12 +178,12 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
           {
             key: 'correct',
             backgroundColor: 'bg-green-300',
-            description: t(translations.greenCellLegend),
+            description: t(translations.attemptsGreenCellLegend),
           },
           {
             key: 'incorrect',
             backgroundColor: 'bg-red-300',
-            description: t(translations.redCellLegend),
+            description: t(translations.attemptsRedCellLegend),
           },
           {
             key: 'undecided',
@@ -251,7 +195,7 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
       <Table
         columns={columns}
         csvDownload={{
-          filename: t(translations.filename, {
+          filename: t(translations.attemptsFilename, {
             assessment: assessment?.title ?? '',
           }),
         }}
@@ -266,11 +210,11 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
           rowsPerPage: [DEFAULT_TABLE_ROWS_PER_PAGE],
           showAllRows: true,
         }}
-        search={{ searchPlaceholder: t(translations.searchText) }}
+        search={{ searchPlaceholder: t(translations.nameGroupsSearchText) }}
         toolbar={{ show: true }}
       />
       <Prompt
-        cancelLabel={t(translations.close)}
+        cancelLabel={t(translations.closePrompt)}
         maxWidth="lg"
         onClose={(): void => setOpenPastAnswers(false)}
         open={openPastAnswers}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -19,6 +19,7 @@ import useTranslation from 'lib/hooks/useTranslation';
 import LastAttemptIndex from './AnswerDisplay/LastAttempt';
 import { getClassNameForMarkCell } from './classNameUtils';
 import { getAssessmentStatistics } from './selectors';
+import { getJointGroupsName, translateStatus } from './utils';
 
 const translations = defineMessages({
   name: {
@@ -78,14 +79,6 @@ const translations = defineMessages({
 interface Props {
   includePhantom: boolean;
 }
-
-const statusTranslations = {
-  attempting: 'Attempting',
-  submitted: 'Submitted',
-  graded: 'Graded, unpublished',
-  published: 'Graded',
-  unstarted: 'Not Started',
-};
 
 const StudentMarksPerQuestionTable: FC<Props> = (props) => {
   const { t } = useTranslation();
@@ -185,14 +178,6 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
     },
   );
 
-  const jointGroupsName = (datum: MainSubmissionInfo): string =>
-    datum.groups
-      ? datum.groups
-          .map((g) => g.name)
-          .sort()
-          .join(', ')
-      : '';
-
   const columns: ColumnTemplate<MainSubmissionInfo>[] = [
     {
       searchProps: {
@@ -219,9 +204,9 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
       sortable: true,
       searchable: true,
       searchProps: {
-        getValue: (datum) => jointGroupsName(datum),
+        getValue: (datum) => getJointGroupsName(datum.groups),
       },
-      cell: (datum) => jointGroupsName(datum),
+      cell: (datum) => getJointGroupsName(datum.groups),
       csvDownloadable: true,
     },
     {
@@ -235,11 +220,9 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
         >
           <Chip
             className={`text-blue-800 ${palette.submissionStatusClassName[datum.workflowState ?? workflowStates.Unstarted]} w-full`}
-            label={
-              statusTranslations[
-                datum.workflowState ?? workflowStates.Unstarted
-              ]
-            }
+            label={translateStatus(
+              datum.workflowState ?? workflowStates.Unstarted,
+            )}
             variant="filled"
           />
         </Link>

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -1,5 +1,4 @@
 import { FC, ReactNode, useState } from 'react';
-import { defineMessages } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { Box, Chip } from '@mui/material';
 import palette from 'theme/palette';
@@ -19,62 +18,8 @@ import useTranslation from 'lib/hooks/useTranslation';
 import LastAttemptIndex from './AnswerDisplay/LastAttempt';
 import { getClassNameForMarkCell } from './classNameUtils';
 import { getAssessmentStatistics } from './selectors';
+import translations from './translations';
 import { getJointGroupsName, translateStatus } from './utils';
-
-const translations = defineMessages({
-  name: {
-    id: 'course.assessment.statistics.name',
-    defaultMessage: 'Name',
-  },
-  greenCellLegend: {
-    id: 'course.assessment.statistics.greenCellLegend',
-    defaultMessage: '>= 0.5 * Maximum Grade',
-  },
-  redCellLegend: {
-    id: 'course.assessment.statistics.redCellLegend',
-    defaultMessage: '< 0.5 * Maximum Grade',
-  },
-  group: {
-    id: 'course.assessment.statistics.group',
-    defaultMessage: 'Group',
-  },
-  totalGrade: {
-    id: 'course.assessment.statistics.totalGrade',
-    defaultMessage: 'Total',
-  },
-  grader: {
-    id: 'course.assessment.statistics.grader',
-    defaultMessage: 'Grader',
-  },
-  searchText: {
-    id: 'course.assessment.statistics.searchText',
-    defaultMessage: 'Search by Student Name, Group or Grader Name',
-  },
-  answers: {
-    id: 'course.assessment.statistics.answers',
-    defaultMessage: 'Answers',
-  },
-  questionIndex: {
-    id: 'course.assessment.statistics.questionIndex',
-    defaultMessage: 'Q{index}',
-  },
-  noSubmission: {
-    id: 'course.assessment.statistics.noSubmission',
-    defaultMessage: 'No Submission yet',
-  },
-  workflowState: {
-    id: 'course.assessment.statistics.workflowState',
-    defaultMessage: 'Status',
-  },
-  filename: {
-    id: 'course.assessment.statistics.filename',
-    defaultMessage: 'Question-level Marks Statistics for {assessment}',
-  },
-  close: {
-    id: 'course.assessment.statistics.close',
-    defaultMessage: 'Close',
-  },
-});
 
 interface Props {
   includePhantom: boolean;
@@ -234,7 +179,7 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
       searchProps: {
         getValue: (datum) => datum.totalGrade?.toString() ?? undefined,
       },
-      title: t(translations.totalGrade),
+      title: t(translations.total),
       sortable: true,
       cell: (datum): ReactNode => {
         const isGradedOrPublished =
@@ -281,19 +226,19 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
           {
             key: 'correct',
             backgroundColor: 'bg-green-500',
-            description: t(translations.greenCellLegend),
+            description: t(translations.marksGreenCellLegend),
           },
           {
             key: 'incorrect',
             backgroundColor: 'bg-red-500',
-            description: t(translations.redCellLegend),
+            description: t(translations.marksRedCellLegend),
           },
         ]}
       />
       <Table
         columns={columns}
         csvDownload={{
-          filename: t(translations.filename, {
+          filename: t(translations.marksFilename, {
             assessment: assessment?.title ?? '',
           }),
         }}
@@ -308,11 +253,13 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
           rowsPerPage: [DEFAULT_TABLE_ROWS_PER_PAGE],
           showAllRows: true,
         }}
-        search={{ searchPlaceholder: t(translations.searchText) }}
+        search={{
+          searchPlaceholder: t(translations.nameGroupsGraderSearchText),
+        }}
         toolbar={{ show: true }}
       />
       <Prompt
-        cancelLabel={t(translations.close)}
+        cancelLabel={t(translations.closePrompt)}
         maxWidth="lg"
         onClose={(): void => setOpenAnswer(false)}
         open={openAnswer}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/classNameUtils.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/classNameUtils.ts
@@ -1,4 +1,3 @@
-import { green } from 'theme/colors';
 import { AttemptInfo } from 'types/course/statistics/assessmentStatistics';
 
 const redBackgroundColorClassName = {

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/classNameUtils.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/classNameUtils.ts
@@ -1,7 +1,7 @@
+import { green } from 'theme/colors';
 import { AttemptInfo } from 'types/course/statistics/assessmentStatistics';
 
-// lower grade means obtaining the grade less than half the maximum possible grade
-const lowerGradeBackgroundColorClassName = {
+const redBackgroundColorClassName = {
   0: 'bg-red-50',
   100: 'bg-red-100',
   200: 'bg-red-200',
@@ -10,8 +10,7 @@ const lowerGradeBackgroundColorClassName = {
   500: 'bg-red-500',
 };
 
-// higher grade means obtaining the grade at least half the maximum possible grade
-const higherGradeBackgroundColorClassName = {
+const greenBackgroundColorClassName = {
   0: 'bg-green-50',
   100: 'bg-green-100',
   200: 'bg-green-200',
@@ -20,15 +19,21 @@ const higherGradeBackgroundColorClassName = {
   500: 'bg-green-500',
 };
 
-// calculate the gradient of the color in each grade cell
-// 1. we compute the distance between the grade and the mid-grade (half the maximum)
+// 1. we compute the distance between the value and the halfMaxValue
 // 2. then, we compute the fraction of it -> range becomes [0,1]
-// 3. then we convert it into range [0,3] so that the shades will become [100, 200, 300]
-const calculateColorGradientLevel = (
-  grade: number,
-  halfMaxGrade: number,
+// 3. then we convert it into range [0,5] so that the shades will become [100, 200, 300, 400, 500]
+const calculateTwoSidedColorGradientLevel = (
+  value: number,
+  halfMaxValue: number,
 ): number => {
-  return Math.round((Math.abs(grade - halfMaxGrade) / halfMaxGrade) * 5) * 100;
+  return Math.round((Math.abs(value - halfMaxValue) / halfMaxValue) * 5) * 100;
+};
+
+const calculateOneSidedColorGradientLevel = (
+  value: number,
+  maxValue: number,
+): number => {
+  return Math.round((Math.min(value, maxValue) / maxValue) * 5) * 100;
 };
 
 // for marks per question cell, the difference in color means the following:
@@ -38,10 +43,13 @@ export const getClassNameForMarkCell = (
   grade: number,
   maxGrade: number,
 ): string => {
-  const gradientLevel = calculateColorGradientLevel(grade, maxGrade / 2);
+  const gradientLevel = calculateTwoSidedColorGradientLevel(
+    grade,
+    maxGrade / 2,
+  );
   return grade >= maxGrade / 2
-    ? `${higherGradeBackgroundColorClassName[gradientLevel]} p-[1rem]`
-    : `${lowerGradeBackgroundColorClassName[gradientLevel]} p-[1rem]`;
+    ? `${greenBackgroundColorClassName[gradientLevel]} p-[1rem]`
+    : `${redBackgroundColorClassName[gradientLevel]} p-[1rem]`;
 };
 
 // for attempt count cell, the difference in color means the following:
@@ -56,4 +64,15 @@ export const getClassNameForAttemptCountCell = (
   }
 
   return attempt.correct ? 'bg-green-300 p-[1rem]' : 'bg-red-300 p-[1rem]';
+};
+
+export const getClassnameForLiveFeedbackCell = (
+  count: number,
+  upperQuartile: number,
+): string => {
+  const gradientLevel = calculateOneSidedColorGradientLevel(
+    count,
+    upperQuartile,
+  );
+  return `${redBackgroundColorClassName[gradientLevel]} p-[1rem]`;
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/selectors.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/selectors.ts
@@ -1,6 +1,17 @@
 import { AppState } from 'store';
+import {
+  LiveFeedbackHistory,
+  QuestionInfo,
+} from 'types/course/assessment/submission/liveFeedback';
 import { AssessmentStatisticsState } from 'types/course/statistics/assessmentStatistics';
 
 export const getAssessmentStatistics = (
   state: AppState,
 ): AssessmentStatisticsState => state.assessments.statistics;
+
+export const getLiveFeedbackHistory = (
+  state: AppState,
+): LiveFeedbackHistory[] => state.assessments.liveFeedback.liveFeedbackHistory;
+
+export const getLiveFeedbadkQuestionInfo = (state: AppState): QuestionInfo =>
+  state.assessments.liveFeedback.question;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/translations.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/translations.ts
@@ -1,0 +1,125 @@
+import { defineMessages } from 'react-intl';
+
+const translations = defineMessages({
+  answers: {
+    id: 'course.assessment.statistics.answers',
+    defaultMessage: 'Answers',
+  },
+  attemptsFilename: {
+    id: 'course.assessment.statistics.attempts.filename',
+    defaultMessage: 'Question-level Attempt Statistics for {assessment}',
+  },
+  attemptsGreenCellLegend: {
+    id: 'course.assessment.statistics.attempts.greenCellLegend',
+    defaultMessage: 'Correct',
+  },
+  attemptsRedCellLegend: {
+    id: 'course.assessment.statistics.attempts.redCellLegend',
+    defaultMessage: 'Incorrect',
+  },
+  closePrompt: {
+    id: 'course.assessment.statistics.closePrompt',
+    defaultMessage: 'Close',
+  },
+  grader: {
+    id: 'course.assessment.statistics.grader',
+    defaultMessage: 'Grader',
+  },
+  grayCellLegend: {
+    id: 'course.assessment.statistics.grayCellLegend',
+    defaultMessage: 'Undecided (question is Non-autogradable)',
+  },
+  group: {
+    id: 'course.assessment.statistics.group',
+    defaultMessage: 'Group',
+  },
+  legendHigherusage: {
+    id: 'course.assessment.statistics.legendHigherusage',
+    defaultMessage: 'Higher Usage',
+  },
+  legendLowerUsage: {
+    id: 'course.assessment.statistics.legendLowerUsage',
+    defaultMessage: 'Lower Usage',
+  },
+  liveFeedbackFilename: {
+    id: 'course.assessment.statistics.liveFeedback.filename',
+    defaultMessage: 'Question-level Live Feedback Statistics for {assessment}',
+  },
+  liveFeedbackHistoryPromptTitle: {
+    id: 'course.assessment.statistics.liveFeedbackHistoryPromptTitle',
+    defaultMessage: 'Live Feedback History',
+  },
+  marksFilename: {
+    id: 'course.assessment.statistics.marks.filename',
+    defaultMessage: 'Question-level Marks Statistics for {assessment}',
+  },
+  marksGreenCellLegend: {
+    id: 'course.assessment.statistics.marks.greenCellLegend',
+    defaultMessage: '>= 0.5 * Maximum Grade',
+  },
+  marksRedCellLegend: {
+    id: 'course.assessment.statistics.marks.redCellLegend',
+    defaultMessage: '< 0.5 * Maximum Grade',
+  },
+  name: {
+    id: 'course.assessment.statistics.name',
+    defaultMessage: 'Name',
+  },
+  nameGroupsGraderSearchText: {
+    id: 'course.assessment.statistics.nameGroupsGraderSearchText',
+    defaultMessage: 'Search by Student Name, Group or Grader Name',
+  },
+  nameGroupsSearchText: {
+    id: 'course.assessment.statistics.nameGroupsSearchText',
+    defaultMessage: 'Search by Name or Groups',
+  },
+  noSubmission: {
+    id: 'course.assessment.statistics.noSubmission',
+    defaultMessage: 'No submission yet',
+  },
+  onlyForAutogradableAssessment: {
+    id: 'course.assessment.statistics.onlyForAutogradableAssessment',
+    defaultMessage:
+      'This table is only displayed for Assessment with at least one Autograded Questions',
+  },
+  questionDisplayTitle: {
+    id: 'course.assessment.statistics.questionDisplayTitle',
+    defaultMessage: 'Q{index} for {student}',
+  },
+  questionIndex: {
+    id: 'course.assessment.statistics.questionIndex',
+    defaultMessage: 'Q{index}',
+  },
+  total: {
+    id: 'course.assessment.statistics.total',
+    defaultMessage: 'Total',
+  },
+  workflowState: {
+    id: 'course.assessment.statistics.workflowState',
+    defaultMessage: 'Status',
+  },
+
+  questionTitle: {
+    id: 'course.assessment.liveFeedback.questionTitle',
+    defaultMessage: 'Question {index}',
+  },
+  feedbackTimingTitle: {
+    id: 'course.assessment.liveFeedback.feedbackTimingTitle',
+    defaultMessage: 'Used at: {usedAt}',
+  },
+
+  liveFeedbackName: {
+    id: 'course.assessment.liveFeedback.comments',
+    defaultMessage: 'Live Feedback',
+  },
+  comments: {
+    id: 'course.assessment.liveFeedback.comments',
+    defaultMessage: 'Comments',
+  },
+  lineHeader: {
+    id: 'course.assessment.liveFeedback.lineHeader',
+    defaultMessage: 'Line {lineNumber}',
+  },
+});
+
+export default translations;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/utils.js
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/utils.js
@@ -61,3 +61,33 @@ export function processSubmissionsIntoChartData(submissions) {
   }
   return { labels, lineData, barData };
 }
+
+// Change to this function when file is converted to TypeScript
+// const getJointGroupsName = (groups: {name: string}[]): string =>
+//   groups
+//     ? groups
+//         .map((group) => group.name)
+//         .sort()
+//         .join(', ')
+//     : '';
+
+export const getJointGroupsName = (groups) =>
+  groups
+    ? groups
+        .map((group) => group.name)
+        .sort()
+        .join(', ')
+    : '';
+
+const statusTranslations = {
+  attempting: 'Attempting',
+  submitted: 'Submitted',
+  graded: 'Graded, unpublished',
+  published: 'Graded',
+  unstarted: 'Not Started',
+};
+
+// Change to this function when file is converted to TypeScript
+// export const translateStatus = (status: WorkflowState): string => statusTranslations[status];
+
+export const translateStatus = (status) => statusTranslations[status];

--- a/client/app/bundles/course/assessment/reducers/liveFeedback.ts
+++ b/client/app/bundles/course/assessment/reducers/liveFeedback.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { LiveFeedbackHistoryState } from 'types/course/assessment/submission/liveFeedback';
+
+const initialState: LiveFeedbackHistoryState = {
+  liveFeedbackHistory: [],
+  question: {
+    id: 0,
+    title: '',
+    description: '',
+  },
+};
+
+export const liveFeedbackSlice = createSlice({
+  name: 'liveFeedbackHistory',
+  initialState,
+  reducers: {
+    initialize: (state, action: PayloadAction<LiveFeedbackHistoryState>) => {
+      state.liveFeedbackHistory = action.payload.liveFeedbackHistory;
+      state.question = action.payload.question;
+    },
+    reset: () => {
+      return initialState;
+    },
+  },
+});
+
+export const liveFeedbackActions = liveFeedbackSlice.actions;
+
+export default liveFeedbackSlice.reducer;

--- a/client/app/bundles/course/assessment/store.ts
+++ b/client/app/bundles/course/assessment/store.ts
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux';
 import editPageReducer from './reducers/editPage';
 import formDialogReducer from './reducers/formDialog';
 import generatePageReducer from './reducers/generation';
+import liveFeedbackHistoryReducer from './reducers/liveFeedback';
 import monitoringReducer from './reducers/monitoring';
 import statisticsReducer from './reducers/statistics';
 import submissionReducer from './submission/reducers';
@@ -14,6 +15,7 @@ const reducer = combineReducers({
   monitoring: monitoringReducer,
   statistics: statisticsReducer,
   submission: submissionReducer,
+  liveFeedback: liveFeedbackHistoryReducer,
 });
 
 export default reducer;

--- a/client/app/bundles/course/assessment/submission/actions/answers/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/answers/index.js
@@ -288,6 +288,7 @@ export function generateLiveFeedback({
             type: actionTypes.LIVE_FEEDBACK_REQUEST,
             payload: {
               questionId,
+              liveFeedbackId: response.data?.liveFeedbackId,
               feedbackUrl: response.data?.feedbackUrl,
               token: response.data?.data?.token,
             },
@@ -309,6 +310,7 @@ export function fetchLiveFeedback({
   answerId,
   questionId,
   feedbackUrl,
+  liveFeedbackId,
   feedbackToken,
   successMessage,
   noFeedbackMessage,
@@ -318,6 +320,10 @@ export function fetchLiveFeedback({
       .fetchLiveFeedback(feedbackUrl, feedbackToken)
       .then((response) => {
         if (response.status === 200) {
+          CourseAPI.assessment.submissions.saveLiveFeedback(
+            liveFeedbackId,
+            response.data?.data?.feedbackFiles ?? [],
+          );
           handleFeedbackOKResponse({
             dispatch,
             response,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionForm.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionForm.tsx
@@ -79,6 +79,8 @@ const SubmissionForm: FC<Props> = (props) => {
   });
 
   const onFetchLiveFeedback = (answerId: number, questionId: number): void => {
+    const liveFeedbackId =
+      liveFeedbacks?.feedbackByQuestion?.[questionId].liveFeedbackId;
     const feedbackToken =
       liveFeedbacks?.feedbackByQuestion?.[questionId].pendingFeedbackToken;
     const questionIndex = questionIds.findIndex((id) => id === questionId) + 1;
@@ -93,6 +95,7 @@ const SubmissionForm: FC<Props> = (props) => {
         answerId,
         questionId,
         feedbackUrl: liveFeedbacks?.feedbackUrl,
+        liveFeedbackId,
         feedbackToken,
         successMessage,
         noFeedbackMessage,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/LiveFeedbackButton.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/LiveFeedbackButton.tsx
@@ -70,7 +70,7 @@ const LiveFeedbackButton: FC<Props> = (props) => {
     );
   };
 
-  // TODO: update logic pending #7418: allow [Get Help] on all programming questions
+  // TODO: update logic pending #7418: allow [Live feedback] on all programming questions
 
   return (
     <Button

--- a/client/app/bundles/course/assessment/submission/reducers/liveFeedback.js
+++ b/client/app/bundles/course/assessment/submission/reducers/liveFeedback.js
@@ -16,6 +16,7 @@ export default function (state = initialState, action) {
             isRequestingLiveFeedback: true,
             pendingFeedbackToken: null,
             answerId: null,
+            liveFeedbackId: null,
             feedbackFiles: {},
           };
         } else {
@@ -27,18 +28,20 @@ export default function (state = initialState, action) {
       });
     }
     case actions.LIVE_FEEDBACK_REQUEST: {
-      const { token, questionId, feedbackUrl } = action.payload;
+      const { token, questionId, liveFeedbackId, feedbackUrl } = action.payload;
       return produce(state, (draft) => {
         draft.feedbackUrl ??= feedbackUrl;
         if (!(questionId in draft)) {
           draft.feedbackByQuestion[questionId] = {
             isRequestingLiveFeedback: false,
+            liveFeedbackId,
             pendingFeedbackToken: token,
           };
         } else {
           draft.feedbackByQuestion[questionId] = {
             isRequestingLiveFeedback: false,
             ...draft.feedbackByQuestion[questionId],
+            liveFeedbackId,
             pendingFeedbackToken: token,
           };
         }

--- a/client/app/bundles/course/assessment/submission/types.ts
+++ b/client/app/bundles/course/assessment/submission/types.ts
@@ -65,6 +65,7 @@ interface LiveFeedback {
   pendingFeedbackToken: string | null;
   answerId: number;
   feedbackFiles: Record<string, FeedbackLine[]>;
+  liveFeedbackId: number;
 }
 
 export interface LiveFeedbackState {

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -1599,7 +1599,7 @@ const translations = defineMessages({
   },
   enableLiveFeedback: {
     id: 'course.assessment.question.programming.enableLiveFeedback',
-    defaultMessage: 'Allow get help generation',
+    defaultMessage: 'Allow live feedback generation',
   },
   enableLiveFeedbackDescription: {
     id: 'course.assessment.question.programming.enableLiveFeedbackDescription',
@@ -1613,7 +1613,7 @@ const translations = defineMessages({
   liveFeedbackCustomPromptDescription: {
     id: 'course.assessment.question.programming.liveFeedbackCustomPromptDescription',
     defaultMessage:
-      'Add instructions to guide the generation of get help here. If unsure, just leave this blank.',
+      'Add instructions to guide the generation of live feedback here. If unsure, just leave this blank.',
   },
   savingChanges: {
     id: 'course.assessment.question.programming.savingChanges',

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/course/StudentPerformanceTable.tsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/course/StudentPerformanceTable.tsx
@@ -1,10 +1,11 @@
 import { FC, useState } from 'react';
 import { defineMessages } from 'react-intl';
-import { Card, CardContent, Slider, Typography } from '@mui/material';
+import { Card, CardContent, Typography } from '@mui/material';
 
 import { CourseStudent, GroupManager } from 'course/statistics/types';
 import LinearProgressWithLabel from 'lib/components/core/LinearProgressWithLabel';
 import Link from 'lib/components/core/Link';
+import CustomSlider from 'lib/components/extensions/CustomSlider';
 import Table, { ColumnTemplate } from 'lib/components/table';
 import {
   DEFAULT_MINI_TABLE_ROWS_PER_PAGE,
@@ -365,7 +366,7 @@ const StudentPerformanceTable: FC<Props> = (props) => {
               : t(translations.correctness),
           })}
         </Typography>
-        <Slider
+        <CustomSlider
           aria-label="Highlight Percentage"
           className="flex flex-row align-right max-w-[500px] min-w-[300px] mb-2"
           defaultValue={highlightPercentage}

--- a/client/app/lib/components/core/fields/EditorField.tsx
+++ b/client/app/lib/components/core/fields/EditorField.tsx
@@ -11,6 +11,7 @@ interface EditorProps extends ComponentProps<typeof AceEditor> {
   value?: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
+  cursorStart?: number;
 }
 
 /**
@@ -31,7 +32,8 @@ const DEFAULT_FONT_FAMILY = [
 
 const EditorField = forwardRef(
   (props: EditorProps, ref: ForwardedRef<AceEditor>): JSX.Element => {
-    const { language, value, disabled, onChange, ...otherProps } = props;
+    const { language, value, disabled, onChange, cursorStart, ...otherProps } =
+      props;
 
     return (
       <AceEditor
@@ -49,6 +51,9 @@ const EditorField = forwardRef(
           $blockScrolling: true,
         }}
         onLoad={(editor) => {
+          if (cursorStart !== undefined) {
+            editor.getSession().getSelection().moveCursorTo(cursorStart, 0);
+          }
           if (language === 'python')
             editor.onPaste = (originalText, event: ClipboardEvent): void => {
               event.preventDefault();

--- a/client/app/lib/components/extensions/CustomSlider.tsx
+++ b/client/app/lib/components/extensions/CustomSlider.tsx
@@ -1,0 +1,25 @@
+import { Slider, SliderProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const CustomSlider = styled(Slider)<SliderProps>(({ theme }) => ({
+  height: 8,
+  '& .MuiSlider-mark': {
+    // Makes marks bigger
+    height: 6,
+    width: 6,
+    borderRadius: '50%', // Make the marks rounded
+    backgroundColor: '#555',
+  },
+  '& .MuiSlider-thumb': {
+    height: 20,
+    width: 20,
+  },
+  '& .MuiSlider-rail': {
+    height: 5,
+  },
+  '& .MuiSlider-track': {
+    height: 5,
+  },
+}));
+
+export default CustomSlider;

--- a/client/app/types/course/assessment/submission/liveFeedback.ts
+++ b/client/app/types/course/assessment/submission/liveFeedback.ts
@@ -1,0 +1,32 @@
+export interface LiveFeedbackComments {
+  lineNumber: number;
+  comment: string;
+}
+
+export interface LiveFeedbackCode {
+  id: number;
+  filename: string;
+  content: string;
+  language: string;
+}
+
+export interface LiveFeedbackCodeAndComments extends LiveFeedbackCode {
+  comments: LiveFeedbackComments[];
+}
+
+export interface LiveFeedbackHistory {
+  id: number;
+  createdAt: string;
+  files: LiveFeedbackCodeAndComments[];
+}
+
+export interface QuestionInfo {
+  id: number;
+  title: string;
+  description: string;
+}
+
+export interface LiveFeedbackHistoryState {
+  liveFeedbackHistory: LiveFeedbackHistory[];
+  question: QuestionInfo;
+}

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -146,4 +146,5 @@ export interface AssessmentLiveFeedbackStatistics {
   workflowState?: WorkflowState;
   liveFeedbackCount?: number[]; // Will already be ordered by question
   totalFeedbackCount?: number;
+  questionIds: number[];
 }

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -139,3 +139,11 @@ export interface QuestionAllAnswerDisplayDetails<
   submissionId: number;
   comments: CommentItem[];
 }
+
+export interface AssessmentLiveFeedbackStatistics {
+  courseUser: StudentInfo;
+  groups: { name: string }[];
+  workflowState?: WorkflowState;
+  liveFeedbackCount?: number[]; // Will already be ordered by question
+  totalFeedbackCount?: number;
+}

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -17,6 +17,7 @@ interface AssessmentInfo {
 interface MainAssessmentInfo extends AssessmentInfo {
   isAutograded: boolean;
   questionCount: number;
+  liveFeedbackEnabled: boolean;
 }
 
 interface AncestorAssessmentInfo extends AssessmentInfo {}

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -2435,6 +2435,93 @@
   "course.assessment.skills.SkillsTable.uncategorised": {
     "defaultMessage": "Uncategorised Skills"
   },
+  "course.assessment.liveFeedback.questionTitle": {
+    "defaultMessage": "Question {index}"
+  },
+  "course.assessment.liveFeedback.feedbackTimingTitle": {
+    "defaultMessage": "Used at: {usedAt}"
+  },
+  "course.assessment.liveFeedback.liveFeedbackName": {
+    "defaultMessage": "Live Feedback"
+  },
+  "course.assessment.liveFeedback.comments": {
+    "defaultMessage": "Comments"
+  },
+  "course.assessment.liveFeedback.lineHeader": {
+    "defaultMessage": "Line {lineNumber}"
+  },
+  "course.assessment.statistics.answers": {
+    "defaultMessage": "Answers"
+  },
+  "course.assessment.statistics.attempts.filename": {
+    "defaultMessage": "Question-level Attempt Statistics for {assessment}"
+  },
+  "course.assessment.statistics.attempts.greenCellLegend": {
+    "defaultMessage": "Correct"
+  },
+  "course.assessment.statistics.attempts.redCellLegend": {
+    "defaultMessage": "Incorrect"
+  },
+  "course.assessment.statistics.closePrompt": {
+    "defaultMessage": "Close"
+  },
+  "course.assessment.statistics.grader": {
+    "defaultMessage": "Grader"
+  },
+  "course.assessment.statistics.grayCellLegend": {
+    "defaultMessage": "Undecided (question is Non-autogradable)"
+  },
+  "course.assessment.statistics.group": {
+    "defaultMessage": "Group"
+  },
+  "course.assessment.statistics.legendHigherusage": {
+    "defaultMessage": "Higher Usage"
+  },
+  "course.assessment.statistics.legendLowerUsage": {
+    "defaultMessage": "Lower Usage"
+  },
+  "course.assessment.statistics.liveFeedback.filename": {
+    "defaultMessage": "Question-level Live Feedback Statistics for {assessment}"
+  },
+  "course.assessment.statistics.liveFeedbackHistoryPromptTitle": {
+    "defaultMessage": "Live Feedback History"
+  },
+  "course.assessment.statistics.marks.filename": {
+    "defaultMessage": "Question-level Marks Statistics for {assessment}"
+  },
+  "course.assessment.statistics.marks.greenCellLegend": {
+    "defaultMessage": ">= 0.5 * Maximum Grade"
+  },
+  "course.assessment.statistics.marks.redCellLegend": {
+    "defaultMessage": "< 0.5 * Maximum Grade"
+  },
+  "course.assessment.statistics.name": {
+    "defaultMessage": "Name"
+  },
+  "course.assessment.statistics.nameGroupsGraderSearchText": {
+    "defaultMessage": "Search by Student Name, Group or Grader Name"
+  },
+  "course.assessment.statistics.nameGroupsSearchText": {
+    "defaultMessage": "Search by Name or Groups"
+  },
+  "course.assessment.statistics.noSubmission": {
+    "defaultMessage": "No submission yet"
+  },
+  "course.assessment.statistics.onlyForAutogradableAssessment": {
+    "defaultMessage": "This table is only displayed for Assessment with at least one Autograded Questions"
+  },
+  "course.assessment.statistics.questionDisplayTitle": {
+    "defaultMessage": "Q{index} for {student}"
+  },
+  "course.assessment.statistics.questionIndex": {
+    "defaultMessage": "Q{index}"
+  },
+  "course.assessment.statistics.total": {
+    "defaultMessage": "Total"
+  },
+  "course.assessment.statistics.workflowState": {
+    "defaultMessage": "Status"
+  },
   "course.assessment.statistics.ancestorFail": {
     "defaultMessage": "Failed to fetch past iterations of this assessment."
   },

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -522,10 +522,10 @@
     "defaultMessage": "Codaveri Evaluator"
   },
   "course.admin.CodaveriSettings.liveFeedbackSettings": {
-    "defaultMessage": "Get Help"
+    "defaultMessage": "Live Feedback"
   },
   "course.admin.CodaveriSettings.errorOccurredWhenUpdatingLiveFeedbackSettings": {
-    "defaultMessage": "An error occurred while updating the get help settings."
+    "defaultMessage": "An error occurred while updating the live feedback settings."
   },
   "course.admin.CodaveriSettings.enableDisableButton": {
     "defaultMessage": "{enabled, select, true {Enable} other {Disable}}"
@@ -534,16 +534,16 @@
     "defaultMessage": "{enabled, select, true {Enable } other {Disable }} Codaveri Evaluator for {questionCount} programming questions in {title}?"
   },
   "course.admin.CodaveriSettings.enableDisableLiveFeedback": {
-    "defaultMessage": "{enabled, select, true {Enable } other {Disable }} Get Help for {questionCount} programming questions in {title}?"
+    "defaultMessage": "{enabled, select, true {Enable } other {Disable }} Live feedback for {questionCount} programming questions in {title}?"
   },
   "course.admin.CodaveriSettings.enableDisableEvaluatorDescription": {
     "defaultMessage": "{questionCount} programming questions in this {type} will use {enabled, select, true {Codaveri } other {Default }} evaluator"
   },
   "course.admin.CodaveriSettings.liveFeedbackEnabledUpdateSuccess": {
-    "defaultMessage": "Get Help for {question} is now {liveFeedbackEnabled, select, true {enabled} other {disabled}}"
+    "defaultMessage": "Live feedback for {question} is now {liveFeedbackEnabled, select, true {enabled} other {disabled}}"
   },
   "course.admin.CodaveriSettings.successfulUpdateAllLiveFeedbackEnabled": {
-    "defaultMessage": "Sucessfully {liveFeedbackEnabled, select, true {enabled} other {disabled}} get help for all questions"
+    "defaultMessage": "Sucessfully {liveFeedbackEnabled, select, true {enabled} other {disabled}} live feedback for all questions"
   },
   "course.admin.CommentsSettings.commentsSettings": {
     "defaultMessage": "Comments settings"
@@ -1326,10 +1326,10 @@
     "defaultMessage": "Visibility"
   },
   "course.assessment.AssessmentForm.toggleLiveFeedbackDescription": {
-    "defaultMessage": "{enabled, select, true {Enable} other {Disable}} Get Help feature for all programming questions"
+    "defaultMessage": "{enabled, select, true {Enable} other {Disable}} live feedback feature for all programming questions"
   },
   "course.assessment.AssessmentForm.noProgrammingQuestion": {
-    "defaultMessage": "You need to add at least one programming question that can be supported by Codaveri to allow enabling Get Help for this Assessment"
+    "defaultMessage": "You need to add at least one programming question that can be supported by Codaveri to allow enabling live feedback for this Assessment"
   },
   "course.assessment.FileManager.addFiles": {
     "defaultMessage": "Add Files"
@@ -1698,7 +1698,7 @@
     "defaultMessage": "Do everything right here in this page. Useful for quick edits (especially exams) or collaborating with other instructors."
   },
   "course.assessment.question.programming.enableLiveFeedback": {
-    "defaultMessage": "Allow get help generation"
+    "defaultMessage": "Allow live feedback generation"
   },
   "course.assessment.question.programming.enableLiveFeedbackDescription": {
     "defaultMessage": "Allow students to request live programming help during submission attempts. (AI-generated feedback may not always be accurate.)"
@@ -1782,7 +1782,7 @@
     "defaultMessage": "Custom Prompt"
   },
   "course.assessment.question.programming.liveFeedbackCustomPromptDescription": {
-    "defaultMessage": "Add instructions to guide the generation of get help here. If unsure, just leave this blank."
+    "defaultMessage": "Add instructions to guide the generation of live feedback here. If unsure, just leave this blank."
   },
   "course.assessment.question.programming.lowestGradingPriority": {
     "defaultMessage": "Lowest grading priority"

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -2384,6 +2384,96 @@
   "course.assessment.skills.SkillsTable.uncategorised": {
     "defaultMessage": "未分类技能"
   },
+  "course.assessment.liveFeedback.questionTitle": {
+    "defaultMessage": "题目 {index}"
+  },
+  "course.assessment.liveFeedback.feedbackTimingTitle": {
+    "defaultMessage": "使用时间：{usedAt}"
+  },
+  "course.assessment.liveFeedback.liveFeedbackName": {
+    "defaultMessage": "实时反馈"
+  },
+  "course.assessment.liveFeedback.comments": {
+    "defaultMessage": "评论"
+  },
+  "course.assessment.liveFeedback.lineHeader": {
+    "defaultMessage": "第 {lineNumber} 行"
+  },
+  "course.assessment.statistics.answers": {
+    "defaultMessage": "答案"
+  },
+  "course.assessment.statistics.attempts.filename": {
+    "defaultMessage": "{assessment} 的题目尝试统计"
+  },
+  "course.assessment.statistics.attempts.greenCellLegend": {
+    "defaultMessage": "正确"
+  },
+  "course.assessment.statistics.attempts.redCellLegend": {
+    "defaultMessage": "错误"
+  },
+  "course.assessment.statistics.closePrompt": {
+    "defaultMessage": "关闭"
+  },
+  "course.assessment.statistics.grader": {
+    "defaultMessage": "评分者"
+  },
+  "course.assessment.statistics.grayCellLegend": {
+    "defaultMessage": "未决定 (问题无法自动评分)"
+  },
+  "course.assessment.statistics.group": {
+    "defaultMessage": "组别"
+  },
+  "course.assessment.statistics.legendHigherusage": {
+    "defaultMessage": "使用较多"
+  },
+  "course.assessment.statistics.legendLowerUsage": {
+    "defaultMessage": "使用较少"
+  },
+  "course.assessment.statistics.liveFeedback.filename": {
+    "defaultMessage": "{assessment} 的题目实时反馈统计"
+  },
+  "course.assessment.statistics.liveFeedbackHistoryPromptTitle": {
+    "defaultMessage": "实时反馈历史"
+  },
+  "course.assessment.statistics.marks.filename": {
+    "defaultMessage": "{assessment} 的题目分数统计"
+  },
+  "course.assessment.statistics.marks.greenCellLegend": {
+    "defaultMessage": ">= 0.5 * 最高分"
+  },
+  "course.assessment.statistics.marks.redCellLegend": {
+    "defaultMessage": "< 0.5 * 最高分"
+  },
+  "course.assessment.statistics.name": {
+    "defaultMessage": "姓名"
+  },
+  "course.assessment.statistics.nameGroupsGraderSearchText": {
+    "defaultMessage": "按学生姓名、组别或评分者姓名搜索"
+  },
+  "course.assessment.statistics.nameGroupsSearchText": {
+    "defaultMessage": "按姓名或组别搜索"
+  },
+  "course.assessment.statistics.noSubmission": {
+    "defaultMessage": "尚未提交"
+  },
+  "course.assessment.statistics.onlyForAutogradableAssessment": {
+    "defaultMessage": "此表仅适用于包含至少一个自动评分问题的评估"
+  },
+  "course.assessment.statistics.questionDisplayTitle": {
+    "defaultMessage": "{student} 的题目 {index}"
+  },
+  "course.assessment.statistics.questionIndex": {
+    "defaultMessage": "题目 {index}"
+  },
+  "course.assessment.statistics.totalFeedbackCount": {
+    "defaultMessage": "总计"
+  },
+  "course.assessment.statistics.totalGrade": {
+    "defaultMessage": "总分"
+  },
+  "course.assessment.statistics.workflowState": {
+    "defaultMessage": "状态"
+  },
   "course.assessment.statistics.ancestorFail": {
     "defaultMessage": "无法获取此测试的过去结果。"
   },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -437,8 +437,6 @@ Rails.application.routes.draw do
       namespace :statistics do
         get '/' => 'statistics#index'
         get 'answer/:id' => 'answers#question_answer_details'
-        get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
-        get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
         get 'assessments' => 'aggregate#all_assessments'
         get 'students' => 'aggregate#all_students'
         get 'staff' => 'aggregate#all_staff'
@@ -446,6 +444,9 @@ Rails.application.routes.draw do
         get 'course/performance' => 'aggregate#course_performance'
         get 'submission_question/:id' => 'answers#all_answers'
         get 'user/:user_id/learning_rate_records' => 'users#learning_rate_records'
+        get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
+        get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
+        get 'assessment/:id/live_feedback_statistics' => 'assessments#live_feedback_statistics'
       end
 
       scope module: :video do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -448,6 +448,7 @@ Rails.application.routes.draw do
         get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
         get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
         get 'assessment/:id/live_feedback_statistics' => 'assessments#live_feedback_statistics'
+        get 'assessment/:id/live_feedback_history' => 'assessments#live_feedback_history'
       end
 
       scope module: :video do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ Rails.application.routes.draw do
               post :generate_feedback, on: :member
               get :fetch_submitted_feedback, on: :member
               post :generate_live_feedback, on: :member
+              post 'save_live_feedback', to: 'live_feedback#save_live_feedback', on: :collection
               get :download_all, on: :collection
               get :download_statistics, on: :collection
               patch :publish_all, on: :collection

--- a/db/migrate/20240808083848_add_live_feedback_code_and_comments.rb
+++ b/db/migrate/20240808083848_add_live_feedback_code_and_comments.rb
@@ -1,0 +1,23 @@
+class AddLiveFeedbackCodeAndComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :course_assessment_live_feedbacks do |t|
+      t.references :assessment, null: false, index: true, foreign_key: { to_table: :course_assessments }
+      t.references :question, null: false, index: true, foreign_key: { to_table: :course_assessment_questions }
+      t.references :creator, null: false, index: true, foreign_key: { to_table: :users }
+      t.datetime :created_at, null: false
+      t.string :feedback_id
+    end
+
+    create_table :course_assessment_live_feedback_code do |t|
+      t.references :feedback, null: false, index: true, foreign_key: { to_table: :course_assessment_live_feedbacks }
+      t.string :filename, null: false
+      t.text :content, null: false
+    end
+
+    create_table :course_assessment_live_feedback_comments do |t|
+      t.references :code, null: false, index: true, foreign_key: { to_table: :course_assessment_live_feedback_code }
+      t.integer :line_number, null: false
+      t.text :comment, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -221,6 +221,31 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_17_170847) do
     t.index ["updater_id"], name: "fk__course_assessment_categories_updater_id"
   end
 
+  create_table "course_assessment_live_feedback_code", force: :cascade do |t|
+    t.bigint "feedback_id", null: false
+    t.string "filename", null: false
+    t.text "content", null: false
+    t.index ["feedback_id"], name: "index_course_assessment_live_feedback_code_on_feedback_id"
+  end
+
+  create_table "course_assessment_live_feedback_comments", force: :cascade do |t|
+    t.bigint "code_id", null: false
+    t.integer "line_number", null: false
+    t.text "comment", null: false
+    t.index ["code_id"], name: "index_course_assessment_live_feedback_comments_on_code_id"
+  end
+
+  create_table "course_assessment_live_feedbacks", force: :cascade do |t|
+    t.bigint "assessment_id", null: false
+    t.bigint "question_id", null: false
+    t.bigint "creator_id", null: false
+    t.datetime "created_at", null: false
+    t.string "feedback_id"
+    t.index ["assessment_id"], name: "index_course_assessment_live_feedbacks_on_assessment_id"
+    t.index ["creator_id"], name: "index_course_assessment_live_feedbacks_on_creator_id"
+    t.index ["question_id"], name: "index_course_assessment_live_feedbacks_on_question_id"
+  end
+
   create_table "course_assessment_question_bundle_assignments", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "assessment_id", null: false
@@ -1491,6 +1516,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_17_170847) do
   add_foreign_key "course_assessment_categories", "courses", name: "fk_course_assessment_categories_course_id"
   add_foreign_key "course_assessment_categories", "users", column: "creator_id", name: "fk_course_assessment_categories_creator_id"
   add_foreign_key "course_assessment_categories", "users", column: "updater_id", name: "fk_course_assessment_categories_updater_id"
+  add_foreign_key "course_assessment_live_feedback_code", "course_assessment_live_feedbacks", column: "feedback_id"
+  add_foreign_key "course_assessment_live_feedback_comments", "course_assessment_live_feedback_code", column: "code_id"
+  add_foreign_key "course_assessment_live_feedbacks", "course_assessment_questions", column: "question_id"
+  add_foreign_key "course_assessment_live_feedbacks", "course_assessments", column: "assessment_id"
+  add_foreign_key "course_assessment_live_feedbacks", "users", column: "creator_id"
   add_foreign_key "course_assessment_question_bundle_assignments", "course_assessment_question_bundles", column: "bundle_id"
   add_foreign_key "course_assessment_question_bundle_assignments", "course_assessment_submissions", column: "submission_id"
   add_foreign_key "course_assessment_question_bundle_assignments", "course_assessments", column: "assessment_id"

--- a/spec/controllers/course/admin/codaveri_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/codaveri_settings_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Course::Admin::CodaveriSettingsController, type: :controller do
     end
 
     describe '#update_live_feedback_enabled' do
-      context 'when the get help is enabled for all assessments within course' do
+      context 'when the live feedback is enabled for all assessments within course' do
         subject do
           patch :update_live_feedback_enabled, params: {
             course_id: course2,
@@ -65,7 +65,7 @@ RSpec.describe Course::Admin::CodaveriSettingsController, type: :controller do
           }
         end
 
-        it 'will activate get help for all questions within those assessments' do
+        it 'will activate live feedback for all questions within those assessments' do
           subject
 
           question1 = course2.assessments.first.questions.first

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -200,8 +200,8 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
         }
       end
 
-      context 'when codaveri evaluator is disabled and get help is enabled' do
-        it 'will have codaveri evaluator turned off and get help turned on' do
+      context 'when codaveri evaluator is disabled and live feedback is enabled' do
+        it 'will have codaveri evaluator turned off and live feedback turned on' do
           subject
           expect(programming_question.reload.live_feedback_enabled).to be_truthy
           expect(programming_question.reload.is_codaveri).to be_falsey

--- a/spec/factories/course_assessment_assessments.rb
+++ b/spec/factories/course_assessment_assessments.rb
@@ -2,6 +2,7 @@
 FactoryBot.define do
   sequence(:course_assessment_assessment_name) { |n| "Assessment #{n}" }
   sequence(:course_assessment_assessment_description) { |n| "Awesome description #{n}" }
+  sequence(:question_weight)
   factory :course_assessment_assessment, class: Course::Assessment, aliases: [:assessment],
                                          parent: :course_lesson_plan_item do
     transient do
@@ -44,74 +45,74 @@ FactoryBot.define do
 
     trait :with_mcq_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_multiple_response, :multiple_choice)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end
 
     trait :with_mrq_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_multiple_response)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end
 
     trait :with_programming_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_programming, :auto_gradable, template_package: true)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end
 
     trait :with_programming_codaveri_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_programming, :auto_gradable, template_package: true,
                                                                                     is_codaveri: true)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end
 
     trait :with_programming_file_submission_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_programming,
                            :auto_gradable, :multiple_file_submission)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end
 
     trait :with_text_response_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_text_response, :allow_multiple_attachments)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end
 
     trait :with_file_upload_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_text_response, :file_upload_question)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end
 
     trait :with_forum_post_response_question do
       after(:build) do |assessment, evaluator|
-        evaluator.question_count.downto(1).each do |i|
+        evaluator.question_count.times do
           question = build(:course_assessment_question_forum_post_response)
-          assessment.question_assessments.build(question: question.acting_as, weight: i)
+          assessment.question_assessments.build(question: question.acting_as, weight: generate(:question_weight))
         end
       end
     end

--- a/spec/factories/course_assessment_live_feedback_code.rb
+++ b/spec/factories/course_assessment_live_feedback_code.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_live_feedback_code, class: Course::Assessment::LiveFeedbackCode do
+    feedback { association(:course_assessment_live_feedback) }
+    filename { 'test_code.rb' }
+    content { 'puts "Hello, World!"' }
+  end
+end

--- a/spec/factories/course_assessment_live_feedback_code.rb
+++ b/spec/factories/course_assessment_live_feedback_code.rb
@@ -4,5 +4,13 @@ FactoryBot.define do
     feedback { association(:course_assessment_live_feedback) }
     filename { 'test_code.rb' }
     content { 'puts "Hello, World!"' }
+
+    transient do
+      with_comment { false }
+    end
+
+    after(:create) do |live_feedback_code, evaluator|
+      create(:course_assessment_live_feedback_comment, code: live_feedback_code) if evaluator.with_comment
+    end
   end
 end

--- a/spec/factories/course_assessment_live_feedback_comments.rb
+++ b/spec/factories/course_assessment_live_feedback_comments.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_live_feedback_comment, class: Course::Assessment::LiveFeedbackComment do
+    code { association(:course_assessment_live_feedback_code) }
+    line_number { 1 }
+    comment { 'This is a test comment' }
+  end
+end

--- a/spec/factories/course_assessment_live_feedbacks.rb
+++ b/spec/factories/course_assessment_live_feedbacks.rb
@@ -2,7 +2,14 @@
 FactoryBot.define do
   factory :course_assessment_live_feedback, class: Course::Assessment::LiveFeedback do
     assessment
-    question { association(:course_assessment_question_programming, assessment: assessment) }
-    creator { association(:course_user, course: assessment.course) }
+    question { association(:course_assessment_question, assessment: assessment) }
+
+    transient do
+      with_comment { false }
+    end
+
+    after(:create) do |live_feedback, evaluator|
+      create(:course_assessment_live_feedback_code, feedback: live_feedback, with_comment: evaluator.with_comment)
+    end
   end
 end

--- a/spec/factories/course_assessment_live_feedbacks.rb
+++ b/spec/factories/course_assessment_live_feedbacks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_live_feedback, class: Course::Assessment::LiveFeedback do
+    assessment
+    question { association(:course_assessment_question_programming, assessment: assessment) }
+    creator { association(:course_user, course: assessment.course) }
+  end
+end

--- a/spec/models/course/assessment/live_feedback_spec.rb
+++ b/spec/models/course/assessment/live_feedback_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::LiveFeedback do
+  # Associations
+  it { is_expected.to belong_to(:assessment).class_name('Course::Assessment').inverse_of(:live_feedbacks).required }
+  it {
+    is_expected.to belong_to(:question).class_name('Course::Assessment::Question').inverse_of(:live_feedbacks).required
+  }
+  it {
+    is_expected.to have_many(:code).
+      class_name('Course::Assessment::LiveFeedbackCode').
+      inverse_of(:feedback).
+      dependent(:destroy)
+  }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:assessment) { create(:assessment) }
+    let(:question) { create(:course_assessment_question_programming, assessment: assessment) }
+    let(:user) { create(:course_user, course: assessment.course).user }
+    let(:files) do
+      [
+        Struct.new(:filename, :content).new('test1.rb', 'Hello World'),
+        Struct.new(:filename, :content).new('test2.rb', 'Goodbye World')
+      ]
+    end
+
+    describe '.create_with_codes' do
+      context 'when the live feedback is successfully created' do
+        it 'creates a live feedback with associated codes' do
+          feedback = Course::Assessment::LiveFeedback.create_with_codes(
+            assessment.id, question.id, user, nil, files
+          )
+
+          expect(feedback).to be_persisted
+          expect(feedback.code.size).to eq(files.size)
+          expect(feedback.code.map(&:filename)).to match_array(files.map(&:filename))
+          expect(feedback.code.map(&:content)).to match_array(files.map(&:content))
+        end
+      end
+
+      context 'when the live feedback fails to save' do
+        it 'returns nil and logs an error' do
+          allow_any_instance_of(Course::Assessment::LiveFeedback).to receive(:save).and_return(false)
+
+          expect(Rails.logger).to receive(:error).with(/Failed to save live_feedback/)
+          feedback = Course::Assessment::LiveFeedback.create_with_codes(
+            assessment.id, question.id, user, nil, files
+          )
+
+          expect(feedback).to be_nil
+        end
+      end
+
+      context 'when a live feedback code fails to save' do
+        it 'logs an error and continues to create the live feedback' do
+          allow_any_instance_of(Course::Assessment::LiveFeedbackCode).to receive(:save).and_return(false)
+
+          expect(Rails.logger).to receive(:error).with(/Failed to save live_feedback_code/).twice
+          feedback = Course::Assessment::LiveFeedback.create_with_codes(
+            assessment.id, question.id, user, nil, files
+          )
+
+          expect(feedback).to be_persisted
+          expect(feedback.code.size).to eq(0) # No codes should be saved
+        end
+      end
+    end
+  end
+end

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -299,19 +299,19 @@ RSpec.describe Course::Assessment::Question::Programming do
         let(:language) { Coursemology::Polyglot::Language::Python::Python2Point7.instance }
         it 'returns correct validation' do
           expect(subject_evaluator).to_not be_valid
-          expect(subject_evaluator.errors.messages[:base]).to include('Language type must be Python 3 and above '\
-                                                                      'to activate either codaveri '\
-                                                                      'evaluator or get help')
+          expect(subject_evaluator.errors.messages[:base]).to include('Language type must be Python 3 and above ' \
+                                                                      'to activate either codaveri ' \
+                                                                      'evaluator or live feedback')
         end
       end
 
-      context 'when the language chosen is not whitelisted for get help' do
+      context 'when the language chosen is not whitelisted for live feedback' do
         let(:language) { Coursemology::Polyglot::Language::Python::Python2Point7.instance }
         it 'returns correct validation' do
           expect(subject_feedback).to_not be_valid
-          expect(subject_feedback.errors.messages[:base]).to include('Language type must be Python 3 and above '\
-                                                                     'to activate either codaveri '\
-                                                                     'evaluator or get help')
+          expect(subject_feedback.errors.messages[:base]).to include('Language type must be Python 3 and above ' \
+                                                                     'to activate either codaveri ' \
+                                                                     'evaluator or live feedback')
         end
       end
 
@@ -321,8 +321,8 @@ RSpec.describe Course::Assessment::Question::Programming do
         it 'returns correct validation' do
           skip
           expect(subject).to_not be_valid
-          expect(subject.errors.messages[:base]).to include('Codaveri component is deactivated.'\
-                                                            'Activate it in the course setting or '\
+          expect(subject.errors.messages[:base]).to include('Codaveri component is deactivated.' \
+                                                            'Activate it in the course setting or ' \
                                                             'switch this question into a non-codaveri type.')
         end
       end


### PR DESCRIPTION
Add support for saving live feedback and displaying it in the assessment statistics page.

## Workflow for saving:
1. GetHelp used, FE sends request to BE.
2. New entry in `course_assessment_live_feedbacks` is created and current code states (`course_assessment_live_feedback_code`) are saved
3. BE requests for live feedback
    1. If feedback is returned:
        1. Save feedback (`course_assessment_live_feedback_comments`)
        2. Send feedback to FE
    2. If token is returned:
        1. Send token to FE
        2. FE polls for feedback
        4. FE sends feedback to BE to be saved (`course_assessment_live_feedback_comments`)

## Schema Changes: Added 3 new tables
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/ed794e90-7ac5-4dd1-a307-60aee34dc150">

`feedback_id` under the `course_assessments_live_feedbacks` table corresponds to the `transaction_id` provided by codaveri. This is to ensure traceability.

The schema is separated as such so that each feedback request can accomadate multiple different code files, and each code file can have multiple comments.


## New Live Feedback statistics page:
<img width="1266" alt="Screenshot 2024-09-30 at 2 26 29 PM" src="https://github.com/user-attachments/assets/930084f9-cb93-4bee-a287-77bb3866743e">



- Table is sorted by descending total
- Individual questions are colour coded


## New Live Feedback History Dialog
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/a6efe63e-5570-4dea-b4d6-25e2716637ac">


## Other Notes:
This PR also standardises the terminology surrounding the live feedback function.
- From now on we will only use 2 terms, "Get Help" and "Live Feedback"
- "Get Help" will be an active, user facing term, which will be used for buttons and their corresponding translations.
- "Live Feedback" will be the technical term, used for describing the feature to course managers etc., and will also be the term used in the codebase when referring to this feature
