### PR TITLE
Drop Virtual Classroom Table from CM DB

### DIFF
--- a/db/migrate/20241118152013_drop_virtual_classroom_table.rb
+++ b/db/migrate/20241118152013_drop_virtual_classroom_table.rb
@@ -1,0 +1,5 @@
+class DropVirtualClassroomTable < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :course_virtual_classrooms
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_28_141424) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_18_152013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -1218,26 +1218,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_28_141424) do
     t.index ["updater_id"], name: "fk__course_videos_updater_id"
   end
 
-  create_table "course_virtual_classrooms", id: :serial, force: :cascade do |t|
-    t.integer "course_id", null: false
-    t.text "instructor_classroom_link"
-    t.integer "classroom_id"
-    t.string "title", limit: 255, null: false
-    t.text "content"
-    t.datetime "start_at", precision: nil, null: false
-    t.datetime "end_at", precision: nil, null: false
-    t.integer "creator_id", null: false
-    t.integer "updater_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.integer "instructor_id"
-    t.jsonb "recorded_videos"
-    t.index ["course_id"], name: "fk__course_virtual_classrooms_course_id"
-    t.index ["creator_id"], name: "fk__course_virtual_classrooms_creator_id"
-    t.index ["instructor_id"], name: "index_course_virtual_classrooms_on_instructor_id"
-    t.index ["updater_id"], name: "fk__course_virtual_classrooms_updater_id"
-  end
-
   create_table "courses", id: :serial, force: :cascade do |t|
     t.integer "instance_id", null: false
     t.string "title", limit: 255, null: false
@@ -1694,10 +1674,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_28_141424) do
   add_foreign_key "course_videos", "course_video_tabs", column: "tab_id"
   add_foreign_key "course_videos", "users", column: "creator_id", name: "fk_course_videos_creator_id"
   add_foreign_key "course_videos", "users", column: "updater_id", name: "fk_course_videos_updater_id"
-  add_foreign_key "course_virtual_classrooms", "courses", name: "fk_course_virtual_classrooms_course_id"
-  add_foreign_key "course_virtual_classrooms", "users", column: "creator_id", name: "fk_course_virtual_classrooms_creator_id"
-  add_foreign_key "course_virtual_classrooms", "users", column: "instructor_id", name: "fk_course_virtual_classrooms_instructor_id", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "course_virtual_classrooms", "users", column: "updater_id", name: "fk_course_virtual_classrooms_updater_id"
   add_foreign_key "courses", "instances", name: "fk_courses_instance_id"
   add_foreign_key "courses", "users", column: "creator_id", name: "fk_courses_creator_id"
   add_foreign_key "courses", "users", column: "updater_id", name: "fk_courses_updater_id"

--- a/spec/fixtures/parallel_runtime_rspec.log
+++ b/spec/fixtures/parallel_runtime_rspec.log
@@ -57,7 +57,6 @@ spec/controllers/course/user_invitations_controller_spec.rb:3.193817
 spec/controllers/course/user_registrations_controller_spec.rb:3.795959
 spec/controllers/course/users_controller_spec.rb:6.095304
 spec/controllers/course/video/submission/submissions_controller_spec.rb:0.729742
-spec/controllers/course/virtual_classrooms_controller_spec.rb:0.579836
 spec/controllers/jobs_controller_spec.rb:0.066339
 spec/controllers/system/admin/admin_controller_spec.rb:0.073279
 spec/controllers/system/admin/announcements_controller_spec.rb:0.176993
@@ -86,7 +85,6 @@ spec/features/course/admin/leaderboard_settings_spec.rb:3.128346
 spec/features/course/admin/material_settings_spec.rb:0.622561
 spec/features/course/admin/sidebar_settings_spec.rb:0.648388
 spec/features/course/admin/video_settings_spec.rb:0.614424
-spec/features/course/admin/virtual_classroom_settings_spec.rb:1.356165
 spec/features/course/announcement_management_spec.rb:4.620901
 spec/features/course/announcement_pagination_spec.rb:3.474845
 spec/features/course/announcement_sticky_spec.rb:0.525406
@@ -142,9 +140,6 @@ spec/features/course/user_profile_spec.rb:1.450512
 spec/features/course/video/submissions_viewing_spec.rb:0.650255
 spec/features/course/video/video_management_spec.rb:1.934766
 spec/features/course/video/video_viewing_and_attempting_spec.rb:1.171395
-spec/features/course/virtual_classroom/virtual_classroom_access_link_spec.rb:3.819229
-spec/features/course/virtual_classroom/virtual_classroom_management_spec.rb:3.167159
-spec/features/course/virtual_classroom/virtual_classroom_pagination_spec.rb:1.738996
 spec/features/course_management_spec.rb:1.16667
 spec/features/global_announcements_spec.rb:1.335721
 spec/features/jobs_query_spec.rb:0.249097
@@ -181,7 +176,6 @@ spec/helpers/course/condition/conditions_helper_spec.rb:0.01495
 spec/helpers/course/controller_helper_spec.rb:3.681278
 spec/helpers/course/lesson_plan/todos_helper_spec.rb:0.392783
 spec/helpers/course/material/folders_helper_spec.rb:0.006572
-spec/helpers/course/virtual_classrooms_helper_spec.rb:0.006687
 spec/helpers/route_overrides_helper_spec.rb:0.022171
 spec/jobs/course/assessment/answer/auto_grading_job_spec.rb:0.804528
 spec/jobs/course/assessment/closing_reminder_job_spec.rb:0.218738
@@ -312,8 +306,6 @@ spec/models/course/user_invitation_spec.rb:0.007652
 spec/models/course/video/submission_spec.rb:1.534878
 spec/models/course/video/video_ability_spec.rb:4.595735
 spec/models/course/video_spec.rb:0.997433
-spec/models/course/virtual_classroom_ability_spec.rb:1.350009
-spec/models/course/virtual_classroom_spec.rb:0.438186
 spec/models/course_ability_spec.rb:2.084716
 spec/models/course_spec.rb:2.367126
 spec/models/course_user_ability_spec.rb:0.32207


### PR DESCRIPTION
## Background

The features to have the virtual classroom has been removed from Coursemology in PR #4751 two years ago, but the table indicating the object related to this (`course_virtual_classrooms`) is still kept. This creates problem when we attempted to delete any existing course with at least one virtual classroom tied to this course, since there's a DB foreign key relationship between `courses` table and `course_virtual_classrooms` table.

## Solution

Since the mentioned table is not used anymore, neither does it being referenced anywhere, we drop the table, to allow for course deletion that was blocked due to foreign key reference with unused virtual classroom table