### PR TITLE
Second Enhancement of Koditsu Features in Coursemology

### DIFF
--- a/app/controllers/concerns/course/assessment/koditsu_assessment_concern.rb
+++ b/app/controllers/concerns/course/assessment/koditsu_assessment_concern.rb
@@ -35,15 +35,7 @@ module Course::Assessment::KoditsuAssessmentConcern
             { status: get_question_status, body: questions }
     end
 
-    existing_questions_hash = @assessment.questions.
-                              select(&:koditsu_question_id).
-                              to_h { |question| [question.koditsu_question_id, true] }
-
-    new_questions = questions.filter do |question|
-      existing_questions_hash[question['id']]
-    end
-
-    status = edit_koditsu_assessment(@assessment, new_questions, current_course, monitoring_configuration)
+    status = edit_koditsu_assessment(@assessment, questions, current_course, monitoring_configuration)
 
     @assessment.update!(is_synced_with_koditsu: status == 200)
   end
@@ -54,6 +46,10 @@ module Course::Assessment::KoditsuAssessmentConcern
     else
       create_assessment_in_koditsu
     end
+  end
+
+  def flag_assessment_not_synced_with_koditsu
+    @assessment.update!(is_synced_with_koditsu: false)
   end
 
   def remove_question_from_assessment_in_koditsu(question_id)

--- a/app/controllers/concerns/course/koditsu_workspace_concern.rb
+++ b/app/controllers/concerns/course/koditsu_workspace_concern.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Course::KoditsuWorkspaceConcern
+  extend ActiveSupport::Concern
+
+  def setup_koditsu_workspace
+    workspace_service = Course::KoditsuWorkspaceService.new(current_course)
+    response = workspace_service.run_create_koditsu_workspace_service
+
+    workspace_id = response['id']
+    current_course.update!(koditsu_workspace_id: workspace_id)
+  end
+end

--- a/app/controllers/course/admin/component_settings_controller.rb
+++ b/app/controllers/course/admin/component_settings_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Course::Admin::ComponentSettingsController < Course::Admin::Controller
+  include Course::KoditsuWorkspaceConcern
   before_action :load_settings
 
   def edit
@@ -22,14 +23,6 @@ class Course::Admin::ComponentSettingsController < Course::Admin::Controller
   end
 
   private
-
-  def setup_koditsu_workspace
-    workspace_service = Course::KoditsuWorkspaceService.new(current_course)
-    response = workspace_service.run_create_koditsu_workspace_service
-
-    workspace_id = response['id']
-    current_course.update!(koditsu_workspace_id: workspace_id)
-  end
 
   def settings_components_params
     params.require(:settings_components)

--- a/app/controllers/course/assessment/question/controller.rb
+++ b/app/controllers/course/assessment/question/controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 class Course::Assessment::Question::Controller < Course::Assessment::ComponentController
+  include Course::Assessment::KoditsuAssessmentConcern
   before_action :authorize_assessment
   before_action :authorize_create_question_in_koditsu, only: [:new, :create]
+
+  after_action :flag_not_synced_with_koditsu, only: [:create, :update]
 
   # Use method to build new questions.
   #
@@ -29,6 +32,14 @@ class Course::Assessment::Question::Controller < Course::Assessment::ComponentCo
     raise CanCan::AccessDenied if @assessment.is_koditsu_enabled && is_course_koditsu_enabled
   end
 
+  def flag_not_synced_with_koditsu
+    return unless instance_of?(Course::Assessment::Question::ProgrammingController)
+
+    question = @programming_question.acting_as
+
+    question.update!(is_synced_with_koditsu: false)
+  end
+
   def load_question_assessment_for(question)
     @assessment.question_assessments.find_by!(question: question.acting_as)
   end
@@ -36,6 +47,10 @@ class Course::Assessment::Question::Controller < Course::Assessment::ComponentCo
   def update_skill_ids_if_params_present(question_assessment_params)
     skill_ids_params = question_assessment_params[:skill_ids] unless question_assessment_params[:skill_ids].nil?
     @question_assessment.skill_ids = skill_ids_params unless skill_ids_params.nil?
+  end
+
+  def destroy
+    flag_assessment_not_synced_with_koditsu
   end
 
   protected

