### PR TITLE
Render Total Grade in Assessment Statistics when it's 0

### DIFF
--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -257,7 +257,7 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
         const isGradedOrPublished =
           datum.workflowState === workflowStates.Graded ||
           datum.workflowState === workflowStates.Published;
-        return datum.totalGrade && isGradedOrPublished ? (
+        return typeof datum.totalGrade === 'number' && isGradedOrPublished ? (
           renderTotalGradeCell(datum.totalGrade, assessment!.maximumGrade)
         ) : (
           <div />


### PR DESCRIPTION
- previously, we check only datum.totalGrade, but if it's 0 then it's rendered as false
- now, we check on the type of its totalGrade, whether it's number or not.