### PR TITLE
Make Heartbeat Monitoring for Exams work again

### DIFF
--- a/app/channels/course/monitoring/live_monitoring_channel.rb
+++ b/app/channels/course/monitoring/live_monitoring_channel.rb
@@ -64,6 +64,9 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
       is_valid_secret = @monitor.valid_secret?(last_heartbeat&.user_agent)
 
       course_user = course_users_hash[session.creator_id]
+      # This technically shouldn't happen, but can happen if someone is removed from
+      # the course after they finish a monitored assessment.
+      next [nil, nil] unless course_user
 
       snapshot = {
         sessionId: session.id,
@@ -77,7 +80,7 @@ class Course::Monitoring::LiveMonitoringChannel < Course::Channel
       }.compact
 
       [session.creator_id, snapshot]
-    end
+    end.compact
   end
 
   def groups

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -222,6 +222,8 @@ class Course::Assessment < ApplicationRecord
     folder.parent = target_tab.category.folder
     self.question_assessments = duplicator.duplicate(other.question_assessments)
     initialize_duplicate_conditions(duplicator, other)
+    self.monitor = duplicator.duplicate(other.monitor)
+
     set_duplication_flag
   end
 

--- a/app/models/course/monitoring/monitor.rb
+++ b/app/models/course/monitoring/monitor.rb
@@ -19,6 +19,11 @@ class Course::Monitoring::Monitor < ApplicationRecord
     secret? ? (string&.include?(secret) || false) : true
   end
 
+  # `Duplicator` already performed a shallow duplicate of the `other` monitor.
+  # There's no need to duplicate `other`'s sessions and heartbeats.
+  def initialize_duplicate(duplicator, other)
+  end
+
   private
 
   def max_interval_greater_than_min

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ConnectionStatus.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ConnectionStatus.tsx
@@ -1,20 +1,44 @@
 import { Circle, Close } from '@mui/icons-material';
 import { Chip, Paper, Typography } from '@mui/material';
 
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import { useAppSelector } from 'lib/hooks/store';
-import useTranslation from 'lib/hooks/useTranslation';
+import useTranslation, { Translated } from 'lib/hooks/useTranslation';
 
 import translations from '../../../translations';
 import { select } from '../selectors';
+import { MonitoringState } from '../types';
 
 interface ConnectionStatusProps {
   title: string;
   className?: string;
 }
 
