### PR TITLE
Support R evaluation using Codaveri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -199,7 +199,7 @@ gem 'rubyzip', require: 'zip'
 gem 'nokogiri', '>= 1.8.1'
 
 # Polyglot support
-gem 'coursemology-polyglot'
+gem 'coursemology-polyglot', git: 'https://github.com/Coursemology/polyglot', ref: '14fbbc2'
 
 # To assist with bulk inserts into database
 gem 'activerecord-import', '>= 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,14 @@ GIT
       activerecord (>= 6.0.0, < 8)
 
 GIT
+  remote: https://github.com/Coursemology/polyglot
+  revision: 14fbbc2943e87479f989056a0ae465f54726c4a1
+  ref: 14fbbc2
+  specs:
+    coursemology-polyglot (0.3.9)
+      activesupport (>= 4.2)
+
+GIT
   remote: https://github.com/Coursemology/rwordnet
   revision: 54a85eed974002cb2cfb858cbcaed8e1069b5cb8
   specs:
@@ -176,8 +184,6 @@ GEM
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     consistency_fail (0.3.7)
-    coursemology-polyglot (0.3.8)
-      activesupport (>= 4.2)
     crass (1.0.6)
     csv (3.3.0)
     date (3.3.4)
@@ -626,7 +632,7 @@ DEPENDENCIES
   capybara-selenium
   carrierwave (~> 3)
   consistency_fail
-  coursemology-polyglot
+  coursemology-polyglot!
   csv
   devise (= 4.9.4)
   devise-multi_email

--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -75,7 +75,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
     @programming_questions = @assessment.programming_questions
 
     @programming_qns_invalid_for_koditsu = @programming_questions.reject do |question|
-      KoditsuAsyncApiService.language_valid_for_koditsu?(question.language)
+      question.language.koditsu_whitelisted?
     end
   end
 

--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -88,7 +88,7 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
     }, status: :ok
   end
 
-  def generate # rubocop:disable Metrics/AbcSize
+  def generate
     language = Coursemology::Polyglot::Language.where(id: params[:language_id]).first
 
     unless CodaveriAsyncApiService.language_valid_for_codaveri?(language)
@@ -101,9 +101,8 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
     generation_service = Course::Assessment::Question::CodaveriProblemGenerationService.new(
       @assessment,
       params[:custom_prompt],
-      # TODO: move these declarations (polyglot_language_name and _version) to polyglot repo
-      language.name.split[0].downcase,
-      language.name.split[1],
+      language.polyglot_name,
+      language.polyglot_version,
       params[:difficulty]
     )
     generated_problem = generation_service.codaveri_generate_problem

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -247,7 +247,6 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   def validate_codaveri_question
     return if (!is_codaveri && !live_feedback_enabled) || duplicating?
 
-    # TODO: Move this validation logic to frontend, to prevent user from submitting in the first place.
     if !language.codaveri_evaluator_whitelisted?
       errors.add(:base, 'Language type must be Python 3 and above to activate either codaveri ' \
                         'evaluator or live feedback')

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -248,7 +248,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
     return if (!is_codaveri && !live_feedback_enabled) || duplicating?
 
     # TODO: Move this validation logic to frontend, to prevent user from submitting in the first place.
-    if !CodaveriAsyncApiService.language_valid_for_codaveri?(language)
+    if !language.codaveri_evaluator_whitelisted?
       errors.add(:base, 'Language type must be Python 3 and above to activate either codaveri ' \
                         'evaluator or live feedback')
     elsif !question_assessments.empty? &&

--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -150,20 +150,6 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
     end
   end
 
-  # Returns language name in lowercase format (eg python, java).
-  #
-  # @return [String] The language name in lowercase format.
-  def polyglot_language_name
-    language.name.split[0].downcase
-  end
-
-  # Returns language version.
-  #
-  # @return [String] The language version.
-  def polyglot_language_version
-    language.name.split[1]
-  end
-
   def create_codaveri_problem
     return unless is_codaveri || live_feedback_enabled
 

--- a/app/models/course/question_assessment.rb
+++ b/app/models/course/question_assessment.rb
@@ -67,7 +67,7 @@ class Course::QuestionAssessment < ApplicationRecord
 
   def language_valid_for_koditsu?
     language = question.actable.language
-    KoditsuAsyncApiService.language_valid_for_koditsu?(language)
+    language.koditsu_whitelisted?
   end
 
   def add_language_errors

