### PR TITLE
Enhancement of Timed Assessment Feature

### DIFF
--- a/app/jobs/course/assessment/submission/force_submit_timed_submission_job.rb
+++ b/app/jobs/course/assessment/submission/force_submit_timed_submission_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# This job performs the force submission for timed assessment
+class Course::Assessment::Submission::ForceSubmitTimedSubmissionJob < ApplicationJob
+  include TrackableJob
+  include Rails.application.routes.url_helpers
+
+  protected
+
+  def perform_tracked(assessment, submission_id, submitter)
+    instance = Course.unscoped { assessment.course.instance }
+
+    ActsAsTenant.with_tenant(instance) do
+      submission = Course::Assessment::Submission.find_by(id: submission_id)
+      return unless submission
+
+      force_submit(submission, submitter)
+    end
+  end
+
+  private
+
+  def force_submit(submission, submitter)
+    User.with_stamper(submitter) do
+      ActiveRecord::Base.transaction do
+        submission.update!('finalise' => 'true')
+      end
+    end
+  end
+end

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -11,7 +11,7 @@ class Course::Assessment::Submission < ApplicationRecord
 
   acts_as_experience_points_record
 
-  BUFFER_TIME_TO_FORCE_SUBMIT_MINUTES = 5.minutes
+  FORCE_SUBMIT_DELAY = 5.minutes
 
   after_save :auto_grade_submission, if: :submitted?
   after_save :retrieve_codaveri_feedback, if: :submitted?
@@ -238,9 +238,9 @@ class Course::Assessment::Submission < ApplicationRecord
   def create_force_submission_job
     return unless assessment.time_limit
 
-    Course::Assessment::Submission::ForceSubmittingJob.
-      set(wait_until: created_at + assessment.time_limit.minutes + BUFFER_TIME_TO_FORCE_SUBMIT_MINUTES).
-      perform_later(assessment, [creator_id], [], creator)
+    Course::Assessment::Submission::ForceSubmitTimedSubmissionJob.
+      set(wait_until: created_at + assessment.time_limit.minutes + FORCE_SUBMIT_DELAY).
+      perform_later(assessment, id, creator)
   end
 
   # The answers with current_answer flag set to true, filtering out orphaned answers to questions which are no longer

--- a/client/app/bundles/course/assessment/submission/components/WarningDialog.tsx
+++ b/client/app/bundles/course/assessment/submission/components/WarningDialog.tsx
@@ -8,39 +8,43 @@ import {
   Typography,
 } from '@mui/material';
 
+import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import { BUFFER_TIME_TO_FORCE_SUBMIT_MS } from '../constants';
+import { TIME_LAPSE_NEW_SUBMISSION_MS, workflowStates } from '../constants';
 import { remainingTimeDisplay } from '../pages/SubmissionEditIndex/TimeLimitBanner';
+import { getAssessment } from '../selectors/assessments';
+import { getSubmission } from '../selectors/submissions';
 import translations from '../translations';
 
