### PR TITLE
Programming Language Deprecation

### DIFF
--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -31,7 +31,9 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   validates :package_type, presence: true
   validates :multiple_file_submission, inclusion: { in: [true, false] }
   validates :import_job_id, uniqueness: { allow_nil: true, if: :import_job_id_changed? }
+
   validates :language, presence: true
+  validate :validate_language_enabled
 
   validate -> { validate_time_limit }
   validate :validate_codaveri_question
@@ -265,8 +267,16 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
     elsif !question_assessments.empty? &&
           !question_assessments.first.assessment.course.component_enabled?(Course::CodaveriComponent)
       errors.add(:base,
-                 'Codaveri component is deactivated.'\
+                 'Codaveri component is deactivated.' \
                  'Activate it in the course setting or switch this question into a non-codaveri type.')
     end
   end
+end
+
+def validate_language_enabled
+  return unless language && !language.enabled
+
+  errors.add(:base,
+             'The selected programming language has been deprecated and cannot be used. ' \
+             'Please select another language.')
 end

--- a/app/views/course/assessment/question/programming/_form.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_form.json.jbuilder
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 json.partial! 'course/assessment/question/skills', course: course
 
-json.languages Coursemology::Polyglot::Language.all.order(:name) do |language|
+json.languages Coursemology::Polyglot::Language.all.order(weight: :desc).map do |language|
+  next unless language.enabled || @programming_question.language_id == language.id
+
   json.id language.id
   json.name language.name
+  json.disabled !language.enabled
   json.editorMode language.ace_mode
 end
 

--- a/client/app/bundles/course/assessment/question/programming/components/sections/LanguageFields.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/sections/LanguageFields.tsx
@@ -50,17 +50,25 @@ const LanguageFields = (props: LanguageFieldsProps): JSX.Element => {
               setValue('question.autograded', false);
             }
           };
-
           return (
-            <FormSelectField
-              disabled={props.disabled}
-              field={{ ...field, onChange }}
-              fieldState={fieldState}
-              label={t(translations.language)}
-              options={props.languageOptions}
-              required
-              variant="filled"
-            />
+            <>
+              <FormSelectField
+                disabled={props.disabled}
+                field={{ ...field, onChange }}
+                fieldState={fieldState}
+                label={t(translations.language)}
+                options={props.languageOptions}
+                required
+                variant="filled"
+              />
+              {props.languageOptions.find(
+                (option) => option.value === field.value && option.disabled,
+              ) && (
+                <Alert severity="warning">
+                  {t(translations.languageDeprecatedWarning)}
+                </Alert>
+              )}
+            </>
           );
         }}
       />