--- a/app/services/codaveri_async_api_service.rb
+++ b/app/services/codaveri_async_api_service.rb
@@ -15,7 +15,7 @@ class CodaveriAsyncApiService
     connection = Excon.new(@api_endpoint)
     response = connection.post(
       headers: {
-        'x-api-key' => ENV['CODAVERI_API_KEY'],
+        'x-api-key' => ENV.fetch('CODAVERI_API_KEY', nil),
         'Content-Type' => 'application/json'
       },
       body: @payload.to_json
@@ -27,28 +27,12 @@ class CodaveriAsyncApiService
     connection = Excon.new(@api_endpoint)
     response = connection.get(
       headers: {
-        'x-api-key' => ENV['CODAVERI_API_KEY']
+        'x-api-key' => ENV.fetch('CODAVERI_API_KEY', nil)
       },
       query: @payload
     )
     parse_response(response)
   end
-
-  def self.language_valid_for_codaveri?(language)
-    codaveri_language_whitelist.include?(language.type.constantize)
-  end
-
-  def self.codaveri_language_whitelist
-    [Coursemology::Polyglot::Language::Python::Python3Point4,
-     Coursemology::Polyglot::Language::Python::Python3Point5,
-     Coursemology::Polyglot::Language::Python::Python3Point6,
-     Coursemology::Polyglot::Language::Python::Python3Point7,
-     Coursemology::Polyglot::Language::Python::Python3Point9,
-     Coursemology::Polyglot::Language::Python::Python3Point10,
-     Coursemology::Polyglot::Language::Python::Python3Point12]
-  end
-
-  private_class_method :codaveri_language_whitelist
 
   private
 

--- a/app/services/course/assessment/answer/programming_codaveri_async_feedback_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_async_feedback_service.rb
@@ -74,8 +74,10 @@ class Course::Assessment::Answer::ProgrammingCodaveriAsyncFeedbackService # rubo
 
     @answer_object[:problemId] = @question.codaveri_id
 
-    @answer_object[:languageVersion][:language] = @question.polyglot_language_name
-    @answer_object[:languageVersion][:version] = @question.polyglot_language_version
+    @answer_object[:languageVersion] = {
+      language: @question.language.polyglot_name,
+      version: @question.language.polyglot_version
+    }
 
     @answer_files.each do |file|
       file_template = default_codaveri_student_file_template

--- a/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
@@ -119,25 +119,24 @@ class Course::Assessment::Answer::ProgrammingCodaveriAutoGradingService < \
   #   graded.
   # @param [Course::Assessment::Answer::ProgrammingAutoGrading] auto_grading The programming auto
   #   grading result to store the test results in.
-  # @param [String] evaluation_results The evaluation results from Codaveri API Response.
+  # @param [Array<Struct>] evaluation_results The evaluation results from Codaveri API Response.
   # @return [Array<Course::Assessment::Question::ProgrammingTestCase>]
   def build_test_case_records_from_test_results(question, auto_grading, evaluation_results) # rubocop:disable Metrics/AbcSize
     test_cases = question.test_cases.to_h { |test_case| [test_case.id, test_case] }
     evaluation_results.map do |result|
-      test_case = find_test_case(test_cases, result['testcase']['index'].to_i)
-      result_run = result['run']
+      test_case = find_test_case(test_cases, result.index)
 
       error_message_sigkill = I18n.t('course.assessment.answer.programming_auto_grading.grade.evaluation_failed_syntax')
       messages ||= {
-        error: result_run['code'] == 137 ? error_message_sigkill : result_run['stderr'],
+        error: (result.exit_code == 137) ? error_message_sigkill : result.stderr,
         hint: test_case.hint,
-        output: result_run['display'],
-        code: result_run['code'],
-        signal: result_run['signal']
+        output: result.output,
+        code: result.exit_code,
+        signal: result.exit_signal
       }.reject! { |_, v| v.blank? }
 
       auto_grading.test_results.build(auto_grading: auto_grading, test_case: test_case,
-                                      passed: result_run['success'],
+                                      passed: result.success,
                                       messages: messages)
     end
   end

--- a/app/services/course/assessment/answer/programming_codaveri_feedback_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_feedback_service.rb
@@ -35,8 +35,8 @@ class Course::Assessment::Answer::ProgrammingCodaveriFeedbackService
 
     @answer_object[:problem_id] = @question.codaveri_id
 
-    @answer_object[:language_version][:language] = @question.polyglot_language_name
-    @answer_object[:language_version][:version] = @question.polyglot_language_version
+    @answer_object[:language_version][:language] = @question.language.polyglot_name
+    @answer_object[:language_version][:version] = @question.language.polyglot_version
 
     @answer_object[:is_only_itsp] = true if @course.codaveri_itsp_enabled?
 

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -132,8 +132,8 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService # rubocop:disable
 
     @answer_object[:problemId] = @question.codaveri_id
 
-    @answer_object[:languageVersion][:language] = @question.polyglot_language_name
-    @answer_object[:languageVersion][:version] = @question.polyglot_language_version
+    @answer_object[:languageVersion][:language] = @question.language.polyglot_name
+    @answer_object[:languageVersion][:version] = @question.language.polyglot_version
 
     @answer.files.each do |file|
       file_template = default_codaveri_student_file_template

--- a/app/services/course/assessment/question/programming/programming_package_service.rb
+++ b/app/services/course/assessment/question/programming/programming_package_service.rb
@@ -48,6 +48,8 @@ class Course::Assessment::Question::Programming::ProgrammingPackageService
         Course::Assessment::Question::Programming::Cpp::CppPackageService.new params
       when Coursemology::Polyglot::Language::Java
         Course::Assessment::Question::Programming::Java::JavaPackageService.new params
+      when Coursemology::Polyglot::Language::R
+        Course::Assessment::Question::Programming::R::RPackageService.new params
       else
         raise NotImplementedError
       end

--- a/app/services/course/assessment/question/programming/r/r_makefile
+++ b/app/services/course/assessment/question/programming/r/r_makefile
@@ -1,0 +1,24 @@
+prepare:
+
+compile: submission/template.R tests/prepend.R tests/append.R
+	cat tests/prepend.R submission/template.R tests/append.R > answer.R
+
+public:
+	echo "Not Implemented"
+
+private:
+	echo "Not Implemented"
+
+evaluation:
+	echo "Not Implemented"
+
+solution:	solution.R
+	echo "Not Implemented"
+
+solution.R: solution/template.R tests/prepend.R tests/append.R
+	cat tests/prepend.R solution/template.R tests/append.R > solution.R
+
+clean:
+	rm -f answer.R
+	rm -f report.xml
+	rm -f solution.R

--- a/app/services/course/assessment/question/programming/r/r_package_service.rb
+++ b/app/services/course/assessment/question/programming/r/r_package_service.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+class Course::Assessment::Question::Programming::R::RPackageService < # rubocop:disable Metrics/ClassLength
+  Course::Assessment::Question::Programming::LanguagePackageService
+  def submission_templates
+    [
+      {
+        filename: 'template.R',
+        content: @test_params[:submission] || ''
+      }
+    ]
+  end
+
+  def generate_package(old_attachment)
+    return nil if @test_params.blank?
+
+    @tmp_dir = Dir.mktmpdir
+    @old_meta = old_attachment.present? ? extract_meta(old_attachment, nil) : nil
+    data_files_to_keep = old_attachment.present? ? find_data_files_to_keep(old_attachment) : []
+    @meta = generate_meta(data_files_to_keep)
+
+    return nil if @meta == @old_meta
+
+    @attachment = generate_zip_file(data_files_to_keep)
+    FileUtils.remove_entry @tmp_dir if @tmp_dir.present?
+    @attachment
+  end
+
+  def extract_meta(attachment, template_files)
+    return @meta if @meta.present? && attachment == @attachment
+
+    # attachment will be nil if the question is not autograded, in that case the meta data will be
+    # generated from the template files in the database.
+    return generate_non_autograded_meta(template_files) if attachment.nil?
+
+    extract_autograded_meta(attachment)
+  end
+
+  private
+
+  def extract_autograded_meta(attachment)
+    attachment.open(binmode: true) do |temporary_file|
+      package = Course::Assessment::ProgrammingPackage.new(temporary_file)
+      meta = package.meta_file
+      @old_meta = meta.present? ? JSON.parse(meta) : nil
+    ensure
+      next unless package
+
+      temporary_file.close
+    end
+  end
+
+  def generate_non_autograded_meta(template_files)
+    meta = default_meta
+
+    return meta if template_files.blank?
+
+    # For python editor, there is only a single submission template file.
+    meta[:submission] = template_files.first.content
+
+    meta.as_json
+  end
+
+  def extract_from_package(package, new_data_filenames, data_files_to_delete)
+    data_files_to_keep = []
+
+    if @old_meta.present?
+      package.unzip_file @tmp_dir
+
+      @old_meta['data_files']&.each do |file|
+        next if data_files_to_delete.try(:include?, (file['filename']))
+        # new files overrides old ones
+        next if new_data_filenames.include?(file['filename'])
+
+        data_files_to_keep.append(File.new(File.join(@tmp_dir, file['filename'])))
+      end
+    end
+
+    data_files_to_keep
+  end
+
+  def find_data_files_to_keep(attachment)
+    new_filenames = (@test_params[:data_files] || []).reject(&:nil?).map(&:original_filename)
+
+    attachment.open(binmode: true) do |temporary_file|
+      package = Course::Assessment::ProgrammingPackage.new(temporary_file)
+      return extract_from_package(package, new_filenames, @test_params[:data_files_to_delete])
+    ensure
+      next unless package
+
+      temporary_file.close
+    end
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def generate_zip_file(data_files_to_keep)
+    tmp = Tempfile.new(['package', '.zip'])
+    makefile_path = get_file_path('r_makefile')
+
+    Zip::OutputStream.open(tmp.path) do |zip|
+      # Create solution directory with template file
+      zip.put_next_entry 'solution/'
+      zip.put_next_entry 'solution/template.R'
+      zip.print @test_params[:solution]
+      zip.print "\n"
+
+      # Create submission directory with template file
+      zip.put_next_entry 'submission/'
+      zip.put_next_entry 'submission/template.R'
+      zip.print @test_params[:submission]
+      zip.print "\n"
+
+      # Create tests directory with prepend, append and autograde files
+      zip.put_next_entry 'tests/'
+      zip.put_next_entry 'tests/append.R'
+      zip.print "\n"
+      zip.print @test_params[:append]
+      zip.print "\n"
+
+      zip.put_next_entry 'tests/prepend.R'
+      zip.print @test_params[:prepend]
+      zip.print "\n"
+
+      [:public, :private, :evaluation].each do |test_type|
+        zip_test_files(test_type, zip)
+      end
+
+      # Creates Makefile
+      zip.put_next_entry 'Makefile'
+      zip.print File.read(makefile_path)
+
+      zip.put_next_entry '.meta'
+      zip.print @meta.to_json
+    end
+
+    Zip::File.open(tmp.path) do |zip|
+      @test_params[:data_files]&.each do |file|
+        next if file.nil?
+
+        zip.add(file.original_filename, file.tempfile.path)
+      end
+
+      data_files_to_keep.each do |file|
+        zip.add(File.basename(file.path), file.path)
+      end
+    end
+
+    tmp
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  # Retrieves the absolute path of the file specified
+  #
+  # @param [String] filename The filename of the file to get the path of
+  def get_file_path(filename)
+    File.join(__dir__, filename).freeze
+  end
+
+  def zip_test_files(test_type, zip)
+    # Create a dummy report to pass test cases to DB/Codaveri
+    tests = @test_params[:test_cases]
+    return unless tests[test_type]&.count&.> 0
+
+    zip.put_next_entry "report-#{test_type}.xml"
+    zip.print build_dummy_report(test_type, tests[test_type])
+  end
+
+  def build_dummy_report(test_type, test_cases)
+    Course::Assessment::ProgrammingTestCaseReportBuilder.build_dummy_report(test_type, test_cases)
+  end
+
+  def get_data_files_meta(data_files_to_keep, new_data_files)
+    data_files = []
+
+    new_data_files.each do |file|
+      sha256 = Digest::SHA256.file(file.tempfile).hexdigest
+      data_files.append(filename: file.original_filename, size: file.tempfile.size, hash: sha256)
+    end
+
+    data_files_to_keep.each do |file|
+      sha256 = Digest::SHA256.file(file).hexdigest
+      data_files.append(filename: File.basename(file.path), size: file.size, hash: sha256)
+    end
+
+    data_files.sort_by { |file| file[:filename].downcase }
+  end
+
+  def generate_meta(data_files_to_keep)
+    meta = default_meta
+
+    [:submission, :solution, :prepend, :append].each { |field| meta[field] = @test_params[field] }
+
+    new_data_files = (@test_params[:data_files] || []).reject(&:nil?)
+    meta[:data_files] = get_data_files_meta(data_files_to_keep, new_data_files)
+
+    [:public, :private, :evaluation].each do |test_type|
+      meta[:test_cases][test_type] = @test_params[:test_cases][test_type] || []
+    end
+
+    meta.as_json
+  end
+end

--- a/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
@@ -62,16 +62,31 @@ class Course::Assessment::Question::ProgrammingCodaveri::LanguagePackageService
     }
   end
 
-  # Defines the default test case template as indicated in the Codevari API problem management spec.
+  # Defines the default expression test case template as indicated in the Codevari API problem management spec.
   #
   # @return [Hash]
-  def default_codaveri_test_case_template
+  def default_codaveri_expr_test_case_template
     {
       index: '',
       type: 'expression',
       timeout: '',
       prefix: '',
       expression: '',
+      display: 'str(out)'
+    }
+  end
+
+  # Defines the default test case template as indicated in the Codevari API problem management spec.
+  #
+  # @return [Hash]
+  def default_codaveri_io_test_case_template
+    {
+      index: '',
+      type: 'io',
+      input: '',
+      output: '',
+      visibility: '',
+      hint: '',
       display: 'str(out)'
     }
   end

--- a/app/services/course/assessment/question/programming_codaveri/programming_codaveri_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/programming_codaveri_package_service.rb
@@ -44,6 +44,8 @@ class Course::Assessment::Question::ProgrammingCodaveri::ProgrammingCodaveriPack
       case @language
       when Coursemology::Polyglot::Language::Python
         Course::Assessment::Question::ProgrammingCodaveri::Python::PythonPackageService.new question, package
+      when Coursemology::Polyglot::Language::R
+        Course::Assessment::Question::ProgrammingCodaveri::R::RPackageService.new question, package
       else
         raise NotImplementedError
       end

--- a/app/services/course/assessment/question/programming_codaveri/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/python/python_package_service.rb
@@ -129,7 +129,7 @@ class Course::Assessment::Question::ProgrammingCodaveri::Python::PythonPackageSe
 
     # Loop through each test case
     test_cases_regex.each do |test_case_match|
-      test_case_object = default_codaveri_test_case_template
+      test_case_object = default_codaveri_expr_test_case_template
       test_name, indentation, test_content, assertion_type, assertion_content = test_case_match
 
       # prefix

