### PR TITLE
Heartbeat Monitoring for Exams: Safe Exam Browser (SEB) browser authorisation

### DIFF
--- a/app/channels/course/monitoring/heartbeat_channel.rb
+++ b/app/channels/course/monitoring/heartbeat_channel.rb
@@ -29,7 +29,8 @@ class Course::Monitoring::HeartbeatChannel < Course::Channel
       session: @session,
       user_agent: user_agent,
       ip_address: ip_address,
-      generated_at: time_from(timestamp)
+      generated_at: time_from(timestamp),
+      seb_payload: data['sebPayload']
     )
 
     return unless heartbeat.save
@@ -128,7 +129,6 @@ class Course::Monitoring::HeartbeatChannel < Course::Channel
   end
 
   def valid_heartbeat?(heartbeat)
-    @monitor.valid_secret?(heartbeat.user_agent) ||
-      Course::Assessment::MonitoringService.unblocked?(assessment_id, session)
+    heartbeat.valid_heartbeat? || Course::Assessment::MonitoringService.unblocked?(assessment_id, session)
   end
 end

--- a/app/controllers/concerns/course/assessment/monitoring/seb_payload_concern.rb
+++ b/app/controllers/concerns/course/assessment/monitoring/seb_payload_concern.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Course::Assessment::Monitoring::SebPayloadConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  def seb_payload_from_request(request)
+    url = request.headers['X-SafeExamBrowser-Url']
+    seb_config_key_hash = request.headers['X-SafeExamBrowser-ConfigKeyHash']
+    return unless url && seb_config_key_hash
+
+    # It's safe to not strip URL fragments (#) here because fragments are never sent to the server.
+    { config_key_hash: seb_config_key_hash, url: url }
+  end
+
+  def stub_heartbeat_from_request(request)
+    Course::Monitoring::Heartbeat.new(
+      user_agent: request.user_agent,
+      seb_payload: seb_payload_from_request(request)
+    )
+  end
+end

--- a/app/controllers/concerns/course/assessment/submission/monitoring_concern.rb
+++ b/app/controllers/concerns/course/assessment/submission/monitoring_concern.rb
@@ -42,6 +42,6 @@ module Course::Assessment::Submission::MonitoringConcern
   end
 
   def blocked_by_monitor?
-    should_monitor? && monitoring_service&.should_block?(request.user_agent)
+    should_monitor? && monitoring_service&.should_block?(request)
   end
 end

--- a/app/models/components/course/monitoring_ability_component.rb
+++ b/app/models/components/course/monitoring_ability_component.rb
@@ -42,5 +42,6 @@ module Course::MonitoringAbilityComponent
 
     can [:create, :read, :update], Course::Monitoring::Session, creator_id: user.id
     can :create, Course::Monitoring::Heartbeat, session: { creator_id: user.id }
+    can :seb_payload, Course::Assessment, course_id: course.id
   end
 end

--- a/app/models/course/monitoring/browser_authorization/base.rb
+++ b/app/models/course/monitoring/browser_authorization/base.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class Course::Monitoring::BrowserAuthorization::Base
+  def initialize(monitor)
+    @monitor = monitor
+  end
+
+  def valid?(monitor, heartbeat)
+    raise NotImplementedError
+  end
+end

--- a/app/models/course/monitoring/browser_authorization/seb_config_key.rb
+++ b/app/models/course/monitoring/browser_authorization/seb_config_key.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Course::Monitoring::BrowserAuthorization::SebConfigKey < Course::Monitoring::BrowserAuthorization::Base
+  # @see https://safeexambrowser.org/developer/seb-config-key.html
+  def valid_heartbeat?(heartbeat)
+    seb_payload = heartbeat.seb_payload&.with_indifferent_access
+    return false unless seb_payload
+
+    url = seb_payload[:url]
+    hash = Digest::SHA256.hexdigest("#{url}#{@monitor.seb_config_key}")
+    hash == seb_payload[:config_key_hash]
+  end
+end

--- a/app/models/course/monitoring/browser_authorization/user_agent.rb
+++ b/app/models/course/monitoring/browser_authorization/user_agent.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Course::Monitoring::BrowserAuthorization::UserAgent < Course::Monitoring::BrowserAuthorization::Base
+  def valid_heartbeat?(heartbeat)
+    @monitor.secret? ? (heartbeat.user_agent&.include?(@monitor.secret) || false) : true
+  end
+end

--- a/app/models/course/monitoring/heartbeat.rb
+++ b/app/models/course/monitoring/heartbeat.rb
@@ -8,13 +8,37 @@ class Course::Monitoring::Heartbeat < ApplicationRecord
   validates :generated_at, presence: true
   validates :stale, inclusion: { in: [true, false] }
 
+  validate :valid_seb_payload_if_exists
+
   default_scope { order(:generated_at) }
 
   before_save :update_session_misses
 
+  def valid_heartbeat?
+    session.monitor.valid_heartbeat?(self)
+  end
+
   private
+
+  SEB_PAYLOAD_SHAPE = { config_key_hash: String, url: String }.freeze
 
   def update_session_misses
     session.update_misses_after_heartbeat_saved!(self)
+  end
+
+  def filter_seb_payload(seb_payload)
+    seb_payload.slice(*SEB_PAYLOAD_SHAPE.keys)
+  end
+
+  def valid_seb_payload?(seb_payload)
+    seb_payload.with_indifferent_access.tap do |payload|
+      return SEB_PAYLOAD_SHAPE.all? { |key, type| payload[key].instance_of?(type) }
+    end
+  end
+
+  def valid_seb_payload_if_exists
+    return if seb_payload.present? ? valid_seb_payload?(seb_payload) : true
+
+    errors.add(:seb_payload, :invalid_seb_payload)
   end
 end

--- a/app/services/course/assessment/monitoring_service.rb
+++ b/app/services/course/assessment/monitoring_service.rb
@@ -2,7 +2,17 @@
 class Course::Assessment::MonitoringService
   class << self
     def params
-      [:enabled, :secret, :min_interval_ms, :max_interval_ms, :offset_ms, :blocks]
+      [
+        :enabled,
+        :min_interval_ms,
+        :max_interval_ms,
+        :offset_ms,
+        :blocks,
+        :browser_authorization,
+        :browser_authorization_method,
+        :secret,
+        :seb_config_key
+      ]
     end
 
     def unblocked_browser_session_key(assessment_id)

