### PR TITLE
Export Assessments Score Summary in CSV Format

### DIFF
--- a/app/controllers/course/statistics/aggregate_controller.rb
+++ b/app/controllers/course/statistics/aggregate_controller.rb
@@ -34,6 +34,13 @@ class Course::Statistics::AggregateController < Course::Statistics::Controller
     fetch_all_assessment_related_statistics_hash
   end
 
+  def download_score_summary
+    job = Course::Statistics::AssessmentsScoreSummaryDownloadJob.
+          perform_later(current_course, params[:assessment_ids]).job
+
+    render partial: 'jobs/submitted', locals: { job: job }
+  end
+
   private
 
   def assessment_info_array

--- a/app/jobs/course/statistics/assessments_score_summary_download_job.rb
+++ b/app/jobs/course/statistics/assessments_score_summary_download_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class Course::Statistics::AssessmentsScoreSummaryDownloadJob < ApplicationJob
+  include TrackableJob
+  queue_as :lowest
+
+  protected
+
+  def perform_tracked(course, assessment_ids)
+    file_name = "#{Pathname.normalize_filename(course.title)}_score_summary_#{Time.now.strftime '%Y%m%d_%H%M'}.csv"
+    csv_file = Course::Statistics::AssessmentsScoreSummaryDownloadService.download(course, assessment_ids, file_name)
+    redirect_to SendFile.send_file(csv_file, file_name)
+  end
+end

--- a/app/services/course/statistics/assessments_score_summary_download_service.rb
+++ b/app/services/course/statistics/assessments_score_summary_download_service.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'csv'
+class Course::Statistics::AssessmentsScoreSummaryDownloadService
+  include ApplicationFormattersHelper
+
+  class << self
+    def download(course, assessment_ids, file_name)
+      service = new(course, assessment_ids, file_name)
+      ActsAsTenant.without_tenant do
+        service.generate_csv_report
+      end
+    end
+  end
+
+  def generate_csv_report
+    assessment_score_summary_file_path = File.join(@base_dir, @file_name)
+
+    load_total_grades
+    CSV.open(assessment_score_summary_file_path, 'w') do |csv|
+      download_score_summary(csv)
+    end
+
+    assessment_score_summary_file_path
+  end
+
+  private
+
+  def initialize(course, assessment_ids, file_name)
+    @course = course
+    @assessment_ids = assessment_ids
+    @file_name = file_name
+    @base_dir = Dir.mktmpdir('assessment-score-summary-')
+  end
+
+  def load_total_grades
+    @course_assessment_hash = Course::Assessment.where(id: @assessment_ids, course_id: @course.id).to_h do |assessment|
+      [assessment.id, assessment]
+    end
+
+    @assessments = assessments
+    @submissions = Course::Assessment::Submission.where(assessment_id: @assessments.map(&:id)).
+                   calculated(:grade).
+                   preload(creator: :course_users)
+
+    @submission_grade_hash = submission_grade_hash
+    @all_students = @course.course_users.students.order_alphabetically.preload(user: :emails)
+  end
+
+  def submission_grade_hash
+    @submissions.to_h do |submission|
+      course_user = submission.creator.course_users.find { |u| u.course_id == @course.id }
+      [[course_user.id, submission.assessment_id], submission.grade]
+    end
+  end
+
+  def assessments
+    @assessment_ids.filter { |assessment_id| !@course_assessment_hash[assessment_id.to_i].nil? }.map do |assessment_id|
+      @course_assessment_hash[assessment_id.to_i]
+    end
+  end
+
+  def download_score_summary(csv)
+    # header
+    csv << [I18n.t('course.statistics.name'), I18n.t('course.statistics.email'), I18n.t('course.statistics.type'),
+            *@assessments.map(&:title)]
+
+    # content
+    @all_students.each do |student|
+      csv << [student.name, student.user.email, student.phantom? ? 'phantom' : 'normal',
+              *@assessments.flat_map do |assessment|
+                @submission_grade_hash[[student.id, assessment.id]] || ''
+              end]
+    end
+  end
+end

