### PR TITLE
Java 21 evaluator support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -199,7 +199,7 @@ gem 'rubyzip', require: 'zip'
 gem 'nokogiri', '>= 1.8.1'
 
 # Polyglot support
-gem 'coursemology-polyglot', git: 'https://github.com/Coursemology/polyglot', ref: '14fbbc2'
+gem 'coursemology-polyglot', git: 'https://github.com/Coursemology/polyglot', ref: 'b2ffccc'
 
 # To assist with bulk inserts into database
 gem 'activerecord-import', '>= 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,10 +22,10 @@ GIT
 
 GIT
   remote: https://github.com/Coursemology/polyglot
-  revision: 14fbbc2943e87479f989056a0ae465f54726c4a1
-  ref: 14fbbc2
+  revision: b2ffccc6d0bf11569733eea395e31ac77df139e9
+  ref: b2ffccc
   specs:
-    coursemology-polyglot (0.3.9)
+    coursemology-polyglot (0.3.10)
       activesupport (>= 4.2)
 
 GIT

--- a/lib/tasks/db/set_polyglot_language_flags.rake
+++ b/lib/tasks/db/set_polyglot_language_flags.rake
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 namespace :db do
-  # Run this after adding the *_whitelisted columns to polyglot_languages table.
-  # (20241028141424_add_language_whitelist_flags.rb)
-
-  # These whitelists are accurate as of the date this migration is merged and performed (2024-11-18)
+  # This rake updates the *_whitelisted fields in the polyglot_languages table. It was created
+  # with the migration introducing these flags (20241028141424_add_language_whitelist_flags.rb)
+  # It should be run whenever any values in those flags need to be changed
+  # (e.g. when a new language is added)
   CODAVERI_EVALUATOR_WHITELIST =
     [
       Coursemology::Polyglot::Language::Python::Python3Point4,

--- a/lib/tasks/db/set_polyglot_language_weights.rake
+++ b/lib/tasks/db/set_polyglot_language_weights.rake
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+namespace :db do
+  # This rake updates the weight column in the polyglot_languages table,
+  # changing the order in which languages are displayed in drop-down menus.
+
+  LANGUAGE_ORDERING = [
+    'python',
+    'java',
+    'c/c++',
+    'r',
+    'javascript'
+  ].freeze
+
+  def version_compare(ver1, ver2)
+    ver1&.split('.')&.map(&:to_i) <=> ver2&.split('.')&.map(&:to_i)
+  end
+
+  def language_compare(lang1, lang2)
+    index1 = LANGUAGE_ORDERING.index { |l| lang1.polyglot_name == l }
+    index2 = LANGUAGE_ORDERING.index { |l| lang2.polyglot_name == l }
+
+    # Put most recent versions first
+    return -version_compare(lang1.polyglot_version, lang2.polyglot_version) if index1 == index2
+    return 1 if index1.nil?
+    return -1 if index2.nil?
+
+    index1 <=> index2
+  end
+
+  task set_polyglot_language_weights: :environment do
+    # this ensures all languages are loaded in the database table before flags are updated below
+    Coursemology::Polyglot::Language.load_languages
+
+    ActsAsTenant.without_tenant do
+      ActiveRecord::Base.connection.execute(
+        'ALTER SEQUENCE polyglot_languages_weight_seq RESTART WITH 1;'
+      )
+      # The highest weight is displayed first, so we perform assignments in reverse order
+      Coursemology::Polyglot::Language.all.sort(&method(:language_compare)).reverse_each do |lang|
+        ActiveRecord::Base.connection.execute(
+          "UPDATE polyglot_languages SET weight = nextval('polyglot_languages_weight_seq') WHERE name = '#{lang.name}';"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related PRs:
- [New Debian 12, Java 21 evaluator images](https://github.com/Coursemology/evaluator-images/pull/38)
- [Add new language entry to Polyglot](https://github.com/Coursemology/polyglot/pull/34/files)

Evaluator images for Debian 12 / Java 21 already deployed.
Sample Java 21 programming package (will error when attempting to run solution on older Java versions):
[EmojiChecker.zip](https://github.com/user-attachments/files/17900513/EmojiChecker.zip)

Command for rakefile to ensure consistency:  
`bundle exec rake db:set_polyglot_language_flags`