### PR TITLE
fix(submission/monitoring_concern): only block in attempting state

### DIFF
--- a/app/controllers/concerns/course/assessment/submission/monitoring_concern.rb
+++ b/app/controllers/concerns/course/assessment/submission/monitoring_concern.rb
@@ -14,7 +14,7 @@ module Course::Assessment::Submission::MonitoringConcern
       current_course_user&.student? &&
       can?(:create, Course::Monitoring::Session.new(creator_id: current_user.id)) &&
       @assessment&.monitor&.enabled? &&
-      !@submission.submitted?
+      @submission.attempting?
   end
 
   def monitoring_service


### PR DESCRIPTION
### Current behaviour

When assessment's setting [Block accesses from unauthorized browsers] is enabled, accessing `/submissions/<submission-id>/edit` page with an invalid browser configuration redirects user to back to `AssessmentShow` at `/courses/<course-id>/assessments/<assessment-id>`, except when the submission is in **submitted** workflow state only.

### Expected behaviour

The submission-level exception should also hold true for **graded** and **published** workflow states  
i.e. only submissions in **attempting** workflow states should be redirected.  
the assessment-level monitoring blocking logic equivalent is https://github.com/Coursemology/coursemology2/blob/2c5354bd014335a57bfb43033fbc50e45c1efe01/app/controllers/concerns/course/assessment/monitoring_concern.rb#L94-L96