### PR TITLE
Fix flaky tests that occasionally timeout/fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
           when: always
           working_directory: tests
           command: |
-            zip -r test-results.zip test-results playright-report
+            zip -r test-results.zip test-results playwright-report
 
       - codecov/upload:
           upload_name: playwright-rails

--- a/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/index.test.tsx
+++ b/client/app/bundles/course/assessment/submission/components/ScribingView/__test__/index.test.tsx
@@ -65,6 +65,8 @@ describe('ScribingView', () => {
 
     const page = render(<ScribingView answerId={answerId} />, { at: [url] });
 
-    expect(await page.findByTestId(`canvas-${answerId}`)).toBeVisible();
+    expect(
+      await page.findByTestId(`canvas-${answerId}`, {}, { timeout: 5000 }),
+    ).toBeVisible();
   });
 });

--- a/spec/features/course/admin/admin_spec.rb
+++ b/spec/features/course/admin/admin_spec.rb
@@ -66,13 +66,13 @@ RSpec.feature 'Course: Administration: Administration', js: true do
 
         click_button 'Save changes'
 
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(course.reload.advance_start_at_duration).to be_within(1.hour).of(days.days)
 
         fill_in advance_start_at_duration_field, with: ''
         click_button 'Save changes'
 
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(course.reload.advance_start_at_duration).to eq 0
       end
 

--- a/spec/features/course/admin/codaveri_settings_spec.rb
+++ b/spec/features/course/admin/codaveri_settings_spec.rb
@@ -18,13 +18,13 @@ RSpec.feature 'Course: Administration: Codaveri', js: true do
         itsp_engine_radio_button = find('label', text: 'ITSP Engine')
         itsp_engine_radio_button.click
         click_button 'Save changes'
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(course.reload.codaveri_itsp_enabled?).to eq(true)
 
         default_engine_radio_button = find('label', text: 'Default Engine')
         default_engine_radio_button.click
         click_button 'Save changes'
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(course.reload.codaveri_itsp_enabled?).to eq(false)
       end
 
@@ -33,12 +33,12 @@ RSpec.feature 'Course: Administration: Codaveri', js: true do
 
         find('label', text: 'Publish feedback directly to student').click
         click_button 'Save changes'
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(course.reload.codaveri_feedback_workflow).to eq('publish')
 
         find('label', text: 'Generate no feedback').click
         click_button 'Save changes'
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(course.reload.codaveri_feedback_workflow).to eq('none')
       end
     end

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -34,12 +34,12 @@ RSpec.feature 'Course: Administration: Components', js: true do
 
         control = find('label', text: sample_component.display_name)
         control.click
-        expect_toastify('Your changes have been saved. Refresh to see the new changes.')
+        expect_toastify('Your changes have been saved. Refresh to see the new changes.', dismiss: true)
 
         expect(control).to have_field(type: 'checkbox', checked: false, visible: false)
 
         control.click
-        expect_toastify('Your changes have been saved. Refresh to see the new changes.')
+        expect_toastify('Your changes have been saved. Refresh to see the new changes.', dismiss: true)
 
         expect(control).to have_field(type: 'checkbox', checked: true, visible: false)
       end

--- a/spec/features/course/admin/forum_settings_spec.rb
+++ b/spec/features/course/admin/forum_settings_spec.rb
@@ -63,13 +63,13 @@ RSpec.feature 'Course: Administration: Forums', js: true do
         find_field('allowAnonymousPost', visible: false).set(true)
 
         click_button 'Save changes'
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(page).to have_field('allowAnonymousPost', checked: true, visible: false)
         expect(course.reload.settings(:course_forums_component).allow_anonymous_post).to be_truthy
 
         find_field('allowAnonymousPost', visible: false).set(false)
         click_button 'Save changes'
-        expect_toastify('Your changes have been saved.')
+        expect_toastify('Your changes have been saved.', dismiss: true)
         expect(page).to have_field('allowAnonymousPost', checked: false, visible: false)
         expect(course.reload.settings(:course_forums_component).allow_anonymous_post).to be_falsy
       end

--- a/spec/features/course/assessment/skill_management_spec.rb
+++ b/spec/features/course/assessment/skill_management_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'Course: Skills' do
         visit course_assessments_skills_path(course)
         click_button 'Skill'
 
+        # ensure form is present
+        find('form#skill-form')
         skill_attributes = attributes_for(:course_assessment_skill)
         fill_in 'title', with: skill_attributes[:title]
 
@@ -33,13 +35,16 @@ RSpec.describe 'Course: Skills' do
         visit course_assessments_skills_path(course)
         find('.skill_branch#skill_branch_-1').click
         find(content_tag_selector(skill)).click
+        wait_for_animation
         find("button.skill-edit-#{skill.id}").click
 
