### PR TITLE
Fix: Display custom error page when folder is missing in course materials

### DIFF
--- a/app/controllers/course/material/materials_controller.rb
+++ b/app/controllers/course/material/materials_controller.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 class Course::Material::MaterialsController < Course::Material::Controller
-  load_and_authorize_resource :material, through: :folder, class: 'Course::Material'
+  load_and_authorize_resource :material, through: :folder, class: 'Course::Material', except: :load_default
+
+  def load_default
+    @folder = Course::Material::Folder.where(course_id: current_course.id, parent_id: nil).order(:created_at).first
+    if @folder
+      render json: @folder, status: :ok
+    else
+      render json: { error: 'No folders available' }, status: :not_found
+    end
+  end
 
   def show
     authorize!(:read_owner, @material.folder)

--- a/client/app/api/course/Materials.ts
+++ b/client/app/api/course/Materials.ts
@@ -3,6 +3,8 @@ import { FileListData } from 'types/course/material/files';
 
 import { APIResponse } from 'api/types';
 
+import { FolderMiniEntity } from '../../types/course/material/folders';
+
 import BaseCourseAPI from './Base';
 
 const getShouldDownloadFromContentDisposition = (
@@ -15,14 +17,22 @@ const getShouldDownloadFromContentDisposition = (
 };
 
 export default class MaterialsAPI extends BaseCourseAPI {
+  get #materialPrefix(): string {
+    return `/courses/${this.courseId}/materials`;
+  }
+
   get #urlPrefix(): string {
-    return `/courses/${this.courseId}/materials/folders`;
+    return `${this.#materialPrefix}/folders`;
   }
 
   fetch(folderId: number, materialId: number): APIResponse<FileListData> {
     return this.client.get(
       `${this.#urlPrefix}/${folderId}/files/${materialId}`,
     );
+  }
+
+  fetchDefault(): APIResponse<FolderMiniEntity> {
+    return this.client.get(`${this.#materialPrefix}/load_default`);
   }
 
   /**

--- a/client/app/bundles/course/material/component/BaseRetrieveMaterialPage.tsx
+++ b/client/app/bundles/course/material/component/BaseRetrieveMaterialPage.tsx
@@ -3,15 +3,15 @@ import { Typography } from '@mui/material';
 
 import Page from 'lib/components/core/layouts/Page';
 
-interface BaseDownloadFilePageProps {
+interface BaseRetrieveMaterialPageProps {
   illustration: ReactNode;
   title: string;
   description: string;
   children?: ReactNode;
 }
 
-const BaseDownloadFilePage = (
-  props: BaseDownloadFilePageProps,
+const BaseRetrieveMaterialPage = (
+  props: BaseRetrieveMaterialPageProps,
 ): JSX.Element => (
   <Page className="h-full m-auto flex flex-col items-center justify-center text-center">
     {props.illustration}
@@ -32,4 +32,4 @@ const BaseDownloadFilePage = (
   </Page>
 );
 
-export default BaseDownloadFilePage;
+export default BaseRetrieveMaterialPage;

--- a/client/app/bundles/course/material/files/DownloadingFilePage.tsx
+++ b/client/app/bundles/course/material/files/DownloadingFilePage.tsx
@@ -10,7 +10,7 @@ import Link from 'lib/components/core/Link';
 import useEffectOnce from 'lib/hooks/useEffectOnce';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import BaseDownloadFilePage from './components/BaseDownloadFilePage';
+import BaseRetrieveMaterialPage from '../component/BaseRetrieveMaterialPage';
 
 const DEFAULT_FILE_NAME = 'file';
 
@@ -51,7 +51,7 @@ const SuccessDownloadingFilePage = (
   const { t } = useTranslation();
 
   return (
-    <BaseDownloadFilePage
+    <BaseRetrieveMaterialPage
       description={t(translations.downloadingDescription)}
       illustration={
         <DownloadingOutlined className="text-[6rem]" color="success" />
@@ -61,7 +61,7 @@ const SuccessDownloadingFilePage = (
       <Link className="mt-10" href={props.url}>
         {t(translations.tryDownloadingAgain)}
       </Link>
-    </BaseDownloadFilePage>
+    </BaseRetrieveMaterialPage>
   );
 };
 
@@ -71,7 +71,7 @@ const ErrorStartingDownloadFilePage = (
   const { t } = useTranslation();
 
   return (
-    <BaseDownloadFilePage
+    <BaseRetrieveMaterialPage
       description={t(translations.clickToDownloadFileDescription)}
       illustration={
         <div className="relative">
@@ -93,7 +93,7 @@ const ErrorStartingDownloadFilePage = (
       >
         {props.name}
       </Button>
-    </BaseDownloadFilePage>
+    </BaseRetrieveMaterialPage>
   );
 };
 

--- a/client/app/bundles/course/material/files/ErrorRetrievingFilePage.tsx
+++ b/client/app/bundles/course/material/files/ErrorRetrievingFilePage.tsx
@@ -5,7 +5,7 @@ import { Cancel, InsertDriveFileOutlined } from '@mui/icons-material';
 import Link from 'lib/components/core/Link';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import BaseDownloadFilePage from './components/BaseDownloadFilePage';
+import BaseRetrieveMaterialPage from '../component/BaseRetrieveMaterialPage';
 
 const translations = defineMessages({
   problemRetrievingFile: {
@@ -30,7 +30,7 @@ const ErrorRetrievingFilePage = (): JSX.Element => {
   const workbinURL = `/courses/${params.courseId}/materials/folders/${params.folderId}`;
 
   return (
-    <BaseDownloadFilePage
+    <BaseRetrieveMaterialPage
       description={t(translations.problemRetrievingFileDescription)}
       illustration={
         <div className="relative">
@@ -47,7 +47,7 @@ const ErrorRetrievingFilePage = (): JSX.Element => {
       <Link className="mt-10" to={workbinURL}>
         {t(translations.goToTheWorkbin)}
       </Link>
-    </BaseDownloadFilePage>
+    </BaseRetrieveMaterialPage>
   );
 };
 

--- a/client/app/bundles/course/material/folderLoader.ts
+++ b/client/app/bundles/course/material/folderLoader.ts
@@ -1,0 +1,15 @@
+import { LoaderFunction, redirect } from 'react-router-dom';
+import { getIdFromUnknown } from 'utilities';
+
+import CourseAPI from 'api/course';
+
+const folderLoader: LoaderFunction = async ({ params }) => {
+  const folderId = getIdFromUnknown(params?.folderId);
+  if (!folderId) return redirect('/');
+
+  const { data } = await CourseAPI.folders.fetch(folderId);
+
+  return data;
+};
+
+export default folderLoader;

--- a/client/app/bundles/course/material/folders/operations.ts
+++ b/client/app/bundles/course/material/folders/operations.ts
@@ -1,5 +1,6 @@
 import { Operation } from 'store';
 import {
+  FolderData,
   FolderFormData,
   MaterialFormData,
   MaterialUploadFormData,
@@ -62,20 +63,20 @@ const formatMaterialAttributes = (data: MaterialFormData): FormData => {
   return payload;
 };
 
-export function loadFolder(folderId: number): Operation<SaveFolderAction> {
-  return async (dispatch) =>
-    CourseAPI.folders.fetch(folderId).then((response) => {
-      const data = response.data;
-      return dispatch(
-        actions.saveFolder(
-          data.currFolderInfo,
-          data.subfolders,
-          data.materials,
-          data.advanceStartAt,
-          data.permissions,
-        ),
-      );
-    });
+export function dispatchFolderData(
+  data: FolderData,
+): Operation<SaveFolderAction> {
+  return async (dispatch) => {
+    return dispatch(
+      actions.saveFolder(
+        data.currFolderInfo,
+        data.subfolders,
+        data.materials,
+        data.advanceStartAt,
+        data.permissions,
+      ),
+    );
+  };
 }
 
 export function createFolder(

--- a/client/app/bundles/course/material/folders/pages/ErrorRetrievingFolderPage.tsx
+++ b/client/app/bundles/course/material/folders/pages/ErrorRetrievingFolderPage.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
+import { Cancel, FolderOutlined } from '@mui/icons-material';
+
+import { loadDefaultMaterialId } from 'course/material/folders/handles';
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import BaseRetrieveMaterialPage from '../../component/BaseRetrieveMaterialPage';
+
+const translations = defineMessages({
+  problemRetrievingFolder: {
+    id: 'course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolder',
+    defaultMessage: 'Problem retrieving folder',
+  },
+  problemRetrievingFolderDescription: {
+    id: 'course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolderDescription',
+    defaultMessage:
+      "Either it no longer exists, you don't have the permission to access it, or something unexpected happened when we were trying to retrieve it.",
+  },
+  goToTheWorkbin: {
+    id: 'course.material.folders.ErrorRetrievingFolderPage.goToTheWorkbin',
+    defaultMessage: 'Go to the Workbin',
+  },
+});
+
+const Illustration = (): JSX.Element => (
+  <div className="relative">
+    <FolderOutlined className="text-[6rem]" color="disabled" />
+    <Cancel
+      className="absolute bottom-0 -right-2 text-[4rem] bg-white rounded-full"
+      color="error"
+    />
+  </div>
+);
+
+const useWorkbinURL = (courseId: string | undefined): string => {
+  const [workbinURL, setWorkbinURL] = useState(`/courses/${courseId}`);
+
+  useEffect(() => {
+    if (courseId) {
+      loadDefaultMaterialId().then((defaultMaterialId) => {
+        setWorkbinURL(
+          `/courses/${courseId}/materials/folders/${defaultMaterialId}`,
+        );
+      });
+    }
+  }, [courseId]);
+
+  return workbinURL;
+};
+
+const ErrorRetrievingFolderPage = (): JSX.Element => {
+  const { t } = useTranslation();
+  const params = useParams();
+  const workbinURL = useWorkbinURL(params.courseId);
+
+  return (
+    <BaseRetrieveMaterialPage
+      description={t(translations.problemRetrievingFolderDescription)}
+      illustration={<Illustration />}
+      title={t(translations.problemRetrievingFolder)}
+    >
+      <Link className="mt-10" to={workbinURL}>
+        {t(translations.goToTheWorkbin)}
+      </Link>
+    </BaseRetrieveMaterialPage>
+  );
+};
+
+export default ErrorRetrievingFolderPage;

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactElement, useEffect, useState } from 'react';
 import { defineMessages } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useLoaderData, useParams } from 'react-router-dom';
 
 import EditButton from 'lib/components/core/buttons/EditButton';
 import Page from 'lib/components/core/layouts/Page';
@@ -10,12 +10,13 @@ import { getCourseId } from 'lib/helpers/url-helpers';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
+import { FolderData } from '../../../../../../types/course/material/folders';
 import DownloadFolderButton from '../../components/buttons/DownloadFolderButton';
 import NewSubfolderButton from '../../components/buttons/NewSubfolderButton';
 import UploadFilesButton from '../../components/buttons/UploadFilesButton';
 import MaterialUpload from '../../components/misc/MaterialUpload';
 import WorkbinTable from '../../components/tables/WorkbinTable';
-import { loadFolder } from '../../operations';
+import { dispatchFolderData } from '../../operations';
 import {
   getCurrFolderInfo,
   getFolderMaterials,
@@ -48,13 +49,16 @@ const FolderShow: FC = () => {
   const materials = useAppSelector(getFolderMaterials);
   const currFolderInfo = useAppSelector(getCurrFolderInfo);
   const permissions = useAppSelector(getFolderPermissions);
+  const loaderData = useLoaderData() as FolderData;
 
   const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
-    if (folderId) {
-      dispatch(loadFolder(+folderId)).finally(() => setIsLoading(false));
+    if (loaderData) {
+      dispatch(dispatchFolderData(loaderData)).finally(() =>
+        setIsLoading(false),
+      );
     }
-  }, [dispatch, folderId]);
+  }, [dispatch, loaderData]);
 
   if (isLoading) {
     return <LoadingIndicator />;

--- a/client/app/routers/AuthenticatedApp.tsx
+++ b/client/app/routers/AuthenticatedApp.tsx
@@ -67,6 +67,7 @@ import LessonPlanShow from 'bundles/course/lesson-plan/pages/LessonPlanShow';
 import LevelsIndex from 'bundles/course/level/pages/LevelsIndex';
 import DownloadingFilePage from 'bundles/course/material/files/DownloadingFilePage';
 import ErrorRetrievingFilePage from 'bundles/course/material/files/ErrorRetrievingFilePage';
+import ErrorRetrievingFolderPage from 'bundles/course/material/folders/pages/ErrorRetrievingFolderPage';
 import FolderShow from 'bundles/course/material/folders/pages/FolderShow';
 import TimelineDesigner from 'bundles/course/reference-timelines/TimelineDesigner';
 import ResponseEdit from 'bundles/course/survey/pages/ResponseEdit';
@@ -127,6 +128,7 @@ import {
   forumTopicHandle,
 } from 'course/forum/handles';
 import { leaderboardHandle } from 'course/leaderboard/handles';
+import folderLoader from 'course/material/folderLoader';
 import { folderHandle } from 'course/material/folders/handles';
 import materialLoader from 'course/material/materialLoader';
 import { videoWatchHistoryHandle } from 'course/statistics/handles';
@@ -221,7 +223,9 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
               children: [
                 {
                   index: true,
+                  loader: folderLoader,
                   element: <FolderShow />,
+                  errorElement: <ErrorRetrievingFolderPage />,
                 },
                 {
                   path: 'files/:materialId',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,6 +410,7 @@ Rails.application.routes.draw do
       end
 
       namespace :material, path: 'materials' do
+        get 'load_default', to: 'materials#load_default'
         resources :folders, except: [:index, :new, :create] do
           post 'create/subfolder', on: :member, as: 'create_subfolder', action: 'create_subfolder'
           put 'upload_materials', on: :member

--- a/spec/controllers/course/material/materials_controller_spec.rb
+++ b/spec/controllers/course/material/materials_controller_spec.rb
@@ -17,6 +17,25 @@ RSpec.describe Course::Material::MaterialsController, type: :controller do
 
     before { controller_sign_in(controller, user) }
 
+    describe '#load_default' do
+      context 'when a folder is found' do
+        it 'renders the folder as JSON with status :ok' do
+          get :load_default, params: { course_id: course.id }
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to be_empty
+        end
+      end
+
+      context 'when no folders are available' do
+        before { Course::Material::Folder.where(course_id: course.id).destroy_all }
+
+        it 'renders an error message with status :not_found' do
+          get :load_default, params: { course_id: course.id }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
     describe '#show' do
       let(:material) { create(:material, folder: folder) }
       subject { get :show, params: { course_id: course, folder_id: folder, id: material } }


### PR DESCRIPTION
This pull request fixes the issue where a default 404 page was shown when a folder was missing in the course materials section. Now, a custom error page is displayed instead. This resolves [Issue #7437](https://github.com/Coursemology/coursemology2/issues/7437), which was raised to improve user experience by providing a more informative error message when materials are not found.