### PR TITLE
yupei/add live feedback history

### DIFF
--- a/app/controllers/concerns/course/statistics/submissions_concern.rb
+++ b/app/controllers/concerns/course/statistics/submissions_concern.rb
@@ -25,23 +25,14 @@ module Course::Statistics::SubmissionsConcern
   def answer_statistics_hash
     submission_answer_statistics = Course::Assessment::Answer.find_by_sql(<<-SQL.squish
       WITH
-        attempt_count AS (
-          SELECT
-            caa.question_id,
-            caa.submission_id,
-            COUNT(*) AS attempt_count
-          FROM course_assessment_answers caa
-          JOIN course_assessment_submissions cas ON caa.submission_id = cas.id
-          WHERE cas.assessment_id = #{assessment_params[:id]}
-          GROUP BY caa.question_id, caa.submission_id
-        ),
         attempt_info AS (
           SELECT
             caa_ranked.question_id,
             caa_ranked.submission_id,
-            jsonb_agg(jsonb_build_array(caa_ranked.grade, caa_ranked.correct, caa_ranked.workflow_state)) AS submission_info
+            jsonb_agg(jsonb_build_array(caa_ranked.id, caa_ranked.grade, caa_ranked.correct, caa_ranked.workflow_state)) AS submission_info
           FROM (
             SELECT
+              caa_inner.id,
               caa_inner.question_id,
               caa_inner.submission_id,
               caa_inner.correct,
@@ -57,19 +48,33 @@ module Course::Statistics::SubmissionsConcern
           ) AS caa_ranked
           WHERE caa_ranked.row_num <= 2
           GROUP BY caa_ranked.question_id, caa_ranked.submission_id
+        ),
+
+        attempt_count AS (
+          SELECT
+            caa.question_id,
+            caa.submission_id,
+            COUNT(*) AS attempt_count
+          FROM course_assessment_answers caa
+          JOIN course_assessment_submissions cas ON caa.submission_id = cas.id
+          WHERE cas.assessment_id = #{assessment_params[:id]} AND caa.workflow_state != 'attempting'
+          GROUP BY caa.question_id, caa.submission_id
         )
       SELECT
-        attempt_count.question_id,
-        attempt_count.submission_id,
-        attempt_count.attempt_count,
-        CASE WHEN jsonb_array_length(attempt_info.submission_info) = 1 OR attempt_info.submission_info->0->>2 != 'attempting'
+        CASE WHEN jsonb_array_length(attempt_info.submission_info) = 1 OR attempt_info.submission_info->0->>3 != 'attempting'
             THEN attempt_info.submission_info->0->>0 ELSE attempt_info.submission_info->1->>0
-        END AS grade,
-        CASE WHEN jsonb_array_length(attempt_info.submission_info) = 1 OR attempt_info.submission_info->0->>2 != 'attempting'
+        END AS last_attempt_answer_id,
+        attempt_info.question_id,
+        attempt_info.submission_id,
+        attempt_count.attempt_count,
+        CASE WHEN jsonb_array_length(attempt_info.submission_info) = 1 OR attempt_info.submission_info->0->>3 != 'attempting'
             THEN attempt_info.submission_info->0->>1 ELSE attempt_info.submission_info->1->>1
+        END AS grade,
+        CASE WHEN jsonb_array_length(attempt_info.submission_info) = 1 OR attempt_info.submission_info->0->>3 != 'attempting'
+            THEN attempt_info.submission_info->0->>2 ELSE attempt_info.submission_info->1->>2
         END AS correct
-      FROM attempt_count
-      JOIN attempt_info
+      FROM attempt_info
+      LEFT JOIN attempt_count
       ON attempt_count.question_id = attempt_info.question_id AND attempt_count.submission_id = attempt_info.submission_id
     SQL
                                                                          )

--- a/app/controllers/course/statistics/answers_controller.rb
+++ b/app/controllers/course/statistics/answers_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+class Course::Statistics::AnswersController < Course::Statistics::Controller
+  helper Course::Assessment::Submission::SubmissionsHelper.name.sub(/Helper$/, '')
+
+  MAX_ANSWERS_COUNT = 10
+
+  def question_answer_details
+    @answer = Course::Assessment::Answer.find(answer_params[:id])
+    @submission = @answer.submission
+    @assessment = @submission.assessment
+
+    @submission_question = Course::Assessment::SubmissionQuestion.
+                           where(submission_id: @answer.submission_id, question_id: @answer.question_id).
+                           includes({ discussion_topic: :posts }).first
+
+    @all_answers = fetch_all_answers(@answer.submission_id, @answer.question_id)
+  end
+
+  def all_answers
+    @submission_question = Course::Assessment::SubmissionQuestion.find(submission_question_params[:id])
+    question_id = @submission_question.question_id
+    submission_id = @submission_question.submission_id
+
+    @question = Course::Assessment::Question.find(question_id)
+    @submission = Course::Assessment::Submission.find(submission_id)
+    @assessment = @submission.assessment
+
+    @submission_question = Course::Assessment::SubmissionQuestion.
+                           where(submission_id: submission_id, question_id: question_id).
+                           includes({ discussion_topic: :posts }).first
+    @question_index = question_index(question_id)
+    @all_answers = Course::Assessment::Answer.
+                   unscope(:order).
+                   order(:created_at).
+                   where(submission_id: submission_id, question_id: question_id)
+  end
+
+  private
+
+  def answer_params
+    params.permit(:id)
+  end
+
+  def submission_question_params
+    params.permit(:id)
+  end
+
+  def question_index(question_id)
+    question_ids = Course::QuestionAssessment.
+                   where(assessment_id: @assessment.id).
+                   order(:weight).
+                   pluck(:question_id)
+
+    question_ids.index(question_id)
+  end
+
+  def fetch_all_answers(submission_id, question_id)
+    answers = Course::Assessment::Answer.
+              unscope(:order).
+              order(created_at: :desc).
+              where(submission_id: submission_id, question_id: question_id)
+
+    current_answer = answers.find(&:current_answer?)
+    past_answers = answers.where(current_answer: false).limit(MAX_ANSWERS_COUNT - 1).to_a.reverse
+    past_answers.unshift(current_answer)
+
+    past_answers
+  end
+end

--- a/app/controllers/course/statistics/assessments_controller.rb
+++ b/app/controllers/course/statistics/assessments_controller.rb
@@ -18,7 +18,7 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
     fetch_all_ancestor_assessments
     create_question_related_hash
 
-    @assessment_autograded = @question_auto_gradable_status_hash.any? { |_, value| value }
+    @assessment_autograded = @question_hash.any? { |_, (_, _, auto_gradable)| auto_gradable }
     @student_submissions_hash = fetch_hash_for_main_assessment(submissions, @all_students)
   end
 
@@ -79,11 +79,8 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
 
   def create_question_related_hash
     create_question_order_hash
-    @question_maximum_grade_hash = @assessment.questions.to_h do |q|
-      [q.id, q.maximum_grade]
-    end
-    @question_auto_gradable_status_hash = @assessment.questions.to_h do |q|
-      [q.id, q.auto_gradable?]
+    @question_hash = @assessment.questions.to_h do |q|
+      [q.id, [q.maximum_grade, q.question_type, q.auto_gradable?]]
     end
   end
 

--- a/app/views/course/statistics/answers/_answer.json.jbuilder
+++ b/app/views/course/statistics/answers/_answer.json.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+specific_answer = answer.specific
+
+json.id answer.id
+json.grade answer.grade
+json.questionType question.question_type
+json.partial! specific_answer, answer: specific_answer, can_grade: false

--- a/app/views/course/statistics/answers/all_answers.json.jbuilder
+++ b/app/views/course/statistics/answers/all_answers.json.jbuilder
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+json.question do
+  json.id @question.id
+  json.title @question.title
+  json.maximumGrade @question.maximum_grade
+  json.description format_ckeditor_rich_text(@question.description)
+  json.type @question.question_type
+  json.questionNumber @question_index + 1
+
+  json.partial! @question, question: @question.specific, can_grade: false, answer: @all_answers.first
+end
+
+json.allAnswers @all_answers do |answer|
+  json.partial! 'answer', answer: answer, question: @question
+  json.createdAt answer.created_at&.iso8601
+  json.currentAnswer answer.current_answer
+  json.workflowState answer.workflow_state
+end
+
+json.submissionId @submission.id
+
+posts = @submission_question.discussion_topic.posts
+
+json.comments posts do |post|
+  json.partial! post, post: post if post.published?
+end

--- a/app/views/course/statistics/answers/question_answer_details.json.jbuilder
+++ b/app/views/course/statistics/answers/question_answer_details.json.jbuilder
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+question = @answer.question
+
+json.question do
+  json.id question.id
+  json.title question.title
+  json.maximumGrade question.maximum_grade
+  json.description format_ckeditor_rich_text(question.description)
+  json.type question.question_type
+
+  json.partial! question, question: question.specific, can_grade: false, answer: @answer
+end
+
+json.answer do
+  json.partial! 'answer', answer: @answer, question: question
+end
+
+json.allAnswers @all_answers do |answer|
+  json.partial! 'answer', answer: answer, question: question
+  json.createdAt answer.created_at&.iso8601
+  json.currentAnswer answer.current_answer
+  json.workflowState answer.workflow_state
+end
+
+posts = @submission_question.discussion_topic.posts
+
+json.comments posts do |post|
+  json.partial! post, post: post if post.published?
+end
+
+json.submissionId @submission.id
+json.submissionQuestionId @submission_question.id

--- a/app/views/course/statistics/assessments/_answer.json.jbuilder
+++ b/app/views/course/statistics/assessments/_answer.json.jbuilder
@@ -5,7 +5,10 @@ json.grader do
 end
 
 json.answers answers.each do |answer|
-  json.id answer.id
+  maximum_grade, question_type, = @question_hash[answer.question_id]
+
+  json.lastAttemptAnswerId answer.last_attempt_answer_id
   json.grade answer.grade
-  json.maximumGrade @question_maximum_grade_hash[answer.question_id]
+  json.maximumGrade maximum_grade
+  json.questionType question_type
 end

--- a/app/views/course/statistics/assessments/_attempt_status.json.jbuilder
+++ b/app/views/course/statistics/assessments/_attempt_status.json.jbuilder
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 json.attemptStatus answers.each do |answer|
-  json.isAutograded @question_auto_gradable_status_hash[answer.question_id]
+  _, _, auto_gradable = @question_hash[answer.question_id]
+
+  json.lastAttemptAnswerId answer.last_attempt_answer_id
+  json.isAutograded auto_gradable
   json.attemptCount answer.attempt_count
   json.correct answer.correct
 end

--- a/app/views/course/statistics/assessments/_live_feedback_history_details.json.jbuilder
+++ b/app/views/course/statistics/assessments/_live_feedback_history_details.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+json.files @live_feedback_details_hash[live_feedback_id].each do |live_feedback_details|
+  json.id live_feedback_details[:code][:id]
+  json.filename live_feedback_details[:code][:filename]
+  json.content live_feedback_details[:code][:content]
+  json.language @question.specific.language[:name]
+  json.comments live_feedback_details[:comments].map do |comment|
+    json.lineNumber comment[:line_number]
+    json.comment comment[:comment]
+  end
+end

--- a/app/views/course/statistics/assessments/live_feedback_history.json.jbuilder
+++ b/app/views/course/statistics/assessments/live_feedback_history.json.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+json.liveFeedbackHistory do
+  json.array! @live_feedbacks.map do |live_feedback|
+    json.id live_feedback.id
+    json.createdAt live_feedback.created_at&.iso8601
+    json.partial! 'live_feedback_history_details', live_feedback_id: live_feedback.id
+  end
+end
+
+json.question do
+  json.id @question.id
+  json.title @question.title
+  json.description format_ckeditor_rich_text(@question.description)
+end

--- a/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
+++ b/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
@@ -10,5 +10,7 @@ json.array! @student_live_feedback_hash.each do |course_user, (submission, live_
   json.groups @group_names_hash[course_user.id] do |name|
     json.name name
   end
+
   json.liveFeedbackCount live_feedback_count
+  json.questionIds(@question_order_hash.keys.sort_by { |key| @question_order_hash[key] })
 end

--- a/client/app/api/course/Statistics/AllAnswerStatistics.ts
+++ b/client/app/api/course/Statistics/AllAnswerStatistics.ts
@@ -1,0 +1,18 @@
+import { QuestionType } from 'types/course/assessment/question';
+import { QuestionAllAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+import { APIResponse } from 'api/types';
+
+import BaseCourseAPI from '../Base';
+
+export default class AllAnswerStatisticsAPI extends BaseCourseAPI {
+  get #urlPrefix(): string {
+    return `/courses/${this.courseId}/statistics/submission_question`;
+  }
+
+  fetchAllAnswers(
+    submissionQuestionId: number,
+  ): APIResponse<QuestionAllAnswerDisplayDetails<keyof typeof QuestionType>> {
+    return this.client.get(`${this.#urlPrefix}/${submissionQuestionId}`);
+  }
+}

--- a/client/app/api/course/Statistics/AnswerStatistics.ts
+++ b/client/app/api/course/Statistics/AnswerStatistics.ts
@@ -1,0 +1,18 @@
+import { QuestionType } from 'types/course/assessment/question';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import { APIResponse } from 'api/types';
+
+import BaseCourseAPI from '../Base';
+
+export default class AnswerStatisticsAPI extends BaseCourseAPI {
+  get #urlPrefix(): string {
+    return `/courses/${this.courseId}/statistics/answer`;
+  }
+
+  fetchQuestionAnswerDetails(
+    answerId: number,
+  ): APIResponse<QuestionAnswerDetails<keyof typeof QuestionType>> {
+    return this.client.get(`${this.#urlPrefix}/${answerId}`);
+  }
+}

