### PR TITLE
Adjust Window Title to be Dynamic Based on Page

### DIFF
--- a/client/app/bundles/course/container/CourseContainer.tsx
+++ b/client/app/bundles/course/container/CourseContainer.tsx
@@ -8,6 +8,9 @@ import CikgoSidebarItems from 'course/stories/components/CikgoSidebarItems';
 import PopupNotifier from 'course/user-notification/PopupNotifier';
 import Footer from 'lib/components/core/layouts/Footer';
 import { DataHandle, useDynamicNest } from 'lib/hooks/router/dynamicNest';
+import { DEFAULT_WINDOW_TITLE } from 'lib/hooks/router/dynamicNest/constants';
+import { getLastCrumbTitle } from 'lib/hooks/router/dynamicNest/crumbs';
+import useTranslation, { translatable } from 'lib/hooks/useTranslation';
 
 import Breadcrumbs from './Breadcrumbs';
 import { loader, useCourseLoader } from './CourseLoader';
@@ -17,6 +20,8 @@ const CourseContainer = (): JSX.Element => {
   const location = useLocation();
 
   const data = useCourseLoader();
+
+  const { t } = useTranslation();
 
   const sidebarRef = useRef<ComponentRef<typeof Sidebar>>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -28,6 +33,13 @@ const CourseContainer = (): JSX.Element => {
   }, [location.pathname]);
 
   const { crumbs, loading, activePath } = useDynamicNest();
+
+  const crumbTitle = getLastCrumbTitle(crumbs);
+  const title = translatable(crumbTitle) ? t(crumbTitle) : crumbTitle;
+
+  useEffect(() => {
+    document.title = title ?? DEFAULT_WINDOW_TITLE;
+  }, [title]);
 
   return (
     <main className="flex h-full min-h-0 w-full">

--- a/client/app/lib/containers/CourselessContainer.tsx
+++ b/client/app/lib/containers/CourselessContainer.tsx
@@ -1,28 +1,15 @@
+import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import Footer from 'lib/components/core/layouts/Footer';
-import {
-  CrumbData,
-  CrumbTitle,
-  useDynamicNest,
-} from 'lib/hooks/router/dynamicNest';
+import { useDynamicNest } from 'lib/hooks/router/dynamicNest';
+import { DEFAULT_WINDOW_TITLE } from 'lib/hooks/router/dynamicNest/constants';
+import { getLastCrumbTitle } from 'lib/hooks/router/dynamicNest/crumbs';
 import useTranslation, { translatable } from 'lib/hooks/useTranslation';
 
 import BrandingHead from '../components/navigation/BrandingHead';
 
 import { useAppContext } from './AppContainer';
-
-const getLastCrumbTitle = (crumbs: CrumbData[]): CrumbTitle | null => {
-  const content = crumbs[crumbs.length - 1]?.content;
-  if (!content) return null;
-
-  const actualContent = Array.isArray(content)
-    ? content[content.length - 1]
-    : content;
-  if (!actualContent) return null;
-
-  return actualContent.title;
-};
 
 interface CourselessContainerProps {
   withCourseSwitcher?: boolean;
@@ -39,6 +26,10 @@ const CourselessContainer = (props: CourselessContainerProps): JSX.Element => {
 
   const crumbTitle = getLastCrumbTitle(crumbs);
   const title = translatable(crumbTitle) ? t(crumbTitle) : crumbTitle;
+
+  useEffect(() => {
+    document.title = title ?? DEFAULT_WINDOW_TITLE;
+  }, [title]);
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/client/app/lib/hooks/router/dynamicNest/constants.ts
+++ b/client/app/lib/hooks/router/dynamicNest/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_WINDOW_TITLE = 'Coursemology';

--- a/client/app/lib/hooks/router/dynamicNest/crumbs.ts
+++ b/client/app/lib/hooks/router/dynamicNest/crumbs.ts
@@ -26,6 +26,18 @@ export interface CrumbPath {
 
 export type CrumbState = Record<string, CrumbData>;
 
+export const getLastCrumbTitle = (crumbs: CrumbData[]): CrumbTitle | null => {
+  const content = crumbs[crumbs.length - 1]?.content;
+  if (!content) return null;
+
+  const actualContent = Array.isArray(content)
+    ? content[content.length - 1]
+    : content;
+  if (!actualContent) return null;
+
+  return actualContent.title;
+};
+
 export const isCrumbPath = (value: unknown): value is CrumbPath =>
   isRecord(value) && 'content' in value;
 


### PR DESCRIPTION
## Background

Previously, the window title for our Coursemology page is always shown as "Coursemology", irrespective of the page we're in. This is not good in case we open multiple tabs / windows that is Coursemology but different pages (for example, Achievement in one tab but Announcement in other), making users unable to distinguish between tabs

## Approach

We make the `document.title` dynamic by following the last piece in our Breadcrumbs, since that last piece is reflective towards what page is opened by user at the moment