--- a/client/app/bundles/course/assessment/question/programming/hooks/useLanguageMode.tsx
+++ b/client/app/bundles/course/assessment/question/programming/hooks/useLanguageMode.tsx
@@ -7,6 +7,7 @@ import {
 export interface LanguageOption {
   label: string;
   value: number;
+  disabled: boolean;
 }
 
 type LanguageIdMap = Record<number, LanguageMode>;
@@ -24,6 +25,7 @@ const useLanguageMode = (languages: LanguageData[]): UseLanguageModeHook => {
           options.push({
             label: language.name,
             value: language.id,
+            disabled: language.disabled,
           });
 
           map[language.id] = language.editorMode;

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -1614,6 +1614,11 @@ const translations = defineMessages({
       'submissions will always receive the maximum grade above since there are nothing for the autograder to test ' +
       'and grade.',
   },
+  languageDeprecatedWarning: {
+    id: 'course.assessment.question.programming.languageDeprecatedWarning',
+    defaultMessage:
+      'Your selected language is deprecated. Please change it to another language.',
+  },
 });
 
 export default translations;

--- a/client/app/lib/components/form/fields/SelectField.jsx
+++ b/client/app/lib/components/form/fields/SelectField.jsx
@@ -82,6 +82,7 @@ const FormSelectField = (props) => {
           options.map((option) => (
             <Option
               key={option.value}
+              disabled={option.disabled ?? false}
               id={`select-${option.value}`}
               value={option.value}
             >

--- a/client/app/types/course/assessment/question/programming.ts
+++ b/client/app/types/course/assessment/question/programming.ts
@@ -5,6 +5,7 @@ export type LanguageMode = 'c_cpp' | 'java' | 'javascript' | 'python';
 export interface LanguageData {
   id: number;
   name: string;
+  disabled: boolean;
   editorMode: LanguageMode;
 }
 

--- a/db/migrate/20240830090759_add_deprecation_support_for_polyglot.rb
+++ b/db/migrate/20240830090759_add_deprecation_support_for_polyglot.rb
@@ -1,0 +1,40 @@
+class AddDeprecationSupportForPolyglot < ActiveRecord::Migration[7.0]
+  def change
+    add_column :polyglot_languages, :weight, :integer
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          CREATE SEQUENCE polyglot_languages_weight_seq START 1;
+          ALTER TABLE polyglot_languages ALTER COLUMN weight SET DEFAULT nextval('polyglot_languages_weight_seq');
+        SQL
+
+        # Optionally update existing records with a custom order
+        execute <<-SQL
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'JavaScript';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Java 8';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Java 11';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Java 17';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 2.7';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 3.4';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 3.5';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 3.6';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 3.7';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 3.9';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 3.10';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'Python 3.12';
+          UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = 'C/C++';     
+        SQL
+      end
+
+      dir.down do
+        execute <<-SQL
+          ALTER TABLE polyglot_languages ALTER COLUMN weight DROP DEFAULT;
+          DROP SEQUENCE polyglot_languages_weight_seq;
+        SQL
+      end
+    end
+
+    add_column :polyglot_languages, :enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_09_020208) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_30_090759) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -1383,6 +1383,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_09_020208) do
     t.string "type", limit: 255, null: false
     t.string "name", limit: 255, null: false
     t.integer "parent_id"
+    t.serial "weight"
+    t.boolean "enabled", default: true, null: false
     t.index "lower((name)::text)", name: "index_polyglot_languages_on_name", unique: true
     t.index ["parent_id"], name: "fk__polyglot_languages_parent_id"
   end


### PR DESCRIPTION
Added 2 new columns to polyglot table: "weight" for ordering of langauges and "enabled" for deprecating languages
<img width="280" alt="image" src="https://github.com/user-attachments/assets/331ab764-e23c-41e4-ab95-f4a00e8e1eaa">


During programming language selection, only enabled languages are displayed
If a currently disabled language is already selected, it will be displayed but the option will no longer be enabled
A warning will be shown in FE as well when a disabled language is selected
Validation is done in backend when trying to save a question with a disabled language


Languages can be deprecated and reordered by directly editing the DB
When a new language is added by modifying the polyglot gem, the will be enabled and have the highest weight by default.


Also fixed ordering of programming languages, they will now appear in this order:
1. C/C++
2. Python
3. Java
4. Javascript

Most recent versions of languages will also appear higher i.e. Python 3.12 will be ordered above Python 3.9

Example where language has been pre-selected and disabled afterwards:
<img width="1470" alt="Screenshot 2024-09-05 at 6 04 15 PM" src="https://github.com/user-attachments/assets/ead3383a-0862-4e67-b7e2-80fac5b86517">

<img width="1467" alt="Screenshot 2024-09-02 at 4 21 46 PM" src="https://github.com/user-attachments/assets/12896163-4f5c-4ba9-a046-e66e9d05add6">

Example where disabled language is still selected when saving edits:
<img width="1468" alt="Screenshot 2024-09-05 at 6 05 35 PM" src="https://github.com/user-attachments/assets/f3952e23-2403-415d-a2fc-3da12bc60578">



Note:
- Sorting of languages is done in backend