--- a/app/controllers/course/assessment/question/forum_post_responses_controller.rb
+++ b/app/controllers/course/assessment/question/forum_post_responses_controller.rb
@@ -31,6 +31,8 @@ class Course::Assessment::Question::ForumPostResponsesController < Course::Asses
 
   def destroy
     if @forum_post_response_question.destroy
+      super
+
       head :ok
     else
       error = @forum_post_response_question.errors.full_messages.to_sentence

--- a/app/controllers/course/assessment/question/multiple_responses_controller.rb
+++ b/app/controllers/course/assessment/question/multiple_responses_controller.rb
@@ -40,6 +40,8 @@ class Course::Assessment::Question::MultipleResponsesController < Course::Assess
 
   def destroy
     if @multiple_response_question.destroy
+      super
+
       head :ok
     else
       error = @multiple_response_question.errors.full_messages.to_sentence

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -21,12 +21,8 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
     @programming_question.package_type = programming_question_params.key?(:file) ? :zip_upload : :online_editor
     process_package
 
-    is_course_koditsu_enabled = current_course.component_enabled?(Course::KoditsuPlatformComponent)
-
     if @programming_question.save
       load_question_assessment
-
-      create_question_in_koditsu if is_course_koditsu_enabled && @assessment.is_koditsu_enabled
 
       render_success_json true
     else
@@ -52,13 +48,6 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
       process_package
 
       raise ActiveRecord::Rollback unless @programming_question.save
-
-      @question = @programming_question.acting_as
-      @question.update!(is_synced_with_koditsu: false)
-
-      is_course_koditsu_enabled = current_course.component_enabled?(Course::KoditsuPlatformComponent)
-
-      edit_koditsu_question if is_course_koditsu_enabled && @assessment.is_koditsu_enabled
 
       true
     end
@@ -120,24 +109,9 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
   end
 
   def destroy
-    koditsu_question_id = @programming_question.acting_as.koditsu_question_id
+    if @programming_question.destroy
+      super
 
-    success = @programming_question.class.transaction do
-      raise ActiveRecord::Rollback unless @programming_question.destroy
-
-      is_course_koditsu_enabled = current_course.component_enabled?(Course::KoditsuPlatformComponent)
-
-      if is_course_koditsu_enabled && @assessment.is_koditsu_enabled
-        @assessment.update!(is_synced_with_koditsu: false)
-        remove_question_from_assessment_in_koditsu(koditsu_question_id)
-
-        delete_koditsu_question(koditsu_question_id)
-      end
-
-      true
-    end
-
-    if success
       head :ok
     else
       error = @programming_question.errors.full_messages.to_sentence

--- a/app/controllers/course/assessment/question/scribing_controller.rb
+++ b/app/controllers/course/assessment/question/scribing_controller.rb
@@ -60,6 +60,8 @@ class Course::Assessment::Question::ScribingController < Course::Assessment::Que
 
   def destroy
     if @scribing_question.destroy
+      super
+
       head :ok
     else
       error = @scribing_question.errors.full_messages.to_sentence

--- a/app/controllers/course/assessment/question/text_responses_controller.rb
+++ b/app/controllers/course/assessment/question/text_responses_controller.rb
@@ -46,6 +46,8 @@ class Course::Assessment::Question::TextResponsesController < Course::Assessment
 
   def destroy
     if @text_response_question.destroy
+      super
+
       head :ok
     else
       error = @text_response_question.errors.full_messages.to_sentence

--- a/app/controllers/course/assessment/question/voice_responses_controller.rb
+++ b/app/controllers/course/assessment/question/voice_responses_controller.rb
@@ -33,6 +33,8 @@ class Course::Assessment::Question::VoiceResponsesController < Course::Assessmen
 
   def destroy
     if @voice_response_question.destroy
+      super
+
       head :ok
     else
       error = @voice_response_question.errors.full_messages.to_sentence

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -278,10 +278,11 @@ class Course::Assessment::Submission::SubmissionsController < # rubocop:disable 
 
   def create_success_response(submission)
     is_course_koditsu_enabled = current_course.component_enabled?(Course::KoditsuPlatformComponent)
-    is_assessment_koditsu_enabled = @assessment.koditsu_assessment_id && @assessment.is_koditsu_enabled
 
-    if is_course_koditsu_enabled && is_assessment_koditsu_enabled
+    if is_course_koditsu_enabled && @assessment.is_koditsu_enabled
       submission.create_new_answers
