### PR TITLE
Redirect User after Sign-In

### DIFF
--- a/client/app/bundles/common/DashboardPage.tsx
+++ b/client/app/bundles/common/DashboardPage.tsx
@@ -10,6 +10,7 @@ import SearchField from 'lib/components/core/fields/SearchField';
 import Page from 'lib/components/core/layouts/Page';
 import Link from 'lib/components/core/Link';
 import { useAppContext } from 'lib/containers/AppContainer';
+import { getUrlParameter } from 'lib/helpers/url-helpers';
 import useItems from 'lib/hooks/items/useItems';
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -129,6 +130,18 @@ const DashboardPageRedirects = (): JSX.Element => {
   if (!courses?.length) return <Navigate to="/courses" />;
 
   if (courses?.length === 1) return <Navigate to={courses[0].url} />;
+
+  if (getUrlParameter('from') === 'auth') {
+    const visitedCourses = courses.filter((c) => !!c.lastActiveAt);
+
+    if (visitedCourses.length > 0) {
+      const lastVisitedCourse = visitedCourses.reduce((c1, c2) =>
+        new Date(c1.lastActiveAt!) > new Date(c2.lastActiveAt!) ? c1 : c2,
+      );
+
+      return <Navigate to={lastVisitedCourse.url} />;
+    }
+  }
 
   return <DashboardPage />;
 };

--- a/client/app/lib/components/wrappers/AuthProvider.tsx
+++ b/client/app/lib/components/wrappers/AuthProvider.tsx
@@ -20,7 +20,9 @@ interface AuthProviderProps {
 export const INVALID_GRANT_ERROR = 'invalid_grant';
 
 const onSigninCallback = (_user: User | void): void => {
-  window.history.replaceState({}, document.title, window.location.pathname);
+  const url = new URL(window.location.pathname, window.location.origin);
+  url.searchParams.set('from', 'auth');
+  window.history.replaceState({}, document.title, url.toString());
 };
 
 export const oidcConfig = {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -61,7 +61,7 @@ const getEmail = (index: number) => `${Date.now()}+${index}@example.org`;
 const extend = <T extends Page>(
   use: (r: T) => Promise<void>,
   page: Page,
-  extension: Omit<T, keyof Page>,
+  extension: Omit<T, keyof Page>
 ) => use(Object.assign(page, extension) as T);
 
 export const test = base.extend<TestFixtures>({
@@ -124,14 +124,14 @@ export const test = base.extend<TestFixtures>({
     await page.getEmailField().fill(user.email);
     await page.getPasswordField().fill(user.password);
     await page.getSignInButton().click();
-    await page.waitForURL('/');
+    await page.waitForURL('/?from=auth');
 
     await extend(use, page.originalPage, {
       user,
       signOut: async () => {
         await page.getUserMenuButton().click();
         await page.getByRole('button', { name: 'Sign out' }).click();
-        await page.getByRole('button', { name: 'Logout' }).click()
+        await page.getByRole('button', { name: 'Logout' }).click();
       },
     });
   },


### PR DESCRIPTION
Some additional redirection we have upon signing-in are as follows:
- if user has visited at least one course in the past, we will redirect them to the course they've seen the latest
- otherwise, we still proceed as per what we have now (if only enrolled in one course, redirect to that course. Otherwise, navigate to Dashboard Page)