### PR TITLE
Programming Question Audit Trail

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -55,7 +55,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
     end
 
     if result
-      render_success_json false
+      render_success_json true
     else
       render_failure_json
     end

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -156,7 +156,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
   def link_to_original_question(duplicated_programming_question)
     @programming_question.question.actable = duplicated_programming_question
     # Update the original programming question's parent_id to link to the new duplicated question
-    duplicated_programming_question.update!(parent_id: @programming_question.id)
+    duplicated_programming_question.update_column(:parent_id, @programming_question.id)
   end
 
   def format_test_cases

--- a/app/controllers/course/assessment/submission_question/submission_questions_controller.rb
+++ b/app/controllers/course/assessment/submission_question/submission_questions_controller.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 class Course::Assessment::SubmissionQuestion::SubmissionQuestionsController < \
   Course::Assessment::SubmissionQuestion::Controller
+  helper Course::Statistics::AnswersHelper.name.sub(/Helper$/, '')
+
   def past_answers
     answers_to_load = past_answers_params[:answers_to_load]&.to_i || 10
     answers = @submission_question.past_answers(answers_to_load)
+    @question = @submission_question.question
+    @submission = @submission_question.submission
 
     respond_to do |format|
-      format.json { render 'past_answers', locals: { answers: answers } }
+      format.json { render 'past_answers', locals: { answers: answers, question: @question } }
     end
   end
 

--- a/app/helpers/course/statistics/answers_helper.rb
+++ b/app/helpers/course/statistics/answers_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Course::Statistics::AnswersHelper
+  def get_historical_auto_gradings(programming_auto_grading)
+    historical = []
+    current = programming_auto_grading
+
+    while current&.parent_id
+      parent = Course::Assessment::Answer::ProgrammingAutoGrading.find_by(id: current.parent_id)
+      historical.unshift(parent) if parent
+      current = parent
+    end
+
+    historical
+  end
+end

--- a/app/models/course/assessment/answer.rb
+++ b/app/models/course/assessment/answer.rb
@@ -80,6 +80,9 @@ class Course::Assessment::Answer < ApplicationRecord
   def auto_grade!(redirect_to_path: nil, reduce_priority: false)
     raise IllegalStateError if attempting?
 
+    # When evaluated or graded, only autograde most recent answer
+    return if !submitted? && !current_answer?
+
     ensure_auto_grading!
     if grade_inline?
       Course::Assessment::Answer::AutoGradingService.grade(self)

--- a/app/models/course/assessment/answer/programming_auto_grading.rb
+++ b/app/models/course/assessment/answer/programming_auto_grading.rb
@@ -7,6 +7,8 @@ class Course::Assessment::Answer::ProgrammingAutoGrading < ApplicationRecord
 
   validates :exit_code, numericality: { only_integer: true }, allow_nil: true
 
+  belongs_to :parent, class_name: 'Course::Assessment::Answer::ProgrammingAutoGrading', optional: true
+
   has_one :programming_answer, through: :answer,
                                source: :actable,
                                source_type: 'Course::Assessment::Answer::Programming'

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -39,6 +39,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
 
   belongs_to :import_job, class_name: 'TrackableJob::Job', inverse_of: nil, optional: true
   belongs_to :language, class_name: 'Coursemology::Polyglot::Language', inverse_of: nil
+  belongs_to :parent, class_name: 'Course::Assessment::Question::Programming', optional: true
   has_one_attachment
   has_many :template_files, class_name: 'Course::Assessment::Question::ProgrammingTemplateFile',
                             dependent: :destroy, foreign_key: :question_id, inverse_of: :question

--- a/app/services/course/assessment/answer/auto_grading_service.rb
+++ b/app/services/course/assessment/answer/auto_grading_service.rb
@@ -6,12 +6,15 @@ class Course::Assessment::Answer::AutoGradingService
     #
     # @param [Course::Assessment::Answer] answer The answer to be graded.
     def grade(answer)
+      old_auto_grading_actable = answer.auto_grading&.actable
       answer = if answer.question.auto_gradable?
                  pick_grader(answer.question).grade(answer)
                else
                  assign_maximum_grade(answer)
                end
+
       answer.save!
+      answer.auto_grading.actable.update!(parent_id: old_auto_grading_actable.id) if old_auto_grading_actable
     end
 
     private

--- a/app/views/course/assessment/question/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_programming.json.jbuilder
@@ -2,7 +2,14 @@
 json.language question.language.name
 json.editorMode question.language.ace_mode
 json.fileSubmission question.multiple_file_submission
+
+json.memoryLimit question.memory_limit if question.memory_limit
+json.timeLimit question.time_limit if question.time_limit
 json.attemptLimit question.attempt_limit if question.attempt_limit
+
+json.fileSubmission question.multiple_file_submission?
+
 json.autogradable question.auto_gradable?
-json.isCodaveri question.is_codaveri
-json.liveFeedbackEnabled question.live_feedback_enabled
+
+json.isCodaveri question.is_codaveri?
+json.liveFeedbackEnabled question.live_feedback_enabled?

--- a/app/views/course/assessment/submission_question/submission_questions/past_answers.json.jbuilder
+++ b/app/views/course/assessment/submission_question/submission_questions/past_answers.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 json.answers answers do |answer|
-  json.partial! answer, answer: answer
+  json.partial! 'course/statistics/answers/answer', answer: answer, question: question
 end

--- a/app/views/course/statistics/answers/_all_questions.json.jbuilder
+++ b/app/views/course/statistics/answers/_all_questions.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.allQuestions @all_actable_questions do |question|
+  json.id question.id
+  json.title question.title
+  json.maximumGrade question.maximum_grade
+  json.description format_ckeditor_rich_text(question.description)
+  json.type question.question_type
+
+  json.partial! question, question: question, can_grade: false, answer: @all_answers.first
+end

--- a/app/views/course/statistics/answers/_answer.json.jbuilder
+++ b/app/views/course/statistics/answers/_answer.json.jbuilder
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+specific_answer = answer.specific
+
+json.id answer.id
+json.grade answer.grade
+json.questionType question.question_type
+
+if answer.actable_type == Course::Assessment::Answer::Programming.name
+  json.partial! 'course/statistics/answers/programming_answer', answer: specific_answer, can_grade: false
+else
+  json.partial! specific_answer, answer: specific_answer, can_grade: false
+end
+
+if answer.actable_type == Course::Assessment::Answer::Programming.name
+  files = answer.specific.files
+  json.partial! 'course/assessment/answer/programming/annotations', programming_files: files,
+                                                                    can_grade: false
+  posts = files.flat_map(&:annotations).map(&:discussion_topic).flat_map(&:posts)
+
+  json.posts posts do |post|
+    json.partial! post, post: post if post.published?
+  end
+end
+
+json.submittedAt answer.submitted_at&.iso8601
+json.currentAnswer answer.current_answer
+json.workflowState answer.workflow_state

--- a/app/views/course/statistics/answers/_programming_answer.json.jbuilder
+++ b/app/views/course/statistics/answers/_programming_answer.json.jbuilder
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+question = @question.specific
+
+# If a non current_answer is being loaded, use it instead of loading the last_attempt.
+is_current_answer = answer.current_answer?
+latest_answer = last_attempt(answer)
+attempt = is_current_answer ? latest_answer : answer
+auto_grading = attempt&.auto_grading&.specific
+
+json.fields do
+  json.questionId answer.question_id
+  json.id answer.acting_as.id
+  json.files_attributes answer.files do |file|
+    json.(file, :id, :filename)
+    json.content file.content
+    json.highlightedContent highlight_code_block(file.content, question.language)
+  end
+end
+
+can_read_tests = can?(:read_tests, @submission)
+show_private = can_read_tests || (@submission.published? && @assessment.show_private?)
+show_evaluation = can_read_tests || (@submission.published? && @assessment.show_evaluation?)
+
+test_cases_by_type = question.test_cases_by_type
+test_cases_and_results = get_test_cases_and_results(test_cases_by_type, auto_grading)
+
+show_stdout_and_stderr = (can_read_tests || current_course.show_stdout_and_stderr) &&
+                         auto_grading && auto_grading&.exit_code != 0
+
+displayed_test_case_types = ['public_test']
+displayed_test_case_types << 'private_test' if show_private
+displayed_test_case_types << 'evaluation_test' if show_evaluation
+
+json.testCases do
+  json.canReadTests can_read_tests
+
+  # Get all historical auto gradings
+  historical_auto_gradings = get_historical_auto_gradings(auto_grading)
+
+  # Include current and historical auto gradings
+  json.tests (historical_auto_gradings + [auto_grading]).each do |ag|
+    question = ag.test_results.first.test_case.question
+    test_cases_by_type = question.test_cases_by_type
+    test_cases_and_results = get_test_cases_and_results(test_cases_by_type, ag)
+
+    json.questionId question.id
+    displayed_test_case_types.each do |test_case_type|
+      show_public = (test_case_type == 'public_test') && current_course.show_public_test_cases_output
+      show_testcase_outputs = can_read_tests || show_public
+      json.set! test_case_type do
+        if test_cases_and_results[test_case_type].present?
+          json.array! test_cases_and_results[test_case_type] do |test_case, test_result|
+            json.identifier test_case.identifier if can_read_tests
+            json.expression test_case.expression
+            json.expected test_case.expected
+            if test_result
+              json.output get_output(test_result) if show_testcase_outputs
+              json.passed test_result.passed?
+            end
+          end
+
+        end
+      end
+      json.(ag, :stdout, :stderr) if show_stdout_and_stderr
+    end
+  end
+end
+
+if answer.codaveri_feedback_job_id && question.is_codaveri
+  codaveri_job = answer.codaveri_feedback_job
+  json.codaveriFeedback do
+    json.jobId answer.codaveri_feedback_job_id
+    json.jobStatus codaveri_job.status
+    json.jobUrl job_path(codaveri_job) if codaveri_job.status == 'submitted'
+    json.errorMessage codaveri_job.error['message'] if codaveri_job.error
+  end
+end