--- a/app/services/course/assessment/monitoring_service.rb
+++ b/app/services/course/assessment/monitoring_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::MonitoringService
+  include Course::Assessment::Monitoring::SebPayloadConcern
+
   class << self
     def params
       [
@@ -45,8 +47,8 @@ class Course::Assessment::MonitoringService
     end
   end
 
-  def should_block?(string)
-    !unblocked? && monitor&.blocks? && !monitor&.valid_secret?(string)
+  def should_block?(request)
+    !unblocked? && monitor&.blocks? && !monitor&.valid_heartbeat?(stub_heartbeat_from_request(request))
   end
 
   def unblock(session_password)

--- a/app/services/course/assessment/submission/monitoring_service.rb
+++ b/app/services/course/assessment/submission/monitoring_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Course::Assessment::Submission::MonitoringService
+  include Course::Assessment::Monitoring::SebPayloadConcern
+
   class << self
     def for(submission, assessment, browser_session)
       new(submission, assessment, browser_session) if assessment.monitor_id?
@@ -55,8 +57,8 @@ class Course::Assessment::Submission::MonitoringService
     @monitor.enabled? && session.listening?
   end
 
-  def should_block?(string)
-    !unblocked? && @monitor&.blocks? && !@monitor&.valid_secret?(string)
+  def should_block?(request)
+    !unblocked? && @monitor&.blocks? && !@monitor&.valid_heartbeat?(stub_heartbeat_from_request(request))
   end
 
   private

--- a/app/views/course/assessment/assessments/_monitoring_details.json.jbuilder
+++ b/app/views/course/assessment/assessments/_monitoring_details.json.jbuilder
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 json.monitoring do
   json.enabled @monitor.enabled
-  json.secret @monitor.secret
   json.min_interval_ms @monitor.min_interval_ms
   json.max_interval_ms @monitor.max_interval_ms
   json.offset_ms @monitor.offset_ms
   json.blocks @monitor.blocks
+  json.browser_authorization @monitor.browser_authorization
+  json.browser_authorization_method @monitor.browser_authorization_method
+  json.secret @monitor.secret
+  json.seb_config_key @monitor.seb_config_key
 end

--- a/client/app/api/course/Assessment/Assessments.js
+++ b/client/app/api/course/Assessment/Assessments.js
@@ -42,6 +42,16 @@ export default class AssessmentsAPI extends BaseCourseAPI {
   }
 
   /**
+   *
+   * @returns {import('api/types').APIResponse<import('types/course/assessment/monitoring').SebPayload | null>}
+   */
+  fetchSebPayload() {
+    return this.client.get(
+      `${this.#urlPrefix}/${this.assessmentId}/seb_payload`,
+    );
+  }
+
+  /**
    * Create an assessment.
    *
    * @param {object} params - params in the format of:

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -18,13 +18,11 @@ import {
 // import AssessmentProgrammingQnList from 'course/admin/pages/CodaveriSettings/components/AssessmentProgrammingQnList';
 // import LiveFeedbackToggleButton from 'course/admin/pages/CodaveriSettings/components/buttons/LiveFeedbackToggleButton';
 // import { getProgrammingQuestionsForAssessments } from 'course/admin/pages/CodaveriSettings/selectors';
-import BetaChip from 'lib/components/core/BetaChip';
 import IconRadio from 'lib/components/core/buttons/IconRadio';
 import ErrorText from 'lib/components/core/ErrorText';
 // import ExperimentalChip from 'lib/components/core/ExperimentalChip';
 import InfoLabel from 'lib/components/core/InfoLabel';
 import Section from 'lib/components/core/layouts/Section';
-import Link from 'lib/components/core/Link';
 import ConditionsManager from 'lib/components/extensions/conditions/ConditionsManager';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormDateTimePickerField from 'lib/components/form/fields/DateTimePickerField';
@@ -35,6 +33,9 @@ import { useAppDispatch } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import FileManager from '../FileManager';
+import BlocksInvalidBrowserFormField from '../monitoring/BlocksInvalidBrowserFormField';
+import EnableMonitoringFormField from '../monitoring/EnableMonitoringFormField';
+import MonitoringOptionsFormFields from '../monitoring/MonitoringOptionsFormFields';
 
 import { fetchTabs } from './operations';
 import translations from './translations';
@@ -78,7 +79,6 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
   const hasTimeLimit = watch('has_time_limit');
 
   const monitoring = watch('monitoring.enabled');
-  const hasMonitoringSecret = watch('monitoring.secret');
 
   // const assessmentId = initialValues.id;
   // const title = initialValues.title;
@@ -744,191 +744,27 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           {!autograded && passwordProtected && renderPasswordFields()}
 
           {passwordProtected && monitoring && (
-            <Controller
+            <BlocksInvalidBrowserFormField
               control={control}
-              name="monitoring.blocks"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormCheckboxField
-                  description={t(translations.blocksAccessesFromInvalidSUSHint)}
-                  disabled={
-                    !canManageMonitor ||
-                    !sessionProtected ||
-                    !hasMonitoringSecret ||
-                    disabled
-                  }
-                  disabledHint={
-                    !sessionProtected || !hasMonitoringSecret
-                      ? t(translations.needSUSAndSessionUnlockPassword)
-                      : undefined
-                  }
-                  field={field}
-                  fieldState={fieldState}
-                  label={t(translations.blocksAccessesFromInvalidSUS)}
-                />
-              )}
+              disabled={!canManageMonitor || disabled}
             />
           )}
 
           {passwordProtected && monitoringEnabled && (
-            <Controller
+            <EnableMonitoringFormField
               control={control}
-              name="monitoring.enabled"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormCheckboxField
-                  description={t(translations.examMonitoringHint, {
-                    pulsegrid: (chunk) => (
-                      <Link opensInNewTab to={pulsegridUrl}>
-                        {chunk}
-                      </Link>
-                    ),
-                  })}
-                  disabled={!canManageMonitor || disabled}
-                  disabledHint={t(translations.onlyManagersOwnersCanEdit)}
-                  field={field}
-                  fieldState={fieldState}
-                  label={
-                    <span className="flex items-center space-x-2">
-                      <span>{t(translations.examMonitoring)}</span>
-                      <BetaChip disabled={!canManageMonitor || disabled} />
-                    </span>
-                  }
-                  labelClassName="mt-10"
-                />
-              )}
+              disabled={!canManageMonitor || disabled}
+              labelClassName="mt-10"
+              pulsegridUrl={pulsegridUrl}
             />
           )}
 
           {passwordProtected && monitoring && (
-            <>
-              <Controller
-                control={control}
-                name="monitoring.secret"
-                render={({ field, fieldState }): JSX.Element => (
-                  <FormTextField
-                    disabled={!canManageMonitor || disabled}
-                    field={field}
-                    fieldState={fieldState}
-                    fullWidth
-                    label={t(translations.secret)}
-                    variant="filled"
-                  />
-                )}
-              />
-
-              <Typography
-                className="!mt-0"
-                color="text.secondary"
-                variant="body2"
-              >
-                {t(translations.secretHint, {
-                  pulsegrid: (chunk) => (
-                    <Link opensInNewTab to={pulsegridUrl}>
-                      {chunk}
-                    </Link>
-                  ),
-                })}
-              </Typography>
-
-              <Grid container direction="row" spacing={2}>
-                <Grid item xs>
-                  <Grid container direction="row" spacing={2}>
-                    <Grid item xs>
-                      <Controller
-                        control={control}
-                        name="monitoring.min_interval_ms"
-                        render={({ field, fieldState }): JSX.Element => (
-                          <FormTextField
-                            disabled={!canManageMonitor || disabled}
-                            field={field}
-                            fieldState={fieldState}
-                            fullWidth
-                            InputProps={{
-                              endAdornment: (
-                                <InputAdornment position="end">
-                                  {t(translations.milliseconds)}
-                                </InputAdornment>
-                              ),
-                            }}
-                            label={t(translations.minInterval)}
-                            required
-                            type="number"
-                            variant="filled"
-                          />
-                        )}
-                      />
-                    </Grid>
-
-                    <Grid item xs>
-                      <Controller
-                        control={control}
-                        name="monitoring.max_interval_ms"
-                        render={({ field, fieldState }): JSX.Element => (
-                          <FormTextField
-                            disabled={!canManageMonitor || disabled}
-                            field={field}
-                            fieldState={fieldState}
-                            fullWidth
-                            InputProps={{
-                              endAdornment: (
-                                <InputAdornment position="end">
-                                  {t(translations.milliseconds)}
-                                </InputAdornment>
-                              ),
-                            }}
-                            label={t(translations.maxInterval)}
-                            required
-                            type="number"
-                            variant="filled"
-                          />
-                        )}
-                      />
-                    </Grid>
-                  </Grid>
-
-                  <Typography
-                    className="!mt-0"
-                    color="text.secondary"
-                    variant="body2"
-                  >
-                    {t(translations.intervalHint)}
-                  </Typography>
-                </Grid>
-
-                <Grid item xs>
-                  <Controller
-                    control={control}
-                    name="monitoring.offset_ms"
-                    render={({ field, fieldState }): JSX.Element => (
-                      <FormTextField
-                        disabled={!canManageMonitor || disabled}
-                        field={field}
-                        fieldState={fieldState}
-                        fullWidth
-                        InputProps={{
-                          endAdornment: (
-                            <InputAdornment position="end">
-                              {t(translations.milliseconds)}
-                            </InputAdornment>
-                          ),
-                        }}
-                        label={t(translations.offset)}
-                        required
-                        type="number"
-                        variant="filled"
-                      />
-                    )}
-                  />
-
-                  <Typography
-                    className="!mt-0"
-                    color="text.secondary"
-                    variant="body2"
-                  >
-                    {t(translations.offsetHint)}
-                  </Typography>
-                </Grid>
-              </Grid>
-            </>
+            <MonitoringOptionsFormFields
+              control={control}
+              disabled={!canManageMonitor || disabled}
+              pulsegridUrl={pulsegridUrl}
+            />
           )}
         </Section>
 
@@ -966,7 +802,8 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
             />
           </Section>
         )}
-        {/* 
+
+        {/*
         {editing && (
           <Section
             sticksToNavbar

--- a/client/app/bundles/course/assessment/components/monitoring/BlocksInvalidBrowserFormField.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/BlocksInvalidBrowserFormField.tsx
@@ -1,0 +1,42 @@
+import { Control, Controller, useWatch } from 'react-hook-form';
+
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from './translations';
+
+const BlocksInvalidBrowserFormField = ({
+  control,
+  disabled,
+}: {
+  control: Control;
+  disabled?: boolean;
+}): JSX.Element => {
+  const { t } = useTranslation();
+
+  const sessionProtected = useWatch({ name: 'session_protected', control });
+  const hasMonitoringSecret = useWatch({ name: 'monitoring.secret', control });
+
+  return (
+    <Controller
+      control={control}
+      name="monitoring.blocks"
+      render={({ field, fieldState }): JSX.Element => (
+        <FormCheckboxField
+          description={t(translations.blocksAccessesFromInvalidSUSHint)}
+          disabled={!sessionProtected || !hasMonitoringSecret || disabled}
+          disabledHint={
+            !sessionProtected || !hasMonitoringSecret
+              ? t(translations.needSUSAndSessionUnlockPassword)
+              : undefined
+          }
+          field={field}
+          fieldState={fieldState}
+          label={t(translations.blocksAccessesFromInvalidSUS)}
+        />
+      )}
+    />
+  );
+};
+
+export default BlocksInvalidBrowserFormField;

--- a/client/app/bundles/course/assessment/components/monitoring/BlocksInvalidBrowserFormField.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/BlocksInvalidBrowserFormField.tsx
@@ -15,7 +15,11 @@ const BlocksInvalidBrowserFormField = ({
   const { t } = useTranslation();
 
   const sessionProtected = useWatch({ name: 'session_protected', control });
-  const hasMonitoringSecret = useWatch({ name: 'monitoring.secret', control });
+
+  const enableBrowserAuthorization = useWatch({
+    name: 'monitoring.browser_authorization',
+    control,
+  });
 
   return (
     <Controller
@@ -24,9 +28,11 @@ const BlocksInvalidBrowserFormField = ({
       render={({ field, fieldState }): JSX.Element => (
         <FormCheckboxField
           description={t(translations.blocksAccessesFromInvalidSUSHint)}
-          disabled={!sessionProtected || !hasMonitoringSecret || disabled}
+          disabled={
+            !sessionProtected || !enableBrowserAuthorization || disabled
+          }
           disabledHint={
-            !sessionProtected || !hasMonitoringSecret
+            !sessionProtected || !enableBrowserAuthorization
               ? t(translations.needSUSAndSessionUnlockPassword)
               : undefined
           }

--- a/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/SebConfigKeyOptionsFormFields.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/SebConfigKeyOptionsFormFields.tsx
@@ -1,0 +1,54 @@
+import { Controller } from 'react-hook-form';
+import { Typography } from '@mui/material';
+
+import Link from 'lib/components/core/Link';
+import FormTextField from 'lib/components/form/fields/TextField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from '../translations';
+
+import { BrowserAuthorizationMethodOptionsProps } from './common';
+
+const SebConfigKeyOptionsFormFields = ({
+  control,
+  disabled,
+  className,
+}: BrowserAuthorizationMethodOptionsProps): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={className}>
+      <Controller
+        control={control}
+        name="monitoring.seb_config_key"
+        render={({ field, fieldState }) => (
+          <FormTextField
+            disabled={disabled}
+            field={field}
+            fieldState={fieldState}
+            fullWidth
+            label={t(translations.sebConfigKeyFieldLabel)}
+            variant="filled"
+          />
+        )}
+      />
+
+      <Typography color="text.secondary" variant="body2">
+        {t(translations.sebConfigKeyFieldHint, {
+          sebConfigKey: (chunk) => (
+            <Link
+              external
+              opensInNewTab
+              to="https://safeexambrowser.org/developer/seb-config-key.html"
+            >
+              {chunk}
+            </Link>
+          ),
+          i: (chunk) => <i>{chunk}</i>,
+        })}
+      </Typography>
+    </div>
+  );
+};
+
+export default SebConfigKeyOptionsFormFields;

--- a/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/UserAgentOptionsFormFields.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/UserAgentOptionsFormFields.tsx
@@ -1,0 +1,50 @@
+import { Controller } from 'react-hook-form';
+import { Typography } from '@mui/material';
+
+import Link from 'lib/components/core/Link';
+import FormTextField from 'lib/components/form/fields/TextField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from '../translations';
+
+import { BrowserAuthorizationMethodOptionsProps } from './common';
+
+const UserAgentOptionsFormFields = ({
+  control,
+  pulsegridUrl,
+  disabled,
+  className,
+}: BrowserAuthorizationMethodOptionsProps): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={className}>
+      <Controller
+        control={control}
+        name="monitoring.secret"
+        render={({ field, fieldState }) => (
+          <FormTextField
+            disabled={disabled}
+            field={field}
+            fieldState={fieldState}
+            fullWidth
+            label={t(translations.secret)}
+            variant="filled"
+          />
+        )}
+      />
+
+      <Typography color="text.secondary" variant="body2">
+        {t(translations.secretHint, {
+          pulsegrid: (chunk) => (
+            <Link opensInNewTab to={pulsegridUrl}>
+              {chunk}
+            </Link>
+          ),
+        })}
+      </Typography>
+    </div>
+  );
+};
+
+export default UserAgentOptionsFormFields;

--- a/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/common.ts
+++ b/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/common.ts
@@ -1,0 +1,16 @@
+import { Control } from 'react-hook-form';
+
+export const BROWSER_AUTHORIZATION_METHODS = [
+  'user_agent',
+  'seb_config_key',
+] as const;
+
+export type BrowserAuthorizationMethod =
+  (typeof BROWSER_AUTHORIZATION_METHODS)[number];
+
+export interface BrowserAuthorizationMethodOptionsProps {
+  control: Control;
+  pulsegridUrl?: string;
+  disabled?: boolean;
+  className?: string;
+}

--- a/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/index.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/index.tsx
@@ -1,0 +1,33 @@
+import { ElementType } from 'react';
+
+import {
+  BrowserAuthorizationMethod,
+  BrowserAuthorizationMethodOptionsProps,
+} from './common';
+import SebConfigKeyOptionsFormFields from './SebConfigKeyOptionsFormFields';
+import UserAgentOptionsFormFields from './UserAgentOptionsFormFields';
+
+const AUTHORIZATION_METHODS: Record<
+  BrowserAuthorizationMethod,
+  ElementType<BrowserAuthorizationMethodOptionsProps>
+> = {
+  user_agent: UserAgentOptionsFormFields,
+  seb_config_key: SebConfigKeyOptionsFormFields,
+};
+
+const BrowserAuthorizationMethodOptionsFormFields = ({
+  authorizationMethod,
+  ...restProps
+}: {
+  authorizationMethod: BrowserAuthorizationMethod;
+} & BrowserAuthorizationMethodOptionsProps): JSX.Element => {
+  const Component = AUTHORIZATION_METHODS[authorizationMethod];
+  if (!Component)
+    throw new Error(
+      `Unregistered authorization method: ${authorizationMethod}`,
+    );
+
+  return <Component {...restProps} />;
+};
+
+export default BrowserAuthorizationMethodOptionsFormFields;

--- a/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationOptionsFormFields.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/BrowserAuthorizationOptionsFormFields.tsx
@@ -1,0 +1,140 @@
+import { Control, Controller, useWatch } from 'react-hook-form';
+import { RadioGroup } from '@mui/material';
+
+import RadioButton from 'lib/components/core/buttons/RadioButton';
+import Subsection from 'lib/components/core/layouts/Subsection';
+import Link from 'lib/components/core/Link';
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import assessmentFormTranslations from '../AssessmentForm/translations';
+
+import BrowserAuthorizationMethodOptionsFormFields from './BrowserAuthorizationMethodOptionsFormFields';
+import translations from './translations';
+
+const BrowserAuthorizationOptionsFormFields = ({
+  control,
+  pulsegridUrl,
+  disabled,
+}: {
+  control: Control;
+  pulsegridUrl?: string;
+  disabled?: boolean;
+}): JSX.Element => {
+  const { t } = useTranslation();
+
+  const enableBrowserAuthorization = useWatch({
+    name: 'monitoring.browser_authorization',
+    control,
+  });
+
+  const authorizationMethod = useWatch({
+    name: 'monitoring.browser_authorization_method',
+    control,
+  });
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name="monitoring.browser_authorization"
+        render={({ field, fieldState }): JSX.Element => (
+          <FormCheckboxField
+            description={t(translations.enableBrowserAuthorizationHint, {
+              pulsegrid: (chunk) => (
+                <Link opensInNewTab to={pulsegridUrl}>
+                  {chunk}
+                </Link>
+              ),
+            })}
+            disabled={disabled}
+            disabledHint={t(
+              assessmentFormTranslations.onlyManagersOwnersCanEdit,
+            )}
+            field={field}
+            fieldState={fieldState}
+            label={t(translations.enableBrowserAuthorization)}
+            labelClassName="mt-8"
+          />
+        )}
+      />
+
+      {enableBrowserAuthorization && (
+        <Subsection
+          className="!mt-8"
+          subtitle={t(translations.browserAuthorizationMethodHint, {
+            pulsegrid: (chunk) => (
+              <Link opensInNewTab to={pulsegridUrl}>
+                {chunk}
+              </Link>
+            ),
+          })}
+          title={t(translations.browserAuthorizationMethod)}
+        >
+          <Controller
+            control={control}
+            name="monitoring.browser_authorization_method"
+            render={({ field }): JSX.Element => (
+              <RadioGroup className="space-y-5" {...field} value={field.value}>
+                <RadioButton
+                  className="my-0"
+                  description={t(translations.userAgentHint, {
+                    ua: (chunk) => (
+                      <Link
+                        external
+                        opensInNewTab
+                        to="https://en.wikipedia.org/wiki/User-Agent_header"
+                      >
+                        {chunk}
+                      </Link>
+                    ),
+                  })}
+                  disabled={disabled}
+                  label={t(translations.userAgent)}
+                  value="user_agent"
+                />
+
+                <RadioButton
+                  className="my-0"
+                  description={t(translations.sebConfigKeyHint, {
+                    seb: (chunk) => (
+                      <Link
+                        external
+                        opensInNewTab
+                        to="https://safeexambrowser.org"
+                      >
+                        {chunk}
+                      </Link>
+                    ),
+                    sebConfigKey: (chunk) => (
+                      <Link
+                        external
+                        opensInNewTab
+                        to="https://safeexambrowser.org/developer/seb-config-key.html"
+                      >
+                        {chunk}
+                      </Link>
+                    ),
+                  })}
+                  disabled={disabled}
+                  label={t(translations.sebConfigKey)}
+                  value="seb_config_key"
+                />
+              </RadioGroup>
+            )}
+          />
+
+          <BrowserAuthorizationMethodOptionsFormFields
+            authorizationMethod={authorizationMethod}
+            className="mt-5"
+            control={control}
+            disabled={disabled}
+            pulsegridUrl={pulsegridUrl}
+          />
+        </Subsection>
+      )}
+    </>
+  );
+};
+
+export default BrowserAuthorizationOptionsFormFields;

--- a/client/app/bundles/course/assessment/components/monitoring/EnableMonitoringFormField.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/EnableMonitoringFormField.tsx
@@ -1,0 +1,55 @@
+import { Control, Controller } from 'react-hook-form';
+
+import BetaChip from 'lib/components/core/BetaChip';
+import Link from 'lib/components/core/Link';
+import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import assessmentFormTranslations from '../AssessmentForm/translations';
+
+import translations from './translations';
+
+const EnableMonitoringFormField = ({
+  control,
+  pulsegridUrl,
+  disabled,
+  labelClassName,
+}: {
+  control: Control;
+  pulsegridUrl?: string;
+  disabled?: boolean;
+  labelClassName?: string;
+}): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Controller
+      control={control}
+      name="monitoring.enabled"
+      render={({ field, fieldState }): JSX.Element => (
+        <FormCheckboxField
+          description={t(translations.examMonitoringHint, {
+            pulsegrid: (chunk) => (
+              <Link opensInNewTab to={pulsegridUrl}>
+                {chunk}
+              </Link>
+            ),
+          })}
+          disabled={disabled}
+          disabledHint={t(assessmentFormTranslations.onlyManagersOwnersCanEdit)}
+          field={field}
+          fieldState={fieldState}
+          label={
+            <span className="flex items-center space-x-2">
+              <span>{t(translations.examMonitoring)}</span>
+              <BetaChip disabled={disabled} />
+            </span>
+          }
+          labelClassName={labelClassName}
+        />
+      )}
+    />
+  );
+};
+
+export default EnableMonitoringFormField;

--- a/client/app/bundles/course/assessment/components/monitoring/MonitoringIntervalsFormFields.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/MonitoringIntervalsFormFields.tsx
@@ -1,0 +1,113 @@
+import { Control, Controller } from 'react-hook-form';
+import { Grid, InputAdornment, Typography } from '@mui/material';
+
+import FormTextField from 'lib/components/form/fields/TextField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from './translations';
+
+const MonitoringIntervalsFormFields = ({
+  control,
+  disabled,
+}: {
+  control: Control;
+  disabled?: boolean;
+}): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Grid container direction="row" spacing={2}>
+      <Grid item xs>
+        <Grid container direction="row" spacing={2}>
+          <Grid item xs>
+            <Controller
+              control={control}
+              name="monitoring.min_interval_ms"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormTextField
+                  disabled={disabled}
+                  field={field}
+                  fieldState={fieldState}
+                  fullWidth
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        {t(translations.milliseconds)}
+                      </InputAdornment>
+                    ),
+                  }}
+                  label={t(translations.minInterval)}
+                  required
+                  type="number"
+                  variant="filled"
+                />
+              )}
+            />
+          </Grid>
+
+          <Grid item xs>
+            <Controller
+              control={control}
+              name="monitoring.max_interval_ms"
+              render={({ field, fieldState }): JSX.Element => (
+                <FormTextField
+                  disabled={disabled}
+                  field={field}
+                  fieldState={fieldState}
+                  fullWidth
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        {t(translations.milliseconds)}
+                      </InputAdornment>
+                    ),
+                  }}
+                  label={t(translations.maxInterval)}
+                  required
+                  type="number"
+                  variant="filled"
+                />
+              )}
+            />
+          </Grid>
+        </Grid>
+
+        <Typography className="!mt-0" color="text.secondary" variant="body2">
+          {t(translations.intervalHint)}
+        </Typography>
+      </Grid>
+
+      <Grid item xs>
+        <Controller
+          control={control}
+          name="monitoring.offset_ms"
+          render={({ field, fieldState }): JSX.Element => (
+            <FormTextField
+              disabled={disabled}
+              field={field}
+              fieldState={fieldState}
+              fullWidth
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    {t(translations.milliseconds)}
+                  </InputAdornment>
+                ),
+              }}
+              label={t(translations.offset)}
+              required
+              type="number"
+              variant="filled"
+            />
+          )}
+        />
+
+        <Typography className="!mt-0" color="text.secondary" variant="body2">
+          {t(translations.offsetHint)}
+        </Typography>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default MonitoringIntervalsFormFields;

--- a/client/app/bundles/course/assessment/components/monitoring/MonitoringOptionsFormFields.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/MonitoringOptionsFormFields.tsx
@@ -1,0 +1,54 @@
+import { Control, Controller } from 'react-hook-form';
+import { Typography } from '@mui/material';
+
+import Link from 'lib/components/core/Link';
+import FormTextField from 'lib/components/form/fields/TextField';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import MonitoringIntervalsFormFields from './MonitoringIntervalsFormFields';
+import translations from './translations';
+
+const MonitoringOptionsFormFields = ({
+  control,
+  pulsegridUrl,
+  disabled,
+}: {
+  control: Control;
+  pulsegridUrl?: string;
+  disabled?: boolean;
+}): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name="monitoring.secret"
+        render={({ field, fieldState }): JSX.Element => (
+          <FormTextField
+            disabled={disabled}
+            field={field}
+            fieldState={fieldState}
+            fullWidth
+            label={t(translations.secret)}
+            variant="filled"
+          />
+        )}
+      />
+
+      <Typography className="!mt-0" color="text.secondary" variant="body2">
+        {t(translations.secretHint, {
+          pulsegrid: (chunk) => (
+            <Link opensInNewTab to={pulsegridUrl}>
+              {chunk}
+            </Link>
+          ),
+        })}
+      </Typography>
+
+      <MonitoringIntervalsFormFields control={control} disabled={disabled} />
+    </>
+  );
+};
+
+export default MonitoringOptionsFormFields;

--- a/client/app/bundles/course/assessment/components/monitoring/MonitoringOptionsFormFields.tsx
+++ b/client/app/bundles/course/assessment/components/monitoring/MonitoringOptionsFormFields.tsx
@@ -1,12 +1,7 @@
-import { Control, Controller } from 'react-hook-form';
-import { Typography } from '@mui/material';
+import { Control } from 'react-hook-form';
 
-import Link from 'lib/components/core/Link';
-import FormTextField from 'lib/components/form/fields/TextField';
-import useTranslation from 'lib/hooks/useTranslation';
-
+import BrowserAuthorizationOptionsFormFields from './BrowserAuthorizationOptionsFormFields';
 import MonitoringIntervalsFormFields from './MonitoringIntervalsFormFields';
-import translations from './translations';
 
 const MonitoringOptionsFormFields = ({
   control,
@@ -17,34 +12,13 @@ const MonitoringOptionsFormFields = ({
   pulsegridUrl?: string;
   disabled?: boolean;
 }): JSX.Element => {
-  const { t } = useTranslation();
-
   return (
     <>
-      <Controller
+      <BrowserAuthorizationOptionsFormFields
         control={control}
-        name="monitoring.secret"
-        render={({ field, fieldState }): JSX.Element => (
-          <FormTextField
-            disabled={disabled}
-            field={field}
-            fieldState={fieldState}
-            fullWidth
-            label={t(translations.secret)}
-            variant="filled"
-          />
-        )}
+        disabled={disabled}
+        pulsegridUrl={pulsegridUrl}
       />
-
-      <Typography className="!mt-0" color="text.secondary" variant="body2">
-        {t(translations.secretHint, {
-          pulsegrid: (chunk) => (
-            <Link opensInNewTab to={pulsegridUrl}>
-              {chunk}
-            </Link>
-          ),
-        })}
-      </Typography>
 
       <MonitoringIntervalsFormFields control={control} disabled={disabled} />
     </>

--- a/client/app/bundles/course/assessment/components/monitoring/translations.ts
+++ b/client/app/bundles/course/assessment/components/monitoring/translations.ts
@@ -3,19 +3,19 @@ import { defineMessages } from 'react-intl';
 export default defineMessages({
   blocksAccessesFromInvalidSUS: {
     id: 'course.assessment.monitoring.blocksAccessesFromInvalidSUS',
-    defaultMessage: 'Block accesses from browsers with invalid UA',
+    defaultMessage: 'Block accesses from unauthorised browsers',
   },
   blocksAccessesFromInvalidSUSHint: {
     id: 'course.assessment.monitoring.blocksAccessesFromInvalidSUSHint',
     defaultMessage:
-      'If enabled, examinees using browsers with invalid UA (does not contain the specified SUS below) will be blocked ' +
-      'from accessing this assessment. Instructors can override access with the session unlock password. Heartbeats ' +
-      'from an overridden browser session will be flagged as valid in the PulseGrid.',
+      "If enabled, examinees using unauthorised browsers can't access this assessment. " +
+      'Instructors can override access with the session unlock password. Heartbeats ' +
+      'from overridden browser sessions will always be valid (green) in the PulseGrid.',
   },
   needSUSAndSessionUnlockPassword: {
     id: 'course.assessment.monitoring.needSUSAndSessionUnlockPassword',
     defaultMessage:
-      'You need to specify a SUS and session unlock password to enable this.',
+      'You must enable browser authorisation and set a session unlock password to enable this.',
   },
   examMonitoring: {
     id: 'course.assessment.monitoring.examMonitoring',
@@ -24,7 +24,7 @@ export default defineMessages({
   examMonitoringHint: {
     id: 'course.assessment.monitoring.examMonitoringHint',
     defaultMessage:
-      "If enabled, examinees' sessions will be monitored in real time from the moment they attempt the exam, until they " +
+      "If enabled, examinees' sessions will be monitored in real time from when they attempt the exam until they " +
       'finalise it or the first 24 hours since their attempt, whichever is earlier. Instructors can monitor these ' +
       'sessions in <pulsegrid>PulseGrid</pulsegrid>.',
   },
@@ -58,11 +58,62 @@ export default defineMessages({
   secretHint: {
     id: 'course.assessment.monitoring.secretHint',
     defaultMessage:
-      "If provided, the <pulsegrid>PulseGrid</pulsegrid> automatically checks if the examinee's browser's User Agent (UA) " +
-      'contains this secret, and marks connections that do not as invalid. This string is case-sensitive.',
+      "If an examinee's browser's User Agent (UA) contains this case-sensitive secret, PulseGrid " +
+      'will flag that session as valid, and invalid otherwise. If you leave this blank, all sessions will be flagged as valid.',
   },
   milliseconds: {
     id: 'course.assessment.monitoring.milliseconds',
     defaultMessage: 'ms',
+  },
+  enableBrowserAuthorization: {
+    id: 'course.assessment.monitoring.enableBrowserAuthorization',
+    defaultMessage: 'Authorise browsers that access this assessment',
+  },
+  enableBrowserAuthorizationHint: {
+    id: 'course.assessment.monitoring.enableBrowserAuthorizationHint',
+    defaultMessage:
+      'If enabled, PulseGrid will additionally check if an examinee is ' +
+      'accessing this assessment from an authorised browser, based on the authorisation method you choose.',
+  },
+  userAgent: {
+    id: 'course.assessment.monitoring.userAgent',
+    defaultMessage: 'User Agent (UA)',
+  },
+  userAgentHint: {
+    id: 'course.assessment.monitoring.userAgentHint',
+    defaultMessage:
+      "Flags a session as valid if the examinee's browser's <ua>User Agent (UA)</ua> contains a secret substring.",
+  },
+  sebConfigKeyFieldLabel: {
+    id: 'course.assessment.monitoring.sebConfigKeyFieldLabel',
+    defaultMessage: 'SEB Config Key',
+  },
+  sebConfigKeyFieldHint: {
+    id: 'course.assessment.monitoring.sebConfigKeyFieldHint',
+    defaultMessage:
+      'Your <sebConfigKey>SEB Config Key</sebConfigKey>, <i>not the Browser Exam Key</i>, is generated from your ' +
+      'specific SEB configuration. It stays the same across operating systems and SEB versions. Ensure this field ' +
+      'is updated if you change your SEB configuration.',
+  },
+  sebConfigKey: {
+    id: 'course.assessment.monitoring.sebConfigKey',
+    defaultMessage: 'Safe Exam Browser (SEB) Config Key',
+  },
+  sebConfigKeyHint: {
+    id: 'course.assessment.monitoring.sebConfigKeyHint',
+    defaultMessage:
+      'Flags a session as valid if the examinee is using <seb>Safe Exam Browser (SEB)</seb> with a valid configuration. ' +
+      'SEB generates a unique <sebConfigKey>Config Key</sebConfigKey> for a specific configuration. This method requires ' +
+      'SEB 3.4 for Windows and SEB 3.0 for iOS and macOS, or later.',
+  },
+  browserAuthorizationMethod: {
+    id: 'course.assessment.monitoring.browserAuthorizationMethod',
+    defaultMessage: 'Browser authorisation method',
+  },
+  browserAuthorizationMethodHint: {
+    id: 'course.assessment.monitoring.browserAuthorizationMethodHint',
+    defaultMessage:
+      'Choose how sessions are authorised as valid or invalid. Changes apply to all sessions and heartbeats ' +
+      'immediately and updates live in PulseGrid.',
   },
 });

--- a/client/app/bundles/course/assessment/components/monitoring/translations.ts
+++ b/client/app/bundles/course/assessment/components/monitoring/translations.ts
@@ -1,0 +1,68 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  blocksAccessesFromInvalidSUS: {
+    id: 'course.assessment.monitoring.blocksAccessesFromInvalidSUS',
+    defaultMessage: 'Block accesses from browsers with invalid UA',
+  },
+  blocksAccessesFromInvalidSUSHint: {
+    id: 'course.assessment.monitoring.blocksAccessesFromInvalidSUSHint',
+    defaultMessage:
+      'If enabled, examinees using browsers with invalid UA (does not contain the specified SUS below) will be blocked ' +
+      'from accessing this assessment. Instructors can override access with the session unlock password. Heartbeats ' +
+      'from an overridden browser session will be flagged as valid in the PulseGrid.',
+  },
+  needSUSAndSessionUnlockPassword: {
+    id: 'course.assessment.monitoring.needSUSAndSessionUnlockPassword',
+    defaultMessage:
+      'You need to specify a SUS and session unlock password to enable this.',
+  },
+  examMonitoring: {
+    id: 'course.assessment.monitoring.examMonitoring',
+    defaultMessage: 'Enable exam monitoring',
+  },
+  examMonitoringHint: {
+    id: 'course.assessment.monitoring.examMonitoringHint',
+    defaultMessage:
+      "If enabled, examinees' sessions will be monitored in real time from the moment they attempt the exam, until they " +
+      'finalise it or the first 24 hours since their attempt, whichever is earlier. Instructors can monitor these ' +
+      'sessions in <pulsegrid>PulseGrid</pulsegrid>.',
+  },
+  minInterval: {
+    id: 'course.assessment.monitoring.minInterval',
+    defaultMessage: 'Min interval',
+  },
+  maxInterval: {
+    id: 'course.assessment.monitoring.maxInterval',
+    defaultMessage: 'Max interval',
+  },
+  intervalHint: {
+    id: 'course.assessment.monitoring.intervalHint',
+    defaultMessage:
+      "Controls how frequent heartbeats are sent from the examinees' browsers. Intervals are randomised between these " +
+      'two ranges.',
+  },
+  offset: {
+    id: 'course.assessment.monitoring.offset',
+    defaultMessage: 'Inter-heartbeat offset',
+  },
+  offsetHint: {
+    id: 'course.assessment.monitoring.offsetHint',
+    defaultMessage:
+      'Controls how long PulseGrid should wait after the frequency interval before flagging a session as late.',
+  },
+  secret: {
+    id: 'course.assessment.monitoring.secret',
+    defaultMessage: 'Secret UA Substring (SUS)',
+  },
+  secretHint: {
+    id: 'course.assessment.monitoring.secretHint',
+    defaultMessage:
+      "If provided, the <pulsegrid>PulseGrid</pulsegrid> automatically checks if the examinee's browser's User Agent (UA) " +
+      'contains this secret, and marks connections that do not as invalid. This string is case-sensitive.',
+  },
+  milliseconds: {
+    id: 'course.assessment.monitoring.milliseconds',
+    defaultMessage: 'ms',
+  },
+});

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/PulseGrid.tsx
@@ -28,7 +28,7 @@ const PulseGrid = (props: PulseGridProps): JSX.Element => {
   const { t } = useTranslation();
   const [userIds, setUserIds] = useState<number[]>([]);
   const [groups, setGroups] = useState<WatchGroup[]>([]);
-  const [hasSecret, setHasSecret] = useState(false);
+  const [validates, setValidates] = useState(false);
   const monitoring = useMonitoring();
 
   const [rejected, setRejected] = useState(false);
@@ -37,7 +37,7 @@ const PulseGrid = (props: PulseGridProps): JSX.Element => {
     watch: (data) => {
       setUserIds(data.userIds);
       setGroups(data.groups);
-      setHasSecret(data.monitor.hasSecret);
+      setValidates(data.monitor.validates);
       monitoring.initialize(data.monitor, data.snapshots);
       monitoring.notifyConnected();
     },
@@ -69,7 +69,7 @@ const PulseGrid = (props: PulseGridProps): JSX.Element => {
 
         <FilterAutocomplete filters={groups} />
 
-        <SessionBlobLegend hasSecret={hasSecret} />
+        <SessionBlobLegend validates={validates} />
 
         <SessionsGrid for={userIds} getHeartbeats={channel.getHeartbeats} />
       </aside>

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ActiveSessionBlob.tsx
@@ -36,7 +36,9 @@ const BaseActiveSessionBlob = (
 ): JSX.Element => {
   const { of: snapshot, for: userId } = props;
 
-  const { hasSecret } = useAppSelector(select('monitor'));
+  const { validates, browserAuthorizationMethod } = useAppSelector(
+    select('monitor'),
+  );
 
   const monitoring = useMonitoring();
 
@@ -66,9 +68,9 @@ const BaseActiveSessionBlob = (
 
       <SessionDetailsPopup
         anchorsOn={popupData?.[0]}
+        browserAuthorizationMethod={browserAuthorizationMethod}
         for={snapshot.userName ?? ''}
         generatedAt={popupData?.[1]}
-        hasSecret={hasSecret}
         onClickShowAllHeartbeats={(): void => {
           props.getHeartbeats?.(snapshot.sessionId, -1);
           setPopupData((data) => [data?.[0], new Date().toISOString()]);
@@ -80,6 +82,7 @@ const BaseActiveSessionBlob = (
         open={Boolean(snapshot.recentHeartbeats && popupData?.[0])}
         showing={snapshot.recentHeartbeats ?? []}
         submissionId={snapshot.submissionId}
+        validates={validates}
       />
     </>
   );

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatDetailCard.tsx
@@ -1,16 +1,19 @@
 import { Chip, Tooltip, Typography } from '@mui/material';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
+import { BrowserAuthorizationMethod } from 'course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/common';
 import useTranslation from 'lib/hooks/useTranslation';
 import { formatPreciseDateTime } from 'lib/moment';
 
 import translations from '../../../translations';
 
+import SebPayloadDetail from './SebPayloadDetail';
 import UserAgentDetail from './UserAgentDetail';
 
 interface HeartbeatDetailCardProps {
   of: HeartbeatDetail;
-  hasSecret?: boolean;
+  validates?: boolean;
+  browserAuthorizationMethod?: BrowserAuthorizationMethod;
   className?: string;
   delta?: number;
 }
@@ -76,7 +79,24 @@ const HeartbeatDetailCard = (props: HeartbeatDetailCardProps): JSX.Element => {
         <UserAgentDetail
           of={heartbeat.userAgent}
           valid={heartbeat.isValid}
-          validate={props.hasSecret}
+          validates={
+            props.validates && props.browserAuthorizationMethod === 'user_agent'
+          }
+        />
+      </section>
+
+      <section className="space-y-2">
+        <Typography color="text.secondary" variant="caption">
+          {t(translations.sebPayload)}
+        </Typography>
+
+        <SebPayloadDetail
+          of={heartbeat.sebPayload}
+          valid={heartbeat.isValid}
+          validates={
+            props.validates &&
+            props.browserAuthorizationMethod === 'seb_config_key'
+          }
         />
       </section>
     </section>

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/HeartbeatsTimeline.tsx
@@ -2,12 +2,15 @@ import { useState } from 'react';
 import moment from 'moment';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
+import { BrowserAuthorizationMethod } from 'course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/common';
+
 import HeartbeatDetailCard from './HeartbeatDetailCard';
 import HeartbeatsTimelineChart from './HeartbeatsTimelineChart';
 
 interface HeartbeatsTimelineProps {
   in: HeartbeatDetail[];
-  hasSecret?: boolean;
+  validates?: boolean;
+  browserAuthorizationMethod?: BrowserAuthorizationMethod;
 }
 
 /**
@@ -48,10 +51,11 @@ const HeartbeatsTimeline = (props: HeartbeatsTimelineProps): JSX.Element => {
 
       {heartbeats[hoveredIndex] && (
         <HeartbeatDetailCard
+          browserAuthorizationMethod={props.browserAuthorizationMethod}
           className="ring-2 ring-offset-0"
           delta={getHeartbeatDelta(heartbeats, hoveredIndex)}
-          hasSecret={props.hasSecret}
           of={heartbeats[hoveredIndex]}
+          validates={props.validates}
         />
       )}
     </>

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SebPayloadDetail.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SebPayloadDetail.tsx
@@ -1,0 +1,59 @@
+import { Launch, Tag } from '@mui/icons-material';
+import { Typography } from '@mui/material';
+import { SebPayload } from 'types/course/assessment/monitoring';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from '../../../translations';
+
+import ValidChip from './ValidChip';
+
+const SebPayloadDetail = ({
+  of: payload,
+  valid,
+  validates,
+}: {
+  of: SebPayload | undefined;
+  valid?: boolean;
+  validates?: boolean;
+}): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <section className="flex flex-col space-y-2">
+      {validates && <ValidChip className="w-fit" valid={valid} />}
+
+      {payload ? (
+        <div className="flex flex-col gap-2">
+          <section className="flex gap-2">
+            <Tag color="disabled" fontSize="small" />
+
+            <Typography
+              className="whitespace-pre-wrap h-full break-all font-mono"
+              variant="body2"
+            >
+              {payload.config_key_hash}
+            </Typography>
+          </section>
+
+          <section className="flex gap-2">
+            <Launch color="disabled" fontSize="small" />
+
+            <Typography
+              className="whitespace-pre-wrap break-all"
+              variant="body2"
+            >
+              {payload.url}
+            </Typography>
+          </section>
+        </div>
+      ) : (
+        <Typography className="italic" color="text.disabled" variant="body2">
+          {t(translations.blankField)}
+        </Typography>
+      )}
+    </section>
+  );
+};
+
+export default SebPayloadDetail;

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionBlobLegend.tsx
@@ -10,7 +10,7 @@ import { PRESENCE_COLORS } from './ActiveSessionBlob';
 import SessionBlob from './SessionBlob';
 
 interface SessionBlobLegendProps {
-  hasSecret: boolean;
+  validates: boolean;
 }
 
 const SessionBlobLegend = (props: SessionBlobLegendProps): JSX.Element => {
@@ -50,7 +50,7 @@ const SessionBlobLegend = (props: SessionBlobLegendProps): JSX.Element => {
             <SessionBlob className={PRESENCE_COLORS.alive} />
 
             <Typography className="mt-1" variant="body2">
-              {props.hasSecret
+              {props.validates
                 ? t(translations.alivePresenceHintSUSMatches)
                 : t(translations.alivePresenceHint)}
             </Typography>

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/SessionDetailsPopup.tsx
@@ -4,6 +4,7 @@ import { Close } from '@mui/icons-material';
 import { IconButton, Popover, Typography } from '@mui/material';
 import { HeartbeatDetail } from 'types/channels/liveMonitoring';
 
+import { BrowserAuthorizationMethod } from 'course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/common';
 import Link from 'lib/components/core/Link';
 import useTranslation from 'lib/hooks/useTranslation';
 import { formatPreciseDateTime } from 'lib/moment';
@@ -19,7 +20,8 @@ interface SessionDetailsPopupProps {
   onClose: () => void;
   generatedAt?: string;
   anchorsOn?: HTMLElement;
-  hasSecret?: boolean;
+  validates?: boolean;
+  browserAuthorizationMethod?: BrowserAuthorizationMethod;
   onClickShowAllHeartbeats?: () => void;
   submissionId?: number;
 }
@@ -90,7 +92,11 @@ const SessionDetailsPopup = (props: SessionDetailsPopupProps): JSX.Element => {
           </Link>
         </div>
 
-        <HeartbeatsTimeline hasSecret={props.hasSecret} in={heartbeats} />
+        <HeartbeatsTimeline
+          browserAuthorizationMethod={props.browserAuthorizationMethod}
+          in={heartbeats}
+          validates={props.validates}
+        />
       </Popover>
     </Draggable>
   );

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/UserAgentDetail.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/UserAgentDetail.tsx
@@ -1,92 +1,55 @@
-import { Apple, Cancel, CheckCircle, WindowSharp } from '@mui/icons-material';
-import { Chip, Typography } from '@mui/material';
+import { ComponentProps } from 'react';
+import { Apple, Public, WindowSharp } from '@mui/icons-material';
+import { SvgIcon, Typography } from '@mui/material';
 
-import useTranslation, {
-  Descriptor,
-  MessageTranslator,
-} from 'lib/hooks/useTranslation';
-import commonTranslations from 'lib/translations';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../../translations';
 
-interface UserAgentDetailProps {
-  of?: string;
-  className?: string;
-  validate?: boolean;
-  valid?: boolean;
-}
+import ValidChip from './ValidChip';
 
-const platforms = {
-  windows: {
-    icon: <WindowSharp className="text-[#2A78D4]" />,
-    label: commonTranslations.windows,
-  },
-  macos: {
-    icon: <Apple />,
-    label: commonTranslations.macos,
-  },
-} satisfies Record<string, { icon: JSX.Element; label: Descriptor }>;
+const PlatformIcon = ({
+  userAgent,
+  ...iconProps
+}: { userAgent: string } & ComponentProps<typeof SvgIcon>): JSX.Element => {
+  if (userAgent.includes('Mac')) return <Apple {...iconProps} />;
 
-const getPlatformChipFromUserAgent = (
-  userAgent: string,
-  t: MessageTranslator,
-): JSX.Element | null => {
-  let platform: keyof typeof platforms | undefined;
-
-  if (userAgent.includes('Windows')) {
-    platform = 'windows';
-  } else if (userAgent.includes('Mac')) {
-    platform = 'macos';
-  }
-
-  if (!platform) return null;
-
-  const { icon, label } = platforms[platform];
-
-  return <Chip icon={icon} label={t(label)} size="small" variant="outlined" />;
-};
-
-const UserAgentDetail = (props: UserAgentDetailProps): JSX.Element => {
-  const { of: userAgent, className } = props;
-
-  const { t } = useTranslation();
-
-  if (userAgent === undefined)
+  if (userAgent.includes('Windows'))
     return (
-      <Typography
-        className={`italic ${className ?? ''}`}
-        color="text.disabled"
-        variant="body2"
-      >
-        {t(translations.blankField)}
-      </Typography>
+      <WindowSharp
+        {...iconProps}
+        className={`text-[#2A78D4] ${iconProps.className ?? ''}`}
+      />
     );
 
-  const platformChip = getPlatformChipFromUserAgent(userAgent, t);
+  return <Public color="disabled" {...iconProps} />;
+};
+
+const UserAgentDetail = ({
+  of: userAgent,
+  validates,
+  valid,
+}: {
+  of?: string;
+  validates?: boolean;
+  valid?: boolean;
+}): JSX.Element => {
+  const { t } = useTranslation();
 
   return (
     <section className="flex flex-col space-y-2">
-      <div className="flex space-x-2 items-center">
-        {props.validate && (
-          <Chip
-            color={props.valid ? 'success' : 'error'}
-            icon={props.valid ? <CheckCircle /> : <Cancel />}
-            label={
-              props.valid
-                ? t(translations.validHeartbeat)
-                : t(translations.invalidHeartbeat)
-            }
-            size="small"
-            variant="outlined"
-          />
-        )}
+      {validates && <ValidChip className="w-fit" valid={valid} />}
 
-        {platformChip}
-      </div>
-
-      <Typography className={className} variant="body2">
-        {userAgent}
-      </Typography>
+      {userAgent ? (
+        <section className="flex gap-2">
+          <PlatformIcon fontSize="small" userAgent={userAgent} />
+          <Typography variant="body2">{userAgent}</Typography>
+        </section>
+      ) : (
+        <Typography className="italic" color="text.disabled" variant="body2">
+          {t(translations.blankField)}
+        </Typography>
+      )}
     </section>
   );
 };

--- a/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ValidChip.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentMonitoring/components/ValidChip.tsx
@@ -1,0 +1,31 @@
+import { ComponentProps } from 'react';
+import { Cancel, CheckCircle } from '@mui/icons-material';
+import { Chip } from '@mui/material';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from '../../../translations';
+
+const ValidChip = ({
+  valid,
+  ...chipProps
+}: { valid?: boolean } & ComponentProps<typeof Chip>): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Chip
+      {...chipProps}
+      color={valid ? 'success' : 'error'}
+      icon={valid ? <CheckCircle /> : <Cancel />}
+      label={
+        valid
+          ? t(translations.validHeartbeat)
+          : t(translations.invalidHeartbeat)
+      }
+      size="small"
+      variant="outlined"
+    />
+  );
+};
+
+export default ValidChip;

--- a/client/app/bundles/course/assessment/reducers/monitoring.ts
+++ b/client/app/bundles/course/assessment/reducers/monitoring.ts
@@ -12,7 +12,12 @@ const initialState: MonitoringState = {
   snapshots: {},
   history: [],
   status: 'connecting',
-  monitor: { maxIntervalMs: 0, offsetMs: 0, hasSecret: false },
+  monitor: {
+    maxIntervalMs: 0,
+    offsetMs: 0,
+    validates: false,
+    browserAuthorizationMethod: 'user_agent',
+  },
 };
 
 export const monitoringSlice = createSlice({

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -987,6 +987,10 @@ const translations = defineMessages({
     id: 'course.assessment.monitoring.userAgent',
     defaultMessage: 'User Agent',
   },
+  sebPayload: {
+    id: 'course.assessment.monitoring.sebPayload',
+    defaultMessage: 'Safe Exam Browser (SEB) Config Key Hash & URL',
+  },
   type: {
     id: 'course.assessment.monitoring.type',
     defaultMessage: 'Type',
@@ -1078,7 +1082,8 @@ const translations = defineMessages({
   },
   alivePresenceHintSUSMatches: {
     id: 'course.assessment.monitoring.alivePresenceHintSUSMatches',
-    defaultMessage: 'Last heartbeat was received in time and the SUS matches.',
+    defaultMessage:
+      'Last heartbeat was received in time and came from an authorised browser, if browser authorisation is enabled.',
   },
   latePresenceHint: {
     id: 'course.assessment.monitoring.latePresenceHint',
@@ -1087,15 +1092,17 @@ const translations = defineMessages({
   },
   missingPresenceHint: {
     id: 'course.assessment.monitoring.missingPresenceHint',
-    defaultMessage: "Next heartbeat hasn't been received in time.",
+    defaultMessage:
+      "Next heartbeat hasn't been received in time, or the last heartbeat came from an unauthorised browser, " +
+      'if browser authorisation is enabled.',
   },
   validHeartbeat: {
     id: 'course.assessment.monitoring.validHeartbeat',
-    defaultMessage: 'Valid UA',
+    defaultMessage: 'Valid',
   },
   invalidHeartbeat: {
     id: 'course.assessment.monitoring.invalidHeartbeat',
-    defaultMessage: 'Invalid UA',
+    defaultMessage: 'Invalid',
   },
   invalidBrowser: {
     id: 'course.assessment.monitoring.invalidBrowser',

--- a/client/app/declaration.d.ts
+++ b/client/app/declaration.d.ts
@@ -35,4 +35,54 @@ declare module '*.md' {
 
 interface Window {
   _CSRF_TOKEN?: string;
+
+  /**
+   * Safe Exam Browser (SEB) JavaScript API. This should be available in SEB 3.4 for Windows
+   * and SEB 3.0 for iOS and macOS, or later.
+   *
+   * For macOS configurations, set the `browserWindowWebView` to the policy "Prefer Modern"
+   * (value `3`) to enable the SEB JavaScript API.
+   *
+   * @see https://safeexambrowser.org/developer/seb-config-key.html
+   *
+   * Types are obtained from the SEB source code.
+   *
+   * @see https://github.com/SafeExamBrowser/seb-mac/blob/6208692490f312566db251532b76b62ed33b9176/Classes/BrowserComponents/SEBAbstractModernWebView.swift
+   */
+  SafeExamBrowser?: {
+    /**
+     * Has the format `appDisplayName_<OS>_versionString_buildNumber_bundleID`. `<OS>` currently
+     * can have the values `iOS`, `macOS` or `Windows`.
+     *
+     * This is set regardless whether `updateKeys()` is called.
+     */
+    version: string;
+    security: {
+      appVersion: string;
+
+      /**
+       * The Browser Exam Key (BEK) hashed with the URL of the page.
+       *
+       * @see https://safeexambrowser.org/developer/seb-config-key.html
+       */
+      browserExamKey: string;
+
+      /**
+       * The Config Key (CK) hashed with the URL of the page.
+       *
+       * @see https://safeexambrowser.org/developer/seb-config-key.html
+       */
+      configKey: string;
+
+      /**
+       * In SEB 3.0 for macOS/iOS, this function needs to be invoked first (for example in
+       * `<body onload="...">`). Indicate a `callback` function as parameter, which will be called
+       * asynchronously by SEB after updating `browserExamKey` and `configKey`.
+       *
+       * In SEB 3.3.2 for Windows and SEB 3.1 for macOS and iOS, calling this function is not
+       * necessary, the `browserExamKey` and `configKey` are already set when the page is loaded.
+       */
+      updateKeys: (callback: () => void) => void;
+    };
+  };
 }