--- a/client/app/api/course/Statistics/AssessmentStatistics.ts
+++ b/client/app/api/course/Statistics/AssessmentStatistics.ts
@@ -1,3 +1,4 @@
+import { LiveFeedbackHistoryState } from 'types/course/assessment/submission/liveFeedback';
 import {
   AncestorAssessmentStats,
   AssessmentLiveFeedbackStatistics,
@@ -40,6 +41,17 @@ export default class AssessmentStatisticsAPI extends BaseCourseAPI {
   ): APIResponse<AssessmentLiveFeedbackStatistics[]> {
     return this.client.get(
       `${this.#urlPrefix}/${assessmentId}/live_feedback_statistics`,
+    );
+  }
+
+  fetchLiveFeedbackHistory(
+    assessmentId: string | number,
+    questionId: string | number,
+    courseUserId: string | number,
+  ): APIResponse<LiveFeedbackHistoryState> {
+    return this.client.get(
+      `${this.#urlPrefix}/${assessmentId}/live_feedback_history`,
+      { params: { question_id: questionId, course_user_id: courseUserId } },
     );
   }
 }

--- a/client/app/api/course/Statistics/index.ts
+++ b/client/app/api/course/Statistics/index.ts
@@ -1,9 +1,13 @@
+import AllAnswerStatisticsAPI from './AllAnswerStatistics';
+import AnswerStatisticsAPI from './AnswerStatistics';
 import AssessmentStatisticsAPI from './AssessmentStatistics';
 import CourseStatisticsAPI from './CourseStatistics';
 import UserStatisticsAPI from './UserStatistics';
 
 const StatisticsAPI = {
   assessment: new AssessmentStatisticsAPI(),
+  answer: new AnswerStatisticsAPI(),
+  allAnswer: new AllAnswerStatisticsAPI(),
   course: new CourseStatisticsAPI(),
   user: new UserStatisticsAPI(),
 };

--- a/client/app/bundles/course/assessment/operations/liveFeedback.ts
+++ b/client/app/bundles/course/assessment/operations/liveFeedback.ts
@@ -1,0 +1,32 @@
+import { AxiosError } from 'axios';
+import { dispatch } from 'store';
+
+import CourseAPI from 'api/course';
+
+import { liveFeedbackActions as actions } from '../reducers/liveFeedback';
+
+export const fetchLiveFeedbackHistory = async (
+  assessmentId: number,
+  questionId: number,
+  courseUserId: number,
+): Promise<void> => {
+  try {
+    const response =
+      await CourseAPI.statistics.assessment.fetchLiveFeedbackHistory(
+        assessmentId,
+        questionId,
+        courseUserId,
+      );
+
+    const data = response.data;
+    dispatch(
+      actions.initialize({
+        liveFeedbackHistory: data.liveFeedbackHistory,
+        question: data.question,
+      }),
+    );
+  } catch (error) {
+    if (error instanceof AxiosError) throw error.response?.data?.errors;
+    throw error;
+  }
+};

--- a/client/app/bundles/course/assessment/operations/statistics.ts
+++ b/client/app/bundles/course/assessment/operations/statistics.ts
@@ -1,8 +1,11 @@
 import { AxiosError } from 'axios';
 import { dispatch } from 'store';
+import { QuestionType } from 'types/course/assessment/question';
 import {
   AncestorAssessmentStats,
   AssessmentLiveFeedbackStatistics,
+  QuestionAllAnswerDisplayDetails,
+  QuestionAnswerDetails,
 } from 'types/course/statistics/assessmentStatistics';
 
 import CourseAPI from 'api/course';