+const CHIPS: Record<
+  MonitoringState['status'],
+  {
+    icon: JSX.Element;
+    getLabel: Translated<string>;
+  }
+> = {
+  connecting: {
+    icon: <LoadingIndicator bare className="p-1" size={18} />,
+    getLabel: (t) => t(translations.connecting),
+  },
+  connected: {
+    icon: <Circle className="animate-pulse" color="success" />,
+    getLabel: (t) => t(translations.connected),
+  },
+  disconnected: {
+    icon: <Close color="error" />,
+    getLabel: (t) => t(translations.disconnected),
+  },
+};
+
 const ConnectionStatus = (props: ConnectionStatusProps): JSX.Element => {
   const { t } = useTranslation();
-  const connected = useAppSelector(select('connected'));
+  const status = useAppSelector(select('status'));
+  const { icon, getLabel } = CHIPS[status];
 
   return (
     <Paper
@@ -22,22 +46,7 @@ const ConnectionStatus = (props: ConnectionStatusProps): JSX.Element => {
       variant="outlined"
     >
       <Typography variant="body2">{props.title}</Typography>
-
-      {connected ? (
-        <Chip
-          icon={<Circle className="animate-pulse" color="success" />}
-          label={t(translations.connected)}
-          size="small"
-          variant="outlined"
-        />
-      ) : (
-        <Chip
-          icon={<Close color="error" />}
-          label={t(translations.disconnected)}
-          size="small"
-          variant="outlined"
-        />
-      )}
+      <Chip icon={icon} label={getLabel(t)} size="small" variant="outlined" />
     </Paper>
   );
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/useMonitoring.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/hooks/useMonitoring.ts
@@ -52,10 +52,10 @@ const useMonitoring = (): UseMonitoringHook => {
       dispatch(actions.filter(userIds));
     },
     notifyConnected: (): void => {
-      dispatch(actions.setConnected(true));
+      dispatch(actions.setStatus('connected'));
     },
     notifyDisconnected: (): void => {
-      dispatch(actions.setConnected(false));
+      dispatch(actions.setStatus('disconnected'));
     },
     notifyMissingAt: (timestamp, userId, name): void => {
       dispatch(

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/types.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/types.ts
@@ -13,7 +13,7 @@ export interface Activity {
 export interface MonitoringState {
   snapshots: Snapshots;
   history: Activity[];
-  connected: boolean;
+  status: 'connecting' | 'connected' | 'disconnected';
   monitor: MonitoringMonitorData;
   selectedUserId?: number;
 }

--- a/client/app/bundles/course/assessment/reducers/monitoring.ts
+++ b/client/app/bundles/course/assessment/reducers/monitoring.ts
@@ -11,7 +11,7 @@ import { Activity, MonitoringState } from '../pages/AssessmentMonitoring/types';
 const initialState: MonitoringState = {
   snapshots: {},
   history: [],
-  connected: false,
+  status: 'connecting',
   monitor: { maxIntervalMs: 0, offsetMs: 0, hasSecret: false },
 };
 
@@ -53,8 +53,8 @@ export const monitoringSlice = createSlice({
       state.selectedUserId = undefined;
       delete state.snapshots[userId].selected;
     },
-    setConnected: (state, action: PayloadAction<boolean>) => {
-      state.connected = action.payload;
+    setStatus: (state, action: PayloadAction<MonitoringState['status']>) => {
+      state.status = action.payload;
     },
     terminate: (state, action: PayloadAction<number>) => {
       const userId = action.payload;

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -955,6 +955,10 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.recentActivitiesHint',
     defaultMessage: 'These logs will disappear if you close this tab!',
   },
+  connecting: {
+    id: 'course.assessment.monitoring.connecting',
+    defaultMessage: 'Connecting',
+  },
   connected: {
     id: 'course.assessment.monitoring.connected',
     defaultMessage: 'Connected',

--- a/client/app/workers/listeners.ts
+++ b/client/app/workers/listeners.ts
@@ -1,5 +1,3 @@
-import { getWebSocketURL } from 'utilities/socket';
-
 import subscribe, { HeartbeatChannel } from './heartbeatChannel';
 import setUpDatabase, { MonitoringDBActions } from './monitoringDatabase';
 import type {
@@ -26,11 +24,10 @@ const terminateWorker = async (): Promise<void> => {
 const createListeners = (
   host: HeartbeatWorkerListenerHost,
 ): HeartbeatWorkerListener => ({
-  start: async (payload): Promise<void> => {
-    const { sessionId, courseId } = payload;
+  start: async ({ url, sessionId, courseId }): Promise<void> => {
     storage ??= await setUpDatabase();
 
-    channel ??= subscribe(getWebSocketURL(), sessionId, courseId, {
+    channel ??= subscribe(url, sessionId, courseId, {
       resetInterval,
       onPulse: storage?.cacheHeartbeat,
       onPulsed: (timestamp: number) => {

--- a/client/app/workers/types.ts
+++ b/client/app/workers/types.ts
@@ -1,4 +1,5 @@
 interface StartPayload {
+  url: string;
   sessionId: number;
   courseId: number;
 }

--- a/client/app/workers/withHeartbeatWorker.tsx
+++ b/client/app/workers/withHeartbeatWorker.tsx
@@ -1,6 +1,7 @@
 import { ComponentType, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { getIdFromUnknown } from 'utilities';
+import { getWebSocketURL } from 'utilities/socket';
 
 import usePrompt from 'lib/hooks/router/usePrompt';
 
@@ -33,7 +34,10 @@ const withHeartbeatWorker = <P extends WrappedComponentProps>(
       const worker = setUpWorker(workerType);
       workerRef.current = worker;
 
-      worker.postMessage({ type: 'start', payload: { sessionId, courseId } });
+      worker.postMessage({
+        type: 'start',
+        payload: { url: getWebSocketURL(), sessionId, courseId },
+      });
 
       const terminateWorker = (): void => {
         worker.terminate();


### PR DESCRIPTION
#7282 appends a `token` query param to the end of the `/cable` WebSocket URL for authentication. `token` is obtained by `getUserToken` from `localStorage` which doesn't exist in the scopes of Web Workers. https://github.com/Coursemology/coursemology2/pull/7524/commits/952b7c0da2d6dcb28d985ec6103a51545006c9c1 moves the logic for obtaining authenticatable WebSocket URL in the main window scope and passing it to the heartbeat worker. This makes heartbeat pulses in submissions of monitored assessments work again.

This PR also fixes some issues with PulseGrid and `Course::Monitoring::Monitor` duplications during assessment duplications.

With https://github.com/Coursemology/coursemology2/pull/7524/commits/df8114fa286ee652ba3f2d360ae4af8ce01157e8, PulseGrid now shows an intermediary "Connecting" state to properly distinguish between the initial UI state of _not connected yet_ from _actually disconnected (probably due to some errors)_.