--- a/app/views/course/statistics/answers/_programming_answer.json.jbuilder
+++ b/app/views/course/statistics/answers/_programming_answer.json.jbuilder
@@ -31,38 +31,35 @@ displayed_test_case_types = ['public_test']
 displayed_test_case_types << 'private_test' if show_private
 displayed_test_case_types << 'evaluation_test' if show_evaluation
 
-json.testCases do
+historical_auto_gradings = get_historical_auto_gradings(auto_grading)
+
+json.testCases (historical_auto_gradings + [auto_grading]).each do |ag|
+  next if ag.nil? # To account for autogradings with no test results (programming with no autograding)
+
+  question = ag.test_results.first.test_case ? ag.test_results.first.test_case.question : @question.actable
+  test_cases_by_type = question.test_cases_by_type
+  test_cases_and_results = get_test_cases_and_results(test_cases_by_type, ag)
+
   json.canReadTests can_read_tests
-
-  # Get all historical auto gradings
-  historical_auto_gradings = get_historical_auto_gradings(auto_grading)
-
-  # Include current and historical auto gradings
-  json.tests (historical_auto_gradings + [auto_grading]).each do |ag|
-    question = ag.test_results.first.test_case.question
-    test_cases_by_type = question.test_cases_by_type
-    test_cases_and_results = get_test_cases_and_results(test_cases_by_type, ag)
-
-    json.questionId question.id
-    displayed_test_case_types.each do |test_case_type|
-      show_public = (test_case_type == 'public_test') && current_course.show_public_test_cases_output
-      show_testcase_outputs = can_read_tests || show_public
-      json.set! test_case_type do
-        if test_cases_and_results[test_case_type].present?
-          json.array! test_cases_and_results[test_case_type] do |test_case, test_result|
-            json.identifier test_case.identifier if can_read_tests
-            json.expression test_case.expression
-            json.expected test_case.expected
-            if test_result
-              json.output get_output(test_result) if show_testcase_outputs
-              json.passed test_result.passed?
-            end
+  json.questionId question.id
+  displayed_test_case_types.each do |test_case_type|
+    show_public = (test_case_type == 'public_test') && current_course.show_public_test_cases_output
+    show_testcase_outputs = can_read_tests || show_public
+    json.set! test_case_type do
+      if test_cases_and_results[test_case_type].present?
+        json.array! test_cases_and_results[test_case_type] do |test_case, test_result|
+          json.identifier test_case.identifier if can_read_tests
+          json.expression test_case.expression
+          json.expected test_case.expected
+          if test_result
+            json.output get_output(test_result) if show_testcase_outputs
+            json.passed test_result.passed?
           end
-
         end
+
       end
-      json.(ag, :stdout, :stderr) if show_stdout_and_stderr
     end
+    json.(ag, :stdout, :stderr) if show_stdout_and_stderr
   end
 end
 

--- a/app/views/course/statistics/answers/all_answers.json.jbuilder
+++ b/app/views/course/statistics/answers/all_answers.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 json.allAnswers @all_answers do |answer|
   json.id answer.id
-  json.createdAt answer.created_at&.iso8601
+  json.submittedAt answer.created_at&.iso8601
   json.currentAnswer answer.current_answer
   json.workflowState answer.workflow_state
 end

--- a/app/views/course/statistics/answers/all_answers.json.jbuilder
+++ b/app/views/course/statistics/answers/all_answers.json.jbuilder
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
+json.partial! 'all_questions'
+
 json.allAnswers @all_answers do |answer|
-  json.id answer.id
-  json.submittedAt answer.created_at&.iso8601
-  json.currentAnswer answer.current_answer
-  json.workflowState answer.workflow_state
+  json.partial! 'answer', answer: answer, question: @question
 end
 
 posts = @submission_question.discussion_topic.posts

--- a/client/app/api/course/Statistics/AnswerStatistics.ts
+++ b/client/app/api/course/Statistics/AnswerStatistics.ts
@@ -1,5 +1,5 @@
 import { QuestionType } from 'types/course/assessment/question';
-import { AnswerStatisticsData } from 'types/course/statistics/assessmentStatistics';
+import { Answer } from 'types/course/statistics/assessmentStatistics';
 
 import { APIResponse } from 'api/types';
 
@@ -10,9 +10,7 @@ export default class AnswerStatisticsAPI extends BaseCourseAPI {
     return `/courses/${this.courseId}/statistics/answers`;
   }
 
-  fetch(
-    answerId: number,
-  ): APIResponse<AnswerStatisticsData<keyof typeof QuestionType>> {
+  fetch(answerId: number): APIResponse<Answer<keyof typeof QuestionType>> {
     return this.client.get(`${this.#urlPrefix}/${answerId}`);
   }
 }

--- a/client/app/bundles/course/assessment/operations/statistics.ts
+++ b/client/app/bundles/course/assessment/operations/statistics.ts
@@ -3,7 +3,7 @@ import { dispatch } from 'store';
 import { QuestionType } from 'types/course/assessment/question';
 import {
   AncestorAssessmentStats,
-  AnswerStatisticsData,
+  Answer,
   AssessmentLiveFeedbackStatistics,
   SubmissionQuestionDetails,
 } from 'types/course/statistics/assessmentStatistics';
