### PR TITLE
fix(tests): fix flaky tests

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -127,7 +127,7 @@ class Course < ApplicationRecord
 
   # Generates a registration key for use with the course.
   def generate_registration_key
-    self.registration_key = "C#{SecureRandom.base64(8)}"
+    self.registration_key = "C#{SecureRandom.urlsafe_base64(8)}"
   end
 
   def code_registration_enabled?

--- a/app/models/course/user_invitation.rb
+++ b/app/models/course/user_invitation.rb
@@ -54,7 +54,7 @@ class Course::UserInvitation < ApplicationRecord
   #
   # @return [void]
   def generate_invitation_key
-    self.invitation_key ||= INVITATION_KEY_IDENTIFIER + SecureRandom.base64(8)
+    self.invitation_key ||= INVITATION_KEY_IDENTIFIER + SecureRandom.urlsafe_base64(8)
   end
 
   # Sets the default for non-null fields.

--- a/app/models/instance/user_invitation.rb
+++ b/app/models/instance/user_invitation.rb
@@ -43,7 +43,7 @@ class Instance::UserInvitation < ApplicationRecord
   #
   # @return [void]
   def generate_invitation_key
-    self.invitation_key ||= INVITATION_KEY_IDENTIFIER + SecureRandom.base64(8)
+    self.invitation_key ||= INVITATION_KEY_IDENTIFIER + SecureRandom.urlsafe_base64(8)
   end
 
   # Sets the default for non-null fields.

--- a/client/app/bundles/system/admin/admin/pages/UsersIndex.tsx
+++ b/client/app/bundles/system/admin/admin/pages/UsersIndex.tsx
@@ -57,7 +57,7 @@ const countWithLink = (
 
 const UsersIndex: FC<Props> = (props) => {
   const { intl } = props;
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [filter, setFilter] = useState({ active: false, role: '' });
   const userCounts = useAppSelector(getAdminCounts);
   const users = useAppSelector(getAllUserMiniEntities);

--- a/client/app/bundles/system/admin/instance/instance/pages/InstanceUsersIndex.tsx
+++ b/client/app/bundles/system/admin/instance/instance/pages/InstanceUsersIndex.tsx
@@ -62,7 +62,7 @@ const countWithLink = (
 
 const UsersIndex: FC<Props> = (props) => {
   const { intl } = props;
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [filter, setFilter] = useState({ active: false, role: '' });
   const users = useAppSelector(getAllUserMiniEntities);
   const userCounts = useAppSelector(getAdminCounts);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -20,7 +20,11 @@ interface User {
 interface Page extends BasePage {
   getReCAPTCHA: () => Locator;
   getUserMenuButton: () => Locator;
-  signIn: (email: string, password: string) => Promise<void>;
+  signIn: (
+    email: string,
+    password: string,
+    isPageRendered?: boolean
+  ) => Promise<void>;
 }
 
 interface SignInPage extends Page {
@@ -73,11 +77,19 @@ export const test = base.extend<TestFixtures>({
       getReCAPTCHA: () =>
         page.frameLocator('[title="reCAPTCHA"]').getByLabel("I'm not a robot"),
       getUserMenuButton: () => page.getByTestId('user-menu-button'),
-      signIn: async (email: string, password: string) => {
-        await page.goto('/users/sign_in');
+      signIn: async (
+        email: string,
+        password: string,
+        isPageRendered: boolean = false
+      ) => {
+        if (!isPageRendered) await page.goto('/users/sign_in');
         await page.getByPlaceholder('Email').fill(email);
         await page.getByPlaceholder('Password').fill(password);
         await page.getByRole('button', { name: 'Sign in' }).click();
+        try {
+          await page.waitForURL(/\?from=auth/, { timeout: 1000 });
+          await page.waitForURL(/^(?!.*\?from=auth)/);
+        } catch {}
       },
     } satisfies Omit<Page, keyof BasePage>);
   },

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -30,7 +30,4 @@ export default defineConfig({
       use: { ...devices['Desktop Safari'] },
     },
   ],
-  expect: {
-    timeout: 15_000,
-  },
 });

--- a/tests/tests/users/sign-up.spec.ts
+++ b/tests/tests/users/sign-up.spec.ts
@@ -55,7 +55,7 @@ test.describe('user invited to a course', () => {
 
     await page.getSignUpButton().click();
 
-    await page.signIn(invitation.email, password)
+    await page.signIn(invitation.email, password, true);
 
     await expect(page).toHaveURL(new RegExp(course.id));
   });
@@ -75,7 +75,6 @@ test.describe('user invited to a course', () => {
 
 test.describe('user invited to 2 courses', () => {
   test('can sign up with first invitation', async ({ signUpPage: page }) => {
-    test.slow();
     const { password } = page.getFieldMocks();
 
     const course1 = await manufacture({ course: {} });
@@ -98,7 +97,7 @@ test.describe('user invited to 2 courses', () => {
     await page.getReCAPTCHA().click();
     await page.getSignUpButton().click();
 
-    await page.signIn(invitation1.email, password)
+    await page.signIn(invitation1.email, password, true);
 
     await page.goto(`/courses/${course1.id}`);
     await expect(page).toHaveURL(new RegExp(course1.id));
@@ -143,7 +142,7 @@ test.describe('user invited to 2 courses', () => {
     await expect.soft(page.getByText(email)).toBeVisible();
     await expect(page.getByText('confirmed')).toBeVisible();
 
-    await page.signIn(email, password)
+    await page.signIn(email, password);
 
     await page.goto(`/courses/${course.id}`);
     await expect(page).toHaveURL(new RegExp(course.id));


### PR DESCRIPTION
Flaky test: `tests/tests/users/sign-up.spec.ts`

- Added parameter to avoid re-rendering the sign-in page --- Previously, on clicking sign up button, page redirects to sign-in page. Playwright also navigates explicitly to sign-in page. Halfway through filling the sign in form, the page refreshes, losing the input.
- Updated invitation/registration keys to url_safe --- Once in awhile, invitations do not work due to presence of `+` symbol in the invitation key. This is parsed as ` ` space character when used in the URL.

Flaky tests: `spec/features/system/admin/user_management_spec.rb` `spec/features/system/admin/instance/user_management_spec.rb`

- ensure admin/users and admin/instance/users tables do not render onPageLoad initially, fixes
       - As a System Administrator I can search users
       - As a Instance Administrator I can search users by email