--- a/client/app/api/course/Statistics/CourseStatistics.ts
+++ b/client/app/api/course/Statistics/CourseStatistics.ts
@@ -1,3 +1,5 @@
+import { JobSubmitted } from 'types/jobs';
+
 import { APIResponse } from 'api/types';
 import {
   AssessmentsStatistics,
@@ -32,5 +34,11 @@ export default class CourseStatisticsAPI extends BaseCourseAPI {
 
   fetchAssessmentsStatistics(): APIResponse<AssessmentsStatistics> {
     return this.client.get(`${this.#urlPrefix}/assessments`);
+  }
+
+  downloadScoreSummary(assessmentIds: number[]): APIResponse<JobSubmitted> {
+    return this.client.get(`${this.#urlPrefix}/assessments/download`, {
+      params: { assessment_ids: assessmentIds },
+    });
   }
 }

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/assessments/AssessmentsScoreSummaryDownload.tsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/assessments/AssessmentsScoreSummaryDownload.tsx
@@ -95,9 +95,7 @@ const AssessmentsScoreSummaryDownload = (
       </Button>
 
       <Prompt
-        // TODO: incorporate CSV download job into onClickPrimary after
-        // implemented properly on Backend
-        onClickPrimary={() => setOpenDialog(false)}
+        onClickPrimary={handleOnClick}
         onClose={() => setOpenDialog(false)}
         open={openDialog}
         primaryColor="info"

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/assessments/AssessmentsScoreSummaryDownload.tsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/assessments/AssessmentsScoreSummaryDownload.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { Button, Typography } from '@mui/material';
+import { AxiosError } from 'axios';
+import { JobCompleted, JobErrored } from 'types/jobs';
+
+import { downloadScoreSummary } from 'course/statistics/operations';
+import { CourseAssessment } from 'course/statistics/types';
+import Prompt, { PromptText } from 'lib/components/core/dialogs/Prompt';
+import loadingToast, { LoadingToast } from 'lib/hooks/toast/loadingToast';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface AssessmentsScoreSummaryDownloadProps {
+  assessments: CourseAssessment[];
+}
+
+const translations = defineMessages({
+  selectedNUsers: {
+    id: 'course.statistics.StatisticsIndex.assessments.selectedNUsers',
+    defaultMessage:
+      'Download Score Summary ({n, plural, =1 {# assessment} other {# assessments}})',
+  },
+  download: {
+    id: 'course.statistics.StatisticsIndex.assessments.downloadCsv',
+    defaultMessage: 'Download',
+  },
+  downloadCsvDialogTitle: {
+    id: 'course.statistics.StatisticsIndex.assessments.downloadCsv',
+    defaultMessage: 'Download Score Summary for the following Assessments?',
+  },
+  downloadScoreSummarySuccess: {
+    id: 'course.statistics.StatisticsIndex.assessments.downloadScoreSummarySuccess',
+    defaultMessage: 'Successfully downloaded score summary',
+  },
+  downloadScoreSummaryFailure: {
+    id: 'course.statistics.StatisticsIndex.assessments.downloadScoreSummaryFailure',
+    defaultMessage: 'An error occurred while downloading score summary',
+  },
+  downloadScoreSummaryPending: {
+    id: 'course.statistics.StatisticsIndex.assessments.downloadScoreSummaryPending',
+    defaultMessage:
+      'Please wait as your request to download is being processed',
+  },
+});
+
+const AssessmentsScoreSummaryDownload = (
+  props: AssessmentsScoreSummaryDownloadProps,
+): JSX.Element => {
+  const { assessments } = props;
+  const { t } = useTranslation();
+
+  const [openDialog, setOpenDialog] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleSuccess =
+    (loadToast: LoadingToast) =>
+    (successData: JobCompleted): void => {
+      window.location.href = successData.redirectUrl!;
+      loadToast.success(t(translations.downloadScoreSummarySuccess));
+      setIsDownloading(false);
+      setOpenDialog(false);
+    };
+
+  const handleFailure =
+    (loadToast: LoadingToast) =>
+    (error: JobErrored | AxiosError): void => {
+      const message =
+        error?.message || t(translations.downloadScoreSummaryFailure);
+      loadToast.error(message);
+      setIsDownloading(false);
+    };
+
+  const handleOnClick = (): void => {
+    setIsDownloading(true);
+    const loadToast = loadingToast(t(translations.downloadScoreSummaryPending));
+    downloadScoreSummary(
+      handleSuccess(loadToast),
+      handleFailure(loadToast),
+      assessments.map((assessment) => assessment.id),
+    );
+  };
+
+  return (
+    <>
+      <Button
+        key="assessment-statistics-csv-download-button"
+        color="primary"
+        disabled={isDownloading || assessments.length === 0}
+        onClick={() => setOpenDialog(true)}
+        variant="outlined"
+      >
+        <Typography variant="body1">
+          {t(translations.selectedNUsers, { n: assessments.length })}
+        </Typography>
+      </Button>
+
+      <Prompt
+        // TODO: incorporate CSV download job into onClickPrimary after
+        // implemented properly on Backend
+        onClickPrimary={() => setOpenDialog(false)}
+        onClose={() => setOpenDialog(false)}
+        open={openDialog}
+        primaryColor="info"
+        primaryLabel={t(translations.download)}
+        title={t(translations.downloadCsvDialogTitle)}
+      >
+        <PromptText>
+          {assessments.map((assessment) => (
+            <li key={assessment.id}>{assessment.title}</li>
+          ))}
+        </PromptText>
+      </Prompt>
+    </>
+  );
+};
+
+export default AssessmentsScoreSummaryDownload;

--- a/client/app/bundles/course/statistics/pages/StatisticsIndex/assessments/AssessmentsStatisticsTable.tsx
+++ b/client/app/bundles/course/statistics/pages/StatisticsIndex/assessments/AssessmentsStatisticsTable.tsx
@@ -19,6 +19,8 @@ import { getCourseId } from 'lib/helpers/url-helpers';
 import useTranslation from 'lib/hooks/useTranslation';
 import { formatMiniDateTime } from 'lib/moment';
 
+import AssessmentsScoreSummaryDownload from './AssessmentsScoreSummaryDownload';
+
 const translations = defineMessages({
   title: {
     id: 'course.statistics.StatisticsIndex.assessments.title',
@@ -238,7 +240,7 @@ const AssessmentsStatisticsTable: FC<Props> = (props) => {
 
   return (
     <>
-      <Typography className="ml-2" variant="h6">
+      <Typography className="ml-6" variant="h6">
         {t(translations.tableTitle, { numStudents })}
       </Typography>
       <Table
@@ -251,7 +253,7 @@ const AssessmentsStatisticsTable: FC<Props> = (props) => {
         }
         getRowEqualityData={(assessment): CourseAssessment => assessment}
         getRowId={(assessment): string => assessment.id.toString()}
-        indexing={{ indices: true }}
+        indexing={{ indices: true, rowSelectable: true }}
         pagination={{
           rowsPerPage: [DEFAULT_TABLE_ROWS_PER_PAGE],
           showAllRows: true,
@@ -280,7 +282,15 @@ const AssessmentsStatisticsTable: FC<Props> = (props) => {
             },
           },
         }}
-        toolbar={{ show: true }}
+        toolbar={{
+          show: true,
+          activeToolbar: (selectedAssessments): JSX.Element => (
+            <AssessmentsScoreSummaryDownload
+              assessments={selectedAssessments}
+            />
+          ),
+          keepNative: true,
+        }}
       />
     </>
   );

--- a/client/app/lib/components/table/MuiTableAdapter/MuiTableToolbar.tsx
+++ b/client/app/lib/components/table/MuiTableAdapter/MuiTableToolbar.tsx
@@ -19,40 +19,42 @@ const ToolbarContainer = ({ children }: ToolbarContainerProps): JSX.Element => (
 const MuiTableToolbar = (props: ToolbarProps): JSX.Element | null => {
   const { t } = useTranslation();
 
-  if (props.alternative?.when())
-    return <ToolbarContainer>{props.alternative.render()}</ToolbarContainer>;
+  const renderAlternative = props.alternative?.when();
+  const renderNative = renderAlternative
+    ? props.alternative?.keepNative
+    : props.renderNative;
 
-  if (props.renderNative)
-    return (
-      <ToolbarContainer>
-        <div className="flex w-full justify-between">
-          {props.onSearchKeywordChange && (
-            <SearchField
-              className="mr-4 lg:mr-0 lg:w-1/2"
-              onChangeKeyword={props.onSearchKeywordChange}
-              placeholder={props.searchPlaceholder ?? t(translations.search)}
-              value={props.searchKeyword}
-            />
+  if (!renderAlternative && !renderNative) return null;
+
+  return (
+    <ToolbarContainer>
+      <div className="flex w-full gap-6">
+        {renderNative && (
+          <SearchField
+            className="mr-4 lg:mr-0 lg:w-1/2"
+            onChangeKeyword={props.onSearchKeywordChange}
+            placeholder={props.searchPlaceholder ?? t(translations.search)}
+            value={props.searchKeyword}
+          />
+        )}
+
+        <div className="flex flex-grow items-center justify-end gap-6">
+          {renderAlternative && props.alternative?.render()}
+          {renderNative && !renderAlternative && props.buttons}
+
+          {renderNative && props.onDownloadCsv && (
+            <Tooltip
+              title={props.csvDownloadLabel ?? t(translations.downloadAsCsv)}
+            >
+              <IconButton onClick={props.onDownloadCsv}>
+                <Download />
+              </IconButton>
+            </Tooltip>
           )}
-
-          <div className="flex items-center">
-            {props.buttons}
-
-            {props.onDownloadCsv && (
-              <Tooltip
-                title={props.csvDownloadLabel ?? t(translations.downloadAsCsv)}
-              >
-                <IconButton onClick={props.onDownloadCsv}>
-                  <Download />
-                </IconButton>
-              </Tooltip>
-            )}
-          </div>
         </div>
-      </ToolbarContainer>
-    );
-
-  return null;
+      </div>
+    </ToolbarContainer>
+  );
 };
 
 export default MuiTableToolbar;

--- a/client/app/lib/components/table/TanStackTableBuilder/useTanStackTableBuilder.tsx
+++ b/client/app/lib/components/table/TanStackTableBuilder/useTanStackTableBuilder.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import {
   Cell,
-  ColumnDef,
   ColumnFiltersState,
   getCoreRowModel,
   getFacetedUniqueValues,
@@ -12,7 +11,7 @@ import {
   Row,
   useReactTable,
 } from '@tanstack/react-table';
-import { isEmpty, isString } from 'lodash';
+import { isEmpty } from 'lodash';
 
 import { RowEqualityData, TableProps } from '../adapters';
 import { TableTemplate } from '../builder';
@@ -186,6 +185,7 @@ const useTanStackTableBuilder = <D extends object>(
           props.toolbar?.activeToolbar?.(
             table.getSelectedRowModel().rows.map((row) => row.original),
           ),
+        keepNative: props.toolbar?.keepNative ?? false,
       },
       searchKeyword,
       onSearchKeywordChange: setSearchKeyword,

--- a/client/app/lib/components/table/adapters/Toolbar.ts
+++ b/client/app/lib/components/table/adapters/Toolbar.ts
@@ -5,6 +5,7 @@ interface ToolbarProps {
   alternative?: {
     when: () => boolean;
     render: () => ReactNode;
+    keepNative: boolean;
   };
   searchKeyword?: string;
   onSearchKeywordChange?: (keyword: string) => void;

--- a/client/app/lib/components/table/builder/featureTemplates.ts
+++ b/client/app/lib/components/table/builder/featureTemplates.ts
@@ -35,6 +35,7 @@ export interface FilterTemplate {
 export interface ToolbarTemplate<D extends Data> {
   show?: boolean;
   activeToolbar?: (rows: D[]) => JSX.Element;
+  keepNative?: boolean;
   buttons?: JSX.Element[];
 }
 

--- a/config/locales/en/course/statistics.yml
+++ b/config/locales/en/course/statistics.yml
@@ -1,4 +1,7 @@
 en:
   course:
     statistics:
+      name: 'Name'
+      type: 'Student Type'
+      email: 'Email'
       header: 'Statistics'

--- a/config/locales/zh/course/statistics.yml
+++ b/config/locales/zh/course/statistics.yml
@@ -1,5 +1,7 @@
 zh:
   course:
     statistics:
+      name: '用户名'
+      type: '学生类型'
+      email: 'Email'
       header: '数据'
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -439,6 +439,7 @@ Rails.application.routes.draw do
         get '/' => 'statistics#index'
         get 'answer/:id' => 'answers#question_answer_details'
         get 'assessments' => 'aggregate#all_assessments'
+        get 'assessments/download' => 'aggregate#download_score_summary'
         get 'students' => 'aggregate#all_students'
         get 'staff' => 'aggregate#all_staff'
         get 'course/progression' => 'aggregate#course_progression'

--- a/spec/services/course/statistics/assessment_score_summary_download_service_spec.rb
+++ b/spec/services/course/statistics/assessment_score_summary_download_service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Statistics::AssessmentsScoreSummaryDownloadService do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let!(:course) { create(:course) }
+    let!(:course2) { create(:course) }
+    let!(:student1) { create(:course_user, course: course, name: 'Student 1') }
+    let!(:student2) { create(:course_user, :phantom, course: course, name: 'Student 2') }
+    let!(:student3) { create(:course_user, course: course, name: 'Student 3') }
+    let!(:student4) { create(:course_user, course: course2, name: 'Student 4') }
+
+    let!(:assessment1) do
+      create(:assessment, :published_with_mrq_question, course: course, end_at: 3.days.from_now, published: true)
+    end
+    let!(:assessment2) do
+      create(:assessment, :published_with_text_response_question, course: course, end_at: 3.days.from_now,
+                                                                  published: true)
+    end
+    let!(:assessment3) do
+      create(:assessment, :published_with_text_response_question, course: course2, end_at: 3.days.from_now,
+                                                                  published: true)
+    end
+
+    let!(:submission11) { create(:submission, :published, assessment: assessment1, creator: student1.user) }
+    let!(:submission12) { create(:submission, :published, assessment: assessment2, creator: student1.user) }
+
+    let!(:submission21) { create(:submission, :published, assessment: assessment1, creator: student2.user) }
+    let!(:submission22) { create(:submission, :published, assessment: assessment2, creator: student2.user) }
+
+    describe '#download' do
+      subject do
+        file_name = "#{Pathname.normalize_filename(course.title)}_score_summary_" \
+                    "#{Time.now.strftime '%Y-%m-%d %H%M'}.csv"
+        assessment_ids_list = [assessment1.id, assessment2.id, assessment3.id]
+        Course::Statistics::AssessmentsScoreSummaryDownloadService.send(:download, course,
+                                                                        assessment_ids_list,
+                                                                        file_name)
+      end
+
+      context 'when all assessments are chosen for score summary export' do
+        let!(:filepath) { subject }
+        let!(:csv_lines) { CSV.open(filepath, 'r').readlines }
+
+        it 'downloads non-empty csv with correct information' do
+          expect(csv_lines.size).to eq(4)
+          expect(csv_lines[0].size).to eq(5)
+
+          first_student_record = csv_lines[1]
+          expect(first_student_record[0]).to eq(student1.name)
+          expect(first_student_record[1]).to eq(student1.user.email)
+          expect(first_student_record[2]).to eq(student1.phantom? ? 'phantom' : 'normal')
+          expect(first_student_record[3]).to eq(submission11.grade.to_s)
+          expect(first_student_record[4]).to eq(submission12.grade.to_s)
+
+          second_student_record = csv_lines[2]
+          expect(second_student_record[0]).to eq(student2.name)
+          expect(second_student_record[1]).to eq(student2.user.email)
+          expect(second_student_record[2]).to eq(student2.phantom? ? 'phantom' : 'normal')
+          expect(second_student_record[3]).to eq(submission21.grade.to_s)
+          expect(second_student_record[4]).to eq(submission22.grade.to_s)
+
+          third_student_record = csv_lines[3]
+          expect(third_student_record[0]).to eq(student3.name)
+          expect(third_student_record[1]).to eq(student3.user.email)
+          expect(third_student_record[2]).to eq(student3.phantom? ? 'phantom' : 'normal')
+          expect(third_student_record[3]).to eq('')
+          expect(third_student_record[4]).to eq('')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Feature Description

Inside the Assessment Statistics (can be navigated through `/courses/{:courseId}/statistics/assessments`), user can pick several assessments in which they would like to get the score summary for all the students in the course. The resulting summary will be in CSV format

<img width="1526" alt="Screenshot 2024-11-15 at 2 59 37 PM" src="https://github.com/user-attachments/assets/98d4115d-963c-4f07-859f-80b339ebe7c0">

After done with selecting the assessments to be exported, then user can just navigate to the Download Button available on top of the table, and the final confirmation prompt will be shown to ensure that user has already chosen all assessments to be exported, as follows

<img width="729" alt="Screenshot 2024-11-15 at 2 59 56 PM" src="https://github.com/user-attachments/assets/c25ed07a-6ee1-4a77-8d68-49b881092c06">

The CSV produced will contain the following info, for each row:
- Student's Name
- Student's Email
- Student's Status (Normal / Phantom)
- The score obtained by this particular student for each assessments chosen