+        # ensure form is present
+        find('form#skill-form')
         new_skill_title = "#{skill.title} there!"
         fill_in 'title', with: new_skill_title
-        # Does not work because it is not visible
-        find('#select').click
-        find("#select-#{skill_branch.id}").click
+        find('form#skill-form #select').click
+        wait_for_animation
+        find("#menu-skillBranchId li#select-#{skill_branch.id}").click
 
         find('.btn-submit').click
 
@@ -51,16 +56,15 @@ RSpec.describe 'Course: Skills' do
         expect(skill.skill_branch).to eq(skill_branch)
       end
 
-      # Flaky test
-      xscenario 'I can delete a skill' do
+      scenario 'I can delete a skill' do
         skill = create(:course_assessment_skill, course: course)
         visit course_assessments_skills_path(course)
         find('.skill_branch#skill_branch_-1').click
         find(content_tag_selector(skill)).click
-        wait_for_page
+        wait_for_animation
         expect do
           find("button.skill-delete-#{skill.id}").click
-          accept_confirm_dialog
+          accept_confirm_dialog('button.prompt-primary-btn')
         end.to change { course.assessment_skills.count }.by(-1)
 
         expect(current_path).to eq(course_assessments_skills_path(course))

--- a/spec/features/course/assessment/submission/past_answers_spec.rb
+++ b/spec/features/course/assessment/submission/past_answers_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
         expect(page).to have_selector('span', text: 'Past Answers', count: past_answer_count)
 
         all('span', text: 'Past Answers').each(&:click)
+        wait_for_animation
         # Label selector matches both the expanded 'Past Answers' section and the labels we clicked
         expect(page).to have_selector('label', text: 'Past Answers', count: past_answer_count * 2)
       end
@@ -47,6 +48,7 @@ RSpec.describe 'Course: Assessment: Submissions: Past Answers', js: true do
         expect(page).to have_selector('span', text: 'Past Answers', count: past_answer_count)
 
         all('span', text: 'Past Answers').each(&:click)
+        wait_for_animation
         expect(page).to have_selector('label', text: 'Past Answers', count: past_answer_count * 2)
       end
     end

--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -6,28 +6,26 @@ RSpec.feature 'Course: Assessments: Management', js: true do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    before { login_as(user, scope: :user) }
+    before { login_as(user, scope: :user, redirect_url: course_assessments_path(course)) }
 
     context 'As a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
 
-      # This test is disabled as CircleCI is unable to detect the following:
-      # first("input[name='start_at']").click.set(assessment.start_at.strftime('%d-%m-%Y'))
-      xscenario 'I can create an assessment' do
+      scenario 'I can create an assessment' do
         assessment_tab = create(:course_assessment_tab,
                                 category: course.assessment_categories.first)
         assessment = build_stubbed(:assessment)
 
         visit course_assessments_path(course, category: assessment_tab.category,
                                               tab: assessment_tab)
-        find('div.new-btn button').click
+        find('button[aria-label="New Assessment"]').click
 
         expect(page).to have_selector('h2', text: 'New Assessment')
 
         fill_in 'title', with: assessment.title
         fill_in 'base_exp', with: assessment.base_exp
-        # Need to click on the field first or `set` won't work.
-        first("input[name='start_at']").click.set(assessment.start_at.strftime('%d-%m-%Y'))
+        start_at = assessment.start_at.strftime('%d-%m-%Y %H:%M')
+        fill_in_mui_datetime('start_at', start_at)
         find('button.btn-submit').click
 
         expect(page).not_to have_selector('h2', text: 'New Assessment')
@@ -35,19 +33,17 @@ RSpec.feature 'Course: Assessments: Management', js: true do
         expect(assessment_created.tab).to eq(assessment_tab)
         expect(assessment_created.title).to eq(assessment.title)
         expect(assessment_created.base_exp).to eq(assessment.base_exp)
-        expect(page).to have_content_tag_for(assessment_created)
         expect(assessment_created).not_to be_autograded
+        expect(page).to have_text(assessment_created.title)
       end
 
       scenario 'I can delete an assessment' do
-        skip 'Flaky tests'
         assessment = create(:assessment, course: course)
         category_id, tab_id = assessment.tab.category_id, assessment.tab_id
         visit course_assessment_path(course, assessment)
 
         expect do
-          wait_for_page
-          click_button 'Delete Assessment'
+          find('svg[data-testid="DeleteIcon"]').click
           Capybara.enable_aria_label = false
           click_button 'Delete Assessment'
           expect_toastify('Assessment successfully deleted.')
@@ -62,8 +58,6 @@ RSpec.feature 'Course: Assessments: Management', js: true do
       let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view the Assessment Sidebar item' do