@@ -35,6 +38,24 @@ export const fetchAncestorStatistics = async (
 ): Promise<AncestorAssessmentStats> => {
   const response =
     await CourseAPI.statistics.assessment.fetchAncestorStatistics(ancestorId);
+
+  return response.data;
+};
+
+export const fetchQuestionAnswerDetails = async (
+  answerId: number,
+): Promise<QuestionAnswerDetails<keyof typeof QuestionType>> => {
+  const response =
+    await CourseAPI.statistics.answer.fetchQuestionAnswerDetails(answerId);
+
+  return response.data;
+};
+
+export const fetchAllAnswers = async (
+  submissionQuestionId: number,
+): Promise<QuestionAllAnswerDisplayDetails<keyof typeof QuestionType>> => {
+  const response =
+    await CourseAPI.statistics.allAnswer.fetchAllAnswers(submissionQuestionId);
 
   return response.data;
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
@@ -1,0 +1,83 @@
+import { defineMessages } from 'react-intl';
+import { Card, CardContent } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+import { AnswerDetailsMap } from 'types/course/statistics/answer';
+import { QuestionDetails } from 'types/course/statistics/assessmentStatistics';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+import FileUploadDetails from './FileUploadDetails';
+import ForumPostResponseDetails from './ForumPostResponseDetails';
+import MultipleChoiceDetails from './MultipleChoiceDetails';
+import MultipleResponseDetails from './MultipleResponseDetails';
+import ProgrammingAnswerDetails from './ProgrammingAnswerDetails';
+import TextResponseDetails from './TextResponseDetails';
+
+const translations = defineMessages({
+  rendererNotImplemented: {
+    id: 'course.assessment.submission.Answer.rendererNotImplemented',
+    defaultMessage:
+      'The display for this question type has not been implemented yet.',
+  },
+});
+
+interface AnswerDetailsProps<T extends keyof typeof QuestionType> {
+  question: QuestionDetails<T>;
+  answer: AnswerDetailsMap[T];
+}
+
+const AnswerNotImplemented = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="bg-yellow-100">
+      <CardContent>{t(translations.rendererNotImplemented)}</CardContent>
+    </Card>
+  );
+};
+
+export const AnswerDetailsMapper = {
+  MultipleChoice: (
+    props: AnswerDetailsProps<'MultipleChoice'>,
+  ): JSX.Element => <MultipleChoiceDetails {...props} />,
+  MultipleResponse: (
+    props: AnswerDetailsProps<'MultipleResponse'>,
+  ): JSX.Element => <MultipleResponseDetails {...props} />,
+  TextResponse: (props: AnswerDetailsProps<'TextResponse'>): JSX.Element => (
+    <TextResponseDetails {...props} />
+  ),
+  FileUpload: (props: AnswerDetailsProps<'FileUpload'>): JSX.Element => (
+    <FileUploadDetails {...props} />
+  ),
+  ForumPostResponse: (
+    props: AnswerDetailsProps<'ForumPostResponse'>,
+  ): JSX.Element => <ForumPostResponseDetails {...props} />,
+  Programming: (props: AnswerDetailsProps<'Programming'>): JSX.Element => (
+    <ProgrammingAnswerDetails {...props} />
+  ),
+  // TODO: define component for Voice Response, Scribing
+  VoiceResponse: (_props: AnswerDetailsProps<'VoiceResponse'>): JSX.Element => (
+    <AnswerNotImplemented />
+  ),
+  Scribing: (_props: AnswerDetailsProps<'Scribing'>): JSX.Element => (
+    <AnswerNotImplemented />
+  ),
+  Comprehension: (_props: AnswerDetailsProps<'Comprehension'>): JSX.Element => (
+    <AnswerNotImplemented />
+  ),
+};
+
+const AnswerDetails = <T extends keyof typeof QuestionType>(
+  props: AnswerDetailsProps<T>,
+): JSX.Element => {
+  const Component = AnswerDetailsMapper[props.answer.questionType];
+
+  // "Any" type is used here as the props are dynamically generated
+  // depending on the different answer type and typescript
+  // does not support union typing for the elements.
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return Component({ ...props } as any);
+};
+
+export default AnswerDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AttachmentDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AttachmentDetails.tsx
@@ -1,0 +1,60 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Chip, Typography } from '@mui/material';
+
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  attachments: {
+    id: string;
+    name: string;
+  }[];
+}
+
+const translations = defineMessages({
+  uploadedFiles: {
+    id: 'course.assessment.submission.UploadedFileView.uploadedFiles',
+    defaultMessage: 'Uploaded Files',
+  },
+  noFiles: {
+    id: 'course.assessment.submission.UploadedFileView.noFiles',
+    defaultMessage: 'No files uploaded.',
+  },
+});
+
+const AttachmentDetails: FC<Props> = (props) => {
+  const { attachments } = props;
+  const { t } = useTranslation();
+
+  const AttachmentComponent = (): JSX.Element => (
+    <div className="mt-4">
+      {attachments.map((attachment) => (
+        <Chip
+          key={attachment.id}
+          clickable
+          label={
+            <Link href={`/attachments/${attachment.id}`}>
+              {attachment.name}
+            </Link>
+          }
+        />
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="mt-4">
+      <Typography variant="h6">{t(translations.uploadedFiles)}</Typography>
+      {attachments.length > 0 ? (
+        <AttachmentComponent />
+      ) : (
+        <Typography color="text.secondary" variant="body2">
+          {t(translations.noFiles)}
+        </Typography>
+      )}
+    </div>
+  );
+};
+
+export default AttachmentDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/FileUploadDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/FileUploadDetails.tsx
@@ -1,0 +1,17 @@
+import { QuestionAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+import AttachmentDetails from './AttachmentDetails';
+
+const FileUploadDetails = (
+  props: QuestionAnswerDisplayDetails<'FileUpload'>,
+): JSX.Element => {
+  const { answer } = props;
+
+  return (
+    <div className="w-full mt-4 mb-4">
+      <AttachmentDetails attachments={answer.attachments} />
+    </div>
+  );
+};
+
+export default FileUploadDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/ParentPostPack.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/ParentPostPack.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Typography } from '@mui/material';
+import { PostPack } from 'types/course/assessment/submission/answer/forumPostResponse';
+
+import Labels from 'course/assessment/submission/components/answers/ForumPostResponse/Labels';
+
+import PostContent from './PostContent';
+
+const translations = defineMessages({
+  postMadeInResponseTo: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ParentPost.postMadeInResponseTo',
+    defaultMessage: 'Post made in response to:',
+  },
+});
+
+interface Props {
+  post: PostPack;
+}
+
+const ParentPostPack: FC<Props> = (props) => {
+  const { post } = props;
+
+  return (
+    <div className="m-4">
+      <Typography className="mb-5" color="text.secondary" variant="body2">
+        <FormattedMessage {...translations.postMadeInResponseTo} />
+      </Typography>
+      <Labels post={post} />
+      <PostContent isExpandable post={post} />
+    </div>
+  );
+};
+
+export default ParentPostPack;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostContent.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostContent.tsx
@@ -1,0 +1,83 @@
+import { FC, useLayoutEffect, useRef, useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import {
+  Avatar,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  Typography,
+} from '@mui/material';
+import { PostPack } from 'types/course/assessment/submission/answer/forumPostResponse';
+
+import { formatLongDateTime } from 'lib/moment';
+
+interface Props {
+  post: PostPack;
+  isExpandable?: boolean;
+}
+
+const MAX_POST_HEIGHT = 60;
+
+export const translations = defineMessages({
+  showMore: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ForumPost.showMore',
+    defaultMessage: 'SHOW MORE',
+  },
+  showLess: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ForumPost.showLess',
+    defaultMessage: 'SHOW LESS',
+  },
+});
+
+const PostContent: FC<Props> = (props) => {
+  const { post, isExpandable } = props;
+  const [renderedHeight, setRenderedHeight] = useState(0);
+
+  const contentIsExpandable = isExpandable && renderedHeight > MAX_POST_HEIGHT;
+  const [isExpanded, setIsExpanded] = useState(!isExpandable);
+
+  const postRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (postRef.current) {
+      setRenderedHeight(postRef.current.clientHeight);
+    }
+  }, [post]);
+
+  return (
+    <div ref={postRef}>
+      <Card className="forum-post shadow-none border-0">
+        <CardHeader
+          avatar={<Avatar src={post.avatar} />}
+          subheader={formatLongDateTime(post.updatedAt)}
+          title={post.userName}
+        />
+        <Divider />
+        <CardContent>
+          <Typography
+            className={`overflow-hidden ${!isExpanded && contentIsExpandable ? `h-20` : 'h-auto'}`}
+            dangerouslySetInnerHTML={{ __html: post.text }}
+            variant="body2"
+          />
+          {contentIsExpandable && (
+            <Button
+              className="forum-post-expand-button mt-2"
+              color="primary"
+              onClick={() => setIsExpanded(!isExpanded)}
+            >
+              {isExpanded ? (
+                <FormattedMessage {...translations.showLess} />
+              ) : (
+                <FormattedMessage {...translations.showMore} />
+              )}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PostContent;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostPack.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseComponent/PostPack.tsx
@@ -1,0 +1,103 @@
+import { FC, useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { ChevronRight, ExpandMore } from '@mui/icons-material';
+import { Typography } from '@mui/material';
+import { SelectedPostPack } from 'types/course/assessment/submission/answer/forumPostResponse';
+
+import Labels from 'course/assessment/submission/components/answers/ForumPostResponse/Labels';
+import Link from 'lib/components/core/Link';
+import { getForumTopicURL, getForumURL } from 'lib/helpers/url-builders';
+import { getCourseId } from 'lib/helpers/url-helpers';
+
+import ParentPostPack from './ParentPostPack';
+import PostContent from './PostContent';
+
+const translations = defineMessages({
+  topicDeleted: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.SelectedPostCard.topicDeleted',
+    defaultMessage: 'Post made under a topic that was subsequently deleted.',
+  },
+  postMadeUnder: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.SelectedPostCard.postMadeUnder',
+    defaultMessage: 'Post made under {topicUrl} in {forumUrl}',
+  },
+});
+
+interface Props {
+  postPack: SelectedPostPack;
+}
+
+const MAX_NAME_LENGTH = 30;
+
+const generateLink = (url: string, name: string): JSX.Element => {
+  const renderedName =
+    name.length > MAX_NAME_LENGTH
+      ? `${name.slice(0, MAX_NAME_LENGTH)}...`
+      : name;
+  return (
+    <Link opensInNewTab to={url}>
+      {renderedName}
+    </Link>
+  );
+};
+
+const PostPack: FC<Props> = (props) => {
+  const { postPack } = props;
+  const courseId = getCourseId();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const ForumPostLabel = (): JSX.Element => {
+    const { forum, topic } = postPack;
+    return (
+      <div className="flex items-center">
+        {isExpanded ? (
+          <ExpandMore fontSize="small" />
+        ) : (
+          <ChevronRight fontSize="small" />
+        )}
+        <Typography variant="body2">
+          {topic.isDeleted ? (
+            <FormattedMessage {...translations.topicDeleted} />
+          ) : (
+            <FormattedMessage
+              values={{
+                topicUrl: generateLink(
+                  getForumTopicURL(courseId, forum.id, topic.id),
+                  topic.title,
+                ),
+                forumUrl: generateLink(
+                  getForumURL(courseId, forum.id),
+                  forum.name,
+                ),
+              }}
+              {...translations.postMadeUnder}
+            />
+          )}
+        </Typography>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      key={`forum-post-pack-${postPack.forum.id}-${postPack.topic.id}`}
+      className="mb-12 shadow-md rounded-md overflow-hidden"
+    >
+      <div
+        className="p-4 bg-green-50 cursor-pointer flex justify-between items-center"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <ForumPostLabel />
+      </div>
+      {isExpanded && (
+        <>
+          <Labels post={postPack.corePost} />
+          <PostContent post={postPack.corePost} />
+          {postPack.parentPost && <ParentPostPack post={postPack.parentPost} />}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PostPack;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ForumPostResponseDetails.tsx
@@ -1,0 +1,40 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Typography } from '@mui/material';
+import { QuestionAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+import PostPack from './ForumPostResponseComponent/PostPack';
+
+const translations = defineMessages({
+  submittedInstructions: {
+    id: 'course.assessment.submission.answers.ForumPostResponse.ForumPostSelect.submittedInstructions',
+    defaultMessage:
+      '{numPosts, plural, =0 {No posts were} one {# post was} other {# posts were}} submitted.',
+  },
+});
+
+const ForumPostResponseDetails = (
+  props: QuestionAnswerDisplayDetails<'ForumPostResponse'>,
+): JSX.Element => {
+  const { answer } = props;
+  const postPacks = answer.fields.selected_post_packs;
+
+  return (
+    <>
+      <Typography className="mb-5 mt-5" color="text.secondary" variant="body2">
+        <FormattedMessage
+          values={{ numPosts: postPacks.length }}
+          {...translations.submittedInstructions}
+        />
+      </Typography>
+      {postPacks.length > 0 &&
+        postPacks.map((postPack) => (
+          <PostPack
+            key={`post-pack-${postPack.forum.id}-${postPack.topic.id}`}
+            postPack={postPack}
+          />
+        ))}
+    </>
+  );
+};
+
+export default ForumPostResponseDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleChoiceDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleChoiceDetails.tsx
@@ -1,0 +1,43 @@
+import { FormControlLabel, Radio, Typography } from '@mui/material';
+import { green } from '@mui/material/colors';
+import { QuestionAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+const MultipleChoiceDetails = (
+  props: QuestionAnswerDisplayDetails<'MultipleChoice'>,
+): JSX.Element => {
+  const { question, answer } = props;
+  return (
+    <>
+      {question.options.map((option) => (
+        <FormControlLabel
+          key={option.id}
+          checked={
+            answer.fields.option_ids.length > 0 &&
+            answer.fields.option_ids.includes(option.id)
+          }
+          className="w-full"
+          control={<Radio />}
+          disabled
+          label={
+            <b>
+              <Typography
+                dangerouslySetInnerHTML={{ __html: option.option.trim() }}
+                style={
+                  option.correct
+                    ? {
+                        backgroundColor: green[50],
+                        verticalAlign: 'middle',
+                      }
+                    : { verticalAlign: 'middle' }
+                }
+                variant="body2"
+              />
+            </b>
+          }
+        />
+      ))}
+    </>
+  );
+};
+
+export default MultipleChoiceDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/MultipleResponseDetails.tsx
@@ -1,0 +1,45 @@
+import { Checkbox, FormControlLabel, Typography } from '@mui/material';
+import { green } from '@mui/material/colors';
+import { QuestionAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+const MultipleResponseDetails = (
+  props: QuestionAnswerDisplayDetails<'MultipleResponse'>,
+): JSX.Element => {
+  const { question, answer } = props;
+  return (
+    <>
+      {question.options.map((option) => {
+        return (
+          <FormControlLabel
+            key={option.id}
+            checked={
+              answer.fields.option_ids.length > 0 &&
+              answer.fields.option_ids.indexOf(option.id) !== -1
+            }
+            className="w-full"
+            control={<Checkbox />}
+            disabled
+            label={
+              <b>
+                <Typography
+                  dangerouslySetInnerHTML={{ __html: option.option.trim() }}
+                  style={
+                    option.correct
+                      ? {
+                          backgroundColor: green[50],
+                          verticalAlign: 'middle',
+                        }
+                      : { verticalAlign: 'middle' }
+                  }
+                  variant="body2"
+                />
+              </b>
+            }
+          />
+        );
+      })}
+    </>
+  );
+};
+
+export default MultipleResponseDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingAnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingAnswerDetails.tsx
@@ -1,0 +1,30 @@
+import { Annotation } from 'types/course/statistics/answer';
+import { QuestionAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+import CodaveriFeedbackStatus from './ProgrammingComponent/CodaveriFeedbackStatus';
+import FileContent from './ProgrammingComponent/FileContent';
+import TestCases from './ProgrammingComponent/TestCases';
+
+const ProgrammingAnswerDetails = (
+  props: QuestionAnswerDisplayDetails<'Programming'>,
+): JSX.Element => {
+  const { answer } = props;
+  const annotations = answer.latestAnswer?.annotations ?? ([] as Annotation[]);
+
+  return (
+    <>
+      {answer.fields.files_attributes.map((file) => (
+        <FileContent
+          key={`file-${file.id}-answer-${answer.id}`}
+          annotations={annotations}
+          answerId={answer.id}
+          file={file}
+        />
+      ))}
+      <TestCases testCase={answer.testCases} />
+      <CodaveriFeedbackStatus status={answer.codaveriFeedback} />
+    </>
+  );
+};
+
+export default ProgrammingAnswerDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/CodaveriFeedbackStatus.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/CodaveriFeedbackStatus.tsx
@@ -1,0 +1,72 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Paper, Typography } from '@mui/material';
+import { CodaveriFeedback } from 'types/course/statistics/answer';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  codaveriFeedbackStatus: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.codaveriFeedbackStatus',
+    defaultMessage: 'Codaveri Feedback Status',
+  },
+  loadingFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.loadingFeedbackGeneration',
+    defaultMessage: 'Generating Feedback. Please wait...',
+  },
+  successfulFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.successfulFeedbackGeneration',
+    defaultMessage: 'Feedback has been successfully generated.',
+  },
+  failedFeedbackGeneration: {
+    id: 'course.assessment.submission.CodaveriFeedbackStatus.failedFeedbackGeneration',
+    defaultMessage: 'Failed to generate feedback. Please try again later.',
+  },
+});
+
+const codaveriJobDisplay = {
+  submitted: {
+    feedbackBgColor: 'bg-orange-100',
+    feedbackDescription: translations.loadingFeedbackGeneration,
+  },
+  completed: {
+    feedbackBgColor: 'bg-green-100',
+    feedbackDescription: translations.successfulFeedbackGeneration,
+  },
+  errored: {
+    feedbackBgColor: 'bg-red-100',
+    feedbackDescription: translations.failedFeedbackGeneration,
+  },
+};
+
+interface Props {
+  status?: CodaveriFeedback;
+}
+
+const CodaveriFeedbackStatus: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const { status } = props;
+
+  if (!status) {
+    return null;
+  }
+
+  const { feedbackBgColor, feedbackDescription } =
+    codaveriJobDisplay[status.jobStatus];
+
+  return (
+    <Paper className="mb-8">
+      <Typography
+        className={`${feedbackBgColor} table-cell p-8 font-bold`}
+        variant="body2"
+      >
+        {t(translations.codaveriFeedbackStatus)}
+      </Typography>
+      <Typography className="table-cell pl-5" variant="body2">
+        {t(feedbackDescription)}
+      </Typography>
+    </Paper>
+  );
+};
+
+export default CodaveriFeedbackStatus;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Warning } from '@mui/icons-material';
+import { Paper, Typography } from '@mui/material';
+import { ProgrammingContent } from 'types/course/assessment/submission/answer/programming';
+import { Annotation, AnnotationTopic } from 'types/course/statistics/answer';
+
+import ProgrammingFileDownloadLink from 'course/assessment/submission/components/answers/Programming/ProgrammingFileDownloadLink';
+import ReadOnlyEditor from 'course/assessment/submission/components/ReadOnlyEditor';
+
+const translations = defineMessages({
+  sizeTooBig: {
+    id: 'course.assessment.submission.answers.Programming.ProgrammingFile.sizeTooBig',
+    defaultMessage: 'The file is too big and cannot be displayed.',
+  },
+});
+
+interface Props {
+  answerId: number;
+  annotations: Annotation[];
+  file: ProgrammingContent;
+}
+
+const FileContent: FC<Props> = (props) => {
+  const { answerId, annotations, file } = props;
+  const fileAnnotation = annotations.find((a) => a.fileId === file.id);
+
+  return file.highlightedContent ? (
+    <ReadOnlyEditor
+      annotations={fileAnnotation?.topics ?? ([] as AnnotationTopic[])}
+      answerId={answerId}
+      file={file}
+    />
+  ) : (
+    <>
+      <ProgrammingFileDownloadLink file={file} />
+      <Paper className="flex items-center bg-yellow-100 p-2">
+        <Warning />
+        <Typography variant="body2">
+          <FormattedMessage {...translations.sizeTooBig} />
+        </Typography>
+      </Paper>
+    </>
+  );
+};
+
+export default FileContent;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCaseRow.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCaseRow.tsx
@@ -1,0 +1,69 @@
+import { FC, Fragment } from 'react';
+import { Clear, Done } from '@mui/icons-material';
+import { TableCell, TableRow, Typography } from '@mui/material';
+import { TestCaseResult } from 'types/course/assessment/submission/answer/programming';
+
+import ExpandableCode from 'lib/components/core/ExpandableCode';
+
+interface Props {
+  result: TestCaseResult;
+}
+
+const TestCaseClassName = {
+  unattempted: '',
+  correct: 'bg-green-50',
+  wrong: 'bg-red-50',
+};
+
+const TestCaseRow: FC<Props> = (props) => {
+  const { result } = props;
+
+  const nameRegex = /\/?(\w+)$/;
+  const idMatch = result.identifier?.match(nameRegex);
+  const truncatedIdentifier = idMatch ? idMatch[1] : '';
+
+  let testCaseResult = 'unattempted';
+  let testCaseIcon;
+  if (result.passed !== undefined) {
+    testCaseResult = result.passed ? 'correct' : 'wrong';
+    testCaseIcon = result.passed ? (
+      <Done color="success" />
+    ) : (
+      <Clear color="error" />
+    );
+  }
+
+  return (
+    <Fragment key={result.identifier}>
+      <TableRow className={TestCaseClassName[testCaseResult]}>
+        <TableCell className="h-fit border-none pb-0 leading-none" colSpan={5}>
+          <Typography
+            className="break-all"
+            color="text.secondary"
+            variant="caption"
+          >
+            {truncatedIdentifier}
+          </Typography>
+        </TableCell>
+      </TableRow>
+
+      <TableRow className={TestCaseClassName[testCaseResult]}>
+        <TableCell className="w-full pt-1">
+          <ExpandableCode>{result.expression}</ExpandableCode>
+        </TableCell>
+
+        <TableCell className="w-full pt-1">
+          <ExpandableCode>{result.expected || ''}</ExpandableCode>
+        </TableCell>
+
+        <TableCell className="w-full pt-1">
+          <ExpandableCode>{result.output || ''}</ExpandableCode>
+        </TableCell>
+
+        <TableCell>{testCaseIcon}</TableCell>
+      </TableRow>
+    </Fragment>
+  );
+};
+
+export default TestCaseRow;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCases.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/TestCases.tsx
@@ -1,0 +1,248 @@
+import { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Close, Done } from '@mui/icons-material';
+import {
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { TestCaseResult } from 'types/course/assessment/submission/answer/programming';
+import { TestCase } from 'types/course/statistics/answer';
+
+import Accordion from 'lib/components/core/layouts/Accordion';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import TestCaseRow from './TestCaseRow';
+
+const translations = defineMessages({
+  expression: {
+    id: 'course.assessment.submission.TestCaseView.experession',
+    defaultMessage: 'Expression',
+  },
+  expected: {
+    id: 'course.assessment.submission.TestCaseView.expected',
+    defaultMessage: 'Expected',
+  },
+  output: {
+    id: 'course.assessment.submission.TestCaseView.output',
+    defaultMessage: 'Output',
+  },
+  allPassed: {
+    id: 'course.assessment.submission.TestCaseView.allPassed',
+    defaultMessage: 'All passed',
+  },
+  allFailed: {
+    id: 'course.assessment.submission.TestCaseView.allFailed',
+    defaultMessage: 'All failed',
+  },
+  testCasesPassed: {
+    id: 'course.assessment.submission.TestCaseView.testCasesPassed',
+    defaultMessage: '{numPassed}/{numTestCases} passed',
+  },
+  publicTestCases: {
+    id: 'course.assessment.submission.TestCaseView.publicTestCases',
+    defaultMessage: 'Public Test Cases',
+  },
+  privateTestCases: {
+    id: 'course.assessment.submission.TestCaseView.privateTestCases',
+    defaultMessage: 'Private Test Cases',
+  },
+  evaluationTestCases: {
+    id: 'course.assessment.submission.TestCaseView.evaluationTestCases',
+    defaultMessage: 'Evaluation Test Cases',
+  },
+  standardOutput: {
+    id: 'course.assessment.submission.TestCaseView.standardOutput',
+    defaultMessage: 'Standard Output',
+  },
+  standardError: {
+    id: 'course.assessment.submission.TestCaseView.standardError',
+    defaultMessage: 'Standard Error',
+  },
+  noOutputs: {
+    id: 'course.assessment.submission.TestCaseView.noOutputs',
+    defaultMessage: 'No outputs',
+  },
+});
+
+interface Props {
+  testCase: TestCase;
+}
+
+interface TestCaseComponentProps {
+  testCaseResults: TestCaseResult[];
+  testCaseType: string;
+}
+
+interface OutputStreamProps {
+  outputStreamType: 'standardOutput' | 'standardError';
+  output?: string;
+}
+
+const TestCaseComponent: FC<TestCaseComponentProps> = (props) => {
+  const { testCaseResults, testCaseType } = props;
+  const { t } = useTranslation();
+  const numPassedTestCases = testCaseResults.filter(
+    (result) => result.passed,
+  ).length;
+  const numTestCases = testCaseResults.length;
+
+  const AllTestCasesPassedChip: FC = () => (
+    <Chip
+      color="success"
+      icon={<Done />}
+      label={t(translations.allPassed)}
+      size="small"
+      variant="outlined"
+    />
+  );
+
+  const SomeTestCasesPassedChip: FC = () => (
+    <Chip
+      color="warning"
+      label={t(translations.testCasesPassed, {
+        numPassed: numPassedTestCases,
+        numTestCases,
+      })}
+      size="small"
+      variant="outlined"
+    />
+  );
+
+  const NoTestCasesPassedChip: FC = () => (
+    <Chip
+      color="error"
+      icon={<Close />}
+      label={t(translations.allFailed)}
+      size="small"
+      variant="outlined"
+    />
+  );
+
+  const TestCasesIndicatorChip: FC = () => {
+    if (numPassedTestCases === numTestCases) {
+      return <AllTestCasesPassedChip />;
+    }
+
+    if (numPassedTestCases > 0) {
+      return <SomeTestCasesPassedChip />;
+    }
+
+    return <NoTestCasesPassedChip />;
+  };
+
+  const testCaseComponentClassName = (): string => {
+    if (numPassedTestCases === numTestCases) {
+      return 'border-success';
+    }
+
+    if (numPassedTestCases > 0) {
+      return 'border-warning';
+    }
+
+    return 'border-error';
+  };
+
+  return (
+    <Accordion
+      className={testCaseComponentClassName()}
+      defaultExpanded={false}
+      disableGutters
+      icon={<TestCasesIndicatorChip />}
+      id={testCaseType}
+      title={t(translations[testCaseType])}
+    >
+      <Table className="table-fixed">
+        <TableHead>
+          <TableRow>
+            <TableCell className="w-full">
+              <FormattedMessage {...translations.expression} />
+            </TableCell>
+
+            <TableCell className="w-full">
+              <FormattedMessage {...translations.expected} />
+            </TableCell>
+
+            <TableCell className="w-full">
+              <FormattedMessage {...translations.output} />
+            </TableCell>
+
+            <TableCell className="w-24" />
+          </TableRow>
+        </TableHead>
+
+        <TableBody>
+          {testCaseResults.map((result) => (
+            <TestCaseRow key={result.identifier} result={result} />
+          ))}
+        </TableBody>
+      </Table>
+    </Accordion>
+  );
+};
+
+const OutputStream: FC<OutputStreamProps> = (props) => {
+  const { outputStreamType, output } = props;
+  const { t } = useTranslation();
+  return (
+    <Accordion
+      defaultExpanded={false}
+      disabled={!output}
+      disableGutters
+      icon={
+        !output && (
+          <Chip
+            label={<FormattedMessage {...translations.noOutputs} />}
+            size="small"
+            variant="outlined"
+          />
+        )
+      }
+      id={outputStreamType}
+      title={t(translations[outputStreamType])}
+    >
+      <pre className="w-full">{output}</pre>
+    </Accordion>
+  );
+};
+
+const TestCases: FC<Props> = (props) => {
+  const { testCase } = props;
+
+  return (
+    <div className="my-5 space-y-5">
+      {testCase.public_test && testCase.public_test.length > 0 && (
+        <TestCaseComponent
+          testCaseResults={testCase.public_test}
+          testCaseType="publicTestCases"
+        />
+      )}
+
+      {testCase.private_test && testCase.private_test.length > 0 && (
+        <TestCaseComponent
+          testCaseResults={testCase.private_test}
+          testCaseType="privateTestCases"
+        />
+      )}
+
+      {testCase.evaluation_test && testCase.evaluation_test.length > 0 && (
+        <TestCaseComponent
+          testCaseResults={testCase.evaluation_test}
+          testCaseType="evaluationTestCases"
+        />
+      )}
+
+      <OutputStream
+        output={testCase.stdout}
+        outputStreamType="standardOutput"
+      />
+
+      <OutputStream output={testCase.stderr} outputStreamType="standardError" />
+    </div>
+  );
+};
+
+export default TestCases;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/TextResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/TextResponseDetails.tsx
@@ -1,0 +1,26 @@
+import { Typography } from '@mui/material';
+import { QuestionAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+import AttachmentDetails from './AttachmentDetails';
+
+const TextResponseDetails = (
+  props: QuestionAnswerDisplayDetails<'TextResponse'>,
+): JSX.Element => {
+  const { question, answer } = props;
+
+  return (
+    <>
+      <Typography
+        dangerouslySetInnerHTML={{ __html: answer.fields.answer_text }}
+        variant="body2"
+      />
+      {question.maxAttachments > 0 && (
+        <div className="w-full mt-4 mb-4">
+          <AttachmentDetails attachments={answer.attachments} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TextResponseDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttempts.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttempts.tsx
@@ -1,0 +1,104 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
+import { Typography } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import { fetchQuestionAnswerDetails } from 'course/assessment/operations/statistics';
+import Link from 'lib/components/core/Link';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+import {
+  getEditSubmissionQuestionURL,
+  getPastAnswersURL,
+} from 'lib/helpers/url-builders';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import AllAttemptsDisplay from './AllAttemptsDisplay';
+import Comment from './Comment';
+
+const translations = defineMessages({
+  questionTitle: {
+    id: 'course.assessment.statistics.questionTitle',
+    defaultMessage: 'Question {index}',
+  },
+  gradeDisplay: {
+    id: 'course.assessment.statistics.gradeDisplay',
+    defaultMessage: 'Grade: {grade} / {maxGrade}',
+  },
+  morePastAnswers: {
+    id: 'course.assessment.statistics.morePastAnswers',
+    defaultMessage: 'View All Past Answers',
+  },
+  currentAnswer: {
+    id: 'course.assessment.statistics.currentAnswer',
+    defaultMessage: 'Most Recent Answer',
+  },
+  pastAnswerTitle: {
+    id: 'course.assessment.statistics.pastAnswerTitle',
+    defaultMessage: 'Submitted At: {submittedAt}',
+  },
+  submissionPage: {
+    id: 'course.assessment.statistics.submissionPage',
+    defaultMessage: 'Go to Answer Page',
+  },
+});
+
+interface Props {
+  curAnswerId: number;
+  index: number;
+}
+
+const AllAttemptsIndex: FC<Props> = (props) => {
+  const { curAnswerId, index } = props;
+  const { t } = useTranslation();
+  const { courseId, assessmentId } = useParams();
+
+  const fetchQuestionAndCurrentAnswerDetails = (): Promise<
+    QuestionAnswerDetails<keyof typeof QuestionType>
+  > => {
+    return fetchQuestionAnswerDetails(curAnswerId);
+  };
+
+  return (
+    <Preload
+      render={<LoadingIndicator />}
+      while={fetchQuestionAndCurrentAnswerDetails}
+    >
+      {(data): JSX.Element => {
+        const pastAnswersURL = getPastAnswersURL(
+          courseId,
+          assessmentId,
+          data.submissionQuestionId,
+        );
+
+        return (
+          <>
+            <AllAttemptsDisplay
+              allAnswers={data.allAnswers}
+              question={data.question}
+              questionNumber={index}
+              submissionEditUrl={getEditSubmissionQuestionURL(
+                courseId,
+                assessmentId,
+                data.submissionId,
+                index,
+              )}
+            />
+
+            <Link opensInNewTab to={pastAnswersURL}>
+              <Typography className="mt-4" variant="body2">
+                {t(translations.morePastAnswers)}
+              </Typography>
+            </Link>
+
+            {data.comments.length > 0 && <Comment comments={data.comments} />}
+          </>
+        );
+      }}
+    </Preload>
+  );
+};
+
+export default AllAttemptsIndex;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
@@ -1,0 +1,155 @@
+import { FC, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Slider, Typography } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+import {
+  AllAnswerDetails,
+  QuestionDetails,
+} from 'types/course/statistics/assessmentStatistics';
+
+import { workflowStates } from 'course/assessment/submission/constants';
+import Accordion from 'lib/components/core/layouts/Accordion';
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+import { formatLongDateTime } from 'lib/moment';
+
+import AnswerDetails from '../AnswerDetails/AnswerDetails';
+
+interface Props {
+  allAnswers: AllAnswerDetails<keyof typeof QuestionType>[];
+  question: QuestionDetails<keyof typeof QuestionType>;
+  questionNumber: number;
+  submissionEditUrl: string;
+}
+
+const translations = defineMessages({
+  questionTitle: {
+    id: 'course.assessment.statistics.questionTitle',
+    defaultMessage: 'Question {index}',
+  },
+  pastAnswerTitle: {
+    id: 'course.assessment.statistics.pastAnswerTitle',
+    defaultMessage: 'Submitted At: {submittedAt}',
+  },
+  mostRecentAnswer: {
+    id: 'course.assessment.statistics.mostRecentAnswer',
+    defaultMessage: 'Current Answer (Attempting)',
+  },
+  submissionPage: {
+    id: 'course.assessment.statistics.submissionPage',
+    defaultMessage: 'Go to Answer Page',
+  },
+});
+
+// only used as a dummy buffer time if the submission's state is attempting
+// this is due to the time record for attempting answer being lower than any other
+// states' answer, while it's actually the latest version.
+const BUFFER_TIME = 100;
+
+const AllAttemptsDisplay: FC<Props> = (props) => {
+  const { allAnswers, question, questionNumber, submissionEditUrl } = props;
+
+  const { t } = useTranslation();
+
+  let currentAnswer = allAnswers.find((answer) => answer.currentAnswer);
+  const sortedAnswers = allAnswers.filter((answer) => !answer.currentAnswer);
+
+  if (
+    sortedAnswers.length > 0 &&
+    currentAnswer?.workflowState === workflowStates.Attempting
+  ) {
+    currentAnswer = {
+      ...currentAnswer,
+      createdAt: new Date(
+        sortedAnswers[sortedAnswers.length - 1].createdAt.getTime() +
+          BUFFER_TIME,
+      ),
+    };
+  }
+
+  sortedAnswers.push(currentAnswer!);
+
+  const answerSubmittedTimes = sortedAnswers.map((answer, idx) => {
+    return {
+      value: idx,
+      label:
+        idx === 0 || idx === sortedAnswers.length - 1
+          ? formatLongDateTime(answer.createdAt)
+          : '',
+    };
+  });
+
+  const currentAnswerMarker =
+    answerSubmittedTimes[answerSubmittedTimes.length - 1];
+
+  const earliestAnswerMarker = answerSubmittedTimes[0];
+  const [displayedIndex, setDisplayedIndex] = useState(
+    currentAnswerMarker.value,
+  );
+
+  const isCurrentAnswerStillAttempting =
+    sortedAnswers[answerSubmittedTimes.length - 1].workflowState ===
+    workflowStates.Attempting;
+
+  return (
+    <>
+      <Link opensInNewTab to={submissionEditUrl}>
+        <Typography className="mb-4" variant="body2">
+          {t(translations.submissionPage)}
+        </Typography>
+      </Link>
+      <Accordion
+        defaultExpanded={false}
+        title={t(translations.questionTitle, {
+          index: questionNumber,
+        })}
+      >
+        <div className="ml-4 mt-4">
+          <Typography variant="body1">{question.title}</Typography>
+          <Typography
+            dangerouslySetInnerHTML={{
+              __html: question.description,
+            }}
+            variant="body2"
+          />
+        </div>
+      </Accordion>
+      {answerSubmittedTimes.length > 1 && (
+        <div className="w-[calc(100%_-_17rem)] mx-auto">
+          <Slider
+            defaultValue={currentAnswerMarker.value}
+            marks={answerSubmittedTimes}
+            max={currentAnswerMarker.value}
+            min={earliestAnswerMarker.value}
+            onChange={(_, value) => {
+              setDisplayedIndex(Array.isArray(value) ? value[0] : value);
+            }}
+            step={null}
+            valueLabelDisplay="off"
+          />
+        </div>
+      )}
+
+      <Typography variant="h6">
+        {(!displayedIndex ||
+          displayedIndex === answerSubmittedTimes.length - 1) &&
+        isCurrentAnswerStillAttempting
+          ? t(translations.mostRecentAnswer)
+          : t(translations.pastAnswerTitle, {
+              submittedAt: formatLongDateTime(
+                sortedAnswers[displayedIndex ?? answerSubmittedTimes.length - 1]
+                  .createdAt,
+              ),
+            })}
+      </Typography>
+      <AnswerDetails
+        answer={
+          sortedAnswers[displayedIndex ?? answerSubmittedTimes.length - 1]
+        }
+        question={question}
+      />
+    </>
+  );
+};
+
+export default AllAttemptsDisplay;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/Comment.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/Comment.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Avatar, Box, CardHeader, Typography } from '@mui/material';
+import { CommentItem } from 'types/course/statistics/assessmentStatistics';
+
+import useTranslation from 'lib/hooks/useTranslation';
+import { formatLongDateTime } from 'lib/moment';
+
+interface Props {
+  comments: CommentItem[];
+}
+
+const translations = defineMessages({
+  comments: {
+    id: 'course.assessment.statistics.comments',
+    defaultMessage: 'Comments',
+  },
+});
+
+const Comment: FC<Props> = (props) => {
+  const { comments } = props;
+  const { t } = useTranslation();
+
+  return (
+    <div className="mt-8">
+      <Typography className="mb-5" variant="h6">
+        {t(translations.comments)}
+      </Typography>
+
+      {comments.map((comment) => (
+        <Box
+          key={comment.id.toString()}
+          className="border-solid border-slate-200"
+        >
+          <div
+            className={
+              comment.isDelayed
+                ? 'flex items-center justify-between bg-orange-100 rounded-sm'
+                : 'flex items-center justify-between bg-gray-100 rounded-sm'
+            }
+          >
+            <CardHeader
+              avatar={
+                <Avatar
+                  className="w-[25px] h-[25px]"
+                  src={comment.creator.imageUrl}
+                />
+              }
+              className="p-6"
+              subheader={`${formatLongDateTime(comment.createdAt)}${
+                comment.isDelayed ? ' (delayed comment)' : ''
+              }`}
+              subheaderTypographyProps={{ display: 'block' }}
+              title={comment.creator.name}
+              titleTypographyProps={{ display: 'block', marginright: 20 }}
+            />
+          </div>
+          <div className="break-words p-2">
+            <Typography
+              dangerouslySetInnerHTML={{ __html: comment.text }}
+              variant="body2"
+            />
+          </div>
+        </Box>
+      ))}
+    </div>
+  );
+};
+
+export default Comment;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAttempt.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAttempt.tsx
@@ -1,0 +1,112 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
+import { Chip, Typography } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+import { QuestionAnswerDetails } from 'types/course/statistics/assessmentStatistics';
+
+import { fetchQuestionAnswerDetails } from 'course/assessment/operations/statistics';
+import Accordion from 'lib/components/core/layouts/Accordion';
+import Link from 'lib/components/core/Link';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+import { getEditSubmissionQuestionURL } from 'lib/helpers/url-builders';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import AnswerDetails from '../AnswerDetails/AnswerDetails';
+import { getClassNameForMarkCell } from '../classNameUtils';
+
+import Comment from './Comment';
+
+const translations = defineMessages({
+  questionTitle: {
+    id: 'course.assessment.statistics.questionTitle',
+    defaultMessage: 'Question {index}',
+  },
+  gradeDisplay: {
+    id: 'course.assessment.statistics.gradeDisplay',
+    defaultMessage: 'Grade: {grade} / {maxGrade}',
+  },
+  morePastAnswers: {
+    id: 'course.assessment.statistics.morePastAnswers',
+    defaultMessage: 'View All Past Answers',
+  },
+  submissionPage: {
+    id: 'course.assessment.statistics.submissionPage',
+    defaultMessage: 'Go to Answer Page',
+  },
+});
+
+interface Props {
+  curAnswerId: number;
+  index: number;
+}
+
+const LastAttemptIndex: FC<Props> = (props) => {
+  const { curAnswerId, index } = props;
+  const { courseId, assessmentId } = useParams();
+  const { t } = useTranslation();
+
+  const fetchQuestionAndCurrentAnswerDetails = (): Promise<
+    QuestionAnswerDetails<keyof typeof QuestionType>
+  > => {
+    return fetchQuestionAnswerDetails(curAnswerId);
+  };
+
+  return (
+    <Preload
+      render={<LoadingIndicator />}
+      while={fetchQuestionAndCurrentAnswerDetails}
+    >
+      {(data): JSX.Element => {
+        const gradeCellColor = getClassNameForMarkCell(
+          data.answer.grade,
+          data.question.maximumGrade,
+        );
+        return (
+          <>
+            <Link
+              opensInNewTab
+              to={getEditSubmissionQuestionURL(
+                courseId,
+                assessmentId,
+                data.submissionId,
+                index,
+              )}
+            >
+              <Typography className="mb-4" variant="body2">
+                {t(translations.submissionPage)}
+              </Typography>
+            </Link>
+            <Accordion
+              defaultExpanded={false}
+              title={t(translations.questionTitle, { index })}
+            >
+              <div className="ml-4 mt-4">
+                <Typography variant="body1">{data.question.title}</Typography>
+                <Typography
+                  dangerouslySetInnerHTML={{
+                    __html: data.question.description,
+                  }}
+                  variant="body2"
+                />
+              </div>
+            </Accordion>
+            <AnswerDetails answer={data.answer} question={data.question} />
+            <Chip
+              className={`w-100 mt-3 ${gradeCellColor}`}
+              label={t(translations.gradeDisplay, {
+                grade: data.answer.grade,
+                maxGrade: data.question.maximumGrade,
+              })}
+              variant="filled"
+            />
+            {data.comments.length > 0 && <Comment comments={data.comments} />}
+          </>
+        );
+      }}
+    </Preload>
+  );
+};
+
+export default LastAttemptIndex;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackDetails.tsx
@@ -1,0 +1,129 @@
+import { FC, useRef, useState } from 'react';
+import ReactAce from 'react-ace';
+import { defineMessages } from 'react-intl';
+import { Box, Card, CardContent, Drawer, Typography } from '@mui/material';
+import { LiveFeedbackCodeAndComments } from 'types/course/assessment/submission/liveFeedback';
+
+import EditorField from 'lib/components/core/fields/EditorField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  liveFeedbackName: {
+    id: 'course.assessment.liveFeedback.comments',
+    defaultMessage: 'Live Feedback',
+  },
+  comments: {
+    id: 'course.assessment.liveFeedback.comments',
+    defaultMessage: 'Comments',
+  },
+  lineHeader: {
+    id: 'course.assessment.liveFeedback.lineHeader',
+    defaultMessage: 'Line {lineNumber}',
+  },
+});
+
+interface Props {
+  file: LiveFeedbackCodeAndComments;
+}
+
+const LiveFeedbackDetails: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const { file } = props;
+
+  const languageMap = {
+    JavaScript: 'javascript',
+    'Python 2.7': 'python',
+    'Python 3.4': 'python',
+    'Python 3.5': 'python',
+    'Python 3.6': 'python',
+    'C/C++': 'c_cpp',
+    'Python 3.7': 'python',
+    'Java 8': 'java',
+    'Java 11': 'java',
+    'Python 3.9': 'python',
+    'Python 3.10': 'python',
+    'Python 3.12': 'python',
+    'Java 17': 'java',
+  };
+
+  const startingLineNum = Math.min(
+    ...file.comments.map((comment) => comment.lineNumber),
+  );
+
+  const [selectedLine, setSelectedLine] = useState<number>(startingLineNum);
+  const editorRef = useRef<ReactAce | null>(null);
+
+  const handleCursorChange = (selection): void => {
+    const currentLine = selection.getCursor().row + 1; // Ace editor uses 0-index, so add 1
+    setSelectedLine(currentLine);
+  };
+
+  const handleCommentClick = (lineNumber: number): void => {
+    setSelectedLine(lineNumber);
+    if (editorRef.current) {
+      editorRef.current.editor.focus();
+      editorRef.current.editor.gotoLine(lineNumber, 0, true);
+    }
+  };
+
+  return (
+    <div className="relative" id={`file-${file.id}`}>
+      <Box marginRight="315px">
+        <EditorField
+          ref={editorRef}
+          cursorStart={startingLineNum - 1}
+          disabled
+          // This height matches the prompt height exactly so there is no awkward scroll bar
+          // and the prompt does not expand weirdly when description is opened
+          focus
+          height="482px"
+          language={languageMap[file.language]}
+          onCursorChange={handleCursorChange}
+          value={file.content}
+        />
+      </Box>
+      <Drawer
+        anchor="right"
+        open
+        PaperProps={{
+          style: {
+            position: 'absolute',
+            width: '315px',
+            border: 0,
+            backgroundColor: 'transparent',
+          },
+        }}
+        variant="persistent"
+      >
+        <div className="p-2">
+          {file.comments.map((comment) => (
+            <Card
+              key={`file-${file.id}-comment-${comment.lineNumber}`}
+              className={`mb-1 border border-solid border-gray-400 rounded-lg shadow-none cursor-pointer ${
+                selectedLine === comment.lineNumber ? 'bg-yellow-100' : ''
+              }`}
+              onClick={() => {
+                handleCommentClick(comment.lineNumber);
+              }}
+            >
+              <Typography
+                className="ml-1"
+                fontWeight="bold"
+                variant="subtitle1"
+              >
+                {t(translations.lineHeader, {
+                  lineNumber: comment.lineNumber,
+                })}
+              </Typography>
+              <CardContent className="px-1 pt-0 last:pb-1">
+                <Typography variant="body2">{comment.comment}</Typography>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </Drawer>
+    </div>
+  );
+};
+
+export default LiveFeedbackDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
@@ -1,0 +1,95 @@
+import { FC, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Slider, Typography } from '@mui/material';
+
+import Accordion from 'lib/components/core/layouts/Accordion';
+import { useAppSelector } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
+import { formatLongDateTime } from 'lib/moment';
+
+import {
+  getLiveFeedbackHistory,
+  getLiveFeedbadkQuestionInfo,
+} from '../selectors';
+
+import LiveFeedbackDetails from './LiveFeedbackDetails';
+
+const translations = defineMessages({
+  questionTitle: {
+    id: 'course.assessment.liveFeedback.questionTitle',
+    defaultMessage: 'Question {index}',
+  },
+});
+
+interface Props {
+  questionNumber: number;
+}
+
+const LiveFeedbackHistoryPage: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const { questionNumber } = props;
+  const allLiveFeedbackHistory = useAppSelector(getLiveFeedbackHistory).filter(
+    (liveFeedbackHistory) => {
+      // Remove live feedbacks that have no comments
+      return liveFeedbackHistory.files.some((file) => file.comments.length > 0);
+    },
+  );
+  const question = useAppSelector(getLiveFeedbadkQuestionInfo);
+
+  const [displayedIndex, setDisplayedIndex] = useState(
+    allLiveFeedbackHistory.length - 1,
+  );
+  const sliderMarks = allLiveFeedbackHistory.map((liveFeedbackHistory, idx) => {
+    return {
+      value: idx,
+      label:
+        idx === 0 || idx === allLiveFeedbackHistory.length - 1
+          ? formatLongDateTime(liveFeedbackHistory.createdAt)
+          : '',
+    };
+  });
+
+  return (
+    <>
+      <div className="pb-2">
+        <Accordion
+          defaultExpanded={false}
+          title={t(translations.questionTitle, {
+            index: questionNumber,
+          })}
+        >
+          <div className="ml-4 mt-4">
+            <Typography variant="body1">{question.title}</Typography>
+            <Typography
+              dangerouslySetInnerHTML={{
+                __html: question.description,
+              }}
+              variant="body2"
+            />
+          </div>
+        </Accordion>
+      </div>
+
+      {allLiveFeedbackHistory.length > 1 && (
+        <div className="w-[calc(100%_-_17rem)] mx-auto">
+          <Slider
+            defaultValue={allLiveFeedbackHistory.length - 1}
+            marks={sliderMarks}
+            max={allLiveFeedbackHistory.length - 1}
+            min={0}
+            onChange={(_, value) => {
+              setDisplayedIndex(Array.isArray(value) ? value[0] : value);
+            }}
+            step={null}
+            valueLabelDisplay="off"
+          />
+        </div>
+      )}
+      {allLiveFeedbackHistory[displayedIndex].files.map((file) => {
+        return <LiveFeedbackDetails key={file.id} file={file} />;
+      })}
+    </>
+  );
+};
+
+export default LiveFeedbackHistoryPage;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/index.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/index.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { fetchLiveFeedbackHistory } from 'course/assessment/operations/liveFeedback';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+
+import LiveFeedbackHistoryPage from './LiveFeedbackHistoryPage';
+
+interface Props {
+  questionNumber: number;
+  questionId: number;
+  courseUserId: number;
+}
+
+const LiveFeedbackHistoryIndex: FC<Props> = (props): JSX.Element => {
+  const { questionNumber, questionId, courseUserId } = props;
+  const { assessmentId } = useParams();
+  const parsedAssessmentId = parseInt(assessmentId!, 10);
+
+  const fetchLiveFeedbackHistoryDetails = (): Promise<void> =>
+    fetchLiveFeedbackHistory(parsedAssessmentId, questionId, courseUserId);
+
+  return (
+    <Preload
+      render={<LoadingIndicator />}
+      while={fetchLiveFeedbackHistoryDetails}
+    >
+      {(): JSX.Element => (
+        <LiveFeedbackHistoryPage questionNumber={questionNumber} />
+      )}
+    </Preload>
+  );
+};
+
+export default LiveFeedbackHistoryIndex;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useState } from 'react';
 import { defineMessages } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { Box, Chip } from '@mui/material';
@@ -9,15 +9,18 @@ import {
 } from 'types/course/statistics/assessmentStatistics';
 
 import { workflowStates } from 'course/assessment/submission/constants';
+import Prompt from 'lib/components/core/dialogs/Prompt';
 import Link from 'lib/components/core/Link';
 import Note from 'lib/components/core/Note';
 import GhostIcon from 'lib/components/icons/GhostIcon';
 import Table, { ColumnTemplate } from 'lib/components/table';
 import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
 import TableLegends from 'lib/containers/TableLegends';
+import { getEditSubmissionURL } from 'lib/helpers/url-builders';
 import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
+import AllAttemptsIndex from './AnswerDisplay/AllAttempts';
 import { getClassNameForAttemptCountCell } from './classNameUtils';
 import { getAssessmentStatistics } from './selectors';
 
@@ -71,6 +74,10 @@ const translations = defineMessages({
     id: 'course.assessment.statistics.filename',
     defaultMessage: 'Question-level Attempt Statistics for {assessment}',
   },
+  close: {
+    id: 'course.assessment.statistics.close',
+    defaultMessage: 'Close',
+  },
 });
 
 interface Props {
@@ -87,10 +94,16 @@ const statusTranslations = {
 
 const StudentAttemptCountTable: FC<Props> = (props) => {
   const { t } = useTranslation();
-  const { courseId } = useParams();
+  const { courseId, assessmentId } = useParams();
   const { includePhantom } = props;
 
   const statistics = useAppSelector(getAssessmentStatistics);
+  const [openPastAnswers, setOpenPastAnswers] = useState(false);
+  const [answerInfo, setAnswerInfo] = useState({
+    index: 0,
+    answerId: 0,
+    studentName: '',
+  });
   const assessment = statistics.assessment;
   const submissions = statistics.submissions;
 
@@ -118,11 +131,27 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
 
   // the case where the attempt count is null is handled separately inside the column
   // (refer to the definition of answerColumns below)
-  const renderNonNullAttemptCountCell = (attempt: AttemptInfo): ReactNode => {
-    const className = getClassNameForAttemptCountCell(attempt);
+  const renderAttemptCountClickableCell = (
+    index: number,
+    datum: MainSubmissionInfo,
+  ): ReactNode => {
+    const className = getClassNameForAttemptCountCell(
+      datum.attemptStatus![index],
+    );
+
     return (
-      <div className={className}>
-        <Box>{attempt.attemptCount}</Box>
+      <div
+        className={`cursor-pointer ${className}`}
+        onClick={(): void => {
+          setOpenPastAnswers(true);
+          setAnswerInfo({
+            index: index + 1,
+            answerId: datum.attemptStatus![index].lastAttemptAnswerId,
+            studentName: datum.courseUser.name,
+          });
+        }}
+      >
+        <Box>{datum.attemptStatus![index].attemptCount}</Box>
       </div>
     );
   };
@@ -159,8 +188,8 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
         },
         title: t(translations.questionIndex, { index: index + 1 }),
         cell: (datum): ReactNode => {
-          return typeof datum.attemptStatus?.[index]?.attemptCount === 'number'
-            ? renderNonNullAttemptCountCell(datum.attemptStatus?.[index])
+          return typeof datum.attemptStatus?.[index].attemptCount === 'number'
+            ? renderAttemptCountClickableCell(index, datum)
             : null;
         },
         sortable: true,
@@ -217,19 +246,20 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
       title: t(translations.workflowState),
       sortable: true,
       cell: (datum) => (
-        <Chip
-          className="w-100"
-          label={
-            statusTranslations[datum.workflowState ?? workflowStates.Unstarted]
-          }
-          style={{
-            backgroundColor:
-              palette.submissionStatus[
+        <Link
+          opensInNewTab
+          to={getEditSubmissionURL(courseId, assessmentId, datum.id)}
+        >
+          <Chip
+            className={`text-blue-800 ${palette.submissionStatusClassName[datum.workflowState ?? workflowStates.Unstarted]} w-full`}
+            label={
+              statusTranslations[
                 datum.workflowState ?? workflowStates.Unstarted
-              ],
-          }}
-          variant="filled"
-        />
+              ]
+            }
+            variant="filled"
+          />
+        </Link>
       ),
       className: 'center',
     },
@@ -278,6 +308,17 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
         search={{ searchPlaceholder: t(translations.searchText) }}
         toolbar={{ show: true }}
       />
+      <Prompt
+        cancelLabel={t(translations.close)}
+        onClose={(): void => setOpenPastAnswers(false)}
+        open={openPastAnswers}
+        title={answerInfo.studentName}
+      >
+        <AllAttemptsIndex
+          curAnswerId={answerInfo.answerId}
+          index={answerInfo.index}
+        />
+      </Prompt>
     </>
   );
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/SubmissionStatusChart.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/SubmissionStatusChart.tsx
@@ -1,0 +1,72 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+import palette from 'theme/palette';
+import {
+  AncestorSubmissionInfo,
+  MainSubmissionInfo,
+} from 'types/course/statistics/assessmentStatistics';
+
+import { workflowStates } from 'course/assessment/submission/constants';
+import BarChart from 'lib/components/core/BarChart';
+
+const translations = defineMessages({
+  datasetLabel: {
+    id: 'course.assessment.statistics.SubmissionStatusChart.datasetLabel',
+    defaultMessage: 'Student Submission Statuses',
+  },
+  published: {
+    id: 'course.assessment.statistics.SubmissionStatusChart.published',
+    defaultMessage: 'Graded',
+  },
+  graded: {
+    id: 'course.assessment.statistics.SubmissionStatusChart.graded',
+    defaultMessage: 'Graded, unpublished',
+  },
+  submitted: {
+    id: 'course.assessment.statistics.SubmissionStatusChart.submitted',
+    defaultMessage: 'Submitted',
+  },
+  attempting: {
+    id: 'course.assessment.statistics.SubmissionStatusChart.attempting',
+    defaultMessage: 'Attempting',
+  },
+  unstarted: {
+    id: 'course.assessment.statistics.SubmissionStatusChart.unattempted',
+    defaultMessage: 'Not Started',
+  },
+});
+
+interface Props {
+  submissions: MainSubmissionInfo[] | AncestorSubmissionInfo[];
+}
+
+const SubmissionStatusChart = (props: Props): JSX.Element => {
+  const { submissions } = props;
+  const workflowStatesArray = Object.values(workflowStates);
+
+  const initialCounts = workflowStatesArray.reduce(
+    (counts, w) => ({ ...counts, [w]: 0 }),
+    {},
+  );
+  const submissionStateCounts = submissions.reduce((counts, submission) => {
+    return {
+      ...counts,
+      [submission.workflowState ?? workflowStates.Unstarted]:
+        counts[submission.workflowState ?? workflowStates.Unstarted] + 1,
+    };
+  }, initialCounts);
+
+  const data = workflowStatesArray
+    .map((w) => {
+      const count = submissionStateCounts[w];
+      return {
+        count,
+        color: palette.submissionStatus[w],
+        label: <FormattedMessage {...translations[w]} />,
+      };
+    })
+    .filter((seg) => seg.count > 0);
+
+  return <BarChart data={data} />;
+};
+
+export default SubmissionStatusChart;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/selectors.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/selectors.ts
@@ -1,6 +1,17 @@
 import { AppState } from 'store';
+import {
+  LiveFeedbackHistory,
+  QuestionInfo,
+} from 'types/course/assessment/submission/liveFeedback';
 import { AssessmentStatisticsState } from 'types/course/statistics/assessmentStatistics';
 
 export const getAssessmentStatistics = (
   state: AppState,
 ): AssessmentStatisticsState => state.assessments.statistics;
+
+export const getLiveFeedbackHistory = (
+  state: AppState,
+): LiveFeedbackHistory[] => state.assessments.liveFeedback.liveFeedbackHistory;
+
+export const getLiveFeedbadkQuestionInfo = (state: AppState): QuestionInfo =>
+  state.assessments.liveFeedback.question;

--- a/client/app/bundles/course/assessment/reducers/liveFeedback.ts
+++ b/client/app/bundles/course/assessment/reducers/liveFeedback.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { LiveFeedbackHistoryState } from 'types/course/assessment/submission/liveFeedback';
+
+const initialState: LiveFeedbackHistoryState = {
+  liveFeedbackHistory: [],
+  question: {
+    id: 0,
+    title: '',
+    description: '',
+  },
+};
+
+export const liveFeedbackSlice = createSlice({
+  name: 'liveFeedbackHistory',
+  initialState,
+  reducers: {
+    initialize: (state, action: PayloadAction<LiveFeedbackHistoryState>) => {
+      state.liveFeedbackHistory = action.payload.liveFeedbackHistory;
+      state.question = action.payload.question;
+    },
+    reset: () => {
+      return initialState;
+    },
+  },
+});
+
+export const liveFeedbackActions = liveFeedbackSlice.actions;
+
+export default liveFeedbackSlice.reducer;

--- a/client/app/bundles/course/assessment/store.ts
+++ b/client/app/bundles/course/assessment/store.ts
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 
 import editPageReducer from './reducers/editPage';
 import formDialogReducer from './reducers/formDialog';
+import liveFeedbackHistoryReducer from './reducers/liveFeedback';
 import monitoringReducer from './reducers/monitoring';
 import statisticsReducer from './reducers/statistics';
 import submissionReducer from './submission/reducers';
@@ -12,6 +13,7 @@ const reducer = combineReducers({
   monitoring: monitoringReducer,
   statistics: statisticsReducer,
   submission: submissionReducer,
+  liveFeedback: liveFeedbackHistoryReducer,
 });
 
 export default reducer;

--- a/client/app/bundles/course/assessment/submission/components/answers/TextResponse/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/TextResponse/index.jsx
@@ -128,8 +128,8 @@ TextResponse.propTypes = {
   answerId: PropTypes.number.isRequired,
   graderView: PropTypes.bool.isRequired,
   handleUploadTextResponseFiles: PropTypes.func.isRequired,
-  question: questionShape.isRequired,
   numAttachments: PropTypes.number,
+  question: questionShape.isRequired,
   readOnly: PropTypes.bool.isRequired,
   saveAnswerAndUpdateClientVersion: PropTypes.func.isRequired,
 };

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -1,7 +1,7 @@
 import { Component, Fragment } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
-import { Done } from '@mui/icons-material';
+import { Close, Done } from '@mui/icons-material';
 import Clear from '@mui/icons-material/Clear';
 import {
   Alert,
@@ -46,6 +46,14 @@ const translations = defineMessages({
   allPassed: {
     id: 'course.assessment.submission.TestCaseView.allPassed',
     defaultMessage: 'All passed',
+  },
+  allFailed: {
+    id: 'course.assessment.submission.TestCaseView.allFailed',
+    defaultMessage: 'All failed',
+  },
+  testCasesPassed: {
+    id: 'course.assessment.submission.TestCaseView.testCasesPassed',
+    defaultMessage: '{numPassed}/{numTestCases} passed',
   },
   publicTestCases: {
     id: 'course.assessment.submission.TestCaseView.publicTestCases',
@@ -191,29 +199,77 @@ export class VisibleTestCaseView extends Component {
       return null;
     }
 
-    const passedTestCases = testCases.reduce(
-      (passed, testCase) => passed && testCase?.passed,
-      true,
+    const numPassedTestCases = testCases.filter(
+      (testCase) => testCase.passed,
+    ).length;
+
+    const AllTestCasesPassedChip = () => (
+      <Chip
+        color="success"
+        icon={<Done />}
+        label={<FormattedMessage {...translations.allPassed} />}
+        size="small"
+        variant="outlined"
+      />
     );
 
-    const shouldShowAllPassed = !isDraftAnswer && passedTestCases;
+    const SomeTestCasesPassedChip = () => (
+      <Chip
+        color="warning"
+        label={
+          <FormattedMessage
+            {...translations.testCasesPassed}
+            values={{
+              numPassed: numPassedTestCases,
+              numTestCases: testCases.length,
+            }}
+          />
+        }
+        size="small"
+        variant="outlined"
+      />
+    );
+
+    const NoTestCasesPassedChip = () => (
+      <Chip
+        color="error"
+        icon={<Close />}
+        label={<FormattedMessage {...translations.allFailed} />}
+        size="small"
+        variant="outlined"
+      />
+    );
+
+    const TestCasesIndicatorChip = () => {
+      if (numPassedTestCases === testCases.length) {
+        return <AllTestCasesPassedChip />;
+      }
+
+      if (numPassedTestCases > 0) {
+        return <SomeTestCasesPassedChip />;
+      }
+
+      return <NoTestCasesPassedChip />;
+    };
+
+    const testCaseComponentClassName = () => {
+      if (numPassedTestCases === testCases.length) {
+        return 'border-success';
+      }
+
+      if (numPassedTestCases > 0) {
+        return 'border-warning';
+      }
+
+      return 'border-error';
+    };
 
     return (
       <Accordion
-        className={shouldShowAllPassed && 'border-success'}
+        className={!isDraftAnswer && testCaseComponentClassName()}
         defaultExpanded={!collapsible}
         disableGutters
-        icon={
-          shouldShowAllPassed && (
-            <Chip
-              color="success"
-              icon={<Done />}
-              label={<FormattedMessage {...translations.allPassed} />}
-              size="small"
-              variant="outlined"
-            />
-          )
-        }
+        icon={!isDraftAnswer && <TestCasesIndicatorChip />}
         id={testCaseType}
         subtitle={
           warn && <FormattedMessage {...translations.staffOnlyTestCases} />

--- a/client/app/bundles/course/assessment/submission/pages/QuestionIndex/PastAttempts.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/QuestionIndex/PastAttempts.tsx
@@ -1,0 +1,50 @@
+import { FC } from 'react';
+import { useParams } from 'react-router-dom';
+import { QuestionType } from 'types/course/assessment/question';
+import { QuestionAllAnswerDisplayDetails } from 'types/course/statistics/assessmentStatistics';
+
+import { fetchAllAnswers } from 'course/assessment/operations/statistics';
+import AllAttemptsDisplay from 'course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay';
+import Comment from 'course/assessment/pages/AssessmentStatistics/AnswerDisplay/Comment';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import Preload from 'lib/components/wrappers/Preload';
+import { getEditSubmissionQuestionURL } from 'lib/helpers/url-builders';
+import { getSubmissionQuestionId } from 'lib/helpers/url-helpers';
+
+const PastAnswers: FC = () => {
+  const submissionQuestionId = getSubmissionQuestionId();
+  const { courseId, assessmentId } = useParams();
+  if (!submissionQuestionId) {
+    return null;
+  }
+
+  const parsedSubmissionQuestionId = parseInt(submissionQuestionId, 10);
+
+  const fetchAnswers = (): Promise<
+    QuestionAllAnswerDisplayDetails<keyof typeof QuestionType>
+  > => {
+    return fetchAllAnswers(parsedSubmissionQuestionId);
+  };
+
+  return (
+    <Preload render={<LoadingIndicator />} while={fetchAnswers}>
+      {(data): JSX.Element => (
+        <>
+          <AllAttemptsDisplay
+            allAnswers={data.allAnswers}
+            question={data.question}
+            questionNumber={data.question.questionNumber!}
+            submissionEditUrl={getEditSubmissionQuestionURL(
+              courseId,
+              assessmentId,
+              data.submissionId,
+              data.question.questionNumber,
+            )}
+          />
+          {data.comments.length > 0 && <Comment comments={data.comments} />}
+        </>
+      )}
+    </Preload>
+  );
+};
+export default PastAnswers;

--- a/client/app/lib/components/core/BarChart.jsx
+++ b/client/app/lib/components/core/BarChart.jsx
@@ -1,5 +1,7 @@
+import { memo } from 'react';
 import { Tooltip } from 'react-tooltip';
 import { Typography } from '@mui/material';
+import { equal } from 'fast-deep-equal';
 import PropTypes from 'prop-types';
 
 const styles = {
@@ -55,4 +57,4 @@ BarChart.propTypes = {
   ).isRequired,
 };
 
-export default BarChart;
+export default memo(BarChart, equal);

--- a/client/app/lib/components/core/dialogs/Prompt.tsx
+++ b/client/app/lib/components/core/dialogs/Prompt.tsx
@@ -19,6 +19,7 @@ interface BasePromptProps {
   onClosed?: () => void;
   disabled?: boolean;
   contentClassName?: string;
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 }
 
 type DefaultActionProps<Action extends string> = {
@@ -66,6 +67,7 @@ const Prompt = (props: PromptProps): JSX.Element => {
   return (
     <Dialog
       fullWidth
+      maxWidth={props.maxWidth ?? 'sm'}
       onClose={handleClose}
       open={props.open ?? false}
       TransitionProps={{ onExited: props.onClosed }}

--- a/client/app/lib/components/core/fields/EditorField.tsx
+++ b/client/app/lib/components/core/fields/EditorField.tsx
@@ -11,6 +11,7 @@ interface EditorProps extends ComponentProps<typeof AceEditor> {
   value?: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
+  cursorStart?: number;
 }
 
 /**
@@ -31,7 +32,8 @@ const DEFAULT_FONT_FAMILY = [
 
 const EditorField = forwardRef(
   (props: EditorProps, ref: ForwardedRef<AceEditor>): JSX.Element => {
-    const { language, value, disabled, onChange, ...otherProps } = props;
+    const { language, value, disabled, onChange, cursorStart, ...otherProps } =
+      props;
 
     return (
       <AceEditor
@@ -49,6 +51,9 @@ const EditorField = forwardRef(
           $blockScrolling: true,
         }}
         onLoad={(editor) => {
+          if (cursorStart !== undefined) {
+            editor.getSession().getSelection().moveCursorTo(cursorStart, 0);
+          }
           if (language === 'python')
             editor.onPaste = (originalText, event: ClipboardEvent): void => {
               event.preventDefault();

--- a/client/app/lib/helpers/url-builders.js
+++ b/client/app/lib/helpers/url-builders.js
@@ -15,6 +15,14 @@ export const getAchievementURL = (courseId, achievementId) =>
 export const getEditSubmissionURL = (courseId, assessmentId, submissionId) =>
   `/courses/${courseId}/assessments/${assessmentId}/submissions/${submissionId}/edit`;
 
+export const getEditSubmissionQuestionURL = (
+  courseId,
+  assessmentId,
+  submissionId,
+  questionNumber,
+) =>
+  `/courses/${courseId}/assessments/${assessmentId}/submissions/${submissionId}/edit?step=${questionNumber}`;
+
 export const getSubmissionLogsURL = (courseId, assessmentId, submissionId) =>
   `/courses/${courseId}/assessments/${assessmentId}/submissions/${submissionId}/logs`;
 
@@ -34,6 +42,13 @@ export const getSurveyResponseURL = (courseId, surveyId, responseId) =>
 
 export const getAssessmentURL = (courseId, assessmentId) =>
   `/courses/${courseId}/assessments/${assessmentId}`;
+
+export const getPastAnswersURL = (
+  courseId,
+  assessmentId,
+  submissionQuestionId,
+) =>
+  `/courses/${courseId}/assessments/${assessmentId}/submission_questions/${submissionQuestionId}/past_attempts`;
 
 export const getAssessmentSubmissionURL = (courseId, assessmentId) =>
   `/courses/${courseId}/assessments/${assessmentId}/submissions`;

--- a/client/app/lib/helpers/url-helpers.js
+++ b/client/app/lib/helpers/url-helpers.js
@@ -113,6 +113,13 @@ function getCourseUserId() {
   return match && match[1];
 }
 
+function getSubmissionQuestionId() {
+  const match = window.location.pathname.match(
+    /^\/courses\/\d+\/assessments\/\d+\/submission_questions\/(\d+)/,
+  );
+  return match && match[1];
+}
+
 /**
  * Get the video submission id from URL.
  *
@@ -144,6 +151,7 @@ export {
   getCurrentPath,
   getScribingId,
   getSubmissionId,
+  getSubmissionQuestionId,
   getSurveyId,
   getUrlParameter,
   getVideoId,

--- a/client/app/routers/AuthenticatedApp.tsx
+++ b/client/app/routers/AuthenticatedApp.tsx
@@ -117,6 +117,7 @@ import {
   questionHandle,
 } from 'course/assessment/handles';
 import QuestionFormOutlet from 'course/assessment/question/components/QuestionFormOutlet';
+import PastAttempts from 'course/assessment/submission/pages/QuestionIndex/PastAttempts';
 import { CourseContainer } from 'course/container';
 import { commentHandle } from 'course/discussion/topics/handles';
 import {
@@ -632,6 +633,20 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
                           path: 'logs',
                           handle: LogsIndex.handle,
                           element: <LogsIndex />,
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  path: 'submission_questions',
+                  children: [
+                    {
+                      path: ':submissionQuestionId',
+                      children: [
+                        {
+                          path: 'past_attempts',
+                          element: <PastAttempts />,
                         },
                       ],
                     },

--- a/client/app/theme/palette.js
+++ b/client/app/theme/palette.js
@@ -81,6 +81,14 @@ const palette = {
     [workflowStates.Published]: colors.green[100],
   },
 
+  submissionStatusClassName: {
+    [workflowStates.Unstarted]: 'bg-red-200',
+    [workflowStates.Attempting]: 'bg-yellow-200',
+    [workflowStates.Submitted]: 'bg-grey-200',
+    [workflowStates.Graded]: 'bg-blue-200',
+    [workflowStates.Published]: 'bg-green-200',
+  },
+
   groupRole: {
     [groupRole.Normal]: colors.green[100],
     [groupRole.Manager]: colors.red[100],

--- a/client/app/types/course/assessment/submission/answer/forumPostResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/forumPostResponse.ts
@@ -6,7 +6,7 @@ import {
   AnswerFieldBaseEntity,
 } from './answer';
 
-interface PostPack {
+export interface PostPack {
   id: number;
   text: string;
   creatorId: number;
@@ -19,19 +19,21 @@ interface PostPack {
 
 // BE Data Type
 
-interface ForumPostResponseFieldData extends AnswerFieldBaseData {
+export interface SelectedPostPack {
+  forum: { id: string; name: string };
+  topic: { id: number; title: string; isDeleted: boolean };
+  corePost: PostPack;
+  parentPost?: PostPack;
+}
+
+export interface ForumPostResponseFieldData extends AnswerFieldBaseData {
   answer_text: string;
+  selected_post_packs: SelectedPostPack[];
 }
 
 export interface ForumPostResponseAnswerData extends AnswerBaseData {
   questionType: QuestionType.ForumPostResponse;
   fields: ForumPostResponseFieldData;
-  selected_post_packs: {
-    forum: { id: string; name: string };
-    topic: { id: number; title: string; isDeleted: boolean };
-    corePost: PostPack;
-    parentPost?: PostPack;
-  };
   explanation: {
     correct: boolean | null;
     explanations: string[];

--- a/client/app/types/course/assessment/submission/answer/multipleResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/multipleResponse.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface MultipleResponseFieldData extends AnswerFieldBaseData {
+export interface MultipleResponseFieldData extends AnswerFieldBaseData {
   option_ids: number[];
 }
 
@@ -22,7 +22,7 @@ export interface MultipleResponseAnswerData extends AnswerBaseData {
   latestAnswer?: MultipleResponseAnswerData;
 }
 
-interface MultipleChoiceFieldData extends AnswerFieldBaseData {
+export interface MultipleChoiceFieldData extends AnswerFieldBaseData {
   option_ids: number[];
 }
 

--- a/client/app/types/course/assessment/submission/answer/programming.ts
+++ b/client/app/types/course/assessment/submission/answer/programming.ts
@@ -15,9 +15,9 @@ export interface ProgrammingContent {
   highlightedContent: string | null;
 }
 
-type TestCaseType = 'public_test' | 'private_test' | 'evaluation_test';
+export type TestCaseType = 'public_test' | 'private_test' | 'evaluation_test';
 
-interface TestCaseResult {
+export interface TestCaseResult {
   identifier?: string;
   expression: string;
   expected: string;
@@ -27,7 +27,7 @@ interface TestCaseResult {
 
 // BE Data Type
 
-interface ProgrammingFieldData extends AnswerFieldBaseData {
+export interface ProgrammingFieldData extends AnswerFieldBaseData {
   files_attributes: ProgrammingContent[];
 }
 

--- a/client/app/types/course/assessment/submission/answer/scribing.ts
+++ b/client/app/types/course/assessment/submission/answer/scribing.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface ScribingFieldData extends AnswerFieldBaseData {}
+export interface ScribingFieldData extends AnswerFieldBaseData {}
 
 export interface ScribingAnswerData extends AnswerBaseData {
   questionType: QuestionType.Scribing;

--- a/client/app/types/course/assessment/submission/answer/textResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/textResponse.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface TextResponseFieldData extends AnswerFieldBaseData {
+export interface TextResponseFieldData extends AnswerFieldBaseData {
   answer_text: string;
 }
 
@@ -23,7 +23,7 @@ export interface TextResponseAnswerData extends AnswerBaseData {
   latestAnswer?: TextResponseAnswerData;
 }
 
-interface FileUploadFieldData extends AnswerFieldBaseData {}
+export interface FileUploadFieldData extends AnswerFieldBaseData {}
 
 export interface FileUploadAnswerData extends AnswerBaseData {
   questionType: QuestionType.FileUpload;

--- a/client/app/types/course/assessment/submission/answer/voiceResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/voiceResponse.ts
@@ -8,7 +8,7 @@ import {
 
 // BE Data Type
 
-interface VoiceResponseFieldData extends AnswerFieldBaseData {
+export interface VoiceResponseFieldData extends AnswerFieldBaseData {
   file: { url: string | null; name: string };
 }
 

--- a/client/app/types/course/assessment/submission/liveFeedback.ts
+++ b/client/app/types/course/assessment/submission/liveFeedback.ts
@@ -1,0 +1,34 @@
+import { LanguageMode } from '../question/programming';
+
+export interface LiveFeedbackComments {
+  lineNumber: number;
+  comment: string;
+}
+
+export interface LiveFeedbackCode {
+  id: number;
+  filename: string;
+  content: string;
+  language: string;
+}
+
+export interface LiveFeedbackCodeAndComments extends LiveFeedbackCode {
+  comments: LiveFeedbackComments[];
+}
+
+export interface LiveFeedbackHistory {
+  id: number;
+  createdAt: string;
+  files: LiveFeedbackCodeAndComments[];
+}
+
+export interface QuestionInfo {
+  id: number;
+  title: string;
+  description: string;
+}
+
+export interface LiveFeedbackHistoryState {
+  liveFeedbackHistory: LiveFeedbackHistory[];
+  question: QuestionInfo;
+}

--- a/client/app/types/course/assessment/submission/question/types.ts
+++ b/client/app/types/course/assessment/submission/question/types.ts
@@ -66,7 +66,7 @@ interface ForumPostResponseQuestionData {
   maxPosts: boolean;
 }
 
-interface SpecificQuestionDataMap {
+export interface SpecificQuestionDataMap {
   MultipleChoice: MultipleResponseQuestionData;
   MultipleResponse: MultipleResponseQuestionData;
   Programming: ProgrammingQuestionData;

--- a/client/app/types/course/statistics/answer.ts
+++ b/client/app/types/course/statistics/answer.ts
@@ -1,0 +1,160 @@
+import { JobStatus, JobStatusResponse } from 'types/jobs';
+
+import { QuestionType } from '../assessment/question';
+import { ForumPostResponseFieldData } from '../assessment/submission/answer/forumPostResponse';
+import {
+  MultipleChoiceFieldData,
+  MultipleResponseFieldData,
+} from '../assessment/submission/answer/multipleResponse';
+import {
+  ProgrammingFieldData,
+  TestCaseResult,
+  TestCaseType,
+} from '../assessment/submission/answer/programming';
+import { ScribingFieldData } from '../assessment/submission/answer/scribing';
+import {
+  FileUploadFieldData,
+  TextResponseFieldData,
+} from '../assessment/submission/answer/textResponse';
+import { VoiceResponseFieldData } from '../assessment/submission/answer/voiceResponse';
+
+interface AnswerCommonDetails<T extends keyof typeof QuestionType> {
+  id: number;
+  grade: number;
+  questionType: T;
+}
+
+export interface McqAnswerDetails
+  extends AnswerCommonDetails<'MultipleChoice'> {
+  fields: MultipleChoiceFieldData;
+  explanation: {
+    correct?: boolean | null;
+    explanations?: string[];
+  };
+  latestAnswer?: McqAnswerDetails;
+}
+
+export interface MrqAnswerDetails
+  extends AnswerCommonDetails<'MultipleResponse'> {
+  fields: MultipleResponseFieldData;
+  explanation: {
+    correct?: boolean | null;
+    explanations?: string[];
+  };
+  latestAnswer?: MrqAnswerDetails;
+}
+
+export interface AnnotationTopic {
+  id: number;
+  postIds: number[];
+  line: string;
+}
+
+export interface Annotation {
+  fileId: number;
+  topics: AnnotationTopic[];
+}
+
+export interface TestCase {
+  canReadTests: boolean;
+  public_test?: TestCaseResult[];
+  private_test?: TestCaseResult[];
+  evaluation_test?: TestCaseResult[];
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface CodaveriFeedback {
+  jobId: string;
+  jobStatus: keyof typeof JobStatus;
+  jobUrl?: string;
+  errorMessage?: string;
+}
+
+export interface ProgrammingAnswerDetails
+  extends AnswerCommonDetails<'Programming'> {
+  fields: ProgrammingFieldData;
+  explanation: {
+    correct?: boolean;
+    explanation: string[];
+    failureType: TestCaseType;
+  };
+  testCases: TestCase;
+  attemptsLeft?: number;
+  autograding?: JobStatusResponse & {
+    path?: string;
+  };
+  codaveriFeedback?: CodaveriFeedback;
+  latestAnswer?: ProgrammingAnswerDetails & {
+    annotations: Annotation[];
+  };
+}
+
+export interface TextResponseAnswerDetails
+  extends AnswerCommonDetails<'TextResponse'> {
+  fields: TextResponseFieldData;
+  attachments: { id: string; name: string }[];
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+  latestAnswer?: TextResponseAnswerDetails;
+}
+
+export interface FileUploadAnswerDetails
+  extends AnswerCommonDetails<'FileUpload'> {
+  fields: FileUploadFieldData;
+  attachments: { id: string; name: string }[];
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+  latestAnswer?: FileUploadAnswerDetails;
+}
+
+export interface ComprehensionAnswerDetails
+  extends AnswerCommonDetails<'Comprehension'> {}
+
+export interface ScribingAnswerDetails extends AnswerCommonDetails<'Scribing'> {
+  fields: ScribingFieldData;
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+  scribing_answer: {
+    image_url: string;
+    user_id: number;
+    answer_id: number;
+    scribbles: { content: string; creator_name: string; creator_id: number }[];
+  };
+}
+
+export interface VoiceResponseAnswerDetails
+  extends AnswerCommonDetails<'VoiceResponse'> {
+  fields: VoiceResponseFieldData;
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+}
+
+export interface ForumPostResponseAnswerDetails
+  extends AnswerCommonDetails<'ForumPostResponse'> {
+  fields: ForumPostResponseFieldData;
+  explanation: {
+    correct: boolean | null;
+    explanations: string[];
+  };
+}
+
+export interface AnswerDetailsMap {
+  MultipleChoice: McqAnswerDetails;
+  MultipleResponse: MrqAnswerDetails;
+  Programming: ProgrammingAnswerDetails;
+  TextResponse: TextResponseAnswerDetails;
+  FileUpload: FileUploadAnswerDetails;
+  Comprehension: ComprehensionAnswerDetails;
+  Scribing: ScribingAnswerDetails;
+  VoiceResponse: VoiceResponseAnswerDetails;
+  ForumPostResponse: ForumPostResponseAnswerDetails;
+}

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -1,4 +1,9 @@
+import { QuestionType } from '../assessment/question';
+import { SpecificQuestionDataMap } from '../assessment/submission/question/types';
 import { WorkflowState } from '../assessment/submission/submission';
+import { CourseUserBasicListData } from '../courseUsers';
+
+import { AnswerDetailsMap } from './answer';
 
 interface AssessmentInfo {
   id: number;
@@ -27,18 +32,21 @@ export interface StudentInfo extends UserInfo {
   role: 'student';
 }
 
-interface AnswerInfo {
+export interface AnswerInfo {
+  lastAttemptAnswerId: number;
   grade: number;
   maximumGrade: number;
 }
 
 export interface AttemptInfo {
+  lastAttemptAnswerId: number;
   isAutograded: boolean;
   attemptCount: number;
   correct: boolean | null;
 }
 
 interface SubmissionInfo {
+  id: number;
   courseUser: StudentInfo;
   workflowState?: WorkflowState;
   submittedAt?: string;
@@ -78,6 +86,58 @@ export interface AncestorAssessmentStats {
 }
 
 export interface AssessmentStatisticsState extends MainAssessmentStats {}
+
+interface QuestionBasicDetails<T extends keyof typeof QuestionType> {
+  id: number;
+  title: string;
+  description: string;
+  type: T;
+  questionNumber?: number;
+  maximumGrade: number;
+}
+
+export interface CommentItem {
+  id: number;
+  createdAt: Date;
+  creator: CourseUserBasicListData;
+  isDelayed: boolean;
+  text: string;
+}
+
+export type QuestionDetails<T extends keyof typeof QuestionType> =
+  QuestionBasicDetails<T> & SpecificQuestionDataMap[T];
+
+export type AllAnswerDetails<T extends keyof typeof QuestionType> =
+  AnswerDetailsMap[T] & {
+    createdAt: Date;
+    currentAnswer: boolean;
+    workflowState: WorkflowState;
+  };
+
+export interface QuestionAnswerDetails<T extends keyof typeof QuestionType> {
+  question: QuestionDetails<T>;
+  answer: AnswerDetailsMap[T];
+  allAnswers: AllAnswerDetails<T>[];
+  comments: CommentItem[];
+  submissionId: number;
+  submissionQuestionId: number;
+}
+
+export interface QuestionAnswerDisplayDetails<
+  T extends keyof typeof QuestionType,
+> {
+  question: QuestionDetails<T>;
+  answer: AnswerDetailsMap[T];
+}
+
+export interface QuestionAllAnswerDisplayDetails<
+  T extends keyof typeof QuestionType,
+> {
+  question: QuestionDetails<T>;
+  allAnswers: AllAnswerDetails<T>[];
+  submissionId: number;
+  comments: CommentItem[];
+}
 
 export interface AssessmentLiveFeedbackStatistics {
   courseUser: StudentInfo;

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -144,4 +144,5 @@ export interface AssessmentLiveFeedbackStatistics {
   groups: { name: string }[];
   workflowState?: WorkflowState;
   liveFeedbackCount?: number[]; // Will already be ordered by question
+  questionIds: number[];
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,6 +441,7 @@ Rails.application.routes.draw do
         get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
         get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
         get 'assessment/:id/live_feedback_statistics' => 'assessments#live_feedback_statistics'
+        get 'assessment/:id/live_feedback_history' => 'assessments#live_feedback_history'
       end
 
       scope module: :video do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -429,10 +429,14 @@ Rails.application.routes.draw do
 
       namespace :statistics do
         get '/' => 'statistics#index'
-        get 'course/progression' => 'aggregate#course_progression'
-        get 'course/performance' => 'aggregate#course_performance'
+        get 'answer/:id' => 'answers#question_answer_details'
+        get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
+        get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
         get 'students' => 'aggregate#all_students'
         get 'staff' => 'aggregate#all_staff'
+        get 'course/progression' => 'aggregate#course_progression'
+        get 'course/performance' => 'aggregate#course_performance'
+        get 'submission_question/:id' => 'answers#all_answers'
         get 'user/:user_id/learning_rate_records' => 'users#learning_rate_records'
         get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
         get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'

--- a/spec/controllers/course/statistics/answers_controller_spec.rb
+++ b/spec/controllers/course/statistics/answers_controller_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Statistics::AnswersController, type: :controller do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:course) { create(:course, :enrollable) }
+    let(:course_user) { create(:course_user, course: course) }
+    let(:assessment) do
+      create(:assessment, :published_with_mrq_question, course: course, start_at: 1.day.from_now)
+    end
+    let(:submission) { create(:submission, :graded, assessment: assessment, creator: course_user.user) }
+    let(:answer) { submission.answers.first }
+    let!(:submission_question) do
+      create(:submission_question, :with_post, submission_id: answer.submission_id, question_id: answer.question_id)
+    end
+
+    describe '#question_answer_details' do
+      render_views
+      subject { get :question_answer_details, format: :json, params: { course_id: course, id: answer.id } }
+
+      context 'when the Normal User get the question answer details for the statistics' do
+        let(:user) { create(:user) }
+        before { controller_sign_in(controller, user) }
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the Course Student get the question answer details for the statistics' do
+        let(:user) { create(:course_student, course: course).user }
+        before { controller_sign_in(controller, user) }
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the Course Manager get the question answer details for the statistics' do
+        let(:user) { create(:course_manager, course: course).user }
+        before { controller_sign_in(controller, user) }
+
+        it 'returns OK with right question id and answer grade being displayed' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          expect(json_result['question']['id']).to eq(answer.question.id)
+          expect(json_result['answer']['grade'].to_f).to eq(answer.grade)
+
+          # expect only one allAnswers
+          expect(json_result['allAnswers'].count).to eq(1)
+
+          # expect only one comment
+          expect(json_result['comments'].count).to eq(1)
+        end
+      end
+
+      context 'when the administrator get the question answer details for the statistics' do
+        let(:administrator) { create(:administrator) }
+        before { controller_sign_in(controller, administrator) }
+
+        it 'returns OK with right question id and answer grade being displayed' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          expect(json_result['question']['id']).to eq(answer.question.id)
+          expect(json_result['answer']['grade'].to_f).to eq(answer.grade)
+
+          # expect only one allAnswers
+          expect(json_result['allAnswers'].count).to eq(1)
+
+          # expect only one comment
+          expect(json_result['comments'].count).to eq(1)
+        end
+      end
+    end
+
+    describe '#all_answers' do
+      render_views
+      subject { get :all_answers, format: :json, params: { course_id: course, id: submission_question.id } }
+
+      context 'when the Normal User get the question answer details for the statistics' do
+        let(:user) { create(:user) }
+        before { controller_sign_in(controller, user) }
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the Course Student get the question answer details for the statistics' do
+        let(:user) { create(:course_student, course: course).user }
+        before { controller_sign_in(controller, user) }
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the Course Manager get the question answer details for the statistics' do
+        let(:user) { create(:course_manager, course: course).user }
+        before { controller_sign_in(controller, user) }
+
+        it 'returns OK with right question id and answer grade being displayed' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          # expect only one allAnswers
+          expect(json_result['allAnswers'].count).to eq(1)
+
+          # expect only one comment
+          expect(json_result['comments'].count).to eq(1)
+        end
+      end
+
+      context 'when the administrator get the question answer details for the statistics' do
+        let(:administrator) { create(:administrator) }
+        before { controller_sign_in(controller, administrator) }
+
+        it 'returns OK with right question id and answer grade being displayed' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          # expect only one allAnswers
+          expect(json_result['allAnswers'].count).to eq(1)
+
+          # expect only one comment
+          expect(json_result['comments'].count).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/statistics/assessment_controller_spec.rb
+++ b/spec/controllers/course/statistics/assessment_controller_spec.rb
@@ -152,5 +152,102 @@ RSpec.describe Course::Statistics::AssessmentsController, type: :controller do
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
     end
+
+    describe '#live_feedback_history' do
+      let(:question) do
+        create(:course_assessment_question_programming, assessment: assessment).acting_as
+      end
+      let(:user) { create(:user) }
+
+      let!(:course_student) { create(:course_student, course: course, user: user) }
+      let!(:live_feedback) do
+        create(:course_assessment_live_feedback, assessment: assessment,
+                                                 question: question,
+                                                 creator: course_student)
+      end
+      let!(:code) { create(:course_assessment_live_feedback_code, feedback: live_feedback) }
+      let!(:comment) do
+        create(:course_assessment_live_feedback_comment, code: code, line_number: 1,
+                                                         comment: 'This is a test comment')
+      end
+      render_views
+      subject do
+        get :live_feedback_history, as: :json,
+                                    params: {
+                                      course_id: course,
+                                      id: assessment.id,
+                                      question_id: question.id,
+                                      course_user_id: course_student.id
+                                    }
+      end
+
+      context 'when the Normal User wants to get live feedback history' do
+        before { controller_sign_in(controller, user) }
+
+        it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
+      end
+
+      context 'when the Course Manager wants to get live feedback history' do
+        let(:course_manager) { create(:course_manager, course: course) }
+
+        before { controller_sign_in(controller, course_manager.user) }
+
+        it 'returns the live feedback history successfully' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          feedback_history = json_result['liveFeedbackHistory']
+          question = json_result['question']
+
+          expect(feedback_history).not_to be_empty
+          expect(feedback_history.first).to have_key('files')
+
+          file = feedback_history.first['files'].first
+          expect(file).to have_key('filename')
+          expect(file).to have_key('content')
+          expect(file).to have_key('language')
+          expect(file).to have_key('comments')
+
+          comment = file['comments'].first
+          expect(comment).to have_key('lineNumber')
+          expect(comment).to have_key('comment')
+
+          expect(question).not_to be_empty
+          expect(question).to have_key('title')
+          expect(question).to have_key('description')
+        end
+      end
+
+      context 'when the Administrator wants to get live feedback history' do
+        let(:administrator) { create(:administrator) }
+
+        before { controller_sign_in(controller, administrator) }
+
+        it 'returns the live feedback history successfully' do
+          expect(subject).to have_http_status(:success)
+          json_result = JSON.parse(response.body)
+
+          feedback_history = json_result['liveFeedbackHistory']
+          question = json_result['question']
+
+          expect(feedback_history).not_to be_empty
+          expect(feedback_history.first).to have_key('files')
+
+          file = feedback_history.first['files'].first
+          expect(file).to have_key('filename')
+          expect(file).to have_key('content')
+          expect(file).to have_key('language')
+          expect(file).to have_key('comments')
+
+          comment = file['comments'].first
+          expect(comment).to have_key('lineNumber')
+          expect(comment).to have_key('comment')
+
+          expect(question).not_to be_empty
+          expect(question).to have_key('title')
+          expect(question).to have_key('description')
+        end
+      end
+    end
   end
 end

--- a/spec/factories/course_assessment_live_feedback_code.rb
+++ b/spec/factories/course_assessment_live_feedback_code.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_live_feedback_code, class: Course::Assessment::LiveFeedbackCode do
+    feedback { association(:course_assessment_live_feedback) }
+    filename { 'test_code.rb' }
+    content { 'puts "Hello, World!"' }
+  end
+end

--- a/spec/factories/course_assessment_live_feedback_comments.rb
+++ b/spec/factories/course_assessment_live_feedback_comments.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_live_feedback_comment, class: Course::Assessment::LiveFeedbackComment do
+    code { association(:course_assessment_live_feedback_code) }
+    line_number { 1 }
+    comment { 'This is a test comment' }
+  end
+end

--- a/spec/factories/course_assessment_live_feedbacks.rb
+++ b/spec/factories/course_assessment_live_feedbacks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_assessment_live_feedback, class: Course::Assessment::LiveFeedback do
+    assessment
+    question { association(:course_assessment_question_programming, assessment: assessment) }
+    creator { association(:course_user, course: assessment.course) }
+  end
+end


### PR DESCRIPTION
Add displaying of live feedback history from the statistics page. This is a continuation of #7497 

UI referenced from #7135 

Now clicking on the cell in the statistics page for live help will being up the histories of live help.
Note that history will only be shown when comments exist.

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/a6d2d543-067e-4d60-b8a8-347a528db3e1">

