### PR TITLE
Refactor Live Feedback Settings for Assessment Edit and Submission Form

### DIFF
--- a/app/controllers/course/assessment/live_feedback_settings/settings_controller.rb
+++ b/app/controllers/course/assessment/live_feedback_settings/settings_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedbackSettings::SettingsController < \
+  Course::Assessment::Controller
+  def index
+    @programming_questions = @assessment.programming_questions.includes(:language)
+  end
+
+  def edit
+    enabled = live_feedback_params[:enabled]
+    @programming_qns = @assessment.programming_questions
+
+    raise ActiveRecord::Rollback unless @programming_qns.update_all(live_feedback_enabled: enabled) &&
+                                        @programming_qns.each(&:create_codaveri_problem)
+  end
+
+  private
+
+  def live_feedback_params
+    params.required(:live_feedback_settings).permit(:enabled)
+  end
+end

--- a/app/models/course/assessment/answer/programming.rb
+++ b/app/models/course/assessment/answer/programming.rb
@@ -96,6 +96,7 @@ class Course::Assessment::Answer::Programming < ApplicationRecord
 
     should_retrieve_feedback = submission.attempting? &&
                                current_answer? &&
+                               current_course.component_enabled?(Course::CodaveriComponent) &&
                                question.live_feedback_enabled
     return unless should_retrieve_feedback
 

--- a/app/views/course/assessment/assessments/edit.json.jbuilder
+++ b/app/views/course/assessment/assessments/edit.json.jbuilder
@@ -31,6 +31,7 @@ json.mode_switching @assessment.allow_mode_switching?
 json.gamified current_course.gamified?
 json.isQuestionsValidForKoditsu is_all_questions_programming_type && @programming_qns_invalid_for_koditsu.empty?
 json.isKoditsuExamEnabled current_course.component_enabled?(Course::KoditsuPlatformComponent)
+json.isCourseCodaveriEnabled current_course.component_enabled?(Course::CodaveriComponent)
 json.show_personalized_timeline_features current_course.show_personalized_timeline_features?
 json.randomization_allowed current_course.allow_randomization
 

--- a/app/views/course/assessment/assessments/live_feedback_settings.json.jbuilder
+++ b/app/views/course/assessment/assessments/live_feedback_settings.json.jbuilder
@@ -6,23 +6,27 @@ json.assessments [@assessment] do |assessment|
   json.title assessment.title
   json.url course_assessment_path(current_course, assessment)
 
-  json.programmingQuestions @programming_questions do |programming_qn|
-    next unless CodaveriAsyncApiService.language_valid_for_codaveri?(programming_qn.language)
+  if current_course.component_enabled?(Course::CodaveriComponent)
+    json.programmingQuestions @programming_questions do |programming_qn|
+      next unless CodaveriAsyncApiService.language_valid_for_codaveri?(programming_qn.language)
 
-    if programming_qn.title.blank?
-      question_assessment = assessment.question_assessments.select do |qa|
-        qa.question_id == programming_qn.question.id
-      end.first
-      question_title = question_assessment&.default_title
-    else
-      question_title = programming_qn.title
+      if programming_qn.title.blank?
+        question_assessment = assessment.question_assessments.select do |qa|
+          qa.question_id == programming_qn.question.id
+        end.first
+        question_title = question_assessment&.default_title
+      else
+        question_title = programming_qn.title
+      end
+
+      json.id programming_qn.id
+      json.editUrl url_for([:edit, current_course, assessment, programming_qn])
+      json.assessmentId assessment.id
+      json.title question_title
+      json.isCodaveri programming_qn.is_codaveri
+      json.liveFeedbackEnabled programming_qn.live_feedback_enabled
     end
-
-    json.id programming_qn.id
-    json.editUrl url_for([:edit, current_course, assessment, programming_qn])
-    json.assessmentId assessment.id
-    json.title question_title
-    json.isCodaveri programming_qn.is_codaveri
-    json.liveFeedbackEnabled programming_qn.live_feedback_enabled
+  else
+    json.programmingQuestions []
   end
 end

