### PR TITLE
test(rspec): rework recently failing tests

### DIFF
--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -19,8 +19,13 @@ RSpec.feature 'Course: Administration: Components', js: true do
         enabled_components = course.enabled_components
         components.each do |component|
           expect(page).to have_selector('label', text: component.display_name)
-          option = find('label', text: component.display_name).find('input', visible: false)
-          expect(option.checked?).to be(enabled_components.include?(component))
+          within find('label', text: component.display_name) do
+            if enabled_components.include?(component)
+              expect(page).to have_field(type: 'checkbox', checked: true, visible: false)
+            else
+              expect(page).to have_field(type: 'checkbox', checked: false, visible: false)
+            end
+          end
         end
       end
 
@@ -31,13 +36,12 @@ RSpec.feature 'Course: Administration: Components', js: true do
         control.click
         expect_toastify('Your changes have been saved. Refresh to see the new changes.')
 
-        option = control.find('input', visible: false)
-        expect(option).not_to be_checked
+        expect(control).to have_field(type: 'checkbox', checked: false, visible: false)
 
         control.click
         expect_toastify('Your changes have been saved. Refresh to see the new changes.')
 
-        expect(option).to be_checked
+        expect(control).to have_field(type: 'checkbox', checked: true, visible: false)
       end
     end
   end

--- a/spec/features/course/assessment/submission/past_answers_spec.rb
+++ b/spec/features/course/assessment/submission/past_answers_spec.rb
@@ -18,18 +18,24 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
              assessment: assessment,
              creator: student)
     end
+    # Forum post response questions currently don't show 'Past Answers' element
+    let(:past_answer_count) do
+      submission.assessment.questions.reject do |q|
+        q.question_type == 'ForumPostResponse'
+      end.count
+    end
 
     context 'As a Course Student' do
       let(:user) { student }
 
       scenario 'I can view my past answers' do
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        past_answers = all('span', text: 'Past Answers')
+        # Ensure all 'Past Answers' labels are rendered before continuing
+        expect(page).to have_selector('span', text: 'Past Answers', count: past_answer_count)
 
-        expect do
-          past_answers.each(&:click)
-          wait_for_page
-        end.to change { all('label', text: 'Past Answers').count }.by(past_answers.count)
+        all('span', text: 'Past Answers').each(&:click)
+        # Label selector matches both the expanded 'Past Answers' section and the labels we clicked
+        expect(page).to have_selector('label', text: 'Past Answers', count: past_answer_count * 2)
       end
     end
 
@@ -38,12 +44,10 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
 
       scenario "I can view my student's past answers" do
         visit edit_course_assessment_submission_path(course, assessment, submission)
-        past_answers = all('span', text: 'Past Answers')
+        expect(page).to have_selector('span', text: 'Past Answers', count: past_answer_count)
 
-        expect do
-          past_answers.each(&:click)
-          wait_for_page
-        end.to change { all('label', text: 'Past Answers').count }.by(past_answers.count)
+        all('span', text: 'Past Answers').each(&:click)
+        expect(page).to have_selector('label', text: 'Past Answers', count: past_answer_count * 2)
       end
     end
   end

--- a/spec/features/course/experience_points/forum_disbursement_spec.rb
+++ b/spec/features/course/experience_points/forum_disbursement_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Course: Experience Points: Forum Disbursement' do
         find('button', text: 'Forum Participation Disbursement').click
 
         within find(content_tag_selector(students[0])) do
-          expect(find('input').value).to eq('100')
+          expect(page).to have_field(type: 'text', with: '100')
         end
 
         start_date = (4.weeks.ago + 1.minute).strftime('%d-%m-%Y %I:%M')
@@ -45,26 +45,25 @@ RSpec.feature 'Course: Experience Points: Forum Disbursement' do
         within find('.forum-participation-search-panel') do
           find('button.filter-btn-submit').click
         end
-        wait_for_page
 
         # The first student gets 400 (2 * weekly_cap) for the 2-week span since his
         # participation score is higher than the rest due to the additional upvote.
         within find(content_tag_selector(students[0])) do
-          expect(find('input').value).to eq('400')
+          expect(page).to have_field(type: 'text', with: '400')
         end
         # The other two students get the same experience points because they have the
         # same participation score.
         within find(content_tag_selector(students[1])) do
-          expect(find('input').value).to eq('200')
+          expect(page).to have_field(type: 'text', with: '200')
         end
         within find(content_tag_selector(students[2])) do
-          expect(find('input').value).to eq('200')
+          expect(page).to have_field(type: 'text', with: '200')
         end
 
         expect do
           find('button.forum-btn-submit').click
-          wait_for_page
-        end.to change(Course::ExperiencePointsRecord, :count).by(3)
+          expect_toastify("Experience points disbursed to #{students.count} recipients.")
+        end.to change(Course::ExperiencePointsRecord, :count).by(students.count)
       end
     end
   end

--- a/spec/features/system/admin/components_settings_spec.rb
+++ b/spec/features/system/admin/components_settings_spec.rb
@@ -22,9 +22,9 @@ RSpec.feature 'System: Administration: Components', type: :feature, js: true do
 
         within find("tr#component_#{component.key}") do
           if enabled_components.include?(component.key.to_s)
-            expect(page).to have_selector('input:checked', visible: false)
+            expect(page).to have_field(type: 'checkbox', checked: true, visible: false)
           else
-            expect(page).to have_selector('input:not(:checked)', visible: false)
+            expect(page).to have_field(type: 'checkbox', checked: false, visible: false)
           end
         end
       end
@@ -39,11 +39,11 @@ RSpec.feature 'System: Administration: Components', type: :feature, js: true do
 
       element_to_modify.find('input', visible: false).click
       expect_toastify('Instance component setting was updated successfully.')
-      expect(element_to_modify).to have_selector('input:not(:checked)', visible: false)
+      expect(element_to_modify).to have_field(type: 'checkbox', checked: false, visible: false)
 
       element_to_modify.find('input', visible: false).click
       expect_toastify('Instance component setting was updated successfully.')
-      expect(element_to_modify).to have_selector('input:checked', visible: false)
+      expect(element_to_modify).to have_field(type: 'checkbox', checked: true, visible: false)
     end
   end
 end


### PR DESCRIPTION
- update past_answers_spec and forum_disbursement_spec async assertions
- rework component_settings_spec to use [Capybara matchers](https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FMatchers:has_field%3F) instead of raw css

For now, we should continue reworking tests flaky because of async issues using native Capybara matchers.
In future, if there are assertions too complex to fold into a single async assertion, we can consider use of [synchronize_expectation](https://capybara-test-helpers.netlify.app/api/#synchronize-expectation) within capybara_test_helpers gem. 