### PR TITLE
Fix Failing Course Deletion if Approved/Rejected Enrol Requests Exist

### DIFF
--- a/app/controllers/course/enrol_requests_controller.rb
+++ b/app/controllers/course/enrol_requests_controller.rb
@@ -24,7 +24,7 @@ class Course::EnrolRequestsController < Course::ComponentController
   # Allow users to withdraw their requests to register for a course that are pending
   # approval/rejection.
   def destroy
-    if @enrol_request.destroy
+    if @enrol_request.validate_before_destroy && @enrol_request.destroy
       head :ok
     else
       render json: { errors: @enrol_request.errors.full_messages.to_sentence }, status: :bad_request

--- a/spec/models/course/enrol_request_spec.rb
+++ b/spec/models/course/enrol_request_spec.rb
@@ -47,25 +47,19 @@ RSpec.describe Course::EnrolRequest, type: :model do
         let!(:approved_request) { create(:course_enrol_request, :approved, course: course, user: user) }
         subject { approved_request.destroy }
 
-        it 'cannot be destroyed' do
+        it 'can be destroyed' do
           subject
-          expect(approved_request).not_to be_destroyed
-          expect(approved_request.errors[:base]).to include(
-            'activerecord.errors.models.course/enrol_request.attributes.base.deletion'
-          )
+          expect(approved_request).to be_destroyed
         end
       end
 
       context 'when a request is already rejected' do
-        let!(:rejected__request) { create(:course_enrol_request, :rejected, course: course, user: user) }
-        subject { rejected__request.destroy }
+        let!(:rejected_request) { create(:course_enrol_request, :rejected, course: course, user: user) }
+        subject { rejected_request.destroy }
 
-        it 'cannot be destroyed' do
+        it 'can be destroyed' do
           subject
-          expect(rejected__request).not_to be_destroyed
-          expect(rejected__request.errors[:base]).to include(
-            'activerecord.errors.models.course/enrol_request.attributes.base.deletion'
-          )
+          expect(rejected_request).to be_destroyed
         end
       end
 


### PR DESCRIPTION
## Background

Previously, having at least one Approved/Rejected enrol requests inside the course will give an error if one wants to delete the course

## Root Causes

Based on this PR https://github.com/Coursemology/coursemology2/pull/4212, we wants to keep track on the enrol requests that are approved/rejected, and hence we disallow the requester to retract their enrol requests if theirs have been approved / rejected (not pending) by adding validation rules before destroying the enrol requests. However, this same validation will also takes place when we delete course, since `enrol_request` is the child of `course` and hence `enrol_request` will be subsequently deleted due to cascading.

## Approach

We moved the validation for destroy towards `enrol_request_controller`, since we noticed that the validation will only be accessed should we send the request through controller and not through parent deletion