### PR TITLE
fix(codaveri-qns-generation): fix codaveri course settings, add covering test case

### DIFF
--- a/app/views/course/admin/codaveri_settings/edit.json.jbuilder
+++ b/app/views/course/admin/codaveri_settings/edit.json.jbuilder
@@ -24,7 +24,7 @@ json.assessments @assessments_with_programming_qns do |assessment|
   json.url course_assessment_path(current_course, assessment)
 
   json.programmingQuestions assessment.programming_questions do |programming_qn|
-    next unless programming_qn.language_valid_for_codaveri?
+    next unless CodaveriAsyncApiService.language_valid_for_codaveri?(programming_qn.language)
 
     if programming_qn.title.blank?
       question_assessment = assessment.question_assessments.select do |qa|

--- a/spec/controllers/course/admin/codaveri_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/codaveri_settings_controller_spec.rb
@@ -5,12 +5,29 @@ RSpec.describe Course::Admin::CodaveriSettingsController, type: :controller do
   let!(:instance) { create(:instance) }
   with_tenant(:instance) do
     let(:user) { create(:user) }
-    let(:course) { create(:course, creator: user) }
+    let(:lang_valid_for_codaveri) { Coursemology::Polyglot::Language::Python::Python3Point12.instance }
+    let(:lang_invalid_for_codaveri) { Coursemology::Polyglot::Language::Java::Java8.instance }
+    let(:course) do
+      course = create(:course, creator: user)
+      assessment = create(:assessment, course: course)
+      create(:course_assessment_question_programming,
+             assessment: assessment, language: lang_valid_for_codaveri, template_package: true)
+      create(:course_assessment_question_programming,
+             assessment: assessment, language: lang_invalid_for_codaveri, template_package: true)
+      course
+    end
     before { controller_sign_in(controller, user) }
 
     describe '#edit' do
+      render_views
       subject { get :edit, params: { course_id: course, format: :json } }
-      it { is_expected.to render_template(:edit) }
+      it 'renders codaveri and assessment question settings' do
+        expect(subject).to render_template(:edit)
+        programming_questions = JSON.parse(subject.body).dig('assessments', 0, 'programmingQuestions')
+        expect(programming_questions).not_to be_nil
+        expect(programming_questions).to be_an_instance_of(Array)
+        expect(programming_questions.count).to eq(1)
+      end
     end
 
     describe '#update' do


### PR DESCRIPTION
- Fixed breaking change from https://github.com/Coursemology/coursemology2/pull/7507 caused by moving `language_valid_for_codaveri?` function
- Amended relevant test case to detect similar breakages in the future.