### PR TITLE
feat(codaveri-evaluation): added support for base64 encoding non UTF-8 files

### DIFF
--- a/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
+++ b/app/services/course/assessment/answer/programming_codaveri_auto_grading_service.rb
@@ -128,7 +128,7 @@ class Course::Assessment::Answer::ProgrammingCodaveriAutoGradingService <
 
       error_message_sigkill = I18n.t('course.assessment.answer.programming_auto_grading.grade.evaluation_failed_syntax')
       messages ||= {
-        error: (result.exit_code == 137) ? error_message_sigkill : result.stderr,
+        error: (result.exit_code == 137 || result.exit_signal == 'SIGKILL') ? error_message_sigkill : result.stderr,
         hint: test_case.hint,
         output: result.output,
         code: result.exit_code,

--- a/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
@@ -108,7 +108,8 @@ class Course::Assessment::Question::ProgrammingCodaveri::LanguagePackageService
     {
       type: '',
       path: '',
-      content: ''
+      content: '',
+      encoding: ''
     }
   end
 end

--- a/app/services/course/assessment/question/programming_codaveri/r/r_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/r/r_package_service.rb
@@ -45,6 +45,8 @@ class Course::Assessment::Question::ProgrammingCodaveri::R::RPackageService <
 
   # Finds and extracts all contents of additional files in the root package folder
   # (excluding the default Makefile and .meta files).
+  # All data files uploaded through the Coursemology UI will be extracted in this function.
+  # The remaining functions are to capture files manually added to the package ZIP by the user.
   def extract_supporting_main_files
     main_files = @package.main_files.compact.to_h
     main_filenames = main_files.keys
@@ -102,13 +104,19 @@ class Course::Assessment::Question::ProgrammingCodaveri::R::RPackageService <
   # @param [Pathname] pathname The pathname of the file.
   # @param [String] content The content of the file.
   def extract_supporting_file(filename, content)
-    supporting_solution_object = default_codaveri_data_file_template
+    supporting_file_object = default_codaveri_data_file_template
 
-    supporting_solution_object[:type] = 'internal' # 'external' s3 upload not yet implemented by codaveri
-    supporting_solution_object[:path] = filename.to_s
-    supporting_solution_object[:content] = content
+    supporting_file_object[:type] = 'internal' # 'external' s3 upload not yet implemented by codaveri
+    supporting_file_object[:path] = filename.to_s
+    if content.force_encoding('UTF-8').valid_encoding?
+      supporting_file_object[:content] = content
+      supporting_file_object[:encoding] = 'utf8'
+    else
+      supporting_file_object[:content] = Base64.strict_encode64(content)
+      supporting_file_object[:encoding] = 'base64'
+    end
 
-    @data_files.append(supporting_solution_object)
+    @data_files.append(supporting_file_object)
   end
 
   # Extracts test cases from the built dummy reports and append all the test cases to the
@@ -121,7 +129,7 @@ class Course::Assessment::Question::ProgrammingCodaveri::R::RPackageService <
 
         # combine all extracted data
         test_case_object[:index] = test_cases_with_id[test_case.name]
-        test_case_object[:timeout] = @question.time_limit unless @question.time_limit.nil?
+        test_case_object[:timeout] = @question.time_limit * 1000 if @question.time_limit # in millisecond
         test_case_object[:input] = test_case.expression
         test_case_object[:output] = test_case.expected
         test_case_object[:hint] = test_case.hint

--- a/spec/fixtures/course/codaveri/codaveri_problem_management_test.json
+++ b/spec/fixtures/course/codaveri/codaveri_problem_management_test.json
@@ -95,6 +95,7 @@
     {
       "type": "internal",
       "path": "codon_mapping.csv",
+      "encoding": "utf8",
       "content": "codon,amino_acid,3_letter_abbreviation,1_letter_abbreviation\nAAA,Lysine,Lys,K\nAAC,Asparagine,Asn,N\nAAG,Lysine,Lys,K\nAAU,Asparagine,Asn,N\nACA,Threonine,Thr,T\nACC,Threonine,Thr,T\nACG,Threonine,Thr,T\nACU,Threonine,Thr,T\nAGA,Arginine,Arg,R\nAGC,Serine,Ser,S\nAGG,Arginine,Arg,R\nAGU,Serine,Ser,S\nAUA,Isoleucine,Ile,I\nAUC,Isoleucine,Ile,I\nAUG,Methionine,Met,M\nAUU,Isoleucine,Ile,I\nCAA,Glutamine,Gln,Q\nCAC,Histidine,His,H\nCAG,Glutamine,Gln,Q\nCAU,Histidine,His,H\nCCA,Proline,Pro,P\nCCC,Proline,Pro,P\nCCG,Proline,Pro,P\nCCU,Proline,Pro,P\nCGA,Arginine,Arg,R\nCGC,Arginine,Arg,R\nCGG,Arginine,Arg,R\nCGU,Arginine,Arg,R\nCUA,Leucine,Leu,L\nCUC,Leucine,Leu,L\nCUG,Leucine,Leu,L\nCUU,Leucine,Leu,L\nGAA,Glutamic acid,Glu,E\nGAC,Aspartic acid,Asp,D\nGAG,Glutamic acid,Glu,E\nGAU,Aspartic acid,Asp,D\nGCA,Alanine,Ala,A\nGCC,Alanine,Ala,A\nGCG,Alanine,Ala,A\nGCU,Alanine,Ala,A\nGGA,Glycine,Gly,G\nGGC,Glycine,Gly,G\nGGG,Glycine,Gly,G\nGGU,Glycine,Gly,G\nGUA,Valine,Val,V\nGUC,Valine,Val,V\nGUG,Valine,Val,V\nGUU,Valine,Val,V\nUAA,Stop codon,STOP,_\nUAC,Tyrosine,Tyr,Y\nUAG,Stop codon,STOP,_\nUAU,Tyrosine,Tyr,Y\nUCA,Serine,Ser,S\nUCC,Serine,Ser,S\nUCG,Serine,Ser,S\nUCU,Serine,Ser,S\nUGA,Stop codon,STOP,_\nUGC,Cysteine,Cys,C\nUGG,Tryptophan,Trp,W\nUGU,Cysteine,Cys,C\nUUA,Leucine,Leu,L\nUUC,Phenylalanine,Phe,F\nUUG,Leucine,Leu,L\nUUU,Phenylalanine,Phe,F"
     }
   ]


### PR DESCRIPTION
Tested with Python and R examples:
- For Python, tested with reading random bytes from file, and unpacking Python [pickle](https://docs.python.org/3/library/pickle.html) file
- For R, tested with sample `.RData` file.