--- a/app/views/course/assessment/assessments/live_feedback_settings.json.jbuilder
+++ b/app/views/course/assessment/assessments/live_feedback_settings.json.jbuilder
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+json.assessments [@assessment] do |assessment|
+  json.id assessment.id
+  json.tabId assessment.tab_id
+  json.categoryId assessment.tab.category_id
+  json.title assessment.title
+  json.url course_assessment_path(current_course, assessment)
+
+  json.programmingQuestions @programming_questions do |programming_qn|
+    next unless CodaveriAsyncApiService.language_valid_for_codaveri?(programming_qn.language)
+
+    if programming_qn.title.blank?
+      question_assessment = assessment.question_assessments.select do |qa|
+        qa.question_id == programming_qn.question.id
+      end.first
+      question_title = question_assessment&.default_title
+    else
+      question_title = programming_qn.title
+    end
+
+    json.id programming_qn.id
+    json.editUrl url_for([:edit, current_course, assessment, programming_qn])
+    json.assessmentId assessment.id
+    json.title question_title
+    json.isCodaveri programming_qn.is_codaveri
+    json.liveFeedbackEnabled programming_qn.live_feedback_enabled
+  end
+end

--- a/app/views/course/assessment/live_feedback_settings/settings/index.json.jbuilder
+++ b/app/views/course/assessment/live_feedback_settings/settings/index.json.jbuilder
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+json.assessments [@assessment] do |assessment|
+  json.id assessment.id
+  json.tabId assessment.tab_id
+  json.categoryId assessment.tab.category_id
+  json.title assessment.title
+  json.url course_assessment_path(current_course, assessment)
+
+  if current_course.component_enabled?(Course::CodaveriComponent)
+    json.programmingQuestions @programming_questions do |programming_qn|
+      next unless CodaveriAsyncApiService.language_valid_for_codaveri?(programming_qn.language)
+
+      if programming_qn.title.blank?
+        question_assessment = assessment.question_assessments.select do |qa|
+          qa.question_id == programming_qn.question.id
+        end.first
+        question_title = question_assessment&.default_title
+      else
+        question_title = programming_qn.title
+      end
+
+      json.id programming_qn.id
+      json.editUrl url_for([:edit, current_course, assessment, programming_qn])
+      json.assessmentId assessment.id
+      json.title question_title
+      json.isCodaveri programming_qn.is_codaveri
+      json.liveFeedbackEnabled programming_qn.live_feedback_enabled
+    end
+  else
+    json.programmingQuestions []
+  end
+end

--- a/app/views/course/assessment/submission/submissions/edit.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/edit.json.jbuilder
@@ -27,7 +27,7 @@ json.assessment do
     json.url url_to_material(@assessment.course, @assessment.folder, material)
     json.name format_inline_text(material.name)
   end
-  json.isCodaveriEnabled current_course.component_enabled?(Course::CodaveriComponent)
+  json.isCourseCodaveriEnabled current_course.component_enabled?(Course::CodaveriComponent)
 end
 
 current_answer_ids = @submission.current_answers.pluck(:id)

--- a/client/app/api/course/Assessment/Assessments.js
+++ b/client/app/api/course/Assessment/Assessments.js
@@ -35,6 +35,19 @@ export default class AssessmentsAPI extends BaseCourseAPI {
     return this.client.get(`${this.#urlPrefix}/${assessmentId}/edit`);
   }
 