--- a/app/services/course/assessment/question/programming_codaveri/r/r_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/r/r_package_service.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+# rubocop:disable Metrics/abcSize
+class Course::Assessment::Question::ProgrammingCodaveri::R::RPackageService <
+  Course::Assessment::Question::ProgrammingCodaveri::LanguagePackageService
+  def process_solutions
+    extract_main_solution
+  end
+
+  def process_test_cases
+    extract_test_cases
+  end
+
+  def process_data
+    extract_supporting_files
+  end
+
+  def process_templates
+    extract_template
+  end
+
+  private
+
+  # Extracts the main solution of a programing question problem and append it to the
+  # [:resources][0][:solutions] array array for the problem management API request body.
+  def extract_main_solution
+    main_solution_object = default_codaveri_solution_template
+
+    solution_files = @package.solution_files
+
+    main_solution_object[:path] = 'template.R'
+    main_solution_object[:content] = solution_files[Pathname.new('template.R')]
+    return if main_solution_object[:content].blank?
+
+    @solution_files.append(main_solution_object)
+  end
+
+  # In a programming question package, there may be data files that are included in the package
+  # The contents of these files are appended to the "additionalFiles" array in the API Request main body.
+  def extract_supporting_files
+    extract_supporting_main_files
+    extract_supporting_tests_files
+    extract_supporting_submission_files
+    extract_supporting_solution_files
+  end
+
+  # Finds and extracts all contents of additional files in the root package folder
+  # (excluding the default Makefile and .meta files).
+  def extract_supporting_main_files
+    main_files = @package.main_files.compact.to_h
+    main_filenames = main_files.keys
+
+    main_filenames.each do |filename|
+      next if ['Makefile', '.meta', 'report-public.xml', 'report-private.xml',
+               'report-evaluation.xml'].include?(filename.to_s)
+
+      extract_supporting_file(filename, main_files[filename])
+    end
+  end
+
+  # Finds and extracts all contents of additional files in the test files folder
+  # (excluding the default append.R and prepend.R files).
+  def extract_supporting_tests_files
+    test_files = @package.test_files
+    test_filenames = test_files.keys
+
+    test_filenames.each do |filename|
+      next if ['append.R', 'prepend.R'].include?(filename.to_s)
+
+      extract_supporting_file(filename, test_files[filename])
+    end
+  end
+
+  # Finds and extracts all contents of additional files in the submission files folder
+  # (excluding the default template.R file).
+  def extract_supporting_submission_files
+    submission_files = @package.submission_files
+    submission_filenames = submission_files.keys
+
+    submission_filenames.each do |filename|
+      next if ['template.R'].include?(filename.to_s)
+
+      extract_supporting_file(filename, submission_files[filename])
+    end
+  end
+
+  # Finds and extracts all contents of additional files in the solution files folder
+  # (excluding the default template.R file).
+  def extract_supporting_solution_files
+    solution_files = @package.solution_files
+    solution_filenames = solution_files.keys
+
+    solution_filenames.each do |filename|
+      next if ['template.R'].include?(filename.to_s)
+
+      extract_supporting_file(filename, solution_files[filename])
+    end
+  end
+
+  # Extracts filename and content of a data file and append it to the
+  # [:additionalFiles] array for the problem management API request body.
+  #
+  # @param [Pathname] pathname The pathname of the file.
+  # @param [String] content The content of the file.
+  def extract_supporting_file(filename, content)
+    supporting_solution_object = default_codaveri_data_file_template
+
+    supporting_solution_object[:type] = 'internal' # 'external' s3 upload not yet implemented by codaveri
+    supporting_solution_object[:path] = filename.to_s
+    supporting_solution_object[:content] = content
+
+    @data_files.append(supporting_solution_object)
+  end
+
+  # Extracts test cases from the built dummy reports and append all the test cases to the
+  # [:IOTestcases] array for the problem management API request body.
+  def extract_test_cases
+    test_cases_with_id = preload_question_test_cases
+    @package.test_reports.each do |test_type, test_report|
+      Course::Assessment::ProgrammingTestCaseReport.new(test_report).test_cases.each do |test_case|
+        test_case_object = default_codaveri_io_test_case_template
+
+        # combine all extracted data
+        test_case_object[:index] = test_cases_with_id[test_case.name]
+        test_case_object[:timeout] = @question.time_limit unless @question.time_limit.nil?
+        test_case_object[:input] = test_case.expression
+        test_case_object[:output] = test_case.expected
+        test_case_object[:hint] = test_case.hint
+        test_case_object[:display] = test_case.display
+        test_case_object[:visibility] = codaveri_test_case_visibility(test_type)
+        @test_case_files.append(test_case_object)
+      end
+    end
+  end
+
+  # Extracts template file from submissions folder and append it to the
+  # [:resources][0][:templates] array for the problem management API request body.
+  def extract_template
+    main_template_object = default_codaveri_template_template
+
+    submission_files = @package.submission_files
+    test_files = @package.test_files
+
+    main_template_object[:path] = 'template.R'
+    main_template_object[:content] = submission_files[Pathname.new('template.R')]
+
+    main_template_object[:prefix] = test_files[Pathname.new('prepend.R')]
+    main_template_object[:suffix] = test_files[Pathname.new('append.R')]
+
+    @template_files.append(main_template_object)
+  end
+
+  def preload_question_test_cases
+    # The regex below finds all text after the last slash
+    # (eg AutoGrader/AutoGrader/test_private_4 -> test_private_4)
+    @question.test_cases.pluck(:identifier, :id).to_h { |x| [x[0].match(/[^\/]+$/).to_s, x[1]] }
+  end
+
+  def codaveri_test_case_visibility(test_case_type)
+    case test_case_type
+    when :public
+      'public'
+    when :private
+      'private'
+    when :evaluation
+      'hidden'
+    else
+      test_case_type
+    end
+  end
+end
+# rubocop:enable Metrics/abcSize

--- a/app/services/course/assessment/question/programming_codaveri_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri_service.rb
@@ -73,8 +73,8 @@ class Course::Assessment::Question::ProgrammingCodaveriService
     @problem_object[:title] = @question.title
     @problem_object[:description] = @question.description
     resources_object = @problem_object[:resources][0]
-    resources_object[:languageVersions][:language] = @question.polyglot_language_name
-    resources_object[:languageVersions][:versions] = [@question.polyglot_language_version]
+    resources_object[:languageVersions][:language] = @question.language.polyglot_name
+    resources_object[:languageVersions][:versions] = [@question.language.polyglot_version]
 
     codaveri_package = Course::Assessment::Question::ProgrammingCodaveri::ProgrammingCodaveriPackageService.new(
       @question, package

--- a/app/services/course/assessment/question/programming_codaveri_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri_service.rb
@@ -54,7 +54,8 @@ class Course::Assessment::Question::ProgrammingCodaveriService
           exprTestcases: []
         }
       ],
-      additionalFiles: []
+      additionalFiles: [],
+      IOTestcases: []
     }
   end
 
@@ -81,7 +82,11 @@ class Course::Assessment::Question::ProgrammingCodaveriService
     )
 
     resources_object[:solutions][0][:files] = codaveri_package.process_solutions
-    resources_object[:exprTestcases] = codaveri_package.process_test_cases
+    all_test_cases = codaveri_package.process_test_cases
+    @problem_object[:IOTestcases] = all_test_cases.filter { |tc| tc[:type] == 'io' }
+    @problem_object.delete(:IOTestcases) if @problem_object[:IOTestcases].empty?
+    resources_object[:exprTestcases] = all_test_cases.filter { |tc| tc[:type] == 'expression' }
+    resources_object.delete(:exprTestcases) if resources_object[:exprTestcases].empty?
     resources_object[:templates] = codaveri_package.process_templates
     @problem_object[:additionalFiles] = codaveri_package.process_data
 

