### PR TITLE
feat(materials): add 404 folder not found page

### DIFF
--- a/app/controllers/components/course/materials_component.rb
+++ b/app/controllers/components/course/materials_component.rb
@@ -19,7 +19,7 @@ class Course::MaterialsComponent < SimpleDelegator
         icon: :material,
         title: settings.title || t('course.material.sidebar_title'),
         weight: 9,
-        path: course_material_folder_path(current_course, current_course.root_folder)
+        path: course_material_folders_path(current_course)
       }
     ]
   end

--- a/app/controllers/course/material/folders_controller.rb
+++ b/app/controllers/course/material/folders_controller.rb
@@ -1,30 +1,29 @@
 # frozen_string_literal: true
 class Course::Material::FoldersController < Course::Material::Controller
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_not_found
+  skip_load_resource :folder, only: [:index]
   before_action :authorize_read_owner!, only: [:show, :download]
 
+  def index
+    load_root_folder_with_subfolders
+    render 'show' unless performed?
+  end
+
   def show
-    respond_to do |format|
-      format.json do
-        @subfolders = @folder.children.with_content_statistics.accessible_by(current_ability).
-                      order(:name).includes(:owner).without_empty_linked_folder
-        # Don't display the folder if the user cannot access its owner.
-        @subfolders.select! { |f| can?(:read_owner, f) }
-      end
-    end
+    load_subfolders
   end
 
   def update
     if @folder.update(folder_params)
       @folder = @folder.parent || @folder
-      show
-      render 'show', status: :ok
+      load_subfolders
+      render 'show'
     else
       render json: { errors: @folder.errors }, status: :bad_request
     end
   end
 
   def destroy
-    parent_folder = @folder.parent
     if @folder.destroy
       head :ok
     else
@@ -36,8 +35,8 @@ class Course::Material::FoldersController < Course::Material::Controller
     @subfolder = Course::Material::Folder.new(folder_params)
     @subfolder.course = current_course
     if @subfolder.save
-      show
-      render 'show', status: :ok
+      load_subfolders
+      render 'show'
     else
       render json: { errors: @subfolder.errors }, status: :bad_request
     end
@@ -45,20 +44,13 @@ class Course::Material::FoldersController < Course::Material::Controller
 
   def upload_materials
     @materials = @folder.build_materials(files_params[:files_attributes])
-    respond_to do |format|
-      if @folder.save
-        format.json do
-          if params[:render_show]
-            show
-            return render 'show', status: :ok
-          end
-        end
-      else
-        format.json do
-          render json: { errors: @folder.errors.full_messages.to_sentence },
-                 status: :bad_request
-        end
+    if @folder.save
+      if params[:render_show]
+        load_subfolders
+        render 'show'
       end
+    else
+      render json: { errors: @folder.errors.full_messages.to_sentence }, status: :bad_request
     end
   end
 
@@ -67,9 +59,7 @@ class Course::Material::FoldersController < Course::Material::Controller
                  map { |f| f.materials.accessible_by(current_ability) }.flatten
     zip_filename = @folder.root? ? root_folder_name : @folder.name
     job = Course::Material::ZipDownloadJob.perform_later(@folder, @materials, zip_filename).job
-    respond_to do |format|
-      format.json { render partial: 'jobs/submitted', locals: { job: job } }
-    end
+    render partial: 'jobs/submitted', locals: { job: job }
   end
 
   private
@@ -85,5 +75,24 @@ class Course::Material::FoldersController < Course::Material::Controller
 
   def files_params
     params.require(:material_folder).permit(files_attributes: [])
+  end
+
+  def load_subfolders
+    @subfolders = @folder.children.with_content_statistics.accessible_by(current_ability).
+                  order(:name).includes(:owner).without_empty_linked_folder
+    # Don't display the folder if the user cannot access its owner.
+    @subfolders.select! { |f| can?(:read_owner, f) }
+  end
+
+  def load_root_folder_with_subfolders
+    @folder = current_course.root_folder
+    load_subfolders
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Missing root folder' }, status: :not_found
+  end
+
+  def handle_not_found
+    load_root_folder_with_subfolders
+    render 'show', status: :not_found unless performed?
   end
 end

--- a/app/views/course/material/folders/show.json.jbuilder
+++ b/app/views/course/material/folders/show.json.jbuilder
@@ -52,7 +52,7 @@ end
 
 json.breadcrumbs @folder.ancestors.reverse << @folder do |folder|
   json.id folder.id