+      raise KoditsuError unless @assessment.koditsu_assessment_id
+
       redirect_url = KoditsuAsyncApiService.assessment_url(@assessment.koditsu_assessment_id)
     else
       redirect_url = edit_course_assessment_submission_path(current_course, @assessment, submission)

--- a/app/models/course/assessment.rb
+++ b/app/models/course/assessment.rb
@@ -226,6 +226,13 @@ class Course::Assessment < ApplicationRecord
     initialize_duplicate_conditions(duplicator, other)
     self.monitor = duplicator.duplicate(other.monitor)
 
+    # we do creation of Koditsu assessment on-demand, which means that the association
+    # between "other" and its Koditsu assessment is not carried over by duplication
+    # once the duplication succeeds, then Koditsu assessment will be created for the
+    # duplication only if it's necessary
+    self.koditsu_assessment_id = nil
+    self.is_synced_with_koditsu = false
+
     set_duplication_flag
   end
 

--- a/app/services/course/duplication/course_duplication_service.rb
+++ b/app/services/course/duplication/course_duplication_service.rb
@@ -43,6 +43,7 @@ class Course::Duplication::CourseDuplicationService < Course::Duplication::BaseS
       begin
         new_course = duplicator.duplicate(source_course)
         new_course.instance_id = destination_instance_id if destination_instance_id
+        new_course.koditsu_workspace_id = nil
         new_course.save!
 
         duplicator.set_option(:destination_course, new_course)

--- a/client/app/bundles/course/assessment/pages/AssessmentShow/AssessmentShowPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentShow/AssessmentShowPage.tsx
@@ -43,15 +43,19 @@ const AssessmentShowPage = (props: AssessmentShowPageProps): JSX.Element => {
 
   const [syncStatus, setSyncStatus] = useState<
     keyof typeof KODITSU_SYNC_STATUS
-  >(assessment.isSyncedWithKoditsu ? 'Synced' : 'Syncing');
+  >(
+    assessment.isSyncedWithKoditsu
+      ? KODITSU_SYNC_STATUS.Synced
+      : KODITSU_SYNC_STATUS.Syncing,
+  );
 
   useEffect(() => {
     if (isKoditsuIndicatorShown && syncStatus === KODITSU_SYNC_STATUS.Syncing) {
       syncWithKoditsu(assessment.id)
-        .then(() => setSyncStatus('Synced'))
-        .catch(() => setSyncStatus('Failed'));
+        .then(() => setSyncStatus(KODITSU_SYNC_STATUS.Synced))
+        .catch(() => setSyncStatus(KODITSU_SYNC_STATUS.Failed));
     }
-  }, []);
+  }, [syncStatus]);
 
   return (
     <Page
@@ -212,7 +216,11 @@ const AssessmentShowPage = (props: AssessmentShowPageProps): JSX.Element => {
           )}
 
           {assessment.questions.length > 0 && (
-            <QuestionsManager in={assessment.id} of={assessment.questions} />
+            <QuestionsManager
+              in={assessment.id}
+              of={assessment.questions}
+              setSyncStatus={setSyncStatus}
+            />
           )}
         </Subsection>
       )}

--- a/client/app/bundles/course/assessment/pages/AssessmentShow/QuestionsManager.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentShow/QuestionsManager.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
 import { Paper } from '@mui/material';
 import { produce } from 'immer';
 import { AssessmentData } from 'types/course/assessment/assessments';
 import { QuestionData } from 'types/course/assessment/questions';
 
+import { KODITSU_SYNC_STATUS } from 'lib/constants/sharedConstants';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -16,6 +17,7 @@ import Question from './Question';
 interface QuestionsManagerProps {
   in: AssessmentData['id'];
   of: QuestionData[];
+  setSyncStatus: Dispatch<SetStateAction<keyof typeof KODITSU_SYNC_STATUS>>;
 }
 
 const QuestionsManager = (props: QuestionsManagerProps): JSX.Element => {
@@ -36,6 +38,7 @@ const QuestionsManager = (props: QuestionsManagerProps): JSX.Element => {
         success: t(translations.questionMoved),
         error: t(translations.errorMovingQuestion),
       })
