### PR TITLE
fix(answer): reintroduce past answer limit

### DIFF
--- a/app/controllers/course/assessment/submission_question/submission_questions_controller.rb
+++ b/app/controllers/course/assessment/submission_question/submission_questions_controller.rb
@@ -2,7 +2,8 @@
 class Course::Assessment::SubmissionQuestion::SubmissionQuestionsController < \
   Course::Assessment::SubmissionQuestion::Controller
   def past_answers
-    answers = @submission_question.past_answers
+    answers_to_load = past_answers_params[:answers_to_load]&.to_i || 10
+    answers = @submission_question.past_answers(answers_to_load)
 
     respond_to do |format|
       format.json { render 'past_answers', locals: { answers: answers } }

--- a/app/models/course/assessment/submission.rb
+++ b/app/models/course/assessment/submission.rb
@@ -275,7 +275,7 @@ class Course::Assessment::Submission < ApplicationRecord
       map do |pair|
       {
         question_id: pair[0],
-        answer_ids: pair[1].reject(&:last).map(&:second)
+        answer_ids: pair[1].reject(&:last).map(&:second).first(10)
       }
     end
   end

--- a/app/models/course/assessment/submission_question.rb
+++ b/app/models/course/assessment/submission_question.rb
@@ -44,12 +44,13 @@ class Course::Assessment::SubmissionQuestion < ApplicationRecord
   end
 
   # Loads the past answers of a specific question
-  def past_answers
+  def past_answers(answers_to_load)
     answers.
       unscope(:order).
       order(created_at: :desc).
       where('workflow_state != ? '\
-            'OR (workflow_state = ? AND current_answer IS false)', 'attempting', 'attempting')
+            'OR (workflow_state = ? AND current_answer IS false)', 'attempting', 'attempting').
+      first(answers_to_load)
   end
 
   private

--- a/client/app/api/course/Assessment/SubmissionQuestions.js
+++ b/client/app/api/course/Assessment/SubmissionQuestions.js
@@ -17,13 +17,16 @@ export default class SubmissionQuestionsAPI extends BaseAssessmentAPI {
 
   /**
    * Gets the past answers from a SubmissionQuestion
+   * Can include answers_to_load in params to indicate how many to pull (default 10)
    *
    * @param {number} submissionQuestionId
    * @return {Promise}
    */
-  getPastAnswers(submissionQuestionId) {
+  getPastAnswers(submissionQuestionId, answersToLoad = 10) {
+    const params = { answers_to_load: answersToLoad };
     return this.client.get(
       `${this.#urlPrefix}/${submissionQuestionId}/past_answers`,
+      { params },
     );
   }
 


### PR DESCRIPTION
Revert change due to performance concerns on large amounts of past answers.

Original commit:
https://github.com/Coursemology/coursemology2/commit/754d9d43985026de28eb16a3d9e0d0bb92c5224d#diff-efa573443add68832345d55a739ac22f66bf9914444a3daf8ddd5dee83ba82ef