-  json.name folder.name == 'Root' ? @settings.title || t('course.material.sidebar_title') : folder.name
+  json.name folder.parent_id.nil? ? @settings.title || t('course.material.sidebar_title') : folder.name
 end
 
 json.advanceStartAt current_course.advance_start_at_duration

--- a/client/app/api/course/Material/Folders.ts
+++ b/client/app/api/course/Material/Folders.ts
@@ -12,9 +12,10 @@ export default class FoldersAPI extends BaseCourseAPI {
 
   /**
    * Fetches a folder, along with all its subfolders and materials.
+   * If `folderId` is not provided, fetches the root folder.
    */
-  fetch(folderId: number): APIResponse<FolderData> {
-    return this.client.get(`${this.#urlPrefix}/${folderId}`);
+  fetch(folderId?: number): APIResponse<FolderData> {
+    return this.client.get(`${this.#urlPrefix}/${folderId ?? ''}`);
   }
 
   /**

--- a/client/app/bundles/course/material/components/MaterialStatusPage.tsx
+++ b/client/app/bundles/course/material/components/MaterialStatusPage.tsx
@@ -3,16 +3,14 @@ import { Typography } from '@mui/material';
 
 import Page from 'lib/components/core/layouts/Page';
 
-interface BaseDownloadFilePageProps {
+interface MaterialStatusPageProps {
   illustration: ReactNode;
   title: string;
   description: string;
   children?: ReactNode;
 }
 
-const BaseDownloadFilePage = (
-  props: BaseDownloadFilePageProps,
-): JSX.Element => (
+const MaterialStatusPage = (props: MaterialStatusPageProps): JSX.Element => (
   <Page className="h-full m-auto flex flex-col items-center justify-center text-center">
     {props.illustration}
 
@@ -32,4 +30,4 @@ const BaseDownloadFilePage = (
   </Page>
 );
 
-export default BaseDownloadFilePage;
+export default MaterialStatusPage;

--- a/client/app/bundles/course/material/files/DownloadingFilePage.tsx
+++ b/client/app/bundles/course/material/files/DownloadingFilePage.tsx
@@ -10,7 +10,7 @@ import Link from 'lib/components/core/Link';
 import useEffectOnce from 'lib/hooks/useEffectOnce';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import BaseDownloadFilePage from './components/BaseDownloadFilePage';
+import MaterialStatusPage from '../components/MaterialStatusPage';
 
 const DEFAULT_FILE_NAME = 'file';
 
@@ -51,7 +51,7 @@ const SuccessDownloadingFilePage = (
   const { t } = useTranslation();
 
   return (
-    <BaseDownloadFilePage
+    <MaterialStatusPage
       description={t(translations.downloadingDescription)}
       illustration={
         <DownloadingOutlined className="text-[6rem]" color="success" />
@@ -61,7 +61,7 @@ const SuccessDownloadingFilePage = (
       <Link className="mt-10" href={props.url}>
         {t(translations.tryDownloadingAgain)}
       </Link>
-    </BaseDownloadFilePage>
+    </MaterialStatusPage>
   );
 };
 
@@ -71,7 +71,7 @@ const ErrorStartingDownloadFilePage = (
   const { t } = useTranslation();
 
   return (
-    <BaseDownloadFilePage
+    <MaterialStatusPage
       description={t(translations.clickToDownloadFileDescription)}
       illustration={
         <div className="relative">
@@ -93,7 +93,7 @@ const ErrorStartingDownloadFilePage = (
       >
         {props.name}
       </Button>
-    </BaseDownloadFilePage>
+    </MaterialStatusPage>
   );
 };
 

--- a/client/app/bundles/course/material/files/ErrorRetrievingFilePage.tsx
+++ b/client/app/bundles/course/material/files/ErrorRetrievingFilePage.tsx
@@ -5,7 +5,7 @@ import { Cancel, InsertDriveFileOutlined } from '@mui/icons-material';
 import Link from 'lib/components/core/Link';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import BaseDownloadFilePage from './components/BaseDownloadFilePage';
+import MaterialStatusPage from '../components/MaterialStatusPage';
 
 const translations = defineMessages({
   problemRetrievingFile: {
@@ -30,7 +30,7 @@ const ErrorRetrievingFilePage = (): JSX.Element => {
   const workbinURL = `/courses/${params.courseId}/materials/folders/${params.folderId}`;
 
   return (
-    <BaseDownloadFilePage
+    <MaterialStatusPage
       description={t(translations.problemRetrievingFileDescription)}
       illustration={
         <div className="relative">
@@ -47,7 +47,7 @@ const ErrorRetrievingFilePage = (): JSX.Element => {
       <Link className="mt-10" to={workbinURL}>
         {t(translations.goToTheWorkbin)}
       </Link>
-    </BaseDownloadFilePage>
+    </MaterialStatusPage>
   );
 };
 

--- a/client/app/bundles/course/material/folders/components/tables/TableSubfolderRow.tsx
+++ b/client/app/bundles/course/material/folders/components/tables/TableSubfolderRow.tsx
@@ -52,9 +52,7 @@ const TableSubfolderRow: FC<Props> = (props) => {
                 whiteSpace: 'normal',
                 wordBreak: 'break-word',
               }}
-              to={`/courses/${getCourseId()}/materials/folders/${
-                subfolder.id
-              }/`}
+              to={`/courses/${getCourseId()}/materials/folders/${subfolder.id}`}
               underline="hover"
             >
               {`${subfolder.name} (${subfolder.itemCount})`}

--- a/client/app/bundles/course/material/folders/handles.ts
+++ b/client/app/bundles/course/material/folders/handles.ts
@@ -5,20 +5,18 @@ import { CrumbPath, DataHandle } from 'lib/hooks/router/dynamicNest';
 
 const getFolderTitle = async (
   courseUrl: string,
-  folderId: number,
-): Promise<CrumbPath> => {
-  const { data } = await CourseAPI.folders.fetch(folderId);
-
-  const workbinUrl = `${courseUrl}/materials/folders/${data.breadcrumbs[0].id}`;
-
-  return {
-    activePath: workbinUrl,
-    content: data.breadcrumbs.map((crumb) => ({
-      title: crumb.name,
-      url: `materials/folders/${crumb.id}`,
-    })),
-  };
-};
+  folderId?: number,
+): Promise<CrumbPath> =>
+  CourseAPI.folders
+    .fetch(folderId)
+    .then((response) => response.data.breadcrumbs)
+    .then((breadcrumbs) => ({
+      activePath: `${courseUrl}/materials/folders/${breadcrumbs[0].id}`,
+      content: breadcrumbs.map((crumb) => ({
+        title: crumb.name,
+        url: `materials/folders/${crumb.id}`,
+      })),
+    }));
 
 /**
  * `shouldRevalidate` here relies on the invariant that `folderHandle` is attached to
@@ -33,7 +31,8 @@ const getFolderTitle = async (
  */
 export const folderHandle: DataHandle = (match) => {
   const folderId = getIdFromUnknown(match.params?.folderId);
-  if (!folderId) throw new Error(`Invalid folder id: ${folderId}`);
+  if (match.params?.folderId && !folderId)
+    throw new Error(`Invalid folder id: ${folderId}`);
 
   const courseUrl = `/courses/${match.params.courseId}`;
 

--- a/client/app/bundles/course/material/folders/operations.ts
+++ b/client/app/bundles/course/material/folders/operations.ts
@@ -62,7 +62,7 @@ const formatMaterialAttributes = (data: MaterialFormData): FormData => {
   return payload;
 };
 
-export function loadFolder(folderId: number): Operation<SaveFolderAction> {
+export function loadFolder(folderId?: number): Operation<SaveFolderAction> {
   return async (dispatch) =>
     CourseAPI.folders.fetch(folderId).then((response) => {
       const data = response.data;

--- a/client/app/bundles/course/material/folders/pages/ErrorRetrievingFolderPage.tsx
+++ b/client/app/bundles/course/material/folders/pages/ErrorRetrievingFolderPage.tsx
@@ -1,0 +1,53 @@
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
+import { Cancel, FolderOutlined } from '@mui/icons-material';
+
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+import MaterialStatusPage from '../../components/MaterialStatusPage';
+
+const translations = defineMessages({
+  problemRetrievingFolder: {
+    id: 'course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolder',
+    defaultMessage: 'Problem retrieving folder',
+  },
+  problemRetrievingFolderDescription: {
+    id: 'course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolderDescription',
+    defaultMessage:
+      "Either it no longer exists, you don't have the permission to access it, or something unexpected happened when we were trying to retrieve it.",
+  },
+  goToTheWorkbin: {
+    id: 'course.material.folders.ErrorRetrievingFolderPage.goToMainFolder',
+    defaultMessage: 'Go to the main folder',
+  },
+});
+
+const ErrorRetrievingFolderPage = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  const params = useParams();
+  const workbinURL = `/courses/${params.courseId}/materials/folders`;
+
+  return (
+    <MaterialStatusPage
+      description={t(translations.problemRetrievingFolderDescription)}
+      illustration={
+        <div className="relative">
+          <FolderOutlined className="text-[6rem]" color="disabled" />
+          <Cancel
+            className="absolute bottom-0 -right-2 text-[4rem] bg-white rounded-full"
+            color="error"
+          />
+        </div>
+      }
+      title={t(translations.problemRetrievingFolder)}
+    >
+      <Link className="mt-10" to={workbinURL}>
+        {t(translations.goToTheWorkbin)}
+      </Link>
+    </MaterialStatusPage>
+  );
+};
+
+export default ErrorRetrievingFolderPage;

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -65,6 +65,15 @@ const FolderShow: FC = () => {
 
   const headerToolbars: ReactElement[] = [];
 
+  if (folderId === undefined) {
+    const rootFolderId = currFolderInfo.id;
+    window.history.replaceState(
+      {},
+      '',
+      getWorkbinFolderURL(getCourseId(), rootFolderId),
+    );
+  }
+
   if (currFolderInfo.isConcrete && permissions.canCreateSubfolder) {
     headerToolbars.push(
       <NewSubfolderButton

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -23,6 +23,7 @@ import {
   getFolderPermissions,
   getFolderSubfolders,
 } from '../../selectors';
+import ErrorRetrievingFolderPage from '../ErrorRetrievingFolderPage';
 import FolderEdit from '../FolderEdit';
 import FolderNew from '../FolderNew';
 
@@ -51,15 +52,16 @@ const FolderShow: FC = () => {
   const permissions = useAppSelector(getFolderPermissions);
 
   const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
   useEffect(() => {
-    dispatch(loadFolder(getIdFromUnknown(folderId))).finally(() =>
-      setIsLoading(false),
-    );
+    setIsError(false);
+    dispatch(loadFolder(getIdFromUnknown(folderId)))
+      .catch(() => setIsError(true))
+      .finally(() => setIsLoading(false));
   }, [dispatch, folderId]);
 
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
+  if (isLoading) return <LoadingIndicator />;
+  if (isError) return <ErrorRetrievingFolderPage />;
 
   const headerToolbars: ReactElement[] = [];
 

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactElement, useEffect, useState } from 'react';
 import { defineMessages } from 'react-intl';
 import { useParams } from 'react-router-dom';
+import { getIdFromUnknown } from 'utilities';
 
 import EditButton from 'lib/components/core/buttons/EditButton';
 import Page from 'lib/components/core/layouts/Page';
@@ -51,9 +52,9 @@ const FolderShow: FC = () => {
 
   const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
-    if (folderId) {
-      dispatch(loadFolder(+folderId)).finally(() => setIsLoading(false));
-    }
+    dispatch(loadFolder(getIdFromUnknown(folderId))).finally(() =>
+      setIsLoading(false),
+    );
   }, [dispatch, folderId]);
 
   if (isLoading) {

--- a/client/app/routers/AuthenticatedApp.tsx
+++ b/client/app/routers/AuthenticatedApp.tsx
@@ -217,6 +217,10 @@ const authenticatedRouter: Translated<RouteObject[]> = (t) =>
           // Dynamic Nest API's builder.
           children: [
             {
+              index: true,
+              element: <FolderShow />,
+            },
+            {
               path: ':folderId',
               children: [
                 {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,7 +410,7 @@ Rails.application.routes.draw do
       end
 
       namespace :material, path: 'materials' do
-        resources :folders, except: [:index, :new, :create] do
+        resources :folders, except: [:new, :create] do
           post 'create/subfolder', on: :member, as: 'create_subfolder', action: 'create_subfolder'
           put 'upload_materials', on: :member
           get 'download', on: :member


### PR DESCRIPTION
resolves issue #7437 by showing a 404 screen when visiting non-existent folders instead of an empty materials table  
supersedes PR #7612 

- [x] opens up new /materials/folders route which returns course's root folder data
- [x] when accessing a non-existent folder, 404 screen will appear (similar to non-existent file)
- [x] other minor changes --- add rspec for material folder show, drop trailing slash in folder links in FE