### PR TITLE
Allow Editing and Duplicate On-Demand for Codaveri Questions

### DIFF
--- a/app/controllers/concerns/course/assessment/question/codaveri_question_concern.rb
+++ b/app/controllers/concerns/course/assessment/question/codaveri_question_concern.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Course::Assessment::Question::CodaveriQuestionConcern
+  extend ActiveSupport::Concern
+
+  def safe_create_or_update_codaveri_question(question)
+    question.with_lock do
+      next if question.is_synced_with_codaveri
+
+      # we bypass the processing of the package since this function is called only when
+      # we create the Codaveri question from duplicate on-demand, which means that
+      # the question has already been created; we just need to propagate this question
+      # to Codaveri
+      question.skip_process_package = true
+      Course::Assessment::Question::ProgrammingCodaveriService.
+        create_or_update_question(question, question.attachment)
+    end
+  end
+end

--- a/app/controllers/course/admin/codaveri_settings_controller.rb
+++ b/app/controllers/course/admin/codaveri_settings_controller.rb
@@ -19,21 +19,15 @@ class Course::Admin::CodaveriSettingsController < Course::Admin::Controller
 
   def update_evaluator
     is_codaveri = update_evaluator_params[:programming_evaluator] == 'codaveri'
-    assessments = current_course.assessments.where(id: update_evaluator_params[:assessment_ids])
-    question_ids = assessments.includes(:programming_questions).flat_map do |assessment|
-      assessment.programming_questions.map(&:id)
-    end
-    @programming_questions = Course::Assessment::Question::Programming.where(id: question_ids)
+    @programming_questions = Course::Assessment::Question::Programming.
+                             where(id: update_evaluator_params[:programming_question_ids])
     raise ActiveRecord::Rollback unless @programming_questions.update_all(is_codaveri: is_codaveri)
   end
 
   def update_live_feedback_enabled
     live_feedback_enabled = update_live_feedback_enabled_params[:live_feedback_enabled]
-    assessments = current_course.assessments.where(id: update_live_feedback_enabled_params[:assessment_ids])
-    question_ids = assessments.includes(:programming_questions).flat_map do |assessment|
-      assessment.programming_questions.map(&:id)
-    end
-    @programming_questions = Course::Assessment::Question::Programming.where(id: question_ids)
+    @programming_questions = Course::Assessment::Question::Programming.
+                             where(id: update_live_feedback_enabled_params[:programming_question_ids])
     raise ActiveRecord::Rollback unless @programming_questions.update_all(live_feedback_enabled: live_feedback_enabled)
   end
 
@@ -48,11 +42,11 @@ class Course::Admin::CodaveriSettingsController < Course::Admin::Controller
   end
 
   def update_evaluator_params
-    params.require(:update_evaluator).permit(:programming_evaluator, assessment_ids: [])
+    params.require(:update_evaluator).permit(:programming_evaluator, programming_question_ids: [])
   end
 
   def update_live_feedback_enabled_params
-    params.require(:update_live_feedback_enabled).permit(:live_feedback_enabled, assessment_ids: [])
+    params.require(:update_live_feedback_enabled).permit(:live_feedback_enabled, programming_question_ids: [])
   end
 
   def component

--- a/app/controllers/course/admin/codaveri_settings_controller.rb
+++ b/app/controllers/course/admin/codaveri_settings_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 class Course::Admin::CodaveriSettingsController < Course::Admin::Controller
-  after_action :create_codaveri_problem, only: [:update_evaluator, :update_live_feedback_enabled]
-
   def edit
     load_course_assessments_data
   end
@@ -63,11 +61,5 @@ class Course::Admin::CodaveriSettingsController < Course::Admin::Controller
 
   def load_course_assessments_data
     @assessments_with_programming_qns = current_course.assessments.includes(:tab, programming_questions: [:language])
-  end
-
-  def create_codaveri_problem
-    # Since update_all bypasses all rails callbacks, we invoke create_codaveri_problem here
-    # to ensure codaveri problem is created
-    @programming_questions.each(&:create_codaveri_problem)
   end
 end

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -45,6 +45,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
                                        try(:[], :skill_ids)
       @programming_question.assign_attributes(programming_question_params.
                                               except(:question_assessment))
+      @programming_question.is_synced_with_codaveri = false
       process_package
 
       raise ActiveRecord::Rollback unless @programming_question.save

