### PR TITLE
Fix OEmbed (Video) not rendered properly on non-attempting answer

### DIFF
--- a/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
+++ b/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
@@ -2,7 +2,11 @@
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id
-  json.answer_text answer.answer_text
+  if answer.submission.workflow_state == 'attempting'
+    json.answer_text answer.answer_text
+  else
+    json.answer_text format_ckeditor_rich_text(answer.answer_text)
+  end
   json.partial! 'course/assessment/submission/answer/forum_post_response/posts/post_packs',
                 selected_posts: answer.compute_post_packs
 end

--- a/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
@@ -3,7 +3,13 @@ json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id
   question = answer.question.specific
-  json.answer_text answer.answer_text unless question.hide_text
+  if question.hide_text
+    json.answer_text nil
+  elsif answer.submission.workflow_state == 'attempting'
+    json.answer_text answer.answer_text
+  else
+    json.answer_text format_ckeditor_rich_text(answer.answer_text)
+  end
 end
 
 json.attachments answer.attachments do |attachment|


### PR DESCRIPTION
## Background

On non-attempting answer (either submitted, graded, or published), the video link being set on the text answer (either Text Response or Forum Text Response) is not rendered.

## Root Cause

Inside the PR https://github.com/Coursemology/coursemology2/pull/6907, we resolved the issue of answer always unequal on text editor due to unnecessary rich-text formatting by removing the function call `format_ckeditor_rich_text` in our jbuilder. This removing leads to any oembed tag (video being one of them) not being rendered properly if, in FE, we don't use the `CKEditorRichText` component (which we don't use for non-attempting state)

## How to Resolve

We differentiate the rendering for attempting and non-attempting answer, considering that answer autosave will only happen during the attempting state, and hence we can safely call `format_ckeditor_rich_text` on other states (submitted, graded, or published)