### PR TITLE
Upgrade to Codaveri v2.1

### DIFF
--- a/app/controllers/course/assessment/question/programming_controller.rb
+++ b/app/controllers/course/assessment/question/programming_controller.rb
@@ -80,11 +80,11 @@ class Course::Assessment::Question::ProgrammingController < Course::Assessment::
 
     generation_service = Course::Assessment::Question::CodaveriProblemGenerationService.new(
       @assessment,
-      params[:custom_prompt],
+      params,
       language.polyglot_name,
-      language.polyglot_version,
-      params[:difficulty]
+      language.polyglot_version
     )
+
     generated_problem = generation_service.codaveri_generate_problem
     render json: generated_problem, status: :ok
   end

--- a/app/services/codaveri_async_api_service.rb
+++ b/app/services/codaveri_async_api_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CodaveriAsyncApiService
+  CODAVERI_API_VERSION = 2.1
+
   def config
     ENV.fetch('CODAVERI_URL')
   end
@@ -16,6 +18,7 @@ class CodaveriAsyncApiService
     response = connection.post(
       headers: {
         'x-api-key' => ENV.fetch('CODAVERI_API_KEY', nil),
+        'x-api-version' => CODAVERI_API_VERSION,
         'Content-Type' => 'application/json'
       },
       body: @payload.to_json
@@ -28,6 +31,7 @@ class CodaveriAsyncApiService
     response = connection.put(
       headers: {
         'x-api-key' => ENV.fetch('CODAVERI_API_KEY', nil),
+        'x-api-version' => CODAVERI_API_VERSION,
         'Content-Type' => 'application/json'
       },
       body: @payload.to_json
@@ -39,7 +43,8 @@ class CodaveriAsyncApiService
     connection = Excon.new(@api_endpoint)
     response = connection.get(
       headers: {
-        'x-api-key' => ENV.fetch('CODAVERI_API_KEY', nil)
+        'x-api-key' => ENV.fetch('CODAVERI_API_KEY', nil),
+        'x-api-version' => CODAVERI_API_VERSION
       },
       query: @payload
     )

--- a/app/services/course/assessment/answer/programming_codaveri_async_feedback_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_async_feedback_service.rb
@@ -34,7 +34,7 @@ class Course::Assessment::Answer::ProgrammingCodaveriAsyncFeedbackService # rubo
   end
 
   def fetch_codaveri_feedback(feedback_id)
-    api_namespace = @course.codaveri_itsp_enabled? ? 'v2/feedback/ITSP' : 'v2/feedback/LLM'
+    api_namespace = @course.codaveri_itsp_enabled? ? 'feedback/ITSP' : 'feedback/LLM'
     codaveri_api_service = CodaveriAsyncApiService.new(api_namespace, { id: feedback_id })
     codaveri_api_service.get
   end
@@ -49,7 +49,7 @@ class Course::Assessment::Answer::ProgrammingCodaveriAsyncFeedbackService # rubo
   def self.default_config
     {
       persona: 'novice',
-      categories: ['functionality'],
+      categories: [],
       revealLevel: 'solution',
       tone: 'encouraging',
       language: 'english',
@@ -91,7 +91,7 @@ class Course::Assessment::Answer::ProgrammingCodaveriAsyncFeedbackService # rubo
   end
 
   def request_codaveri_feedback
-    api_namespace = @course.codaveri_itsp_enabled? ? 'v2/feedback/ITSP' : 'v2/feedback/LLM'
+    api_namespace = @course.codaveri_itsp_enabled? ? 'feedback/ITSP' : 'feedback/LLM'
     codaveri_api_service = CodaveriAsyncApiService.new(api_namespace, @answer_object)
     response_status, response_body = codaveri_api_service.post
 

--- a/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Course::Assessment::Answer::ProgrammingCodaveriAutoGradingService < \
+class Course::Assessment::Answer::ProgrammingCodaveriAutoGradingService <
   Course::Assessment::Answer::AutoGradingService
   def evaluate(answer)
     unless answer.submission.assessment.course.component_enabled?(Course::CodaveriComponent)

--- a/app/services/course/assessment/programming_codaveri_evaluation_service.rb
+++ b/app/services/course/assessment/programming_codaveri_evaluation_service.rb
@@ -154,7 +154,7 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService # rubocop:disable
   end
 
   def request_codaveri_evaluation
-    codaveri_api_service = CodaveriAsyncApiService.new('v2/evaluate', @answer_object)
+    codaveri_api_service = CodaveriAsyncApiService.new('evaluate', @answer_object)
     response_status, response_body = codaveri_api_service.post
 
     response_success = response_body['success']
@@ -170,7 +170,7 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService # rubocop:disable
   end
 
   def fetch_codaveri_evaluation(evaluation_id)
-    codaveri_api_service = CodaveriAsyncApiService.new('v2/evaluate', { id: evaluation_id })
+    codaveri_api_service = CodaveriAsyncApiService.new('evaluate', { id: evaluation_id })
     codaveri_api_service.get
   end
 
@@ -211,7 +211,7 @@ class Course::Assessment::ProgrammingCodaveriEvaluationService # rubocop:disable
     TestCaseResult.new(
       index: result['testcase']['index'].to_i,
       success: result_run['success'],
-      output: result_run['display'],
+      output: result_run['displayValue'],
       stdout: result_run['stdout'],
       stderr: result_run['stderr'],
       exit_code: result_run['code'],

--- a/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
@@ -69,9 +69,7 @@ class Course::Assessment::Question::ProgrammingCodaveri::LanguagePackageService
     {
       index: '',
       type: 'expression',
-      timeout: '',
       prefix: '',
-      expression: '',
       display: 'str(out)'
     }
   end

--- a/app/services/course/assessment/question/programming_codaveri/python/python_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/python/python_package_service.rb
@@ -135,8 +135,9 @@ class Course::Assessment::Question::ProgrammingCodaveri::Python::PythonPackageSe
       # prefix
       prefix = test_content.gsub(reg_meta, '').gsub(/^#{indentation}/, '').strip
 
-      # expression
-      expression = assertion_types[assertion_type.to_sym].call(assertion_content)
+      # lhsExpression and rhsExpression
+      lhs_expression, rhs_expression =
+        assertion_types[assertion_type.to_sym].call(assertion_content).split('==').map(&:strip)
 
       # display
       display_list = test_content.scan(reg_meta_display)
@@ -144,9 +145,10 @@ class Course::Assessment::Question::ProgrammingCodaveri::Python::PythonPackageSe
 
       # combine all extracted data
       test_case_object[:index] = test_cases_with_id[test_name]
-      test_case_object[:timeout] = @question.time_limit ? @question.time_limit * 1000 : nil # in millisecond
+      test_case_object[:timeout] = @question.time_limit * 1000 if @question.time_limit # in millisecond
       test_case_object[:prefix] = prefix
-      test_case_object[:expression] = expression
+      test_case_object[:lhsExpression] = lhs_expression
+      test_case_object[:rhsExpression] = rhs_expression
       test_case_object[:display] = display
 
       @test_case_files.append(test_case_object)

--- a/app/services/course/assessment/question/programming_codaveri_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri_service.rb
@@ -97,14 +97,14 @@ class Course::Assessment::Question::ProgrammingCodaveriService
   end
 
   def create_codaveri_problem
-    codaveri_api_service = CodaveriAsyncApiService.new('v2/problem', @problem_object)
+    codaveri_api_service = CodaveriAsyncApiService.new('problem', @problem_object)
     response_status, response_body = codaveri_api_service.post
 
     handle_codaveri_response(response_status, response_body)
   end
 
   def update_codaveri_problem
-    codaveri_api_service = CodaveriAsyncApiService.new('v2/problem', @problem_object)
+    codaveri_api_service = CodaveriAsyncApiService.new('problem', @problem_object)
     response_status, response_body = codaveri_api_service.put
 
     handle_codaveri_response(response_status, response_body)

--- a/app/services/course/discussion/post/codaveri_feedback_rating_service.rb
+++ b/app/services/course/discussion/post/codaveri_feedback_rating_service.rb
@@ -29,7 +29,7 @@ class Course::Discussion::Post::CodaveriFeedbackRatingService
   end
 
   def send_codaveri_feedback_rating
-    codaveri_api_service = CodaveriAsyncApiService.new('v2/feedback/rating', @payload)
+    codaveri_api_service = CodaveriAsyncApiService.new('feedback/rating', @payload)
     response_status, response_body = codaveri_api_service.post
 
     response_success = response_body['success']

--- a/client/app/api/course/Assessment/Submissions.js
+++ b/client/app/api/course/Assessment/Submissions.js
@@ -130,10 +130,11 @@ export default class SubmissionsAPI extends BaseAssessmentAPI {
   }
 
   fetchLiveFeedback(feedbackUrl, feedbackToken) {
-    return this.externalClient.get(`/signed/v2/feedback/llm`, {
+    const CODAVERI_API_VERSION = '2.1';
+
+    return this.externalClient.get(`/signed/feedback/llm`, {
       baseURL: feedbackUrl,
-      // TODO remove this when we cutover to live CV instance
-      headers: { 'ngrok-skip-browser-warning': '1' },
+      headers: { 'x-api-version': CODAVERI_API_VERSION },
       params: { token: feedbackToken },
     });
   }

--- a/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateProgrammingQuestionPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentGenerate/GenerateProgrammingQuestionPage.tsx
@@ -4,11 +4,8 @@ import { defineMessages } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Container, Divider, Grid } from '@mui/material';
-import { FetchAssessmentData } from 'types/course/assessment/assessments';
-import { MetadataTestCase } from 'types/course/assessment/question/programming';
 import * as yup from 'yup';
 
-import { fetchAssessment } from 'course/assessment/operations/assessments';
 import GenerateConversation from 'course/assessment/pages/AssessmentGenerate/GenerateConversation';
 import GenerateQuestionPrototypeForm from 'course/assessment/pages/AssessmentGenerate/GenerateQuestionPrototypeForm';
 import GenerateTabs from 'course/assessment/pages/AssessmentGenerate/GenerateTabs';
@@ -35,6 +32,7 @@ import {
   generate,
 } from '../../question/programming/operations';
 
+import { defaultCodaveriFormData, defaultQuestionFormData } from './constants';
 import GenerateExportDialog from './GenerateExportDialog';
 
 const translations = defineMessages({
@@ -72,30 +70,6 @@ const areObjectArraysEqual = <T extends object>(
         ),
       )
       .every((p) => p));
-
-const defaultCodaveriFormData: CodaveriGenerateFormData = {
-  languageId: 0,
-  customPrompt: '',
-  difficulty: 'easy',
-};
-
-const defaultQuestionFormData: QuestionPrototypeFormData = {
-  question: {
-    title: '',
-    description: '',
-  },
-  testUi: {
-    metadata: {
-      solution: '',
-      submission: '',
-      testCases: {
-        public: [] as MetadataTestCase[],
-        private: [] as MetadataTestCase[],
-        evaluation: [] as MetadataTestCase[],
-      },
-    },
-  },
-};
 
 const compareFormData = (
   oldState,
@@ -140,9 +114,6 @@ const GenerateProgrammingQuestionPage = (): JSX.Element => {
     throw new Error(
       `GenerateProgrammingQuestionPage was loaded with ID: ${id}.`,
     );
-
-  const fetchAssessmentWithId = (): Promise<FetchAssessmentData> =>
-    fetchAssessment(id);
 
   const dispatch = useAppDispatch();
   const [exportDialogOpen, setExportDialogOpen] = useState<boolean>(false);

--- a/client/app/bundles/course/assessment/pages/AssessmentGenerate/constants.ts
+++ b/client/app/bundles/course/assessment/pages/AssessmentGenerate/constants.ts
@@ -1,0 +1,27 @@
+import { MetadataTestCase } from 'types/course/assessment/question/programming';
+
+import { CodaveriGenerateFormData, QuestionPrototypeFormData } from './types';
+
+export const defaultQuestionFormData: QuestionPrototypeFormData = {
+  question: {
+    title: '',
+    description: '',
+  },
+  testUi: {
+    metadata: {
+      solution: '',
+      submission: '',
+      testCases: {
+        public: [] as MetadataTestCase[],
+        private: [] as MetadataTestCase[],
+        evaluation: [] as MetadataTestCase[],
+      },
+    },
+  },
+};
+
+export const defaultCodaveriFormData: CodaveriGenerateFormData = {
+  languageId: 0,
+  customPrompt: '',
+  difficulty: 'easy',
+};

--- a/client/app/types/course/assessment/question-generation.ts
+++ b/client/app/types/course/assessment/question-generation.ts
@@ -22,7 +22,8 @@ export interface CodaveriGenerateResponseData {
       }[];
     }[];
     exprTestcases: {
-      expression: string;
+      lhsExpression: string;
+      rhsExpression: string;
       hint: string;
       visibility: TestcaseVisibility;
     }[];

--- a/spec/fixtures/course/codaveri/codaveri_problem_management_test.json
+++ b/spec/fixtures/course/codaveri/codaveri_problem_management_test.json
@@ -1,83 +1,101 @@
 {
   "languageVersions": {
     "language": "python",
-    "versions": [ "3.10" ]
+    "versions": ["3.10"]
   },
-  "resources": [{
-  "templates": [{
-    "path": "template.py",
-    "prefix": "import csv\r\n\r\ndef read_csv(csvfilename):\r\n    with open(csvfilename) as f:\r\n        return tuple(tuple(row) for row in csv.reader(f))\r\n\r\n#######################\r\n# OPERATION_TABLE ADT #\r\n#######################\r\n\r\nOPERATION_TABLE = {}\r\nVALID_TAGS = ('dna', 'rna', 'protein')\r\n\r\ndef put_op(name, tuple_of_tags_types, operator):\r\n    if name not in OPERATION_TABLE:\r\n        OPERATION_TABLE[name] = {}\r\n    OPERATION_TABLE[name][tuple_of_tags_types] = operator\r\n\r\ndef get_op(name, tuple_of_tags_types):\r\n    if not all(map(lambda tag_type: tag_type in VALID_TAGS, tuple_of_tags_types)):\r\n        raise Exception('Invalid tag-type(s). Are you sure you are working with Tagged-Data?')\r\n    if name not in OPERATION_TABLE:\r\n        raise Exception(f'Missing operation: {name}. Did you misspell the operation or forget to put_op?')\r\n    if tuple_of_tags_types not in OPERATION_TABLE[name]:\r\n        raise Exception(f'Missing operation for these tags: {tuple_of_tags_types}. Did you forget to put_op?')\r\n    return OPERATION_TABLE[name][tuple_of_tags_types]\r\n\r\n#############################\r\n# Functions from Mission 11 #\r\n#############################\r\n\r\ndef replicate(dna_strand):\r\n    dna_base_pairings = dict([\"AT\",\"TA\",\"GC\",\"CG\"])\r\n    return \"\".join(dna_base_pairings[base] for base in dna_strand[::-1])\r\n\r\ndef transcribe(dna_strand):\r\n    return replicate(dna_strand).replace('T','U')\r\n\r\ndef reverse_transcribe(rna_strand):\r\n    return replicate(rna_strand.replace('U','T'))\r\n\r\ndef get_mapping(csvfilename):\r\n    data = read_csv(csvfilename)[1:]\r\n    return {codon: amino for codon, *_, amino in data}\r\n\r\ndef translate(rna_strand):\r\n    codon2amino = get_mapping(\"codon_mapping.csv\")\r\n    if \"AUG\" in rna_strand:\r\n        protein, start = '', rna_strand.index(\"AUG\")\r\n        for x in range(start+3, len(rna_strand)+1, 3):\r\n            protein += codon2amino[rna_strand[x-3:x]]\r\n            if protein[-1] == '_':\r\n                return protein\r\n\r\n##########\r\n# Task 1 #\r\n##########\r\n# Abstraction changed to check if students broke abstraction here\r\ndef tag(type, data):\r\n    def helper(code):\r\n        if code == 'foo':\r\n            return type\r\n        elif code == 'bar':\r\n            return data\r\n    return helper\r\n\r\ndef get_tag_type(tagged_data):\r\n    return tagged_data('foo')\r\n\r\ndef get_data(tagged_data):\r\n    return tagged_data('bar')\r\n    \r\n##########\r\n# Task 2 #\r\n##########\r\n    \r\n### DO NOT CHANGE THE CODE IN THIS BOX ##################################\r\n                                                                        #\r\nput_op(\"to_dna\", (\"dna\",), lambda x: x)                                 #\r\nput_op(\"to_dna\", (\"rna\",), reverse_transcribe)                          #\r\nput_op(\"to_rna\", (\"dna\",), transcribe)                                  #\r\nput_op(\"to_rna\", (\"rna\",), lambda x: x)                                 #\r\nput_op(\"is_same_dogma\", (\"dna\",\"dna\"), lambda x, y: x == y)             #\r\nput_op(\"is_same_dogma\", (\"dna\",\"rna\"), lambda x, y: transcribe(x) == y) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"dna\"), lambda x, y: x == transcribe(y)) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"rna\"), lambda x, y: x == y)             #\r\n                                                                        #\r\ndef to_dna(tagged_data):                                                #\r\n    tag_type = get_tag_type(tagged_data)                                #\r\n    data     = get_data(tagged_data)                                    #\r\n    op       = get_op(\"to_dna\", (tag_type,))                            #\r\n    return tag(\"dna\", op(data))                                         #\r\n                                                                        #\r\n### DO NOT CHANGE THE CODE IN THIS BOX ##################################\n",
-    "content": "def to_rna(your_args_here):\r\n    \"\"\"Your code here\"\"\"\r\n\r\ndef is_same_dogma(your_args_here):\r\n    \"\"\"Your code here\"\"\"\n",
-    "suffix": "\ntagged_dna1 = tag(\"dna\", \"AAATGC\")\r\ntagged_rna1 = tag(\"rna\", \"GCAUUU\")\r\ntagged_dna2 = tag(\"dna\", \"TTACAT\")\r\ntagged_rna2 = tag(\"rna\", \"AUGUAA\")\r\n\r\n\n"
-  }],
-  "solutions": [{
-    "tag": "default",
-    "files": [{
-      "path": "template.py",
-      "content": "### DO NOT CHANGE THE CODE IN THIS BOX ##################################\r\n                                                                        #\r\nput_op(\"to_dna\", (\"dna\",), lambda x: x)                                 #\r\nput_op(\"to_dna\", (\"rna\",), reverse_transcribe)                          #\r\nput_op(\"to_rna\", (\"dna\",), transcribe)                                  #\r\nput_op(\"to_rna\", (\"rna\",), lambda x: x)                                 #\r\nput_op(\"is_same_dogma\", (\"dna\",\"dna\"), lambda x, y: x == y)             #\r\nput_op(\"is_same_dogma\", (\"dna\",\"rna\"), lambda x, y: transcribe(x) == y) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"dna\"), lambda x, y: x == transcribe(y)) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"rna\"), lambda x, y: x == y)             #\r\n                                                                        #\r\ndef to_dna(tagged_data):                                                #\r\n    tag_type = get_tag_type(tagged_data)                                #\r\n    data     = get_data(tagged_data)                                    #\r\n    op       = get_op(\"to_dna\", (tag_type,))                            #\r\n    return tag(\"dna\", op(data))                                         #\r\n                                                                        #\r\n### DO NOT CHANGE THE CODE IN THIS BOX ##################################\r\n\r\n# [Marking Scheme]\r\n# 3 marks for to_rna\r\n#   +1 keeps Tagged-Data abstraction, uses get_tag_type/get_data\r\n#   +1 keeps OPERATION_TABLE abstraction, uses get_op\r\n#   +1 returns a correctly tagged Tagged-Data object\r\n# 3 marks for is_same_dogma\r\n#   +2 both abstractions as above\r\n#   +1 returns a boolean\r\n# Total: 6 marks\r\n# Note: Do not double-deduct breaking of abstraction for each ADT\r\n\r\ndef to_rna(tagged_data):\r\n    tag_type = get_tag_type(tagged_data)\r\n    data     = get_data(tagged_data)\r\n    op       = get_op(\"to_rna\", (tag_type,))\r\n    return tag(\"rna\", op(data))\r\n\r\ndef is_same_dogma(tagged_data1, tagged_data2):\r\n    tag_type1 = get_tag_type(tagged_data1)\r\n    tag_type2 = get_tag_type(tagged_data2)\r\n    op        = get_op(\"is_same_dogma\", (tag_type1, tag_type2))\r\n    data1     = get_data(tagged_data1)\r\n    data2     = get_data(tagged_data2)\r\n    return op(data1, data2)\n"
-    }]
-  }],
-  "exprTestcases": [
+  "resources": [
     {
-      "index": 293,
-      "type": "expression",
-      "timeout": 10000,
-      "prefix": "_out = get_data(to_rna(tagged_dna1))",
-      "expression": "_out == 'GCAUUU'",
-      "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
-    },
-    {
-      "index": 294,
-      "type": "expression",
-      "timeout": 10000,
-      "prefix": "_out = get_data(to_rna(tagged_rna1))",
-      "expression": "_out == 'GCAUUU'",
-      "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
-    },
-    {
-      "index": 295,
-      "type": "expression",
-      "timeout": 10000,
-      "prefix": "_out = is_same_dogma(tagged_dna1, tagged_rna1)",
-      "expression": "_out == True",
-      "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
-    },
-    {
-      "index": 296,
-      "type": "expression",
-      "timeout": 10000,
-      "prefix": "_out = is_same_dogma(tagged_rna1, tagged_rna1)",
-      "expression": "_out == True",
-      "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
-    },
-    {
-      "index": 297,
-      "type": "expression",
-      "timeout": 10000,
-      "prefix": "_out = is_same_dogma(tagged_rna1, tagged_dna2)",
-      "expression": "_out == False",
-      "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
-    },
-    {
-      "index": 291,
-      "timeout": 10000,
-      "type": "expression",
-      "prefix": "_out = get_tag_type(to_rna(tagged_dna1))",
-      "expression": "_out == 'rna'",
-      "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
-    },
-    {
-      "index": 292,
-      "timeout": 10000,
-      "type": "expression",
-      "prefix": "_out = get_tag_type(to_dna(tagged_rna1))",
-      "expression": "_out == 'dna'",
-      "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+      "templates": [
+        {
+          "path": "template.py",
+          "prefix": "import csv\r\n\r\ndef read_csv(csvfilename):\r\n    with open(csvfilename) as f:\r\n        return tuple(tuple(row) for row in csv.reader(f))\r\n\r\n#######################\r\n# OPERATION_TABLE ADT #\r\n#######################\r\n\r\nOPERATION_TABLE = {}\r\nVALID_TAGS = ('dna', 'rna', 'protein')\r\n\r\ndef put_op(name, tuple_of_tags_types, operator):\r\n    if name not in OPERATION_TABLE:\r\n        OPERATION_TABLE[name] = {}\r\n    OPERATION_TABLE[name][tuple_of_tags_types] = operator\r\n\r\ndef get_op(name, tuple_of_tags_types):\r\n    if not all(map(lambda tag_type: tag_type in VALID_TAGS, tuple_of_tags_types)):\r\n        raise Exception('Invalid tag-type(s). Are you sure you are working with Tagged-Data?')\r\n    if name not in OPERATION_TABLE:\r\n        raise Exception(f'Missing operation: {name}. Did you misspell the operation or forget to put_op?')\r\n    if tuple_of_tags_types not in OPERATION_TABLE[name]:\r\n        raise Exception(f'Missing operation for these tags: {tuple_of_tags_types}. Did you forget to put_op?')\r\n    return OPERATION_TABLE[name][tuple_of_tags_types]\r\n\r\n#############################\r\n# Functions from Mission 11 #\r\n#############################\r\n\r\ndef replicate(dna_strand):\r\n    dna_base_pairings = dict([\"AT\",\"TA\",\"GC\",\"CG\"])\r\n    return \"\".join(dna_base_pairings[base] for base in dna_strand[::-1])\r\n\r\ndef transcribe(dna_strand):\r\n    return replicate(dna_strand).replace('T','U')\r\n\r\ndef reverse_transcribe(rna_strand):\r\n    return replicate(rna_strand.replace('U','T'))\r\n\r\ndef get_mapping(csvfilename):\r\n    data = read_csv(csvfilename)[1:]\r\n    return {codon: amino for codon, *_, amino in data}\r\n\r\ndef translate(rna_strand):\r\n    codon2amino = get_mapping(\"codon_mapping.csv\")\r\n    if \"AUG\" in rna_strand:\r\n        protein, start = '', rna_strand.index(\"AUG\")\r\n        for x in range(start+3, len(rna_strand)+1, 3):\r\n            protein += codon2amino[rna_strand[x-3:x]]\r\n            if protein[-1] == '_':\r\n                return protein\r\n\r\n##########\r\n# Task 1 #\r\n##########\r\n# Abstraction changed to check if students broke abstraction here\r\ndef tag(type, data):\r\n    def helper(code):\r\n        if code == 'foo':\r\n            return type\r\n        elif code == 'bar':\r\n            return data\r\n    return helper\r\n\r\ndef get_tag_type(tagged_data):\r\n    return tagged_data('foo')\r\n\r\ndef get_data(tagged_data):\r\n    return tagged_data('bar')\r\n    \r\n##########\r\n# Task 2 #\r\n##########\r\n    \r\n### DO NOT CHANGE THE CODE IN THIS BOX ##################################\r\n                                                                        #\r\nput_op(\"to_dna\", (\"dna\",), lambda x: x)                                 #\r\nput_op(\"to_dna\", (\"rna\",), reverse_transcribe)                          #\r\nput_op(\"to_rna\", (\"dna\",), transcribe)                                  #\r\nput_op(\"to_rna\", (\"rna\",), lambda x: x)                                 #\r\nput_op(\"is_same_dogma\", (\"dna\",\"dna\"), lambda x, y: x == y)             #\r\nput_op(\"is_same_dogma\", (\"dna\",\"rna\"), lambda x, y: transcribe(x) == y) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"dna\"), lambda x, y: x == transcribe(y)) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"rna\"), lambda x, y: x == y)             #\r\n                                                                        #\r\ndef to_dna(tagged_data):                                                #\r\n    tag_type = get_tag_type(tagged_data)                                #\r\n    data     = get_data(tagged_data)                                    #\r\n    op       = get_op(\"to_dna\", (tag_type,))                            #\r\n    return tag(\"dna\", op(data))                                         #\r\n                                                                        #\r\n### DO NOT CHANGE THE CODE IN THIS BOX ##################################\n",
+          "content": "def to_rna(your_args_here):\r\n    \"\"\"Your code here\"\"\"\r\n\r\ndef is_same_dogma(your_args_here):\r\n    \"\"\"Your code here\"\"\"\n",
+          "suffix": "\ntagged_dna1 = tag(\"dna\", \"AAATGC\")\r\ntagged_rna1 = tag(\"rna\", \"GCAUUU\")\r\ntagged_dna2 = tag(\"dna\", \"TTACAT\")\r\ntagged_rna2 = tag(\"rna\", \"AUGUAA\")\r\n\r\n\n"
+        }
+      ],
+      "solutions": [
+        {
+          "tag": "default",
+          "files": [
+            {
+              "path": "template.py",
+              "content": "### DO NOT CHANGE THE CODE IN THIS BOX ##################################\r\n                                                                        #\r\nput_op(\"to_dna\", (\"dna\",), lambda x: x)                                 #\r\nput_op(\"to_dna\", (\"rna\",), reverse_transcribe)                          #\r\nput_op(\"to_rna\", (\"dna\",), transcribe)                                  #\r\nput_op(\"to_rna\", (\"rna\",), lambda x: x)                                 #\r\nput_op(\"is_same_dogma\", (\"dna\",\"dna\"), lambda x, y: x == y)             #\r\nput_op(\"is_same_dogma\", (\"dna\",\"rna\"), lambda x, y: transcribe(x) == y) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"dna\"), lambda x, y: x == transcribe(y)) #\r\nput_op(\"is_same_dogma\", (\"rna\",\"rna\"), lambda x, y: x == y)             #\r\n                                                                        #\r\ndef to_dna(tagged_data):                                                #\r\n    tag_type = get_tag_type(tagged_data)                                #\r\n    data     = get_data(tagged_data)                                    #\r\n    op       = get_op(\"to_dna\", (tag_type,))                            #\r\n    return tag(\"dna\", op(data))                                         #\r\n                                                                        #\r\n### DO NOT CHANGE THE CODE IN THIS BOX ##################################\r\n\r\n# [Marking Scheme]\r\n# 3 marks for to_rna\r\n#   +1 keeps Tagged-Data abstraction, uses get_tag_type/get_data\r\n#   +1 keeps OPERATION_TABLE abstraction, uses get_op\r\n#   +1 returns a correctly tagged Tagged-Data object\r\n# 3 marks for is_same_dogma\r\n#   +2 both abstractions as above\r\n#   +1 returns a boolean\r\n# Total: 6 marks\r\n# Note: Do not double-deduct breaking of abstraction for each ADT\r\n\r\ndef to_rna(tagged_data):\r\n    tag_type = get_tag_type(tagged_data)\r\n    data     = get_data(tagged_data)\r\n    op       = get_op(\"to_rna\", (tag_type,))\r\n    return tag(\"rna\", op(data))\r\n\r\ndef is_same_dogma(tagged_data1, tagged_data2):\r\n    tag_type1 = get_tag_type(tagged_data1)\r\n    tag_type2 = get_tag_type(tagged_data2)\r\n    op        = get_op(\"is_same_dogma\", (tag_type1, tag_type2))\r\n    data1     = get_data(tagged_data1)\r\n    data2     = get_data(tagged_data2)\r\n    return op(data1, data2)\n"
+            }
+          ]
+        }
+      ],
+      "exprTestcases": [
+        {
+          "index": 293,
+          "type": "expression",
+          "timeout": 10000,
+          "prefix": "_out = get_data(to_rna(tagged_dna1))",
+          "lhsExpression": "_out",
+          "rhsExpression": "'GCAUUU'",
+          "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+        },
+        {
+          "index": 294,
+          "type": "expression",
+          "timeout": 10000,
+          "prefix": "_out = get_data(to_rna(tagged_rna1))",
+          "lhsExpression": "_out",
+          "rhsExpression": "'GCAUUU'",
+          "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+        },
+        {
+          "index": 295,
+          "type": "expression",
+          "timeout": 10000,
+          "prefix": "_out = is_same_dogma(tagged_dna1, tagged_rna1)",
+          "lhsExpression": "_out",
+          "rhsExpression": "True",
+          "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+        },
+        {
+          "index": 296,
+          "type": "expression",
+          "timeout": 10000,
+          "prefix": "_out = is_same_dogma(tagged_rna1, tagged_rna1)",
+          "lhsExpression": "_out",
+          "rhsExpression": "True",
+          "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+        },
+        {
+          "index": 297,
+          "type": "expression",
+          "timeout": 10000,
+          "prefix": "_out = is_same_dogma(tagged_rna1, tagged_dna2)",
+          "lhsExpression": "_out",
+          "rhsExpression": "False",
+          "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+        },
+        {
+          "index": 291,
+          "timeout": 10000,
+          "type": "expression",
+          "prefix": "_out = get_tag_type(to_rna(tagged_dna1))",
+          "lhsExpression": "_out",
+          "rhsExpression": "'rna'",
+          "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+        },
+        {
+          "index": 292,
+          "timeout": 10000,
+          "type": "expression",
+          "prefix": "_out = get_tag_type(to_dna(tagged_rna1))",
+          "lhsExpression": "_out",
+          "rhsExpression": "'dna'",
+          "display": "\"'\" + _out + \"'\" if isinstance(_out, str) else _out"
+        }
+      ]
     }
-  ]}],
-  "additionalFiles": [{
-    "type": "internal",
-    "path": "codon_mapping.csv",
-    "content": "codon,amino_acid,3_letter_abbreviation,1_letter_abbreviation\nAAA,Lysine,Lys,K\nAAC,Asparagine,Asn,N\nAAG,Lysine,Lys,K\nAAU,Asparagine,Asn,N\nACA,Threonine,Thr,T\nACC,Threonine,Thr,T\nACG,Threonine,Thr,T\nACU,Threonine,Thr,T\nAGA,Arginine,Arg,R\nAGC,Serine,Ser,S\nAGG,Arginine,Arg,R\nAGU,Serine,Ser,S\nAUA,Isoleucine,Ile,I\nAUC,Isoleucine,Ile,I\nAUG,Methionine,Met,M\nAUU,Isoleucine,Ile,I\nCAA,Glutamine,Gln,Q\nCAC,Histidine,His,H\nCAG,Glutamine,Gln,Q\nCAU,Histidine,His,H\nCCA,Proline,Pro,P\nCCC,Proline,Pro,P\nCCG,Proline,Pro,P\nCCU,Proline,Pro,P\nCGA,Arginine,Arg,R\nCGC,Arginine,Arg,R\nCGG,Arginine,Arg,R\nCGU,Arginine,Arg,R\nCUA,Leucine,Leu,L\nCUC,Leucine,Leu,L\nCUG,Leucine,Leu,L\nCUU,Leucine,Leu,L\nGAA,Glutamic acid,Glu,E\nGAC,Aspartic acid,Asp,D\nGAG,Glutamic acid,Glu,E\nGAU,Aspartic acid,Asp,D\nGCA,Alanine,Ala,A\nGCC,Alanine,Ala,A\nGCG,Alanine,Ala,A\nGCU,Alanine,Ala,A\nGGA,Glycine,Gly,G\nGGC,Glycine,Gly,G\nGGG,Glycine,Gly,G\nGGU,Glycine,Gly,G\nGUA,Valine,Val,V\nGUC,Valine,Val,V\nGUG,Valine,Val,V\nGUU,Valine,Val,V\nUAA,Stop codon,STOP,_\nUAC,Tyrosine,Tyr,Y\nUAG,Stop codon,STOP,_\nUAU,Tyrosine,Tyr,Y\nUCA,Serine,Ser,S\nUCC,Serine,Ser,S\nUCG,Serine,Ser,S\nUCU,Serine,Ser,S\nUGA,Stop codon,STOP,_\nUGC,Cysteine,Cys,C\nUGG,Tryptophan,Trp,W\nUGU,Cysteine,Cys,C\nUUA,Leucine,Leu,L\nUUC,Phenylalanine,Phe,F\nUUG,Leucine,Leu,L\nUUU,Phenylalanine,Phe,F"
-  }]
+  ],
+  "additionalFiles": [
+    {
+      "type": "internal",
+      "path": "codon_mapping.csv",
+      "content": "codon,amino_acid,3_letter_abbreviation,1_letter_abbreviation\nAAA,Lysine,Lys,K\nAAC,Asparagine,Asn,N\nAAG,Lysine,Lys,K\nAAU,Asparagine,Asn,N\nACA,Threonine,Thr,T\nACC,Threonine,Thr,T\nACG,Threonine,Thr,T\nACU,Threonine,Thr,T\nAGA,Arginine,Arg,R\nAGC,Serine,Ser,S\nAGG,Arginine,Arg,R\nAGU,Serine,Ser,S\nAUA,Isoleucine,Ile,I\nAUC,Isoleucine,Ile,I\nAUG,Methionine,Met,M\nAUU,Isoleucine,Ile,I\nCAA,Glutamine,Gln,Q\nCAC,Histidine,His,H\nCAG,Glutamine,Gln,Q\nCAU,Histidine,His,H\nCCA,Proline,Pro,P\nCCC,Proline,Pro,P\nCCG,Proline,Pro,P\nCCU,Proline,Pro,P\nCGA,Arginine,Arg,R\nCGC,Arginine,Arg,R\nCGG,Arginine,Arg,R\nCGU,Arginine,Arg,R\nCUA,Leucine,Leu,L\nCUC,Leucine,Leu,L\nCUG,Leucine,Leu,L\nCUU,Leucine,Leu,L\nGAA,Glutamic acid,Glu,E\nGAC,Aspartic acid,Asp,D\nGAG,Glutamic acid,Glu,E\nGAU,Aspartic acid,Asp,D\nGCA,Alanine,Ala,A\nGCC,Alanine,Ala,A\nGCG,Alanine,Ala,A\nGCU,Alanine,Ala,A\nGGA,Glycine,Gly,G\nGGC,Glycine,Gly,G\nGGG,Glycine,Gly,G\nGGU,Glycine,Gly,G\nGUA,Valine,Val,V\nGUC,Valine,Val,V\nGUG,Valine,Val,V\nGUU,Valine,Val,V\nUAA,Stop codon,STOP,_\nUAC,Tyrosine,Tyr,Y\nUAG,Stop codon,STOP,_\nUAU,Tyrosine,Tyr,Y\nUCA,Serine,Ser,S\nUCC,Serine,Ser,S\nUCG,Serine,Ser,S\nUCU,Serine,Ser,S\nUGA,Stop codon,STOP,_\nUGC,Cysteine,Cys,C\nUGG,Tryptophan,Trp,W\nUGU,Cysteine,Cys,C\nUUA,Leucine,Leu,L\nUUC,Phenylalanine,Phe,F\nUUG,Leucine,Leu,L\nUUU,Phenylalanine,Phe,F"
+    }
+  ]
 }

--- a/spec/services/course/assessment/question/codaveri_problem_generation_service_spec.rb
+++ b/spec/services/course/assessment/question/codaveri_problem_generation_service_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::CodaveriProblemGenerationService do
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:user) { create(:administrator) }
+    let(:course) { create(:course, creator: user) }
+    let(:assessment) { create(:assessment, course: course, creator: user) }
+    let(:params) do
+      {
+        custom_prompt: 'This is a custom prompt.',
+        is_default_question_form_data: 'false',
+        title: 'Absolute Value',
+        description: 'Given a number n, return its absolute value',
+        template: 'def absolute(n): pass',
+        solution: '',
+        public_test_cases: '{
+          "0": {"hint": "Positive number", "expression": "absolute(1)", "expected": "1"},
+          "1": {"hint": "Negative number", "expression": "absolute(-2)", "expected": "2"}
+        }',
+        private_test_cases: '{
+          "0": {"hint": "Zero number", "expression": "absolute(0)", "expected": "0"}
+        }',
+        evaluation_test_cases: '{
+          "0": {"hint": "Any number", "expression": "absolute(0.5)", "expected": "0.5"}
+        }'
+      }
+    end
+    let(:language) { 'python' }
+    let(:version) { '3.12' }
+
+    subject { described_class.new(assessment, params, language, version) }
+
+    describe '#initialize' do
+      before { described_class.new(assessment, params, language, version) }
+      context 'when initializing with problem details' do
+        it 'sets the problem title and description correctly' do
+          payload = subject.instance_variable_get(:@payload)
+          expect(payload[:problem][:title]).to eq('Absolute Value')
+          expect(payload[:problem][:description]).to eq('Given a number n, return its absolute value')
+        end
+
+        it 'sets the template content correctly' do
+          payload = subject.instance_variable_get(:@payload)
+          expect(payload[:problem][:templates].first[:path]).to eq('main.py')
+          expect(payload[:problem][:templates].first[:content]).to eq('def absolute(n): pass')
+        end
+
+        it 'initializes solution as an empty string' do
+          payload = subject.instance_variable_get(:@payload)
+          expect(payload[:problem][:solutions].first[:tag]).to eq('solution')
+          expect(payload[:problem][:solutions].first[:files].first[:path]).to eq('main.py')
+          expect(payload[:problem][:solutions].first[:files].first[:content]).to eq('')
+        end
+      end
+
+      context 'when appending test cases' do
+        it 'appends public test cases to exprTestcases' do
+          payload = subject.instance_variable_get(:@payload)
+          public_test_cases = payload[:problem][:exprTestcases].select { |tc| tc[:visibility] == 'public' }
+
+          expect(public_test_cases.size).to eq(2)
+          expect(public_test_cases[0]).to include(
+            hint: 'Positive number',
+            lhsExpression: 'absolute(1)',
+            rhsExpression: '1',
+            display: 'absolute(1)'
+          )
+          expect(public_test_cases[1]).to include(
+            hint: 'Negative number',
+            lhsExpression: 'absolute(-2)',
+            rhsExpression: '2',
+            display: 'absolute(-2)'
+          )
+        end
+
+        it 'appends private test cases to exprTestcases' do
+          payload = subject.instance_variable_get(:@payload)
+          private_test_case = payload[:problem][:exprTestcases].find { |tc| tc[:visibility] == 'private' }
+
+          expect(private_test_case).to include(
+            hint: 'Zero number',
+            lhsExpression: 'absolute(0)',
+            rhsExpression: '0',
+            display: 'absolute(0)'
+          )
+        end
+
+        it 'appends hidden (evaluation) test cases to exprTestcases' do
+          payload = subject.instance_variable_get(:@payload)
+          hidden_test_case = payload[:problem][:exprTestcases].find { |tc| tc[:visibility] == 'hidden' }
+
+          expect(hidden_test_case).to include(
+            hint: 'Any number',
+            lhsExpression: 'absolute(0.5)',
+            rhsExpression: '0.5',
+            display: 'absolute(0.5)'
+          )
+        end
+
+        it 'assigns incremental indices to exprTestcases' do
+          payload = subject.instance_variable_get(:@payload)
+          indices = payload[:problem][:exprTestcases].map { |tc| tc[:index] }
+
+          expect(indices).to eq([1, 2, 3, 4]) # Ensuring the indices are assigned incrementally
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**_NOTE: This PR should be merged after https://github.com/Coursemology/coursemology2/pull/7630_**

We did the adjustment to our codebase to follow-up with the recent upgrade done by Codaveri to v2.1

Several notable adjustments made:
- Include API Version in the headers everytime we send request to Codaveri
- remove 'functionality' from the default config since it's already set as default in Codaveri
- refactoring payload for Problem Generation to resolve 500 characters limit issue (more explanation below)
- splitting `expression` inside each Codaveri problem into `lhsExpression` and `rhsExpression`
- refactoring of `GenerateProgrammingQuestionPage` to make it more readable and more clean

## Problem Generation

Previously we run into issue of limiting 500 characters limit since we need to dump every information about already generated problem into `customPrompt`, including title, description, test cases info, etc. which obviously will far exceeding 500 chars if combined. In Codaveri v2.1, they have the separate field for the recently-generated question so this char limit should not be a problem anymore

## Miscellaneous

After merging this PR and deploying, we need to add `CODAVERI_API_VERSION` to our ENV variables inside our deployment configuration. Value should be '2.1', the version of the Codaveri API we're supposed to follow