+      .then(() => props.setSyncStatus(KODITSU_SYNC_STATUS.Syncing))
       .catch(onError)
       .finally(() => {
         setSubmitting(false);
@@ -68,12 +71,14 @@ const QuestionsManager = (props: QuestionsManagerProps): JSX.Element => {
     moveItemAndUpdate(sourceIndex, destinationIndex);
   };
 
-  const removeQuestion = (index: number) => () =>
+  const removeQuestion = (index: number) => () => {
     setQuestions((currentQuestions) =>
       produce(currentQuestions, (draft) => {
         draft.splice(index, 1);
       }),
     );
+    props.setSyncStatus(KODITSU_SYNC_STATUS.Syncing);
+  };
 
   const updateQuestion = (index: number) => (newQuestion: QuestionData) =>
     setQuestions((currentQuestions) =>

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/StatusBadges.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/StatusBadges.tsx
@@ -44,8 +44,6 @@ const NonStudentStatusBadges = (
         </Tooltip>
       )}
 
-      {assessment.isKoditsuAssessmentEnabled && <KoditsuChip />}
-
       {assessment.autograded && (
         <Tooltip disableInteractive title={t(translations.autograded)}>
           <CheckCircle className="text-3xl text-neutral-500 hover?:text-neutral-600" />
@@ -85,6 +83,8 @@ const StatusBadges = (props: StatusBadgesProps): JSX.Element => {
       )}
 
       {!isStudent && <NonStudentStatusBadges for={assessment} />}
+
+      {assessment.isKoditsuAssessmentEnabled && <KoditsuChip />}
 
       <PersonalTimeBooleanIcons
         affectsPersonalTimes={assessment.affectsPersonalTimes}

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -180,7 +180,7 @@ const translations = defineMessages({
   },
   syncingWithKoditsu: {
     id: 'course.assessment.show.syncingWithKoditsu',
-    defaultMessage: 'Syncing',
+    defaultMessage: 'Syncing with Koditsu',
   },
   syncedWithKoditsu: {
     id: 'course.assessment.show.syncedWithKoditsu',
@@ -188,7 +188,7 @@ const translations = defineMessages({
   },
   failedSyncingWithKoditsu: {
     id: 'course.assessment.show.failedSyncingWithKoditsu',
-    defaultMessage: 'Sync Failed',
+    defaultMessage: 'Not Synced with Koditsu',
   },
   koditsuMode: {
     id: 'course.assessment.show.koditsuMode',


### PR DESCRIPTION
Continuation of this [previously existing PR](https://github.com/Coursemology/coursemology2/pull/7592)

## Changes

### Duplication of Koditsu Entity

In duplicating either Koditsu course, assessment, or question, it's customary that the result of this duplication should not share the Koditsu ID with its origin, since they are basically different entities in Coursemology. Therefore, we did not send the Koditsu ID over duplication i.e. the value of all of `koditsu_workspace_id`, `koditsu_assessment_id`, and `koditsu_question_id` shall be `null`

### Synchronizing with Koditsu done on-demand

The previous implementation to support Koditsu integration was quite convoluted due to the assumption made that everytime we create/update/delete assessments or questions that will be sent over to Koditsu, we need to make its Koditsu counterpart right away. This implementation is simplified in this PR by merely flagging those entities in CM as not synced, then the synchronization will be done when `sync_with_koditsu` is called. Upon further inspection, the redirection to its Assessment Page is indeed done right away after we did create/edit assessments, and also create/edit questions, and thus the sync will be indeed done straight away with this adjustment

### Set to Synchronizing upon Delete/Reorder Questions

Different from create/update question, deleting and reordering questions are done inside the page `AssessmentShow` itself, and the state change was not incurred, leading to the synchronising of the assessment not done straight away (need to refresh). We fix this by invoking state change for `SyncStatus` for assessment after either deleting or reordering questions are done.

### Invoke Error when attempt/resume Koditsu Assessment with null Koditsu ID

To ensure consistency when students put their answer in Koditsu Assessment, we need to ensure that, at all times, students will do their assessment in Koditsu platform if that assessment is proctored using Koditsu. Therefore, should this case occur, we raise an error and then teacher needs to synchronise the assessment properly to Koditsu

## Notes

Currently, reordering questions in Coursemology won't lead to reordering in Koditsu, but it's because of the bug within Koditsu. In this case, we still have the synchronising takes place, and the effect will properly takes place after Koditsu fix the bug. For now, only the ordering of the questions might be inconsistent but other than that, there won't be any bugs in CM caused by this