### PR TITLE
fix(mailers): increase email confirmation / password reset mailer priorities

### DIFF
--- a/lib/extensions/devise_async_email/devise/models/authenticatable.rb
+++ b/lib/extensions/devise_async_email/devise/models/authenticatable.rb
@@ -2,7 +2,7 @@
 module Extensions::DeviseAsyncEmail::Devise::Models::Authenticatable
   module PrependMethods
     def send_devise_notification(notification, *args)
-      devise_mailer.send(notification, self, *args).deliver_later
+      devise_mailer.send(notification, self, *args).deliver_later(queue: :highest) # default :mailers
     end
   end
 end

--- a/spec/models/user/email_spec.rb
+++ b/spec/models/user/email_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe User::Email, type: :model do
 
       with_active_job_queue_adapter(:test) do
         it 'sends email with ActiveJob queue' do
-          expect { subject }.to have_enqueued_job.on_queue('mailers')
+          expect { subject }.to have_enqueued_job.on_queue('highest')
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe User do
       with_active_job_queue_adapter(:test) do
         it 'sends email with ActiveJob queue' do
           expect { subject.send_reset_password_instructions }.to \
-            have_enqueued_job.on_queue('mailers')
+            have_enqueued_job.on_queue('highest')
         end
       end
     end


### PR DESCRIPTION
- These jobs (email confirmation/resend confirmation and password reset) are handled by Devise mailer, which uses `mailers` queue by default
- This behavior is actually our code from this PR (https://github.com/Coursemology/coursemology2/pull/1031) overriding the default behavior of Devise 3
- This PR moves them to `highest` priority queue.
- We are using Devise 4 now, which seems to have a related [devise-async](https://github.com/mhfs/devise-async) gem to do this, but I recommend keeping what we have now since we would have to monkey patch it anyway.