### PR TITLE
Fix Flaky Test: User Management in Instance Table and System Admin Table

### DIFF
--- a/app/controllers/system/admin/instance/users_controller.rb
+++ b/app/controllers/system/admin/instance/users_controller.rb
@@ -33,7 +33,7 @@ class System::Admin::Instance::UsersController < System::Admin::Instance::Contro
   private
 
   def load_instance_users
-    @instance_users = @instance.instance_users.includes(user: [:emails, :courses]).
+    @instance_users = @instance.instance_users.human_users.includes(user: [:emails, :courses]).
                       search_and_ordered_by_username(search_param)
     @instance_users = @instance_users.active_in_past_7_days if ActiveRecord::Type::Boolean.new.cast(params[:active])
     @instance_users = @instance_users.where(role: params[:role]) \

--- a/app/models/instance_user.rb
+++ b/app/models/instance_user.rb
@@ -16,6 +16,7 @@ class InstanceUser < ApplicationRecord
   belongs_to :user, inverse_of: :instance_users
 
   scope :ordered_by_username, -> { joins(:user).merge(User.order(name: :asc)) }
+  scope :human_users, -> { where.not(user_id: [User::SYSTEM_USER_ID, User::DELETED_USER_ID]) }
   scope :active_in_past_7_days, -> { where('last_active_at > ?', 7.days.ago) }
 
   def self.search_and_ordered_by_username(keyword)

--- a/spec/features/course/assessment/question/text_response_management_spec.rb
+++ b/spec/features/course/assessment/question/text_response_management_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe 'Course: Assessments: Questions: Text Response Management', js: t
         question = create(:course_assessment_question_text_response, assessment: assessment)
         visit course_assessment_path(course, assessment)
 
-        within find('section', text: question.title) { click_button 'Delete' }
-        click_button 'Delete question'
+        within find('section', text: question.title) { find('button[aria-label="Delete"]').click }
+        accept_prompt
 
         expect_toastify('Question successfully deleted.')
         expect(page).not_to have_content(question.title)

--- a/spec/features/system/admin/instance/user_management_spec.rb
+++ b/spec/features/system/admin/instance/user_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'System: Administration: Instance: Users', js: true do
 
   with_tenant(:instance) do
     let(:instance_admin) { create(:instance_user, role: :administrator).user }
-    let!(:prefix) { "testadm-#{rand(36**12).to_s(36)}-usr-" }
+    let!(:prefix) { "testadm-#{SecureRandom.hex}-usr-" }
     let!(:instance_users) do
       (1..2).map do |i|
         create(:instance_user, user_name: "#{prefix}#{i}")
@@ -72,25 +72,23 @@ RSpec.feature 'System: Administration: Instance: Users', js: true do
 
       # Generate new users to search so it doesn't conflict with above scenarios
       scenario 'I can search users by name' do
-        search_prefix = "testadm-search-#{rand(36**12).to_s(36)}-usr-"
-        instance_users_to_search = (1..2).map do |i|
-          create(:instance_user, user_name: "#{search_prefix}#{i}")
-        end
+        user_name = SecureRandom.hex
+        instance_users_to_search = create_list(:instance_user, 2, user_name: user_name)
 
         # Search by username
-        search_for_users(search_prefix)
+        search_for_users(user_name)
 
         instance_users_to_search.each do |instance_user|
-          expect(page).to have_text(instance_user.user.name)
+          expect(page).to have_selector('p.user_email', text: instance_user.user.email)
         end
         expect(page).to have_selector('.instance_user', count: 2)
       end
 
       scenario 'I can search users by email' do
-        random_instance_user = InstanceUser.order('RANDOM()').first
+        random_instance_user = InstanceUser.human_users.order('RANDOM()').first
         search_for_users(random_instance_user.user.email)
 
-        expect(page).to have_text(random_instance_user.user.name)
+        expect(page).to have_selector('p.user_email', text: random_instance_user.user.email)
         expect(page).to have_selector('.instance_user', count: 1)
       end
     end

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -62,26 +62,30 @@ RSpec.feature 'System: Administration: Users', js: true do
         expect_toastify('User was deleted.')
       end
 
-      scenario 'I can search users' do
+      scenario 'I can search users by name' do
         user_name = SecureRandom.hex
         users_to_search = create_list(:user, 2, name: user_name)
 
-        # Search by username
         find_button('Search').click
         find('div[aria-label="Search"]').find('input').set(user_name)
 
         wait_for_field_debouncing # timeout for search debouncing
         users_to_search.each do |user|
-          expect(page).to have_selector('div.user_name', text: user.name)
+          expect(page).to have_selector('p.user_email', text: user.email)
         end
         expect(all('.system_user').count).to eq(2)
+      end
 
-        # Search by email
+      scenario 'I can search users by email' do
+        user_name = SecureRandom.hex
+        users_to_search = create_list(:user, 2, name: user_name)
+
+        find_button('Search').click
         random_user = users_to_search.sample
         find('div[aria-label="Search"]').find('input').set(random_user.email)
         wait_for_field_debouncing # timeout for search debouncing
 
-        expect(page).to have_selector('div.user_name', text: random_user.name)
+        expect(page).to have_selector('p.user_email', text: random_user.email)
         expect(all('.system_user').count).to eq(1)
       end
     end


### PR DESCRIPTION
## Background

We noticed the flaky tests for the following file `spec/features/system/admin/instance/user_management_spec.rb:89` because `InstanceUser` that was being searched on might has non-human user inside (might be either System or Deleted). After further inspection, we found the discrepancy in behavior between Users table inside `Admin Instance` and `System Admin`, in which `System Admin` filters out non-human user from the displaying, while `Admin Instance` does not do that

Other than that, we also noticed the flaky tests inside `spec/features/system/admin/user_management_spec.rb`, which is basically caused by while the component's still rendering, the test already assumes the component is there and tries to interact with it, hence component not found error is invoked. Also, when doing the search, they did not wait for the unmatched entry to disappear before counting.

## Approach

We filter out non-human users from Admin Instance table, as well as adding the scope of `human_users` inside the said test. Also, we utilise the `have_selector` and `have_no_selector` to ensure the test is proper