### PR TITLE
feat(course-user-deletion): Improve Performance of Deleting Course User

### DIFF
--- a/app/controllers/course/users_controller.rb
+++ b/app/controllers/course/users_controller.rb
@@ -8,6 +8,15 @@ class Course::UsersController < Course::ComponentController
   def index
   end
 
+  def destroy
+    if @course_user.deleted_at.nil? && @course_user.update_attribute(:deleted_at, Time.now)
+      Course::UserDeletionJob.perform_later(current_course, @course_user, current_user)
+      head :ok
+    else
+      head :bad_request
+    end
+  end
+
   def show
     @skills_service = Course::SkillsMasteryPreloadService.new(current_course,
                                                               @course_user)

--- a/app/jobs/course/user_deletion_job.rb
+++ b/app/jobs/course/user_deletion_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class Course::UserDeletionJob < ApplicationJob
+  protected
+
+  def perform(course, course_user, current_user)
+    ActsAsTenant.without_tenant do
+      unless course_user.destroy
+        course_user.update_attribute(:deleted_at, nil)
+        Course::Mailer.
+          course_user_deletion_failed_email(course, course_user, current_user).
+          deliver_later
+      end
+    end
+  end
+end

--- a/app/mailers/course/mailer.rb
+++ b/app/mailers/course/mailer.rb
@@ -107,6 +107,18 @@ class Course::Mailer < ApplicationMailer
     end
   end
 
+  def course_user_deletion_failed_email(course, course_user, user)
+    return unless user.email
+
+    @course = course
+    @course_user = course_user
+    @recipient = user
+    I18n.with_locale(@recipient.locale) do
+      mail(to: @recipient.email,
+           subject: t('.subject', course_user_name: @course_user.name, course_name: @course.title))
+    end
+  end
+
   # Send a reminder of the assessment closing to a single user
   #
   # @param [Course::Assessment] assessment The assessment that is closing.

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -51,6 +51,8 @@ class CourseUser < ApplicationRecord
   has_many :personal_times, class_name: 'Course::PersonalTime', inverse_of: :course_user, dependent: :destroy
   belongs_to :reference_timeline, class_name: 'Course::ReferenceTimeline', inverse_of: :course_users, optional: true
 
+  default_scope { where(deleted_at: nil) }
+
   validate :validate_reference_timeline_belongs_to_course
 
   # @!attribute [r] experience_points

--- a/app/views/course/mailer/course_user_deletion_failed_email.html.slim
+++ b/app/views/course/mailer/course_user_deletion_failed_email.html.slim
@@ -1,0 +1,3 @@
+= simple_format(t('.message', course_user_name: @course_user.name,
+                              course_name: @course.title))
+

--- a/app/views/course/mailer/course_user_deletion_failed_email.text.erb
+++ b/app/views/course/mailer/course_user_deletion_failed_email.text.erb
@@ -1,0 +1,3 @@
+<%= t('.message', course_user_name: @course_user.name,
+                  course_name: @course.title) %>
+

