### PR TITLE
Show the grades in Assessment Statistics (Marks per Question, Attempt Count) for Graded state

### DIFF
--- a/app/views/course/statistics/assessments/main_statistics.json.jbuilder
+++ b/app/views/course/statistics/assessments/main_statistics.json.jbuilder
@@ -13,7 +13,7 @@ json.submissions @student_submissions_hash.each do |course_user, (submission, an
     json.name name
   end
 
-  if !submission.nil? && submission.workflow_state == 'published' && submission.grader_ids
+  if !submission.nil? && (submission.graded? || submission.published?) && submission.grader_ids
     # the graders are all the same regardless of question, so we just pick the first one
     json.partial! 'answer', grader: @course_users_hash[submission.grader_ids.first], answers: answers
     json.partial! 'attempt_status', answers: answers

--- a/spec/controllers/course/statistics/assessment_controller_spec.rb
+++ b/spec/controllers/course/statistics/assessment_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Course::Statistics::AssessmentsController, type: :controller do
 
     let(:assessment) { course.assessments.first }
 
-    let(:students) { create_list(:course_student, 3, course: course) }
+    let(:students) { create_list(:course_student, 4, course: course) }
     let(:teaching_assistant) { create(:course_teaching_assistant, course: course) }
 
     let!(:submission1) do
@@ -26,6 +26,10 @@ RSpec.describe Course::Statistics::AssessmentsController, type: :controller do
     let!(:submission2) do
       create(:submission, :attempting,
              assessment: assessment, course: course, creator: students[1].user)
+    end
+    let!(:submission3) do
+      create(:submission, :graded,
+             assessment: assessment, course: course, creator: students[2].user)
     end
     let!(:submission_teaching_assistant) do
       create(:submission, :published,
@@ -57,22 +61,25 @@ RSpec.describe Course::Statistics::AssessmentsController, type: :controller do
           json_result = JSON.parse(response.body)
 
           # all the students data will be included here, including the non-existing submission one
-          expect(json_result['submissions'].count).to eq(3)
+          expect(json_result['submissions'].count).to eq(4)
 
           # showing the correct workflow state
           expect(json_result['submissions'][0]['workflowState']).to eq('published')
           expect(json_result['submissions'][1]['workflowState']).to eq('attempting')
-          expect(json_result['submissions'][2]['workflowState']).to eq('unstarted')
+          expect(json_result['submissions'][2]['workflowState']).to eq('graded')
+          expect(json_result['submissions'][3]['workflowState']).to eq('unstarted')
 
-          # only published submissions' answers will be included in the stats
+          # only graded and published submissions' answers will be included in the stats
           expect(json_result['submissions'][0]['answers']).not_to be_nil
           expect(json_result['submissions'][1]['answers']).to be_nil
-          expect(json_result['submissions'][2]['answers']).to be_nil
+          expect(json_result['submissions'][2]['answers']).not_to be_nil
+          expect(json_result['submissions'][3]['answers']).to be_nil
 
-          # only published submissions' answers will be included in the stats
+          # only graded and published submissions' answers will be included in the stats
           expect(json_result['submissions'][0]['courseUser']['role']).to eq('student')
           expect(json_result['submissions'][1]['courseUser']['role']).to eq('student')
           expect(json_result['submissions'][2]['courseUser']['role']).to eq('student')
+          expect(json_result['submissions'][3]['courseUser']['role']).to eq('student')
 
           # only 1 ancestor will be returned (current) as no permission for ancestor assessment
           expect(json_result['ancestors'].count).to eq(1)
@@ -88,22 +95,25 @@ RSpec.describe Course::Statistics::AssessmentsController, type: :controller do
           json_result = JSON.parse(response.body)
 
           # all the students data will be included here, including the non-existing submission one
-          expect(json_result['submissions'].count).to eq(3)
+          expect(json_result['submissions'].count).to eq(4)
 
           # showing the correct workflow state
           expect(json_result['submissions'][0]['workflowState']).to eq('published')
           expect(json_result['submissions'][1]['workflowState']).to eq('attempting')
-          expect(json_result['submissions'][2]['workflowState']).to eq('unstarted')
+          expect(json_result['submissions'][2]['workflowState']).to eq('graded')
+          expect(json_result['submissions'][3]['workflowState']).to eq('unstarted')
 
-          # only published submissions' answers will be included in the stats
+          # only graded and published submissions' answers will be included in the stats
           expect(json_result['submissions'][0]['answers']).not_to be_nil
           expect(json_result['submissions'][1]['answers']).to be_nil
-          expect(json_result['submissions'][2]['answers']).to be_nil
+          expect(json_result['submissions'][2]['answers']).not_to be_nil
+          expect(json_result['submissions'][3]['answers']).to be_nil
 
-          # only published submissions' answers will be included in the stats
+          # only graded and published submissions' answers will be included in the stats
           expect(json_result['submissions'][0]['courseUser']['role']).to eq('student')
           expect(json_result['submissions'][1]['courseUser']['role']).to eq('student')
           expect(json_result['submissions'][2]['courseUser']['role']).to eq('student')
+          expect(json_result['submissions'][3]['courseUser']['role']).to eq('student')
 
           expect(json_result['ancestors'].count).to eq(2)
         end


### PR DESCRIPTION
## Background

Previously, the requirement is that only when the submission has been Published that we will show the grades in the Marks per Question and Attempt Count tables. Now, the requirement has been expanded to also show the grades in those table for the submission that has been Graded (including those that is Delayed Grade -> still unpublished)

<img width="888" alt="Screenshot 2024-08-22 at 10 35 45 AM" src="https://github.com/user-attachments/assets/8077869b-0f75-4f81-88ad-06539f63868c">