-        visit course_path(course)
-
         assessment_sidebar = 'activerecord.attributes.course/assessment/category/title.default'
         expect(find_sidebar).to have_text(assessment_sidebar)
       end

--- a/spec/features/course/experience_points/forum_disbursement_spec.rb
+++ b/spec/features/course/experience_points/forum_disbursement_spec.rb
@@ -35,8 +35,8 @@ RSpec.feature 'Course: Experience Points: Forum Disbursement' do
           expect(page).to have_field(type: 'text', with: '100')
         end
 
-        start_date = (4.weeks.ago + 1.minute).strftime('%d-%m-%Y %I:%M')
-        end_date = 2.weeks.ago.strftime('%d-%m-%Y %I:%M')
+        start_date = (4.weeks.ago + 1.minute).strftime('%d-%m-%Y %H:%M')
+        end_date = 2.weeks.ago.strftime('%d-%m-%Y %H:%M')
 
         fill_in_mui_datetime('Start Date', start_date)
         fill_in_mui_datetime('End Date', end_date)

--- a/spec/features/system/admin/components_settings_spec.rb
+++ b/spec/features/system/admin/components_settings_spec.rb
@@ -9,11 +9,10 @@ RSpec.feature 'System: Administration: Components', type: :feature, js: true do
     let(:components) { instance.disableable_components }
 
     before do
-      login_as(admin, scope: :user)
+      login_as(admin, scope: :user, redirect_url: admin_instance_components_path)
     end
 
     scenario 'Admin visits the page' do
-      visit admin_instance_components_path
       settings = Instance::Settings::Components.new(instance)
       enabled_components = settings.enabled_component_ids
 
@@ -31,18 +30,17 @@ RSpec.feature 'System: Administration: Components', type: :feature, js: true do
     end
 
     scenario 'Enable/disable a component' do
-      visit admin_instance_components_path
       settings = Instance::Settings::Components.new(instance)
       enabled_components = settings.enabled_component_ids
       component_to_modify = enabled_components.sample
       element_to_modify = find("tr#component_#{component_to_modify}")
 
       element_to_modify.find('input', visible: false).click
-      expect_toastify('Instance component setting was updated successfully.')
+      expect_toastify('Instance component setting was updated successfully.', dismiss: true)
       expect(element_to_modify).to have_field(type: 'checkbox', checked: false, visible: false)
 
       element_to_modify.find('input', visible: false).click
-      expect_toastify('Instance component setting was updated successfully.')
+      expect_toastify('Instance component setting was updated successfully.', dismiss: true)
       expect(element_to_modify).to have_field(type: 'checkbox', checked: true, visible: false)
     end
   end

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -7,15 +7,14 @@ RSpec.feature 'System: Administration: Users', js: true do
   with_tenant(:instance) do
     context 'As a System Administrator' do
       let(:admin) { create(:administrator) }
-      before { login_as(admin, scope: :user) }
-
       let!(:users) do
         create_list(:user, 2)
         User.human_users.ordered_by_name.limit(5)
       end
-      scenario 'I can view the users in the system' do
-        visit admin_users_path
+      let!(:user_to_delete) { create(:user, name: "!#{users.first.name}") }
+      before { login_as(admin, scope: :user, redirect_url: admin_users_path) }
 
+      scenario 'I can view the users in the system' do
         users.each do |user|
           expect(page).to have_selector('div.user_name', text: user.name)
           expect(page).to have_selector('p.user_email', text: user.email)
@@ -23,8 +22,6 @@ RSpec.feature 'System: Administration: Users', js: true do
       end
 
       scenario 'I can filter users by role and view only administrators' do
-        visit admin_users_path
-
         within find('p', text: 'Total Users', exact_text: false) do
           find_all('a').first.click
         end
@@ -40,51 +37,36 @@ RSpec.feature 'System: Administration: Users', js: true do
         end
       end
 
-      # Flaky test
-      xscenario "I can change a user's record" do
-        visit admin_users_path
-
+      scenario "I can change a user's record" do
         user_to_change = users.sample
         new_name = 'updated user name'
-        wait_for_page
-        # change name
         within find("tr.system_user_#{user_to_change.id}") do
           find('button.inline-edit-button', visible: false).click
           find('input').set(new_name)
           find('button.confirm-btn').click
         end
-        # Disabled due to flaky test
-        # expect_toastify("#{user_to_change.name} was renamed to #{new_name}.")
-        wait_for_page
+        expect_toastify("#{user_to_change.name} was renamed to #{new_name}.")
         # change role
         within find("tr.system_user_#{user_to_change.id}") do
           find('div.user_role').click
         end
         find("#role-#{user_to_change.id}-administrator").select_option