--- a/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
+++ b/client/app/bundles/course/users/components/buttons/UserManagementButtons.tsx
@@ -22,13 +22,13 @@ const styles = {
 };
 
 const translations = defineMessages({
-  deletionSuccess: {
-    id: 'course.users.UserManagementButtons.deletionSuccess',
-    defaultMessage: 'User was deleted.',
+  deletionScheduled: {
+    id: 'course.users.UserManagementButtons.deletionScheduled',
+    defaultMessage: '{role} {name} ({email}) has been scheduled for deletion.',
   },
   deletionFailure: {
     id: 'course.users.UserManagementButtons.deletionFailure',
-    defaultMessage: 'Failed to delete user.',
+    defaultMessage: 'Failed to delete {role} {name} ({email}).',
   },
   deletionConfirm: {
     id: 'course.users.UserManagementButtons.deletionConfirm',
@@ -41,17 +41,30 @@ const UserManagementButtons: FC<Props> = (props) => {
   const dispatch = useAppDispatch();
   const [isDeleting, setIsDeleting] = useState(false);
 
+  const userTranslationDict = {
+    role: COURSE_USER_ROLES[user.role],
+    name: user.name,
+    email: user.email,
+  };
+
   const onDelete = (): Promise<void> => {
     setIsDeleting(true);
     return dispatch(deleteUser(user.id))
       .then(() => {
-        toast.success(intl.formatMessage(translations.deletionSuccess));
+        toast.success(
+          intl.formatMessage(
+            translations.deletionScheduled,
+            userTranslationDict,
+          ),
+        );
       })
       .finally(() => {
         setIsDeleting(false);
       })
       .catch((error) => {
-        toast.error(intl.formatMessage(translations.deletionFailure));
+        toast.error(
+          intl.formatMessage(translations.deletionFailure, userTranslationDict),
+        );
         throw error;
       })
       .finally(() => setIsDeleting(false));

--- a/config/locales/en/course/mailer/course_user_deletion_failed_email.yml
+++ b/config/locales/en/course/mailer/course_user_deletion_failed_email.yml
@@ -1,0 +1,8 @@
+en:
+  course:
+    mailer:
+      course_user_deletion_failed_email:
+        subject: 'User %{course_user_name} Failed to be Deleted from %{course_name}'
+        message: >
+          Deletion of %{course_user_name} from the Course %{course_name} has failed.
+          Please try again later or contact support if the problem persists.

--- a/config/locales/ko/course/mailer/course_user_deletion_failed_email.yml
+++ b/config/locales/ko/course/mailer/course_user_deletion_failed_email.yml
@@ -1,0 +1,8 @@
+ko:
+  course:
+    mailer:
+      course_user_deletion_failed_email:
+        subject: '사용자 %{course_user_name}을(를) %{course_name}에서 삭제하지 못했습니다'
+        message: >
+          사용자 %{course_user_name}을(를) %{course_name} 강좌에서 삭제하지 못했습니다.
+          나중에 다시 시도하거나 문제가 지속되면 지원팀에 문의하십시오.

--- a/config/locales/zh/course/mailer/course_user_deletion_failed_email.yml
+++ b/config/locales/zh/course/mailer/course_user_deletion_failed_email.yml
@@ -1,0 +1,8 @@
+zh:
+  course:
+    mailer:
+      course_user_deletion_failed_email:
+        subject: '无法将用户 %{course_user_name} 从 %{course_name} 中删除'
+        message: >
+          无法将用户 %{course_user_name} 从课程 %{course_name} 中删除。
+          请稍后再试，或者如果问题持续，请联系支持团队。

--- a/db/migrate/20241216104132_add_deleted_column_in_course_user.rb
+++ b/db/migrate/20241216104132_add_deleted_column_in_course_user.rb
@@ -1,0 +1,5 @@
+class AddDeletedColumnInCourseUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :course_users, :deleted_at, :datetime
+  end  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_04_104627) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -1118,6 +1118,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_04_104627) do
     t.integer "updater_id", null: false
     t.bigint "reference_timeline_id"
     t.integer "timeline_algorithm", default: 0, null: false
+    t.datetime "deleted_at"
     t.index ["course_id", "user_id"], name: "index_course_users_on_course_id_and_user_id", unique: true
     t.index ["course_id"], name: "fk__course_users_course_id"
     t.index ["creator_id"], name: "fk__course_users_creator_id"

--- a/spec/jobs/course/user_deletion_job_spec.rb
+++ b/spec/jobs/course/user_deletion_job_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::UserDeletionJob do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let!(:course) { create(:course) }
+    let!(:user) { create(:course_manager, course: course).user }
+    let!(:student) { create(:course_student, course: course) }
+    subject { Course::UserDeletionJob }
+
+    before do
+      subject.instance_variable_set(:@course, course)
+      subject.instance_variable_set(:@course_user, student)
+      subject.instance_variable_set(:@current_user, user)
+    end
+
+    it 'can be queued' do
+      expect { subject.perform_later(course, student, user) }.
+        to have_enqueued_job(subject).exactly(:once)
+    end
+
+    it 'delete one user upon successful course user deletion' do
+      expect { subject.perform_now(course, student, user) }.
+        to change { course.course_users.count }.by(-1)
+    end
+
+    it 'sends failure email upon failing course user deletion' do
+      allow(student).to receive(:destroy).and_return(false)
+
+      deletion_job = subject.perform_later(course, student, user)
+      deletion_job.perform_now
+
+      emails = ActionMailer::Base.deliveries.map(&:to).map(&:first)
+      email_subjects = ActionMailer::Base.deliveries.map(&:subject)
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(emails).to include(user.email)
+      expect(email_subjects).to include('course.mailer.course_user_deletion_failed_email.subject')
+    end
+  end
+end


### PR DESCRIPTION
## Main Approach

We firstly mark the intended course user as deleted, and also use the default scoping of when the column value of deleted-related column is null. At the same time, we send the task to delete the course user to our worker so that the operation won't choke our main application server as the deletion of course user typically takes long time should the intended user has done lots of things inside the course itself.

In the event of deletion failure, we rollback the operation and send email notification to the deleter that the deletion operation has failed.