@@ -57,7 +57,7 @@ export const fetchSubmissionQuestionDetails = async (
 
 export const fetchAnswer = async (
   answerId: number,
-): Promise<AnswerStatisticsData<keyof typeof QuestionType>> => {
+): Promise<Answer<keyof typeof QuestionType>> => {
   const response = await CourseAPI.statistics.answer.fetch(answerId);
 
   return response.data;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
@@ -2,7 +2,7 @@ import { defineMessages } from 'react-intl';
 import { Card, CardContent } from '@mui/material';
 import { QuestionType } from 'types/course/assessment/question';
 import { AnswerDetailsMap } from 'types/course/statistics/answer';
-import { QuestionDetails } from 'types/course/statistics/assessmentStatistics';
+import { Question } from 'types/course/statistics/assessmentStatistics';
 
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -22,7 +22,7 @@ const translations = defineMessages({
 });
 
 interface AnswerDetailsProps<T extends keyof typeof QuestionType> {
-  question: QuestionDetails<T>;
+  question: Question<T>;
   answer: AnswerDetailsMap[T];
 }
 

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/AnswerDetails.tsx
@@ -1,8 +1,10 @@
 import { defineMessages } from 'react-intl';
 import { Card, CardContent } from '@mui/material';
 import { QuestionType } from 'types/course/assessment/question';
-import { AnswerDetailsMap } from 'types/course/statistics/answer';
-import { Question } from 'types/course/statistics/assessmentStatistics';
+import {
+  ProcessedAnswer,
+  Question,
+} from 'types/course/statistics/assessmentStatistics';
 
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -23,7 +25,7 @@ const translations = defineMessages({
 
 interface AnswerDetailsProps<T extends keyof typeof QuestionType> {
   question: Question<T>;
-  answer: AnswerDetailsMap[T];
+  answer: ProcessedAnswer<T>;
 }
 
 const AnswerNotImplemented = (): JSX.Element => {

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttempts.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttempts.tsx
@@ -31,6 +31,7 @@ const AllAttemptsIndex: FC<Props> = (props) => {
           <>
             <AllAttemptsDisplay
               allAnswers={data.allAnswers}
+              allQuestions={data.allQuestions}
               questionNumber={index}
             />
 

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
@@ -4,8 +4,8 @@ import { Alert, Typography } from '@mui/material';
 import { QuestionType } from 'types/course/assessment/question';
 import {
   AllAnswerItem,
-  AnswerStatisticsData,
-  QuestionDetails,
+  Answer,
+  Question,
 } from 'types/course/statistics/assessmentStatistics';
 
 import { fetchAnswer } from 'course/assessment/operations/statistics';
@@ -41,7 +41,7 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
 
   const [answersCache, setAnswersCache] = useState<{
     [id: number]: {
-      details: AnswerStatisticsData<keyof typeof QuestionType> | null;
+      details: Answer<keyof typeof QuestionType> | null;
       status: 'pending' | 'completed' | 'errored';
     };
   }>({});
@@ -56,7 +56,7 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
   // (e.g. option randomization for mcq/mrq questions). However, we can take advantage of the fact that
   // the question should remain the same across all answers.
   const [question, setQuestion] =
-    useState<QuestionDetails<keyof typeof QuestionType>>();
+    useState<Question<keyof typeof QuestionType>>();
 
   const tryFetchAnswerById = (answerId: number): Promise<void> => {
     setAnswersCache({

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
@@ -117,6 +117,8 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
         <Accordion
           defaultExpanded={false}
           disabled={false}
+          disableGutters
+          displayDotIndicator
           title={t(translations.questionTitle, {
             index: questionNumber,
           })}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
@@ -101,7 +101,7 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
       value: idx,
       label:
         idx === 0 || idx === allAnswers.length - 1
-          ? formatLongDateTime(answer.createdAt)
+          ? formatLongDateTime(answer.submittedAt)
           : '',
     };
   });
@@ -151,7 +151,7 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
         <>
           <Typography variant="body1">
             {t(translations.pastAnswerTitle, {
-              submittedAt: formatLongDateTime(answerDetails!.createdAt),
+              submittedAt: formatLongDateTime(answerDetails!.submittedAt),
             })}
           </Typography>
           <AnswerDetails answer={answerDetails!} question={question!} />

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/AllAttemptsDisplay.tsx
@@ -11,7 +11,7 @@ import {
 import { fetchAnswer } from 'course/assessment/operations/statistics';
 import Accordion from 'lib/components/core/layouts/Accordion';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import CustomSlider from 'lib/components/extensions/CustomSlider';
+import Slider from 'lib/components/extensions/CustomSlider';
 import useTranslation from 'lib/hooks/useTranslation';
 import { formatLongDateTime } from 'lib/moment';
 import messagesTranslations from 'lib/translations/messages';
@@ -109,8 +109,6 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
   const currentAnswerMarker =
     answerSubmittedTimes[answerSubmittedTimes.length - 1];
 
-  const earliestAnswerMarker = answerSubmittedTimes[0];
-
   const renderQuestionComponent = (): JSX.Element => {
     if (question) {
       return (
@@ -186,12 +184,9 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
     <>
       {renderQuestionComponent()}
       {answerSubmittedTimes.length > 1 && (
-        <div className="w-[calc(100%_-_17rem)] mx-auto pt-8">
-          <CustomSlider
+        <div className="w-[calc(100%_-_17rem)] mx-auto mb-4">
+          <Slider
             defaultValue={currentAnswerMarker.value}
-            marks={answerSubmittedTimes}
-            max={currentAnswerMarker.value}
-            min={earliestAnswerMarker.value}
             onChange={(event, value) => {
               // The component specs mention that value can either be number or Array,
               // but since there is only a single slider value it will always be a number
@@ -209,11 +204,8 @@ const AllAttemptsDisplay: FC<Props> = (props) => {
               const newIndex = value as number;
               changeDisplayedIndex(newIndex);
             }}
-            step={null}
-            valueLabelDisplay="on"
-            valueLabelFormat={(value) =>
-              `${formatLongDateTime(allAnswers[value].createdAt)} (${value + 1} of ${allAnswers.length})`
-            }
+            points={answerSubmittedTimes}
+            valueLabelDisplay="auto"
           />
         </div>
       )}

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAnswerDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAnswerDisplay.tsx
@@ -1,6 +1,13 @@
 import { FC } from 'react';
 import { defineMessages } from 'react-intl';
-import { Chip, Typography } from '@mui/material';
+import {
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+} from '@mui/material';
 import { QuestionType } from 'types/course/assessment/question';
 import {
   Answer,
@@ -15,6 +22,7 @@ import Accordion from 'lib/components/core/layouts/Accordion';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import Preload from 'lib/components/wrappers/Preload';
 import useTranslation from 'lib/hooks/useTranslation';
+import { formatLongDateTime } from 'lib/moment';
 
 import AnswerDetails from '../AnswerDetails/AnswerDetails';
 import { getClassNameForMarkCell } from '../classNameUtils';
@@ -33,6 +41,10 @@ const translations = defineMessages({
   submissionPage: {
     id: 'course.assessment.statistics.submissionPage',
     defaultMessage: 'Go to Answer Page',
+  },
+  submittedAt: {
+    id: 'course.assessment.statistics.submittedAt',
+    defaultMessage: 'Submitted At',
   },
 });
 
@@ -70,8 +82,22 @@ const LastAnswerDisplay: FC<Props> = (props) => {
         );
         return (
           <>
+            <Table>
+              <TableBody>
+                <TableRow>
+                  <TableCell className="w-1/4">
+                    {t(translations.submittedAt)}
+                  </TableCell>
+                  <TableCell>
+                    {formatLongDateTime(answer.submittedAt)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+
             <Accordion
               defaultExpanded={false}
+              disableGutters
               title={t(translations.questionTitle, { index })}
             >
               <div className="ml-4 mt-4">

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAnswerDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAnswerDisplay.tsx
@@ -37,14 +37,14 @@ const translations = defineMessages({
 });
 
 interface Props {
-  curAnswerId: number;
+  currAnswerId: number;
   index: number;
   questionId: number;
   submissionId: number;
 }
 
-const LastAttemptIndex: FC<Props> = (props) => {
-  const { curAnswerId, index, submissionId, questionId } = props;
+const LastAnswerDisplay: FC<Props> = (props) => {
+  const { currAnswerId, index, submissionId, questionId } = props;
   const { t } = useTranslation();
 
   const fetchAnswerDetailsAndComments = async (): Promise<{
@@ -52,7 +52,7 @@ const LastAttemptIndex: FC<Props> = (props) => {
     comments: CommentItem[];
   }> => {
     const [answer, submissionQuestion] = await Promise.all([
-      fetchAnswer(curAnswerId),
+      fetchAnswer(currAnswerId),
       fetchSubmissionQuestionDetails(submissionId, questionId),
     ]);
     return { answer, comments: submissionQuestion.comments };
@@ -101,4 +101,4 @@ const LastAttemptIndex: FC<Props> = (props) => {
   );
 };
 
-export default LastAttemptIndex;
+export default LastAnswerDisplay;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAnswerDisplay.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAnswerDisplay.tsx
@@ -28,6 +28,7 @@ import AnswerDetails from '../AnswerDetails/AnswerDetails';
 import { getClassNameForMarkCell } from '../classNameUtils';
 
 import Comment from './Comment';
+import { processLastAttempt } from './utils';
 
 const translations = defineMessages({
   questionTitle: {
@@ -80,6 +81,12 @@ const LastAnswerDisplay: FC<Props> = (props) => {
           answer.grade,
           answer.question.maximumGrade,
         );
+
+        const { allProcessedAnswers } = processLastAttempt(
+          answer.question,
+          answer,
+        );
+
         return (
           <>
             <Table>
@@ -110,7 +117,10 @@ const LastAnswerDisplay: FC<Props> = (props) => {
                 />
               </div>
             </Accordion>
-            <AnswerDetails answer={answer} question={answer.question} />
+            <AnswerDetails
+              answer={allProcessedAnswers}
+              question={answer.question}
+            />
             <Chip
               className={`w-100 mt-3 ${gradeCellColor}`}
               label={t(translations.gradeDisplay, {

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAttempt.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/LastAttempt.tsx
@@ -3,7 +3,7 @@ import { defineMessages } from 'react-intl';
 import { Chip, Typography } from '@mui/material';
 import { QuestionType } from 'types/course/assessment/question';
 import {
-  AnswerStatisticsData,
+  Answer,
   CommentItem,
 } from 'types/course/statistics/assessmentStatistics';
 
@@ -48,7 +48,7 @@ const LastAttemptIndex: FC<Props> = (props) => {
   const { t } = useTranslation();
 
   const fetchAnswerDetailsAndComments = async (): Promise<{
-    answer: AnswerStatisticsData<keyof typeof QuestionType>;
+    answer: Answer<keyof typeof QuestionType>;
     comments: CommentItem[];
   }> => {
     const [answer, submissionQuestion] = await Promise.all([

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/utils.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDisplay/utils.ts
@@ -1,0 +1,125 @@
+import { QuestionType } from 'types/course/assessment/question';
+import {
+  Answer,
+  ProcessedAnswer,
+  Question,
+} from 'types/course/statistics/assessmentStatistics';
+
+import { SliderElement } from 'lib/components/extensions/CustomSlider';
+import { formatLongDateTime } from 'lib/moment';
+
+/**
+ * Processes attempts and generates a list of processed answers and their corresponding slider points.
+ * All these have their corresponding indexes, and the indexes are mapped to the questions.
+ */
+export const processAttempts = (
+  allQuestions: Question<keyof typeof QuestionType>[],
+  allAnswers: Answer<keyof typeof QuestionType>[],
+): {
+  questionMap: Map<number, Question<keyof typeof QuestionType>>;
+  allProcessedAnswers: ProcessedAnswer<keyof typeof QuestionType>[];
+  sliderPoints: SliderElement[];
+  maxIndex: number;
+} => {
+  const type = allQuestions[0].type;
+  const questionMap = new Map<number, Question<keyof typeof QuestionType>>();
+  const allProcessedAnswers: ProcessedAnswer<keyof typeof QuestionType>[] = [];
+  const sliderPoints: SliderElement[] = [];
+
+  let currIndex = 0;
+  let baseIndex = 1;
+
+  if (type === 'Programming') {
+    (allAnswers as Answer<'Programming'>[]).forEach((answer) => {
+      if (answer.testCases.length === 0) {
+        allProcessedAnswers.push({
+          ...answer,
+          testCases: {},
+        });
+        questionMap.set(currIndex, allQuestions[0]);
+        sliderPoints.push({
+          value: currIndex,
+          tooltip: `Attempt ${baseIndex} - ${formatLongDateTime(answer.submittedAt)}`,
+        });
+        currIndex += 1;
+        baseIndex += 1;
+      } else {
+        const tempSliderPoints: SliderElement[] = [];
+
+        answer.testCases.forEach((testCase) => {
+          allProcessedAnswers.push({
+            ...answer,
+            testCases: testCase,
+          });
+          const question = allQuestions.find(
+            (q) => q.id === testCase.questionId,
+          );
+          if (question) {
+            questionMap.set(currIndex, question);
+          }
+
+          tempSliderPoints.push({
+            value: currIndex,
+            tooltip: `Attempt ${baseIndex} - ${formatLongDateTime(answer.submittedAt)}`,
+          });
+
+          currIndex += 1;
+        });
+        baseIndex += 1;
+        sliderPoints.push(tempSliderPoints);
+      }
+    });
+  } else {
+    (
+      allAnswers as Answer<Exclude<keyof typeof QuestionType, 'Programming'>>[]
+    ).forEach((answer) => {
+      allProcessedAnswers.push(answer);
+      questionMap.set(currIndex, allQuestions[0]);
+      sliderPoints.push({ value: currIndex, label: '' });
+      currIndex += 1;
+    });
+  }
+
+  return {
+    questionMap,
+    allProcessedAnswers,
+    sliderPoints,
+    maxIndex: currIndex - 1,
+  };
+};
+
+export const processLastAttempt = (
+  question: Question<keyof typeof QuestionType>,
+  answer: Answer<keyof typeof QuestionType>,
+): {
+  allProcessedAnswers: ProcessedAnswer<keyof typeof QuestionType>;
+} => {
+  const type = question.type;
+
+  if (type === 'Programming') {
+    const processedAnswer = answer as ProcessedAnswer<'Programming'>;
+    if (
+      (processedAnswer.testCases.public_test?.length ?? 0) +
+        (processedAnswer.testCases.private_test?.length ?? 0) +
+        (processedAnswer.testCases.evaluation_test?.length ?? 0) ===
+      0
+    ) {
+      return { allProcessedAnswers: { ...processedAnswer, testCases: {} } };
+    }
+    return {
+      allProcessedAnswers: {
+        ...processedAnswer,
+        testCases: {
+          public_test: processedAnswer.testCases.public_test,
+          private_test: processedAnswer.testCases.private_test,
+          evaluation_test: processedAnswer.testCases.evaluation_test,
+        },
+      },
+    };
+  }
+  return {
+    allProcessedAnswers: answer as Answer<
+      Exclude<keyof typeof QuestionType, 'Programming'>
+    >,
+  };
+};

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackHistory/LiveFeedbackHistoryPage.tsx
@@ -34,14 +34,15 @@ const LiveFeedbackHistoryPage: FC<Props> = (props) => {
   const [displayedIndex, setDisplayedIndex] = useState(
     nonEmptyLiveFeedbackHistory.length - 1,
   );
-  const sliderMarks = nonEmptyLiveFeedbackHistory.map(
+  const sliderPoints = nonEmptyLiveFeedbackHistory.map(
     (liveFeedbackHistory, idx) => {
       return {
-        value: idx + 1,
+        value: idx,
         label:
           idx === 0 || idx === nonEmptyLiveFeedbackHistory.length - 1
             ? formatLongDateTime(liveFeedbackHistory.createdAt)
             : '',
+        tooltip: `${idx + 1}`,
       };
     },
   );
@@ -72,15 +73,10 @@ const LiveFeedbackHistoryPage: FC<Props> = (props) => {
         <div className="w-[calc(100%_-_17rem)] mx-auto">
           <CustomSlider
             defaultValue={nonEmptyLiveFeedbackHistory.length}
-            marks={sliderMarks}
-            max={nonEmptyLiveFeedbackHistory.length}
-            min={1}
             onChange={(_, value) => {
-              setDisplayedIndex(
-                Array.isArray(value) ? value[0] - 1 : value - 1,
-              );
+              setDisplayedIndex(Array.isArray(value) ? value[0] : value);
             }}
-            step={null}
+            points={sliderPoints}
             valueLabelDisplay="auto"
           />
         </div>

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/QuestionDetails/ProgrammingQuestionDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/QuestionDetails/ProgrammingQuestionDetails.tsx
@@ -1,0 +1,71 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { Table, TableBody, TableCell, TableRow } from '@mui/material';
+import { Question } from 'types/course/statistics/assessmentStatistics';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+const translations = defineMessages({
+  memoryLimit: {
+    id: 'course.assessment.statistics.ProgrammingQuestionDetails.memoryLimit',
+    defaultMessage: '{memoryLimit}MB',
+  },
+  timeLimit: {
+    id: 'course.assessment.statistics.ProgrammingQuestionDetails.timeLimit',
+    defaultMessage: '{timeLimit}s',
+  },
+});
+
+const CELL_WIDTH = '50%';
+
+interface Props {
+  question: Question<'Programming'>;
+}
+
+const ProgrammingQuestionDetails: FC<Props> = (props): JSX.Element => {
+  const { question } = props;
+  const { t } = useTranslation();
+
+  return (
+    <Table size="small">
+      <TableBody>
+        <TableRow>
+          <TableCell width={CELL_WIDTH}>Language</TableCell>
+          <TableCell>{question.language || '-'}</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell width={CELL_WIDTH}>Memory Limit</TableCell>
+          <TableCell>
+            {question.memoryLimit
+              ? t(translations.memoryLimit, {
+                  memoryLimit: question.memoryLimit,
+                })
+              : '-'}
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell width={CELL_WIDTH}>Time Limit</TableCell>
+          <TableCell>
+            {question.timeLimit
+              ? t(translations.timeLimit, { timeLimit: question.timeLimit })
+              : '-'}
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell width={CELL_WIDTH}>Attempt Limit</TableCell>
+          <TableCell>{question.attemptLimit || '-'}</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell width={CELL_WIDTH}>Is Codaveri</TableCell>
+          <TableCell>{question.isCodaveri ? '✅' : '❌'}</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell width={CELL_WIDTH}>Live Feedback Enabled</TableCell>
+          <TableCell>{question.liveFeedbackEnabled ? '✅' : '❌'}</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+};
+
+export default ProgrammingQuestionDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/QuestionDetails/QuestionDetails.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/QuestionDetails/QuestionDetails.tsx
@@ -1,0 +1,76 @@
+import { defineMessages } from 'react-intl';
+import { Card, CardContent } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+import { Question } from 'types/course/statistics/assessmentStatistics';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+import ProgrammingQuestionDetails from './ProgrammingQuestionDetails';
+
+const translations = defineMessages({
+  rendererNotImplemented: {
+    id: 'course.assessment.submission.Question.rendererNotImplemented',
+    defaultMessage:
+      'The display for this question type has not been implemented yet.',
+  },
+});
+
+interface QuestionDetailsProps<T extends keyof typeof QuestionType> {
+  question: Question<T>;
+}
+
+const QuestionNotImplemented = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="bg-yellow-100">
+      <CardContent>{t(translations.rendererNotImplemented)}</CardContent>
+    </Card>
+  );
+};
+
+// TODO: define component for unimplemented parts
+export const QuestionDetailsMapper = {
+  MultipleChoice: (
+    _props: QuestionDetailsProps<'MultipleChoice'>,
+  ): JSX.Element => <QuestionNotImplemented />,
+  MultipleResponse: (
+    _props: QuestionDetailsProps<'MultipleResponse'>,
+  ): JSX.Element => <QuestionNotImplemented />,
+  TextResponse: (_props: QuestionDetailsProps<'TextResponse'>): JSX.Element => (
+    <QuestionNotImplemented />
+  ),
+  FileUpload: (_props: QuestionDetailsProps<'FileUpload'>): JSX.Element => (
+    <QuestionNotImplemented />
+  ),
+  ForumPostResponse: (
+    _props: QuestionDetailsProps<'ForumPostResponse'>,
+  ): JSX.Element => <QuestionNotImplemented />,
+  Programming: (props: QuestionDetailsProps<'Programming'>): JSX.Element => (
+    <ProgrammingQuestionDetails {...props} />
+  ),
+  VoiceResponse: (
+    _props: QuestionDetailsProps<'VoiceResponse'>,
+  ): JSX.Element => <QuestionNotImplemented />,
+  Scribing: (_props: QuestionDetailsProps<'Scribing'>): JSX.Element => (
+    <QuestionNotImplemented />
+  ),
+  Comprehension: (
+    _props: QuestionDetailsProps<'Comprehension'>,
+  ): JSX.Element => <QuestionNotImplemented />,
+};
+
+const QuestionDetails = <T extends keyof typeof QuestionType>(
+  props: QuestionDetailsProps<T>,
+): JSX.Element => {
+  const Component = QuestionDetailsMapper[props.question.type];
+
+  // "Any" type is used here as the props are dynamically generated
+  // depending on the different question type and typescript
+  // does not support union typing for the elements.
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return Component({ ...props } as any);
+};
+
+export default QuestionDetails;

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -114,8 +114,8 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
         },
         title: t(translations.questionIndex, { index: index + 1 }),
         cell: (datum): ReactNode => {
-          return typeof datum.attemptStatus?.[index]?.attemptCount ===
-            'number' ? (
+          return datum.attemptStatus?.[index] &&
+            typeof datum.attemptStatus[index].attemptCount === 'number' ? (
             renderAttemptCountClickableCell(index, datum)
           ) : (
             <div />

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -282,22 +282,24 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
         onClose={(): void => setOpenAnswer(false)}
         open={openAnswer}
         title={
-          <span className="flex items-center">
-            {answerDisplayInfo.studentName}
-            <SubmissionWorkflowState
-              className="ml-3"
-              linkTo={getEditSubmissionQuestionURL(
-                courseId,
-                assessmentId,
-                answerDisplayInfo.submissionId,
-                answerDisplayInfo.index,
-              )}
-              opensInNewTab
-              workflowState={
-                answerDisplayInfo.workflowState ?? workflowStates.Unstarted
-              }
-            />
-          </span>
+          <div className="flex flex-row">
+            <span className="flex items-center">
+              {answerDisplayInfo.studentName}
+              <SubmissionWorkflowState
+                className="ml-3"
+                linkTo={getEditSubmissionQuestionURL(
+                  courseId,
+                  assessmentId,
+                  answerDisplayInfo.submissionId,
+                  answerDisplayInfo.index,
+                )}
+                opensInNewTab
+                workflowState={
+                  answerDisplayInfo.workflowState ?? workflowStates.Unstarted
+                }
+              />
+            </span>
+          </div>
         }
       >
         <LastAnswerDisplay

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -18,7 +18,7 @@ import {
 import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import LastAttemptIndex from './AnswerDisplay/LastAttempt';
+import LastAnswerDisplay from './AnswerDisplay/LastAnswerDisplay';
 import { getClassNameForMarkCell } from './classNameUtils';
 import { getAssessmentStatistics } from './selectors';
 import translations from './translations';
@@ -120,7 +120,8 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
         },
         title: t(translations.questionIndex, { index: index + 1 }),
         cell: (datum): ReactNode => {
-          return typeof datum.answers?.[index]?.grade === 'number' ? (
+          return datum.answers?.[index] &&
+            typeof datum.answers?.[index].grade === 'number' ? (
             renderAnswerGradeClickableCell(index, datum)
           ) : (
             <div />
@@ -299,8 +300,8 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
           </span>
         }
       >
-        <LastAttemptIndex
-          curAnswerId={answerDisplayInfo.answerId}
+        <LastAnswerDisplay
+          currAnswerId={answerDisplayInfo.answerId}
           index={answerDisplayInfo.index}
           questionId={answerDisplayInfo.questionId}
           submissionId={answerDisplayInfo.submissionId}

--- a/client/app/bundles/course/assessment/question/programming/EditProgrammingQuestionPage.tsx
+++ b/client/app/bundles/course/assessment/question/programming/EditProgrammingQuestionPage.tsx
@@ -19,6 +19,14 @@ const EditProgrammingQuestionPage = (): JSX.Element => {
 
   const fetchData = (): Promise<ProgrammingFormData> => fetchEdit(id);
 
+  const reFetchData = async (
+    response: ProgrammingPostStatusData,
+    _rawData: ProgrammingFormData,
+  ): Promise<ProgrammingFormData> => {
+    const newId = response.id ?? id;
+    return fetchEdit(newId);
+  };
+
   return (
     <Preload render={<LoadingIndicator />} while={fetchData}>
       {(data): JSX.Element => (
@@ -26,7 +34,7 @@ const EditProgrammingQuestionPage = (): JSX.Element => {
           onSubmit={(rawData): Promise<ProgrammingPostStatusData> =>
             update(id, buildFormData(rawData))
           }
-          revalidate={fetchData}
+          revalidate={reFetchData}
           with={data}
         />
       )}

--- a/client/app/bundles/course/assessment/question/programming/ProgrammingForm.tsx
+++ b/client/app/bundles/course/assessment/question/programming/ProgrammingForm.tsx
@@ -82,6 +82,10 @@ const ProgrammingForm = (props: ProgrammingFormProps): JSX.Element => {
           if (debounced) return;
           debounced = true;
 
+          if (response.redirectEditUrl) {
+            navigate(response.redirectEditUrl, { replace: true });
+          }
+
           const newData = await props.revalidate?.(response, rawData);
           if (newData) {
             setData(newData);

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/__test__/index.test.js
@@ -52,10 +52,9 @@ const defaultStaffViewProps = {
 };
 
 const getWarning = (page, text) =>
-  within(page.getByText(text).closest('div')).queryByText(
-    'Only staff can see this.',
-    { exact: false },
-  );
+  within(
+    page.getByText(text).closest('.MuiAccordionSummary-content'),
+  ).queryByText('Only staff can see this.', { exact: false });
 
 describe('TestCaseView', () => {
   describe('when viewing as staff', () => {

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -411,7 +411,7 @@ function mapStateToProps({ assessments: { submission } }, ownProps) {
   let testCases;
   let isAutograding;
   if (viewHistory) {
-    testCases = submission.history.testCases[answerId];
+    testCases = submission.history.testCases[answerId][0];
     isAutograding = false;
   } else {
     testCases = submission.testCases[questionId];

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/course/StudentPerformanceTable.tsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/course/StudentPerformanceTable.tsx
@@ -1,11 +1,10 @@
 import { FC, useState } from 'react';
 import { defineMessages } from 'react-intl';
-import { Card, CardContent, Typography } from '@mui/material';
+import { Card, CardContent, Slider, Typography } from '@mui/material';
 
 import { CourseStudent, GroupManager } from 'course/statistics/types';
 import LinearProgressWithLabel from 'lib/components/core/LinearProgressWithLabel';
 import Link from 'lib/components/core/Link';
-import CustomSlider from 'lib/components/extensions/CustomSlider';
 import Table, { ColumnTemplate } from 'lib/components/table';
 import {
   DEFAULT_MINI_TABLE_ROWS_PER_PAGE,
@@ -366,7 +365,7 @@ const StudentPerformanceTable: FC<Props> = (props) => {
               : t(translations.correctness),
           })}
         </Typography>
-        <CustomSlider
+        <Slider
           aria-label="Highlight Percentage"
           className="flex flex-row align-right max-w-[500px] min-w-[300px] mb-2"
           defaultValue={highlightPercentage}

--- a/client/app/lib/components/core/layouts/Accordion.tsx
+++ b/client/app/lib/components/core/layouts/Accordion.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ReactNode } from 'react';
+import { ComponentProps, ReactNode, useState } from 'react';
 import { ExpandMore } from '@mui/icons-material';
 import {
   Accordion as MuiAccordion,
@@ -13,11 +13,20 @@ interface AccordionProps extends ComponentProps<typeof MuiAccordion> {
   subtitle?: string;
   disabled?: boolean;
   icon?: ReactNode;
+  displayDotIndicator?: boolean;
 }
 
 const Accordion = (props: AccordionProps): JSX.Element => {
-  const { title, children, subtitle, disabled, icon, ...accordionProps } =
-    props;
+  const {
+    title,
+    children,
+    subtitle,
+    disabled,
+    icon,
+    displayDotIndicator,
+    ...accordionProps
+  } = props;
+  const [isExpanded, setIsExpanded] = useState(props.defaultExpanded ?? false);
 
   return (
     <MuiAccordion
@@ -27,8 +36,11 @@ const Accordion = (props: AccordionProps): JSX.Element => {
       variant="outlined"
       {...accordionProps}
       className={`overflow-clip rounded-lg ${props.className ?? ''}`}
-      TransitionProps={{
-        className: 'overflow-clip',
+      onChange={(_, expanded) => setIsExpanded(expanded)}
+      slotProps={{
+        transition: {
+          className: 'overflow-clip',
+        },
       }}
     >
       <MuiAccordionSummary
@@ -39,7 +51,12 @@ const Accordion = (props: AccordionProps): JSX.Element => {
         className="space-x-2 px-9 py-6 hover:bg-neutral-100"
         expandIcon={icon || <ExpandMore />}
       >
-        <Typography>{title}</Typography>
+        <div className="flex items-center">
+          <Typography>{title}</Typography>
+          {!isExpanded && displayDotIndicator && (
+            <Typography className="ml-2 text-gray-400">...</Typography>
+          )}
+        </div>
 
         {subtitle && (
           <Typography color="text.secondary" variant="body2">

--- a/client/app/lib/components/core/layouts/Accordion.tsx
+++ b/client/app/lib/components/core/layouts/Accordion.tsx
@@ -23,7 +23,7 @@ const Accordion = (props: AccordionProps): JSX.Element => {
     subtitle,
     disabled,
     icon,
-    displayDotIndicator,
+    displayDotIndicator = false,
     ...accordionProps
   } = props;
   const [isExpanded, setIsExpanded] = useState(props.defaultExpanded ?? false);
@@ -37,11 +37,6 @@ const Accordion = (props: AccordionProps): JSX.Element => {
       {...accordionProps}
       className={`overflow-clip rounded-lg ${props.className ?? ''}`}
       onChange={(_, expanded) => setIsExpanded(expanded)}
-      slotProps={{
-        transition: {
-          className: 'overflow-clip',
-        },
-      }}
     >
       <MuiAccordionSummary
         classes={{

--- a/client/app/lib/components/extensions/CustomSlider.tsx
+++ b/client/app/lib/components/extensions/CustomSlider.tsx
@@ -1,35 +1,159 @@
+import { FC } from 'react';
 import { Slider, SliderProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-const CustomSlider = styled(Slider)<SliderProps>(({ theme }) => ({
+const StyledSlider = styled(Slider)<SliderProps>(() => ({
   height: 8,
   '& .MuiSlider-mark': {
-    // Makes marks bigger
-    height: 6,
-    width: 6,
-    borderRadius: '50%', // Make the marks rounded
-    backgroundColor: '#555',
+    height: 4,
+    width: 4,
+    borderRadius: '50%',
+    backgroundColor: '#FFF',
   },
   '& .MuiSlider-thumb': {
     height: 20,
     width: 20,
   },
   '& .MuiSlider-rail': {
-    height: 5,
+    height: 3,
   },
   '& .MuiSlider-track': {
-    height: 5,
-  },
-  '& .MuiSlider-valueLabel': {
-    backgroundColor: `transparent`,
-    color: theme.palette.text.primary,
-    fontWeight: 'normal',
-    top: '-2px',
+    height: 3,
   },
   '& .MuiSlider-markLabel': {
-    color: theme.palette.text.primary,
-    fontWeight: 'normal',
+    top: '40px',
+  },
+  '& .MuiSlider-valueLabel': {
+    backgroundColor: '#00BCD4',
+    borderRadius: '5px',
+    '&:before': {
+      display: 'none',
+    },
+    '& *': {
+      background: 'transparent',
+      color: '#FFF',
+    },
   },
 }));
+
+interface SliderPoint {
+  value: number;
+  label?: string;
+  tooltip?: string;
+}
+
+export type SliderElement = SliderPoint | SliderElement[];
+
+interface Props extends Omit<SliderProps, 'marks' | 'min' | 'max' | 'step'> {
+  points: SliderElement[];
+}
+
+const Bubble = styled('div')<{
+  left: string;
+  width: string;
+}>(({ left, width }) => ({
+  position: 'absolute',
+  left,
+  width,
+  top: '13px',
+  height: '8px',
+  backgroundColor: `rgba(0, 188, 212, 0.8)`,
+  borderRadius: '5px',
+  transition: 'transform 0.2s',
+  pointerEvents: 'none',
+}));
+
+const CustomSlider: FC<Props> = ({ points, ...sliderProps }) => {
+  const flattenPoints = (elements: SliderElement[]): SliderPoint[] => {
+    const result: SliderPoint[] = [];
+    elements.forEach((element) => {
+      if (Array.isArray(element)) {
+        result.push(...flattenPoints(element));
+      } else {
+        result.push(element);
+      }
+    });
+    return result;
+  };
+
+  const flattenedPoints = flattenPoints(points);
+  const values = flattenedPoints.map((p) => p.value);
+  const marks = flattenedPoints.map((p) => ({
+    value: p.value,
+    label: p.label,
+  }));
+
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+
+  const renderBackgroundBubbles = (
+    elements: SliderElement[],
+  ): JSX.Element[] => {
+    const bubbles: JSX.Element[] = [];
+    elements.forEach((element, index) => {
+      if (Array.isArray(element)) {
+        const childPoints = flattenPoints(element);
+        const childValues = childPoints.map((p) => p.value);
+        const groupMin = Math.min(...childValues);
+        const groupMax = Math.max(...childValues);
+        const leftPercent =
+          ((groupMin - minValue) / (maxValue - minValue)) * 100;
+        const rightPercent =
+          ((groupMax - minValue) / (maxValue - minValue)) * 100;
+        bubbles.push(
+          <Bubble
+            // eslint-disable-next-line react/no-array-index-key
+            key={`bubble-${index}`}
+            left={`calc(${leftPercent}% - 4px)`}
+            width={`calc(${rightPercent - leftPercent}% + 10px)`}
+          />,
+        );
+        bubbles.push(...renderBackgroundBubbles(element));
+      } else {
+        bubbles.push(
+          <Bubble
+            // eslint-disable-next-line react/no-array-index-key
+            key={`bubble-${index}`}
+            left={`calc(${
+              ((element.value - minValue) / (maxValue - minValue)) * 100
+            }% - 3px)`}
+            width="8px"
+          />,
+        );
+      }
+    });
+    return bubbles;
+  };
+
+  // Makes tooltip above the slider show 'tooltip' instead of 'value'
+  const valueLabelFormat = (
+    index: number,
+    _value: number,
+  ): string | React.ReactNode => {
+    const point = flattenedPoints[index];
+    return point?.tooltip || <div />;
+  };
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+      }}
+    >
+      {renderBackgroundBubbles(points)}
+      <StyledSlider
+        {...sliderProps}
+        marks={marks}
+        max={maxValue}
+        min={minValue}
+        step={null}
+        style={{ position: 'relative' }}
+        track={false}
+        valueLabelFormat={valueLabelFormat}
+      />
+    </div>
+  );
+};
 
 export default CustomSlider;

--- a/client/app/types/course/assessment/submission/question/types.ts
+++ b/client/app/types/course/assessment/submission/question/types.ts
@@ -15,9 +15,12 @@ interface MultipleResponseQuestionData {
 
 interface ProgrammingQuestionData {
   language: string;
+  memoryLimit?: number;
+  timeLimit?: number;
+  attemptLimit?: number;
   fileSubmission: boolean;
   isCodaveri: boolean;
-  attemptLimit?: number;
+  liveFeedbackEnabled: boolean;
 }
 
 interface TextResponseParentQuestionData {}

--- a/client/app/types/course/assessment/submission/question/types.ts
+++ b/client/app/types/course/assessment/submission/question/types.ts
@@ -19,6 +19,7 @@ interface ProgrammingQuestionData {
   timeLimit?: number;
   attemptLimit?: number;
   fileSubmission: boolean;
+  autoGradable: boolean;
   isCodaveri: boolean;
   liveFeedbackEnabled: boolean;
 }

--- a/client/app/types/course/statistics/answer.ts
+++ b/client/app/types/course/statistics/answer.ts
@@ -1,4 +1,4 @@
-import { JobStatus, JobStatusResponse } from 'types/jobs';
+import { JobStatus } from 'types/jobs';
 import { UserBasicListData } from 'types/users';
 
 import { QuestionType } from '../assessment/question';
@@ -10,7 +10,6 @@ import {
 import {
   ProgrammingFieldData,
   TestCaseResult,
-  TestCaseType,
 } from '../assessment/submission/answer/programming';
 import { ScribingFieldData } from '../assessment/submission/answer/scribing';
 import {
@@ -70,7 +69,7 @@ export interface Post {
 }
 
 export interface TestCase {
-  canReadTests: boolean;
+  questionId?: number;
   public_test?: TestCaseResult[];
   private_test?: TestCaseResult[];
   evaluation_test?: TestCaseResult[];
@@ -88,20 +87,17 @@ export interface CodaveriFeedback {
 export interface ProgrammingAnswerDetails
   extends AnswerCommonDetails<'Programming'> {
   fields: ProgrammingFieldData;
-  explanation: {
-    correct?: boolean;
-    explanation: string[];
-    failureType: TestCaseType;
-  };
-  testCases: TestCase;
-  attemptsLeft?: number;
-  autograding?: JobStatusResponse & {
-    path?: string;
-  };
+  // Tests might not be present (e.g. no autograding)
+  testCases: TestCase[];
   codaveriFeedback?: CodaveriFeedback;
-  latestAnswer?: ProgrammingAnswerDetails & {
-    annotations: Annotation[];
-  };
+  annotations: Annotation[];
+  posts: Post[];
+}
+export interface ProcessedProgrammingAnswerDetails
+  extends AnswerCommonDetails<'Programming'> {
+  fields: ProgrammingFieldData;
+  testCases: TestCase;
+  codaveriFeedback?: CodaveriFeedback;
   annotations: Annotation[];
   posts: Post[];
 }
@@ -167,6 +163,19 @@ export interface AnswerDetailsMap {
   MultipleChoice: McqAnswerDetails;
   MultipleResponse: MrqAnswerDetails;
   Programming: ProgrammingAnswerDetails;
+  TextResponse: TextResponseAnswerDetails;
+  FileUpload: FileUploadAnswerDetails;
+  Comprehension: ComprehensionAnswerDetails;
+  Scribing: ScribingAnswerDetails;
+  VoiceResponse: VoiceResponseAnswerDetails;
+  ForumPostResponse: ForumPostResponseAnswerDetails;
+}
+
+// Currently, only ProgrammingAnswerDetails is processed
+export interface ProcessedAnswerDetailsMap {
+  MultipleChoice: McqAnswerDetails;
+  MultipleResponse: MrqAnswerDetails;
+  Programming: ProcessedProgrammingAnswerDetails;
   TextResponse: TextResponseAnswerDetails;
   FileUpload: FileUploadAnswerDetails;
   Comprehension: ComprehensionAnswerDetails;

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -118,19 +118,19 @@ export interface SubmissionQuestionDetails {
   comments: CommentItem[];
 }
 
-export type QuestionDetails<T extends keyof typeof QuestionType> =
+export type Question<T extends keyof typeof QuestionType> =
   QuestionBasicDetails<T> & SpecificQuestionDataMap[T];
 
-export type AnswerStatisticsData<T extends keyof typeof QuestionType> =
+export type Answer<T extends keyof typeof QuestionType> =
   AnswerDetailsMap[T] & {
     createdAt: Date;
-    question: QuestionDetails<T>;
+    question: Question<T>;
   };
 
 export interface QuestionAnswerDisplayDetails<
   T extends keyof typeof QuestionType,
 > {
-  question: QuestionDetails<T>;
+  question: Question<T>;
   answer: AnswerDetailsMap[T];
 }
 

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -108,7 +108,7 @@ export interface CommentItem {
 
 export interface AllAnswerItem {
   id: number;
-  createdAt: Date;
+  submittedAt: Date;
   currentAnswer: boolean;
   workflowState: WorkflowState;
 }
@@ -123,7 +123,7 @@ export type Question<T extends keyof typeof QuestionType> =
 
 export type Answer<T extends keyof typeof QuestionType> =
   AnswerDetailsMap[T] & {
-    createdAt: Date;
+    submittedAt: Date;
     question: Question<T>;
   };
 

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -3,7 +3,7 @@ import { SpecificQuestionDataMap } from '../assessment/submission/question/types
 import { WorkflowState } from '../assessment/submission/submission';
 import { CourseUserBasicListData } from '../courseUsers';
 
-import { AnswerDetailsMap } from './answer';
+import { AnswerDetailsMap, ProcessedAnswerDetailsMap } from './answer';
 
 interface AssessmentInfo {
   id: number;
@@ -113,8 +113,15 @@ export interface AllAnswerItem {
   workflowState: WorkflowState;
 }
 
+export type ProcessedAnswer<T extends keyof typeof QuestionType> =
+  ProcessedAnswerDetailsMap[T] & {
+    submittedAt: Date;
+    question: Question<T>;
+  };
+
 export interface SubmissionQuestionDetails {
-  allAnswers: AllAnswerItem[];
+  allAnswers: Answer<keyof typeof QuestionType>[];
+  allQuestions: Question<keyof typeof QuestionType>[];
   comments: CommentItem[];
 }
 
@@ -131,7 +138,7 @@ export interface QuestionAnswerDisplayDetails<
   T extends keyof typeof QuestionType,
 > {
   question: Question<T>;
-  answer: AnswerDetailsMap[T];
+  answer: ProcessedAnswer<T>;
 }
 
 export interface AssessmentLiveFeedbackStatistics {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -447,8 +447,6 @@ Rails.application.routes.draw do
         get 'course/performance' => 'aggregate#course_performance'
         get 'submissions/:submission_id/questions/:question_id' => 'answers#all_answers'
         get 'user/:user_id/learning_rate_records' => 'users#learning_rate_records'
-        get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
-        get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
         get 'assessment/:id/live_feedback_statistics' => 'assessments#live_feedback_statistics'
         get 'assessment/:id/live_feedback_history' => 'assessments#live_feedback_history'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,6 +441,8 @@ Rails.application.routes.draw do
         get 'answers/:id' => 'answers#show'
         get 'assessments' => 'aggregate#all_assessments'
         get 'assessments/download' => 'aggregate#download_score_summary'
+        get 'assessment/:id/main_statistics' => 'assessments#main_statistics'
+        get 'assessment/:id/ancestor_statistics' => 'assessments#ancestor_statistics'
         get 'students' => 'aggregate#all_students'
         get 'staff' => 'aggregate#all_staff'
         get 'course/progression' => 'aggregate#course_progression'

--- a/db/migrate/20240924091355_add_parent_id_for_programming.rb
+++ b/db/migrate/20240924091355_add_parent_id_for_programming.rb
@@ -1,0 +1,13 @@
+class AddParentIdForProgramming < ActiveRecord::Migration[7.0]
+  def change
+    add_column :course_assessment_answer_programming_auto_gradings, :parent_id, :integer
+     # Manual definition of name is needed because default name is too long
+    add_index :course_assessment_answer_programming_auto_gradings, :parent_id, name: 'index_ca_answer_programming_auto_gradings_on_parent_id'  
+    add_foreign_key :course_assessment_answer_programming_auto_gradings, :course_assessment_answer_programming_auto_gradings, column: :parent_id
+
+    add_column :course_assessment_question_programming, :parent_id, :integer
+    # Manual definition of name is needed because default name is too long
+    add_index :course_assessment_question_programming, :parent_id, name: 'index_ca_question_programming_on_parent_id'
+    add_foreign_key :course_assessment_question_programming, :course_assessment_question_programming, column: :parent_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,6 +141,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
     t.text "stdout"
     t.text "stderr"
     t.integer "exit_code"
+    t.integer "parent_id"
+    t.index ["parent_id"], name: "index_ca_answer_programming_auto_gradings_on_parent_id"
   end
 
   create_table "course_assessment_answer_programming_file_annotations", id: :serial, force: :cascade do |t|
@@ -315,8 +317,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
     t.boolean "live_feedback_enabled", default: false, null: false
     t.string "live_feedback_custom_prompt", default: "", null: false
     t.boolean "is_synced_with_codaveri", default: false, null: false
+    t.integer "parent_id"
     t.index ["import_job_id"], name: "index_course_assessment_question_programming_on_import_job_id", unique: true
     t.index ["language_id"], name: "fk__course_assessment_question_programming_language_id"
+    t.index ["parent_id"], name: "index_ca_question_programming_on_parent_id"
   end
 
   create_table "course_assessment_question_programming_template_files", id: :serial, force: :cascade do |t|
@@ -1489,6 +1493,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
   add_foreign_key "course_assessment_answer_multiple_response_options", "course_assessment_answer_multiple_responses", column: "answer_id", name: "fk_course_assessment_answer_multiple_response_options_answer_id"
   add_foreign_key "course_assessment_answer_multiple_response_options", "course_assessment_question_multiple_response_options", column: "option_id", name: "fk_course_assessment_answer_multiple_response_options_option_id"
   add_foreign_key "course_assessment_answer_programming", "jobs", column: "codaveri_feedback_job_id", on_delete: :nullify
+  add_foreign_key "course_assessment_answer_programming_auto_gradings", "course_assessment_answer_programming_auto_gradings", column: "parent_id"
   add_foreign_key "course_assessment_answer_programming_file_annotations", "course_assessment_answer_programming_files", column: "file_id", name: "fk_course_assessment_answer_ed21459e7a2a5034dcf43a14812cb17d"
   add_foreign_key "course_assessment_answer_programming_files", "course_assessment_answer_programming", column: "answer_id", name: "fk_course_assessment_answer_programming_files_answer_id"
   add_foreign_key "course_assessment_answer_programming_test_results", "course_assessment_answer_programming_auto_gradings", column: "auto_grading_id", name: "fk_course_assessment_answer_e3d785447112439bb306849be8690102"
@@ -1515,6 +1520,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
   add_foreign_key "course_assessment_question_bundles", "course_assessment_question_groups", column: "group_id"
   add_foreign_key "course_assessment_question_groups", "course_assessments", column: "assessment_id"
   add_foreign_key "course_assessment_question_multiple_response_options", "course_assessment_question_multiple_responses", column: "question_id", name: "fk_course_assessment_question_multiple_response_options_questio"
+  add_foreign_key "course_assessment_question_programming", "course_assessment_question_programming", column: "parent_id"
   add_foreign_key "course_assessment_question_programming", "jobs", column: "import_job_id", name: "fk_course_assessment_question_programming_import_job_id", on_delete: :nullify
   add_foreign_key "course_assessment_question_programming", "polyglot_languages", column: "language_id", name: "fk_course_assessment_question_programming_language_id"
   add_foreign_key "course_assessment_question_programming_template_files", "course_assessment_question_programming", column: "question_id", name: "fk_course_assessment_questi_0788633b496294e558f55f2b41bc7c45"

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -154,14 +154,18 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
         end
       end
 
-      context 'when the question cannot be saved' do
-        let(:programming_question) { immutable_programming_question }
+      # Test case commented out as it is not relevant
+      # Updating will duplicate the question.
+      # Any restrictions (such as an auto grading taking place) will not block execution
 
-        it 'returns bad request' do
-          subject
-          expect(response).to have_http_status(:bad_request)
-        end
-      end
+      # context 'when the question cannot be saved' do
+      #   let(:programming_question) { immutable_programming_question }
+
+      #   it 'returns bad request' do
+      #     subject
+      #     expect(response).to have_http_status(:bad_request)
+      #   end
+      # end
 
       context 'when attaching a template package' do
         include Rails.application.routes.url_helpers

--- a/spec/controllers/course/statistics/answers_controller_spec.rb
+++ b/spec/controllers/course/statistics/answers_controller_spec.rb
@@ -24,19 +24,19 @@ RSpec.describe Course::Statistics::AnswersController, type: :controller do
             params: { course_id: course, submission_id: answer.submission_id, question_id: answer.question_id }
       end
 
-      context 'when the Normal User get the question answer details for the statistics' do
+      context 'when the Normal User get the attempts for the statistics' do
         let(:user) { create(:user) }
         before { controller_sign_in(controller, user) }
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
 
-      context 'when the Course Student get the question answer details for the statistics' do
+      context 'when the Course Student get the attempts for the statistics' do
         let(:user) { create(:course_student, course: course).user }
         before { controller_sign_in(controller, user) }
         it { expect { subject }.to raise_exception(CanCan::AccessDenied) }
       end
 
-      context 'when the Course Manager get the question answer details for the statistics' do
+      context 'when the Course Manager get the attempts for the statistics' do
         let(:user) { create(:course_manager, course: course).user }
         before { controller_sign_in(controller, user) }
 

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -166,10 +166,11 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management', js: tru
       end
 
       scenario 'I can edit a question without updating the programming package' do
-        question = create(:course_assessment_question_programming, assessment: assessment)
+        programming_question = create(:course_assessment_question_programming, assessment: assessment)
+        question = programming_question.acting_as
         visit course_assessment_path(course, assessment)
 
-        edit_path = edit_course_assessment_question_programming_path(course, assessment, question)
+        edit_path = edit_course_assessment_question_programming_path(course, assessment, programming_question)
         find_link(nil, href: edit_path).click
 
         maximum_grade = 999.9

--- a/spec/features/course/assessment/question/programming_management_spec.rb
+++ b/spec/features/course/assessment/question/programming_management_spec.rb
@@ -118,13 +118,15 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management', js: tru
       end
 
       scenario 'I can upload a template package' do
-        question = create(:course_assessment_question_programming,
-                          assessment: assessment, template_file_count: 0, package_type: :zip_upload)
+        programming_question = create(:course_assessment_question_programming,
+                                      assessment: assessment, template_file_count: 0, package_type: :zip_upload)
+
+        question = programming_question.acting_as
 
         empty_package = File.join(file_fixture_path, 'course/empty_programming_question_template.zip')
         valid_package = File.join(file_fixture_path, 'course/programming_question_template.zip')
 
-        visit edit_course_assessment_question_programming_path(course, assessment, question)
+        visit edit_course_assessment_question_programming_path(course, assessment, programming_question)
         find('span', text: 'Evaluate and test code').click
 
         attach_file(empty_package) do
@@ -151,14 +153,16 @@ RSpec.describe 'Course: Assessments: Questions: Programming Management', js: tru
 
         expect(page).to have_current_path(course_assessment_path(course, assessment))
 
-        visit edit_course_assessment_question_programming_path(course, assessment, question)
+        programming_question = question.reload.actable
+
+        visit edit_course_assessment_question_programming_path(course, assessment, programming_question)
         expect(page).to have_text('success')
 
-        question.template_files.reload.each do |template|
+        programming_question.template_files.reload.each do |template|
           expect(page).to have_text(template.filename)
         end
 
-        question.test_cases.reload.each do |test_case|
+        programming_question.test_cases.reload.each do |test_case|
           expect(page).to have_text(test_case[:expression])
           expect(page).to have_text(test_case[:expected])
           expect(page).to have_text(test_case[:hint])


### PR DESCRIPTION
## Motivation

**Old Behavior** - When question is updated and regrading is triggered, there was no preservation of the:
1. Previous question state
2. Previous test case evaluations

This resulted in a dilemma when randomness in test cases (such as in machine learning) resulted in a student failing test cases that were previously passing


## Details

<img width="1453" alt="image" src="https://github.com/user-attachments/assets/65f6d925-fe71-482e-8a44-a6d6275e1208">

- parentId added to `course_assessment_question_programming` and `course_assessment_answer_programming_auto_gradings`
- All evaluation data is preserved now
- Old evaluations and there corresponding questions can be accessed via the parentId