--- a/app/services/koditsu_async_api_service.rb
+++ b/app/services/koditsu_async_api_service.rb
@@ -15,7 +15,7 @@ class KoditsuAsyncApiService
     connection = Excon.new(@api_endpoint)
     response = connection.post(
       headers: {
-        'x-api-key' => ENV['KODITSU_API_KEY'],
+        'x-api-key' => ENV.fetch('KODITSU_API_KEY', nil),
         'Content-Type' => 'application/json'
       },
       body: @payload.to_json
@@ -29,7 +29,7 @@ class KoditsuAsyncApiService
     connection = Excon.new(@api_endpoint)
     response = connection.put(
       headers: {
-        'x-api-key' => ENV['KODITSU_API_KEY'],
+        'x-api-key' => ENV.fetch('KODITSU_API_KEY', nil),
         'Content-Type' => 'application/json'
       },
       body: @payload.to_json
@@ -43,7 +43,7 @@ class KoditsuAsyncApiService
     connection = Excon.new(@api_endpoint)
     response = connection.get(
       headers: {
-        'x-api-key' => ENV['KODITSU_API_KEY']
+        'x-api-key' => ENV.fetch('KODITSU_API_KEY', nil)
       }
     )
     parse_response(response)
@@ -55,7 +55,7 @@ class KoditsuAsyncApiService
     connection = Excon.new(@api_endpoint)
     response = connection.delete(
       headers: {
-        'x-api-key' => ENV['KODITSU_API_KEY']
+        'x-api-key' => ENV.fetch('KODITSU_API_KEY', nil)
       }
     )
     parse_response(response)
@@ -63,23 +63,8 @@ class KoditsuAsyncApiService
     [500, nil]
   end
 
-  def self.language_valid_for_koditsu?(language)
-    koditsu_language_whitelist.include?(language.type.constantize)
-  end
-
-  def self.koditsu_language_whitelist
-    [Coursemology::Polyglot::Language::CPlusPlus,
-     Coursemology::Polyglot::Language::Python::Python3Point4,
-     Coursemology::Polyglot::Language::Python::Python3Point5,
-     Coursemology::Polyglot::Language::Python::Python3Point6,
-     Coursemology::Polyglot::Language::Python::Python3Point7,
-     Coursemology::Polyglot::Language::Python::Python3Point9,
-     Coursemology::Polyglot::Language::Python::Python3Point10,
-     Coursemology::Polyglot::Language::Python::Python3Point12]
-  end
-
   def self.assessment_url(assessment_id)
-    url = ENV['KODITSU_WEB_URL']
+    url = ENV.fetch('KODITSU_WEB_URL', nil)
 
     "#{url}?assessment=#{assessment_id}"
   end

--- a/app/views/course/admin/codaveri_settings/assessment.json.jbuilder
+++ b/app/views/course/admin/codaveri_settings/assessment.json.jbuilder
@@ -7,7 +7,7 @@ json.assessments [@assessment_with_programming_qns] do |assessment|
   json.url course_assessment_path(current_course, assessment)
 
   json.programmingQuestions assessment.programming_questions do |programming_qn|
-    next unless CodaveriAsyncApiService.language_valid_for_codaveri?(programming_qn.language)
+    next unless programming_qn.language.codaveri_evaluator_whitelisted?
 
     if programming_qn.title.blank?
       question_assessment = assessment.question_assessments.select do |qa|

--- a/app/views/course/admin/codaveri_settings/edit.json.jbuilder
+++ b/app/views/course/admin/codaveri_settings/edit.json.jbuilder
@@ -24,7 +24,7 @@ json.assessments @assessments_with_programming_qns do |assessment|
   json.url course_assessment_path(current_course, assessment)
 
   json.programmingQuestions assessment.programming_questions do |programming_qn|
-    next unless CodaveriAsyncApiService.language_valid_for_codaveri?(programming_qn.language)
+    next unless programming_qn.language.codaveri_evaluator_whitelisted?
 
     if programming_qn.title.blank?
       question_assessment = assessment.question_assessments.select do |qa|

--- a/app/views/course/assessment/question/programming/_form.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_form.json.jbuilder
@@ -4,16 +4,12 @@ json.partial! 'course/assessment/question/skills', course: course
 is_course_koditsu_enabled = current_course.component_enabled?(Course::KoditsuPlatformComponent)
 is_assessment_koditsu_enabled = @assessment.is_koditsu_enabled
 
-json.languages Coursemology::Polyglot::Language.all.order(weight: :desc).map do |language|
-  next unless language.enabled || @programming_question.language_id == language.id
-
-  next if is_course_koditsu_enabled && is_assessment_koditsu_enabled &&
-          !KoditsuAsyncApiService.language_valid_for_koditsu?(language)
-
-  json.id language.id
-  json.name language.name
-  json.disabled !language.enabled
-  json.editorMode language.ace_mode
+languages = Coursemology::Polyglot::Language.all.order(weight: :desc).select do |language|
+  (language.enabled || @programming_question.language_id == language.id) &&
+    !(is_course_koditsu_enabled && is_assessment_koditsu_enabled && !language.koditsu_whitelisted?)
+end
+json.languages do
+  json.partial! 'languages', locals: { languages: languages }
 end
 
 json.partial! 'question'

--- a/app/views/course/assessment/question/programming/_languages.json.jbuilder
+++ b/app/views/course/assessment/question/programming/_languages.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+json.array! languages do |language|
+  json.id language.id
+  json.name language.name
+  json.disabled !language.enabled
+  json.whitelists do
+    # we could return the other flags here, but they are currently not used by FE
+    json.defaultEvaluator language.default_evaluator_whitelisted?
+    json.codaveriEvaluator language.codaveri_evaluator_whitelisted?
+  end
+  json.editorMode language.ace_mode
+end

--- a/app/views/course/assessment/question/programming/metadata/_r.json.jbuilder
+++ b/app/views/course/assessment/question/programming/metadata/_r.json.jbuilder
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+json.partial! 'course/assessment/question/programming/metadata/default', data: data

--- a/app/views/course/question_assessments/_question_assessment.json.jbuilder
+++ b/app/views/course/question_assessments/_question_assessment.json.jbuilder
@@ -16,7 +16,7 @@ is_programming_question = question.actable_type == Course::Assessment::Question:
 is_course_koditsu_enabled = current_course.component_enabled?(Course::KoditsuPlatformComponent)
 
 if is_course_koditsu_enabled && is_programming_question
-  is_language_supportable_by_koditsu = KoditsuAsyncApiService.language_valid_for_koditsu?(question.actable.language)
+  is_language_supportable_by_koditsu = question.actable.language.koditsu_whitelisted?
   json.isCompatibleWithKoditsu is_programming_question && is_language_supportable_by_koditsu
 end
 

--- a/client/app/api/course/Assessment/Question/Programming.ts
+++ b/client/app/api/course/Assessment/Question/Programming.ts
@@ -30,7 +30,7 @@ export default class ProgrammingAPI extends BaseAPI {
     return this.client.patch(`${this.#urlPrefix}/${id}`, data);
   }
 
-  fetchCodaveriLanguages(): APIResponse<{ languages: LanguageData[] }> {
+  fetchCodaveriLanguages(): APIResponse<LanguageData[]> {
     return this.client.get(`${this.#urlPrefix}/codaveri_languages`);
   }
 

--- a/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateProgrammingQuestionPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateProgrammingQuestionPage.tsx
@@ -285,7 +285,7 @@ const GenerateProgrammingQuestionPage = (): JSX.Element => {
   return (
     // TODO: Update these queries to return only data needed for this page, instead of the full objects.
     <Preload render={<LoadingIndicator />} while={fetchCodaveriLanguages}>
-      {(data): JSX.Element => {
+      {(languages): JSX.Element => {
         return (
           <>
             <GenerateTabs
@@ -323,7 +323,7 @@ const GenerateProgrammingQuestionPage = (): JSX.Element => {
                       <GenerateConversation
                         activeSnapshotId={activeSnapshotId}
                         codaveriForm={codaveriForm}
-                        languages={data.languages.map((l) => ({
+                        languages={languages.map((l) => ({
                           label: l.name,
                           value: l.id,
                         }))}
@@ -523,7 +523,7 @@ const GenerateProgrammingQuestionPage = (): JSX.Element => {
               <Divider className="mt-8" />
             </Container>
             <GenerateExportDialog
-              languages={data.languages}
+              languages={languages}
               open={exportDialogOpen}
               saveActiveFormData={saveActiveFormData}
               setOpen={setExportDialogOpen}

--- a/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateQuestionPrototypeForm.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateQuestionPrototypeForm.tsx
@@ -161,7 +161,10 @@ const GenerateQuestionPrototypeForm: FC<Props> = (props) => {
         <Container disableGutters maxWidth={false}>
           <TestCases
             disabled={lockStates['testUi.metadata.testCases.public']}
+            hintHeader={t(translations.hint)}
+            lhsHeader={t(translations.expression)}
             name="testUi.metadata.testCases.public"
+            rhsHeader={t(translations.expected)}
             title={t(translations.publicTestCases)}
           />
         </Container>
@@ -174,7 +177,10 @@ const GenerateQuestionPrototypeForm: FC<Props> = (props) => {
         <Container disableGutters maxWidth={false}>
           <TestCases
             disabled={lockStates['testUi.metadata.testCases.private']}
+            hintHeader={t(translations.hint)}
+            lhsHeader={t(translations.expression)}
             name="testUi.metadata.testCases.private"
+            rhsHeader={t(translations.expected)}
             subtitle={t(translations.privateTestCasesHint)}
             title={t(translations.privateTestCases)}
           />
@@ -189,7 +195,10 @@ const GenerateQuestionPrototypeForm: FC<Props> = (props) => {
         <Container disableGutters maxWidth={false}>
           <TestCases
             disabled={lockStates['testUi.metadata.testCases.evaluation']}
+            hintHeader={t(translations.hint)}
+            lhsHeader={t(translations.expression)}
             name="testUi.metadata.testCases.evaluation"
+            rhsHeader={t(translations.expected)}
             subtitle={t(translations.evaluationTestCasesHint)}
             title={t(translations.evaluationTestCases)}
           />

--- a/client/app/bundles/course/assessment/question/programming/ProgrammingForm.tsx
+++ b/client/app/bundles/course/assessment/question/programming/ProgrammingForm.tsx
@@ -45,7 +45,7 @@ const ProgrammingForm = (props: ProgrammingFormProps): JSX.Element => {
   const [form, setForm] = useState<FormEmitter<ProgrammingFormData>>();
   const [pending, setPending] = useState<() => void>();
 
-  const { languageOptions, getModeFromId } = useLanguageMode(data.languages);
+  const { languageOptions, getDataFromId } = useLanguageMode(data.languages);
 
   const navigate = useNavigate();
 
@@ -104,7 +104,7 @@ const ProgrammingForm = (props: ProgrammingFormProps): JSX.Element => {
 
   const preProcessForm = (draft: ProgrammingFormData): ProgrammingFormData => {
     if (draft.testUi?.mode) {
-      draft.testUi.mode = getModeFromId(draft.question.languageId);
+      draft.testUi.mode = getDataFromId(draft.question.languageId)?.editorMode;
     }
 
     return draft;
@@ -131,22 +131,26 @@ const ProgrammingForm = (props: ProgrammingFormProps): JSX.Element => {
         }}
         transformsBy={preProcessForm}
         validates={schema(t)}
+        validatesWith={{ getDataFromId }}
       >
         <QuestionFields disabled={submitting} />
 
         <Section sticksToNavbar title={t(translations.languageAndEvaluation)}>
           <LanguageFields
             disabled={submitting}
-            getModeFromId={getModeFromId}
+            getDataFromId={getDataFromId}
             languageOptions={languageOptions}
           />
 
-          <EvaluatorFields disabled={submitting} />
+          <EvaluatorFields
+            disabled={submitting}
+            getDataFromId={getDataFromId}
+          />
         </Section>
 
-        <PackageFields disabled={submitting} getModeFromId={getModeFromId} />
+        <PackageFields disabled={submitting} getDataFromId={getDataFromId} />
 
-        <FeedbackFields disabled={submitting} />
+        <FeedbackFields disabled={submitting} getDataFromId={getDataFromId} />
 
         <BuildLog />
       </Form>

--- a/client/app/bundles/course/assessment/question/programming/commons/builder.ts
+++ b/client/app/bundles/course/assessment/question/programming/commons/builder.ts
@@ -145,6 +145,7 @@ const POLYGLOT_BUILDER: Partial<
   python: basicBuilder,
   c_cpp: basicBuilder,
   java: javaBuilder,
+  r: basicBuilder,
 };
 
 const appendSkillIdsInto = (data: FormData, skillIds: number[]): void =>

--- a/client/app/bundles/course/assessment/question/programming/components/common/ControlledEditor.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/common/ControlledEditor.tsx
@@ -17,10 +17,11 @@ interface ControlledEditorChildProps extends Partial<EditorAccordionProps> {
 interface ControlledEditorProps extends ControlledEditorChildProps {
   name: FieldPathByValue<ProgrammingFormData, string | null>;
   title: EditorAccordionProps['title'];
+  defaultValue?: string;
 }
 
 const ControlledEditor = (props: ControlledEditorProps): JSX.Element => {
-  const { name, ...editorProps } = props;
+  const { name, defaultValue, ...editorProps } = props;
 
   const { control } = useFormContext<ProgrammingFormData>();
 
@@ -33,7 +34,7 @@ const ControlledEditor = (props: ControlledEditorProps): JSX.Element => {
           {...editorProps}
           name={field.name}
           onChange={field.onChange}
-          value={field.value ?? ''}
+          value={field.value ?? defaultValue ?? ''}
         />
       )}
     />

--- a/client/app/bundles/course/assessment/question/programming/components/common/TestCasesTable.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/common/TestCasesTable.tsx
@@ -20,6 +20,9 @@ export interface TestCasesTableProps {
   onClickAdd?: () => void;
   disabled?: boolean;
   subtitle?: string;
+  lhsHeader: string;
+  rhsHeader: string;
+  hintHeader: string;
 }
 
 const TestCasesTable = (
@@ -38,15 +41,15 @@ const TestCasesTable = (
         <TableHead className="sticky top-0 z-10 bg-white">
           <TableRow>
             <TableCell className="border-b border-solid border-b-neutral-200 py-0 pl-4 pr-0">
-              {t(translations.expression)}
+              {props.lhsHeader}
             </TableCell>
 
             <TableCell className="border-b border-solid border-b-neutral-200 px-2 py-0">
-              {t(translations.expected)}
+              {props.rhsHeader}
             </TableCell>
 
             <TableCell className="border-b border-solid border-b-neutral-200 px-0 py-0">
-              {t(translations.hint)}
+              {props.hintHeader}
             </TableCell>
 
             {props.onClickAdd && (

--- a/client/app/bundles/course/assessment/question/programming/components/package/BasicPackageEditor.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/package/BasicPackageEditor.tsx
@@ -52,20 +52,29 @@ const BasicPackageEditor = (props: BasicPackageEditorProps): JSX.Element => {
       <PackageEditor.TestCases hint={props.hint}>
         <TestCases
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="testUi.metadata.testCases.public"
+          rhsHeader={t(translations.expected)}
           title={t(translations.publicTestCases)}
         />
 
         <TestCases
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="testUi.metadata.testCases.private"
+          rhsHeader={t(translations.expected)}
           subtitle={t(translations.privateTestCasesHint)}
           title={t(translations.privateTestCases)}
         />
 
         <TestCases
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="testUi.metadata.testCases.evaluation"
+          rhsHeader={t(translations.expected)}
           subtitle={t(translations.evaluationTestCasesHint)}
           title={t(translations.evaluationTestCases)}
         />

--- a/client/app/bundles/course/assessment/question/programming/components/package/JavaPackageEditor.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/package/JavaPackageEditor.tsx
@@ -156,14 +156,20 @@ const JavaPackageEditor = (props: PackageEditorProps): JSX.Element => {
         <TestCases
           as={JavaTestCase}
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="testUi.metadata.testCases.public"
+          rhsHeader={t(translations.expected)}
           title={t(translations.publicTestCases)}
         />
 
         <TestCases
           as={JavaTestCase}
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="testUi.metadata.testCases.private"
+          rhsHeader={t(translations.expected)}
           subtitle={t(translations.privateTestCasesHint)}
           title={t(translations.privateTestCases)}
         />
@@ -171,7 +177,10 @@ const JavaPackageEditor = (props: PackageEditorProps): JSX.Element => {
         <TestCases
           as={JavaTestCase}
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="testUi.metadata.testCases.evaluation"
+          rhsHeader={t(translations.expected)}
           subtitle={t(translations.evaluationTestCasesHint)}
           title={t(translations.evaluationTestCases)}
         />

--- a/client/app/bundles/course/assessment/question/programming/components/package/PackageDetails.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/package/PackageDetails.tsx
@@ -44,12 +44,12 @@ const PackageDetails = (props: PackageDetailsProps): JSX.Element | null => {
             testCases.public[index].identifier
           }
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="packageUi.testCases.public"
+          rhsHeader={t(translations.expected)}
           static
           title={t(translations.publicTestCases)}
-          lhsHeader={t(translations.expression)}
-          rhsHeader={t(translations.expected)}
-          hintHeader={t(translations.hint)}
         />
 
         <TestCases
@@ -58,13 +58,13 @@ const PackageDetails = (props: PackageDetailsProps): JSX.Element | null => {
             testCases.private[index].identifier
           }
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="packageUi.testCases.private"
+          rhsHeader={t(translations.expected)}
           static
           subtitle={t(translations.privateTestCasesHint)}
           title={t(translations.privateTestCases)}
-          lhsHeader={t(translations.expression)}
-          rhsHeader={t(translations.expected)}
-          hintHeader={t(translations.hint)}
         />
 
         <TestCases
@@ -73,13 +73,13 @@ const PackageDetails = (props: PackageDetailsProps): JSX.Element | null => {
             testCases.evaluation[index].identifier
           }
           disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.expression)}
           name="packageUi.testCases.evaluation"
+          rhsHeader={t(translations.expected)}
           static
           subtitle={t(translations.evaluationTestCasesHint)}
           title={t(translations.evaluationTestCases)}
-          lhsHeader={t(translations.expression)}
-          rhsHeader={t(translations.expected)}
-          hintHeader={t(translations.hint)}
         />
       </PackageEditor.TestCases>
     </>

--- a/client/app/bundles/course/assessment/question/programming/components/package/PackageDetails.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/package/PackageDetails.tsx
@@ -47,6 +47,9 @@ const PackageDetails = (props: PackageDetailsProps): JSX.Element | null => {
           name="packageUi.testCases.public"
           static
           title={t(translations.publicTestCases)}
+          lhsHeader={t(translations.expression)}
+          rhsHeader={t(translations.expected)}
+          hintHeader={t(translations.hint)}
         />
 
         <TestCases
@@ -59,6 +62,9 @@ const PackageDetails = (props: PackageDetailsProps): JSX.Element | null => {
           static
           subtitle={t(translations.privateTestCasesHint)}
           title={t(translations.privateTestCases)}
+          lhsHeader={t(translations.expression)}
+          rhsHeader={t(translations.expected)}
+          hintHeader={t(translations.hint)}
         />
 
         <TestCases
@@ -71,6 +77,9 @@ const PackageDetails = (props: PackageDetailsProps): JSX.Element | null => {
           static
           subtitle={t(translations.evaluationTestCasesHint)}
           title={t(translations.evaluationTestCases)}
+          lhsHeader={t(translations.expression)}
+          rhsHeader={t(translations.expected)}
+          hintHeader={t(translations.hint)}
         />
       </PackageEditor.TestCases>
     </>

--- a/client/app/bundles/course/assessment/question/programming/components/package/PolyglotEditor.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/package/PolyglotEditor.tsx
@@ -15,22 +15,17 @@ import CppPackageEditor from './CppPackageEditor';
 import JavaPackageEditor from './JavaPackageEditor';
 import PackageDetails from './PackageDetails';
 import PythonPackageEditor from './PythonPackageEditor';
+import RPackageEditor from './RPackageEditor';
 
 const EDITORS: Partial<Record<LanguageMode, ElementType>> = {
   python: PythonPackageEditor,
   java: JavaPackageEditor,
   c_cpp: CppPackageEditor,
+  r: RPackageEditor,
 };
 
-export const SUPPORTED_EDITORS = new Set(
-  Object.keys(EDITORS) as LanguageMode[],
-);
-
-export const isLanguageSupported = (language: LanguageMode): boolean =>
-  SUPPORTED_EDITORS.has(language);
-
 interface PolyglotEditorProps {
-  getModeFromId: (id: number) => LanguageMode;
+  languageMode: LanguageMode;
   disabled?: boolean;
 }
 
@@ -39,7 +34,6 @@ const PolyglotEditor = (props: PolyglotEditorProps): JSX.Element => {
 
   const { watch } = useFormContext<ProgrammingFormData>();
 
-  const language = props.getModeFromId(watch('question.languageId'));
   const autograded = watch('question.autograded');
   const editOnline = watch('question.editOnline');
 
@@ -48,17 +42,17 @@ const PolyglotEditor = (props: PolyglotEditorProps): JSX.Element => {
       <Section sticksToNavbar title={t(translations.templates)}>
         <ControlledEditor.Template
           disabled={props.disabled}
-          language={language}
+          language={props.languageMode}
         />
       </Section>
     );
 
   if (!editOnline) return <PackageDetails disabled={props.disabled} />;
 
-  const EditorComponent = EDITORS[language];
+  const EditorComponent = EDITORS[props.languageMode];
 
   if (!EditorComponent)
-    throw new Error(`Unsupported language mode: "${language}".`);
+    throw new Error(`Unsupported language mode: "${props.languageMode}".`);
 
   return <EditorComponent disabled={props.disabled} />;
 };

--- a/client/app/bundles/course/assessment/question/programming/components/package/RPackageEditor.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/package/RPackageEditor.tsx
@@ -1,0 +1,96 @@
+import { Link, Typography } from '@mui/material';
+
+import useTranslation from 'lib/hooks/useTranslation';
+
+import translations from '../../../../translations';
+import ControlledEditor from '../common/ControlledEditor';
+import DataFilesManager from '../common/DataFilesManager';
+import TestCases from '../common/TestCases';
+
+import PackageEditor, { PackageEditorProps } from './PackageEditor';
+
+const PREPEND_DIV_ID = 'code-inserts-prepend';
+const APPEND_DIV_ID = 'code-inserts-append';
+
+const TestCasesHint = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <Typography color="text.secondary" variant="body2">
+      {t(translations.rTestCasesHint, {
+        prepend: (chunk) => <Link href={`#${PREPEND_DIV_ID}`}>{chunk}</Link>,
+        append: (chunk) => <Link href={`#${APPEND_DIV_ID}`}>{chunk}</Link>,
+      })}
+    </Typography>
+  );
+};
+
+const RPackageEditor = (props: PackageEditorProps): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <PackageEditor.Templates>
+        <ControlledEditor.Template disabled={props.disabled} language="r" />
+        <ControlledEditor.Solution disabled={props.disabled} language="r" />
+      </PackageEditor.Templates>
+
+      <PackageEditor.CodeInserts>
+        <div id={PREPEND_DIV_ID}>
+          <ControlledEditor.Prepend disabled={props.disabled} language="r" />
+        </div>
+        <div id={APPEND_DIV_ID}>
+          <ControlledEditor.Append
+            defaultValue={
+              "# N <- as.integer(readLines('stdin', n=1))\n" +
+              '# result <- my_function(N)\n' +
+              '# cat(result)\n'
+            }
+            disabled={props.disabled}
+            language="r"
+          />
+        </div>
+      </PackageEditor.CodeInserts>
+
+      <PackageEditor.DataFiles>
+        <DataFilesManager
+          disabled={props.disabled}
+          name="testUi.metadata.dataFiles"
+        />
+      </PackageEditor.DataFiles>
+
+      <PackageEditor.TestCases hint={<TestCasesHint />}>
+        <TestCases
+          disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.input)}
+          name="testUi.metadata.testCases.public"
+          rhsHeader={t(translations.expectedOutput)}
+          title={t(translations.publicTestCases)}
+        />
+
+        <TestCases
+          disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.input)}
+          name="testUi.metadata.testCases.private"
+          rhsHeader={t(translations.expectedOutput)}
+          subtitle={t(translations.privateTestCasesHint)}
+          title={t(translations.privateTestCases)}
+        />
+
+        <TestCases
+          disabled={props.disabled}
+          hintHeader={t(translations.hint)}
+          lhsHeader={t(translations.input)}
+          name="testUi.metadata.testCases.evaluation"
+          rhsHeader={t(translations.expectedOutput)}
+          subtitle={t(translations.evaluationTestCasesHint)}
+          title={t(translations.evaluationTestCases)}
+        />
+      </PackageEditor.TestCases>
+    </>
+  );
+};
+
+export default RPackageEditor;

--- a/client/app/bundles/course/assessment/question/programming/components/sections/EvaluatorFields.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/sections/EvaluatorFields.tsx
@@ -1,6 +1,9 @@
 import { Controller, useFormContext } from 'react-hook-form';
-import { Grid, InputAdornment, RadioGroup } from '@mui/material';
-import { ProgrammingFormData } from 'types/course/assessment/question/programming';
+import { Grid, InputAdornment, RadioGroup, Typography } from '@mui/material';
+import {
+  LanguageData,
+  ProgrammingFormData,
+} from 'types/course/assessment/question/programming';
 
 import RadioButton from 'lib/components/core/buttons/RadioButton';
 import ExperimentalChip from 'lib/components/core/ExperimentalChip';
@@ -14,6 +17,7 @@ import { useProgrammingFormDataContext } from '../../hooks/ProgrammingFormDataCo
 
 interface EvaluatorFieldsProps {
   disabled?: boolean;
+  getDataFromId: (id: number) => LanguageData;
 }
 
 const EvaluatorFields = (props: EvaluatorFieldsProps): JSX.Element | null => {
@@ -23,6 +27,7 @@ const EvaluatorFields = (props: EvaluatorFieldsProps): JSX.Element | null => {
 
   const { question } = useProgrammingFormDataContext();
 
+  const currentLanguage = props.getDataFromId(watch('question.languageId'));
   const autograded = watch('question.autograded');
   if (!autograded) return null;
 
@@ -35,21 +40,28 @@ const EvaluatorFields = (props: EvaluatorFieldsProps): JSX.Element | null => {
         <Controller
           control={control}
           name="question.isCodaveri"
-          render={({ field }): JSX.Element => (
+          render={({ field, fieldState: { error } }): JSX.Element => (
             <RadioGroup
               className="space-y-5"
               {...field}
               onChange={(e): void => {
                 if (codaveriDisabled) return;
-
                 field.onChange(e.target.value === 'codaveri');
               }}
               value={field.value ? 'codaveri' : 'default'}
             >
+              {error && (
+                <Typography color="error" variant="body2">
+                  {error.message}
+                </Typography>
+              )}
               <RadioButton
                 className="my-0"
                 description={t(translations.defaultEvaluatorHint)}
-                disabled={props.disabled}
+                disabled={
+                  !currentLanguage?.whitelists.defaultEvaluator ||
+                  props.disabled
+                }
                 label={t(translations.defaultEvaluator)}
                 value="default"
               />
@@ -57,7 +69,11 @@ const EvaluatorFields = (props: EvaluatorFieldsProps): JSX.Element | null => {
               <RadioButton
                 className="my-0"
                 description={t(translations.codaveriEvaluatorHint)}
-                disabled={codaveriDisabled || props.disabled}
+                disabled={
+                  codaveriDisabled ||
+                  !currentLanguage?.whitelists.codaveriEvaluator ||
+                  props.disabled
+                }
                 disabledHint={
                   codaveriDisabled &&
                   t(translations.canEnableCodaveriInComponents)
@@ -67,7 +83,11 @@ const EvaluatorFields = (props: EvaluatorFieldsProps): JSX.Element | null => {
                     <span>{t(translations.codaveriEvaluator)}</span>
 
                     <ExperimentalChip
-                      disabled={codaveriDisabled || props.disabled}
+                      disabled={
+                        codaveriDisabled ||
+                        !currentLanguage?.whitelists.codaveriEvaluator ||
+                        props.disabled
+                      }
                     />
                   </span>
                 }

--- a/client/app/bundles/course/assessment/question/programming/components/sections/FeedbackFields.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/sections/FeedbackFields.tsx
@@ -1,5 +1,8 @@
 import { Controller, useFormContext } from 'react-hook-form';
-import { ProgrammingFormData } from 'types/course/assessment/question/programming';
+import {
+  LanguageData,
+  ProgrammingFormData,
+} from 'types/course/assessment/question/programming';
 
 import ExperimentalChip from 'lib/components/core/ExperimentalChip';
 import Section from 'lib/components/core/layouts/Section';
@@ -12,6 +15,7 @@ import translations from '../../../../translations';
 
 interface FeedbackFieldsProps {
   disabled?: boolean;
+  getDataFromId: (id: number) => LanguageData;
 }
 
 export const FEEDBACK_SECTION_ID = 'feedback-fields' as const;
@@ -20,7 +24,7 @@ const FeedbackFields = (props: FeedbackFieldsProps): JSX.Element | null => {
   const { t } = useTranslation();
 
   const { control, watch } = useFormContext<ProgrammingFormData>();
-
+  const currentLanguage = props.getDataFromId(watch('question.languageId'));
   const liveFeedbackEnabled = watch('question.liveFeedbackEnabled');
 
   return (
@@ -40,7 +44,9 @@ const FeedbackFields = (props: FeedbackFieldsProps): JSX.Element | null => {
         render={({ field, fieldState }): JSX.Element => (
           <FormCheckboxField
             description={t(translations.enableLiveFeedbackDescription)}
-            disabled={props.disabled}
+            disabled={
+              props.disabled || !currentLanguage?.whitelists.codaveriEvaluator
+            }
             field={field}
             fieldState={fieldState}
             label={t(translations.enableLiveFeedback)}
@@ -57,7 +63,11 @@ const FeedbackFields = (props: FeedbackFieldsProps): JSX.Element | null => {
           name="question.liveFeedbackCustomPrompt"
           render={({ field, fieldState }): JSX.Element => (
             <FormRichTextField
-              disabled={props.disabled || !liveFeedbackEnabled}
+              disabled={
+                props.disabled ||
+                !currentLanguage?.whitelists.codaveriEvaluator ||
+                !liveFeedbackEnabled
+              }
               field={field}
               fieldState={fieldState}
               fullWidth

--- a/client/app/bundles/course/assessment/question/programming/components/sections/LanguageFields.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/sections/LanguageFields.tsx
@@ -2,7 +2,7 @@ import { ChangeEventHandler } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Alert } from '@mui/material';
 import {
-  LanguageMode,
+  LanguageData,
   ProgrammingFormData,
 } from 'types/course/assessment/question/programming';
 
@@ -13,11 +13,10 @@ import useTranslation from 'lib/hooks/useTranslation';
 import translations from '../../../../translations';
 import { useProgrammingFormDataContext } from '../../hooks/ProgrammingFormDataContext';
 import { LanguageOption } from '../../hooks/useLanguageMode';
-import { isLanguageSupported } from '../package/PolyglotEditor';
 
 interface LanguageFieldsProps {
   languageOptions: LanguageOption[];
-  getModeFromId: (id: number) => LanguageMode;
+  getDataFromId: (id: number) => LanguageData;
   disabled?: boolean;
 }
 
@@ -28,7 +27,7 @@ const LanguageFields = (props: LanguageFieldsProps): JSX.Element => {
 
   const { question } = useProgrammingFormDataContext();
 
-  const currentLanguage = props.getModeFromId(watch('question.languageId'));
+  const currentLanguage = props.getDataFromId(watch('question.languageId'));
   const autogradedAssessment = question.autogradedAssessment;
   const autograded = watch('question.autograded');
 
@@ -42,11 +41,14 @@ const LanguageFields = (props: LanguageFieldsProps): JSX.Element => {
             field.onChange(e.target.value);
 
             const value = parseInt(e.target.value, 10);
-            const language = props.getModeFromId(value);
+            const language = props.getDataFromId(value);
 
-            setValue('testUi.mode', language);
+            setValue('testUi.mode', language.editorMode);
 
-            if (!isLanguageSupported(language)) {
+            if (
+              !language.whitelists.codaveriEvaluator &&
+              !language.whitelists.defaultEvaluator
+            ) {
               setValue('question.autograded', false);
             }
           };
@@ -80,7 +82,8 @@ const LanguageFields = (props: LanguageFieldsProps): JSX.Element => {
           <FormCheckboxField
             description={t(translations.evaluateAndTestCodeHint)}
             disabled={
-              !isLanguageSupported(currentLanguage) ||
+              (!currentLanguage?.whitelists.codaveriEvaluator &&
+                !currentLanguage?.whitelists.defaultEvaluator) ||
               question.hasAutoGradings ||
               props.disabled
             }

--- a/client/app/bundles/course/assessment/question/programming/components/sections/PackageFields.tsx
+++ b/client/app/bundles/course/assessment/question/programming/components/sections/PackageFields.tsx
@@ -1,7 +1,7 @@
 import { Controller, useFormContext } from 'react-hook-form';
 import { RadioGroup } from '@mui/material';
 import {
-  LanguageMode,
+  LanguageData,
   ProgrammingFormData,
 } from 'types/course/assessment/question/programming';
 
@@ -20,7 +20,7 @@ import PolyglotEditor from '../package/PolyglotEditor';
 export const PACKAGE_SECTION_ID = 'package-fields' as const;
 
 interface PackageFieldsProps {
-  getModeFromId: (id: number) => LanguageMode;
+  getDataFromId: (id: number) => LanguageData;
   disabled?: boolean;
 }
 
@@ -111,7 +111,7 @@ const PackageFields = (props: PackageFieldsProps): JSX.Element => {
       {languageId && (
         <PolyglotEditor
           disabled={props.disabled}
-          getModeFromId={props.getModeFromId}
+          languageMode={props.getDataFromId(languageId)?.editorMode}
         />
       )}
     </>

--- a/client/app/bundles/course/assessment/question/programming/hooks/useLanguageMode.tsx
+++ b/client/app/bundles/course/assessment/question/programming/hooks/useLanguageMode.tsx
@@ -1,20 +1,16 @@
 import { useMemo } from 'react';
-import {
-  LanguageData,
-  LanguageMode,
-} from 'types/course/assessment/question/programming';
+import { LanguageData } from 'types/course/assessment/question/programming';
 
-export interface LanguageOption {
+export type LanguageOption = Omit<LanguageData, 'id' | 'name'> & {
   label: string;
   value: number;
-  disabled: boolean;
-}
+};
 
-type LanguageIdMap = Record<number, LanguageMode>;
+type LanguageIdMap = Record<number, LanguageData>;
 
 interface UseLanguageModeHook {
   languageOptions: LanguageOption[];
-  getModeFromId: (id: number) => LanguageMode;
+  getDataFromId: (id: number) => LanguageData;
 }
 
 const useLanguageMode = (languages: LanguageData[]): UseLanguageModeHook => {
@@ -22,13 +18,18 @@ const useLanguageMode = (languages: LanguageData[]): UseLanguageModeHook => {
     () =>
       languages.reduce<[LanguageOption[], LanguageIdMap]>(
         ([options, map], language) => {
-          options.push({
+          const option = {
             label: language.name,
             value: language.id,
             disabled: language.disabled,
-          });
-
-          map[language.id] = language.editorMode;
+            editorMode: language.editorMode,
+            whitelists: {
+              codaveriEvaluator: language.whitelists.codaveriEvaluator,
+              defaultEvaluator: language.whitelists.defaultEvaluator,
+            },
+          };
+          options.push(option);
+          map[language.id] = language;
 
           return [options, map];
         },
@@ -37,9 +38,9 @@ const useLanguageMode = (languages: LanguageData[]): UseLanguageModeHook => {
     [],
   );
 
-  const getModeFromId = (id: number): LanguageMode => languageIdToModeMap[id];
+  const getDataFromId = (id: number): LanguageData => languageIdToModeMap[id];
 
-  return { languageOptions, getModeFromId };
+  return { languageOptions, getDataFromId };
 };
 
 export default useLanguageMode;

--- a/client/app/bundles/course/assessment/question/programming/operations.ts
+++ b/client/app/bundles/course/assessment/question/programming/operations.ts
@@ -13,9 +13,7 @@ const EVALUATION_INTERVAL_MS = 500 as const;
 
 const ProgrammingAPI = CourseAPI.assessment.question.programming;
 
-export const fetchCodaveriLanguages = async (): Promise<{
-  languages: LanguageData[];
-}> => {
+export const fetchCodaveriLanguages = async (): Promise<LanguageData[]> => {
   const response = await ProgrammingAPI.fetchCodaveriLanguages();
   return response.data;
 };

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -1445,6 +1445,14 @@ const translations = defineMessages({
       'against the Expected expectations using the equality operator (<code>==</code>). Notably, <code>print()</code> ' +
       'returns <code>None</code>, so <code>print</code>ed outputs should not be confused with actual return values.',
   },
+  rTestCasesHint: {
+    id: 'course.assessment.question.programming.rTestCasesHint',
+    defaultMessage:
+      'Each test case launches a separate R console instance and provides input via standard input. This console will ' +
+      'run the <prepend>Prepend</prepend> script, the student submission, and the <append>Append</append> script. ' +
+      'The standard output of these scripts will be compared (as a string) to the expected output of the test case. We recommend ' +
+      'processing the standard input in one of these scripts.',
+  },
   inlineCode: {
     id: 'course.assessment.question.programming.inlineCode',
     defaultMessage: 'Inline code',
@@ -1573,6 +1581,14 @@ const translations = defineMessages({
     id: 'course.assessment.question.programming.hint',
     defaultMessage: 'Hint',
   },
+  input: {
+    id: 'course.assessment.question.programming.input',
+    defaultMessage: 'Input',
+  },
+  expectedOutput: {
+    id: 'course.assessment.question.programming.expectedOutput',
+    defaultMessage: 'Expected Output',
+  },
   addTestCase: {
     id: 'course.assessment.question.programming.addTestCase',
     defaultMessage: 'Add a test case',
@@ -1641,6 +1657,20 @@ const translations = defineMessages({
     id: 'course.assessment.question.programming.languageDeprecatedWarning',
     defaultMessage:
       'Your selected language is deprecated. Please change it to another language.',
+  },
+  defaultEvaluatorNotSupported: {
+    id: 'course.assessment.question.programming.defaultEvaluatorNotSupported',
+    defaultMessage: '{languageName} is not supported by the default evaluator.',
+  },
+  codaveriEvaluatorNotSupported: {
+    id: 'course.assessment.question.programming.codaveriEvaluatorNotSupported',
+    defaultMessage:
+      '{languageName} is not supported by the Codaveri evaluator.',
+  },
+  liveFeedbackNotSupported: {
+    id: 'course.assessment.question.programming.liveFeedbackNotSupported',
+    defaultMessage:
+      'Live feedback generation is not supported for {languageName}.',
   },
 });
 

--- a/client/app/lib/initializers/ace-editor.js
+++ b/client/app/lib/initializers/ace-editor.js
@@ -5,6 +5,7 @@ require('ace-builds/src-noconflict/mode-c_cpp');
 require('ace-builds/src-noconflict/mode-java');
 require('ace-builds/src-noconflict/mode-javascript');
 require('ace-builds/src-noconflict/mode-python');
+require('ace-builds/src-noconflict/mode-r');
 require('ace-builds/src-noconflict/theme-github');
 
 /**

--- a/client/app/types/course/assessment/question/programming.ts
+++ b/client/app/types/course/assessment/question/programming.ts
@@ -1,12 +1,16 @@
 import { AvailableSkills, QuestionFormData } from '../questions';
 
-export type LanguageMode = 'c_cpp' | 'java' | 'javascript' | 'python';
+export type LanguageMode = 'c_cpp' | 'java' | 'javascript' | 'python' | 'r';
 
 export interface LanguageData {
   id: number;
   name: string;
   disabled: boolean;
   editorMode: LanguageMode;
+  whitelists: {
+    defaultEvaluator: boolean;
+    codaveriEvaluator: boolean;
+  };
 }
 
 export interface PackageInfoData {

--- a/db/migrate/20241028141424_add_language_whitelist_flags.rb
+++ b/db/migrate/20241028141424_add_language_whitelist_flags.rb
@@ -1,0 +1,10 @@
+class AddLanguageWhitelistFlags < ActiveRecord::Migration[7.2]
+  def change
+    add_column :polyglot_languages, :default_evaluator_whitelisted, :boolean, default: true, null: false
+    add_column :polyglot_languages, :codaveri_evaluator_whitelisted, :boolean, default: false, null: false
+    add_column :polyglot_languages, :question_generation_whitelisted, :boolean, default: false, null: false
+    add_column :polyglot_languages, :koditsu_whitelisted, :boolean, default: false, null: false
+
+    Rake::Task['db:set_polyglot_language_flags'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_17_170847) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_28_141424) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -1419,6 +1419,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_17_170847) do
     t.integer "parent_id"
     t.serial "weight"
     t.boolean "enabled", default: true, null: false
+    t.boolean "default_evaluator_whitelisted", default: true, null: false
+    t.boolean "codaveri_evaluator_whitelisted", default: false, null: false
+    t.boolean "question_generation_whitelisted", default: false, null: false
+    t.boolean "koditsu_whitelisted", default: false, null: false
     t.index "lower((name)::text)", name: "index_polyglot_languages_on_name", unique: true
     t.index ["parent_id"], name: "fk__polyglot_languages_parent_id"
   end

--- a/db/seeds/test.rb
+++ b/db/seeds/test.rb
@@ -9,3 +9,5 @@ ActsAsTenant.with_tenant(Instance.default) do
     user.save!
   end
 end
+
+Rake::Task['db:set_polyglot_language_flags'].invoke

--- a/lib/autoload/course/assessment/programming_package.rb
+++ b/lib/autoload/course/assessment/programming_package.rb
@@ -191,6 +191,21 @@ class Course::Assessment::ProgrammingPackage
     retrieve_files_in_main_dir
   end
 
+  # Gets the contents of the XML test reports (if present).
+  # Under normal circumstances, they will not be present in the evaluation package,
+  # but current implementation of Codaveri-only evaluations requires them.
+  def test_reports
+    ensure_file_open!
+    reports_map = {}
+    [:public, :private, :evaluation].each do |test_type|
+      if @file.find_entry("report-#{test_type}.xml").present?
+        reports_map[test_type] =
+          @file.read("report-#{test_type}.xml")
+      end
+    end
+    reports_map
+  end
+
   private
 
   # Ensures that the zip file is open.

--- a/lib/autoload/course/assessment/programming_test_case_report_builder.rb
+++ b/lib/autoload/course/assessment/programming_test_case_report_builder.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+# rubocop:disable Metrics/AbcSize
+class Course::Assessment::ProgrammingTestCaseReportBuilder
+  def self.build_dummy_report(test_type, test_cases)
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.testsuites do
+        xml.testsuite(
+          name: "#{test_type.capitalize}TestsGrader",
+          tests: test_cases.count.to_s,
+          file: '.R',
+          time: '0.01',
+          timestamp: Time.now.iso8601,
+          failures: 0.to_s,
+          errors: test_cases.count.to_s
+        ) do
+          test_cases.each.with_index(1) do |test_case, index|
+            xml.testcase(
+              classname: "#{test_type.capitalize}TestsGrader",
+              name: "test_#{test_type}_#{format('%<index>02i', index: index)}",
+              time: '0.00001',
+              timestamp: Time.now.iso8601,
+              file: 'answer.R',
+              line: '1'
+            ) do
+              xml.meta(expression: test_case[:expression], expected: test_case[:expected], hint: test_case[:hint])
+              xml.error(type: 'NotImplementedError', message: 'This is a dummy report, so this test was not run.')
+            end
+          end
+        end
+      end
+    end
+
+    builder.to_xml
+  end
+end
+# rubocop:enable Metrics/AbcSize

--- a/lib/extensions/polyglot_with_database/coursemology/polyglot/language.rb
+++ b/lib/extensions/polyglot_with_database/coursemology/polyglot/language.rb
@@ -67,9 +67,25 @@ module Extensions::PolyglotWithDatabase::Coursemology::Polyglot::Language
   end
 end
 
-# This directly injects a method into all concrete languages' class methods.
-module Coursemology::Polyglot::ConcreteLanguage::ClassMethods
-  def instance
-    root_instance
+module Coursemology::Polyglot::ConcreteLanguage
+  # Returns language name in lowercase format (eg python, java).
+  #
+  # @return [String] The language name in lowercase format.
+  def polyglot_name
+    name.split[0].downcase
+  end
+
+  # Returns language version.
+  #
+  # @return [String] The language version.
+  def polyglot_version
+    name.split[1]
+  end
+
+  # This directly injects a method into all concrete languages' class methods.
+  module ClassMethods
+    def instance
+      root_instance
+    end
   end
 end

--- a/lib/tasks/db/set_polyglot_language_flags.rake
+++ b/lib/tasks/db/set_polyglot_language_flags.rake
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+namespace :db do
+  # Run this after adding the *_whitelisted columns to polyglot_languages table.
+  # (20241028141424_add_language_whitelist_flags.rb)
+
+  # These whitelists are accurate as of the date this migration is merged and performed (2024-11-18)
+  CODAVERI_EVALUATOR_WHITELIST =
+    [
+      Coursemology::Polyglot::Language::Python::Python3Point4,
+      Coursemology::Polyglot::Language::Python::Python3Point5,
+      Coursemology::Polyglot::Language::Python::Python3Point6,
+      Coursemology::Polyglot::Language::Python::Python3Point7,
+      Coursemology::Polyglot::Language::Python::Python3Point9,
+      Coursemology::Polyglot::Language::Python::Python3Point10,
+      Coursemology::Polyglot::Language::Python::Python3Point12,
+      Coursemology::Polyglot::Language::R::R4Point1
+    ].freeze
+
+  QUESTION_GENERATION_WHITELIST =
+    [
+      Coursemology::Polyglot::Language::Python::Python3Point4,
+      Coursemology::Polyglot::Language::Python::Python3Point5,
+      Coursemology::Polyglot::Language::Python::Python3Point6,
+      Coursemology::Polyglot::Language::Python::Python3Point7,
+      Coursemology::Polyglot::Language::Python::Python3Point9,
+      Coursemology::Polyglot::Language::Python::Python3Point10,
+      Coursemology::Polyglot::Language::Python::Python3Point12
+    ].freeze
+
+  KODITSU_WHITELIST =
+    [
+      Coursemology::Polyglot::Language::CPlusPlus,
+      Coursemology::Polyglot::Language::Python::Python3Point4,
+      Coursemology::Polyglot::Language::Python::Python3Point5,
+      Coursemology::Polyglot::Language::Python::Python3Point6,
+      Coursemology::Polyglot::Language::Python::Python3Point7,
+      Coursemology::Polyglot::Language::Python::Python3Point9,
+      Coursemology::Polyglot::Language::Python::Python3Point10,
+      Coursemology::Polyglot::Language::Python::Python3Point12
+    ].freeze
+
+  DEPRECATED_LANGUAGES =
+    [
+      Coursemology::Polyglot::Language::Python::Python2Point7,
+      Coursemology::Polyglot::Language::Python::Python3Point4,
+      Coursemology::Polyglot::Language::Python::Python3Point5,
+      Coursemology::Polyglot::Language::JavaScript
+    ].freeze
+
+  EVALUATOR_UNSUPPORTED_LANGUAGES =
+    [
+      Coursemology::Polyglot::Language::JavaScript,
+      Coursemology::Polyglot::Language::R::R4Point1
+    ].freeze
+
+  task set_polyglot_language_flags: :environment do
+    # this ensures all languages are loaded in the database table before flags are updated below
+    Coursemology::Polyglot::Language.load_languages
+
+    ActsAsTenant.without_tenant do
+      Coursemology::Polyglot::Language.
+        where(type: CODAVERI_EVALUATOR_WHITELIST.map(&:name)).
+        update_all(codaveri_evaluator_whitelisted: true)
+
+      Coursemology::Polyglot::Language.
+        where(type: QUESTION_GENERATION_WHITELIST.map(&:name)).
+        update_all(question_generation_whitelisted: true)
+
+      Coursemology::Polyglot::Language.
+        where(type: KODITSU_WHITELIST.map(&:name)).
+        update_all(koditsu_whitelisted: true)
+
+      Coursemology::Polyglot::Language.
+        where(type: DEPRECATED_LANGUAGES.map(&:name)).
+        update_all(enabled: false)
+
+      Coursemology::Polyglot::Language.
+        where(type: EVALUATOR_UNSUPPORTED_LANGUAGES.map(&:name)).
+        update_all(default_evaluator_whitelisted: false)
+    end
+  end
+end

--- a/spec/controllers/course/assessment/question/programming_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/programming_controller_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
         it 'returns the enabled languages' do
           subject
           expect(response).to have_http_status(:ok)
-          expect(JSON.parse(response.body)['languages'].map { |language| language['name'] }).to include('Python 3.10')
+          expect(JSON.parse(response.body).map { |language| language['name'] }).to include('Python 3.10')
         end
       end
 
@@ -255,7 +255,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingController do
 
         it 'does not return the disabled language' do
           subject
-          expect(JSON.parse(response.body)['languages'].map { |l| l['name'] }).not_to include('Python 3.10')
+          expect(JSON.parse(response.body).map { |l| l['name'] }).not_to include('Python 3.10')
         end
       end
     end

--- a/spec/libraries/polyglot_spec.rb
+++ b/spec/libraries/polyglot_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe 'Extension: Coursemology::Polyglot' do
       self.class::WorkingLanguage.remove_instance_variable(:@root_instance)
     end
 
+    describe '#polyglot_name' do
+      subject { self.class::WorkingLanguage.new(name: 'Workinglanguage 0.3.4') }
+      it 'returns correct language name' do
+        expect(subject.polyglot_name).to eq 'workinglanguage'
+      end
+    end
+
+    describe '#polyglot_version' do
+      subject { self.class::WorkingLanguage.new(name: 'Workinglanguage 0.3.4') }
+      it 'returns correct language version' do
+        expect(subject.polyglot_version).to eq '0.3.4'
+      end
+    end
+
     subject { self.class::DummyLanguage }
 
     describe 'Validations' do

--- a/spec/models/course/assessment/question/programming_spec.rb
+++ b/spec/models/course/assessment/question/programming_spec.rb
@@ -270,20 +270,6 @@ RSpec.describe Course::Assessment::Question::Programming do
       end
     end
 
-    describe '#polyglot_language_name' do
-      subject { build(:course_assessment_question_programming) }
-      it 'returns correct language name' do
-        expect(subject.polyglot_language_name).to eq 'python'
-      end
-    end
-
-    describe '#polyglot_language_version' do
-      subject { build(:course_assessment_question_programming) }
-      it 'returns correct language version' do
-        expect(subject.polyglot_language_version).to eq '3.10'
-      end
-    end
-
     describe '#validate_codaveri_question' do
       let(:subject_evaluator) do
         build(:course_assessment_question_programming, is_codaveri: true, assessment: assessment, language: language)

--- a/spec/services/course/assessment/question/programming_import_service_spec.rb
+++ b/spec/services/course/assessment/question/programming_import_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Course::Assessment::Question::ProgrammingImportService do
       it 'does not trigger another attachment import' do
         expect(question).to receive(:imported_attachment=).with(attachment)
         mock_result = Course::Assessment::ProgrammingEvaluationService::Result.new('', '', {}, 1)
-        subject.send(:save!, {}, mock_result)
+        subject.send(:save!, {}, mock_result.test_reports)
       end
     end
 


### PR DESCRIPTION
Associated with this PR on polyglot repo:

https://github.com/Coursemology/polyglot/pull/33

- Moved whitelist logic (evaluators, koditsu, question generation) into columns in polyglot_languages table
    - Created Rake task to populate whitelist data in database. It will be run as part of `db:setup` and `db:migrate`
- Created dummy R package service. Currently it doesn't evaluate anything, its purpose is to encode test case information for importing programming packages.
- Created codaveri R package service. We use IOTestcases when evaluating R problems in Codaveri: the existing exprTestcases for Python problems is unaffected.
- Updated frontend code to handle R programming questions