--- a/client/app/lib/translations/index.ts
+++ b/client/app/lib/translations/index.ts
@@ -21,14 +21,6 @@ const translations = defineMessages({
     id: 'lib.translations.experimental',
     defaultMessage: 'Experimental',
   },
-  windows: {
-    id: 'lib.translations.windows',
-    defaultMessage: 'Windows',
-  },
-  macos: {
-    id: 'lib.translations.macos',
-    defaultMessage: 'macOS',
-  },
 });
 
 export default translations;

--- a/client/app/types/channels/heartbeat.ts
+++ b/client/app/types/channels/heartbeat.ts
@@ -1,5 +1,8 @@
+import { SebPayload } from 'types/course/assessment/monitoring';
+
 export interface HeartbeatPostData {
   timestamp: number;
+  sebPayload?: SebPayload;
 }
 
 export interface NextActionData {

--- a/client/app/types/channels/liveMonitoring.ts
+++ b/client/app/types/channels/liveMonitoring.ts
@@ -1,15 +1,21 @@
+import { SebPayload } from 'types/course/assessment/monitoring';
+
+import { BrowserAuthorizationMethod } from 'course/assessment/components/monitoring/BrowserAuthorizationMethodOptionsFormFields/common';
+
 export interface MonitoringMonitorData {
   maxIntervalMs: number;
   offsetMs: number;
-  hasSecret: boolean;
+  validates: boolean;
+  browserAuthorizationMethod: BrowserAuthorizationMethod;
 }
 
 export interface HeartbeatDetail {
-  isValid: boolean;
   stale: boolean;
   userAgent: string;
   ipAddress: string;
   generatedAt: string;
+  isValid: boolean;
+  sebPayload?: SebPayload;
 }
 
 export interface SnapshotData {

--- a/client/app/types/course/assessment/monitoring.ts
+++ b/client/app/types/course/assessment/monitoring.ts
@@ -3,3 +3,8 @@ export interface MonitoringRequestData {
   monitorId: number;
   title: string;
 }
+
+export interface SebPayload {
+  config_key_hash: string;
+  url: string;
+}

--- a/client/app/workers/heartbeatChannel.ts
+++ b/client/app/workers/heartbeatChannel.ts
@@ -9,6 +9,7 @@ interface HeartbeatChannelCallbacks {
   resetInterval: (action: () => void, interval: number) => void;
   onPulse?: (heartbeat: HeartbeatPostData) => void;
   onPulsed?: (timestamp: number) => void;
+  getHeartbeatData: () => HeartbeatPostData;
   getFlushData?: () => Promise<HeartbeatPostData[]>;
   onFlushed?: (from: number, to: number) => void;
   onTerminate?: () => void;
@@ -27,7 +28,7 @@ const flushThenPulseOn = async (
   const flushData = await callbacks.getFlushData?.();
   if (flushData?.length) channel.perform('flush', { heartbeats: flushData });
 
-  const heartbeat: HeartbeatPostData = { timestamp: Date.now() };
+  const heartbeat = callbacks.getHeartbeatData();
 
   callbacks.onPulse?.(heartbeat);
   channel.perform('pulse', heartbeat);

--- a/client/app/workers/listeners.ts
+++ b/client/app/workers/listeners.ts
@@ -24,7 +24,7 @@ const terminateWorker = async (): Promise<void> => {
 const createListeners = (
   host: HeartbeatWorkerListenerHost,
 ): HeartbeatWorkerListener => ({
-  start: async ({ url, sessionId, courseId }): Promise<void> => {
+  start: async ({ url, sessionId, courseId, sebPayload }): Promise<void> => {
     storage ??= await setUpDatabase();
 
     channel ??= subscribe(url, sessionId, courseId, {
@@ -34,6 +34,7 @@ const createListeners = (
         storage?.updateLastSuccessfulPulse(timestamp);
         storage?.removeHeartbeat(timestamp);
       },
+      getHeartbeatData: () => ({ timestamp: Date.now(), sebPayload }),
       getFlushData: storage?.getHeartbeats,
       onFlushed: storage?.removeHeartbeats,
       onTerminate: terminateWorker,

--- a/client/app/workers/types.ts
+++ b/client/app/workers/types.ts
@@ -1,7 +1,10 @@
+import type { SebPayload } from 'types/course/assessment/monitoring';
+
 interface StartPayload {
   url: string;
   sessionId: number;
   courseId: number;
+  sebPayload?: SebPayload;
 }
 
 export interface HeartbeatWorkerListener {

--- a/config/locales/en/activerecord/course/monitoring/heartbeat.yml
+++ b/config/locales/en/activerecord/course/monitoring/heartbeat.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        course/monitoring/heartbeat:
+          attributes:
+            seb_payload:
+              invalid_seb_payload: 'seb payload must be either blank or a valid json object'

--- a/config/locales/en/activerecord/course/monitoring/monitor.yml
+++ b/config/locales/en/activerecord/course/monitoring/monitor.yml
@@ -9,6 +9,6 @@ en:
             max_interval_ms:
               greater_than_min_interval: 'must be greater than min interval'
             blocks:
-              must_have_secret_and_session_protection: 'must have secret and session protection enabled'
+              must_have_browser_authorization_and_session_protection: 'must have browser authorization and session protection enabled'
             seb_config_key:
               required_if_using_seb_config_key_browser_authorization: 'must have seb config key if using seb config key browser authorization method'

--- a/config/locales/en/activerecord/course/monitoring/monitor.yml
+++ b/config/locales/en/activerecord/course/monitoring/monitor.yml
@@ -10,3 +10,5 @@ en:
               greater_than_min_interval: 'must be greater than min interval'
             blocks:
               must_have_secret_and_session_protection: 'must have secret and session protection enabled'
+            seb_config_key:
+              required_if_using_seb_config_key_browser_authorization: 'must have seb config key if using seb config key browser authorization method'

--- a/config/locales/zh/activerecord/course/monitoring/monitor.yml
+++ b/config/locales/zh/activerecord/course/monitoring/monitor.yml
@@ -8,5 +8,3 @@ zh:
               must_be_password_protected: '评估必须受密码保护才能启用'
             max_interval_ms:
               greater_than_min_interval: '必须大于最小间隔'
-            blocks:
-              must_have_secret_and_session_protection: '必须启用秘密和会话保护'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Rails.application.routes.draw do
           get :requirements, on: :member
           get :statistics, on: :member
           get :monitoring, on: :member
+          get :seb_payload, on: :member
 
           resources :questions, only: [] do
             post 'duplicate/:destination_assessment_id', on: :member, action: 'duplicate', as: :duplicate

--- a/db/migrate/20240904091136_add_browser_authorization_to_monitoring.rb
+++ b/db/migrate/20240904091136_add_browser_authorization_to_monitoring.rb
@@ -1,0 +1,13 @@
+class AddBrowserAuthorizationToMonitoring < ActiveRecord::Migration[7.0]
+  def change
+    change_table :course_monitoring_monitors do |t|
+      t.column :browser_authorization, :boolean, null: false, default: true
+      t.column :browser_authorization_method, :integer, null: false, default: 0
+      t.column :seb_config_key, :string
+    end
+
+    change_table :course_monitoring_heartbeats do |t|
+      t.column :seb_payload, :jsonb
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_30_090759) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_04_091136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -857,6 +857,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_30_090759) do
     t.boolean "stale", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "seb_payload"
     t.index ["generated_at"], name: "index_course_monitoring_heartbeats_on_generated_at"
     t.index ["session_id"], name: "index_course_monitoring_heartbeats_on_session_id"
   end
@@ -870,6 +871,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_30_090759) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "blocks", default: false, null: false
+    t.boolean "browser_authorization", default: true, null: false
+    t.integer "browser_authorization_method", default: 0, null: false
+    t.string "seb_config_key"
   end
 
   create_table "course_monitoring_sessions", force: :cascade do |t|

--- a/spec/factories/course_monitoring_monitors.rb
+++ b/spec/factories/course_monitoring_monitors.rb
@@ -20,5 +20,9 @@ FactoryBot.define do
       with_secret
       blocks { true }
     end
+
+    trait :with_seb_config_key do
+      browser_authorization_method { :seb_config_key }
+    end
   end
 end

--- a/spec/services/course/assessment/submission/monitoring_service_spec.rb
+++ b/spec/services/course/assessment/submission/monitoring_service_spec.rb
@@ -61,8 +61,13 @@ RSpec.describe Course::Assessment::Submission::MonitoringService, type: :service
       end
 
       describe '#should_block?' do
-        let(:valid_user_agent) { "#{base_user_agent} #{monitor.secret}" }
-        let(:invalid_user_agent) { "#{base_user_agent} #{SecureRandom.hex}" }
+        let(:valid_request) do
+          ActionDispatch::Request.new({ 'HTTP_USER_AGENT' => "#{base_user_agent} #{monitor.secret}" })
+        end
+
+        let(:invalid_request) do
+          ActionDispatch::Request.new({ 'HTTP_USER_AGENT' => "#{base_user_agent} #{SecureRandom.hex}" })
+        end
 
         before { monitor.update!(secret: SecureRandom.hex) }
 
@@ -73,17 +78,17 @@ RSpec.describe Course::Assessment::Submission::MonitoringService, type: :service
           end
 
           it 'blocks when the user agent is invalid' do
-            expect(subject.should_block?(invalid_user_agent)).to be_truthy
+            expect(subject.should_block?(invalid_request)).to be_truthy
           end
 
           it 'does not block when the user agent is valid' do
-            expect(subject.should_block?(valid_user_agent)).to be_falsey
+            expect(subject.should_block?(valid_request)).to be_falsey
           end
 
           it 'does not block when the user agent is invalid but the browser session is unblocked' do
             Course::Assessment::MonitoringService.new(assessment, browser_session).unblock(assessment.session_password)
 
-            expect(subject.should_block?(invalid_user_agent)).to be_falsey
+            expect(subject.should_block?(invalid_request)).to be_falsey
           end
         end
 
@@ -91,11 +96,11 @@ RSpec.describe Course::Assessment::Submission::MonitoringService, type: :service
           before { monitor.update!(blocks: false) }
 
           it 'does not block when the user agent is invalid' do
-            expect(subject.should_block?(invalid_user_agent)).to be_falsey
+            expect(subject.should_block?(invalid_request)).to be_falsey
           end
 
           it 'does not block when the user agent is valid' do
-            expect(subject.should_block?(valid_user_agent)).to be_falsey
+            expect(subject.should_block?(valid_request)).to be_falsey
           end
         end
       end


### PR DESCRIPTION
This PR adds the long-awaited support for [Safe Exam Browser (SEB) Config Keys](https://safeexambrowser.org/developer/seb-config-key.html) to be used to authorise accesses to monitored assessments. For backwards compatibility, User Agent (UA)-based browser authorisation is still available, and instructors can now choose to,
1. enable browser authorisation if needed, and
2. if enabled, which method to authorise a given heartbeat in PulseGrid.

The defaults for browser authorisation and browser authorisation method are enabled and User Agent (UA), respectively.

This PR also improves the translations of some parts of UIs pertaining to the monitoring feature, making them more succinct and clearer.

>[!IMPORTANT]
>A config key and config key _hash_ are two very different things. A config key is (effectively) a hash of a specific SEB configuration. A config key _hash_ is a SHA256 hash of some URL and the config key of the configuration in which browser the config key hash is generated from.
>
>In our runtime, SEB only provides us with a config key hash; we can get the URL ourselves. We authorise a browser access by hashing the URL with our config key _in the server_ and comparing if the resulting hash equals to the config key hash from SEB. SEB doesn't reveal config keys for security purposes.

A change to our global Axios client is that it will always append a `X-SafeExamBrowser-Url` header with the request URL on every request on SEB. The rationale for this change was documented in the TSDoc for `appendRequestURLIfOnSEB`.

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/c5c01b3b-8d75-4e61-8e10-dd42241f9bba">

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/63047e19-d613-4924-8c0c-29352903f274">
