### PR TITLE
Add email column to CSV download in assessment statistics

### DIFF
--- a/app/controllers/course/statistics/assessments_controller.rb
+++ b/app/controllers/course/statistics/assessments_controller.rb
@@ -72,7 +72,7 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
   end
 
   def load_course_user_students_info
-    @all_students = current_course.course_users.students
+    @all_students = current_course.course_users.students.includes(user: :emails)
     @group_names_hash = group_names_hash
   end
 

--- a/app/views/course/statistics/assessments/_course_user.json.jbuilder
+++ b/app/views/course/statistics/assessments/_course_user.json.jbuilder
@@ -4,4 +4,5 @@ json.courseUser do
   json.name course_user.name
   json.role course_user.role
   json.isPhantom course_user.phantom?
+  json.email course_user.user.email
 end

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
@@ -166,6 +166,17 @@ const LiveFeedbackStatisticsTable: FC<Props> = (props) => {
       csvDownloadable: true,
     },
     {
+      searchProps: {
+        getValue: (datum) => datum.courseUser.email,
+      },
+      title: t(translations.email),
+      hidden: true,
+      cell: (datum) => (
+        <div className="flex grow items-center">{datum.courseUser.email}</div>
+      ),
+      csvDownloadable: true,
+    },
+    {
       of: 'groups',
       title: t(translations.group),
       sortable: true,

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentAttemptCountTable.tsx
@@ -138,6 +138,17 @@ const StudentAttemptCountTable: FC<Props> = (props) => {
       csvDownloadable: true,
     },
     {
+      searchProps: {
+        getValue: (datum) => datum.courseUser.email,
+      },
+      title: t(translations.email),
+      hidden: true,
+      cell: (datum) => (
+        <div className="flex grow items-center">{datum.courseUser.email}</div>
+      ),
+      csvDownloadable: true,
+    },
+    {
       of: 'groups',
       title: t(translations.group),
       sortable: true,

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentMarksPerQuestionTable.tsx
@@ -144,6 +144,17 @@ const StudentMarksPerQuestionTable: FC<Props> = (props) => {
       csvDownloadable: true,
     },
     {
+      searchProps: {
+        getValue: (datum) => datum.courseUser.email,
+      },
+      title: t(translations.email),
+      hidden: true,
+      cell: (datum) => (
+        <div className="flex grow items-center">{datum.courseUser.email}</div>
+      ),
+      csvDownloadable: true,
+    },
+    {
       of: 'groups',
       title: t(translations.group),
       sortable: true,

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/translations.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/translations.ts
@@ -65,6 +65,10 @@ const translations = defineMessages({
     id: 'course.assessment.statistics.name',
     defaultMessage: 'Name',
   },
+  email: {
+    id: 'course.assessment.statistics.email',
+    defaultMessage: 'Email',
+  },
   nameGroupsGraderSearchText: {
     id: 'course.assessment.statistics.nameGroupsGraderSearchText',
     defaultMessage: 'Search by Student Name, Group or Grader Name',

--- a/client/app/lib/components/table/TanStackTableBuilder/csvGenerator.ts
+++ b/client/app/lib/components/table/TanStackTableBuilder/csvGenerator.ts
@@ -5,7 +5,7 @@ import { unparse } from 'papaparse';
 import { ColumnTemplate, Data } from '../builder';
 
 interface CsvGenerator<D extends Data> {
-  headers: () => Header<D, unknown>[];
+  headers: string[];
   rows: () => Row<D>[];
   getRealColumn: (index: number) => ColumnTemplate<D> | undefined;
 }
@@ -14,20 +14,11 @@ const generateCsv = <D extends Data>(
   options: CsvGenerator<D>,
 ): Promise<string> =>
   new Promise((resolve) => {
-    const headers = options.headers().reduce<string[]>((cells, cell, index) => {
-      const realColumn = options.getRealColumn(index);
-      const csvDownloadable = realColumn?.csvDownloadable;
-      if (!csvDownloadable) return cells;
-
-      cells.push(cell.column.columnDef.header?.toString() ?? '');
-      return cells;
-    }, []);
-
-    const rows = [headers];
+    const rows = [options.headers];
 
     options.rows().forEach((row) => {
       const rowData = row
-        .getVisibleCells()
+        .getAllCells()
         .reduce<string[]>((cells, cell, index) => {
           const realColumn = options.getRealColumn(index);
           const csvDownloadable = realColumn?.csvDownloadable;

--- a/client/app/lib/components/table/builder/ColumnTemplate.ts
+++ b/client/app/lib/components/table/builder/ColumnTemplate.ts
@@ -27,6 +27,7 @@ interface ColumnTemplate<D extends Data> {
   sortable?: boolean;
   filterable?: boolean;
   searchable?: boolean;
+  hidden?: boolean;
   csvDownloadable?: boolean;
   filterProps?: FilteringProps<D>;
   csvValue?: (value) => string;

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -30,6 +30,7 @@ interface UserInfo {
 export interface StudentInfo extends UserInfo {
   isPhantom: boolean;
   role: 'student';
+  email?: string;
 }
 
 export interface AnswerInfo {


### PR DESCRIPTION
### Description:
This pull request adds a new column for the primary email of course users in the CSV download from the assessment statistics page (/courses/{course-id}/assessments/{assessment-id}/statistics). The email column is positioned directly after the Name column in the CSV, providing a unique identifier for each user.

### Changes:
Updated the CSV generation logic to include the email column for each courseUser.
The email column is only included in the CSV download and is not displayed in the frontend table to avoid cluttering the UI.
Ensured that the UI remains unchanged, maintaining the current user experience.
Issue Reference:
Resolves [Issue #7607](https://github.com/Coursemology/coursemology2/issues/7607).

### Testing:
Verified that the downloaded CSV now includes the email column for each user.
Confirmed that the statistics page UI remains unchanged and the additional column does not affect the visible table.