-interface Props {
-  submissionTimeLimitAt: number | null;
-  isExamMode: boolean;
-  isTimedMode: boolean;
-  isAttempting: boolean;
-}
-
-const WarningDialog: FC<Props> = (props) => {
+const WarningDialog: FC = () => {
   const { t } = useTranslation();
-  const { isExamMode, isTimedMode, isAttempting, submissionTimeLimitAt } =
-    props;
+
+  const assessment = useAppSelector(getAssessment);
+  const submission = useAppSelector(getSubmission);
+
+  const { timeLimit, passwordProtected: isExamMode } = assessment;
+  const { workflowState, attemptedAt } = submission;
+
+  const isAttempting = workflowState === workflowStates.Attempting;
+  const isTimedMode = isAttempting && !!timeLimit;
+
+  const startTime = new Date(attemptedAt).getTime();
+  const currentTime = new Date().getTime();
+
+  const submissionTimeLimitAt = isTimedMode
+    ? startTime + timeLimit * 60 * 1000
+    : null;
+
+  const isNewSubmission =
+    currentTime - startTime < TIME_LAPSE_NEW_SUBMISSION_MS;
 
   const [examNotice, setExamNotice] = useState(isExamMode);
   const [timedNotice, setTimedNotice] = useState(isTimedMode);
 
-  const currentTime = new Date().getTime();
-
   const remainingTime =
-    submissionTimeLimitAt && submissionTimeLimitAt > currentTime
-      ? submissionTimeLimitAt - currentTime
-      : null;
-
-  const remainingBufferTime =
-    submissionTimeLimitAt &&
-    submissionTimeLimitAt <= currentTime &&
-    currentTime < submissionTimeLimitAt + BUFFER_TIME_TO_FORCE_SUBMIT_MS
-      ? submissionTimeLimitAt + BUFFER_TIME_TO_FORCE_SUBMIT_MS - currentTime
+    isTimedMode && submissionTimeLimitAt! > currentTime
+      ? submissionTimeLimitAt! - currentTime
       : null;
 
   let dialogTitle: string = '';
@@ -48,24 +52,28 @@ const WarningDialog: FC<Props> = (props) => {
 
   if (examNotice && timedNotice) {
     dialogTitle = t(translations.timedExamDialogTitle, {
-      remainingTime: remainingTimeDisplay(remainingTime ?? 0),
+      isNewSubmission,
+      remainingTime: remainingTimeDisplay(
+        isNewSubmission ? timeLimit! * 60 * 1000 : remainingTime ?? 0,
+      ),
       stillSomeTimeRemaining: !!remainingTime,
     });
     dialogMessage = t(translations.timedExamDialogMessage, {
       stillSomeTimeRemaining: !!remainingTime,
-      remainingBufferTime: remainingTimeDisplay(remainingBufferTime ?? 0),
     });
   } else if (examNotice) {
     dialogTitle = t(translations.examDialogTitle);
     dialogMessage = t(translations.examDialogMessage);
   } else if (timedNotice) {
     dialogTitle = t(translations.timedAssessmentDialogTitle, {
-      remainingTime: remainingTimeDisplay(remainingTime ?? 0),
+      isNewSubmission,
+      remainingTime: remainingTimeDisplay(
+        isNewSubmission ? timeLimit! * 60 * 1000 : remainingTime ?? 0,
+      ),
       stillSomeTimeRemaining: !!remainingTime,
     });
     dialogMessage = t(translations.timedAssessmentDialogMessage, {
       stillSomeTimeRemaining: !!remainingTime,
-      remainingBufferTime: remainingTimeDisplay(remainingBufferTime ?? 0),
     });
   }
 

--- a/client/app/bundles/course/assessment/submission/constants.ts
+++ b/client/app/bundles/course/assessment/submission/constants.ts
@@ -16,7 +16,11 @@ export const questionTypes = mirrorCreator([
 
 export const MEGABYTES_TO_BYTES = 1024 * 1024;
 
-export const BUFFER_TIME_TO_FORCE_SUBMIT_MS = 2 * 60 * 1000;
+export const BUFFER_TIME_TO_FORCE_SUBMIT_MS = 5 * 1000;
+
+// calculate how long has it passed since the student starts the submission
+// to still be considered a "newly created" submission
+export const TIME_LAPSE_NEW_SUBMISSION_MS = 10 * 1000;
 
 export const POLL_INTERVAL_MILLISECONDS = 2000;
 

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionForm.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionForm.tsx
@@ -55,13 +55,10 @@ const SubmissionForm: FC<Props> = (props) => {
   const liveFeedbacks = useAppSelector(getLiveFeedbacks);
   const initialValues = useAppSelector(getInitialAnswer);
 
-  const { autograded, timeLimit, tabbedView, questionIds, passwordProtected } =
-    assessment;
+  const { autograded, timeLimit, tabbedView, questionIds } = assessment;
   const { workflowState, attemptedAt } = submission;
 
   const maxInitialStep = submission.maxStep ?? questionIds.length - 1;
-
-  const attempting = workflowState === workflowStates.Attempting;
 
   const submissionId = getSubmissionId();
 
@@ -218,12 +215,7 @@ const SubmissionForm: FC<Props> = (props) => {
         </form>
       </FormProvider>
 
-      <WarningDialog
-        isAttempting={attempting}
-        isExamMode={passwordProtected}
-        isTimedMode={!!submissionTimeLimitAt}
-        submissionTimeLimitAt={submissionTimeLimitAt}
-      />
+      <WarningDialog />
     </div>
   );
 };

--- a/client/app/bundles/course/assessment/submission/translations.ts
+++ b/client/app/bundles/course/assessment/submission/translations.ts
@@ -445,21 +445,19 @@ const translations = defineMessages({
   timedAssessmentDialogTitle: {
     id: 'course.assessment.submission.timedAssessmentDialogTitle',
     defaultMessage:
-      '{stillSomeTimeRemaining, select, true {{remainingTime} remaining to \
+      '{stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {remaining}} to \
       complete this assessment.} other {The assessment has ended!}}',
   },
   timedAssessmentDialogMessage: {
     id: 'course.assessment.submission.timedAssessmentDialogMessage',
     defaultMessage:
       '{stillSomeTimeRemaining, select, true {Once the time is up, \
-      the assessment will be automatically finalised.} other {You have \
-      {remainingBufferTime} before your submission is automatically finalised by the system. \
-      Alternatively, you may choose to finalise it on your own within this time.}}',
+      the assessment will be automatically finalised.} other {Finalising the submission now!}}',
   },
   timedExamDialogTitle: {
     id: 'course.assessment.submission.timedExamDialogTitle',
     defaultMessage:
-      '{stillSomeTimeRemaining, select, true {{remainingTime} remaining to \
+      '{stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {remaining}} to \
       complete this exam.} other {The exam has ended!}}',
   },
   timedExamDialogMessage: {
@@ -467,9 +465,7 @@ const translations = defineMessages({
     defaultMessage:
       '{stillSomeTimeRemaining, select, true {Please \
       do not sign out or close the browser while attempting this exam. Once the time is up, \
-      the assessment will be automatically finalised.} other {You have \
-      {remainingBufferTime} before your submission is automatically finalised by the system. \
-      Alternatively, you may choose to finalise it on your own within this time.}}',
+      the assessment will be automatically finalised.} other {Finalising the submission now!}}',
   },
   emptyAssessment: {
     id: 'course.assessment.submission.emptyAssessment',
@@ -594,14 +590,14 @@ const translations = defineMessages({
     id: 'course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.hoursMinutesSeconds',
     defaultMessage:
       '{hrs, plural, one {# hour} other {# hours}} \
-    {mins, plural, one {# minute} other {# minutes}} \
-    {secs, plural, one {# second} other {# seconds}}',
+    {mins, plural, =0 {} one {# minute} other {# minutes}} \
+    {secs, plural, =0 {} one {# second} other {# seconds}}',
   },
   minutesSeconds: {
     id: 'course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.minutesSeconds',
     defaultMessage:
       '{mins, plural, one {# minute} other {# minutes}} \
-    {secs, plural, one {# second} other {# seconds}}',
+    {secs, plural, =0 {} one {# second} other {# seconds}}',
   },
   seconds: {
     id: 'course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.minutesSeconds',


### PR DESCRIPTION
## Background

Even though we already have the timed assessment feature inside Coursemology, the feature itself still have some unwanted behavior that we did not fix at that time due to time constraint. Several bugs that we resolve here are:

- If student's submission was deleted and then student tried to re-attempt the assessment, the timer on backend will still refer to the old submission, even though that has been deleted, resulting in unwanted force submission. We fixed this behavior in this commit
- When student started the assessment, the timer will count from the time they click on "Attempt", but due to the page loading, they might get several seconds cut from what they need to be. This one case is still unresolved completely but we made the workaround not to make student feel their timing's being cut by not showing the dialog when student just newly created the submission (i.e. attempting the assessment for the first time). We set up the buffer duration for the submission to be considered "newly created" to be 10 seconds after the student click on "Attempt"
- We changed the buffer time to 5 seconds instead of 2 minutes