### PR TITLE
Disable Group Leaderboard immediately after Disabling it from Admin Settings

### DIFF
--- a/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
+++ b/client/app/bundles/course/leaderboard/pages/LeaderboardIndex/index.tsx
@@ -75,7 +75,9 @@ const LeaderboardIndex: FC<Props> = (props) => {
   }, [dispatch]);
 
   const isAchievementHidden = leaderboardAchievements.length === 0;
-  const isGroupHidden = groupLeaderboardPoints.length === 0;
+  const isGroupHidden =
+    settings.groupleaderboardTitle === undefined ||
+    groupLeaderboardPoints.length === 0;
 
   return (
     <Page


### PR DESCRIPTION
Resolves issue https://github.com/Coursemology/coursemology2/issues/7430

## Background

Previously, when admin was disabling the group leaderboard settings from the admin panel (inside Course Settings), others need to refresh the page (basically rehydrating the redux store) in order for the disabling to take place. If not, then after it's disabled, upon navigating towards Leaderboard page through sidebar, the disabling won't take place and the group leaderboard can still be seen.