+  liveFeedbackSettings(assessmentId) {
+    return this.client.get(
+      `${this.#urlPrefix}/${assessmentId}/live_feedback_settings`,
+    );
+  }
+
+  updateLiveFeedbackSettings(assessmentId, params) {
+    return this.client.patch(
+      `${this.#urlPrefix}/${assessmentId}/live_feedback_settings`,
+      params,
+    );
+  }
+
   fetchMonitoringData() {
     return this.client.get(
       `${this.#urlPrefix}/${this.assessmentId}/monitoring`,

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/CodaveriToggleButtons.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/CodaveriToggleButtons.tsx
@@ -19,7 +19,11 @@ const CodaveriToggleButtons: FC<CodaveriToggleButtonsProps> = (props) => {
         for={title}
         type={type}
       />
-      <LiveFeedbackToggleButton assessmentIds={assessmentIds} for={title} />
+      <LiveFeedbackToggleButton
+        assessmentIds={assessmentIds}
+        for={title}
+        isCourseCodaveriEnabled
+      />
     </div>
   );
 };

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/LiveFeedbackToggleButton.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/LiveFeedbackToggleButton.tsx
@@ -2,6 +2,7 @@ import { FC, useState } from 'react';
 import { Switch } from '@mui/material';
 
 import { updateProgrammingQuestionLiveFeedbackEnabledForAssessments } from 'course/admin/reducers/codaveriSettings';
+import { updateLiveFeedbackForAllQuestionsInAssessment } from 'course/assessment/operations/assessments';
 import Prompt from 'lib/components/core/dialogs/Prompt';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 import toast from 'lib/hooks/toast';
@@ -15,11 +16,11 @@ import CodaveriSettingsChip from '../CodaveriSettingsChip';
 interface LiveFeedbackToggleButtonProps {
   assessmentIds: number[];
   for: string;
-  hideChipIndicator?: boolean;
+  forSpecificAssessment?: boolean;
 }
 
 const LiveFeedbackToggleButton: FC<LiveFeedbackToggleButtonProps> = (props) => {
-  const { assessmentIds, for: title, hideChipIndicator } = props;
+  const { assessmentIds, for: title, forSpecificAssessment } = props;
   const { t } = useTranslation();
 
   const dispatch = useAppDispatch();
@@ -40,9 +41,22 @@ const LiveFeedbackToggleButton: FC<LiveFeedbackToggleButtonProps> = (props) => {
 
   const hasNoProgrammingQuestions = programmingQuestions.length === 0;
 
+  const updateLiveFeedbackEnabled = (
+    liveFeedbackEnabled: boolean,
+  ): Promise<void> =>
+    forSpecificAssessment
+      ? updateLiveFeedbackForAllQuestionsInAssessment(
+          assessmentIds[0],
+          liveFeedbackEnabled,
+        )
+      : updateLiveFeedbackEnabledForAllQuestions(
+          assessmentIds,
+          liveFeedbackEnabled,
+        );
+
   const handleLiveFeedbackUpdate = (liveFeedbackEnabled: boolean): void => {
     setIsLiveFeedbackUpdating(true);
-    updateLiveFeedbackEnabledForAllQuestions(assessmentIds, liveFeedbackEnabled)
+    updateLiveFeedbackEnabled(liveFeedbackEnabled)
       .then(() => {
         dispatch(
           updateProgrammingQuestionLiveFeedbackEnabledForAssessments({
@@ -84,7 +98,7 @@ const LiveFeedbackToggleButton: FC<LiveFeedbackToggleButtonProps> = (props) => {
             setLiveFeedbackSettingsConfirmation(true);
           }}
         />
-        {!hideChipIndicator && (
+        {!forSpecificAssessment && (
           <CodaveriSettingsChip
             assessmentIds={assessmentIds}
             for="live_feedback"

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/LiveFeedbackToggleButton.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/LiveFeedbackToggleButton.tsx
@@ -16,11 +16,17 @@ import CodaveriSettingsChip from '../CodaveriSettingsChip';
 interface LiveFeedbackToggleButtonProps {
   assessmentIds: number[];
   for: string;
-  forSpecificAssessment?: boolean;
+  isSpecificAssessment?: boolean;
+  isCourseCodaveriEnabled?: boolean;
 }
 
 const LiveFeedbackToggleButton: FC<LiveFeedbackToggleButtonProps> = (props) => {
-  const { assessmentIds, for: title, forSpecificAssessment } = props;
+  const {
+    assessmentIds,
+    for: title,
+    isSpecificAssessment,
+    isCourseCodaveriEnabled,
+  } = props;
   const { t } = useTranslation();
 
   const dispatch = useAppDispatch();
@@ -44,7 +50,7 @@ const LiveFeedbackToggleButton: FC<LiveFeedbackToggleButtonProps> = (props) => {
   const updateLiveFeedbackEnabled = (
     liveFeedbackEnabled: boolean,
   ): Promise<void> =>
-    forSpecificAssessment
+    isSpecificAssessment
       ? updateLiveFeedbackForAllQuestionsInAssessment(
           assessmentIds[0],
           liveFeedbackEnabled,
@@ -86,19 +92,23 @@ const LiveFeedbackToggleButton: FC<LiveFeedbackToggleButtonProps> = (props) => {
       <div>
         <Switch
           checked={
-            hasNoProgrammingQuestions
+            hasNoProgrammingQuestions || !isCourseCodaveriEnabled
               ? false
               : qnsWithLiveFeedbackEnabled.length ===
                 programmingQuestions.length
           }
           color="primary"
-          disabled={hasNoProgrammingQuestions || isLiveFeedbackUpdating}
+          disabled={
+            hasNoProgrammingQuestions ||
+            !isCourseCodaveriEnabled ||
+            isLiveFeedbackUpdating
+          }
           onChange={(_, isChecked): void => {
             setLiveFeedbackChecked(isChecked);
             setLiveFeedbackSettingsConfirmation(true);
           }}
         />
-        {!forSpecificAssessment && (
+        {!isSpecificAssessment && (
           <CodaveriSettingsChip
             assessmentIds={assessmentIds}
             for="live_feedback"

--- a/client/app/bundles/course/admin/reducers/codaveriSettings.ts
+++ b/client/app/bundles/course/admin/reducers/codaveriSettings.ts
@@ -47,8 +47,8 @@ export const codaveriSettingsSlice = createSlice({
     saveAllAssessmentsQuestions: (
       state,
       action: PayloadAction<{
-        categories: AssessmentCategoryData[];
-        tabs: AssessmentTabData[];
+        categories?: AssessmentCategoryData[];
+        tabs?: AssessmentTabData[];
         assessments: AssessmentProgrammingQuestionsData[];
       }>,
     ) => {
@@ -56,11 +56,17 @@ export const codaveriSettingsSlice = createSlice({
       const questions = assessments.flatMap(
         (assessment) => assessment.programmingQuestions,
       );
-      assessmentCategoriesAdapter.setAll(
-        state.assessmentCategories,
-        categories,
-      );
-      assessmentTabsAdapter.setAll(state.assessmentTabs, tabs);
+      if (categories) {
+        assessmentCategoriesAdapter.setAll(
+          state.assessmentCategories,
+          categories,
+        );
+      }
+
+      if (tabs) {
+        assessmentTabsAdapter.setAll(state.assessmentTabs, tabs);
+      }
+
       assessmentsAdapter.setAll(state.assessments, assessments);
       programmingQuestionsAdapter.setAll(state.programmingQuestions, questions);
     },

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -10,17 +10,17 @@ import {
 import {
   Grid,
   InputAdornment,
-  // List,
+  List,
   RadioGroup,
   Typography,
 } from '@mui/material';
 
-// import AssessmentProgrammingQnList from 'course/admin/pages/CodaveriSettings/components/AssessmentProgrammingQnList';
-// import LiveFeedbackToggleButton from 'course/admin/pages/CodaveriSettings/components/buttons/LiveFeedbackToggleButton';
-// import { getProgrammingQuestionsForAssessments } from 'course/admin/pages/CodaveriSettings/selectors';
+import AssessmentProgrammingQnList from 'course/admin/pages/CodaveriSettings/components/AssessmentProgrammingQnList';
+import LiveFeedbackToggleButton from 'course/admin/pages/CodaveriSettings/components/buttons/LiveFeedbackToggleButton';
+import { getProgrammingQuestionsForAssessments } from 'course/admin/pages/CodaveriSettings/selectors';
 import IconRadio from 'lib/components/core/buttons/IconRadio';
 import ErrorText from 'lib/components/core/ErrorText';
-// import ExperimentalChip from 'lib/components/core/ExperimentalChip';
+import ExperimentalChip from 'lib/components/core/ExperimentalChip';
 import InfoLabel from 'lib/components/core/InfoLabel';
 import Section from 'lib/components/core/layouts/Section';
 import ConditionsManager from 'lib/components/extensions/conditions/ConditionsManager';
@@ -29,7 +29,7 @@ import FormDateTimePickerField from 'lib/components/form/fields/DateTimePickerFi
 import FormRichTextField from 'lib/components/form/fields/RichTextField';
 import FormSelectField from 'lib/components/form/fields/SelectField';
 import FormTextField from 'lib/components/form/fields/TextField';
-import { useAppDispatch } from 'lib/hooks/store';
+import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import FileManager from '../FileManager';
@@ -93,20 +93,20 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
       : t(translations.questionsIncompatibleWithKoditsu);
   };
 
-  // const assessmentId = initialValues.id;
-  // const title = initialValues.title;
+  const assessmentId = initialValues.id;
+  const title = initialValues.title;
 
-  // const programmingQuestions = useAppSelector((state) =>
-  //   getProgrammingQuestionsForAssessments(state, [assessmentId]),
-  // );
+  const programmingQuestions = useAppSelector((state) =>
+    getProgrammingQuestionsForAssessments(state, [assessmentId]),
+  );
 
-  // const qnsWithLiveFeedbackEnabled = programmingQuestions.filter(
-  //   (question) => question.liveFeedbackEnabled,
-  // );
+  const qnsWithLiveFeedbackEnabled = programmingQuestions.filter(
+    (question) => question.liveFeedbackEnabled,
+  );
 
-  // const hasNoProgrammingQuestions = programmingQuestions.length === 0;
-  // const isSomeLiveFeedbackEnabled =
-  //   qnsWithLiveFeedbackEnabled.length < programmingQuestions.length;
+  const hasNoProgrammingQuestions = programmingQuestions.length === 0;
+  const isSomeLiveFeedbackEnabled =
+    qnsWithLiveFeedbackEnabled.length < programmingQuestions.length;
 
   // Load all tabs if data is loaded, otherwise fall back to current assessment tab.
   const loadedTabs = tabs ?? watch('tabs');
@@ -834,7 +834,6 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
           </Section>
         )}
 
-        {/*
         {editing && (
           <Section
             sticksToNavbar
@@ -849,7 +848,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
               <LiveFeedbackToggleButton
                 assessmentIds={[assessmentId]}
                 for={title}
-                hideChipIndicator
+                forSpecificAssessment
               />
               <div>
                 <Typography className="mt-3" variant="body1">
@@ -880,7 +879,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
               </List>
             )}
           </Section>
-        )} */}
+        )}
       </form>
     </div>
   );

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -52,6 +52,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
     initialValues,
     isKoditsuExamEnabled,
     isQuestionsValidForKoditsu,
+    isCourseCodaveriEnabled,
     modeSwitching,
     onSubmit,
     pulsegridUrl,
@@ -100,13 +101,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
     getProgrammingQuestionsForAssessments(state, [assessmentId]),
   );
 
-  const qnsWithLiveFeedbackEnabled = programmingQuestions.filter(
-    (question) => question.liveFeedbackEnabled,
-  );
-
   const hasNoProgrammingQuestions = programmingQuestions.length === 0;
-  const isSomeLiveFeedbackEnabled =
-    qnsWithLiveFeedbackEnabled.length < programmingQuestions.length;
 
   // Load all tabs if data is loaded, otherwise fall back to current assessment tab.
   const loadedTabs = tabs ?? watch('tabs');
@@ -848,17 +843,21 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
               <LiveFeedbackToggleButton
                 assessmentIds={[assessmentId]}
                 for={title}
-                forSpecificAssessment
+                isCourseCodaveriEnabled={isCourseCodaveriEnabled}
+                isSpecificAssessment
               />
               <div>
                 <Typography className="mt-3" variant="body1">
-                  {t(translations.toggleLiveFeedbackDescription, {
-                    enabled:
-                      hasNoProgrammingQuestions || isSomeLiveFeedbackEnabled,
-                  })}
+                  {t(translations.toggleLiveFeedbackDescription)}
                 </Typography>
-                {hasNoProgrammingQuestions && (
-                  <InfoLabel label={t(translations.noProgrammingQuestion)} />
+                {(hasNoProgrammingQuestions || !isCourseCodaveriEnabled) && (
+                  <InfoLabel
+                    label={
+                      !isCourseCodaveriEnabled
+                        ? t(translations.isCourseCodaveriDisabled)
+                        : t(translations.noProgrammingQuestion)
+                    }
+                  />
                 )}
               </div>
             </div>

--- a/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/translations.ts
@@ -34,6 +34,12 @@ const translations = defineMessages({
     defaultMessage:
       'Enable live feedback feature for all programming questions',
   },
+  isCourseCodaveriDisabled: {
+    id: 'course.assessment.AssessmentForm.isCourseCodaveriDisabled',
+    defaultMessage:
+      'Please contact the course manager or owner to enable Codaveri Evaluator\
+      Component in Course Settings',
+  },
   noProgrammingQuestion: {
     id: 'course.assessment.AssessmentForm.noProgrammingQuestion',
     defaultMessage:

--- a/client/app/bundles/course/assessment/components/AssessmentForm/types.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/types.ts
@@ -38,6 +38,7 @@ export interface AssessmentFormProps
   initialValues?;
   isKoditsuExamEnabled: boolean;
   isQuestionsValidForKoditsu: boolean;
+  isCourseCodaveriEnabled?: boolean;
   disabled?: boolean;
   showPersonalizedTimelineFeatures?: boolean;
   randomizationAllowed?: boolean;

--- a/client/app/bundles/course/assessment/operations/assessments.ts
+++ b/client/app/bundles/course/assessment/operations/assessments.ts
@@ -10,6 +10,7 @@ import {
 
 import CourseAPI from 'api/course';
 import { JustRedirect } from 'api/types';
+import { saveAllAssessmentsQuestions } from 'course/admin/reducers/codaveriSettings';
 import { setNotification } from 'lib/actions';
 import { setReactHookFormError } from 'lib/helpers/react-hook-form-helper';
 import { getCourseId } from 'lib/helpers/url-helpers';
@@ -50,6 +51,46 @@ export const fetchAssessmentEditData = async (
     await CourseAPI.assessment.assessments.fetchEditData(assessmentId);
 
   return response.data;
+};
+
+export const fetchAssessmentLiveFeedbackSettings = (
+  assessmentId: number,
+): Operation => {
+  return async (dispatch) => {
+    return CourseAPI.assessment.assessments
+      .liveFeedbackSettings(assessmentId)
+      .then((response) => {
+        dispatch(
+          saveAllAssessmentsQuestions({
+            assessments: response.data.assessments,
+          }),
+        );
+      })
+      .catch((error) => {
+        if (error instanceof AxiosError) throw error.response?.data?.errors;
+        throw error;
+      });
+  };
+};
+
+export const updateLiveFeedbackForAllQuestionsInAssessment = async (
+  assessmentId: number,
+  liveFeedbackEnabled: boolean,
+): Promise<void> => {
+  const adaptedData = {
+    live_feedback_settings: {
+      enabled: liveFeedbackEnabled,
+    },
+  };
+  try {
+    await CourseAPI.assessment.assessments.updateLiveFeedbackSettings(
+      assessmentId,
+      adaptedData,
+    );
+  } catch (error) {
+    if (error instanceof AxiosError) throw error.response?.data?.errors;
+    throw error;
+  }
 };
 
 export const createAssessment = (

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/AssessmentEditPage.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/AssessmentEditPage.jsx
@@ -53,6 +53,7 @@ class AssessmentEditPage extends Component {
   render() {
     const {
       intl,
+      isCourseCodaveriEnabled,
       conditionAttributes,
       disabled,
       folderAttributes,
@@ -94,6 +95,7 @@ class AssessmentEditPage extends Component {
           folderAttributes={folderAttributes}
           gamified={gamified}
           initialValues={initialValues}
+          isCourseCodaveriEnabled={isCourseCodaveriEnabled}
           isKoditsuExamEnabled={isKoditsuExamEnabled}
           isQuestionsValidForKoditsu={isQuestionsValidForKoditsu}
           modeSwitching={modeSwitching}
@@ -128,6 +130,7 @@ AssessmentEditPage.propTypes = {
   initialValues: PropTypes.shape({}),
   isKoditsuExamEnabled: PropTypes.bool,
   isQuestionsValidForKoditsu: PropTypes.bool,
+  isCourseCodaveriEnabled: PropTypes.bool,
 
   // Whether to disable the inner form.
   disabled: PropTypes.bool,

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/index.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/index.tsx
@@ -63,6 +63,7 @@ const AssessmentEdit = (): JSX.Element => {
                   ? DEFAULT_MONITORING_OPTIONS
                   : undefined),
             }}
+            isCourseCodaveriEnabled={data.isCourseCodaveriEnabled}
             isKoditsuExamEnabled={data.isKoditsuExamEnabled}
             isQuestionsValidForKoditsu={data.isQuestionsValidForKoditsu}
             modeSwitching={data.mode_switching}

--- a/client/app/bundles/course/assessment/pages/AssessmentEdit/index.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentEdit/index.tsx
@@ -1,16 +1,20 @@
-// import { fetchCodaveriSettingsForAssessment } from 'course/admin/pages/CodaveriSettings/operations';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import Preload from 'lib/components/wrappers/Preload';
 import { getAssessmentId } from 'lib/helpers/url-helpers';
+import { useAppDispatch } from 'lib/hooks/store';
 
 import { DEFAULT_MONITORING_OPTIONS } from '../../constants';
-import { fetchAssessmentEditData } from '../../operations/assessments';
+import {
+  fetchAssessmentEditData,
+  fetchAssessmentLiveFeedbackSettings,
+} from '../../operations/assessments';
 import translations from '../../translations';
 import { categoryAndTabTitle } from '../../utils';
 
 import AssessmentEditPage from './AssessmentEditPage';
 
 const AssessmentEdit = (): JSX.Element => {
+  const dispatch = useAppDispatch();
   const assessmentId = getAssessmentId();
   if (!assessmentId) {
     return <div />;
@@ -24,11 +28,11 @@ const AssessmentEdit = (): JSX.Element => {
       while={() =>
         Promise.all([
           fetchAssessmentEditData(parsedAssessmentId),
-          // fetchCodaveriSettingsForAssessment(parsedAssessmentId),
+          dispatch(fetchAssessmentLiveFeedbackSettings(parsedAssessmentId)),
         ])
       }
     >
-      {([data]): JSX.Element => {
+      {([data, _]): JSX.Element => {
         const tabAttr = data.tab_attributes;
         const currentTab = {
           tab_id: data.attributes.tab_id,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/AutogradedActionButtonsRow.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/AutogradedActionButtonsRow.tsx
@@ -27,7 +27,7 @@ const AutogradedActionButtonsRow: FC<Props> = (props) => {
   const submission = useAppSelector(getSubmission);
   const questions = useAppSelector(getQuestions);
 
-  const { questionIds } = assessment;
+  const { questionIds, isCourseCodaveriEnabled } = assessment;
   const { workflowState } = submission;
 
   const attempting = workflowState === workflowStates.Attempting;
@@ -43,7 +43,8 @@ const AutogradedActionButtonsRow: FC<Props> = (props) => {
         <ContinueButton onContinue={handleNext} stepIndex={stepIndex} />
         <Box sx={{ flex: '1', width: '100%' }} />
         {question.type === questionTypes.Programming &&
-          question.liveFeedbackEnabled && (
+          question.liveFeedbackEnabled &&
+          isCourseCodaveriEnabled && (
             <LiveFeedbackButton questionId={questionId} />
           )}
       </div>

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/NonAutogradedProgrammingActionButtonsRow.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/NonAutogradedProgrammingActionButtonsRow.tsx
@@ -5,6 +5,7 @@ import {
   questionTypes,
   workflowStates,
 } from 'course/assessment/submission/constants';
+import { getAssessment } from 'course/assessment/submission/selectors/assessments';
 import { getQuestions } from 'course/assessment/submission/selectors/questions';
 import { getSubmission } from 'course/assessment/submission/selectors/submissions';
 import { useAppSelector } from 'lib/hooks/store';
@@ -20,6 +21,7 @@ interface Props {
 const NonAutogradedProgrammingActionButtonsRow: FC<Props> = (props) => {
   const { questionId } = props;
 
+  const assessment = useAppSelector(getAssessment);
   const submission = useAppSelector(getSubmission);
   const questions = useAppSelector(getQuestions);
 
@@ -30,6 +32,8 @@ const NonAutogradedProgrammingActionButtonsRow: FC<Props> = (props) => {
   const question = questions[questionId];
   const { viewHistory } = question;
 
+  const { isCourseCodaveriEnabled } = assessment;
+
   return (
     !viewHistory &&
     attempting &&
@@ -38,7 +42,7 @@ const NonAutogradedProgrammingActionButtonsRow: FC<Props> = (props) => {
         <ResetProgrammingAnswerButton questionId={questionId} />
         {question.autogradable && <RunCodeButton questionId={questionId} />}
         <Box sx={{ flex: '1', width: '100%' }} />
-        {question.liveFeedbackEnabled && (
+        {question.liveFeedbackEnabled && isCourseCodaveriEnabled && (
           <LiveFeedbackButton questionId={questionId} />
         )}
       </div>

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/ReevaluateButton.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/ReevaluateButton.tsx
@@ -35,7 +35,7 @@ const ReevaluateButton: FC<Props> = (props) => {
 
   const dispatch = useAppDispatch();
 
-  const { isCodaveriEnabled } = assessment;
+  const { isCourseCodaveriEnabled } = assessment;
 
   const question = questions[questionId];
   const { answerId } = question;
@@ -46,7 +46,7 @@ const ReevaluateButton: FC<Props> = (props) => {
 
   const shouldRender =
     question.type === questionTypes.Programming &&
-    isCodaveriEnabled &&
+    isCourseCodaveriEnabled &&
     question.isCodaveri;
 
   const onGenerateFeedback = (): void => {

--- a/client/app/bundles/course/assessment/submission/types.ts
+++ b/client/app/bundles/course/assessment/submission/types.ts
@@ -25,6 +25,7 @@ export interface AssessmentState {
   gamified: boolean;
   isCodaveriEnabled: boolean;
   isKoditsuEnabled: boolean;
+  isCourseCodaveriEnabled: boolean;
   liveFeedbackEnabled: boolean;
   passwordProtected: boolean;
   questionIds: number[];

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,6 +226,11 @@ Rails.application.routes.draw do
           get :monitoring, on: :member
           get :seb_payload, on: :member
 
+          namespace :live_feedback_settings do
+            get '/' => 'settings#index'
+            patch '/' => 'settings#edit'
+          end
+
           resources :questions, only: [] do
             post 'duplicate/:destination_assessment_id', on: :member, action: 'duplicate', as: :duplicate
           end

--- a/spec/controllers/course/assessment/live_feedback_settings/settings_controller_spec.rb
+++ b/spec/controllers/course/assessment/live_feedback_settings/settings_controller_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::LiveFeedbackSettings::SettingsController do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+    let!(:course) { create(:course, creator: user) }
+    let(:category) { course.assessment_categories.first }
+    let(:tab) { category.tabs.first }
+    let!(:immutable_assessment) do
+      create(:assessment, course: course).tap do |stub|
+        allow(stub).to receive(:destroy).and_return(false)
+      end
+    end
+
+    before { controller_sign_in(controller, user) }
+
+    describe '#index' do
+      render_views
+      let(:assessment) { create(:assessment, course: course) }
+      let(:lang_valid_for_codaveri) { Coursemology::Polyglot::Language::Python::Python3Point12.instance }
+      let(:lang_invalid_for_codaveri) { Coursemology::Polyglot::Language::Java::Java8.instance }
+      let!(:programming_qn1) do
+        create(:course_assessment_question_programming, assessment: assessment,
+                                                        language: lang_valid_for_codaveri,
+                                                        template_package: true)
+      end
+      let!(:programming_qn2) do
+        create(:course_assessment_question_programming, assessment: assessment,
+                                                        language: lang_invalid_for_codaveri,
+                                                        template_package: true)
+      end
+
+      subject do
+        get :index, as: :json, params: {
+          course_id: course.id,
+          assessment_id: assessment.id
+        }
+      end
+
+      context 'on fetching the live feedback settings for this assessment' do
+        it 'returns programming languages that has valid languages for codaveri' do
+          subject
+
+          json_result = JSON.parse(response.body)
+          expect(json_result['assessments'][0]['programmingQuestions'].count).to eq(1)
+        end
+      end
+    end
+
+    describe '#edit' do
+      let(:assessment) { create(:assessment, course: course) }
+
+      # TODO: this part needs to be updated everytime codaveri_language_whitelist is updated
+      let(:lang_valid_for_codaveri) { Coursemology::Polyglot::Language::Python::Python3Point12.instance }
+      let(:lang_invalid_for_codaveri) { Coursemology::Polyglot::Language::Java::Java8.instance }
+      let!(:programming_qn1) do
+        create(:course_assessment_question_programming, assessment: assessment,
+                                                        language: lang_valid_for_codaveri,
+                                                        template_package: true)
+      end
+      let!(:programming_qn2) do
+        create(:course_assessment_question_programming, assessment: assessment,
+                                                        language: lang_valid_for_codaveri,
+                                                        template_package: true)
+      end
+
+      subject do
+        patch :edit, params: {
+          course_id: course.id,
+          assessment_id: assessment.id,
+          live_feedback_settings: {
+            enabled: true
+          }
+        }
+      end
+
+      context 'on fetching the live feedback settings for this assessment' do
+        it 'returns programming languages that has valid languages for codaveri' do
+          subject
+
+          expect(programming_qn1.reload.live_feedback_enabled).to eq(true)
+          expect(programming_qn2.reload.live_feedback_enabled).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Background

It's been found out that recently, only Manager/Owner can access the Assessment Edit Page, and that accessing this page while having Codaveri Component disabled caused unexpected error. Upon further inspection, it's found out that the attempt to fetch the Codaveri Settings for Assessment, which is being done while accessing the Assessment Edit Page, calls out the controller in which only Manager/Owner has the ability to do so.

## Fix

Upon this inspection, we decided to do several fixes, as well as the further enhancement towards the Assessment Edit Page, as follows:
- decouple the logic for fetching codaveri settings and toggling on/off codaveri settings for assessment from codaveri settings controller. We placed the logic for these 2 inside the Assessment controller, in which Teaching Assistant also has right to access the controller
- we do not return any programming questions (regardless of whether some of them is support-ible by codaveri) and disable Get Help in the assessment level if the Codaveri Component is disabled for the course, and give info to user to enable the codaveri component first
<img width="1041" alt="Screenshot 2024-09-14 at 10 38 11 PM" src="https://github.com/user-attachments/assets/ae60fa2d-2389-41aa-a505-b42b1159a3aa">

## Miscellaneous

Within this PR, we also do the refactor of Submission Form, not to render Get Help button if Codaveri Component is disabled