-        # Disabled due to flaky test
-        # expect_toastify("Successfully changed #{new_name}'s role to Administrator.")
-        wait_for_page
+        expect_toastify("Successfully changed #{new_name}'s role to Administrator.")
         expect(user_to_change.reload).to be_administrator
         expect(user_to_change.name).to eq(new_name)
       end
 
-      let!(:user_to_delete) { create(:user, name: "!#{users.first.name}") }
       scenario 'I can delete a user' do
-        visit admin_users_path
-
         find("button.user-delete-#{user_to_delete.id}").click
         accept_prompt
         expect_toastify('User was deleted.')
       end
 
       scenario 'I can search users' do
-        skip 'Flaky tests'
         user_name = SecureRandom.hex
         users_to_search = create_list(:user, 2, name: user_name)
-        visit admin_users_path
 
         # Search by username
-        wait_for_page
         find_button('Search').click
         find('div[aria-label="Search"]').find('input').set(user_name)
 

--- a/spec/support/authentication_performers.rb
+++ b/spec/support/authentication_performers.rb
@@ -4,13 +4,13 @@ module AuthenticationPerformersTestHelpers
 
   alias_method :warden_logout, :logout
 
-  def login_as(user, _ = {})
+  def login_as(user, **kwargs)
     # For some reasons, sometimes new scenarios are automatically logged in as the previous user.
     # Clearing cookies isn't enough and subsequent requests still carries over an old, authenticated
     # session cookie. We force the server to log out all remaining sessions before logging in.
     # warden_logout
 
-    visit new_user_session_path
+    visit new_user_session_path(next: kwargs[:redirect_url])
 
     fill_in 'Email', with: user.email
     fill_in 'Password', with: password_for(user)
@@ -22,6 +22,7 @@ module AuthenticationPerformersTestHelpers
 
   def logout(*_)
     find('div[data-testid="user-menu-button"]').click
+    wait_for_animation
     find('li', text: 'Sign out').click
     click_button('Logout')
     expect(page).to_not have_css('div[data-testid="user-menu-button"]')

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -36,7 +36,6 @@ module Capybara::TestGroupHelpers
     end
 
     def accept_confirm_dialog(class_name = 'button.confirm-btn')
-      expect(page).to have_selector(class_name)
       find(class_name).click
       yield if block_given?
       wait_for_ajax
@@ -86,11 +85,13 @@ module Capybara::TestGroupHelpers
     #
     # Since capybara's `find` has a default timeout until the element is found, this helps
     # to ensure certain changes are made before continuing with the tests.
-    def expect_toastify(message)
-      expect(page).to have_css('.Toastify', visible: true)
-      container = find_all('.Toastify').first
+    def expect_toastify(message, dismiss: false)
+      container = find('.Toastify')
       expect(container).to have_text(message)
+      return unless dismiss
+
       container.find('p', text: message).click
+      expect(page).to have_no_css('.Toastify')
     end
 
     # Finds a react-beautiful-dnd draggable element
@@ -146,8 +147,7 @@ module Capybara::TestGroupHelpers
     end
 
     def expect_forbidden
-      sleep 1 # wait for the page to load
-      expect(page).to have_content("You don't have permission to access")
+      expect(page).to have_content("You don't have permission to access", wait: 10)
     end
 
     def confirm_registration_token_via_email

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -30,4 +30,7 @@ export default defineConfig({
       use: { ...devices['Desktop Safari'] },
     },
   ],
+  expect: {
+    timeout: 15_000,
+  },
 });

--- a/tests/tests/users/password-management.spec.ts
+++ b/tests/tests/users/password-management.spec.ts
@@ -11,6 +11,9 @@ test('can change password', async ({ authedPage: page }) => {
 
   await page.getByRole('button', { name: 'Save changes' }).click();
   await expect(page.getByText('Your changes have been saved')).toBeVisible();
+  await expect(
+    page.getByText('Your changes have been saved')
+  ).not.toBeVisible();
 
   await page.signOut();
   await page.signIn(page.user.email, page.user.password);

--- a/tests/tests/users/sign-up.spec.ts
+++ b/tests/tests/users/sign-up.spec.ts
@@ -75,6 +75,7 @@ test.describe('user invited to a course', () => {
 
 test.describe('user invited to 2 courses', () => {
   test('can sign up with first invitation', async ({ signUpPage: page }) => {
+    test.slow();
     const { password } = page.getFieldMocks();
 
     const course1 = await manufacture({ course: {} });


### PR DESCRIPTION
- add [`test.slow()`](https://playwright.dev/docs/api/class-test#test-slow) to triple default test timeout 30s -> 90s
- fix playwright naming in `circleci.yml` config
- fix flaky jstest by increasing timeout for slow scribing test
- fix flaky rspec by adding a wait to allow user-menu popover to fully appear before clicking logout