--- a/app/models/course/assessment/answer/programming.rb
+++ b/app/models/course/assessment/answer/programming.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Course::Assessment::Answer::Programming < ApplicationRecord
+  include Course::Assessment::Question::CodaveriQuestionConcern
   # The table name for this model is singular.
   self.table_name = table_name.singularize
 
@@ -99,6 +100,8 @@ class Course::Assessment::Answer::Programming < ApplicationRecord
                                question.live_feedback_enabled
     return unless should_retrieve_feedback
 
+    safe_create_or_update_codaveri_question(question)
+
     feedback_config = Course::Assessment::Answer::ProgrammingCodaveriAsyncFeedbackService.default_config.merge(
       revealLevel: 'guidance',
       language: Course::Assessment::Answer::ProgrammingCodaveriAsyncFeedbackService.language_from_locale(
@@ -123,6 +126,8 @@ class Course::Assessment::Answer::Programming < ApplicationRecord
 
     should_retrieve_feedback = question.is_codaveri && !submission.attempting? && current_answer?
     return unless should_retrieve_feedback
+
+    safe_create_or_update_codaveri_question(question)
 
     feedback_job = Course::Assessment::Answer::ProgrammingCodaveriFeedbackJob.perform_later(
       assessment, question, self

--- a/app/services/codaveri_async_api_service.rb
+++ b/app/services/codaveri_async_api_service.rb
@@ -23,6 +23,18 @@ class CodaveriAsyncApiService
     parse_response(response)
   end
 
+  def put
+    connection = Excon.new(@api_endpoint)
+    response = connection.put(
+      headers: {
+        'x-api-key' => ENV.fetch('CODAVERI_API_KEY', nil),
+        'Content-Type' => 'application/json'
+      },
+      body: @payload.to_json
+    )
+    parse_response(response)
+  end
+
   def get
     connection = Excon.new(@api_endpoint)
     response = connection.get(

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # Sets up a programming evaluation, queues it for execution by codaveri evaluators, then returns the results.
 class Course::Assessment::ProgrammingCodaveriEvaluationService # rubocop:disable Metrics/ClassLength
+  include Course::Assessment::Question::CodaveriQuestionConcern
   # The default timeout for the job to finish.
   DEFAULT_TIMEOUT = 5.minutes
   MEMORY_LIMIT = Course::Assessment::Question::Programming::MEMORY_LIMIT
@@ -122,6 +123,7 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService # rubocop:disable
   # @return [Array<(String, String, String, Integer)>] The stdout, stderr, test report and exit
   #   code.
   def evaluate_in_codaveri
+    safe_create_or_update_codaveri_question(@question)
     construct_grading_object
     response_status, response_body, evaluation_id = request_codaveri_evaluation
     poll_codaveri_evaluation_results(response_status, response_body, evaluation_id)

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentCategory.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentCategory.tsx
@@ -13,6 +13,7 @@ import { useAppSelector } from 'lib/hooks/store';
 import {
   getAllAssessmentTabsFor,
   getAssessmentForCategory,
+  getProgrammingQuestionsForAssessments,
 } from '../selectors';
 
 import CodaveriToggleButtons from './buttons/CodaveriToggleButtons';
@@ -41,13 +42,17 @@ const AssessmentCategory: FC<AssessmentCategoryProps> = (props) => {
   const assessmentIds = assessments.map((assessment) => assessment.id);
   const { processedItems: sortedTabs } = useItems(tabs, [], sortTabs);
 
+  const programmingQuestions = useAppSelector((state) =>
+    getProgrammingQuestionsForAssessments(state, assessmentIds),
+  );
+
   return (
     <CollapsibleList
       headerAction={
         <div className="pr-2">
           <CodaveriToggleButtons
-            assessmentIds={assessmentIds}
             for={category.title}
+            programmingQuestions={programmingQuestions}
             type="category"
           />
         </div>

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentList.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentList.tsx
@@ -7,7 +7,11 @@ import useItems from 'lib/hooks/items/useItems';
 import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import { getAllAssessmentCategories, getAllAssessments } from '../selectors';
+import {
+  getAllAssessmentCategories,
+  getAllAssessments,
+  getProgrammingQuestionsForAssessments,
+} from '../selectors';
 import translations from '../translations';
 
 import CodaveriToggleButtons from './buttons/CodaveriToggleButtons';
@@ -39,6 +43,10 @@ const AssessmentList: FC<Props> = (props) => {
   );
   const { t } = useTranslation();
   const assessmentIds = assessments.map((item) => item.id);
+  const programmingQuestions = useAppSelector((state) =>
+    getProgrammingQuestionsForAssessments(state, assessmentIds),
+  );
+
   return (
     <Section
       contentClassName="flex flex-col space-y-3"
@@ -72,8 +80,8 @@ const AssessmentList: FC<Props> = (props) => {
         </div>
         <div className="mb-4 pr-2 flex justify-end">
           <CodaveriToggleButtons
-            assessmentIds={assessmentIds}
             for={courseTitle}
+            programmingQuestions={programmingQuestions}
             type="course"
           />
         </div>

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentListItem.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentListItem.tsx
@@ -6,7 +6,10 @@ import { AssessmentProgrammingQuestionsData } from 'types/course/admin/codaveri'
 import Link from 'lib/components/core/Link';
 import { useAppSelector } from 'lib/hooks/store';
 
-import { getViewSettings } from '../selectors';
+import {
+  getProgrammingQuestionsForAssessments,
+  getViewSettings,
+} from '../selectors';
 
 import CodaveriToggleButtons from './buttons/CodaveriToggleButtons';
 import CollapsibleList from './lists/CollapsibleList';
@@ -20,6 +23,10 @@ const AssessmentListItem: FC<AssessmentListItemProps> = (props) => {
   const { assessment } = props;
   const { isAssessmentListExpanded } = useAppSelector(getViewSettings);
 
+  const programmingQuestions = useAppSelector((state) =>
+    getProgrammingQuestionsForAssessments(state, [assessment.id]),
+  );
+
   if (assessment.programmingQuestions.length === 0) return null;
 
   return (
@@ -29,8 +36,8 @@ const AssessmentListItem: FC<AssessmentListItemProps> = (props) => {
       headerAction={
         <div className="pr-2">
           <CodaveriToggleButtons
-            assessmentIds={[assessment.id]}
             for={assessment.title}
+            programmingQuestions={programmingQuestions}
             type="assessment"
           />
         </div>

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentProgrammingQnList.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentProgrammingQnList.tsx
@@ -9,12 +9,11 @@ import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import {
-  updateProgrammingQuestionCodaveri,
-  updateProgrammingQuestionLiveFeedback,
-} from '../operations';
+import { updateProgrammingQuestionLiveFeedback } from '../operations';
 import { getProgrammingQuestion, getViewSettings } from '../selectors';
 import translations from '../translations';
+
+import CodaveriToggleButtons from './buttons/CodaveriToggleButtons';
 
 interface ProgrammingQnListProps {
   questionId: number;
@@ -32,31 +31,6 @@ const ProgrammingQnList: FC<ProgrammingQnListProps> = (props) => {
 
   if (!programmingQn || (showCodaveriEnabled && !programmingQn.isCodaveri))
     return null;
-
-  const handleCodaveriEvaluatorChange = (isChecked: boolean): void => {
-    const updatedQn = produce(programmingQn, (draft) => {
-      draft.isCodaveri = isChecked;
-    });
-    updateProgrammingQuestionCodaveri(
-      programmingQn.assessmentId,
-      programmingQn.id,
-      updatedQn,
-    )
-      .then(() => {
-        dispatch(updateProgrammingQuestion(updatedQn));
-        toast.success(
-          t(translations.evaluatorUpdateSuccess, {
-            question: programmingQn.title,
-            evaluator: isChecked ? 'codaveri' : 'default',
-          }),
-        );
-      })
-      .catch(() => {
-        toast.error(
-          t(translations.errorOccurredWhenUpdatingCodaveriEvaluatorSettings),
-        );
-      });
-  };
 
   const handleLiveFeedbackEnabledChange = (isChecked: boolean): void => {
     const updatedQn = produce(programmingQn, (draft) => {
@@ -82,16 +56,6 @@ const ProgrammingQnList: FC<ProgrammingQnListProps> = (props) => {
         );
       });
   };
-
-  const CodaveriEvaluatorToggle = (): JSX.Element => (
-    <Switch
-      checked={programmingQn.isCodaveri}
-      color="primary"
-      onChange={(_, isChecked): void =>
-        handleCodaveriEvaluatorChange(isChecked)
-      }
-    />
-  );
 
   const LiveFeedbackToggle = (): JSX.Element => (
     <Switch
@@ -119,10 +83,10 @@ const ProgrammingQnList: FC<ProgrammingQnListProps> = (props) => {
             <LiveFeedbackToggle />
           </div>
         ) : (
-          <div className="mr-[6.6rem] space-x-32">
-            <CodaveriEvaluatorToggle />
-            <LiveFeedbackToggle />
-          </div>
+          <CodaveriToggleButtons
+            programmingQuestions={[programmingQn]}
+            type="question"
+          />
         )}
       </ListItem>
       <Divider className="border-neutral-200 last:border-none" />

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentTab.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/AssessmentTab.tsx
@@ -10,7 +10,10 @@ import Link from 'lib/components/core/Link';
 import useItems from 'lib/hooks/items/useItems';
 import { useAppSelector } from 'lib/hooks/store';
 
-import { getAssessmentsForTab } from '../selectors';
+import {
+  getAssessmentsForTab,
+  getProgrammingQuestionsForAssessments,
+} from '../selectors';
 
 import CodaveriToggleButtons from './buttons/CodaveriToggleButtons';
 import CollapsibleList from './lists/CollapsibleList';
@@ -44,6 +47,9 @@ const AssessmentTab: FC<AssessmentTabProps> = (props) => {
   const assessmentWithProgrammingQns = assessments.filter(
     (assessment) => assessment.programmingQuestions.length > 0,
   );
+  const programmingQuestions = useAppSelector((state) =>
+    getProgrammingQuestionsForAssessments(state, assessmentIds),
+  );
 
   if (assessmentWithProgrammingQns.length === 0) return null;
 
@@ -52,8 +58,8 @@ const AssessmentTab: FC<AssessmentTabProps> = (props) => {
       headerAction={
         <div className="pr-2">
           <CodaveriToggleButtons
-            assessmentIds={assessmentIds}
             for={tab.title}
+            programmingQuestions={programmingQuestions}
             type="tab"
           />
         </div>

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/CodaveriSettingsChip.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/CodaveriSettingsChip.tsx
@@ -1,25 +1,22 @@
 import { FC } from 'react';
 import { Chip } from '@mui/material';
-import { CodaveriSettings } from 'types/course/admin/codaveri';
+import {
+  CodaveriSettings,
+  ProgrammingQuestion,
+} from 'types/course/admin/codaveri';
 
-import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import { getProgrammingQuestionsForAssessments } from '../selectors';
 import translations from '../translations';
 
 interface CodaveriSettingsChipProps {
-  assessmentIds: number[];
+  questions: ProgrammingQuestion[];
   for: CodaveriSettings;
 }
 
 const CodaveriSettingsChip: FC<CodaveriSettingsChipProps> = (props) => {
-  const { assessmentIds, for: settings } = props;
+  const { questions, for: settings } = props;
   const { t } = useTranslation();
-
-  const questions = useAppSelector((state) =>
-    getProgrammingQuestionsForAssessments(state, assessmentIds),
-  );
 
   const codaveriQnsCount = questions.filter((qn) => qn.isCodaveri).length;
   const liveFeedbackEnabledQnsCount = questions.filter(

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/CodaveriToggleButtons.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/buttons/CodaveriToggleButtons.tsx
@@ -1,25 +1,31 @@
 import { FC } from 'react';
+import { ProgrammingQuestion } from 'types/course/admin/codaveri';
 
 import CodaveriEvaluatorToggleButton from './CodaveriEvaluatorToggleButton';
 import LiveFeedbackToggleButton from './LiveFeedbackToggleButton';
 
 interface CodaveriToggleButtonsProps {
-  assessmentIds: number[];
-  for: string;
-  type: 'course' | 'category' | 'tab' | 'assessment';
+  programmingQuestions: ProgrammingQuestion[];
+  for?: string;
+  type: 'course' | 'category' | 'tab' | 'assessment' | 'question';
 }
 
 const CodaveriToggleButtons: FC<CodaveriToggleButtonsProps> = (props) => {
-  const { assessmentIds, for: title, type } = props;
+  const { programmingQuestions, for: title, type } = props;
+  const className = `${type === 'question' ? 'pr-[0.65rem]' : 'pr-7'} space-x-8 flex justify-between`;
 
   return (
-    <div className="pr-7 space-x-8 flex justify-between">
+    <div className={className}>
       <CodaveriEvaluatorToggleButton
-        assessmentIds={assessmentIds}
         for={title}
+        programmingQuestions={programmingQuestions}
         type={type}
       />
-      <LiveFeedbackToggleButton assessmentIds={assessmentIds} for={title} />
+      <LiveFeedbackToggleButton
+        for={title}
+        programmingQuestions={programmingQuestions}
+        type={type}
+      />
     </div>
   );
 };

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/operations.ts
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/operations.ts
@@ -125,12 +125,12 @@ export const updateProgrammingQuestionLiveFeedback = async (
 };
 
 export const updateEvaluatorForAllQuestions = async (
-  assessmentIds: number[],
+  programmingQuestionIds: number[],
   evaluator: ProgrammingEvaluator,
 ): Promise<void> => {
   const adaptedData = {
     update_evaluator: {
-      assessment_ids: assessmentIds,
+      programming_question_ids: programmingQuestionIds,
       programming_evaluator: evaluator,
     },
   };
@@ -143,12 +143,12 @@ export const updateEvaluatorForAllQuestions = async (
 };
 
 export const updateLiveFeedbackEnabledForAllQuestions = async (
-  assessmentIds: number[],
+  programmingQuestionIds: number[],
   liveFeedbackEnabled: boolean,
 ): Promise<void> => {
   const adaptedData = {
     update_live_feedback_enabled: {
-      assessment_ids: assessmentIds,
+      programming_question_ids: programmingQuestionIds,
       live_feedback_enabled: liveFeedbackEnabled,
     },
   };

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/selectors.ts
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/selectors.ts
@@ -99,12 +99,6 @@ export const getAssessmentForCategory = (
   );
 };
 
-export const getAllProgrammingQuestions = (
-  state: AppState,
-): ProgrammingQuestion[] => {
-  return programmingQuestionsSelector.selectAll(state);
-};
-
 export const getProgrammingQuestion = (
   state: AppState,
   id: EntityId,

--- a/client/app/bundles/course/admin/reducers/codaveriSettings.ts
+++ b/client/app/bundles/course/admin/reducers/codaveriSettings.ts
@@ -78,15 +78,12 @@ export const codaveriSettingsSlice = createSlice({
       state,
       action: PayloadAction<{
         evaluator: ProgrammingEvaluator;
-        assessmentIds: number[];
+        programmingQuestionIds: number[];
       }>,
     ) => {
-      state.programmingQuestions.ids.forEach((qnId) => {
+      action.payload.programmingQuestionIds.forEach((qnId) => {
         const question = state.programmingQuestions.entities[qnId];
-        if (
-          question &&
-          action.payload.assessmentIds.includes(question.assessmentId)
-        ) {
+        if (question) {
           question.isCodaveri = action.payload.evaluator === 'codaveri';
         }
       });
@@ -95,15 +92,12 @@ export const codaveriSettingsSlice = createSlice({
       state,
       action: PayloadAction<{
         liveFeedbackEnabled: boolean;
-        assessmentIds: number[];
+        programmingQuestionIds: number[];
       }>,
     ) => {
-      state.programmingQuestions.ids.forEach((qnId) => {
+      action.payload.programmingQuestionIds.forEach((qnId) => {
         const question = state.programmingQuestions.entities[qnId];
-        if (
-          question &&
-          action.payload.assessmentIds.includes(question.assessmentId)
-        ) {
+        if (question) {
           question.liveFeedbackEnabled = action.payload.liveFeedbackEnabled;
         }
       });

--- a/client/app/types/course/admin/codaveri.ts
+++ b/client/app/types/course/admin/codaveri.ts
@@ -58,14 +58,14 @@ export interface CodaveriSettingsPatchData {
 
 export interface CodaveriSwitchQnsEvaluatorPatchData {
   update_evaluator: {
-    assessment_ids: number[];
+    programming_question_ids: number[];
     programming_evaluator: ProgrammingEvaluator;
   };
 }
 
 export interface CodaveriSwitchQnsLiveFeedbackEnabledPatchData {
   update_live_feedback_enabled: {
-    assessment_ids: number[];
+    programming_question_ids: number[];
     live_feedback_enabled: boolean;
   };
 }

--- a/db/migrate/20241204104627_add_question_sync_status_with_codaveri.rb
+++ b/db/migrate/20241204104627_add_question_sync_status_with_codaveri.rb
@@ -1,0 +1,10 @@
+class AddQuestionSyncStatusWithCodaveri < ActiveRecord::Migration[7.0]
+  def change
+    add_column :course_assessment_question_programming, :is_synced_with_codaveri, :boolean, default: false, null: false
+
+    # for all existing questions with Codaveri ID, we mark them as synced with Codaveri
+    # since in the past, we always ensure that Codaveri question got synced whenever we
+    # activate either codaveri evaluation or live feedback
+    Course::Assessment::Question::Programming.where.not(codaveri_id: nil).update_all(is_synced_with_codaveri: true)
+  end  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_18_152013) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_04_104627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -314,6 +314,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_18_152013) do
     t.text "codaveri_message"
     t.boolean "live_feedback_enabled", default: false, null: false
     t.string "live_feedback_custom_prompt", default: "", null: false
+    t.boolean "is_synced_with_codaveri", default: false, null: false
     t.index ["import_job_id"], name: "index_course_assessment_question_programming_on_import_job_id", unique: true
     t.index ["language_id"], name: "fk__course_assessment_question_programming_language_id"
   end

--- a/spec/controllers/course/admin/codaveri_settings_controller_spec.rb
+++ b/spec/controllers/course/admin/codaveri_settings_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Course::Admin::CodaveriSettingsController, type: :controller do
             course_id: course2,
             update_live_feedback_enabled: {
               live_feedback_enabled: true,
-              assessment_ids: course2.assessments.map(&:id)
+              programming_question_ids: course2.assessments.first.programming_questions.map(&:id)
             }
           }
         end

--- a/spec/factories/course_assessment_question_programming.rb
+++ b/spec/factories/course_assessment_question_programming.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     end
     imported_attachment do
       if template_package
-        file = File.new(File.join(Rails.root, 'spec/fixtures/course/'\
+        file = File.new(File.join(Rails.root, 'spec/fixtures/course/' \
                                               'programming_question_template.zip'), 'rb')
         AttachmentReference.new(file: file)
       end
@@ -48,6 +48,9 @@ FactoryBot.define do
     end
 
     is_codaveri do
+      with_codaveri_question ? true : false
+    end
+    is_synced_with_codaveri do
       with_codaveri_question ? true : false
     end
     codaveri_id do
@@ -90,6 +93,7 @@ FactoryBot.define do
 
     trait :with_codaveri_question do
       is_codaveri { true }
+      is_synced_with_codaveri { true }
       codaveri_id { '6311a0548c57aae93d260927' }
       codaveri_status { 200 }
       codaveri_message { 'Problem successfully created' }

--- a/spec/services/course/assessment/question/programming_codaveri_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_codaveri_service_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Course::Assessment::Question::ProgrammingCodaveriService do
     let(:assessment) { create(:assessment, :with_programming_question, course: course) }
     let(:question) do
       create(:course_assessment_question_programming, template_file_count: 0, package_type: :zip_upload,
-                                                      assessment: assessment, is_codaveri: true)
+                                                      assessment: assessment, is_codaveri: false,
+                                                      is_synced_with_codaveri: false)
     end
     let(:package_path) do
       File.join(Rails.root, 'spec/fixtures/course/programming_question_template_codaveri.zip')
@@ -31,7 +32,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingCodaveriService do
     end
     subject { Course::Assessment::Question::ProgrammingCodaveriService.new(question, attachment) }
 
-    describe '.create_or_update_question' do
+    describe '.create_question' do
       subject { Course::Assessment::Question::ProgrammingCodaveriService }
 
       context 'when the API request is successful' do


### PR DESCRIPTION
## Background

In the past, we do not allow editing Codaveri questions, and thus everytime we edit the programming questions that is Codaveri, we ended up creating the brand new question, detach that question from the old Codaveri ID, and attach it to the new one. This process, albeit maintaining the correctness in Coursemology, is actually redundant to do and only creating lots of orphaned questions in Codaveri side.

The same goes to duplication, in which we didn't handle the case in which something goes wrong with linking to Codaveri during creation of the questions (for example, the connection error or Codaveri temporarily down), leading the Codaveri-related operation (getting feedback and evaluate in codaveri) to just render error when invoked on those questions.

## Approach

- Currently, Codaveri has opened the API Route for editing the questions, and hence we modify the question update operation from `create_codaveri_question` to `create_or_update_codaveri_question`, to accommodate the updating of Codaveri questions
- In each Codaveri operations, we firstly check if `codaveri_id` exists, then we proceed to do safe-creating of Codaveri question by utilising lock. After the creation is successful, then we proceed to whatever operation we are going to do (either evaluate or generate feedback)