### PR TITLE
Allow Inviting Users to Course by Email

### DIFF
--- a/client/app/bundles/course/user-invitations/components/forms/IndividualInvitations.tsx
+++ b/client/app/bundles/course/user-invitations/components/forms/IndividualInvitations.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import {
   Control,
   UseFieldArrayAppend,
@@ -12,6 +12,12 @@ import {
   IndividualInvite,
   IndividualInvites,
 } from 'types/course/userInvitations';
+
+import { parseInvitationInput } from 'course/user-invitations/operations';
+import { InvitationEntry } from 'course/user-invitations/types';
+import ErrorText from 'lib/components/core/ErrorText';
+import TextField from 'lib/components/core/fields/TextField';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import IndividualInvitation from './IndividualInvitation';
 
@@ -35,17 +41,37 @@ const translations = defineMessages({
     id: 'course.userInvitations.IndividualInvitations.invite',
     defaultMessage: 'Invite All Users',
   },
+  nameEmailInput: {
+    id: 'course.userInvitations.IndividualInvitations.nameEmailInput',
+    defaultMessage:
+      "John Doe '<john.doe@example.org'>; \"Doe, Jane\" '<jane.doe@example.org'>; ...",
+  },
+  addRowsByEmail: {
+    id: 'course.userInvitations.IndividualInvitations.addRowsByEmail',
+    defaultMessage: 'Add Rows by Email',
+  },
+  malformedEmail: {
+    id: 'course.userInvitations.IndividualInvitations.malformedEmail',
+    defaultMessage:
+      '{n, plural, one {This email is } other {These emails are }} wrongly formatted: {emails}',
+  },
 });
 
 const IndividualInvitations: FC<Props> = (props) => {
   const { isLoading, permissions, fieldsConfig, intl } = props;
-  const { append, fields } = fieldsConfig;
+  const { append, remove, fields } = fieldsConfig;
 
-  const appendNewRow = (): void => {
-    const lastRow = fields[fields.length - 1];
+  const { t } = useTranslation();
+
+  const [nameEmailInput, setNameEmailInput] = useState('');
+
+  const appendRow = (
+    lastRow: IndividualInvite,
+    entry?: InvitationEntry,
+  ): void => {
     append({
-      name: '',
-      email: '',
+      name: entry?.name ?? '',
+      email: entry?.email ?? '',
       role: lastRow.role,
       phantom: lastRow.phantom,
       ...(permissions.canManagePersonalTimes && {
@@ -54,8 +80,62 @@ const IndividualInvitations: FC<Props> = (props) => {
     });
   };
 
+  const appendNewRow = (): void => {
+    const lastRow = fields[fields.length - 1];
+    appendRow(lastRow, undefined);
+  };
+
+  const appendInputs = (results: InvitationEntry[]): void => {
+    const lastRow = fields[fields.length - 1];
+
+    for (let idx = fields.length - 1; idx >= 0; idx--) {
+      const { name, email } = fields[idx];
+      if (!name && !email) remove(idx);
+    }
+
+    results.forEach((entry) => appendRow(lastRow, entry));
+  };
+
+  const parsedInput = parseInvitationInput(nameEmailInput);
+
   return (
     <>
+      <div className="flex items-center gap-3">
+        <TextField
+          className="w-full"
+          hiddenLabel
+          multiline
+          name="nameEmailInvitation"
+          onChange={(e): void => setNameEmailInput(e.target.value)}
+          placeholder={t(translations.nameEmailInput)}
+          size="small"
+          value={nameEmailInput}
+          variant="filled"
+        />
+        <Button
+          className="whitespace-nowrap"
+          color="primary"
+          onClick={(): void => {
+            appendInputs(parsedInput.results);
+            setNameEmailInput(parsedInput.errors.join('; '));
+          }}
+          variant="outlined"
+        >
+          {t(translations.addRowsByEmail)}
+        </Button>
+      </div>
+
+      {parsedInput.errors.length > 0 && (
+        <div className="mt-1">
+          <ErrorText
+            errors={t(translations.malformedEmail, {
+              n: parsedInput.errors.length,
+              emails: parsedInput.errors.join(', '),
+            })}
+          />
+        </div>
+      )}
+
       {fields.map(
         (field, index): JSX.Element => (
           <IndividualInvitation

--- a/client/app/bundles/course/user-invitations/types.ts
+++ b/client/app/bundles/course/user-invitations/types.ts
@@ -80,3 +80,8 @@ export interface InvitationsState {
   manageCourseUsersData: ManageCourseUsersSharedData;
   courseRegistrationKey: string;
 }
+
+export interface InvitationEntry {
+  name: string;
+  email: string;
+}


### PR DESCRIPTION
## Feature

Inside Manage Users > Invite Users, we have an additional feature in which user can copy-paste list of names and emails, and then the invitation lists will be updated automatically to include all the users enlisted within the list.

<img width="1529" alt="Screenshot 2024-11-21 at 4 40 41 PM" src="https://github.com/user-attachments/assets/e0184de3-176a-4fc5-9c84-15205077f828">

Should the format has an error in some of the users, then we updated the list to include those correctly-formatted users and inform user about the errors, so that the inviter can modify the name / email accordingly

<img width="1529" alt="Screenshot 2024-11-21 at 4 43 56 PM" src="https://github.com/user-attachments/assets/33226663-cb82-4297-9d82-30035952f6e3">