### PR TITLE
Fix programming annotations bug

### DIFF
--- a/app/views/course/assessment/answer/programming/_annotations.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_annotations.json.jbuilder
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 json.annotations programming_files do |file|
   json.fileId file.id
   json.topics(file.annotations.reject { |a| a.discussion_topic.post_ids.empty? }) do |annotation|
@@ -7,7 +6,11 @@ json.annotations programming_files do |file|
     next unless can_grade || !topic.posts.only_published_posts.empty?
 
     json.id topic.id
-    json.postIds topic.post_ids
+    if can_grade
+      json.postIds topic.post_ids
+    else
+      json.postIds topic.posts.only_published_posts.ids
+    end
     json.line annotation.line
   end
 end


### PR DESCRIPTION
 fix student being able to see unpublished annotations

- filter to only the published posts if a user "cannot grade"
- previously unpublished postIds were sent to students
- they should not have been able to see this postId, this resulted in frontend crashes as the erroneously sent postId is not present in json.posts