### PR TITLE
fix(codaveri-qns-generation): test case generation fix; update api calls

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -80,6 +80,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
             {
               id: language.id,
               name: language.name,
+              disabled: !language.enabled,
               editorMode: language.ace_mode
             }
           end

--- a/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateExportDialog.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateExportDialog.tsx
@@ -42,7 +42,6 @@ interface Props {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
   languages: LanguageData[];
-  assessmentAutograded: boolean;
   saveActiveFormData: () => void;
 }
 
@@ -66,8 +65,7 @@ const translations = defineMessages({
 });
 
 const GenerateExportDialog: FC<Props> = (props) => {
-  const { open, setOpen, saveActiveFormData, assessmentAutograded, languages } =
-    props;
+  const { open, setOpen, saveActiveFormData, languages } = props;
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const generatePageData = useAppSelector(getAssessmentGenerateQuestionsData);
@@ -227,6 +225,7 @@ const GenerateExportDialog: FC<Props> = (props) => {
           color="primary"
           disabled={generatePageData.exportCount === 0}
           onClick={() => {
+            saveActiveFormData();
             generatePageData.conversationIds
               .map((id) => {
                 const conversation = generatePageData.conversations[id];
@@ -240,10 +239,11 @@ const GenerateExportDialog: FC<Props> = (props) => {
               })
               .filter(
                 ({ conversation, snapshot }) =>
-                  conversation?.toExport && snapshot,
+                  conversation?.toExport &&
+                  snapshot &&
+                  snapshot.state !== 'sentinel',
               )
-              .forEach(({ conversation }) => {
-                saveActiveFormData();
+              .forEach(({ conversation }, index) => {
                 const questionData = conversation.activeSnapshotEditedData;
                 const { codaveriData } =
                   conversation.snapshots[conversation.activeSnapshotId];
@@ -256,7 +256,6 @@ const GenerateExportDialog: FC<Props> = (props) => {
                     questionData!,
                     languageId,
                     languageMode,
-                    assessmentAutograded,
                   ),
                 );
                 dispatch(

--- a/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateProgrammingQuestionPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateProgrammingQuestionPage.tsx
@@ -4,10 +4,7 @@ import { defineMessages } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Container, Divider, Grid } from '@mui/material';
-import {
-  FetchAssessmentData,
-  isAuthenticatedAssessmentData,
-} from 'types/course/assessment/assessments';
+import { FetchAssessmentData } from 'types/course/assessment/assessments';
 import { MetadataTestCase } from 'types/course/assessment/question/programming';
 import * as yup from 'yup';
 
@@ -287,15 +284,8 @@ const GenerateProgrammingQuestionPage = (): JSX.Element => {
 
   return (
     // TODO: Update these queries to return only data needed for this page, instead of the full objects.
-    <Preload
-      render={<LoadingIndicator />}
-      while={() =>
-        Promise.all([fetchAssessmentWithId(), fetchCodaveriLanguages()])
-      }
-    >
-      {([assessment, data]): JSX.Element => {
-        const assessmentAutograded =
-          isAuthenticatedAssessmentData(assessment) && assessment.autograded;
+    <Preload render={<LoadingIndicator />} while={fetchCodaveriLanguages}>
+      {(data): JSX.Element => {
         return (
           <>
             <GenerateTabs
@@ -533,7 +523,6 @@ const GenerateProgrammingQuestionPage = (): JSX.Element => {
               <Divider className="mt-8" />
             </Container>
             <GenerateExportDialog
-              assessmentAutograded={assessmentAutograded}
               languages={data.languages}
               open={exportDialogOpen}
               saveActiveFormData={saveActiveFormData}

--- a/client/app/bundles/course/assessment/pages/AssessmentGenerate/utils.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentGenerate/utils.ts
@@ -152,7 +152,6 @@ export const buildQuestionDataFromPrototype = (
   prefilledData: QuestionPrototypeFormData,
   languageId: LanguageData['id'],
   languageMode: LanguageMode,
-  assessmentAutograded: boolean,
 ): ProgrammingFormRequestData => {
   const metadata: BasicMetadata = {
     solution: prefilledData?.testUi?.metadata?.solution,
@@ -178,10 +177,9 @@ export const buildQuestionDataFromPrototype = (
       liveFeedbackEnabled: false,
       // set question to autograded if it includes at least one test case
       autograded:
-        assessmentAutograded &&
-        (prefilledData?.testUi?.metadata?.testCases?.public?.length > 0 ||
-          prefilledData?.testUi?.metadata?.testCases?.private?.length > 0 ||
-          prefilledData?.testUi?.metadata?.testCases?.evaluation?.length > 0),
+        prefilledData?.testUi?.metadata?.testCases?.public?.length > 0 ||
+        prefilledData?.testUi?.metadata?.testCases?.private?.length > 0 ||
+        prefilledData?.testUi?.metadata?.testCases?.evaluation?.length > 0,
     },
     testUi: {
       mode: languageMode,


### PR DESCRIPTION
- removed assessment autograded api calls/checks

Whether assessment is auto graded or manual no longer influences Question Generation page. Consequently, the API call to fetch this information has also been removed.

These are one-line fixes also included in this PR:
- updated codaveri_languages to return if language disabled, hiding disabled languages on question generation page (app/controllers/course/assessment/question/programming_controller.rb, line 83)
- fix crash on exporting with blank questions (client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateExportDialog.tsx, line 243)