### PR TITLE
fix(i18n): add missing translation keys for all locales

### DIFF
--- a/client/app/bundles/course/achievement/components/tables/AchievementTable.tsx
+++ b/client/app/bundles/course/achievement/components/tables/AchievementTable.tsx
@@ -1,5 +1,5 @@
 import { FC, memo } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { DragIndicator } from '@mui/icons-material';
 import { Switch, Typography } from '@mui/material';
 import equal from 'fast-deep-equal';
@@ -15,6 +15,7 @@ import Link from 'lib/components/core/Link';
 import Note from 'lib/components/core/Note';
 import { getAchievementURL } from 'lib/helpers/url-builders';
 import { getCourseId } from 'lib/helpers/url-helpers';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import AchievementManagementButtons from '../buttons/AchievementManagementButtons';
 
@@ -30,6 +31,30 @@ const translations = defineMessages({
     id: 'course.achievement.AchievementTable.noAchievement',
     defaultMessage: 'No achievement',
   },
+  badge: {
+    id: 'course.achievement.AchievementTable.badge',
+    defaultMessage: 'Badge',
+  },
+  title: {
+    id: 'course.achievement.AchievementTable.title',
+    defaultMessage: 'Title',
+  },
+  description: {
+    id: 'course.achievement.AchievementTable.description',
+    defaultMessage: 'Description',
+  },
+  requirements: {
+    id: 'course.achievement.AchievementTable.requirements',
+    defaultMessage: 'Requirements',
+  },
+  published: {
+    id: 'course.achievement.AchievementTable.published',
+    defaultMessage: 'Published',
+  },
+  actions: {
+    id: 'course.achievement.AchievementTable.actions',
+    defaultMessage: 'Actions',
+  },
 });
 
 const styles = {
@@ -42,6 +67,7 @@ const styles = {
 
 const AchievementTable: FC<Props> = (props) => {
   const { achievements, permissions, onTogglePublished, isReordering } = props;
+  const { t } = useTranslation();
 
   if (achievements && achievements.length === 0) {
     return (
@@ -104,7 +130,7 @@ const AchievementTable: FC<Props> = (props) => {
     },
     {
       name: 'badge',
-      label: 'Badge',
+      label: t(translations.badge),
       options: {
         filter: false,
         sort: false,
@@ -128,7 +154,7 @@ const AchievementTable: FC<Props> = (props) => {
     },
     {
       name: 'title',
-      label: 'Title',
+      label: t(translations.title),
       options: {
         filter: false,
         sort: false,
@@ -149,7 +175,7 @@ const AchievementTable: FC<Props> = (props) => {
     },
     {
       name: 'description',
-      label: 'Description',
+      label: t(translations.description),
       options: {
         filter: false,
         sort: false,
@@ -170,7 +196,7 @@ const AchievementTable: FC<Props> = (props) => {
     },
     {
       name: 'conditions',
-      label: 'Requirements',
+      label: t(translations.requirements),
       options: {
         filter: false,
         sort: false,
@@ -194,7 +220,7 @@ const AchievementTable: FC<Props> = (props) => {
   if (permissions?.canManage) {
     columns.push({
       name: 'published',
-      label: 'Published',
+      label: t(translations.published),
       options: {
         filter: false,
         sort: false,
@@ -218,7 +244,7 @@ const AchievementTable: FC<Props> = (props) => {
     });
     columns.push({
       name: 'id',
-      label: 'Actions',
+      label: t(translations.actions),
       options: {
         filter: false,
         sort: false,

--- a/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardManager.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardManager.tsx
@@ -77,7 +77,7 @@ const translations = defineMessages({
     id: 'course.achievement.AchievementAward.AchievementAwardManager.note',
     defaultMessage:
       'If an Achievement has conditions associated with it, \
-      Coursemology will automatically award achievements when the student meets those conditions. ',
+        Coursemology will automatically award achievements when the student meets those conditions. ',
   },
   noUser: {
     id: 'course.achievement.AchievementAward.AchievementAwardManager.noUser',
@@ -242,7 +242,7 @@ const AchievementAwardManager: FC<Props> = (props) => {
     },
     {
       name: 'id',
-      label: 'Obtained Achievement',
+      label: columnHeadLabelAchievement,
       options: {
         filter: false,
         search: false,

--- a/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardSummary.tsx
+++ b/client/app/bundles/course/achievement/pages/AchievementAward/AchievementAwardSummary.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import { Grid } from '@mui/material';
 import { green, red } from '@mui/material/colors';
 import { TableColumns, TableOptions } from 'types/components/DataTable';
@@ -12,8 +13,36 @@ interface Props {
   selectedUserIds: Set<number>;
 }
 
+const translations = defineMessages({
+  name: {
+    id: 'course.achievement.AchievementAward.AchievementAwardSummary.name',
+    defaultMessage: 'Name',
+  },
+  userType: {
+    id: 'course.achievement.AchievementAward.AchievementAwardSummary.userType',
+    defaultMessage: 'User Type',
+  },
+  awardedStudents: {
+    id: 'course.achievement.AchievementAward.AchievementAwardSummary.awardedStudents',
+    defaultMessage: 'Awarded Students',
+  },
+  revokedStudents: {
+    id: 'course.achievement.AchievementAward.AchievementAwardSummary.revokedStudents',
+    defaultMessage: 'Revoked Students',
+  },
+  phantomStudent: {
+    id: 'course.achievement.AchievementAward.AchievementAwardSummary.phantomStudent',
+    defaultMessage: 'Phantom Student',
+  },
+  normalStudent: {
+    id: 'course.achievement.AchievementAward.AchievementAwardSummary.normalStudent',
+    defaultMessage: 'Normal Student',
+  },
+});
+
 const AchievementAwardSummary: FC<Props> = (props) => {
   const { achievementUsers, initialObtainedUserIds, selectedUserIds } = props;
+  const { formatMessage: t } = useIntl();
 
   const removedUserIds = new Set(
     [...initialObtainedUserIds].filter(
@@ -57,22 +86,21 @@ const AchievementAwardSummary: FC<Props> = (props) => {
   const awardedTableColumns: TableColumns[] = [
     {
       name: 'name',
-      label: 'Name',
+      label: t(translations.name),
       options: {
         filter: false,
       },
     },
     {
       name: 'phantom',
-      label: 'User Type',
+      label: t(translations.userType),
       options: {
         search: false,
         customBodyRenderLite: (dataIndex): string => {
           const isPhantom = awardedUsers[dataIndex].phantom;
-          if (isPhantom) {
-            return 'Phantom Student';
-          }
-          return 'Normal Student';
+          return isPhantom
+            ? t(translations.phantomStudent)
+            : t(translations.normalStudent);
         },
       },
     },
@@ -81,22 +109,21 @@ const AchievementAwardSummary: FC<Props> = (props) => {
   const removedTableColumns: TableColumns[] = [
     {
       name: 'name',
-      label: 'Name',
+      label: t(translations.name),
       options: {
         filter: false,
       },
     },
     {
       name: 'phantom',
-      label: 'User Type',
+      label: t(translations.userType),
       options: {
         search: false,
         customBodyRenderLite: (dataIndex): string => {
           const isPhantom = removedUsers[dataIndex].phantom;
-          if (isPhantom) {
-            return 'Phantom Student';
-          }
-          return 'Normal Student';
+          return isPhantom
+            ? t(translations.phantomStudent)
+            : t(translations.normalStudent);
         },
       },
     },
@@ -109,7 +136,7 @@ const AchievementAwardSummary: FC<Props> = (props) => {
           columns={awardedTableColumns}
           data={awardedUsers}
           options={awardedTableOptions}
-          title={`Awarded Students (${awardedUsers.length})`}
+          title={`${t(translations.awardedStudents)} (${awardedUsers.length})`}
         />
       </Grid>
       <Grid item xs={6}>
@@ -117,7 +144,7 @@ const AchievementAwardSummary: FC<Props> = (props) => {
           columns={removedTableColumns}
           data={removedUsers}
           options={removedTableOptions}
-          title={`Revoked Students (${removedUsers.length})`}
+          title={`${t(translations.revokedStudents)} (${removedUsers.length})`}
         />
       </Grid>
     </Grid>

--- a/client/app/bundles/course/assessment/submission/pages/LogsIndex/LogsHead.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/LogsIndex/LogsHead.tsx
@@ -1,11 +1,12 @@
 import { FC } from 'react';
+import { defineMessages } from 'react-intl';
 import { Chip, TableBody, TableCell, TableRow } from '@mui/material';
 import palette from 'theme/palette';
 import { LogsMainInfo } from 'types/course/assessment/submission/logs';
 
 import TableContainer from 'lib/components/core/layouts/TableContainer';
 import Link from 'lib/components/core/Link';
-import useTranslation from 'lib/hooks/useTranslation';
+import useTranslation, { Descriptor } from 'lib/hooks/useTranslation';
 
 import translations from './translations';
 
@@ -13,15 +14,30 @@ interface Props {
   with: LogsMainInfo;
 }
 
-const statusTranslations = {
-  attempting: 'Attempting',
-  submitted: 'Submitted',
-  graded: 'Graded, unpublished',
-  published: 'Graded',
-  unknown: 'Unknown status, please contact administrator',
-};
+const statusTranslations = defineMessages({
+  attempting: {
+    id: 'course.assessment.submission.pages.LogsIndex.LogsHead.attempting',
+    defaultMessage: 'Attempting',
+  },
+  submitted: {
+    id: 'course.assessment.submission.pages.LogsIndex.LogsHead.submitted',
+    defaultMessage: 'Submitted',
+  },
+  graded: {
+    id: 'course.assessment.submission.pages.LogsIndex.LogsHead.graded',
+    defaultMessage: 'Graded, unpublished',
+  },
+  published: {
+    id: 'course.assessment.submission.pages.LogsIndex.LogsHead.published',
+    defaultMessage: 'Graded',
+  },
+  unknown: {
+    id: 'course.assessment.submission.pages.LogsIndex.LogsHead.unknown',
+    defaultMessage: 'Unknown status, please contact administrator',
+  },
+});
 
-const translateStatus: (var1: string) => string = (oldStatus) => {
+const translateStatus: (var1: string) => Descriptor = (oldStatus) => {
   switch (oldStatus) {
     case 'attempting':
       return statusTranslations.attempting;
@@ -66,7 +82,7 @@ const LogsHead: FC<Props> = (props) => {
           <TableCell>
             <Link to={info.editUrl}>
               <Chip
-                label={translateStatus(info.submissionWorkflowState)}
+                label={t(translateStatus(info.submissionWorkflowState))}
                 style={{
                   width: 100,
                   backgroundColor:

--- a/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
+++ b/client/app/bundles/course/leaderboard/components/tables/LeaderboardTable.tsx
@@ -15,6 +15,7 @@ import Link from 'lib/components/core/Link';
 import { getAchievementURL, getCourseUserURL } from 'lib/helpers/url-builders';
 import { getCourseId } from 'lib/helpers/url-helpers';
 import useMedia from 'lib/hooks/useMedia';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import { LeaderboardTableType } from '../../types';
 
@@ -48,6 +49,30 @@ const translations = defineMessages({
     id: 'course.leaderboard.LeaderboardTable.achievements',
     defaultMessage: 'Achievements',
   },
+  rank: {
+    id: 'course.leaderboard.LeaderboardTable.rank',
+    defaultMessage: 'Rank',
+  },
+  name: {
+    id: 'course.leaderboard.LeaderboardTable.name',
+    defaultMessage: 'Name',
+  },
+  level: {
+    id: 'course.leaderboard.LeaderboardTable.level',
+    defaultMessage: 'Level',
+  },
+  averageExperience: {
+    id: 'course.leaderboard.LeaderboardTable.averageExperience',
+    defaultMessage: 'Average Experience',
+  },
+  averageAchievements: {
+    id: 'course.leaderboard.LeaderboardTable.averageAchievements',
+    defaultMessage: 'Average Achievements',
+  },
+  members: {
+    id: 'course.leaderboard.LeaderboardTable.members',
+    defaultMessage: 'Members',
+  },
 });
 
 const styles = {
@@ -78,6 +103,7 @@ const styles = {
 
 const LeaderboardTable: FC<Props> = (props: Props) => {
   const { data, id: tableType } = props;
+  const { t } = useTranslation();
   const tabletView = useMedia.MinWidth('sm');
   const phoneView = useMedia.MinWidth('xs');
   const [maxAvatars, setMaxAvatars] = useState(6);
@@ -95,7 +121,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
   const columns: TableColumns[] = [
     {
       name: 'id',
-      label: 'Rank',
+      label: t(translations.rank),
       options: {
         filter: false,
         sort: false,
@@ -116,7 +142,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
       | LeaderboardAchievement[];
     columns.push({
       name: 'name',
-      label: 'Name',
+      label: t(translations.name),
       options: {
         filter: false,
         sort: false,
@@ -157,7 +183,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
     columns.push(
       {
         name: 'level',
-        label: 'Level',
+        label: t(translations.level),
         options: {
           filter: false,
           sort: false,
@@ -172,7 +198,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
       },
       {
         name: 'experience',
-        label: 'Experience',
+        label: t(translations.experience),
         options: {
           filter: false,
           sort: false,
@@ -192,7 +218,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
     const achievementData = data as LeaderboardAchievement[];
     columns.push({
       name: 'achievements',
-      label: 'Achievements',
+      label: t(translations.achievements),
       options: {
         filter: false,
         sort: false,
@@ -249,7 +275,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
     columns.push(
       {
         name: 'name',
-        label: 'Name',
+        label: t(translations.name),
         options: {
           filter: false,
           sort: false,
@@ -268,7 +294,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
       },
       {
         name: 'members',
-        label: 'Members',
+        label: t(translations.members),
         options: {
           filter: false,
           sort: false,
@@ -306,7 +332,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
     const groupPointData = data as GroupLeaderboardPoints[];
     columns.push({
       name: 'points',
-      label: 'Average Experience',
+      label: t(translations.averageExperience),
       options: {
         filter: false,
         sort: false,
@@ -332,7 +358,7 @@ const LeaderboardTable: FC<Props> = (props: Props) => {
     const groupAchievementData = data as GroupLeaderboardAchievement[];
     columns.push({
       name: 'achievements',
-      label: 'Average Achievements',
+      label: t(translations.averageAchievements),
       options: {
         filter: false,
         sort: false,

--- a/client/app/bundles/course/material/folders/components/tables/WorkbinTable.tsx
+++ b/client/app/bundles/course/material/folders/components/tables/WorkbinTable.tsx
@@ -1,5 +1,5 @@
 import { FC, memo, ReactNode, useMemo, useState } from 'react';
-import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
 import {
   ArrowDropDown as ArrowDropDownIcon,
   ArrowDropUp as ArrowDropUpIcon,
@@ -18,6 +18,7 @@ import {
 } from 'types/course/material/folders';
 
 import TableContainer from 'lib/components/core/layouts/TableContainer';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import TableMaterialRow from './TableMaterialRow';
 import TableSubfolderRow from './TableSubfolderRow';
@@ -29,6 +30,29 @@ interface Props extends WrappedComponentProps {
   isCurrentCourseStudent: boolean;
   isConcrete: boolean;
 }
+
+const translations = defineMessages({
+  name: {
+    id: 'course.material.folders.WorkbinTable.name',
+    defaultMessage: 'Name',
+  },
+  lastModified: {
+    id: 'course.material.folders.WorkbinTable.lastModified',
+    defaultMessage: 'Last Modified',
+  },
+  startAt: {
+    id: 'course.material.folders.WorkbinTable.startAt',
+    defaultMessage: 'Start At',
+  },
+});
+
+const translationsMap: {
+  [key: string]: { id: string; defaultMessage: string };
+} = {
+  Name: translations.name,
+  'Last Modified': translations.lastModified,
+  'Start At': translations.startAt,
+};
 
 const WorkbinTable: FC<Props> = (props) => {
   const {
@@ -104,6 +128,7 @@ const WorkbinTable: FC<Props> = (props) => {
   };
 
   const columnHeaderWithSort = (columnName: string): JSX.Element => {
+    const { t } = useTranslation();
     let endIcon: ReactNode = null;
     if (sortBy === columnName && sortDirection === 'desc') {
       endIcon = <ArrowDropDownIcon />;
@@ -121,7 +146,7 @@ const WorkbinTable: FC<Props> = (props) => {
         }}
         style={{ padding: 0, alignItems: 'center', justifyContent: 'start' }}
       >
-        {columnName}
+        {t(translationsMap[columnName])}
       </Button>
     );
   };

--- a/client/app/bundles/course/video/components/tables/VideoTable.tsx
+++ b/client/app/bundles/course/video/components/tables/VideoTable.tsx
@@ -30,14 +30,39 @@ const translations = defineMessages({
     id: 'course.video.VideoTable.noVideo',
     defaultMessage: 'No Video',
   },
+  title: {
+    id: 'course.video.VideoTable.title',
+    defaultMessage: 'Title',
+  },
+  startAt: {
+    id: 'course.video.VideoTable.startAt',
+    defaultMessage: 'Start At',
+  },
+  watchCount: {
+    id: 'course.video.VideoTable.watchCount',
+    defaultMessage: 'Watch Count',
+  },
+  averageWatched: {
+    id: 'course.video.VideoTable.averageWatched',
+    defaultMessage: 'Average % Watched',
+  },
+  published: {
+    id: 'course.video.VideoTable.published',
+    defaultMessage: 'Published',
+  },
+  actions: {
+    id: 'course.video.VideoTable.actions',
+    defaultMessage: 'Actions',
+  },
 });
 
 const VideoTable: FC<Props> = (props) => {
   const { videos, permissions, onTogglePublished, intl } = props;
+  const { formatMessage: t } = intl;
   const videoMetadata = useAppSelector(getVideoMetadata);
 
   if (videos && videos.length === 0) {
-    return <Note message={intl.formatMessage(translations.noVideo)} />;
+    return <Note message={t(translations.noVideo)} />;
   }
 
   const videoSortMethodByDate = (
@@ -92,7 +117,7 @@ const VideoTable: FC<Props> = (props) => {
   const columns: TableColumns[] = [
     {
       name: 'title',
-      label: 'Title',
+      label: t(translations.title),
       options: {
         filter: false,
         sort: false,
@@ -119,7 +144,7 @@ const VideoTable: FC<Props> = (props) => {
     },
     {
       name: 'startTimeInfo',
-      label: 'Start At',
+      label: t(translations.startAt),
       options: {
         filter: false,
         sort: true,
@@ -159,7 +184,7 @@ const VideoTable: FC<Props> = (props) => {
   if (permissions?.canAnalyze) {
     columns.push({
       name: 'watchCount',
-      label: 'Watch Count',
+      label: t(translations.watchCount),
       options: {
         filter: false,
         sort: false,
@@ -185,7 +210,7 @@ const VideoTable: FC<Props> = (props) => {
     });
     columns.push({
       name: 'percentWatched',
-      label: 'Average % Watched',
+      label: t(translations.averageWatched),
       options: {
         filter: false,
         sort: false,
@@ -203,7 +228,7 @@ const VideoTable: FC<Props> = (props) => {
   if (permissions?.canManage) {
     columns.push({
       name: 'published',
-      label: 'Published',
+      label: t(translations.published),
       options: {
         filter: false,
         sort: false,
@@ -227,7 +252,7 @@ const VideoTable: FC<Props> = (props) => {
     });
     columns.push({
       name: 'id',
-      label: 'Actions',
+      label: t(translations.actions),
       options: {
         filter: false,
         sort: false,

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -251,6 +251,24 @@
   "course.achievement.AchievementAward.AchievementAwardManager.saveChanges": {
     "defaultMessage": "Save Changes"
   },
+  "course.achievement.AchievementAward.AchievementAwardSummary.awardedStudents": {
+    "defaultMessage": "Awarded Students"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.name": {
+    "defaultMessage": "Name"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.normalStudent": {
+    "defaultMessage": "Normal Student"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.phantomStudent": {
+    "defaultMessage": "Phantom Student"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.revokedStudents": {
+    "defaultMessage": "Revoked Students"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.userType": {
+    "defaultMessage": "User Type"
+  },
   "course.achievement.AchievementAward.awardAchievement": {
     "defaultMessage": "Award Achievement"
   },
@@ -323,8 +341,26 @@
   "course.achievement.AchievementShow.studentsWithAchievement": {
     "defaultMessage": "Students with this achievement"
   },
+  "course.achievement.AchievementTable.actions": {
+    "defaultMessage": "Actions"
+  },
+  "course.achievement.AchievementTable.badge": {
+    "defaultMessage": "Badge"
+  },
+  "course.achievement.AchievementTable.description": {
+    "defaultMessage": "Description"
+  },
   "course.achievement.AchievementTable.noAchievement": {
     "defaultMessage": "No achievement"
+  },
+  "course.achievement.AchievementTable.published": {
+    "defaultMessage": "Published"
+  },
+  "course.achievement.AchievementTable.requirements": {
+    "defaultMessage": "Requirements"
+  },
+  "course.achievement.AchievementTable.title": {
+    "defaultMessage": "Title"
   },
   "course.achievement.AchievementsIndex.achievements": {
     "defaultMessage": "Achievements"
@@ -467,11 +503,20 @@
   "course.admin.AssessmentSettings.toTab": {
     "defaultMessage": "to {tab}"
   },
+  "course.admin.CodaveriSettings.Some": {
+    "defaultMessage": "Some"
+  },
+  "course.admin.CodaveriSettings.assessments": {
+    "defaultMessage": "Assessments"
+  },
   "course.admin.CodaveriSettings.codaveriEngine": {
     "defaultMessage": "Codaveri Engine"
   },
   "course.admin.CodaveriSettings.codaveriEngineDescription": {
     "defaultMessage": "Type of codaveri engine used to generate programming code feedback"
+  },
+  "course.admin.CodaveriSettings.codaveriEvaluatorSettings": {
+    "defaultMessage": "Codaveri Evaluator"
   },
   "course.admin.CodaveriSettings.codaveriSettings": {
     "defaultMessage": "Codaveri settings"
@@ -485,8 +530,29 @@
   "course.admin.CodaveriSettings.defaultEngineDescription": {
     "defaultMessage": "Uses generative AI and verification techniques"
   },
-  "course.admin.CodaveriSettings.enableIsOnlyITSP": {
-    "defaultMessage": "Enable ITSP"
+  "course.admin.CodaveriSettings.enableDisableButton": {
+    "defaultMessage": "{enabled, select, true {Enable} other {Disable}}"
+  },
+  "course.admin.CodaveriSettings.enableDisableEvaluator": {
+    "defaultMessage": "{enabled, select, true {Enable } other {Disable }} Codaveri Evaluator for {questionCount} programming questions in {title}?"
+  },
+  "course.admin.CodaveriSettings.enableDisableEvaluatorDescription": {
+    "defaultMessage": "{questionCount} programming questions in this {type} will use {enabled, select, true {Codaveri } other {Default }} evaluator"
+  },
+  "course.admin.CodaveriSettings.enableDisableLiveFeedback": {
+    "defaultMessage": "{enabled, select, true {Enable } other {Disable }} live feedback for {questionCount} programming questions in {title}?"
+  },
+  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingCodaveriEvaluatorSettings": {
+    "defaultMessage": "An error occurred while updating the codaveri evaluator settings."
+  },
+  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingLiveFeedbackSettings": {
+    "defaultMessage": "An error occurred while updating the live feedback settings."
+  },
+  "course.admin.CodaveriSettings.evaluatorUpdateSuccess": {
+    "defaultMessage": "{question} is now using {evaluator} evaluator"
+  },
+  "course.admin.CodaveriSettings.expandAll": {
+    "defaultMessage": "Expand All Questions"
   },
   "course.admin.CodaveriSettings.feedbackWorkflow": {
     "defaultMessage": "Automatic Post-Submission Comments"
@@ -494,17 +560,14 @@
   "course.admin.CodaveriSettings.feedbackWorkflowDescription": {
     "defaultMessage": "When a submission with programming question is finalised,"
   },
-  "course.admin.CodaveriSettings.feedbackWorkflowNone": {
-    "defaultMessage": "Generate no feedback"
-  },
   "course.admin.CodaveriSettings.feedbackWorkflowDraft": {
     "defaultMessage": "Generate feedback as a draft requiring approval from staff"
   },
+  "course.admin.CodaveriSettings.feedbackWorkflowNone": {
+    "defaultMessage": "Generate no feedback"
+  },
   "course.admin.CodaveriSettings.feedbackWorkflowPublish": {
     "defaultMessage": "Publish feedback directly to student"
-  },
-  "course.admin.CodaveriSettings.error": {
-    "defaultMessage": "An error occurred while updating the codaveri setting."
   },
   "course.admin.CodaveriSettings.itspEngine": {
     "defaultMessage": "ITSP Engine"
@@ -512,35 +575,20 @@
   "course.admin.CodaveriSettings.itspEngineDescription": {
     "defaultMessage": "Uses automated program repair technique"
   },
-  "course.admin.CodaveriSettings.Some": {
-    "defaultMessage": "Some"
-  },
-  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingCodaveriEvaluatorSettings": {
-    "defaultMessage": "An error occurred while updating the codaveri evaluator settings."
-  },
-  "course.admin.CodaveriSettings.codaveriEvaluatorSettings": {
-    "defaultMessage": "Codaveri Evaluator"
-  },
-  "course.admin.CodaveriSettings.liveFeedbackSettings": {
-    "defaultMessage": "Live Feedback"
-  },
-  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingLiveFeedbackSettings": {
-    "defaultMessage": "An error occurred while updating the live feedback settings."
-  },
-  "course.admin.CodaveriSettings.enableDisableButton": {
-    "defaultMessage": "{enabled, select, true {Enable} other {Disable}}"
-  },
-  "course.admin.CodaveriSettings.enableDisableEvaluator": {
-    "defaultMessage": "{enabled, select, true {Enable } other {Disable }} Codaveri Evaluator for {questionCount} programming questions in {title}?"
-  },
-  "course.admin.CodaveriSettings.enableDisableLiveFeedback": {
-    "defaultMessage": "{enabled, select, true {Enable } other {Disable }} Live feedback for {questionCount} programming questions in {title}?"
-  },
-  "course.admin.CodaveriSettings.enableDisableEvaluatorDescription": {
-    "defaultMessage": "{questionCount} programming questions in this {type} will use {enabled, select, true {Codaveri } other {Default }} evaluator"
-  },
   "course.admin.CodaveriSettings.liveFeedbackEnabledUpdateSuccess": {
     "defaultMessage": "Live feedback for {question} is now {liveFeedbackEnabled, select, true {enabled} other {disabled}}"
+  },
+  "course.admin.CodaveriSettings.liveFeedbackSettings": {
+    "defaultMessage": "Get Help"
+  },
+  "course.admin.CodaveriSettings.programmingQuestionSettings": {
+    "defaultMessage": "Programming Question Settings"
+  },
+  "course.admin.CodaveriSettings.programmingQuestionSettingsSubtitle": {
+    "defaultMessage": "Enable/disable Codaveri as evaluator for programming questions in various assessments."
+  },
+  "course.admin.CodaveriSettings.succesfulUpdateAllEvaluator": {
+    "defaultMessage": "Sucessfully updated all questions to use {evaluator} evaluator"
   },
   "course.admin.CodaveriSettings.successfulUpdateAllLiveFeedbackEnabled": {
     "defaultMessage": "Sucessfully {liveFeedbackEnabled, select, true {enabled} other {disabled}} live feedback for all questions"
@@ -556,6 +604,9 @@
   },
   "course.admin.ComponentSettings.errorOccurredWhenUpdatingComponents": {
     "defaultMessage": "An error occurred while updating the component settings."
+  },
+  "course.admin.ComponentSettings.settingUpComponent": {
+    "defaultMessage": "Setting up component for this course"
   },
   "course.admin.CourseSettings.allowUsersToSendEnrolmentRequests": {
     "defaultMessage": "Allow users to send enrolment requests"
@@ -795,7 +846,10 @@
     "defaultMessage": "Component Item Settings"
   },
   "course.admin.LessonPlanSettings.lessonPlanItemSettings": {
-    "defaultMessage": "Lesson Plan Item Settings"
+    "defaultMessage": "Item Settings"
+  },
+  "course.admin.LessonPlanSettings.lessonPlanSettings": {
+    "defaultMessage": "Lesson Plan Settings"
   },
   "course.admin.LessonPlanSettings.noLessonPlanItems": {
     "defaultMessage": "There are no lesson plan items to configure for lesson plan display."
@@ -816,7 +870,7 @@
     "defaultMessage": "Description"
   },
   "course.admin.NotificationSettings.emailSettings": {
-    "defaultMessage": "Email Settings"
+    "defaultMessage": "Email settings"
   },
   "course.admin.NotificationSettings.noEmailSettings": {
     "defaultMessage": "None of the enabled components have email settings."
@@ -992,6 +1046,51 @@
   "course.admin.courseSettings": {
     "defaultMessage": "Course Settings"
   },
+  "course.admin.storiesSettings.autoCreateAccounts": {
+    "defaultMessage": "User accounts and chat rooms on Cikgo will automatically be created if they don't yet exist. Information shared with Cikgo is governed by <ourPpLink>our Privacy Policy</ourPpLink> and <cikgoPpLink>Cikgo's Privacy Policy</cikgoPpLink>."
+  },
+  "course.admin.storiesSettings.integrationHint": {
+    "defaultMessage": "To integrate your course on Cikgo with this course, enter its integration key here. Here's what's going to happen once this course is integrated with Cikgo."
+  },
+  "course.admin.storiesSettings.integrationSettings": {
+    "defaultMessage": "Integration settings"
+  },
+  "course.admin.storiesSettings.learnTitle": {
+    "defaultMessage": "Learn page title"
+  },
+  "course.admin.storiesSettings.leaveEmptyToUseDefaultTitle": {
+    "defaultMessage": "Leave empty to use the default \"Learn\" title."
+  },
+  "course.admin.storiesSettings.onlyOwnersCanManage": {
+    "defaultMessage": "Only you, Owners, and Managers can configure the integration of this course with Cikgo."
+  },
+  "course.admin.storiesSettings.pingError": {
+    "defaultMessage": "There was a problem connecting to Cikgo. You may try again at a later time."
+  },
+  "course.admin.storiesSettings.publishTaskCompletions": {
+    "defaultMessage": "Student's submission statuses will be reflected in their chat rooms in Cikgo."
+  },
+  "course.admin.storiesSettings.pushKey": {
+    "defaultMessage": "Integration key"
+  },
+  "course.admin.storiesSettings.pushKeyError": {
+    "defaultMessage": "This integration key doesn't point to a valid course on Cikgo. Please check your settings on Cikgo and try again."
+  },
+  "course.admin.storiesSettings.pushKeyHint": {
+    "defaultMessage": "Integration keys aren't strictly secretive, but should be handled in confidence."
+  },
+  "course.admin.storiesSettings.pushKeyPointsToCourse": {
+    "defaultMessage": "This integration key points to <link>{course}</link> on Cikgo."
+  },
+  "course.admin.storiesSettings.redirects": {
+    "defaultMessage": "When students access this <link>course's root URL</link>, they'll be redirected to the Learn page. The home page is still accessible from the sidebar."
+  },
+  "course.admin.storiesSettings.storiesSettings": {
+    "defaultMessage": "Stories settings"
+  },
+  "course.admin.storiesSettings.syncs": {
+    "defaultMessage": "Published assessments, videos, and surveys in this course will be available in and kept in sync with Cikgo as resources."
+  },
   "course.announcement.AnnouncementsDisplay.searchBarPlaceholder": {
     "defaultMessage": "Search by title or content"
   },
@@ -1103,6 +1202,12 @@
   "course.assessment.AssessmentForm.blockStudentViewingAfterSubmittedHint": {
     "defaultMessage": "Students will only be able to view their submissions after their grades have been published."
   },
+  "course.assessment.AssessmentForm.blocksAccessesFromInvalidSUS": {
+    "defaultMessage": "Block accesses from browsers with invalid UA"
+  },
+  "course.assessment.AssessmentForm.blocksAccessesFromInvalidSUSHint": {
+    "defaultMessage": "If enabled, examinees using browsers with invalid UA (does not contain the specified SUS below) will be blocked from accessing this assessment. Instructors can override access with the session unlock password. Heartbeats from an overridden browser session will be flagged as valid in the PulseGrid."
+  },
   "course.assessment.AssessmentForm.bonusEndAt": {
     "defaultMessage": "Bonus ends at"
   },
@@ -1114,9 +1219,6 @@
   },
   "course.assessment.AssessmentForm.delayedGradePublicationHint": {
     "defaultMessage": "If enabled, gradings will not be immediately shown to students. To publish all gradings, you may click Publish Grades in the Submissions page."
-  },
-  "course.assessment.AssessmentForm.canEnableCodaveriInComponents": {
-    "defaultMessage": "Contact the course manager or owner to enable this feature in Components in the Course Settings."
   },
   "course.assessment.AssessmentForm.description": {
     "defaultMessage": "Description"
@@ -1172,11 +1274,23 @@
   "course.assessment.AssessmentForm.hasPersonalTimesHint": {
     "defaultMessage": "Timings for this item will be automatically adjusted for users based on learning rate."
   },
+  "course.assessment.AssessmentForm.hasTimeLimit": {
+    "defaultMessage": "Automatically submit when timer ends"
+  },
+  "course.assessment.AssessmentForm.hasTimeLimitHint": {
+    "defaultMessage": "When enabled, each submission will have its own timer and will automatically be finalised when its timer ends."
+  },
   "course.assessment.AssessmentForm.hasToBeMoreThanMinInterval": {
     "defaultMessage": "Has to be greater than the minimum value."
   },
   "course.assessment.AssessmentForm.hasToBeMoreThanValueMs": {
     "defaultMessage": "Has to be at least 3000 ms."
+  },
+  "course.assessment.AssessmentForm.hasToBeNumber": {
+    "defaultMessage": "Has to be valid number."
+  },
+  "course.assessment.AssessmentForm.hasToBePositive": {
+    "defaultMessage": "Has to be positive."
   },
   "course.assessment.AssessmentForm.hasToBePositiveInteger": {
     "defaultMessage": "Has to be a positive integer less than 86,400,000 ms"
@@ -1190,6 +1304,12 @@
   "course.assessment.AssessmentForm.intervalHint": {
     "defaultMessage": "Controls how frequent heartbeats are sent from the students' browsers. Intervals are randomised between these two ranges."
   },
+  "course.assessment.AssessmentForm.koditsuDisabledInCourse": {
+    "defaultMessage": "Please contact the Course Administrator to enable Koditsu Exam in Course Settings."
+  },
+  "course.assessment.AssessmentForm.liveFeedback": {
+    "defaultMessage": "Get Help"
+  },
   "course.assessment.AssessmentForm.maxInterval": {
     "defaultMessage": "Max interval"
   },
@@ -1199,8 +1319,17 @@
   "course.assessment.AssessmentForm.minInterval": {
     "defaultMessage": "Min interval"
   },
+  "course.assessment.AssessmentForm.minutes": {
+    "defaultMessage": "minute(s)"
+  },
   "course.assessment.AssessmentForm.modeSwitchingHint": {
     "defaultMessage": "You can no longer change the grading mode because there are already submissions for this assessment."
+  },
+  "course.assessment.AssessmentForm.needSUSAndSessionUnlockPassword": {
+    "defaultMessage": "You need to specify a SUS and session unlock password to enable this."
+  },
+  "course.assessment.AssessmentForm.noProgrammingQuestion": {
+    "defaultMessage": "You need to add at least one programming question that can be supported by Codaveri to allow enabling live feedback for this Assessment"
   },
   "course.assessment.AssessmentForm.noTestCaseChosenError": {
     "defaultMessage": "Select at least one type of test case"
@@ -1226,29 +1355,32 @@
   "course.assessment.AssessmentForm.personalisedTimelines": {
     "defaultMessage": "Personalised timelines"
   },
+  "course.assessment.AssessmentForm.proctorWithKoditsu": {
+    "defaultMessage": "Proctor Exam using Koditsu"
+  },
   "course.assessment.AssessmentForm.published": {
     "defaultMessage": "Published"
   },
   "course.assessment.AssessmentForm.publishedHint": {
     "defaultMessage": "Everyone can see this assessment."
   },
+  "course.assessment.AssessmentForm.questionsIncompatibleWithKoditsu": {
+    "defaultMessage": "Please make sure that all questions in this assessment is compatible with Koditsu before activating proctoring in Koditsu"
+  },
   "course.assessment.AssessmentForm.secret": {
     "defaultMessage": "Secret UA Substring (SUS)"
   },
   "course.assessment.AssessmentForm.secretHint": {
-    "defaultMessage": "If provided, Coursemology can automatically flag a connection as valid in <pulsegrid>PulseGrid</pulsegrid> if the examinee's User Agent (UA) contains this secret. Otherwise, connections will be flagged only by heartbeat intervals."
+    "defaultMessage": "If provided, the <pulsegrid>PulseGrid</pulsegrid> automatically checks if the examinee's browser's User Agent (UA) contains this secret, and marks connections that do not as invalid. This string is case-sensitive."
   },
   "course.assessment.AssessmentForm.sessionPassword": {
     "defaultMessage": "Session unlock password"
-  },
-  "course.assessment.AssessmentForm.sessionPasswordHint": {
-    "defaultMessage": "Ideally, do NOT give this password to students."
   },
   "course.assessment.AssessmentForm.sessionProtection": {
     "defaultMessage": "Enable session protection"
   },
   "course.assessment.AssessmentForm.sessionProtectionHint": {
-    "defaultMessage": "If enabled, students can only access their attempt once. Further access will require the session unlock password."
+    "defaultMessage": "If enabled, students can only access their attempt once. Further access will require the session unlock password. Ideally, <b>do NOT give this password to students</b>."
   },
   "course.assessment.AssessmentForm.showEvaluation": {
     "defaultMessage": "Show evaluation test cases"
@@ -1289,8 +1421,14 @@
   "course.assessment.AssessmentForm.timeBonusExp": {
     "defaultMessage": "Time Bonus EXP"
   },
+  "course.assessment.AssessmentForm.timeLimit": {
+    "defaultMessage": "Time Limit"
+  },
   "course.assessment.AssessmentForm.title": {
     "defaultMessage": "Title"
+  },
+  "course.assessment.AssessmentForm.toggleLiveFeedbackDescription": {
+    "defaultMessage": "Enable live feedback feature for all programming questions"
   },
   "course.assessment.AssessmentForm.unavailableInAutograded": {
     "defaultMessage": "Unavailable in autograded assessments."
@@ -1321,12 +1459,6 @@
   },
   "course.assessment.AssessmentForm.visibility": {
     "defaultMessage": "Visibility"
-  },
-  "course.assessment.AssessmentForm.toggleLiveFeedbackDescription": {
-    "defaultMessage": "{enabled, select, true {Enable} other {Disable}} live feedback feature for all programming questions"
-  },
-  "course.assessment.AssessmentForm.noProgrammingQuestion": {
-    "defaultMessage": "You need to add at least one programming question that can be supported by Codaveri to allow enabling live feedback for this Assessment"
   },
   "course.assessment.FileManager.addFiles": {
     "defaultMessage": "Add Files"
@@ -1373,14 +1505,89 @@
   "course.assessment.edit.update": {
     "defaultMessage": "Save"
   },
+  "course.assessment.generation.allFieldsLocked": {
+    "defaultMessage": "All fields are locked, so nothing can be generated."
+  },
+  "course.assessment.generation.confirmDeleteConversation": {
+    "defaultMessage": "Are you sure you want to delete \"{title}\" and all its history items? THIS ACTION IS IRREVERSIBLE!"
+  },
+  "course.assessment.generation.exportAction": {
+    "defaultMessage": "Export"
+  },
+  "course.assessment.generation.exportClose": {
+    "defaultMessage": "Close"
+  },
+  "course.assessment.generation.exportDialogHeader": {
+    "defaultMessage": "Export Questions ({exportCount} selected)"
+  },
+  "course.assessment.generation.exportError": {
+    "defaultMessage": "An error occured in exporting this question."
+  },
+  "course.assessment.generation.generateError": {
+    "defaultMessage": "An error occured generating question \"{title}\"."
+  },
+  "course.assessment.generation.generatePage": {
+    "defaultMessage": "Generate Programming Question"
+  },
+  "course.assessment.generation.generateQuestion": {
+    "defaultMessage": "Generate"
+  },
+  "course.assessment.generation.generateSuccess": {
+    "defaultMessage": "Generation for \"{title}\" successful."
+  },
+  "course.assessment.generation.languageField": {
+    "defaultMessage": "Language"
+  },
+  "course.assessment.generation.newTab": {
+    "defaultMessage": "New"
+  },
+  "course.assessment.generation.openExportDialog": {
+    "defaultMessage": "Export"
+  },
+  "course.assessment.generation.promptPlaceholder": {
+    "defaultMessage": "Type something here..."
+  },
+  "course.assessment.generation.resetConversation": {
+    "defaultMessage": "Reset"
+  },
+  "course.assessment.generation.showInactive": {
+    "defaultMessage": "Show inactive items"
+  },
+  "course.assessment.liveFeedback.comments": {
+    "defaultMessage": "Comments"
+  },
+  "course.assessment.liveFeedback.feedbackTimingTitle": {
+    "defaultMessage": "Used at: {usedAt}"
+  },
+  "course.assessment.liveFeedback.lineHeader": {
+    "defaultMessage": "Line {lineNumber}"
+  },
+  "course.assessment.liveFeedback.questionTitle": {
+    "defaultMessage": "Question {index}"
+  },
+  "course.assessment.monitoring.accessGrantedForThisSessionOnly": {
+    "defaultMessage": "Access will be granted only for this browser session."
+  },
   "course.assessment.monitoring.alivePresenceHint": {
     "defaultMessage": "Last heartbeat was received in time."
   },
   "course.assessment.monitoring.alivePresenceHintSUSMatches": {
-    "defaultMessage": "Last heartbeat was received in time and the SUS matches."
+    "defaultMessage": "Last heartbeat was received in time and came from an authorised browser, if browser authorisation is enabled."
   },
   "course.assessment.monitoring.blankField": {
     "defaultMessage": "(blank)"
+  },
+  "course.assessment.monitoring.blocksAccessesFromInvalidSUS": {
+    "defaultMessage": "Block accesses from unauthorised browsers"
+  },
+  "course.assessment.monitoring.blocksAccessesFromInvalidSUSHint": {
+    "defaultMessage": "If enabled, examinees using unauthorised browsers can't access this assessment. Instructors can override access with the session unlock password. Heartbeats from overridden browser sessions will always be valid (green) in the PulseGrid."
+  },
+  "course.assessment.monitoring.browserAuthorizationMethod": {
+    "defaultMessage": "Browser authorisation method"
+  },
+  "course.assessment.monitoring.browserAuthorizationMethodHint": {
+    "defaultMessage": "Choose how sessions are authorised as valid or invalid. Changes apply to all sessions and heartbeats immediately and updates live in PulseGrid."
   },
   "course.assessment.monitoring.cannotConnectToLiveMonitoringChannel": {
     "defaultMessage": "Oops, an error occurred when connecting to the live monitoring channel."
@@ -1388,29 +1595,56 @@
   "course.assessment.monitoring.connected": {
     "defaultMessage": "Connected"
   },
-  "course.assessment.monitoring.connectedToLiveMonitoringChannel": {
-    "defaultMessage": "Connected to the live monitoring channel"
+  "course.assessment.monitoring.connecting": {
+    "defaultMessage": "Connecting"
+  },
+  "course.assessment.monitoring.deltaFromPreviousHeartbeat": {
+    "defaultMessage": "{ms} ms from previous heartbeat"
   },
   "course.assessment.monitoring.detailsOfNHeartbeats": {
-    "defaultMessage": "Details of the last {n} heartbeats"
+    "defaultMessage": "Last {n} heartbeats"
   },
   "course.assessment.monitoring.disconnected": {
     "defaultMessage": "Disconnected"
   },
-  "course.assessment.monitoring.disconnectedFromLiveMonitoringChannel": {
-    "defaultMessage": "Disconnected from the live monitoring channel"
+  "course.assessment.monitoring.enableBrowserAuthorization": {
+    "defaultMessage": "Authorise browsers that access this assessment"
+  },
+  "course.assessment.monitoring.enableBrowserAuthorizationHint": {
+    "defaultMessage": "If enabled, PulseGrid will additionally check if an examinee is accessing this assessment from an authorised browser, based on the authorisation method you choose."
+  },
+  "course.assessment.monitoring.examMonitoring": {
+    "defaultMessage": "Enable exam monitoring"
+  },
+  "course.assessment.monitoring.examMonitoringHint": {
+    "defaultMessage": "If enabled, examinees' sessions will be monitored in real time from when they attempt the exam until they finalise it or the first 24 hours since their attempt, whichever is earlier. Instructors can monitor these sessions in <pulsegrid>PulseGrid</pulsegrid>."
+  },
+  "course.assessment.monitoring.expiredSession": {
+    "defaultMessage": "Expired session. It has been at least 24 hours since the submission was made."
   },
   "course.assessment.monitoring.filterByGroup": {
     "defaultMessage": "Filter by Group"
   },
+  "course.assessment.monitoring.firstReceivedHeartbeat": {
+    "defaultMessage": "First received heartbeat"
+  },
   "course.assessment.monitoring.generatedAt": {
     "defaultMessage": "Generated at"
   },
+  "course.assessment.monitoring.intervalHint": {
+    "defaultMessage": "Controls how frequent heartbeats are sent from the examinees' browsers. Intervals are randomised between these two ranges."
+  },
+  "course.assessment.monitoring.invalidBrowser": {
+    "defaultMessage": "Invalid browser configuration"
+  },
+  "course.assessment.monitoring.invalidBrowserSubtitle": {
+    "defaultMessage": "Access to this assessment is not allowed with your current browser and/or its configuration. Contact your instructor for assistance."
+  },
+  "course.assessment.monitoring.invalidHeartbeat": {
+    "defaultMessage": "Invalid"
+  },
   "course.assessment.monitoring.ipAddress": {
     "defaultMessage": "IP Address"
-  },
-  "course.assessment.monitoring.lastHeartbeat": {
-    "defaultMessage": "Last heartbeat"
   },
   "course.assessment.monitoring.latePresenceHint": {
     "defaultMessage": "Next heartbeat hasn't been received in time, but still within the configured inter-heartbeats interval."
@@ -1418,11 +1652,44 @@
   "course.assessment.monitoring.live": {
     "defaultMessage": "Live"
   },
+  "course.assessment.monitoring.liveHint": {
+    "defaultMessage": "This heartbeat was immediately received by the server."
+  },
+  "course.assessment.monitoring.liveness": {
+    "defaultMessage": "Liveness"
+  },
+  "course.assessment.monitoring.loadAllHeartbeats": {
+    "defaultMessage": "Load all"
+  },
+  "course.assessment.monitoring.maxInterval": {
+    "defaultMessage": "Max interval"
+  },
+  "course.assessment.monitoring.milliseconds": {
+    "defaultMessage": "ms"
+  },
+  "course.assessment.monitoring.minInterval": {
+    "defaultMessage": "Min interval"
+  },
   "course.assessment.monitoring.missingPresenceHint": {
-    "defaultMessage": "Next heartbeat hasn't been received in time."
+    "defaultMessage": "Next heartbeat hasn't been received in time, or the last heartbeat came from an unauthorised browser, if browser authorisation is enabled."
+  },
+  "course.assessment.monitoring.needSUSAndSessionUnlockPassword": {
+    "defaultMessage": "You must enable browser authorisation and set a session unlock password to enable this."
   },
   "course.assessment.monitoring.noActiveSessions": {
-    "defaultMessage": "No active sessions."
+    "defaultMessage": "No active sessions. No attempts have been made."
+  },
+  "course.assessment.monitoring.offset": {
+    "defaultMessage": "Inter-heartbeat offset"
+  },
+  "course.assessment.monitoring.offsetHint": {
+    "defaultMessage": "Controls how long PulseGrid should wait after the frequency interval before flagging a session as late."
+  },
+  "course.assessment.monitoring.openSubmissionInNewTab": {
+    "defaultMessage": "Open submission in new tab"
+  },
+  "course.assessment.monitoring.overrideAccess": {
+    "defaultMessage": "Override access"
   },
   "course.assessment.monitoring.pulsegrid": {
     "defaultMessage": "PulseGrid"
@@ -1433,8 +1700,41 @@
   "course.assessment.monitoring.recentActivitiesHint": {
     "defaultMessage": "These logs will disappear if you close this tab!"
   },
+  "course.assessment.monitoring.resetZoom": {
+    "defaultMessage": "Reset zoom"
+  },
+  "course.assessment.monitoring.sebConfigKey": {
+    "defaultMessage": "Safe Exam Browser (SEB) Config Key"
+  },
+  "course.assessment.monitoring.sebConfigKeyFieldHint": {
+    "defaultMessage": "Your <sebConfigKey>SEB Config Key</sebConfigKey>, <i>not the Browser Exam Key</i>, is generated from your specific SEB configuration. It stays the same across operating systems and SEB versions. Ensure this field is updated if you change your SEB configuration."
+  },
+  "course.assessment.monitoring.sebConfigKeyFieldLabel": {
+    "defaultMessage": "SEB Config Key"
+  },
+  "course.assessment.monitoring.sebConfigKeyHint": {
+    "defaultMessage": "Flags a session as valid if the examinee is using <seb>Safe Exam Browser (SEB)</seb> with a valid configuration. SEB generates a unique <sebConfigKey>Config Key</sebConfigKey> for a specific configuration. This method requires SEB 3.4 for Windows and SEB 3.0 for iOS and macOS, or later."
+  },
+  "course.assessment.monitoring.sebPayload": {
+    "defaultMessage": "Safe Exam Browser (SEB) Config Key Hash & URL"
+  },
+  "course.assessment.monitoring.secret": {
+    "defaultMessage": "Secret UA Substring (SUS)"
+  },
+  "course.assessment.monitoring.secretHint": {
+    "defaultMessage": "If an examinee's browser's User Agent (UA) contains this case-sensitive secret, PulseGrid will flag that session as valid, and invalid otherwise. If you leave this blank, all sessions will be flagged as valid."
+  },
+  "course.assessment.monitoring.sessionUnlockPassword": {
+    "defaultMessage": "Session unlock password"
+  },
   "course.assessment.monitoring.stale": {
     "defaultMessage": "Stale"
+  },
+  "course.assessment.monitoring.staleHint": {
+    "defaultMessage": "This heartbeat wasn't immediately received by the server because the examinee's browser was temporarily unreachable. It was cached in the browser, and sent to the server when the browser was reachable again."
+  },
+  "course.assessment.monitoring.stoppedSession": {
+    "defaultMessage": "Stopped session. Student may have finalised their submission."
   },
   "course.assessment.monitoring.summaryCorrectAsAt": {
     "defaultMessage": "Summary correct as at {time}"
@@ -1443,13 +1743,22 @@
     "defaultMessage": "Type"
   },
   "course.assessment.monitoring.userAgent": {
-    "defaultMessage": "User Agent"
+    "defaultMessage": "User Agent (UA)"
+  },
+  "course.assessment.monitoring.userAgentHint": {
+    "defaultMessage": "Flags a session as valid if the examinee's browser's <ua>User Agent (UA)</ua> contains a secret substring."
   },
   "course.assessment.monitoring.userHeartbeatContinuedStreaming": {
     "defaultMessage": "{name}'s heartbeat just continued streaming."
   },
   "course.assessment.monitoring.userHeartbeatNotReceivedInTime": {
     "defaultMessage": "{name}'s heartbeat wasn't received in time."
+  },
+  "course.assessment.monitoring.validHeartbeat": {
+    "defaultMessage": "Valid"
+  },
+  "course.assessment.monitoring.zoomPanHint": {
+    "defaultMessage": "Pinch or scroll to zoom. Drag to pan."
   },
   "course.assessment.newAssessment": {
     "defaultMessage": "New Assessment"
@@ -1538,8 +1847,17 @@
   "course.assessment.question.multipleResponses.maximumGrade": {
     "defaultMessage": "Maximum grade"
   },
+  "course.assessment.question.multipleResponses.mustBeLessThanMaxAttachmentSize": {
+    "defaultMessage": "Must be at most {defaultMax}MB."
+  },
+  "course.assessment.question.multipleResponses.mustBeLessThanMaxAttachments": {
+    "defaultMessage": "Must be at most {defaultMax}."
+  },
   "course.assessment.question.multipleResponses.mustBeLessThanMaxMaximumGrade": {
     "defaultMessage": "Must be less than 1000."
+  },
+  "course.assessment.question.multipleResponses.mustHaveAtLeastOneResponse": {
+    "defaultMessage": "You must specify at least one response."
   },
   "course.assessment.question.multipleResponses.mustSpecifyAtLeastOneCorrectChoice": {
     "defaultMessage": "You must specify at least one correct choice."
@@ -1547,8 +1865,20 @@
   "course.assessment.question.multipleResponses.mustSpecifyChoice": {
     "defaultMessage": "You must specify a valid choice title."
   },
+  "course.assessment.question.multipleResponses.mustSpecifyMaxAttachment": {
+    "defaultMessage": "You must specify a valid, positive maximum attachment number."
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyMaxAttachmentSize": {
+    "defaultMessage": "You must specify a valid, positive maximum attachment size."
+  },
   "course.assessment.question.multipleResponses.mustSpecifyMaximumGrade": {
     "defaultMessage": "You must specify a valid, non-negative maximum grade to award."
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachment": {
+    "defaultMessage": "Maximum Number of Attachments has to be positive."
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachmentSize": {
+    "defaultMessage": "Max Size has to be positive."
   },
   "course.assessment.question.multipleResponses.mustSpecifyPositiveMaximumGrade": {
     "defaultMessage": "Maximum grade has to be non-negative."
@@ -1664,6 +1994,9 @@
   "course.assessment.question.programming.codaveriEvaluatorHint": {
     "defaultMessage": "On top of the default evaluation, this evaluator will provide automated code feedback powered by Codaveri when the submission is finalised. They will appear as draft comments for the instructors to review, edit, and publish."
   },
+  "course.assessment.question.programming.codaveriEvaluatorNotSupported": {
+    "defaultMessage": "{languageName} is not supported by the Codaveri evaluator."
+  },
   "course.assessment.question.programming.codeInserts": {
     "defaultMessage": "Code inserts"
   },
@@ -1687,6 +2020,9 @@
   },
   "course.assessment.question.programming.defaultEvaluatorHint": {
     "defaultMessage": "No fuss; just run the code according to the evaluation package below and report the test results."
+  },
+  "course.assessment.question.programming.defaultEvaluatorNotSupported": {
+    "defaultMessage": "{languageName} is not supported by the default evaluator."
   },
   "course.assessment.question.programming.editOnline": {
     "defaultMessage": "Create/edit online"
@@ -1713,7 +2049,7 @@
     "defaultMessage": "Hold tight, evaluating all submissions with the new package..."
   },
   "course.assessment.question.programming.evaluationLimits": {
-    "defaultMessage": "Evaluationlimits"
+    "defaultMessage": "Evaluation limits"
   },
   "course.assessment.question.programming.evaluationTestCases": {
     "defaultMessage": "Evaluation test cases"
@@ -1726,6 +2062,9 @@
   },
   "course.assessment.question.programming.expected": {
     "defaultMessage": "Expected"
+  },
+  "course.assessment.question.programming.expectedOutput": {
+    "defaultMessage": "Expected Output"
   },
   "course.assessment.question.programming.expression": {
     "defaultMessage": "Expression"
@@ -1757,6 +2096,9 @@
   "course.assessment.question.programming.inlineCode": {
     "defaultMessage": "Inline code"
   },
+  "course.assessment.question.programming.input": {
+    "defaultMessage": "Input"
+  },
   "course.assessment.question.programming.javaTestCasesHint": {
     "defaultMessage": "Expressions will be evaluated in the context of the submitted code. Their return values will be compared against the Expected expectations using the <code>expectEquals(expression, expected)</code> void. Its simplified definition is as follows, where <code>Object</code> has been overloaded for all Java primitives."
   },
@@ -1772,6 +2114,9 @@
   "course.assessment.question.programming.languageAndEvaluation": {
     "defaultMessage": "Language and evaluation"
   },
+  "course.assessment.question.programming.languageDeprecatedWarning": {
+    "defaultMessage": "Your selected language is deprecated. Please change it to another language."
+  },
   "course.assessment.question.programming.lastUpdated": {
     "defaultMessage": "Last updated by {by} on {on}."
   },
@@ -1780,6 +2125,9 @@
   },
   "course.assessment.question.programming.liveFeedbackCustomPromptDescription": {
     "defaultMessage": "Add instructions to guide the generation of live feedback here. If unsure, just leave this blank."
+  },
+  "course.assessment.question.programming.liveFeedbackNotSupported": {
+    "defaultMessage": "Live feedback generation is not supported for {languageName}."
   },
   "course.assessment.question.programming.lowestGradingPriority": {
     "defaultMessage": "Lowest grading priority"
@@ -1847,6 +2195,9 @@
   "course.assessment.question.programming.questionSavedButPackageError": {
     "defaultMessage": "Your changes was saved, but the package wasn't successfully imported."
   },
+  "course.assessment.question.programming.rTestCasesHint": {
+    "defaultMessage": "Each test case launches a separate R console instance and provides input via standard input. This console will run the <prepend>Prepend</prepend> script, the student submission, and the <append>Append</append> script. The standard output of these scripts will be compared (as a string) to the expected output of the test case. We recommend processing the standard input in one of these scripts."
+  },
   "course.assessment.question.programming.savingChanges": {
     "defaultMessage": "Saving your changes..."
   },
@@ -1894,6 +2245,9 @@
   },
   "course.assessment.question.programming.timeLimit": {
     "defaultMessage": "Time limit"
+  },
+  "course.assessment.question.programming.timeLimitDetail": {
+    "defaultMessage": "{timeLimit, plural, one {# minute} other {# minutes}}"
   },
   "course.assessment.question.programming.uploadNewPackage": {
     "defaultMessage": "Upload a new package"
@@ -1979,8 +2333,14 @@
   "course.assessment.question.textResponses.addSolution": {
     "defaultMessage": "Add a new solution"
   },
-  "course.assessment.question.textResponses.allowFileUpload": {
-    "defaultMessage": "Allow file upload in the answer"
+  "course.assessment.question.textResponses.attachmentSettingRequired": {
+    "defaultMessage": "Attachment Setting should be defined in this question"
+  },
+  "course.assessment.question.textResponses.attachmentSettings": {
+    "defaultMessage": "Attachment Settings"
+  },
+  "course.assessment.question.textResponses.attachmentSettingsDescription": {
+    "defaultMessage": "When students are attempting this question,"
   },
   "course.assessment.question.textResponses.deleteSolution": {
     "defaultMessage": "Delete solution"
@@ -1994,8 +2354,23 @@
   "course.assessment.question.textResponses.grade": {
     "defaultMessage": "Grade"
   },
+  "course.assessment.question.textResponses.isAttachmentRequired": {
+    "defaultMessage": "Require file upload for this question"
+  },
   "course.assessment.question.textResponses.keyword": {
     "defaultMessage": "Keyword"
+  },
+  "course.assessment.question.textResponses.maxAttachmentSize": {
+    "defaultMessage": "Max Size per Attachment"
+  },
+  "course.assessment.question.textResponses.maxAttachments": {
+    "defaultMessage": "Max Number of Attachments"
+  },
+  "course.assessment.question.textResponses.multipleAttachments": {
+    "defaultMessage": "Multiple Attachments"
+  },
+  "course.assessment.question.textResponses.multipleFileAttachmentDescription": {
+    "defaultMessage": "They can upload several attachments."
   },
   "course.assessment.question.textResponses.mustSpecifyGrade": {
     "defaultMessage": "You must specify a valid number for grade."
@@ -2008,6 +2383,18 @@
   },
   "course.assessment.question.textResponses.newSolutionCannotUndo": {
     "defaultMessage": "This is a new solution. It will immediately disappear if you delete before saving it."
+  },
+  "course.assessment.question.textResponses.noAttachment": {
+    "defaultMessage": "No Attachment"
+  },
+  "course.assessment.question.textResponses.noAttachmentDescription": {
+    "defaultMessage": "They will not be able to upload any attachment."
+  },
+  "course.assessment.question.textResponses.singleFileAttachment": {
+    "defaultMessage": "Single Attachment"
+  },
+  "course.assessment.question.textResponses.singleFileAttachmentDescription": {
+    "defaultMessage": "They can only upload one attachment."
   },
   "course.assessment.question.textResponses.solution": {
     "defaultMessage": "Solution"
@@ -2032,6 +2419,9 @@
   },
   "course.assessment.question.textResponses.undoDeleteSolution": {
     "defaultMessage": "Undo delete solution"
+  },
+  "course.assessment.question.textResponses.validAttachmentSettingValues": {
+    "defaultMessage": "Attachment Settings should be either no attachment, single file attachment, or multiple file attachment"
   },
   "course.assessment.question.textResponses.zeroGrade": {
     "defaultMessage": "0.0"
@@ -2059,9 +2449,6 @@
   },
   "course.assessment.show.assessmentOnlyAvailableFrom": {
     "defaultMessage": "This assessment will only be available from"
-  },
-  "course.assessment.show.audioResponse": {
-    "defaultMessage": "Audio Response"
   },
   "course.assessment.show.baseExp": {
     "defaultMessage": "Base EXP"
@@ -2095,6 +2482,9 @@
   },
   "course.assessment.show.chooseAssessmentToDuplicateInto": {
     "defaultMessage": "Choose an assessment to duplicate into"
+  },
+  "course.assessment.show.comprehension": {
+    "defaultMessage": "Comprehension"
   },
   "course.assessment.show.delete": {
     "defaultMessage": "Delete"
@@ -2153,8 +2543,14 @@
   "course.assessment.show.errorMovingQuestion": {
     "defaultMessage": "An error occurred while moving the question."
   },
+  "course.assessment.show.failedSyncingWithKoditsu": {
+    "defaultMessage": "Not Synced with Koditsu"
+  },
   "course.assessment.show.fileUpload": {
     "defaultMessage": "File Upload"
+  },
+  "course.assessment.show.fileUploadDescription": {
+    "defaultMessage": "Settings for the number of attachments allowed (none, one, or multiple)"
   },
   "course.assessment.show.files": {
     "defaultMessage": "Files"
@@ -2167,6 +2563,9 @@
   },
   "course.assessment.show.forumPostResponse": {
     "defaultMessage": "Forum Post Response"
+  },
+  "course.assessment.show.generate": {
+    "defaultMessage": "Generate Programming Question"
   },
   "course.assessment.show.gradedTestCases": {
     "defaultMessage": "Graded test cases"
@@ -2185,6 +2584,9 @@
   },
   "course.assessment.show.hideOptions": {
     "defaultMessage": "Hide options"
+  },
+  "course.assessment.show.koditsuMode": {
+    "defaultMessage": "Koditsu"
   },
   "course.assessment.show.manageComponents": {
     "defaultMessage": "Manage Components in Course Settings"
@@ -2312,6 +2714,12 @@
   "course.assessment.show.sureDeletingQuestion": {
     "defaultMessage": "Sure you're deleting this question?"
   },
+  "course.assessment.show.syncedWithKoditsu": {
+    "defaultMessage": "Synced with Koditsu"
+  },
+  "course.assessment.show.syncingWithKoditsu": {
+    "defaultMessage": "Syncing with Koditsu"
+  },
   "course.assessment.show.textResponse": {
     "defaultMessage": "Text Response"
   },
@@ -2326,6 +2734,9 @@
   },
   "course.assessment.show.unsubmittingAndChangingQuestionType": {
     "defaultMessage": "Unsubmitting submissions and changing your question type..."
+  },
+  "course.assessment.show.voiceResponse": {
+    "defaultMessage": "Audio Response"
   },
   "course.assessment.show.whileHoldingToCancelMoving": {
     "defaultMessage": "while holding to cancel moving."
@@ -2429,23 +2840,47 @@
   "course.assessment.skills.SkillsTable.uncategorised": {
     "defaultMessage": "Uncategorised Skills"
   },
-  "course.assessment.liveFeedback.questionTitle": {
-    "defaultMessage": "Question {index}"
+  "course.assessment.statistics.SubmissionStatusChart.attempting": {
+    "defaultMessage": "Attempting"
   },
-  "course.assessment.liveFeedback.feedbackTimingTitle": {
-    "defaultMessage": "Used at: {usedAt}"
+  "course.assessment.statistics.SubmissionStatusChart.datasetLabel": {
+    "defaultMessage": "Student Submission Statuses"
   },
-  "course.assessment.liveFeedback.liveFeedbackName": {
-    "defaultMessage": "Live Feedback"
+  "course.assessment.statistics.SubmissionStatusChart.graded": {
+    "defaultMessage": "Graded, unpublished"
   },
-  "course.assessment.liveFeedback.comments": {
-    "defaultMessage": "Comments"
+  "course.assessment.statistics.SubmissionStatusChart.published": {
+    "defaultMessage": "Graded"
   },
-  "course.assessment.liveFeedback.lineHeader": {
-    "defaultMessage": "Line {lineNumber}"
+  "course.assessment.statistics.SubmissionStatusChart.submitted": {
+    "defaultMessage": "Submitted"
+  },
+  "course.assessment.statistics.SubmissionStatusChart.unattempted": {
+    "defaultMessage": "Not Started"
+  },
+  "course.assessment.statistics.ancestorFail": {
+    "defaultMessage": "Failed to fetch past iterations of this assessment."
+  },
+  "course.assessment.statistics.ancestorSelect.current": {
+    "defaultMessage": "Current"
+  },
+  "course.assessment.statistics.ancestorSelect.fromCourse": {
+    "defaultMessage": "From {courseTitle}"
+  },
+  "course.assessment.statistics.ancestorSelect.subtitle": {
+    "defaultMessage": "Compare against past versions of this assessment:"
+  },
+  "course.assessment.statistics.ancestorSelect.title": {
+    "defaultMessage": "Duplication History"
+  },
+  "course.assessment.statistics.ancestorStatisticsFail": {
+    "defaultMessage": "Failed to fetch ancestor's statistics."
   },
   "course.assessment.statistics.answers": {
     "defaultMessage": "Answers"
+  },
+  "course.assessment.statistics.attemptCount": {
+    "defaultMessage": "Attempt Count"
   },
   "course.assessment.statistics.attempts.filename": {
     "defaultMessage": "Question-level Attempt Statistics for {assessment}"
@@ -2459,6 +2894,33 @@
   "course.assessment.statistics.closePrompt": {
     "defaultMessage": "Close"
   },
+  "course.assessment.statistics.comments": {
+    "defaultMessage": "Comments"
+  },
+  "course.assessment.statistics.duplicationHistory": {
+    "defaultMessage": "Duplication History"
+  },
+  "course.assessment.statistics.email": {
+    "defaultMessage": "Email"
+  },
+  "course.assessment.statistics.fail": {
+    "defaultMessage": "Failed to fetch statistics."
+  },
+  "course.assessment.statistics.gradeDisplay": {
+    "defaultMessage": "Grade: {grade} / {maxGrade}"
+  },
+  "course.assessment.statistics.gradeDistribution": {
+    "defaultMessage": "Grade Distribution"
+  },
+  "course.assessment.statistics.gradeViolin.datasetLabel": {
+    "defaultMessage": "Distribution"
+  },
+  "course.assessment.statistics.gradeViolin.xAxisLabel": {
+    "defaultMessage": "Grades"
+  },
+  "course.assessment.statistics.gradeViolin.yAxisLabel": {
+    "defaultMessage": "Submissions"
+  },
   "course.assessment.statistics.grader": {
     "defaultMessage": "Grader"
   },
@@ -2468,11 +2930,20 @@
   "course.assessment.statistics.group": {
     "defaultMessage": "Group"
   },
+  "course.assessment.statistics.header": {
+    "defaultMessage": "Statistics for {title}"
+  },
+  "course.assessment.statistics.includePhantom": {
+    "defaultMessage": "Include Phantom Student"
+  },
   "course.assessment.statistics.legendHigherusage": {
     "defaultMessage": "Higher Usage"
   },
   "course.assessment.statistics.legendLowerUsage": {
     "defaultMessage": "Lower Usage"
+  },
+  "course.assessment.statistics.liveFeedback": {
+    "defaultMessage": "Live Feedback"
   },
   "course.assessment.statistics.liveFeedback.filename": {
     "defaultMessage": "Question-level Live Feedback Statistics for {assessment}"
@@ -2489,6 +2960,9 @@
   "course.assessment.statistics.marks.redCellLegend": {
     "defaultMessage": "< 0.5 * Maximum Grade"
   },
+  "course.assessment.statistics.marksPerQuestion": {
+    "defaultMessage": "Marks Per Question"
+  },
   "course.assessment.statistics.name": {
     "defaultMessage": "Name"
   },
@@ -2498,11 +2972,17 @@
   "course.assessment.statistics.nameGroupsSearchText": {
     "defaultMessage": "Search by Name or Groups"
   },
+  "course.assessment.statistics.noIncludePhantom": {
+    "defaultMessage": "*All statistics in this duplicated assessments does not include Phantom Students"
+  },
   "course.assessment.statistics.noSubmission": {
     "defaultMessage": "No submission yet"
   },
   "course.assessment.statistics.onlyForAutogradableAssessment": {
     "defaultMessage": "This table is only displayed for Assessment with at least one Autograded Questions"
+  },
+  "course.assessment.statistics.pastAnswerTitle": {
+    "defaultMessage": "Submitted At: {submittedAt}"
   },
   "course.assessment.statistics.questionDisplayTitle": {
     "defaultMessage": "Q{index} for {student}"
@@ -2510,50 +2990,14 @@
   "course.assessment.statistics.questionIndex": {
     "defaultMessage": "Q{index}"
   },
-  "course.assessment.statistics.total": {
-    "defaultMessage": "Total"
-  },
-  "course.assessment.statistics.workflowState": {
-    "defaultMessage": "Status"
-  },
-  "course.assessment.statistics.ancestorFail": {
-    "defaultMessage": "Failed to fetch past iterations of this assessment."
-  },
-  "course.assessment.statistics.ancestorStatisticsFail": {
-    "defaultMessage": "Failed to fetch ancestor's statistics."
-  },
-  "course.assessment.statistics.fail": {
-    "defaultMessage": "Failed to fetch statistics."
-  },
-  "course.assessment.statistics.gradeDistribution": {
-    "defaultMessage": "Grade Distribution"
-  },
-  "course.assessment.statistics.gradeViolin.datasetLabel": {
-    "defaultMessage": "Distribution"
-  },
-  "course.assessment.statistics.gradeViolin.xAxisLabel": {
-    "defaultMessage": "Grades"
-  },
-  "course.assessment.statistics.gradeViolin.yAxisLabel": {
-    "defaultMessage": "Submissions"
-  },
-  "course.assessment.statistics.header": {
-    "defaultMessage": "Statistics for {title}"
+  "course.assessment.statistics.questionTitle": {
+    "defaultMessage": "Question {index}"
   },
   "course.assessment.statistics.statistics": {
     "defaultMessage": "Statistics"
   },
-  "course.assessment.statistics.SubmissionStatusChart.attempting": {
-    "defaultMessage": "Attempting"
-  },
-  "course.assessment.statistics.SubmissionStatusChart.datasetLabel": {
-    "defaultMessage": "Student Submission Statuses"
-  },
-  "course.assessment.statistics.SubmissionStatusChart.submitted": {
-    "defaultMessage": "Submitted"
-  },
-  "course.assessment.statistics.SubmissionStatusChart.unattempted": {
-    "defaultMessage": "Unattempted"
+  "course.assessment.statistics.submissionPage": {
+    "defaultMessage": "Go to Answer Page"
   },
   "course.assessment.statistics.submissionStatuses": {
     "defaultMessage": "Submission Statuses"
@@ -2573,8 +3017,20 @@
   "course.assessment.statistics.submissionTimeGradeChart.xAxisLabel.withoutDeadline": {
     "defaultMessage": "Submission Date"
   },
+  "course.assessment.statistics.total": {
+    "defaultMessage": "Total"
+  },
+  "course.assessment.statistics.workflowState": {
+    "defaultMessage": "Status"
+  },
   "course.assessment.submission.Annotations.comment": {
     "defaultMessage": "Add Comment"
+  },
+  "course.assessment.submission.Answer.missingAnswer": {
+    "defaultMessage": "There is no answer submitted for this question - this might be caused by the addition of this question after the submission is submitted."
+  },
+  "course.assessment.submission.Answer.rendererNotImplemented": {
+    "defaultMessage": "The display for this question type has not been implemented yet."
   },
   "course.assessment.submission.CodaveriFeedbackStatus.codaveriFeedbackStatus": {
     "defaultMessage": "Codaveri Feedback Status"
@@ -2594,14 +3050,41 @@
   "course.assessment.submission.EvaluatorErrorPanel.emailSubject": {
     "defaultMessage": "[Bug Report] Evaluator Error"
   },
+  "course.assessment.submission.FileInput.exactlyOneFileUploadAllowed": {
+    "defaultMessage": "*You must upload EXACTLY 1 file for this question"
+  },
+  "course.assessment.submission.FileInput.fileName": {
+    "defaultMessage": "{index}. {name}"
+  },
+  "course.assessment.submission.FileInput.fileTooLargeErrorMessage": {
+    "defaultMessage": "The following files have size larger than allowed ({maxAttachmentSize} MB)"
+  },
+  "course.assessment.submission.FileInput.fileUploadErrorTitle": {
+    "defaultMessage": "Error in Uploading Files"
+  },
+  "course.assessment.submission.FileInput.onlyOneFileUploadAllowed": {
+    "defaultMessage": "*You can only upload AT MOST {maxAttachments} file for this question"
+  },
+  "course.assessment.submission.FileInput.requiredUploadLimitedNumberOfFiles": {
+    "defaultMessage": "*You can upload AT LEAST 1 and AT MOST {maxAttachments} files for this question"
+  },
+  "course.assessment.submission.FileInput.tooManyFilesErrorMessage": {
+    "defaultMessage": "You have attempted to upload {numFiles} files, but ONLY {maxAttachmentsAllowed} {maxAttachmentsAllowed, plural, one {file} other {files}} can be uploaded {numAttachments, plural, =0 {} one {since 1 file has been uploaded before} other {since {numAttachments} files has been uploaded before}}"
+  },
   "course.assessment.submission.FileInput.uploadDisabled": {
     "defaultMessage": "File upload disabled"
   },
   "course.assessment.submission.FileInput.uploadLabel": {
     "defaultMessage": "Drag and drop or click to upload files"
   },
+  "course.assessment.submission.ImportedFileView.delete": {
+    "defaultMessage": "Delete"
+  },
   "course.assessment.submission.ImportedFileView.deleteConfirmation": {
-    "defaultMessage": "Are you sure you want to delete this file?"
+    "defaultMessage": "Are you sure you want to delete \"{fileName}\"?"
+  },
+  "course.assessment.submission.ImportedFileView.deleteTitle": {
+    "defaultMessage": "Delete File"
   },
   "course.assessment.submission.ImportedFileView.noFiles": {
     "defaultMessage": "No files uploaded."
@@ -2609,17 +3092,11 @@
   "course.assessment.submission.ImportedFileView.uploadedFiles": {
     "defaultMessage": "Uploaded Files:"
   },
-  "course.assessment.submission.Answer.missingAnswer": {
-    "defaultMessage": "There is no answer submitted for this question - this might be caused by the addition of this question after the submission is submitted."
+  "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.hoursMinutesSeconds": {
+    "defaultMessage": "{hrs, plural, one {# hour} other {# hours}} {mins, plural, =0 {} one {# minute} other {# minutes}} {secs, plural, =0 {} one {# second} other {# seconds}}"
   },
-  "course.assessment.submission.answers.AnswerHeader.noPastAnswers": {
-    "defaultMessage": "No past answers."
-  },
-  "course.assessment.submission.Answer.rendererNotImplemented": {
-    "defaultMessage": "The display for this question type has not been implemented yet."
-  },
-  "course.assessment.submission.SubmissionAnswer.viewPastAnswers": {
-    "defaultMessage": "Past Answers"
+  "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.minutesSeconds": {
+    "defaultMessage": "{secs, plural, one {# second} other {# seconds}}"
   },
   "course.assessment.submission.SubmissionsIndex.accessLogs": {
     "defaultMessage": "Access Logs"
@@ -2653,6 +3130,9 @@
   },
   "course.assessment.submission.SubmissionsIndex.experiencePoints": {
     "defaultMessage": "EXP Awarded"
+  },
+  "course.assessment.submission.SubmissionsIndex.fetchFromKoditsu": {
+    "defaultMessage": "Fetch Submissions from Koditsu"
   },
   "course.assessment.submission.SubmissionsIndex.forceSubmit": {
     "defaultMessage": "Force Submit Remaining"
@@ -2702,6 +3182,9 @@
   "course.assessment.submission.SubmissionsIndex.userName": {
     "defaultMessage": "Name"
   },
+  "course.assessment.submission.TestCaseView.allFailed": {
+    "defaultMessage": "All failed"
+  },
   "course.assessment.submission.TestCaseView.allPassed": {
     "defaultMessage": "All passed"
   },
@@ -2741,8 +3224,17 @@
   "course.assessment.submission.TestCaseView.standardOutput": {
     "defaultMessage": "Standard Output"
   },
+  "course.assessment.submission.TestCaseView.testCasesPassed": {
+    "defaultMessage": "{numPassed}/{numTestCases} passed"
+  },
   "course.assessment.submission.UploadedFileView.deleteConfirmation": {
-    "defaultMessage": "Are you sure you want to delete this attachment?"
+    "defaultMessage": "Are you sure you want to delete {fileName}?"
+  },
+  "course.assessment.submission.UploadedFileView.deleteTitle": {
+    "defaultMessage": "Delete File"
+  },
+  "course.assessment.submission.UploadedFileView.deleting": {
+    "defaultMessage": "Delete"
   },
   "course.assessment.submission.UploadedFileView.noFiles": {
     "defaultMessage": "No files uploaded."
@@ -2751,7 +3243,7 @@
     "defaultMessage": "Uploaded Files"
   },
   "course.assessment.submission.VoiceResponseAnswer.chooseVoiceFileExplain": {
-    "defaultMessage": "Drag your audio file here, or click to select an audio file. Only wav and mp3 formats are supported. Alternatively, you may use the recorder below to record your response"
+    "defaultMessage": "Drag and drop or click to upload your WAV / MP3 files. Alternatively, use the recorder below to record your response"
   },
   "course.assessment.submission.VoiceResponseAnswer.pleaseRecordYourVoice": {
     "defaultMessage": "Please record your voice"
@@ -2876,6 +3368,12 @@
   "course.assessment.submission.answerSubmitted": {
     "defaultMessage": "Answer Submitted"
   },
+  "course.assessment.submission.answers.AnswerHeader.noPastAnswers": {
+    "defaultMessage": "No past answers."
+  },
+  "course.assessment.submission.answers.AnswerHeader.viewPastAnswers": {
+    "defaultMessage": "Past Answers"
+  },
   "course.assessment.submission.answers.ForumPostResponse.ForumCard.forumCardTitleTypeNoneSelected": {
     "defaultMessage": "Forum"
   },
@@ -2948,11 +3446,23 @@
   "course.assessment.submission.answers.ForumPostResponse.TopicCard.viewTopicInNewTab": {
     "defaultMessage": "View Topic"
   },
-  "course.assessment.submission.answers.Programming.ProgrammingFile.downloadFile": {
-    "defaultMessage": "Download File"
-  },
   "course.assessment.submission.answers.Programming.ProgrammingFile.sizeTooBig": {
     "defaultMessage": "The file is too big and cannot be displayed."
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDelete": {
+    "defaultMessage": "Dismiss"
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDislike": {
+    "defaultMessage": "Dislike"
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLike": {
+    "defaultMessage": "Like"
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLineHeading": {
+    "defaultMessage": "Line {linenum}"
+  },
+  "course.assessment.submission.attachmentRequired": {
+    "defaultMessage": "*please upload AT LEAST 1 file for this question"
   },
   "course.assessment.submission.attemptedAt": {
     "defaultMessage": "Attempted At"
@@ -2977,12 +3487,6 @@
   },
   "course.assessment.submission.codaveriAutogradeFailure": {
     "defaultMessage": "There is an error while evaluating your code in Codaveri. Try submitting your code again in a couple of minutes or check the error message in the network response."
-  },
-  "course.assessment.submission.liveFeedbackNoneGenerated": {
-    "defaultMessage": "Question {questionIndex}: No feedback generated."
-  },
-  "course.assessment.submission.liveFeedbackSuccess": {
-    "defaultMessage": "Question {questionIndex}: Feedback successfully generated."
   },
   "course.assessment.submission.comment.CodaveriCommentCard.finalise": {
     "defaultMessage": "Finalise and Post Feedback"
@@ -3025,18 +3529,6 @@
   },
   "course.assessment.submission.comments": {
     "defaultMessage": "Comments"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDelete": {
-    "defaultMessage": "Dismiss"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDislike": {
-    "defaultMessage": "Dislike"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLike": {
-    "defaultMessage": "Like"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLineHeading": {
-    "defaultMessage": "Line {linenum}"
   },
   "course.assessment.submission.continue": {
     "defaultMessage": "Continue"
@@ -3083,6 +3575,9 @@
   "course.assessment.submission.emptyAssessment": {
     "defaultMessage": "This assessment currently has no questions."
   },
+  "course.assessment.submission.errorUnknown": {
+    "defaultMessage": "Error is Unknown"
+  },
   "course.assessment.submission.examDialogMessage": {
     "defaultMessage": "Please do not sign out or close the browser, otherwise you may have trouble continuing the exam."
   },
@@ -3091,6 +3586,15 @@
   },
   "course.assessment.submission.expAwarded": {
     "defaultMessage": "EXP Awarded"
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuConfirmation": {
+    "defaultMessage": "Are you sure you want to fetch all submissions from Koditsu? all the existing answers here will be overwritten by the newer one. NOTE THAT THIS ACTION IS IRREVERSIBLE!"
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuPending": {
+    "defaultMessage": "Please wait as the submissions are currently being fetched from Koditsu."
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuSuccess": {
+    "defaultMessage": "All submissions have been fetched successfully from Koditsu"
   },
   "course.assessment.submission.finalise": {
     "defaultMessage": "Finalise Submission"
@@ -3131,9 +3635,6 @@
   "course.assessment.submission.gradeSummary": {
     "defaultMessage": "Grade Summary"
   },
-  "course.assessment.submission.gradeUnsaved": {
-    "defaultMessage": "Unsaved"
-  },
   "course.assessment.submission.gradeUnsavedHint": {
     "defaultMessage": "This grade is not yet saved. Click Save Grade at the end of the page to save all grade changes."
   },
@@ -3158,8 +3659,23 @@
   "course.assessment.submission.invalidFileUpload": {
     "defaultMessage": "File uploads failed: Only java files can be uploaded"
   },
+  "course.assessment.submission.isSaved": {
+    "defaultMessage": "Saved"
+  },
+  "course.assessment.submission.isSaving": {
+    "defaultMessage": "Saving"
+  },
+  "course.assessment.submission.isUnsaved": {
+    "defaultMessage": "Unsaved"
+  },
   "course.assessment.submission.lateSubmission": {
     "defaultMessage": "This submission is LATE! You may want to penalize the student for late submission."
+  },
+  "course.assessment.submission.liveFeedbackNoneGenerated": {
+    "defaultMessage": "Question {questionIndex}: No feedback generated."
+  },
+  "course.assessment.submission.liveFeedbackSuccess": {
+    "defaultMessage": "Question {questionIndex}: Feedback successfully generated."
   },
   "course.assessment.submission.loadingComment": {
     "defaultMessage": "Loading comment field..."
@@ -3209,6 +3725,24 @@
   "course.assessment.submission.ok": {
     "defaultMessage": "OK"
   },
+  "course.assessment.submission.onlyOneAttachmentAllowed": {
+    "defaultMessage": "*ONLY 1 file is allowed for this question"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.attempting": {
+    "defaultMessage": "Attempting"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.graded": {
+    "defaultMessage": "Graded, unpublished"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.published": {
+    "defaultMessage": "Graded"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.submitted": {
+    "defaultMessage": "Submitted"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.unknown": {
+    "defaultMessage": "Unknown status, please contact administrator"
+  },
   "course.assessment.submission.pastAnswers": {
     "defaultMessage": "Past Answers"
   },
@@ -3254,6 +3788,12 @@
   "course.assessment.submission.reevaluate": {
     "defaultMessage": "Re-evaluate Answer"
   },
+  "course.assessment.submission.remainingBufferTime": {
+    "defaultMessage": "Finalising in: {timeLimit}"
+  },
+  "course.assessment.submission.remainingTime": {
+    "defaultMessage": "Time Remaining: {timeLimit}"
+  },
   "course.assessment.submission.rendererNotImplemented": {
     "defaultMessage": "The display for this question type has not been implemented yet."
   },
@@ -3277,6 +3817,15 @@
   },
   "course.assessment.submission.saveGrade": {
     "defaultMessage": "Save Grade"
+  },
+  "course.assessment.submission.saved": {
+    "defaultMessage": "Saved"
+  },
+  "course.assessment.submission.saving": {
+    "defaultMessage": "Saving"
+  },
+  "course.assessment.submission.savingFailed": {
+    "defaultMessage": "Saving Failed"
   },
   "course.assessment.submission.sendReminderEmailConfirmation": {
     "defaultMessage": "Send reminder emails to {unattempted} unattempted and {attempting} attempting user(s) ({selectedUsers}) who have not completed the assessment?"
@@ -3314,6 +3863,9 @@
   "course.assessment.submission.submissionBy": {
     "defaultMessage": "Submission by {name}"
   },
+  "course.assessment.submission.submissionError": {
+    "defaultMessage": "There is a problem in submitting question for {questions}"
+  },
   "course.assessment.submission.submissionsHeader": {
     "defaultMessage": "Submissions: {assessment}"
   },
@@ -3331,6 +3883,21 @@
   },
   "course.assessment.submission.submittedAt": {
     "defaultMessage": "Submitted At"
+  },
+  "course.assessment.submission.timeIsUp": {
+    "defaultMessage": "Time is Up!"
+  },
+  "course.assessment.submission.timedAssessmentDialogMessage": {
+    "defaultMessage": "{stillSomeTimeRemaining, select, true {Once the time is up, the assessment will be automatically finalised.} other {Finalising the submission now!}}"
+  },
+  "course.assessment.submission.timedAssessmentDialogTitle": {
+    "defaultMessage": "{stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {remaining}} to complete this assessment.} other {The assessment has ended!}}"
+  },
+  "course.assessment.submission.timedExamDialogMessage": {
+    "defaultMessage": "{stillSomeTimeRemaining, select, true {Please do not sign out or close the browser while attempting this exam. Once the time is up, the assessment will be automatically finalised.} other {Finalising the submission now!}}"
+  },
+  "course.assessment.submission.timedExamDialogTitle": {
+    "defaultMessage": "{stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {remaining}} to complete this exam.} other {The exam has ended!}}"
   },
   "course.assessment.submission.totalGrade": {
     "defaultMessage": "Total Grade"
@@ -3367,6 +3934,9 @@
   },
   "course.assessment.submission.updateFailure": {
     "defaultMessage": "Submission update failed: {errors}"
+  },
+  "course.assessment.submission.updateIndividualSuccess": {
+    "defaultMessage": "Submission for {errors} updated successfully"
   },
   "course.assessment.submission.updateSuccess": {
     "defaultMessage": "Submission updated successfully."
@@ -3485,6 +4055,18 @@
   "course.assessments.index.hasTodo": {
     "defaultMessage": "Has TODO"
   },
+  "course.assessments.index.inviteToKoditsu": {
+    "defaultMessage": "Invite users to Koditsu Exam"
+  },
+  "course.assessments.index.invitingUserToKoditsu": {
+    "defaultMessage": "Inviting users to Koditsu Exam"
+  },
+  "course.assessments.index.invitingUserToKoditsuFailure": {
+    "defaultMessage": "There is a problem in inviting users to Koditsu. Please try again later"
+  },
+  "course.assessments.index.invitingUserToKoditsuSuccess": {
+    "defaultMessage": "Successful in inviting users to Koditsu Exam"
+  },
   "course.assessments.index.neededFor": {
     "defaultMessage": "Needed for"
   },
@@ -3511,6 +4093,9 @@
   },
   "course.assessments.index.submissions": {
     "defaultMessage": "Submissions"
+  },
+  "course.assessments.index.timeLimitIcon": {
+    "defaultMessage": "Time Limit: {timeLimit, plural, one {# minute} other {# minutes}}"
   },
   "course.assessments.index.title": {
     "defaultMessage": "Title"
@@ -3962,14 +4547,14 @@
   "course.duplication.Duplication.duplicateData": {
     "defaultMessage": "Duplicate Data"
   },
-  "course.duplication.Duplication.fromCourse": {
-    "defaultMessage": "Duplicate Data from {courseTitle}"
-  },
   "course.duplication.Duplication.duplicationDisabled": {
     "defaultMessage": "Duplication is disabled for this course."
   },
   "course.duplication.Duplication.existingCourse": {
     "defaultMessage": "Existing Course"
+  },
+  "course.duplication.Duplication.fromCourse": {
+    "defaultMessage": "Duplicate data from {courseTitle}"
   },
   "course.duplication.Duplication.items": {
     "defaultMessage": "Selected Items"
@@ -4092,13 +4677,16 @@
     "defaultMessage": "Disburse Points"
   },
   "course.experiencePoints.disbursement.DisbursementIndex.disbursements": {
-    "defaultMessage": "Disburse Experience Points"
+    "defaultMessage": "Experience Points"
+  },
+  "course.experiencePoints.disbursement.DisbursementIndex.experienceTab": {
+    "defaultMessage": "History"
   },
   "course.experiencePoints.disbursement.DisbursementIndex.fetchDisbursementFailure": {
     "defaultMessage": "Failed to retrieve data."
   },
   "course.experiencePoints.disbursement.DisbursementIndex.forumTab": {
-    "defaultMessage": "Forum Participation"
+    "defaultMessage": "Forum Participation Disbursement"
   },
   "course.experiencePoints.disbursement.DisbursementIndex.generalTab": {
     "defaultMessage": "General Disbursement"
@@ -4127,6 +4715,15 @@
   "course.experiencePoints.disbursement.FilterForm.weeklyCap": {
     "defaultMessage": "Weekly Cap"
   },
+  "course.experiencePoints.disbursement.ForumDisbursement.fetchDisbursementFailure": {
+    "defaultMessage": "Failed to retrieve data."
+  },
+  "course.experiencePoints.disbursement.ForumDisbursement.fetchForumPostsFailure": {
+    "defaultMessage": "Failed to fetch forum posts."
+  },
+  "course.experiencePoints.disbursement.ForumDisbursement.postListDialogHeader": {
+    "defaultMessage": "Posts created between {startDate} and {endDate} by"
+  },
   "course.experiencePoints.disbursement.ForumDisbursementForm.createDisbursementFailure": {
     "defaultMessage": "Failed to award experience points."
   },
@@ -4135,9 +4732,6 @@
   },
   "course.experiencePoints.disbursement.ForumDisbursementForm.fetchForumPostsFailure": {
     "defaultMessage": "Failed to fetch forum posts."
-  },
-  "course.experiencePoints.disbursement.ForumDisbursementForm.postListDialogHeader": {
-    "defaultMessage": "Posts created between {startDate} and {endDate} by"
   },
   "course.experiencePoints.disbursement.ForumDisbursementForm.reason": {
     "defaultMessage": "Reason For Disbursement"
@@ -4177,6 +4771,27 @@
   },
   "course.experiencePoints.disbursement.ForumPostTable.voteTally": {
     "defaultMessage": "Vote Tally"
+  },
+  "course.experiencePoints.disbursement.GeneralDisbursement.fetchDisbursementFailure": {
+    "defaultMessage": "Failed to retrieve data."
+  },
+  "course.experiencePoints.downloadCsvButton": {
+    "defaultMessage": "Download CSV"
+  },
+  "course.experiencePoints.downloadFailure": {
+    "defaultMessage": "An error occurred while doing your request for download."
+  },
+  "course.experiencePoints.downloadPending": {
+    "defaultMessage": "Please wait as your request to download is being processed."
+  },
+  "course.experiencePoints.downloadRequestSuccess": {
+    "defaultMessage": "Your request to download is successful"
+  },
+  "course.experiencePoints.fetchRecordsFailure": {
+    "defaultMessage": "Failed to fetch records"
+  },
+  "course.experiencePoints.filterByNameButton": {
+    "defaultMessage": "Filter by Name"
   },
   "course.forum.FormShow.fetchTopicsFailure": {
     "defaultMessage": "Failed to retrieve forum topic data."
@@ -4415,20 +5030,17 @@
   "course.forum.HideButton.hide": {
     "defaultMessage": "Hide"
   },
-  "course.forum.HideButton.hideTooltip": {
-    "defaultMessage": "Hide topic from students"
-  },
   "course.forum.HideButton.hideFailure": {
     "defaultMessage": "Failed to hide the topic \"{title}\" - {error}"
   },
   "course.forum.HideButton.hideSuccess": {
     "defaultMessage": "The topic \"{title}\" has successfully been hidden."
   },
+  "course.forum.HideButton.hideTooltip": {
+    "defaultMessage": "Hide topic from students"
+  },
   "course.forum.HideButton.unhide": {
     "defaultMessage": "Unhide"
-  },
-  "course.forum.HideButton.unhideTooltip": {
-    "defaultMessage": "Show topic to students"
   },
   "course.forum.HideButton.unhideFailure": {
     "defaultMessage": "Failed to unhide the topic \"{title}\" - {error}"
@@ -4436,11 +5048,14 @@
   "course.forum.HideButton.unhideSuccess": {
     "defaultMessage": "The topic \"{title}\" has successfully been unhidden."
   },
-  "course.forum.LockButton.locked": {
-    "defaultMessage": "Lock"
+  "course.forum.HideButton.unhideTooltip": {
+    "defaultMessage": "Show topic to students"
   },
   "course.forum.LockButton.lockTooltip": {
     "defaultMessage": "Lock to stop students from posting in this topic"
+  },
+  "course.forum.LockButton.locked": {
+    "defaultMessage": "Lock"
   },
   "course.forum.LockButton.lockedFailure": {
     "defaultMessage": "Failed to locked the topic \"{title}\" - {error}"
@@ -4448,11 +5063,11 @@
   "course.forum.LockButton.lockedSuccess": {
     "defaultMessage": "The topic \"{title}\" has successfully been locked."
   },
-  "course.forum.LockButton.unlocked": {
-    "defaultMessage": "Unlock"
-  },
   "course.forum.LockButton.unlockTooltip": {
     "defaultMessage": "Unlock to allow students to post within this topic"
+  },
+  "course.forum.LockButton.unlocked": {
+    "defaultMessage": "Unlock"
   },
   "course.forum.LockButton.unlockedFailure": {
     "defaultMessage": "Failed to unlocked the topic \"{title}\" - {error}"
@@ -4835,8 +5450,26 @@
   "course.leaderboard.LeaderboardTable.average": {
     "defaultMessage": "Average"
   },
+  "course.leaderboard.LeaderboardTable.averageAchievements": {
+    "defaultMessage": "Average Achievements"
+  },
+  "course.leaderboard.LeaderboardTable.averageExperience": {
+    "defaultMessage": "Average Experience"
+  },
   "course.leaderboard.LeaderboardTable.experience": {
     "defaultMessage": "Experience"
+  },
+  "course.leaderboard.LeaderboardTable.level": {
+    "defaultMessage": "Level"
+  },
+  "course.leaderboard.LeaderboardTable.members": {
+    "defaultMessage": "Members"
+  },
+  "course.leaderboard.LeaderboardTable.name": {
+    "defaultMessage": "Name"
+  },
+  "course.leaderboard.LeaderboardTable.rank": {
+    "defaultMessage": "Rank"
   },
   "course.leaderboard.LeaderboardTable.titleAchievements": {
     "defaultMessage": "By Achievements"
@@ -5006,20 +5639,56 @@
   "course.level.Level.levelHeader": {
     "defaultMessage": "Levels"
   },
-  "course.level.Level.saveFailure": {
-    "defaultMessage": "Level saving failed, please try again."
+  "course.level.Level.orderedIncorrectly": {
+    "defaultMessage": "Levels will be sorted automatically when saved regardless of their order here."
   },
-  "course.level.Level.saveLevels": {
-    "defaultMessage": "Save Levels"
+  "course.level.Level.placeholder": {
+    "defaultMessage": "0"
+  },
+  "course.level.Level.reset": {
+    "defaultMessage": "Reset"
+  },
+  "course.level.Level.resetTooltip": {
+    "defaultMessage": "Reset changes"
+  },
+  "course.level.Level.saveChanges": {
+    "defaultMessage": "Save"
+  },
+  "course.level.Level.saveFailure": {
+    "defaultMessage": "Failed to save levels"
   },
   "course.level.Level.saveSuccess": {
     "defaultMessage": "Levels Saved"
   },
   "course.level.Level.thresholdHeader": {
-    "defaultMessage": "Threshold"
+    "defaultMessage": "EXP Threshold"
   },
-  "course.level.LevelRow.zeroThresholdError": {
-    "defaultMessage": "Experience points threshold cannot be 0"
+  "course.level.Level.unsavedChanges": {
+    "defaultMessage": "You have unsaved changes"
+  },
+  "course.material.files.DownloadingFilePage.clickToDownloadFile": {
+    "defaultMessage": "Download {name}"
+  },
+  "course.material.files.DownloadingFilePage.clickToDownloadFileDescription": {
+    "defaultMessage": "Something happened when initiating an automatic download. Click the link below to immediately download the file."
+  },
+  "course.material.files.DownloadingFilePage.downloading": {
+    "defaultMessage": "Downloading {name}"
+  },
+  "course.material.files.DownloadingFilePage.downloadingDescription": {
+    "defaultMessage": "This file should start downloading automatically now. If it doesn't, you can try again by clicking the link below or refreshing this page."
+  },
+  "course.material.files.DownloadingFilePage.tryDownloadingAgain": {
+    "defaultMessage": "Try downloading again"
+  },
+  "course.material.files.ErrorRetrievingFilePage.goToTheWorkbin": {
+    "defaultMessage": "Go to the Workbin"
+  },
+  "course.material.files.ErrorRetrievingFilePage.problemRetrievingFile": {
+    "defaultMessage": "Problem retrieving file"
+  },
+  "course.material.files.ErrorRetrievingFilePage.problemRetrievingFileDescription": {
+    "defaultMessage": "Either it no longer exists, you don't have the permission to access it, or something unexpected happened when we were trying to retrieve it."
   },
   "course.material.folders.DownloadFolderButton.downloadFolderErrorMessage": {
     "defaultMessage": "Download has failed. Please try again later."
@@ -5029,6 +5698,15 @@
   },
   "course.material.folders.DownloadFolderButton.downloading": {
     "defaultMessage": "Downloading..."
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.goToMainFolder": {
+    "defaultMessage": "Go to the main folder"
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolder": {
+    "defaultMessage": "Problem retrieving folder"
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolderDescription": {
+    "defaultMessage": "Either it no longer exists, you don't have the permission to access it, or something unexpected happened when we were trying to retrieve it."
   },
   "course.material.folders.FolderEdit.editSubfolderTitle": {
     "defaultMessage": "Edit Folder"
@@ -5068,6 +5746,9 @@
   },
   "course.material.folders.FolderShow.defaultHeader": {
     "defaultMessage": "Materials"
+  },
+  "course.material.folders.FolderShow.folderNotFound": {
+    "defaultMessage": "Folder not found"
   },
   "course.material.folders.MaterialEdit.editMaterialTitle": {
     "defaultMessage": "Edit Material"
@@ -5114,6 +5795,15 @@
   "course.material.folders.UploadFilesButton.uploadFilesTooltip": {
     "defaultMessage": "Upload"
   },
+  "course.material.folders.WorkbinTable.lastModified": {
+    "defaultMessage": "Last Modified"
+  },
+  "course.material.folders.WorkbinTable.name": {
+    "defaultMessage": "Name"
+  },
+  "course.material.folders.WorkbinTable.startAt": {
+    "defaultMessage": "Start At"
+  },
   "course.material.folders.WorkbinTableButtons.DeletionFailure": {
     "defaultMessage": "could not be deleted"
   },
@@ -5126,20 +5816,65 @@
   "course.material.folders.WorkbinTableButtons.tableButtonDeleteTooltip": {
     "defaultMessage": "Delete"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.achievementCount": {
-    "defaultMessage": "No. of Achievements (Total: {courseAchievementCount})"
+  "course.statistics.StatisticsIndex.assessments.averageGrade": {
+    "defaultMessage": "Avg Grade"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.ascending": {
-    "defaultMessage": "Ascending"
+  "course.statistics.StatisticsIndex.assessments.averageTimeTaken": {
+    "defaultMessage": "Avg Time"
+  },
+  "course.statistics.StatisticsIndex.assessments.category": {
+    "defaultMessage": "Category"
+  },
+  "course.statistics.StatisticsIndex.assessments.csvFileTitle": {
+    "defaultMessage": "Assessments Statistics"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadCsv": {
+    "defaultMessage": "Download Score Summary for the following Assessments?"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummaryFailure": {
+    "defaultMessage": "An error occurred while downloading score summary"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummaryPending": {
+    "defaultMessage": "Please wait as your request to download is being processed"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummarySuccess": {
+    "defaultMessage": "Successfully downloaded score summary"
+  },
+  "course.statistics.StatisticsIndex.assessments.numLateStudents": {
+    "defaultMessage": "# Late"
+  },
+  "course.statistics.StatisticsIndex.assessments.numSubmittedStudents": {
+    "defaultMessage": "# Attempted"
+  },
+  "course.statistics.StatisticsIndex.assessments.searchBar": {
+    "defaultMessage": "Search by Assessment Title, Tab, or Category"
+  },
+  "course.statistics.StatisticsIndex.assessments.selectedNUsers": {
+    "defaultMessage": "Download Score Summary ({n, plural, =1 {# assessment} other {# assessments}})"
+  },
+  "course.statistics.StatisticsIndex.assessments.startAt": {
+    "defaultMessage": "Starts At"
+  },
+  "course.statistics.StatisticsIndex.assessments.stdevGrade": {
+    "defaultMessage": "Stdev Grade"
+  },
+  "course.statistics.StatisticsIndex.assessments.stdevTimeTaken": {
+    "defaultMessage": "Stdev Time"
+  },
+  "course.statistics.StatisticsIndex.assessments.tab": {
+    "defaultMessage": "Tab"
+  },
+  "course.statistics.StatisticsIndex.assessments.tableTitle": {
+    "defaultMessage": "Assessments Statistics ({numStudents} students)"
+  },
+  "course.statistics.StatisticsIndex.assessments.title": {
+    "defaultMessage": "Title"
+  },
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.achievementCountDetails": {
+    "defaultMessage": "No. of Achievements (Total: {courseAchievementCount})"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.correctness": {
     "defaultMessage": "Correctness"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.correctnessHint": {
-    "defaultMessage": "Correctness is the average grade percentage of all graded assessments by a student."
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.descending": {
-    "defaultMessage": "Descending"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.experiencePoints": {
     "defaultMessage": "Experience Points"
@@ -5148,19 +5883,13 @@
     "defaultMessage": "Tutors"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.highlight": {
-    "defaultMessage": "Highlight top and bottom {percent}%"
+    "defaultMessage": "Highlight top and bottom {percent}% based on {criteria}"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.learningRate": {
     "defaultMessage": "Learning Rate"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.learningRateHint": {
-    "defaultMessage": "A learning rate of 200% means that they can complete the course in half the time."
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.level": {
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.levelInfo": {
     "defaultMessage": "Level (Max: {maxLevel})"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.levelFilter": {
-    "defaultMessage": "Level: {name}"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.name": {
     "defaultMessage": "Name"
@@ -5168,11 +5897,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.noData": {
     "defaultMessage": "No Data"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.numSubmissions": {
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.numSubmissionsDetails": {
     "defaultMessage": "No. of Submissions (Total: {courseAssessmentCount})"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.phantom": {
-    "defaultMessage": "Include phantom users"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.studentType": {
     "defaultMessage": "Student Type"
@@ -5183,17 +5909,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.studentType.phantom": {
     "defaultMessage": "Phantom"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.tableTitle": {
-    "defaultMessage": "Students Sorted in {direction} {column}"
-  },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.title": {
     "defaultMessage": "Student Performance"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.tutorFilter": {
-    "defaultMessage": "Tutor: {name}"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.videoPercentWatched": {
-    "defaultMessage": "Video % Count"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.videoPercentWatchedHeader": {
     "defaultMessage": "Average Video % Watched"
@@ -5231,14 +5948,14 @@
   "course.statistics.StatisticsIndex.course.StudentProgressionChart.yAxisLabel": {
     "defaultMessage": "Assessment (Sorted by Deadline)"
   },
-  "course.statistics.StatisticsIndex.course.error": {
-    "defaultMessage": "Something went wrong when fetching course statistics! Please refresh to try again."
+  "course.statistics.StatisticsIndex.course.csvFileTitle": {
+    "defaultMessage": "Student Performance Statistics"
   },
-  "course.statistics.StatisticsIndex.course.performanceError": {
-    "defaultMessage": "Something went wrong when fetching course performance statistics! Please refresh to try again."
+  "course.statistics.StatisticsIndex.course.searchBar": {
+    "defaultMessage": "Search by Student Name"
   },
-  "course.statistics.StatisticsIndex.course.progressionError": {
-    "defaultMessage": "Something went wrong when fetching course progression statistics! Please refresh to try again."
+  "course.statistics.StatisticsIndex.header.assessments": {
+    "defaultMessage": "Assessments"
   },
   "course.statistics.StatisticsIndex.header.statistics": {
     "defaultMessage": "Statistics"
@@ -5246,8 +5963,8 @@
   "course.statistics.StatisticsIndex.staff.averageMarkingTime": {
     "defaultMessage": "Avg Time / Assessment"
   },
-  "course.statistics.StatisticsIndex.staff.error": {
-    "defaultMessage": "Something went wrong when fetching staff statistics! Please refresh to try again."
+  "course.statistics.StatisticsIndex.staff.csvFileTitle": {
+    "defaultMessage": "Staff Statistics"
   },
   "course.statistics.StatisticsIndex.staff.name": {
     "defaultMessage": "Name"
@@ -5258,17 +5975,17 @@
   "course.statistics.StatisticsIndex.staff.numStudents": {
     "defaultMessage": "# Students"
   },
+  "course.statistics.StatisticsIndex.staff.searchBar": {
+    "defaultMessage": "Search by Staff Name"
+  },
   "course.statistics.StatisticsIndex.staff.stddev": {
-    "defaultMessage": "Standard Deviation"
+    "defaultMessage": "Stdev Time / Assessment"
   },
   "course.statistics.StatisticsIndex.staff.tableTitle": {
     "defaultMessage": "Staff Statistics"
   },
-  "course.statistics.StatisticsIndex.staffFailure": {
-    "defaultMessage": "Failed to fetch staff data!"
-  },
-  "course.statistics.StatisticsIndex.students.error": {
-    "defaultMessage": "Something went wrong when fetching student statistics! Please refresh to try again."
+  "course.statistics.StatisticsIndex.students.csvFileTitle": {
+    "defaultMessage": "Student Statistics"
   },
   "course.statistics.StatisticsIndex.students.experiencePoints": {
     "defaultMessage": "Experience Points"
@@ -5282,20 +5999,14 @@
   "course.statistics.StatisticsIndex.students.name": {
     "defaultMessage": "Name"
   },
-  "course.statistics.StatisticsIndex.students.noStudents": {
-    "defaultMessage": "There is no student in this course, yet..."
-  },
-  "course.statistics.StatisticsIndex.students.showMyStudentsOnly": {
-    "defaultMessage": "Show My Students Only"
+  "course.statistics.StatisticsIndex.students.searchBar": {
+    "defaultMessage": "Search by Students Name or Student Type"
   },
   "course.statistics.StatisticsIndex.students.studentsType": {
     "defaultMessage": "Student Type"
   },
   "course.statistics.StatisticsIndex.students.tableTitle": {
     "defaultMessage": "Student Statistics ({numStudents} students, {numPhantom} phantom)"
-  },
-  "course.statistics.StatisticsIndex.students.tutorFilter": {
-    "defaultMessage": "Tutor: {name}"
   },
   "course.statistics.StatisticsIndex.students.videoPercentWatched": {
     "defaultMessage": "Average % Watched"
@@ -5321,14 +6032,26 @@
   "course.statistics.course.studentProgressionChart.startAt": {
     "defaultMessage": "Starts at: {startAt}"
   },
-  "course.statistics.failures.coursePerformance": {
-    "defaultMessage": "Failed to fetch course performance data!"
-  },
-  "course.statistics.failures.courseProgression": {
-    "defaultMessage": "Failed to fetch course progression data!"
-  },
   "course.statistics.tabs.course": {
     "defaultMessage": "Course"
+  },
+  "course.statistics.tabs.coursePerformance": {
+    "defaultMessage": "Course Performance"
+  },
+  "course.statistics.tabs.courseProgression": {
+    "defaultMessage": "Course Progression"
+  },
+  "course.stories.CikgoErrorPage.errorFetching": {
+    "defaultMessage": "Either it's supposed to be naught, or something went wrong."
+  },
+  "course.stories.CikgoErrorPage.errorFetchingDescription": {
+    "defaultMessage": "<cikgo>Cikgo</cikgo> is our partner that powers this experience. They were contactable, but did not give us any resources for this request just now. Please try again later, and if this persists, <link>contact us</link>."
+  },
+  "course.stories.pages.LearnPage": {
+    "defaultMessage": "Learn"
+  },
+  "course.stories.pages.MissionControlPage": {
+    "defaultMessage": "Mission Control"
   },
   "course.survey.DeleteSectionButton.deleteSection": {
     "defaultMessage": "Delete Section"
@@ -5987,6 +6710,9 @@
   "course.userInvitation.InviteUsersRegistrationCode.registrationCodeNote": {
     "defaultMessage": "Users who have been invited and use this invitation code to register for the course would not have the proper status reflected in the Invitations page."
   },
+  "course.userInvitations.IndividualInvitations.addRowsByEmail": {
+    "defaultMessage": "Add Rows by Email"
+  },
   "course.userInvitations.IndividualInvitations.appendNewRow": {
     "defaultMessage": "Add Row"
   },
@@ -5995,6 +6721,12 @@
   },
   "course.userInvitations.IndividualInvitations.invite": {
     "defaultMessage": "Invite All Users"
+  },
+  "course.userInvitations.IndividualInvitations.malformedEmail": {
+    "defaultMessage": "{n, plural, one {This email is } other {These emails are }} wrongly formatted: {emails}"
+  },
+  "course.userInvitations.IndividualInvitations.nameEmailInput": {
+    "defaultMessage": "John Doe '<john.doe@example.org'>; \"Doe, Jane\" '<jane.doe@example.org'>; ..."
   },
   "course.userInvitations.IndividualInvitations.namePlaceholder": {
     "defaultMessage": "Awesome User"
@@ -6163,12 +6895,6 @@
   },
   "course.users.ExperiencePointsRecords.experiencePointsHistoryHeader": {
     "defaultMessage": "Experience Points History: {for}"
-  },
-  "course.users.ExperiencePointsRecords.fetchUsersFailure": {
-    "defaultMessage": "Failed to fetch records"
-  },
-  "course.users.ExperiencePointsTable.fetchRecordsFailure": {
-    "defaultMessage": "Failed to fetch records"
   },
   "course.users.ManageStaff.noStaff": {
     "defaultMessage": "No staff in course."
@@ -6485,8 +7211,26 @@
   "course.video.VideoShow.videoTitle": {
     "defaultMessage": "Video - {title}"
   },
+  "course.video.VideoTable.actions": {
+    "defaultMessage": "Actions"
+  },
+  "course.video.VideoTable.averageWatched": {
+    "defaultMessage": "Average % Watched"
+  },
   "course.video.VideoTable.noVideo": {
     "defaultMessage": "No Video"
+  },
+  "course.video.VideoTable.published": {
+    "defaultMessage": "Published"
+  },
+  "course.video.VideoTable.startAt": {
+    "defaultMessage": "Start At"
+  },
+  "course.video.VideoTable.title": {
+    "defaultMessage": "Title"
+  },
+  "course.video.VideoTable.watchCount": {
+    "defaultMessage": "Watch Count"
   },
   "course.video.VideosIndex.fetchVideosFailure": {
     "defaultMessage": "Failed to retrieve videos."
@@ -6637,6 +7381,21 @@
   },
   "landing_page.create_an_account": {
     "defaultMessage": "Create an account"
+  },
+  "landing_page.iconEngaging": {
+    "defaultMessage": "Engaging"
+  },
+  "landing_page.iconEngagingSubtitle": {
+    "defaultMessage": "It is built for all teachers. You do not need to have any programming knowledge to master the platform. Coursemology is easy and intuitive to use for both teachers and students."
+  },
+  "landing_page.iconGeneral": {
+    "defaultMessage": "General"
+  },
+  "landing_page.iconGeneralSubtitle": {
+    "defaultMessage": "It is built for all subjects. The gamification system of Coursemology does not make any assumptions on the subject. Through Coursemology, any teacher who teaches any subject can turn his course exercises into an online game."
+  },
+  "landing_page.iconSimple": {
+    "defaultMessage": "Simple"
   },
   "landing_page.new_to_coursemology": {
     "defaultMessage": "New to Coursemology?"
@@ -7160,9 +7919,6 @@
   "lib.translations.yes": {
     "defaultMessage": "Yes"
   },
-  "material.attemptLoader.errorAccessingMaterial": {
-    "defaultMessage": "An error occurred while accessing this material. Try again later."
-  },
   "sysstem.admin.instance.instance.InstanceAdminNavigator.announcements": {
     "defaultMessage": "Announcements"
   },
@@ -7277,14 +8033,23 @@
   "system.admin.admin.InstancesTable.updateSuccess": {
     "defaultMessage": "Renamed {field} from {prevValue} to {newValue}"
   },
+  "system.admin.admin.UsersButton.associatedInstances": {
+    "defaultMessage": "{index}. {instanceName}"
+  },
   "system.admin.admin.UsersButton.deleteTooltip": {
     "defaultMessage": "Delete User"
   },
   "system.admin.admin.UsersButton.deletionConfirm": {
-    "defaultMessage": "Are you sure you wish to delete {role} {name} ({email})?"
+    "defaultMessage": "Are you sure?"
+  },
+  "system.admin.admin.UsersButton.deletionConfirmTitle": {
+    "defaultMessage": "Deleting {role} {name} ({email})"
   },
   "system.admin.admin.UsersButton.deletionFailure": {
     "defaultMessage": "Failed to delete user - {error}"
+  },
+  "system.admin.admin.UsersButton.deletionPromptContent": {
+    "defaultMessage": "After deleting this user, all associated instance users in the following instances will be deleted."
   },
   "system.admin.admin.UsersButton.deletionSuccess": {
     "defaultMessage": "User was deleted."

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -6,7 +6,7 @@
     "defaultMessage": "모든 공지사항"
   },
   "app.BrandingItem.coursemology": {
-    "defaultMessage": "코스몰로지"
+    "defaultMessage": "Coursemology"
   },
   "app.BrandingItem.goToOtherCourses": {
     "defaultMessage": "강좌"
@@ -251,6 +251,24 @@
   "course.achievement.AchievementAward.AchievementAwardManager.saveChanges": {
     "defaultMessage": "변경 사항 저장"
   },
+  "course.achievement.AchievementAward.AchievementAwardSummary.awardedStudents": {
+    "defaultMessage": "수상한 학생들"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.name": {
+    "defaultMessage": "이름"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.normalStudent": {
+    "defaultMessage": "평범한 학생"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.phantomStudent": {
+    "defaultMessage": "팬텀 학생"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.revokedStudents": {
+    "defaultMessage": "퇴학생"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.userType": {
+    "defaultMessage": "사용자 유형"
+  },
   "course.achievement.AchievementAward.awardAchievement": {
     "defaultMessage": "성과 부여"
   },
@@ -323,8 +341,26 @@
   "course.achievement.AchievementShow.studentsWithAchievement": {
     "defaultMessage": "이 성과를 가진 학생들"
   },
+  "course.achievement.AchievementTable.actions": {
+    "defaultMessage": "행동"
+  },
+  "course.achievement.AchievementTable.badge": {
+    "defaultMessage": "배지"
+  },
+  "course.achievement.AchievementTable.description": {
+    "defaultMessage": "설명"
+  },
   "course.achievement.AchievementTable.noAchievement": {
     "defaultMessage": "성과 없음"
+  },
+  "course.achievement.AchievementTable.published": {
+    "defaultMessage": "출판된"
+  },
+  "course.achievement.AchievementTable.requirements": {
+    "defaultMessage": "요구 사항"
+  },
+  "course.achievement.AchievementTable.title": {
+    "defaultMessage": "제목"
   },
   "course.achievement.AchievementsIndex.achievements": {
     "defaultMessage": "성과"
@@ -470,6 +506,9 @@
   "course.admin.CodaveriSettings.Some": {
     "defaultMessage": "일부"
   },
+  "course.admin.CodaveriSettings.assessments": {
+    "defaultMessage": "평가"
+  },
   "course.admin.CodaveriSettings.codaveriEngine": {
     "defaultMessage": "코다베리 엔진"
   },
@@ -503,17 +542,17 @@
   "course.admin.CodaveriSettings.enableDisableLiveFeedback": {
     "defaultMessage": "{enabled, select, true {활성화} other {비활성화}} {questionCount}개의 프로그래밍 질문에 대한 실시간 피드백 {title}?"
   },
-  "course.admin.CodaveriSettings.enableIsOnlyITSP": {
-    "defaultMessage": "ITSP 활성화"
-  },
-  "course.admin.CodaveriSettings.error": {
-    "defaultMessage": "코다베리 설정을 업데이트하는 동안 오류가 발생했습니다."
-  },
   "course.admin.CodaveriSettings.errorOccurredWhenUpdatingCodaveriEvaluatorSettings": {
     "defaultMessage": "코다베리 평가자 설정을 업데이트하는 동안 오류가 발생했습니다."
   },
   "course.admin.CodaveriSettings.errorOccurredWhenUpdatingLiveFeedbackSettings": {
     "defaultMessage": "실시간 피드백 설정을 업데이트하는 동안 오류가 발생했습니다."
+  },
+  "course.admin.CodaveriSettings.evaluatorUpdateSuccess": {
+    "defaultMessage": "{question}은(는) 이제 {evaluator} 평가자를 사용 중입니다"
+  },
+  "course.admin.CodaveriSettings.expandAll": {
+    "defaultMessage": "모든 질문 펼치기"
   },
   "course.admin.CodaveriSettings.feedbackWorkflow": {
     "defaultMessage": "자동 게시 제출 댓글"
@@ -542,6 +581,15 @@
   "course.admin.CodaveriSettings.liveFeedbackSettings": {
     "defaultMessage": "실시간 피드백"
   },
+  "course.admin.CodaveriSettings.programmingQuestionSettings": {
+    "defaultMessage": "프로그래밍 문제 설정"
+  },
+  "course.admin.CodaveriSettings.programmingQuestionSettingsSubtitle": {
+    "defaultMessage": "다양한 평가에서 프로그래밍 문제의 Codaveri를 평가자로 활성화/비활성화합니다."
+  },
+  "course.admin.CodaveriSettings.succesfulUpdateAllEvaluator": {
+    "defaultMessage": "모든 질문이 {evaluator} 평가자를 사용하도록 성공적으로 업데이트되었습니다"
+  },
   "course.admin.CodaveriSettings.successfulUpdateAllLiveFeedbackEnabled": {
     "defaultMessage": "모든 질문에 대해 {liveFeedbackEnabled, select, true {활성화} other {비활성화}}된 실시간 피드백이 성공적으로 {liveFeedbackEnabled, select, true {활성화} other {비활성화}}되었습니다"
   },
@@ -556,6 +604,9 @@
   },
   "course.admin.ComponentSettings.errorOccurredWhenUpdatingComponents": {
     "defaultMessage": "컴포넌트 설정을 업데이트하는 동안 오류가 발생했습니다."
+  },
+  "course.admin.ComponentSettings.settingUpComponent": {
+    "defaultMessage": "이 강좌를 위한 구성 요소 설정"
   },
   "course.admin.CourseSettings.allowUsersToSendEnrolmentRequests": {
     "defaultMessage": "사용자가 등록 요청을 보낼 수 있도록 허용"
@@ -797,6 +848,9 @@
   "course.admin.LessonPlanSettings.lessonPlanItemSettings": {
     "defaultMessage": "교육 계획 항목 설정"
   },
+  "course.admin.LessonPlanSettings.lessonPlanSettings": {
+    "defaultMessage": "수업 계획 설정"
+  },
   "course.admin.LessonPlanSettings.noLessonPlanItems": {
     "defaultMessage": "교육 계획 디스플레이를 구성할 수 있는 교육 계획 항목이 없습니다."
   },
@@ -992,6 +1046,51 @@
   "course.admin.courseSettings": {
     "defaultMessage": "강좌 설정"
   },
+  "course.admin.storiesSettings.autoCreateAccounts": {
+    "defaultMessage": "Cikgo의 사용자 계정 및 채팅방은 아직 존재하지 않는 경우 자동으로 생성됩니다. Cikgo와 공유된 정보는 <ourPpLink>개인정보 처리방침</ourPpLink> 및 <cikgoPpLink>Cikgo의 개인정보 처리방침</cikgoPpLink>에 따라 관리됩니다."
+  },
+  "course.admin.storiesSettings.integrationHint": {
+    "defaultMessage": "Cikgo에 대한 귀하의 강좌를 이 강좌와 통합하려면 여기에 해당 통합 키를 입력하십시오. 이 강좌가 Cikgo와 통합되면 무슨 일이 일어날지 여기 있습니다."
+  },
+  "course.admin.storiesSettings.integrationSettings": {
+    "defaultMessage": "통합 설정"
+  },
+  "course.admin.storiesSettings.learnTitle": {
+    "defaultMessage": "페이지 제목 배우기"
+  },
+  "course.admin.storiesSettings.leaveEmptyToUseDefaultTitle": {
+    "defaultMessage": "기본 '학습' 제목을 사용하려면 비워 두세요."
+  },
+  "course.admin.storiesSettings.onlyOwnersCanManage": {
+    "defaultMessage": "Cikgo와 이 과정의 통합은 귀하와 소유자, 관리자만 설정할 수 있습니다."
+  },
+  "course.admin.storiesSettings.pingError": {
+    "defaultMessage": "Cikgo에 연결하는 데 문제가 있었습니다. 나중에 다시 시도해보실 수 있습니다."
+  },
+  "course.admin.storiesSettings.publishTaskCompletions": {
+    "defaultMessage": "학생의 제출 상태는 Cikgo의 채팅방에 반영됩니다."
+  },
+  "course.admin.storiesSettings.pushKey": {
+    "defaultMessage": "통합 키"
+  },
+  "course.admin.storiesSettings.pushKeyError": {
+    "defaultMessage": "이 통합 키는 Cikgo의 유효한 강좌를 가리키지 않습니다. Cikgo의 설정을 확인하고 다시 시도해주세요."
+  },
+  "course.admin.storiesSettings.pushKeyHint": {
+    "defaultMessage": "통합 키는 기밀사항은 아니지만, 조심히 다뤄야 합니다."
+  },
+  "course.admin.storiesSettings.pushKeyPointsToCourse": {
+    "defaultMessage": "이 통합 키는 Cikgo의 <link>{course}</link>을(를) 가리킵니다."
+  },
+  "course.admin.storiesSettings.redirects": {
+    "defaultMessage": "학생들이 이 <link>코스 루트 URL</link>에 접속하면, 학습 페이지로 리디렉션됩니다. 홈페이지는 여전히 사이드바에서 접근할 수 있습니다."
+  },
+  "course.admin.storiesSettings.storiesSettings": {
+    "defaultMessage": "이야기 설정"
+  },
+  "course.admin.storiesSettings.syncs": {
+    "defaultMessage": "이 강좌에 게시된 평가, 비디오 및 설문 조사 자료는 자원으로서 Cikgo와 동기화되어 제공됩니다."
+  },
   "course.announcement.AnnouncementsDisplay.searchBarPlaceholder": {
     "defaultMessage": "제목이나 내용으로 검색"
   },
@@ -1103,14 +1202,17 @@
   "course.assessment.AssessmentForm.blockStudentViewingAfterSubmittedHint": {
     "defaultMessage": "학생은 성적이 발표된 후에만 제출물을 볼 수 있습니다."
   },
+  "course.assessment.AssessmentForm.blocksAccessesFromInvalidSUS": {
+    "defaultMessage": "잘못된 UA를 가진 브라우저로부터의 접근 차단"
+  },
+  "course.assessment.AssessmentForm.blocksAccessesFromInvalidSUSHint": {
+    "defaultMessage": "활성화된 경우, 지정된 SUS를 포함하지 않는 무효한 UA를 사용하는 응시자는 이 평가에 액세스하는 것이 차단됩니다. 강사는 세션 잠금 비밀번호로 액세스를 재설정할 수 있습니다. 재설정된 브라우저 세션에서의 하트비트는 PulseGrid에서 유효로 표시됩니다."
+  },
   "course.assessment.AssessmentForm.bonusEndAt": {
     "defaultMessage": "보너스 종료 시각"
   },
   "course.assessment.AssessmentForm.calculateGradeWith": {
     "defaultMessage": "등급 및 EXP 계산"
-  },
-  "course.assessment.AssessmentForm.canEnableCodaveriInComponents": {
-    "defaultMessage": "이 기능을 구성 요소에서 활성화하려면 강좌 관리자나 소유자에게 연락하십시오."
   },
   "course.assessment.AssessmentForm.delayedGradePublication": {
     "defaultMessage": "연기된 성적 발표 활성화"
@@ -1172,11 +1274,23 @@
   "course.assessment.AssessmentForm.hasPersonalTimesHint": {
     "defaultMessage": "이 항목의 타이밍은 학습 속도에 따라 사용자를 위해 자동으로 조정됩니다."
   },
+  "course.assessment.AssessmentForm.hasTimeLimit": {
+    "defaultMessage": "타이머가 종료되면 자동으로 제출됩니다"
+  },
+  "course.assessment.AssessmentForm.hasTimeLimitHint": {
+    "defaultMessage": "활성화되면 각 제출물은 자체 타이머를 가지고 있으며 해당 타이머가 종료되면 자동으로 완료됩니다."
+  },
   "course.assessment.AssessmentForm.hasToBeMoreThanMinInterval": {
     "defaultMessage": "최소값보다 커야 합니다."
   },
   "course.assessment.AssessmentForm.hasToBeMoreThanValueMs": {
     "defaultMessage": "적어도 3000ms 이상이어야 합니다."
+  },
+  "course.assessment.AssessmentForm.hasToBeNumber": {
+    "defaultMessage": "유효한 숫자여야 합니다."
+  },
+  "course.assessment.AssessmentForm.hasToBePositive": {
+    "defaultMessage": "양수여야 합니다."
   },
   "course.assessment.AssessmentForm.hasToBePositiveInteger": {
     "defaultMessage": "86,400,000ms 미만의 양의 정수여야 합니다"
@@ -1190,6 +1304,12 @@
   "course.assessment.AssessmentForm.intervalHint": {
     "defaultMessage": "학생의 브라우저에서 하트비트가 전송되는 빈도를 제어합니다. 간격은 이 두 범위 사이에서 무작위화됩니다."
   },
+  "course.assessment.AssessmentForm.koditsuDisabledInCourse": {
+    "defaultMessage": "코스 설정에서 Koditsu 시험을 활성화하려면 코스 관리자에게 문의하십시오."
+  },
+  "course.assessment.AssessmentForm.liveFeedback": {
+    "defaultMessage": "도움받기"
+  },
   "course.assessment.AssessmentForm.maxInterval": {
     "defaultMessage": "최대 간격"
   },
@@ -1199,8 +1319,14 @@
   "course.assessment.AssessmentForm.minInterval": {
     "defaultMessage": "최소 간격"
   },
+  "course.assessment.AssessmentForm.minutes": {
+    "defaultMessage": "분"
+  },
   "course.assessment.AssessmentForm.modeSwitchingHint": {
     "defaultMessage": "이 과제에 대한 제출물이 이미 있으므로 더 이상 채점 방식을 변경할 수 없습니다."
+  },
+  "course.assessment.AssessmentForm.needSUSAndSessionUnlockPassword": {
+    "defaultMessage": "이 작업을 활성화하려면 SUS 및 세션 잠금 비밀번호를 지정해야 합니다."
   },
   "course.assessment.AssessmentForm.noProgrammingQuestion": {
     "defaultMessage": "이 평가에서 실시간 피드백을 활성화하려면 적어도 하나의 프로그래밍 질문을 추가해야 합니다."
@@ -1229,11 +1355,17 @@
   "course.assessment.AssessmentForm.personalisedTimelines": {
     "defaultMessage": "개별화 시간표"
   },
+  "course.assessment.AssessmentForm.proctorWithKoditsu": {
+    "defaultMessage": "Kositsu을 사용하여 프록터 시험"
+  },
   "course.assessment.AssessmentForm.published": {
     "defaultMessage": "게시됨"
   },
   "course.assessment.AssessmentForm.publishedHint": {
     "defaultMessage": "모두가 이 평가를 볼 수 있습니다."
+  },
+  "course.assessment.AssessmentForm.questionsIncompatibleWithKoditsu": {
+    "defaultMessage": "Koditsu에서 감독을 활성화하기 전에 이 평가의 모든 질문이 Koditsu와 호환되는지 확인해주세요."
   },
   "course.assessment.AssessmentForm.secret": {
     "defaultMessage": "비밀 UA 서브스트링 (SUS)"
@@ -1243,9 +1375,6 @@
   },
   "course.assessment.AssessmentForm.sessionPassword": {
     "defaultMessage": "세션 잠금 비밀번호"
-  },
-  "course.assessment.AssessmentForm.sessionPasswordHint": {
-    "defaultMessage": "이상적으로는 이 비밀번호를 학생에게 제공하지 않아야 합니다."
   },
   "course.assessment.AssessmentForm.sessionProtection": {
     "defaultMessage": "세션 보호 활성화"
@@ -1291,6 +1420,9 @@
   },
   "course.assessment.AssessmentForm.timeBonusExp": {
     "defaultMessage": "시간 보너스 EXP"
+  },
+  "course.assessment.AssessmentForm.timeLimit": {
+    "defaultMessage": "시간 제한"
   },
   "course.assessment.AssessmentForm.title": {
     "defaultMessage": "제목"
@@ -1373,6 +1505,54 @@
   "course.assessment.edit.update": {
     "defaultMessage": "저장"
   },
+  "course.assessment.generation.allFieldsLocked": {
+    "defaultMessage": "모든 필드가 잠겨 있어서 아무것도 생성할 수 없습니다."
+  },
+  "course.assessment.generation.confirmDeleteConversation": {
+    "defaultMessage": "정말 \"{title}\"을(를) 삭제하고 모든 히스토리 항목을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다!"
+  },
+  "course.assessment.generation.exportAction": {
+    "defaultMessage": "수출"
+  },
+  "course.assessment.generation.exportClose": {
+    "defaultMessage": "닫다"
+  },
+  "course.assessment.generation.exportDialogHeader": {
+    "defaultMessage": "질문 내보내기 ({exportCount} 선택됨)"
+  },
+  "course.assessment.generation.exportError": {
+    "defaultMessage": "이 질문을 내보내는 중에 오류가 발생했습니다."
+  },
+  "course.assessment.generation.generateError": {
+    "defaultMessage": "질문 \"{title}\" 생성 중 오류가 발생했습니다."
+  },
+  "course.assessment.generation.generatePage": {
+    "defaultMessage": "프로그래밍 문제 생성"
+  },
+  "course.assessment.generation.generateQuestion": {
+    "defaultMessage": "생성하다"
+  },
+  "course.assessment.generation.generateSuccess": {
+    "defaultMessage": "세대 {title} 성공적으로 생성됨."
+  },
+  "course.assessment.generation.languageField": {
+    "defaultMessage": "언어"
+  },
+  "course.assessment.generation.newTab": {
+    "defaultMessage": "새로운"
+  },
+  "course.assessment.generation.openExportDialog": {
+    "defaultMessage": "수출"
+  },
+  "course.assessment.generation.promptPlaceholder": {
+    "defaultMessage": "여기에 무언가를 입력하세요..."
+  },
+  "course.assessment.generation.resetConversation": {
+    "defaultMessage": "재설정"
+  },
+  "course.assessment.generation.showInactive": {
+    "defaultMessage": "비활성 항목 표시"
+  },
   "course.assessment.liveFeedback.comments": {
     "defaultMessage": "댓글"
   },
@@ -1382,11 +1562,11 @@
   "course.assessment.liveFeedback.lineHeader": {
     "defaultMessage": "{lineNumber} 줄"
   },
-  "course.assessment.liveFeedback.liveFeedbackName": {
-    "defaultMessage": "라이브 피드백"
-  },
   "course.assessment.liveFeedback.questionTitle": {
     "defaultMessage": "질문 {index}"
+  },
+  "course.assessment.monitoring.accessGrantedForThisSessionOnly": {
+    "defaultMessage": "이 브라우저 세션에 대해서만 액세스가 허용됩니다."
   },
   "course.assessment.monitoring.alivePresenceHint": {
     "defaultMessage": "마지막 하트비트가 시간 내에 수신되었습니다."
@@ -1397,14 +1577,29 @@
   "course.assessment.monitoring.blankField": {
     "defaultMessage": "(빈칸)"
   },
+  "course.assessment.monitoring.blocksAccessesFromInvalidSUS": {
+    "defaultMessage": "미인증 브라우저로부터의 접근 차단"
+  },
+  "course.assessment.monitoring.blocksAccessesFromInvalidSUSHint": {
+    "defaultMessage": "활성화된 경우, 무단 브라우저를 사용하는 응시자는 이 평가에 액세스할 수 없습니다. 강사는 세션 잠금 비밀번호로 액세스를 재정의할 수 있습니다. 재정의된 브라우저 세션에서의 심박수는 항상 PulseGrid에서 유효합니다(녹색)."
+  },
+  "course.assessment.monitoring.browserAuthorizationMethod": {
+    "defaultMessage": "브라우저 인증 방법"
+  },
+  "course.assessment.monitoring.browserAuthorizationMethodHint": {
+    "defaultMessage": "세션이 유효하거나 무효화되는 방법을 선택하십시오. 변경 사항은 모든 세션 및 하트비트에 즉시 적용되며 PulseGrid에서 실시간으로 업데이트됩니다."
+  },
   "course.assessment.monitoring.cannotConnectToLiveMonitoringChannel": {
     "defaultMessage": "실시간 모니터링 채널에 연결하는 동안 오류가 발생했습니다."
   },
   "course.assessment.monitoring.connected": {
     "defaultMessage": "연결됨"
   },
-  "course.assessment.monitoring.connectedToLiveMonitoringChannel": {
-    "defaultMessage": "실시간 모니터링 채널에 연결됨"
+  "course.assessment.monitoring.connecting": {
+    "defaultMessage": "연결"
+  },
+  "course.assessment.monitoring.deltaFromPreviousHeartbeat": {
+    "defaultMessage": "{ms} 밀리초 전의 심박동으로부터"
   },
   "course.assessment.monitoring.detailsOfNHeartbeats": {
     "defaultMessage": "마지막 {n}개 하트비트의 세부사항"
@@ -1412,20 +1607,44 @@
   "course.assessment.monitoring.disconnected": {
     "defaultMessage": "연결 해제됨"
   },
-  "course.assessment.monitoring.disconnectedFromLiveMonitoringChannel": {
-    "defaultMessage": "실시간 모니터링 채널 연결 해제됨"
+  "course.assessment.monitoring.enableBrowserAuthorization": {
+    "defaultMessage": "이 평가에 접근하는 브라우저를 승인하세요"
+  },
+  "course.assessment.monitoring.enableBrowserAuthorizationHint": {
+    "defaultMessage": "활성화된 경우, PulseGrid는 선택한 인증 방법에 따라 응시자가 허가된 브라우저에서 이 평가에 접근하는지 여부를 추가로 확인합니다."
+  },
+  "course.assessment.monitoring.examMonitoring": {
+    "defaultMessage": "시험 감독 활성화"
+  },
+  "course.assessment.monitoring.examMonitoringHint": {
+    "defaultMessage": "활성화된 경우, 응시자의 세션은 시험을 시도하는 순간부터 시험을 완료하거나 시도한 후 24시간이 경과하기 전까지 실시간으로 모니터링됩니다. 강사는 <pulsegrid>PulseGrid</pulsegrid>에서 이러한 세션을 모니터링할 수 있습니다."
+  },
+  "course.assessment.monitoring.expiredSession": {
+    "defaultMessage": "만료된 세션입니다. 제출된 지 최소 24시간이 지났습니다."
   },
   "course.assessment.monitoring.filterByGroup": {
     "defaultMessage": "그룹별 필터"
   },
+  "course.assessment.monitoring.firstReceivedHeartbeat": {
+    "defaultMessage": "첫 번째로 받은 심장 박동"
+  },
   "course.assessment.monitoring.generatedAt": {
     "defaultMessage": "생성된 시간"
   },
+  "course.assessment.monitoring.intervalHint": {
+    "defaultMessage": "시험 응시자의 브라우저에서 심장박동이 전송되는 빈도를 제어합니다. 간격은 이 두 범위 내에서 무작위로 설정됩니다."
+  },
+  "course.assessment.monitoring.invalidBrowser": {
+    "defaultMessage": "잘못된 브라우저 구성"
+  },
+  "course.assessment.monitoring.invalidBrowserSubtitle": {
+    "defaultMessage": "현재 브라우저나 설정으로는 이 평가에 접근할 수 없습니다. 도움이 필요하면 강사에게 문의하십시오."
+  },
+  "course.assessment.monitoring.invalidHeartbeat": {
+    "defaultMessage": "잘못된"
+  },
   "course.assessment.monitoring.ipAddress": {
     "defaultMessage": "IP 주소"
-  },
-  "course.assessment.monitoring.lastHeartbeat": {
-    "defaultMessage": "마지막 하트비트"
   },
   "course.assessment.monitoring.latePresenceHint": {
     "defaultMessage": "다음 하트비트가 시간 내에 수신되지 않았지만 아직 구성된 하트비트 간격 내에 있습니다."
@@ -1433,14 +1652,47 @@
   "course.assessment.monitoring.live": {
     "defaultMessage": "실시간"
   },
+  "course.assessment.monitoring.liveHint": {
+    "defaultMessage": "이 심장박동은 즉시 서버에 받아들여졌습니다."
+  },
+  "course.assessment.monitoring.liveness": {
+    "defaultMessage": "생동감"
+  },
+  "course.assessment.monitoring.loadAllHeartbeats": {
+    "defaultMessage": "모두 불러오기"
+  },
+  "course.assessment.monitoring.maxInterval": {
+    "defaultMessage": "최대 간격"
+  },
+  "course.assessment.monitoring.milliseconds": {
+    "defaultMessage": "밀리초"
+  },
+  "course.assessment.monitoring.minInterval": {
+    "defaultMessage": "최소 간격"
+  },
   "course.assessment.monitoring.missingPresenceHint": {
     "defaultMessage": "다음 하트비트가 시간 내에 수신되지 않았습니다."
+  },
+  "course.assessment.monitoring.needSUSAndSessionUnlockPassword": {
+    "defaultMessage": "이 작업을 수행하려면 브라우저 인증을 활성화하고 세션 잠금 비밀번호를 설정해야 합니다."
   },
   "course.assessment.monitoring.noActiveSessions": {
     "defaultMessage": "활성 세션이 없습니다."
   },
+  "course.assessment.monitoring.offset": {
+    "defaultMessage": "인터-심박동 오프셋"
+  },
+  "course.assessment.monitoring.offsetHint": {
+    "defaultMessage": "PulseGrid가 세션을 지연으로 플래그 지정하기 전에 주파수 간격 이후 얼마나 기다려야 하는지 제어합니다."
+  },
+  "course.assessment.monitoring.openSubmissionInNewTab": {
+    "defaultMessage": "새 탭에서 제출 열기"
+  },
+  "course.assessment.monitoring.overrideAccess": {
+    "defaultMessage": "액세스 재정의"
+  },
   "course.assessment.monitoring.pulsegrid": {
-    "defaultMessage": "PulseGrid"
+    "defaultMessage": "펄스그리드"
   },
   "course.assessment.monitoring.recentActivities": {
     "defaultMessage": "최근 활동"
@@ -1448,8 +1700,41 @@
   "course.assessment.monitoring.recentActivitiesHint": {
     "defaultMessage": "이 탭을 닫으면 이 로그가 사라집니다!"
   },
+  "course.assessment.monitoring.resetZoom": {
+    "defaultMessage": "줌 재설정"
+  },
+  "course.assessment.monitoring.sebConfigKey": {
+    "defaultMessage": "안전한 시험 브라우저(SEB) 구성 키"
+  },
+  "course.assessment.monitoring.sebConfigKeyFieldHint": {
+    "defaultMessage": "귀하의 <sebConfigKey>SEB 구성 키</sebConfigKey>은 브라우저 시험 키가 아닌 귀하의 특정 SEB 구성에서 생성됩니다. 이는 운영 체제 및 SEB 버전 간에 동일합니다. SEB 구성을 변경하면이 필드를 업데이트하십시오."
+  },
+  "course.assessment.monitoring.sebConfigKeyFieldLabel": {
+    "defaultMessage": "SEB 구성 키"
+  },
+  "course.assessment.monitoring.sebConfigKeyHint": {
+    "defaultMessage": "시험 응시자가 유효한 구성을 사용하여 <seb>Safe Exam Browser (SEB)</seb>를 사용하는 경우 세션을 유효하게 표시합니다. SEB는 특정 구성을 위해 고유한 <sebConfigKey>구성 키</sebConfigKey>를 생성합니다. 이 방법은 Windows용 SEB 3.4 및 iOS 및 macOS용 SEB 3.0 이상을 필요로 합니다."
+  },
+  "course.assessment.monitoring.sebPayload": {
+    "defaultMessage": "안전한 시험 브라우저(SEB) 구성 키 해시 및 URL"
+  },
+  "course.assessment.monitoring.secret": {
+    "defaultMessage": "비밀 UA 부분 문자열 (SUS)"
+  },
+  "course.assessment.monitoring.secretHint": {
+    "defaultMessage": "시험자의 브라우저 User Agent (UA)에 대소문자를 구분하는 비밀이 포함되어 있다면, PulseGrid는 해당 세션을 유효하다고 표시하고, 그렇지 않으면 무효로 표시합니다. 이 부분을 비워 둔다면, 모든 세션이 유효하다고 표시됩니다."
+  },
+  "course.assessment.monitoring.sessionUnlockPassword": {
+    "defaultMessage": "세션 잠금 해제 비밀번호"
+  },
   "course.assessment.monitoring.stale": {
     "defaultMessage": "오래된"
+  },
+  "course.assessment.monitoring.staleHint": {
+    "defaultMessage": "수험자의 브라우저가 일시적으로 접속할 수 없어 서버로 즉시 전달되지 않았습니다. 브라우저에 캐시되어 브라우저가 다시 접속 가능해지면 서버로 전송되었습니다."
+  },
+  "course.assessment.monitoring.stoppedSession": {
+    "defaultMessage": "세션을 중지했습니다. 학생들이 제출을 완료했을 수 있습니다."
   },
   "course.assessment.monitoring.summaryCorrectAsAt": {
     "defaultMessage": "{time} 기준 요약이 정확합니다."
@@ -1460,11 +1745,20 @@
   "course.assessment.monitoring.userAgent": {
     "defaultMessage": "사용자 에이전트"
   },
+  "course.assessment.monitoring.userAgentHint": {
+    "defaultMessage": "시험 응시자의 브라우저 <ua>User Agent (UA)</ua>에 비밀 서브스트링이 포함되어 있으면 세션을 유효하게 표시합니다."
+  },
   "course.assessment.monitoring.userHeartbeatContinuedStreaming": {
     "defaultMessage": "{name}의 하트비트가 계속 스트리밍 중입니다."
   },
   "course.assessment.monitoring.userHeartbeatNotReceivedInTime": {
     "defaultMessage": "{name}의 하트비트가 시간 내에 수신되지 않았습니다."
+  },
+  "course.assessment.monitoring.validHeartbeat": {
+    "defaultMessage": "유효한"
+  },
+  "course.assessment.monitoring.zoomPanHint": {
+    "defaultMessage": "줌을 하려면 핀치하거나 스크롤하세요. 이동하려면 드래그하세요."
   },
   "course.assessment.newAssessment": {
     "defaultMessage": "새 평가"
@@ -1553,8 +1847,17 @@
   "course.assessment.question.multipleResponses.maximumGrade": {
     "defaultMessage": "최대 등급"
   },
+  "course.assessment.question.multipleResponses.mustBeLessThanMaxAttachmentSize": {
+    "defaultMessage": "최대 {defaultMax}MB 이하여야 합니다."
+  },
+  "course.assessment.question.multipleResponses.mustBeLessThanMaxAttachments": {
+    "defaultMessage": "최대 {defaultMax} 이하여야 합니다."
+  },
   "course.assessment.question.multipleResponses.mustBeLessThanMaxMaximumGrade": {
     "defaultMessage": "1000보다 작아야 합니다."
+  },
+  "course.assessment.question.multipleResponses.mustHaveAtLeastOneResponse": {
+    "defaultMessage": "적어도 하나의 응답을 지정해야 합니다."
   },
   "course.assessment.question.multipleResponses.mustSpecifyAtLeastOneCorrectChoice": {
     "defaultMessage": "적어도 하나의 정답을 지정해야 합니다."
@@ -1562,8 +1865,20 @@
   "course.assessment.question.multipleResponses.mustSpecifyChoice": {
     "defaultMessage": "유효한 선택 제목을 지정해야 합니다."
   },
+  "course.assessment.question.multipleResponses.mustSpecifyMaxAttachment": {
+    "defaultMessage": "유효하고 양수인 최대 첨부 파일 수를 지정해야 합니다."
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyMaxAttachmentSize": {
+    "defaultMessage": "유효하고 양수인 최대 첨부 파일 크기를 지정해야 합니다."
+  },
   "course.assessment.question.multipleResponses.mustSpecifyMaximumGrade": {
     "defaultMessage": "부여할 유효하고 비음수 최대 등급을 지정해야 합니다."
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachment": {
+    "defaultMessage": "첨부 파일의 최대 개수는 양수여야 합니다."
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachmentSize": {
+    "defaultMessage": "최대 크기는 양수여야 합니다."
   },
   "course.assessment.question.multipleResponses.mustSpecifyPositiveMaximumGrade": {
     "defaultMessage": "최대 등급은 비음수여야 합니다."
@@ -1679,6 +1994,9 @@
   "course.assessment.question.programming.codaveriEvaluatorHint": {
     "defaultMessage": "기본 평가 외에도, 이 평가자는 제출이 완료되었을 때 Codaveri가 제공하는 자동 코드 피드백을 제공합니다. 이들은 교사가 검토, 편집 및 게시할 수 있는 초안 코멘트로 표시됩니다."
   },
+  "course.assessment.question.programming.codaveriEvaluatorNotSupported": {
+    "defaultMessage": "Codaveri 평가자에서 {languageName}은(는) 지원되지 않습니다."
+  },
   "course.assessment.question.programming.codeInserts": {
     "defaultMessage": "코드 삽입"
   },
@@ -1702,6 +2020,9 @@
   },
   "course.assessment.question.programming.defaultEvaluatorHint": {
     "defaultMessage": "아무 문제 없이, 아래 평가 패키지에 따라 코드를 실행하고 테스트 결과를 보고합니다."
+  },
+  "course.assessment.question.programming.defaultEvaluatorNotSupported": {
+    "defaultMessage": "기본 평가자에서 {languageName}은(는) 지원되지 않습니다."
   },
   "course.assessment.question.programming.editOnline": {
     "defaultMessage": "온라인으로 생성/편집"
@@ -1742,6 +2063,9 @@
   "course.assessment.question.programming.expected": {
     "defaultMessage": "예상"
   },
+  "course.assessment.question.programming.expectedOutput": {
+    "defaultMessage": "예상 출력"
+  },
   "course.assessment.question.programming.expression": {
     "defaultMessage": "식"
   },
@@ -1772,6 +2096,9 @@
   "course.assessment.question.programming.inlineCode": {
     "defaultMessage": "인라인 코드"
   },
+  "course.assessment.question.programming.input": {
+    "defaultMessage": "입력"
+  },
   "course.assessment.question.programming.javaTestCasesHint": {
     "defaultMessage": "식은 제출된 코드의 맥락에서 평가됩니다. 그런 다음 반환 값은 <code>expectEquals(expression, expected)</code> void를 사용하여 예상 기대치와 비교됩니다. <code>Object</code>는 모든 Java 기본 유형에 대해 오버로드되었습니다."
   },
@@ -1787,6 +2114,9 @@
   "course.assessment.question.programming.languageAndEvaluation": {
     "defaultMessage": "언어 및 평가"
   },
+  "course.assessment.question.programming.languageDeprecatedWarning": {
+    "defaultMessage": "선택하신 언어는 사용이 중단되었습니다. 다른 언어로 변경해주세요."
+  },
   "course.assessment.question.programming.lastUpdated": {
     "defaultMessage": "{by}에 의해 {on}에 마지막으로 업데이트되었습니다."
   },
@@ -1796,6 +2126,9 @@
   "course.assessment.question.programming.liveFeedbackCustomPromptDescription": {
     "defaultMessage": "실시간 피드백 생성을 안내하기 위한 지침을 여기에 추가하세요. 확실하지 않은 경우, 이 필드를 비워두세요."
   },
+  "course.assessment.question.programming.liveFeedbackNotSupported": {
+    "defaultMessage": "실시간 피드백 생성은 {languageName}을(를) 지원하지 않습니다."
+  },
   "course.assessment.question.programming.lowestGradingPriority": {
     "defaultMessage": "가장 낮은 채점 우선순위"
   },
@@ -1803,7 +2136,7 @@
     "defaultMessage": "활성화하면, 이 질문의 평가는 항상 가장 낮은 우선 순위의 평가자를 사용합니다. 확실하지 않은 경우, 이 옵션을 선택하지 마세요."
   },
   "course.assessment.question.programming.megabytes": {
-    "defaultMessage": "MB"
+    "defaultMessage": "엠비"
   },
   "course.assessment.question.programming.memoryLimit": {
     "defaultMessage": "메모리 제한"
@@ -1862,6 +2195,9 @@
   "course.assessment.question.programming.questionSavedButPackageError": {
     "defaultMessage": "변경 사항은 저장되었지만 패키지는 성공적으로 가져오지 못했습니다."
   },
+  "course.assessment.question.programming.rTestCasesHint": {
+    "defaultMessage": "각 테스트 케이스는 별도의 R 콘솔 인스턴스를 시작하고 표준 입력을 통해 입력을 제공합니다. 이 콘솔은 <prepend>Prepend</prepend> 스크립트, 학생 제출물 및 <append>Append</append> 스크립트를 실행할 것입니다. 이러한 스크립트의 표준 출력은 해당 테스트 케이스의 예상 출력과 비교될 것입니다. 우리는 이러한 스크립트 중 하나에서 표준 입력을 처리하는 것을 권장합니다."
+  },
   "course.assessment.question.programming.savingChanges": {
     "defaultMessage": "변경 사항 저장 중..."
   },
@@ -1910,6 +2246,9 @@
   "course.assessment.question.programming.timeLimit": {
     "defaultMessage": "시간 제한"
   },
+  "course.assessment.question.programming.timeLimitDetail": {
+    "defaultMessage": "{timeLimit, plural, one {# 분} other {# 분}}"
+  },
   "course.assessment.question.programming.uploadNewPackage": {
     "defaultMessage": "새 패키지 업로드"
   },
@@ -1929,10 +2268,12 @@
     "defaultMessage": "공란으로 둘 수 없습니다."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.chooseFileButton": {
-    "defaultMessage": "파일 선택"
+    "defaultMessage": "파일 선택",
+    "description": "Button for adding an image attachment."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.descriptionFieldLabel": {
-    "defaultMessage": "설명"
+    "defaultMessage": "설명",
+    "description": "Label for the description input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.fetchFailureMessage": {
     "defaultMessage": "오류가 발생했습니다. 다시 시도하세요."
@@ -1947,10 +2288,12 @@
     "defaultMessage": "값은 0보다 커야 합니다."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.maximumGradeFieldLabel": {
-    "defaultMessage": "최대 등급"
+    "defaultMessage": "최대 등급",
+    "description": "Label for the maximum grade input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.noFileChosenMessage": {
-    "defaultMessage": "선택된 파일이 없습니다"
+    "defaultMessage": "선택된 파일이 없습니다",
+    "description": "Message to be displayed when no file is chosen for a file input."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.positiveNumberValidationError": {
     "defaultMessage": "값은 양수여야 합니다."
@@ -1962,22 +2305,27 @@
     "defaultMessage": "참고: PDF 파일의 각 페이지는 동일한 질문 세부사항을 갖는 단일 스크라이빙 질문으로 생성됩니다. 선택 입력을 비워 두고 생성 후 질문을 다시 편집할 수 있습니다."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.skillsFieldLabel": {
-    "defaultMessage": "기술"
+    "defaultMessage": "기술",
+    "description": "Label for the skills input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.staffOnlyCommentsFieldLabel": {
-    "defaultMessage": "직원 전용 코멘트"
+    "defaultMessage": "직원 전용 코멘트",
+    "description": "Label for the staff only comments input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.submitButton": {
-    "defaultMessage": "제출"
+    "defaultMessage": "제출",
+    "description": "Button for submitting the form."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.submitFailureMessage": {
     "defaultMessage": "오류가 발생했습니다. 다시 시도하세요."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.submittingMessage": {
-    "defaultMessage": "제출 중..."
+    "defaultMessage": "제출 중...",
+    "description": "Text to be displayed when waiting for server response after form submission."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.titleFieldLabel": {
-    "defaultMessage": "제목"
+    "defaultMessage": "제목",
+    "description": "Label for the title input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.valueMoreThan1000Error": {
     "defaultMessage": "값은 1000보다 작아야 합니다."
@@ -1985,8 +2333,14 @@
   "course.assessment.question.textResponses.addSolution": {
     "defaultMessage": "새 솔루션 추가"
   },
-  "course.assessment.question.textResponses.allowFileUpload": {
-    "defaultMessage": "답변에서 파일 업로드 허용"
+  "course.assessment.question.textResponses.attachmentSettingRequired": {
+    "defaultMessage": "이 질문에 첨부 설정을 정의해야 합니다"
+  },
+  "course.assessment.question.textResponses.attachmentSettings": {
+    "defaultMessage": "첨부 파일 설정"
+  },
+  "course.assessment.question.textResponses.attachmentSettingsDescription": {
+    "defaultMessage": "학생들이 이 질문을 시도할 때,"
   },
   "course.assessment.question.textResponses.deleteSolution": {
     "defaultMessage": "솔루션 삭제"
@@ -2000,8 +2354,23 @@
   "course.assessment.question.textResponses.grade": {
     "defaultMessage": "등급"
   },
+  "course.assessment.question.textResponses.isAttachmentRequired": {
+    "defaultMessage": "이 질문에 파일 업로드가 필요합니다"
+  },
   "course.assessment.question.textResponses.keyword": {
     "defaultMessage": "키워드"
+  },
+  "course.assessment.question.textResponses.maxAttachmentSize": {
+    "defaultMessage": "첨부 파일 당 최대 크기"
+  },
+  "course.assessment.question.textResponses.maxAttachments": {
+    "defaultMessage": "첨부 파일 최대 개수"
+  },
+  "course.assessment.question.textResponses.multipleAttachments": {
+    "defaultMessage": "다중 첨부 파일"
+  },
+  "course.assessment.question.textResponses.multipleFileAttachmentDescription": {
+    "defaultMessage": "그들은 여러 첨부 파일을 업로드할 수 있습니다."
   },
   "course.assessment.question.textResponses.mustSpecifyGrade": {
     "defaultMessage": "성적에 대해 유효한 숫자를 지정해야 합니다."
@@ -2014,6 +2383,18 @@
   },
   "course.assessment.question.textResponses.newSolutionCannotUndo": {
     "defaultMessage": "이것은 새 솔루션입니다. 저장하기 전에 삭제하면 즉시 사라집니다."
+  },
+  "course.assessment.question.textResponses.noAttachment": {
+    "defaultMessage": "첨부 없음"
+  },
+  "course.assessment.question.textResponses.noAttachmentDescription": {
+    "defaultMessage": "그들은 어떤 첨부 파일도 업로드할 수 없을 것입니다."
+  },
+  "course.assessment.question.textResponses.singleFileAttachment": {
+    "defaultMessage": "단일 첨부파일"
+  },
+  "course.assessment.question.textResponses.singleFileAttachmentDescription": {
+    "defaultMessage": "그들은 한 개의 첨부 파일만 업로드할 수 있습니다."
   },
   "course.assessment.question.textResponses.solution": {
     "defaultMessage": "솔루션"
@@ -2039,8 +2420,11 @@
   "course.assessment.question.textResponses.undoDeleteSolution": {
     "defaultMessage": "솔루션 삭제 취소"
   },
+  "course.assessment.question.textResponses.validAttachmentSettingValues": {
+    "defaultMessage": "첨부 파일 설정은 첨부 파일 없음, 단일 파일 첨부 또는 다중 파일 첨부 중 하나여야 합니다"
+  },
   "course.assessment.question.textResponses.zeroGrade": {
-    "defaultMessage": "0.0"
+    "defaultMessage": "영점 영"
   },
   "course.assessment.session.assessmentNotStarted": {
     "defaultMessage": "평가가 아직 시작되지 않았습니다. {startDate} 이후에 다시 방문하세요."
@@ -2065,9 +2449,6 @@
   },
   "course.assessment.show.assessmentOnlyAvailableFrom": {
     "defaultMessage": "이 평가는 다음부터만 사용 가능합니다"
-  },
-  "course.assessment.show.audioResponse": {
-    "defaultMessage": "오디오 응답"
   },
   "course.assessment.show.baseExp": {
     "defaultMessage": "기본 EXP"
@@ -2101,6 +2482,9 @@
   },
   "course.assessment.show.chooseAssessmentToDuplicateInto": {
     "defaultMessage": "복제할 평가 선택"
+  },
+  "course.assessment.show.comprehension": {
+    "defaultMessage": "이해"
   },
   "course.assessment.show.delete": {
     "defaultMessage": "삭제"
@@ -2159,8 +2543,14 @@
   "course.assessment.show.errorMovingQuestion": {
     "defaultMessage": "질문을 이동하는 동안 오류가 발생했습니다."
   },
+  "course.assessment.show.failedSyncingWithKoditsu": {
+    "defaultMessage": "Koditsu와 동기화되지 않았습니다"
+  },
   "course.assessment.show.fileUpload": {
     "defaultMessage": "파일 업로드"
+  },
+  "course.assessment.show.fileUploadDescription": {
+    "defaultMessage": "허용된 첨부 파일 수 설정 (없음, 하나 또는 여러 개)"
   },
   "course.assessment.show.files": {
     "defaultMessage": "파일"
@@ -2173,6 +2563,9 @@
   },
   "course.assessment.show.forumPostResponse": {
     "defaultMessage": "포럼 게시물 응답"
+  },
+  "course.assessment.show.generate": {
+    "defaultMessage": "프로그래밍 문제 생성"
   },
   "course.assessment.show.gradedTestCases": {
     "defaultMessage": "평가된 테스트 케이스"
@@ -2191,6 +2584,9 @@
   },
   "course.assessment.show.hideOptions": {
     "defaultMessage": "옵션 숨기기"
+  },
+  "course.assessment.show.koditsuMode": {
+    "defaultMessage": "Koditsu"
   },
   "course.assessment.show.manageComponents": {
     "defaultMessage": "강좌 설정에서 컴포넌트 관리"
@@ -2318,6 +2714,12 @@
   "course.assessment.show.sureDeletingQuestion": {
     "defaultMessage": "이 질문을 삭제하시겠습니까?"
   },
+  "course.assessment.show.syncedWithKoditsu": {
+    "defaultMessage": "Koditsu와 동기화됨"
+  },
+  "course.assessment.show.syncingWithKoditsu": {
+    "defaultMessage": "Kositsu와 동기화 중"
+  },
   "course.assessment.show.textResponse": {
     "defaultMessage": "텍스트 응답"
   },
@@ -2332,6 +2734,9 @@
   },
   "course.assessment.show.unsubmittingAndChangingQuestionType": {
     "defaultMessage": "제출을 취소하고 질문 유형을 변경하는 중..."
+  },
+  "course.assessment.show.voiceResponse": {
+    "defaultMessage": "오디오 응답"
   },
   "course.assessment.show.whileHoldingToCancelMoving": {
     "defaultMessage": "이동 취소를 위해 계속 누르세요."
@@ -2441,6 +2846,12 @@
   "course.assessment.statistics.SubmissionStatusChart.datasetLabel": {
     "defaultMessage": "학생 제출 상태"
   },
+  "course.assessment.statistics.SubmissionStatusChart.graded": {
+    "defaultMessage": "등급이 매겨지고 발표되지 않은"
+  },
+  "course.assessment.statistics.SubmissionStatusChart.published": {
+    "defaultMessage": "등급이 매겨진"
+  },
   "course.assessment.statistics.SubmissionStatusChart.submitted": {
     "defaultMessage": "제출됨"
   },
@@ -2450,11 +2861,26 @@
   "course.assessment.statistics.ancestorFail": {
     "defaultMessage": "이 평가의 이전 반복을 검색하지 못했습니다."
   },
+  "course.assessment.statistics.ancestorSelect.current": {
+    "defaultMessage": "현재"
+  },
+  "course.assessment.statistics.ancestorSelect.fromCourse": {
+    "defaultMessage": "강좌 제목: {courseTitle}에서"
+  },
+  "course.assessment.statistics.ancestorSelect.subtitle": {
+    "defaultMessage": "이 평가의 이전 버전과 비교하십시오:"
+  },
+  "course.assessment.statistics.ancestorSelect.title": {
+    "defaultMessage": "복제 기록"
+  },
   "course.assessment.statistics.ancestorStatisticsFail": {
     "defaultMessage": "조상의 통계를 검색하지 못했습니다."
   },
   "course.assessment.statistics.answers": {
     "defaultMessage": "답변"
+  },
+  "course.assessment.statistics.attemptCount": {
+    "defaultMessage": "시도 횟수"
   },
   "course.assessment.statistics.attempts.filename": {
     "defaultMessage": "{assessment}에 대한 질문별 시도 통계"
@@ -2468,8 +2894,20 @@
   "course.assessment.statistics.closePrompt": {
     "defaultMessage": "닫기"
   },
+  "course.assessment.statistics.comments": {
+    "defaultMessage": "의견"
+  },
+  "course.assessment.statistics.duplicationHistory": {
+    "defaultMessage": "복제 기록"
+  },
+  "course.assessment.statistics.email": {
+    "defaultMessage": "이메일"
+  },
   "course.assessment.statistics.fail": {
     "defaultMessage": "통계를 검색하지 못했습니다."
+  },
+  "course.assessment.statistics.gradeDisplay": {
+    "defaultMessage": "등급: {grade} / {maxGrade}"
   },
   "course.assessment.statistics.gradeDistribution": {
     "defaultMessage": "성적 분포"
@@ -2495,11 +2933,17 @@
   "course.assessment.statistics.header": {
     "defaultMessage": "{title}에 대한 통계"
   },
+  "course.assessment.statistics.includePhantom": {
+    "defaultMessage": "팬텀 학생 포함"
+  },
   "course.assessment.statistics.legendHigherusage": {
     "defaultMessage": "사용량이 많음"
   },
   "course.assessment.statistics.legendLowerUsage": {
     "defaultMessage": "사용량이 적음"
+  },
+  "course.assessment.statistics.liveFeedback": {
+    "defaultMessage": "실시간 피드백"
   },
   "course.assessment.statistics.liveFeedback.filename": {
     "defaultMessage": "{assessment}에 대한 질문별 라이브 피드백 통계"
@@ -2516,6 +2960,9 @@
   "course.assessment.statistics.marks.redCellLegend": {
     "defaultMessage": "최대 점수의 < 0.5"
   },
+  "course.assessment.statistics.marksPerQuestion": {
+    "defaultMessage": "문제 당 점수"
+  },
   "course.assessment.statistics.name": {
     "defaultMessage": "이름"
   },
@@ -2525,11 +2972,17 @@
   "course.assessment.statistics.nameGroupsSearchText": {
     "defaultMessage": "이름 또는 그룹으로 검색"
   },
+  "course.assessment.statistics.noIncludePhantom": {
+    "defaultMessage": "이 중복된 평가의 모든 통계에는 팬텀 학생이 포함되어 있지 않습니다"
+  },
   "course.assessment.statistics.noSubmission": {
     "defaultMessage": "아직 제출물 없음"
   },
   "course.assessment.statistics.onlyForAutogradableAssessment": {
     "defaultMessage": "이 테이블은 적어도 하나의 자동 채점 질문이 있는 평가에만 표시됩니다"
+  },
+  "course.assessment.statistics.pastAnswerTitle": {
+    "defaultMessage": "제출 일시: {submittedAt}"
   },
   "course.assessment.statistics.questionDisplayTitle": {
     "defaultMessage": "{student}을(를) 위한 Q{index}"
@@ -2537,8 +2990,14 @@
   "course.assessment.statistics.questionIndex": {
     "defaultMessage": "Q{index}"
   },
+  "course.assessment.statistics.questionTitle": {
+    "defaultMessage": "질문 {index}"
+  },
   "course.assessment.statistics.statistics": {
     "defaultMessage": "통계"
+  },
+  "course.assessment.statistics.submissionPage": {
+    "defaultMessage": "답변 페이지로 이동"
   },
   "course.assessment.statistics.submissionStatuses": {
     "defaultMessage": "제출 상태"
@@ -2591,14 +3050,41 @@
   "course.assessment.submission.EvaluatorErrorPanel.emailSubject": {
     "defaultMessage": "[버그 보고] 평가기 오류"
   },
+  "course.assessment.submission.FileInput.exactlyOneFileUploadAllowed": {
+    "defaultMessage": "이 질문에 정확히 1개의 파일을 업로드해야 합니다"
+  },
+  "course.assessment.submission.FileInput.fileName": {
+    "defaultMessage": "{index}. {name}"
+  },
+  "course.assessment.submission.FileInput.fileTooLargeErrorMessage": {
+    "defaultMessage": "다음 파일은 허용된 크기보다 큽니다 ({maxAttachmentSize} MB)"
+  },
+  "course.assessment.submission.FileInput.fileUploadErrorTitle": {
+    "defaultMessage": "파일 업로드 오류"
+  },
+  "course.assessment.submission.FileInput.onlyOneFileUploadAllowed": {
+    "defaultMessage": "이 질문에는 최대 {maxAttachments}개의 파일만 업로드할 수 있습니다"
+  },
+  "course.assessment.submission.FileInput.requiredUploadLimitedNumberOfFiles": {
+    "defaultMessage": "이 질문에는 최소 1개 이상, 최대 {maxAttachments}개의 파일을 업로드할 수 있습니다."
+  },
+  "course.assessment.submission.FileInput.tooManyFilesErrorMessage": {
+    "defaultMessage": "당신은 {numFiles}개의 파일을 업로드하려고 시도했지만, {maxAttachmentsAllowed}개의 {maxAttachmentsAllowed, plural, one {파일} other {파일들}}만 업로드할 수 있습니다. {numAttachments, plural, =0 {} one {이전에 1개의 파일이 업로드되었으므로} other {이전에 {numAttachments}개의 파일이 업로드되었으므로}}"
+  },
   "course.assessment.submission.FileInput.uploadDisabled": {
     "defaultMessage": "파일 업로드 비활성화됨"
   },
   "course.assessment.submission.FileInput.uploadLabel": {
     "defaultMessage": "파일을 업로드하려면 드래그 앤 드롭하거나 클릭하세요."
   },
+  "course.assessment.submission.ImportedFileView.delete": {
+    "defaultMessage": "삭제"
+  },
   "course.assessment.submission.ImportedFileView.deleteConfirmation": {
     "defaultMessage": "이 파일을 삭제하시겠습니까?"
+  },
+  "course.assessment.submission.ImportedFileView.deleteTitle": {
+    "defaultMessage": "파일 삭제"
   },
   "course.assessment.submission.ImportedFileView.noFiles": {
     "defaultMessage": "업로드된 파일이 없습니다."
@@ -2606,8 +3092,11 @@
   "course.assessment.submission.ImportedFileView.uploadedFiles": {
     "defaultMessage": "업로드된 파일:"
   },
-  "course.assessment.submission.SubmissionAnswer.viewPastAnswers": {
-    "defaultMessage": "과거 답변 보기"
+  "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.hoursMinutesSeconds": {
+    "defaultMessage": "{hrs, plural, one {# 시간} other {# 시간}} {mins, plural, =0 {} one {# 분} other {# 분}} {secs, plural, =0 {} one {# 초} other {# 초}}"
+  },
+  "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.minutesSeconds": {
+    "defaultMessage": "{secs, plural, one {# 초} other {# 초들}}"
   },
   "course.assessment.submission.SubmissionsIndex.accessLogs": {
     "defaultMessage": "접속 로그"
@@ -2641,6 +3130,9 @@
   },
   "course.assessment.submission.SubmissionsIndex.experiencePoints": {
     "defaultMessage": "획득한 경험치"
+  },
+  "course.assessment.submission.SubmissionsIndex.fetchFromKoditsu": {
+    "defaultMessage": "Kositsu로부터 제출물 가져오기"
   },
   "course.assessment.submission.SubmissionsIndex.forceSubmit": {
     "defaultMessage": "남은 제출 강제 제출"
@@ -2690,6 +3182,9 @@
   "course.assessment.submission.SubmissionsIndex.userName": {
     "defaultMessage": "이름"
   },
+  "course.assessment.submission.TestCaseView.allFailed": {
+    "defaultMessage": "모두 실패했습니다"
+  },
   "course.assessment.submission.TestCaseView.allPassed": {
     "defaultMessage": "모두 통과됨"
   },
@@ -2729,8 +3224,17 @@
   "course.assessment.submission.TestCaseView.standardOutput": {
     "defaultMessage": "표준 출력"
   },
+  "course.assessment.submission.TestCaseView.testCasesPassed": {
+    "defaultMessage": "{numPassed}/{numTestCases} 테스트 통과"
+  },
   "course.assessment.submission.UploadedFileView.deleteConfirmation": {
     "defaultMessage": "이 첨부 파일을 삭제하시겠습니까?"
+  },
+  "course.assessment.submission.UploadedFileView.deleteTitle": {
+    "defaultMessage": "파일 삭제"
+  },
+  "course.assessment.submission.UploadedFileView.deleting": {
+    "defaultMessage": "삭제"
   },
   "course.assessment.submission.UploadedFileView.noFiles": {
     "defaultMessage": "업로드된 파일이 없습니다."
@@ -2751,7 +3255,7 @@
     "defaultMessage": "녹음 중지"
   },
   "course.assessment.submission.answer.scribing.arial": {
-    "defaultMessage": "Arial"
+    "defaultMessage": "아리얼"
   },
   "course.assessment.submission.answer.scribing.arialBlack": {
     "defaultMessage": "Arial Black"
@@ -2763,7 +3267,7 @@
     "defaultMessage": "색상:"
   },
   "course.assessment.submission.answer.scribing.comicSansMs": {
-    "defaultMessage": "Comic Sans MS"
+    "defaultMessage": "코믹 산스 MS"
   },
   "course.assessment.submission.answer.scribing.dashed": {
     "defaultMessage": "점선"
@@ -2787,7 +3291,7 @@
     "defaultMessage": "글꼴 크기:"
   },
   "course.assessment.submission.answer.scribing.georgia": {
-    "defaultMessage": "Georgia"
+    "defaultMessage": "조지아"
   },
   "course.assessment.submission.answer.scribing.impact": {
     "defaultMessage": "Impact"
@@ -2799,7 +3303,7 @@
     "defaultMessage": "선"
   },
   "course.assessment.submission.answer.scribing.lucidaSanUnicode": {
-    "defaultMessage": "Lucida Sans Unicode"
+    "defaultMessage": "루시다 산스 유니코드"
   },
   "course.assessment.submission.answer.scribing.move": {
     "defaultMessage": "이동"
@@ -2808,7 +3312,7 @@
     "defaultMessage": "채우기 없음"
   },
   "course.assessment.submission.answer.scribing.palatinoLinotype": {
-    "defaultMessage": "Palatino Linotype"
+    "defaultMessage": "팔라티노 리노타입"
   },
   "course.assessment.submission.answer.scribing.pencil": {
     "defaultMessage": "연필"
@@ -2841,7 +3345,7 @@
     "defaultMessage": "스타일:"
   },
   "course.assessment.submission.answer.scribing.tahoma": {
-    "defaultMessage": "Tahoma"
+    "defaultMessage": "타호마"
   },
   "course.assessment.submission.answer.scribing.text": {
     "defaultMessage": "텍스트"
@@ -2850,7 +3354,7 @@
     "defaultMessage": "두께:"
   },
   "course.assessment.submission.answer.scribing.timesNewRoman": {
-    "defaultMessage": "Times New Roman"
+    "defaultMessage": "타임스 뉴 로만"
   },
   "course.assessment.submission.answer.scribing.undo": {
     "defaultMessage": "실행 취소"
@@ -2866,6 +3370,9 @@
   },
   "course.assessment.submission.answers.AnswerHeader.noPastAnswers": {
     "defaultMessage": "과거 답변이 없습니다."
+  },
+  "course.assessment.submission.answers.AnswerHeader.viewPastAnswers": {
+    "defaultMessage": "과거의 대답"
   },
   "course.assessment.submission.answers.ForumPostResponse.ForumCard.forumCardTitleTypeNoneSelected": {
     "defaultMessage": "포럼"
@@ -2939,9 +3446,6 @@
   "course.assessment.submission.answers.ForumPostResponse.TopicCard.viewTopicInNewTab": {
     "defaultMessage": "새 탭에서 주제 보기"
   },
-  "course.assessment.submission.answers.Programming.ProgrammingFile.downloadFile": {
-    "defaultMessage": "파일 다운로드"
-  },
   "course.assessment.submission.answers.Programming.ProgrammingFile.sizeTooBig": {
     "defaultMessage": "파일이 너무 커서 표시할 수 없습니다."
   },
@@ -2956,6 +3460,9 @@
   },
   "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLineHeading": {
     "defaultMessage": "라인 {linenum}"
+  },
+  "course.assessment.submission.attachmentRequired": {
+    "defaultMessage": "이 질문에 적어도 1개의 파일을 업로드해주세요"
   },
   "course.assessment.submission.attemptedAt": {
     "defaultMessage": "시도한 시간"
@@ -3068,6 +3575,9 @@
   "course.assessment.submission.emptyAssessment": {
     "defaultMessage": "현재 이 평가에는 질문이 없습니다."
   },
+  "course.assessment.submission.errorUnknown": {
+    "defaultMessage": "오류는 알 수 없습니다"
+  },
   "course.assessment.submission.examDialogMessage": {
     "defaultMessage": "브라우저를 종료하거나 로그아웃하지 마세요. 그렇지 않으면 시험을 계속 진행하는데 문제가 발생할 수 있습니다."
   },
@@ -3076,6 +3586,15 @@
   },
   "course.assessment.submission.expAwarded": {
     "defaultMessage": "획득한 경험치"
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuConfirmation": {
+    "defaultMessage": "Koditsu에서 모든 제출물을 가져오길 원하시는 건가요? 여기 있는 모든 기존 답변이 새로운 것으로 덮어씌워질 거에요. 이 작업은 되돌릴 수 없다는 점을 주의하세요!"
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuPending": {
+    "defaultMessage": "Koditsu에서 제출물을 현재 가져오는 중이니 잠시 기다려 주세요."
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuSuccess": {
+    "defaultMessage": "Koditsu로부터 모든 제출물이 성공적으로 가져와졌습니다"
   },
   "course.assessment.submission.finalise": {
     "defaultMessage": "제출 완료"
@@ -3116,9 +3635,6 @@
   "course.assessment.submission.gradeSummary": {
     "defaultMessage": "등급 요약"
   },
-  "course.assessment.submission.gradeUnsaved": {
-    "defaultMessage": "저장되지 않음"
-  },
   "course.assessment.submission.gradeUnsavedHint": {
     "defaultMessage": "이 등급은 아직 저장되지 않았습니다. 페이지 끝에 있는 '등급 저장'을 클릭하여 모든 등급 변경 사항을 저장하세요."
   },
@@ -3142,6 +3658,15 @@
   },
   "course.assessment.submission.invalidFileUpload": {
     "defaultMessage": "파일 업로드 실패: 자바 파일만 업로드할 수 있습니다"
+  },
+  "course.assessment.submission.isSaved": {
+    "defaultMessage": "저장됨"
+  },
+  "course.assessment.submission.isSaving": {
+    "defaultMessage": "저축"
+  },
+  "course.assessment.submission.isUnsaved": {
+    "defaultMessage": "저장되지 않은"
   },
   "course.assessment.submission.lateSubmission": {
     "defaultMessage": "이 제출이 늦었습니다! 늦게 제출한 학생에게 패널티를 적용할 수 있습니다."
@@ -3200,6 +3725,24 @@
   "course.assessment.submission.ok": {
     "defaultMessage": "확인"
   },
+  "course.assessment.submission.onlyOneAttachmentAllowed": {
+    "defaultMessage": "이 질문에는 파일 1개만 허용됩니다"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.attempting": {
+    "defaultMessage": "시도 중"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.graded": {
+    "defaultMessage": "채점 완료, 미발행"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.published": {
+    "defaultMessage": "채점 완료"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.submitted": {
+    "defaultMessage": "제출됨"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.unknown": {
+    "defaultMessage": "알 수 없는 상태입니다. 관리자에게 문의해주세요"
+  },
   "course.assessment.submission.pastAnswers": {
     "defaultMessage": "이전 답변"
   },
@@ -3245,6 +3788,12 @@
   "course.assessment.submission.reevaluate": {
     "defaultMessage": "답변 재평가"
   },
+  "course.assessment.submission.remainingBufferTime": {
+    "defaultMessage": "마감 시간: {timeLimit}"
+  },
+  "course.assessment.submission.remainingTime": {
+    "defaultMessage": "남은 시간: {timeLimit}"
+  },
   "course.assessment.submission.rendererNotImplemented": {
     "defaultMessage": "이 질문 유형에 대한 디스플레이가 아직 구현되지 않았습니다."
   },
@@ -3268,6 +3817,15 @@
   },
   "course.assessment.submission.saveGrade": {
     "defaultMessage": "등급 저장"
+  },
+  "course.assessment.submission.saved": {
+    "defaultMessage": "저장됨"
+  },
+  "course.assessment.submission.saving": {
+    "defaultMessage": "저축"
+  },
+  "course.assessment.submission.savingFailed": {
+    "defaultMessage": "저장 실패"
   },
   "course.assessment.submission.sendReminderEmailConfirmation": {
     "defaultMessage": "평가를 완료하지 않은 {unattempted}명의 미시도 및 {attempting}명의 시도 중인 사용자 ({selectedUsers})에게 리마인더 이메일을 보내시겠습니까?"
@@ -3305,6 +3863,9 @@
   "course.assessment.submission.submissionBy": {
     "defaultMessage": "{name}의 제출"
   },
+  "course.assessment.submission.submissionError": {
+    "defaultMessage": "질문 제출 중에 문제가 있습니다 {questions}"
+  },
   "course.assessment.submission.submissionsHeader": {
     "defaultMessage": "제출물: {assessment}"
   },
@@ -3322,6 +3883,21 @@
   },
   "course.assessment.submission.submittedAt": {
     "defaultMessage": "제출 시각"
+  },
+  "course.assessment.submission.timeIsUp": {
+    "defaultMessage": "시간이 끝났어요!"
+  },
+  "course.assessment.submission.timedAssessmentDialogMessage": {
+    "defaultMessage": "아직 시간이 남았습니다. 시간이 다 되면, 평가가 자동으로 완료됩니다."
+  },
+  "course.assessment.submission.timedAssessmentDialogTitle": {
+    "defaultMessage": "이 평가를 완료하려면 {stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {남은 시간}}을(를) 사용하십시오.} other {평가가 종료되었습니다!}}"
+  },
+  "course.assessment.submission.timedExamDialogMessage": {
+    "defaultMessage": "아직 시간이 남았습니다. 시험을 시도하는 동안 로그아웃하거나 브라우저를 닫지 마십시오. 시간이 다 되면 평가가 자동으로 완료됩니다."
+  },
+  "course.assessment.submission.timedExamDialogTitle": {
+    "defaultMessage": "{stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {남은 시간}}을(를) 완료하기 위해 남았습니다.} other {시험이 종료되었습니다!}}"
   },
   "course.assessment.submission.totalGrade": {
     "defaultMessage": "총 등급"
@@ -3358,6 +3934,9 @@
   },
   "course.assessment.submission.updateFailure": {
     "defaultMessage": "제출 업데이트 실패: {errors}"
+  },
+  "course.assessment.submission.updateIndividualSuccess": {
+    "defaultMessage": "제출 항목 {errors}이(가) 성공적으로 업데이트되었습니다"
   },
   "course.assessment.submission.updateSuccess": {
     "defaultMessage": "제출이 성공적으로 업데이트되었습니다."
@@ -3476,6 +4055,18 @@
   "course.assessments.index.hasTodo": {
     "defaultMessage": "할 일 있음"
   },
+  "course.assessments.index.inviteToKoditsu": {
+    "defaultMessage": "Kositsu 시험에 사용자를 초대하세요"
+  },
+  "course.assessments.index.invitingUserToKoditsu": {
+    "defaultMessage": "Kositsu 시험에 사용자 초대"
+  },
+  "course.assessments.index.invitingUserToKoditsuFailure": {
+    "defaultMessage": "Kositsu에 사용자를 초대하는 데 문제가 있습니다. 나중에 다시 시도해주세요."
+  },
+  "course.assessments.index.invitingUserToKoditsuSuccess": {
+    "defaultMessage": "Kositsu 시험에 사용자를 성공적으로 초대함"
+  },
   "course.assessments.index.neededFor": {
     "defaultMessage": "필요한 경우"
   },
@@ -3502,6 +4093,9 @@
   },
   "course.assessments.index.submissions": {
     "defaultMessage": "제출물"
+  },
+  "course.assessments.index.timeLimitIcon": {
+    "defaultMessage": "시간 제한: {timeLimit, plural, one {# 분} other {# 분}}"
   },
   "course.assessments.index.title": {
     "defaultMessage": "제목"
@@ -4085,6 +4679,9 @@
   "course.experiencePoints.disbursement.DisbursementIndex.disbursements": {
     "defaultMessage": "경험치 부여"
   },
+  "course.experiencePoints.disbursement.DisbursementIndex.experienceTab": {
+    "defaultMessage": "역사"
+  },
   "course.experiencePoints.disbursement.DisbursementIndex.fetchDisbursementFailure": {
     "defaultMessage": "데이터를 검색하는 데 실패했습니다."
   },
@@ -4118,6 +4715,15 @@
   "course.experiencePoints.disbursement.FilterForm.weeklyCap": {
     "defaultMessage": "주간 한도"
   },
+  "course.experiencePoints.disbursement.ForumDisbursement.fetchDisbursementFailure": {
+    "defaultMessage": "데이터를 검색하지 못했습니다."
+  },
+  "course.experiencePoints.disbursement.ForumDisbursement.fetchForumPostsFailure": {
+    "defaultMessage": "포럼 게시물을 가져오지 못했습니다."
+  },
+  "course.experiencePoints.disbursement.ForumDisbursement.postListDialogHeader": {
+    "defaultMessage": "시작일 {startDate}과 종료일 {endDate} 사이에 작성된 게시물"
+  },
   "course.experiencePoints.disbursement.ForumDisbursementForm.createDisbursementFailure": {
     "defaultMessage": "경험치 부여 실패."
   },
@@ -4126,9 +4732,6 @@
   },
   "course.experiencePoints.disbursement.ForumDisbursementForm.fetchForumPostsFailure": {
     "defaultMessage": "포럼 게시물을 가져오는 데 실패했습니다."
-  },
-  "course.experiencePoints.disbursement.ForumDisbursementForm.postListDialogHeader": {
-    "defaultMessage": "{startDate}와 {endDate} 사이에 생성된 게시물"
   },
   "course.experiencePoints.disbursement.ForumDisbursementForm.reason": {
     "defaultMessage": "부여 이유"
@@ -4168,6 +4771,27 @@
   },
   "course.experiencePoints.disbursement.ForumPostTable.voteTally": {
     "defaultMessage": "투표 집계"
+  },
+  "course.experiencePoints.disbursement.GeneralDisbursement.fetchDisbursementFailure": {
+    "defaultMessage": "데이터를 검색하지 못했습니다."
+  },
+  "course.experiencePoints.downloadCsvButton": {
+    "defaultMessage": "CSV 다운로드"
+  },
+  "course.experiencePoints.downloadFailure": {
+    "defaultMessage": "다운로드 요청 중 오류가 발생했습니다."
+  },
+  "course.experiencePoints.downloadPending": {
+    "defaultMessage": "다운로드 요청이 처리되는 동안 기다려 주세요."
+  },
+  "course.experiencePoints.downloadRequestSuccess": {
+    "defaultMessage": "다운로드 요청이 성공적으로 완료되었습니다"
+  },
+  "course.experiencePoints.fetchRecordsFailure": {
+    "defaultMessage": "기록을 가져오지 못했습니다"
+  },
+  "course.experiencePoints.filterByNameButton": {
+    "defaultMessage": "이름으로 필터링"
   },
   "course.forum.FormShow.fetchTopicsFailure": {
     "defaultMessage": "포럼 주제 데이터를 검색하는 데 실패했습니다."
@@ -4623,7 +5247,7 @@
     "defaultMessage": "설명이 없습니다."
   },
   "course.group.GroupShow.CategoryCard.subtitle": {
-    "defaultMessage": "{numGroups} {numGroups, plural, one {group} other {groups}}"
+    "defaultMessage": "{numGroups, plural, one {그룹} other {그룹들}}"
   },
   "course.group.GroupShow.CategoryCard.updateFailure": {
     "defaultMessage": "{categoryName} 업데이트 실패."
@@ -4698,7 +5322,7 @@
     "defaultMessage": "변경 사항 저장"
   },
   "course.group.GroupShow.GroupManager.GroupManager.subtitle": {
-    "defaultMessage": "{numGroups} {numGroups, plural, one {group} other {groups}}"
+    "defaultMessage": "{numGroups, plural, one {그룹} other {그룹들}}"
   },
   "course.group.GroupShow.GroupManager.GroupManager.title": {
     "defaultMessage": "{categoryName}의 그룹 관리"
@@ -4737,7 +5361,7 @@
     "defaultMessage": "이름으로 검색 (여러 개를 검색하려면 쉼표로 구분)"
   },
   "course.group.GroupShow.GroupManager.GroupUserManager.subtitle": {
-    "defaultMessage": "{numMembers} {numMembers, plural, one {member} other {members}}"
+    "defaultMessage": "{numMembers, plural, one {멤버} other {멤버들}}"
   },
   "course.group.GroupShow.GroupManager.GroupUserManager.updateFailure": {
     "defaultMessage": "{groupName} 업데이트 실패."
@@ -4785,7 +5409,7 @@
     "defaultMessage": "일련 번호"
   },
   "course.group.GroupShow.GroupTableCard.subtitle": {
-    "defaultMessage": "{numMembers} {numMembers, plural, one {member} other {members}}"
+    "defaultMessage": "{numMembers, plural, one {한 명의 회원} other {# 명의 회원}}"
   },
   "course.group.GroupShow.fetchFailure": {
     "defaultMessage": "그룹 데이터를 가져오는 데 실패했습니다! 새로 고침 후 다시 시도하세요."
@@ -4826,8 +5450,26 @@
   "course.leaderboard.LeaderboardTable.average": {
     "defaultMessage": "평균"
   },
+  "course.leaderboard.LeaderboardTable.averageAchievements": {
+    "defaultMessage": "평균 성취"
+  },
+  "course.leaderboard.LeaderboardTable.averageExperience": {
+    "defaultMessage": "평균 경험"
+  },
   "course.leaderboard.LeaderboardTable.experience": {
     "defaultMessage": "경험"
+  },
+  "course.leaderboard.LeaderboardTable.level": {
+    "defaultMessage": "레벨"
+  },
+  "course.leaderboard.LeaderboardTable.members": {
+    "defaultMessage": "회원"
+  },
+  "course.leaderboard.LeaderboardTable.name": {
+    "defaultMessage": "이름"
+  },
+  "course.leaderboard.LeaderboardTable.rank": {
+    "defaultMessage": "순위"
   },
   "course.leaderboard.LeaderboardTable.titleAchievements": {
     "defaultMessage": "성과별"
@@ -4848,7 +5490,7 @@
     "defaultMessage": "이 조건 삭제"
   },
   "course.learningMap.responseDashboardMessage": {
-    "defaultMessage": "{responseMessage}"
+    "defaultMessage": "응답 메시지"
   },
   "course.learningMap.selectedArrowDashboardMessage": {
     "defaultMessage": "선택된 조건: {fromNode} --> {toNode}"
@@ -4857,7 +5499,7 @@
     "defaultMessage": "{node}의 선택된 게이트"
   },
   "course.learningMap.summaryGateContent": {
-    "defaultMessage": "{numerator}/{denominator}"
+    "defaultMessage": "{분자}/{분모}"
   },
   "course.learningMap.toggleSatisfiabilityType": {
     "defaultMessage": "만족도 유형을 {satisfiabilityType}(으)로 전환"
@@ -4997,11 +5639,23 @@
   "course.level.Level.levelHeader": {
     "defaultMessage": "레벨"
   },
+  "course.level.Level.orderedIncorrectly": {
+    "defaultMessage": "레벨은 여기의 순서와 상관없이 저장될 때 자동으로 정렬됩니다."
+  },
+  "course.level.Level.placeholder": {
+    "defaultMessage": "영"
+  },
+  "course.level.Level.reset": {
+    "defaultMessage": "초기화"
+  },
+  "course.level.Level.resetTooltip": {
+    "defaultMessage": "변경 사항 초기화"
+  },
+  "course.level.Level.saveChanges": {
+    "defaultMessage": "저장"
+  },
   "course.level.Level.saveFailure": {
     "defaultMessage": "레벨 저장 실패, 다시 시도하세요."
-  },
-  "course.level.Level.saveLevels": {
-    "defaultMessage": "레벨 저장"
   },
   "course.level.Level.saveSuccess": {
     "defaultMessage": "레벨이 저장되었습니다"
@@ -5009,8 +5663,32 @@
   "course.level.Level.thresholdHeader": {
     "defaultMessage": "기준"
   },
-  "course.level.LevelRow.zeroThresholdError": {
-    "defaultMessage": "경험치 기준은 0이 될 수 없습니다"
+  "course.level.Level.unsavedChanges": {
+    "defaultMessage": "저장되지 않은 변경 사항이 있습니다"
+  },
+  "course.material.files.DownloadingFilePage.clickToDownloadFile": {
+    "defaultMessage": "다운로드 {name}"
+  },
+  "course.material.files.DownloadingFilePage.clickToDownloadFileDescription": {
+    "defaultMessage": "자동 다운로드를 시작할 때 문제가 발생했습니다. 파일을 즉시 다운로드하려면 아래 링크를 클릭하세요."
+  },
+  "course.material.files.DownloadingFilePage.downloading": {
+    "defaultMessage": "다운로드 중 {name}"
+  },
+  "course.material.files.DownloadingFilePage.downloadingDescription": {
+    "defaultMessage": "이 파일은 지금 자동으로 다운로드를 시작해야 합니다. 그렇지 않으면 아래 링크를 클릭하거나 이 페이지를 새로고침하여 다시 시도할 수 있습니다."
+  },
+  "course.material.files.DownloadingFilePage.tryDownloadingAgain": {
+    "defaultMessage": "다시 다운로드 해보세요"
+  },
+  "course.material.files.ErrorRetrievingFilePage.goToTheWorkbin": {
+    "defaultMessage": "작업함으로 이동하세요"
+  },
+  "course.material.files.ErrorRetrievingFilePage.problemRetrievingFile": {
+    "defaultMessage": "파일을 검색하는 중 문제가 발생했습니다"
+  },
+  "course.material.files.ErrorRetrievingFilePage.problemRetrievingFileDescription": {
+    "defaultMessage": "해당 항목이 더 이상 존재하지 않거나 액세스 권한이 없거나, 검색하는 동안 예기치 않은 문제가 발생했습니다."
   },
   "course.material.folders.DownloadFolderButton.downloadFolderErrorMessage": {
     "defaultMessage": "다운로드에 실패했습니다. 나중에 다시 시도하세요."
@@ -5020,6 +5698,15 @@
   },
   "course.material.folders.DownloadFolderButton.downloading": {
     "defaultMessage": "다운로드 중..."
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.goToMainFolder": {
+    "defaultMessage": "주 폴더로 이동하세요"
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolder": {
+    "defaultMessage": "폴더를 검색하는 중 문제가 발생했습니다"
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolderDescription": {
+    "defaultMessage": "해당 항목이 더 이상 존재하지 않거나 액세스 권한이 없거나, 검색하는 동안 예기치 않은 문제가 발생했습니다."
   },
   "course.material.folders.FolderEdit.editSubfolderTitle": {
     "defaultMessage": "폴더 수정"
@@ -5059,6 +5746,9 @@
   },
   "course.material.folders.FolderShow.defaultHeader": {
     "defaultMessage": "자료"
+  },
+  "course.material.folders.FolderShow.folderNotFound": {
+    "defaultMessage": "폴더를 찾을 수 없습니다"
   },
   "course.material.folders.MaterialEdit.editMaterialTitle": {
     "defaultMessage": "자료 수정"
@@ -5105,6 +5795,15 @@
   "course.material.folders.UploadFilesButton.uploadFilesTooltip": {
     "defaultMessage": "업로드"
   },
+  "course.material.folders.WorkbinTable.lastModified": {
+    "defaultMessage": "최종 수정"
+  },
+  "course.material.folders.WorkbinTable.name": {
+    "defaultMessage": "이름"
+  },
+  "course.material.folders.WorkbinTable.startAt": {
+    "defaultMessage": "시작"
+  },
   "course.material.folders.WorkbinTableButtons.DeletionFailure": {
     "defaultMessage": "삭제할 수 없습니다"
   },
@@ -5117,20 +5816,65 @@
   "course.material.folders.WorkbinTableButtons.tableButtonDeleteTooltip": {
     "defaultMessage": "삭제"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.achievementCount": {
-    "defaultMessage": "성과 개수 (총계: {courseAchievementCount})"
+  "course.statistics.StatisticsIndex.assessments.averageGrade": {
+    "defaultMessage": "평균 성적"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.ascending": {
-    "defaultMessage": "오름차순"
+  "course.statistics.StatisticsIndex.assessments.averageTimeTaken": {
+    "defaultMessage": "평균 시간"
+  },
+  "course.statistics.StatisticsIndex.assessments.category": {
+    "defaultMessage": "카테고리"
+  },
+  "course.statistics.StatisticsIndex.assessments.csvFileTitle": {
+    "defaultMessage": "평가 통계"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadCsv": {
+    "defaultMessage": "다음 평가에 대한 점수 요약을 다운로드하시겠습니까?"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummaryFailure": {
+    "defaultMessage": "점수 요약을 다운로드하는 동안 오류가 발생했습니다"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummaryPending": {
+    "defaultMessage": "다운로드 요청이 처리되는 동안 기다려 주세요"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummarySuccess": {
+    "defaultMessage": "성공적으로 점수 요약을 다운로드했습니다"
+  },
+  "course.statistics.StatisticsIndex.assessments.numLateStudents": {
+    "defaultMessage": "# 늦게"
+  },
+  "course.statistics.StatisticsIndex.assessments.numSubmittedStudents": {
+    "defaultMessage": "# 시도함"
+  },
+  "course.statistics.StatisticsIndex.assessments.searchBar": {
+    "defaultMessage": "평가 제목, 탭 또는 카테고리로 검색하세요"
+  },
+  "course.statistics.StatisticsIndex.assessments.selectedNUsers": {
+    "defaultMessage": "점수 요약 다운로드 ({n, plural, =1 {# 평가} other {# 평가들}})"
+  },
+  "course.statistics.StatisticsIndex.assessments.startAt": {
+    "defaultMessage": "시작"
+  },
+  "course.statistics.StatisticsIndex.assessments.stdevGrade": {
+    "defaultMessage": "표준편차 등급"
+  },
+  "course.statistics.StatisticsIndex.assessments.stdevTimeTaken": {
+    "defaultMessage": "표준편차 시간"
+  },
+  "course.statistics.StatisticsIndex.assessments.tab": {
+    "defaultMessage": "탭"
+  },
+  "course.statistics.StatisticsIndex.assessments.tableTitle": {
+    "defaultMessage": "평가 통계 ({numStudents} 학생)"
+  },
+  "course.statistics.StatisticsIndex.assessments.title": {
+    "defaultMessage": "제목"
+  },
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.achievementCountDetails": {
+    "defaultMessage": "성취 횟수 ({courseAchievementCount}개 중)"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.correctness": {
     "defaultMessage": "정확도"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.correctnessHint": {
-    "defaultMessage": "정확도는 학생이 수행한 모든 평가의 평균 등급 백분율입니다."
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.descending": {
-    "defaultMessage": "내림차순"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.experiencePoints": {
     "defaultMessage": "경험치"
@@ -5144,14 +5888,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.learningRate": {
     "defaultMessage": "학습 속도"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.learningRateHint": {
-    "defaultMessage": "학습 속도가 200%인 경우, 학생은 과정을 절반의 시간에 완료할 수 있습니다."
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.level": {
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.levelInfo": {
     "defaultMessage": "레벨 (최대: {maxLevel})"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.levelFilter": {
-    "defaultMessage": "레벨: {name}"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.name": {
     "defaultMessage": "이름"
@@ -5159,11 +5897,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.noData": {
     "defaultMessage": "데이터 없음"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.numSubmissions": {
-    "defaultMessage": "제출 횟수 (총계: {courseAssessmentCount})"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.phantom": {
-    "defaultMessage": "팬텀 사용자 포함"
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.numSubmissionsDetails": {
+    "defaultMessage": "제출 횟수 (총: {courseAssessmentCount}회)"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.studentType": {
     "defaultMessage": "학생 유형"
@@ -5174,17 +5909,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.studentType.phantom": {
     "defaultMessage": "팬텀"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.tableTitle": {
-    "defaultMessage": "{direction} {column} 순 학생 정렬"
-  },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.title": {
     "defaultMessage": "학생 성능"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.tutorFilter": {
-    "defaultMessage": "튜터: {name}"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.videoPercentWatched": {
-    "defaultMessage": "비디오 % 수"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.videoPercentWatchedHeader": {
     "defaultMessage": "평균 비디오 % 시청"
@@ -5222,14 +5948,14 @@
   "course.statistics.StatisticsIndex.course.StudentProgressionChart.yAxisLabel": {
     "defaultMessage": "마감일별 평가 정렬"
   },
-  "course.statistics.StatisticsIndex.course.error": {
-    "defaultMessage": "과정 통계를 가져오는 동안 문제가 발생했습니다! 새로고침해서 다시 시도하세요."
+  "course.statistics.StatisticsIndex.course.csvFileTitle": {
+    "defaultMessage": "학생 성적 통계"
   },
-  "course.statistics.StatisticsIndex.course.performanceError": {
-    "defaultMessage": "과정 성능 통계를 가져오는 동안 문제가 발생했습니다! 새로고침해서 다시 시도하세요."
+  "course.statistics.StatisticsIndex.course.searchBar": {
+    "defaultMessage": "학생 이름으로 검색"
   },
-  "course.statistics.StatisticsIndex.course.progressionError": {
-    "defaultMessage": "과정 진행 통계를 가져오는 동안 문제가 발생했습니다! 새로고침해서 다시 시도하세요."
+  "course.statistics.StatisticsIndex.header.assessments": {
+    "defaultMessage": "평가"
   },
   "course.statistics.StatisticsIndex.header.statistics": {
     "defaultMessage": "통계"
@@ -5237,8 +5963,8 @@
   "course.statistics.StatisticsIndex.staff.averageMarkingTime": {
     "defaultMessage": "평균 평가 시간"
   },
-  "course.statistics.StatisticsIndex.staff.error": {
-    "defaultMessage": "교직원 통계를 가져오는 동안 문제가 발생했습니다! 새로고침해서 다시 시도하세요."
+  "course.statistics.StatisticsIndex.staff.csvFileTitle": {
+    "defaultMessage": "직원 통계"
   },
   "course.statistics.StatisticsIndex.staff.name": {
     "defaultMessage": "이름"
@@ -5249,17 +5975,17 @@
   "course.statistics.StatisticsIndex.staff.numStudents": {
     "defaultMessage": "# 학생"
   },
+  "course.statistics.StatisticsIndex.staff.searchBar": {
+    "defaultMessage": "직원 이름으로 검색"
+  },
   "course.statistics.StatisticsIndex.staff.stddev": {
     "defaultMessage": "표준 편차"
   },
   "course.statistics.StatisticsIndex.staff.tableTitle": {
     "defaultMessage": "교직원 통계"
   },
-  "course.statistics.StatisticsIndex.staffFailure": {
-    "defaultMessage": "교직원 데이터를 가져오는 데 실패했습니다!"
-  },
-  "course.statistics.StatisticsIndex.students.error": {
-    "defaultMessage": "학생 통계를 가져오는 동안 문제가 발생했습니다! 새로고침해서 다시 시도하세요."
+  "course.statistics.StatisticsIndex.students.csvFileTitle": {
+    "defaultMessage": "학생 통계"
   },
   "course.statistics.StatisticsIndex.students.experiencePoints": {
     "defaultMessage": "경험치"
@@ -5273,20 +5999,14 @@
   "course.statistics.StatisticsIndex.students.name": {
     "defaultMessage": "이름"
   },
-  "course.statistics.StatisticsIndex.students.noStudents": {
-    "defaultMessage": "아직 이 과정에 학생이 없습니다..."
-  },
-  "course.statistics.StatisticsIndex.students.showMyStudentsOnly": {
-    "defaultMessage": "내 학생만 보기"
+  "course.statistics.StatisticsIndex.students.searchBar": {
+    "defaultMessage": "학생 이름 또는 학생 유형으로 검색"
   },
   "course.statistics.StatisticsIndex.students.studentsType": {
     "defaultMessage": "학생 유형"
   },
   "course.statistics.StatisticsIndex.students.tableTitle": {
     "defaultMessage": "학생 통계 ({numStudents}명의 학생, {numPhantom}명의 팬텀)"
-  },
-  "course.statistics.StatisticsIndex.students.tutorFilter": {
-    "defaultMessage": "튜터: {name}"
   },
   "course.statistics.StatisticsIndex.students.videoPercentWatched": {
     "defaultMessage": "평균 % 시청"
@@ -5312,14 +6032,26 @@
   "course.statistics.course.studentProgressionChart.startAt": {
     "defaultMessage": "시작일: {startAt}"
   },
-  "course.statistics.failures.coursePerformance": {
-    "defaultMessage": "코스 성과 데이터를 가져오지 못했습니다!"
-  },
-  "course.statistics.failures.courseProgression": {
-    "defaultMessage": "코스 진행 데이터를 가져오지 못했습니다!"
-  },
   "course.statistics.tabs.course": {
     "defaultMessage": "과정"
+  },
+  "course.statistics.tabs.coursePerformance": {
+    "defaultMessage": "수업 성적"
+  },
+  "course.statistics.tabs.courseProgression": {
+    "defaultMessage": "코스 진도"
+  },
+  "course.stories.CikgoErrorPage.errorFetching": {
+    "defaultMessage": "아마도 없거나, 뭔가 잘못된 것 같습니다."
+  },
+  "course.stories.CikgoErrorPage.errorFetchingDescription": {
+    "defaultMessage": "<cikgo>Cikgo</cikgo>는 이 경험을 지원하는 파트너입니다. 그들은 연락이 가능했지만, 현재 이 요청에 대한 자원을 제공하지 않았습니다. 나중에 다시 시도해 주세요. 만약 문제가 계속된다면, <link>저희에게 연락하세요</link>."
+  },
+  "course.stories.pages.LearnPage": {
+    "defaultMessage": "배우다"
+  },
+  "course.stories.pages.MissionControlPage": {
+    "defaultMessage": "미션 컨트롤"
   },
   "course.survey.DeleteSectionButton.deleteSection": {
     "defaultMessage": "섹션 삭제"
@@ -5978,6 +6710,9 @@
   "course.userInvitation.InviteUsersRegistrationCode.registrationCodeNote": {
     "defaultMessage": "초대받은 사용자가 이 초대 코드를 사용하여 과정에 등록할 경우, 초대 페이지에서 해당 상태가 올바르게 반영되지 않을 수 있습니다."
   },
+  "course.userInvitations.IndividualInvitations.addRowsByEmail": {
+    "defaultMessage": "이메일로 행 추가"
+  },
   "course.userInvitations.IndividualInvitations.appendNewRow": {
     "defaultMessage": "행 추가"
   },
@@ -5986,6 +6721,12 @@
   },
   "course.userInvitations.IndividualInvitations.invite": {
     "defaultMessage": "모든 사용자 초대"
+  },
+  "course.userInvitations.IndividualInvitations.malformedEmail": {
+    "defaultMessage": "{n, plural, one {이 이메일은 } other {이 이메일들은 }} 잘못된 형식입니다: {emails}"
+  },
+  "course.userInvitations.IndividualInvitations.nameEmailInput": {
+    "defaultMessage": "존 도 '<john.doe@example.org>'; '도, 제인' '<jane.doe@example.org>'; ..."
   },
   "course.userInvitations.IndividualInvitations.namePlaceholder": {
     "defaultMessage": "멋진 사용자"
@@ -6154,12 +6895,6 @@
   },
   "course.users.ExperiencePointsRecords.experiencePointsHistoryHeader": {
     "defaultMessage": "경험치 기록: {for}"
-  },
-  "course.users.ExperiencePointsRecords.fetchUsersFailure": {
-    "defaultMessage": "기록을 가져오지 못했습니다."
-  },
-  "course.users.ExperiencePointsTable.fetchRecordsFailure": {
-    "defaultMessage": "기록을 가져오지 못했습니다."
   },
   "course.users.ManageStaff.noStaff": {
     "defaultMessage": "과정에 직원이 없습니다."
@@ -6476,8 +7211,26 @@
   "course.video.VideoShow.videoTitle": {
     "defaultMessage": "비디오 - {title}"
   },
+  "course.video.VideoTable.actions": {
+    "defaultMessage": "행동"
+  },
+  "course.video.VideoTable.averageWatched": {
+    "defaultMessage": "평균 시청률"
+  },
   "course.video.VideoTable.noVideo": {
     "defaultMessage": "비디오 없음"
+  },
+  "course.video.VideoTable.published": {
+    "defaultMessage": "출판된"
+  },
+  "course.video.VideoTable.startAt": {
+    "defaultMessage": "시작하다"
+  },
+  "course.video.VideoTable.title": {
+    "defaultMessage": "제목"
+  },
+  "course.video.VideoTable.watchCount": {
+    "defaultMessage": "시청 횟수"
   },
   "course.video.VideosIndex.fetchVideosFailure": {
     "defaultMessage": "비디오를 가져오지 못했습니다."
@@ -6628,6 +7381,21 @@
   },
   "landing_page.create_an_account": {
     "defaultMessage": "계정 생성"
+  },
+  "landing_page.iconEngaging": {
+    "defaultMessage": "매력적인"
+  },
+  "landing_page.iconEngagingSubtitle": {
+    "defaultMessage": "모든 교사를 위해 만들어졌습니다. 플랫폼을 마스터하기 위해 프로그래밍 지식이 필요하지 않습니다. Coursemology는 교사와 학생 모두에게 사용하기 쉽고 직관적입니다."
+  },
+  "landing_page.iconGeneral": {
+    "defaultMessage": "장군"
+  },
+  "landing_page.iconGeneralSubtitle": {
+    "defaultMessage": "모든 주제를 위해 만들어졌습니다. Coursemology의 게임화 시스템은 주제에 대한 어떠한 가정도 하지 않습니다. Coursemology를 통해 어떤 주제를 가르치는 어떤 교사라도 자신의 강의 연습 문제를 온라인 게임으로 변환할 수 있습니다."
+  },
+  "landing_page.iconSimple": {
+    "defaultMessage": "간단한"
   },
   "landing_page.new_to_coursemology": {
     "defaultMessage": "Coursemology를 처음 사용하시나요?"
@@ -7050,7 +7818,7 @@
     "defaultMessage": "호스트 이름"
   },
   "lib.translations.table.column.id": {
-    "defaultMessage": "ID"
+    "defaultMessage": "식별 번호"
   },
   "lib.translations.table.column.instance": {
     "defaultMessage": "인스턴스"
@@ -7150,9 +7918,6 @@
   },
   "lib.translations.yes": {
     "defaultMessage": "예"
-  },
-  "material.attemptLoader.errorAccessingMaterial": {
-    "defaultMessage": "이 자료에 접근하는 중 오류가 발생했습니다. 나중에 다시 시도해 주세요."
   },
   "sysstem.admin.instance.instance.InstanceAdminNavigator.announcements": {
     "defaultMessage": "공지사항"
@@ -7268,14 +8033,23 @@
   "system.admin.admin.InstancesTable.updateSuccess": {
     "defaultMessage": "{field}이(가) {prevValue}에서 {newValue}로 변경되었습니다."
   },
+  "system.admin.admin.UsersButton.associatedInstances": {
+    "defaultMessage": "{index}. {instanceName}"
+  },
   "system.admin.admin.UsersButton.deleteTooltip": {
     "defaultMessage": "사용자 삭제"
   },
   "system.admin.admin.UsersButton.deletionConfirm": {
     "defaultMessage": "{role} {name} ({email})을(를) 삭제하시겠습니까?"
   },
+  "system.admin.admin.UsersButton.deletionConfirmTitle": {
+    "defaultMessage": "역할 {role} {name} ({email}) 삭제 중"
+  },
   "system.admin.admin.UsersButton.deletionFailure": {
     "defaultMessage": "사용자를 삭제하지 못했습니다 - {error}"
+  },
+  "system.admin.admin.UsersButton.deletionPromptContent": {
+    "defaultMessage": "이 사용자를 삭제한 후 다음 인스턴스에 연결된 모든 인스턴스 사용자가 삭제됩니다."
   },
   "system.admin.admin.UsersButton.deletionSuccess": {
     "defaultMessage": "사용자가 삭제되었습니다."

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -251,6 +251,24 @@
   "course.achievement.AchievementAward.AchievementAwardManager.saveChanges": {
     "defaultMessage": "保存更改"
   },
+  "course.achievement.AchievementAward.AchievementAwardSummary.awardedStudents": {
+    "defaultMessage": "获奖学生"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.name": {
+    "defaultMessage": "名字"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.normalStudent": {
+    "defaultMessage": "普通学生"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.phantomStudent": {
+    "defaultMessage": "虚拟学生"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.revokedStudents": {
+    "defaultMessage": "被取消资格的学生"
+  },
+  "course.achievement.AchievementAward.AchievementAwardSummary.userType": {
+    "defaultMessage": "用户类型"
+  },
   "course.achievement.AchievementAward.awardAchievement": {
     "defaultMessage": "获奖成就"
   },
@@ -323,8 +341,26 @@
   "course.achievement.AchievementShow.studentsWithAchievement": {
     "defaultMessage": "有此成就的学生"
   },
+  "course.achievement.AchievementTable.actions": {
+    "defaultMessage": "行动"
+  },
+  "course.achievement.AchievementTable.badge": {
+    "defaultMessage": "徽章"
+  },
+  "course.achievement.AchievementTable.description": {
+    "defaultMessage": "描述"
+  },
   "course.achievement.AchievementTable.noAchievement": {
     "defaultMessage": "暂无成就"
+  },
+  "course.achievement.AchievementTable.published": {
+    "defaultMessage": "出版"
+  },
+  "course.achievement.AchievementTable.requirements": {
+    "defaultMessage": "要求"
+  },
+  "course.achievement.AchievementTable.title": {
+    "defaultMessage": "标题"
   },
   "course.achievement.AchievementsIndex.achievements": {
     "defaultMessage": "成就"
@@ -467,32 +503,32 @@
   "course.admin.AssessmentSettings.toTab": {
     "defaultMessage": "到 {tab}"
   },
-  "course.admin.CodaveriSettings.codaveriSettingsSubtitle": {
-    "defaultMessage": "目前这是一项实验性功能。 Codaveri 为学生的代码提供代码测验和自动代码反馈服务。"
-  },
-  "course.admin.CodaveriSettings.codaveriSettings": {
-    "defaultMessage": "Codaveri 设置"
-  },
-  "course.admin.CodaveriSettings.enableIsOnlyITSP": {
-    "defaultMessage": "启用 ITSP"
-  },
-  "course.admin.CodaveriSettings.error": {
-    "defaultMessage": "更新 codaveri 设置时出错。"
-  },
   "course.admin.CodaveriSettings.Some": {
     "defaultMessage": "一些"
   },
-  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingCodaveriEvaluatorSettings": {
-    "defaultMessage": "更新 Codaveri 评估器设置时发生了错误。"
+  "course.admin.CodaveriSettings.assessments": {
+    "defaultMessage": "评估"
+  },
+  "course.admin.CodaveriSettings.codaveriEngine": {
+    "defaultMessage": "Codaveri Engine"
+  },
+  "course.admin.CodaveriSettings.codaveriEngineDescription": {
+    "defaultMessage": "Type of codaveri engine used to generate programming code feedback"
   },
   "course.admin.CodaveriSettings.codaveriEvaluatorSettings": {
     "defaultMessage": "Codaveri 评估器"
   },
-  "course.admin.CodaveriSettings.liveFeedbackSettings": {
-    "defaultMessage": "实时帮助"
+  "course.admin.CodaveriSettings.codaveriSettings": {
+    "defaultMessage": "Codaveri 设置"
   },
-  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingLiveFeedbackSettings": {
-    "defaultMessage": "更新实时帮助设置时发生了错误。"
+  "course.admin.CodaveriSettings.codaveriSettingsSubtitle": {
+    "defaultMessage": "目前这是一项实验性功能。 Codaveri 为学生的代码提供代码测验和自动代码反馈服务。"
+  },
+  "course.admin.CodaveriSettings.defaultEngine": {
+    "defaultMessage": "Default Engine"
+  },
+  "course.admin.CodaveriSettings.defaultEngineDescription": {
+    "defaultMessage": "Uses generative AI and verification techniques"
   },
   "course.admin.CodaveriSettings.enableDisableButton": {
     "defaultMessage": "{enabled, select, true {启用} other {禁用}}"
@@ -500,14 +536,59 @@
   "course.admin.CodaveriSettings.enableDisableEvaluator": {
     "defaultMessage": "{enabled, select, true {启用} other {禁用}} Codaveri 评估器 对 {questionCount} 道编程题目在 {title} 中?"
   },
-  "course.admin.CodaveriSettings.enableDisableLiveFeedback": {
-    "defaultMessage": "{enabled, select, true {启用} other {禁用}} 实时帮助 对 {questionCount} 道编程题目在 {title} 中?"
-  },
   "course.admin.CodaveriSettings.enableDisableEvaluatorDescription": {
     "defaultMessage": "这 {type} 中的 {questionCount} 道编程题目将使用 {enabled, select, true {Codaveri} other {默认}} 评估器"
   },
+  "course.admin.CodaveriSettings.enableDisableLiveFeedback": {
+    "defaultMessage": "{enabled, select, true {启用} other {禁用}} 实时帮助 对 {questionCount} 道编程题目在 {title} 中?"
+  },
+  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingCodaveriEvaluatorSettings": {
+    "defaultMessage": "更新 Codaveri 评估器设置时发生了错误。"
+  },
+  "course.admin.CodaveriSettings.errorOccurredWhenUpdatingLiveFeedbackSettings": {
+    "defaultMessage": "更新实时帮助设置时发生了错误。"
+  },
+  "course.admin.CodaveriSettings.evaluatorUpdateSuccess": {
+    "defaultMessage": "{question}现在正在使用{evaluator}评估者"
+  },
+  "course.admin.CodaveriSettings.expandAll": {
+    "defaultMessage": "展开所有问题"
+  },
+  "course.admin.CodaveriSettings.feedbackWorkflow": {
+    "defaultMessage": "Automatic Post-Submission Comments"
+  },
+  "course.admin.CodaveriSettings.feedbackWorkflowDescription": {
+    "defaultMessage": "When a submission with programming question is finalised,"
+  },
+  "course.admin.CodaveriSettings.feedbackWorkflowDraft": {
+    "defaultMessage": "Generate feedback as a draft requiring approval from staff"
+  },
+  "course.admin.CodaveriSettings.feedbackWorkflowNone": {
+    "defaultMessage": "Generate no feedback"
+  },
+  "course.admin.CodaveriSettings.feedbackWorkflowPublish": {
+    "defaultMessage": "Publish feedback directly to student"
+  },
+  "course.admin.CodaveriSettings.itspEngine": {
+    "defaultMessage": "ITSP Engine"
+  },
+  "course.admin.CodaveriSettings.itspEngineDescription": {
+    "defaultMessage": "Uses automated program repair technique"
+  },
   "course.admin.CodaveriSettings.liveFeedbackEnabledUpdateSuccess": {
     "defaultMessage": "对于 {question}，实时帮助现在已 {liveFeedbackEnabled, select, true {启用} other {禁用}}"
+  },
+  "course.admin.CodaveriSettings.liveFeedbackSettings": {
+    "defaultMessage": "实时帮助"
+  },
+  "course.admin.CodaveriSettings.programmingQuestionSettings": {
+    "defaultMessage": "编程问题设置"
+  },
+  "course.admin.CodaveriSettings.programmingQuestionSettingsSubtitle": {
+    "defaultMessage": "在各种评估中启用/禁用Codaveri作为编程问题的评估者。"
+  },
+  "course.admin.CodaveriSettings.succesfulUpdateAllEvaluator": {
+    "defaultMessage": "成功将所有问题更新为使用 {evaluator} 评估器"
   },
   "course.admin.CodaveriSettings.successfulUpdateAllLiveFeedbackEnabled": {
     "defaultMessage": "成功地将所有问题的实时帮助设置为 {liveFeedbackEnabled, select, true {启用} other {禁用}}"
@@ -523,6 +604,9 @@
   },
   "course.admin.ComponentSettings.errorOccurredWhenUpdatingComponents": {
     "defaultMessage": "更新组件设置时出错。"
+  },
+  "course.admin.ComponentSettings.settingUpComponent": {
+    "defaultMessage": "为这门课程设置组件"
   },
   "course.admin.CourseSettings.allowUsersToSendEnrolmentRequests": {
     "defaultMessage": "允许用户发送注册请求"
@@ -764,6 +848,9 @@
   "course.admin.LessonPlanSettings.lessonPlanItemSettings": {
     "defaultMessage": "课程计划项目设置"
   },
+  "course.admin.LessonPlanSettings.lessonPlanSettings": {
+    "defaultMessage": "课程计划设置"
+  },
   "course.admin.LessonPlanSettings.noLessonPlanItems": {
     "defaultMessage": "没有教案项目以配置展示。"
   },
@@ -959,6 +1046,51 @@
   "course.admin.courseSettings": {
     "defaultMessage": "课程设置"
   },
+  "course.admin.storiesSettings.autoCreateAccounts": {
+    "defaultMessage": "如果Cikgo上的用户帐户和聊天室尚不存在，它们将自动创建。与Cikgo共享的信息受 <ourPpLink>我们的隐私政策</ourPpLink> 和 <cikgoPpLink>Cikgo的隐私政策</cikgoPpLink> 管辖。"
+  },
+  "course.admin.storiesSettings.integrationHint": {
+    "defaultMessage": "要将您的Cikgo课程与此课程集成，请在此处输入其集成密钥。以下是一旦此课程与Cikgo集成后将会发生的事情。"
+  },
+  "course.admin.storiesSettings.integrationSettings": {
+    "defaultMessage": "集成设置"
+  },
+  "course.admin.storiesSettings.learnTitle": {
+    "defaultMessage": "学习页面标题"
+  },
+  "course.admin.storiesSettings.leaveEmptyToUseDefaultTitle": {
+    "defaultMessage": "留空使用默认的“学习”标题。"
+  },
+  "course.admin.storiesSettings.onlyOwnersCanManage": {
+    "defaultMessage": "只有您、所有者和管理员才能配置此课程与Cikgo的集成。"
+  },
+  "course.admin.storiesSettings.pingError": {
+    "defaultMessage": "连接到Cikgo时出现问题。您可以稍后再试。"
+  },
+  "course.admin.storiesSettings.publishTaskCompletions": {
+    "defaultMessage": "学生的提交状态将反映在Cikgo的聊天室中。"
+  },
+  "course.admin.storiesSettings.pushKey": {
+    "defaultMessage": "集成密钥"
+  },
+  "course.admin.storiesSettings.pushKeyError": {
+    "defaultMessage": "此集成密钥未指向Cikgo上的有效课程。请检查您在Cikgo上的设置，然后重试。"
+  },
+  "course.admin.storiesSettings.pushKeyHint": {
+    "defaultMessage": "集成密钥并非严格保密，但应保密处理。"
+  },
+  "course.admin.storiesSettings.pushKeyPointsToCourse": {
+    "defaultMessage": "这个集成密钥指向 Cikgo 上的 <link>{course}</link>。"
+  },
+  "course.admin.storiesSettings.redirects": {
+    "defaultMessage": "当学生访问这个<link>课程的根URL</link>时，他们将被重定向到学习页面。主页仍然可以从侧边栏访问。"
+  },
+  "course.admin.storiesSettings.storiesSettings": {
+    "defaultMessage": "故事设置"
+  },
+  "course.admin.storiesSettings.syncs": {
+    "defaultMessage": "本课程中发布的测验、视频和调查将作为资源在Cikgo中提供并保持同步。"
+  },
   "course.announcement.AnnouncementsDisplay.searchBarPlaceholder": {
     "defaultMessage": "按标题或内容搜索"
   },
@@ -1070,6 +1202,12 @@
   "course.assessment.AssessmentForm.blockStudentViewingAfterSubmittedHint": {
     "defaultMessage": "学生只有在成绩公布后才能查看他们提交的内容。"
   },
+  "course.assessment.AssessmentForm.blocksAccessesFromInvalidSUS": {
+    "defaultMessage": "阻止具有无效UA的浏览器访问"
+  },
+  "course.assessment.AssessmentForm.blocksAccessesFromInvalidSUSHint": {
+    "defaultMessage": "如果启用，使用浏览器的考生，其UA无效（不包含下面指定的SUS）将被阻止访问此评估。教师可以使用会话解锁密码覆盖访问权限。来自被覆盖的浏览器会话的心跳将在PulseGrid中标记为有效。"
+  },
   "course.assessment.AssessmentForm.bonusEndAt": {
     "defaultMessage": "额外奖励结束于"
   },
@@ -1136,11 +1274,23 @@
   "course.assessment.AssessmentForm.hasPersonalTimesHint": {
     "defaultMessage": "该项目的时间将根据学习率自动为用户调整。"
   },
+  "course.assessment.AssessmentForm.hasTimeLimit": {
+    "defaultMessage": "计时器结束时自动提交"
+  },
+  "course.assessment.AssessmentForm.hasTimeLimitHint": {
+    "defaultMessage": "启用后，每个提交将拥有自己的计时器，并在计时器结束时自动完成。"
+  },
   "course.assessment.AssessmentForm.hasToBeMoreThanMinInterval": {
     "defaultMessage": "必须大于设定的最小值"
   },
   "course.assessment.AssessmentForm.hasToBeMoreThanValueMs": {
     "defaultMessage": "必须至少为 3000 毫秒"
+  },
+  "course.assessment.AssessmentForm.hasToBeNumber": {
+    "defaultMessage": "必须是有效的数字。"
+  },
+  "course.assessment.AssessmentForm.hasToBePositive": {
+    "defaultMessage": "必须是正数。"
   },
   "course.assessment.AssessmentForm.hasToBePositiveInteger": {
     "defaultMessage": "必须为一个小于 86,400,000 毫秒的正整数"
@@ -1154,6 +1304,12 @@
   "course.assessment.AssessmentForm.intervalHint": {
     "defaultMessage": "控制来自学生浏览器的心跳数据包的发送频率。发送间隔在这两个范围内随机选取"
   },
+  "course.assessment.AssessmentForm.koditsuDisabledInCourse": {
+    "defaultMessage": "请联系课程管理员，在课程设置中启用 Koditsu 考试。"
+  },
+  "course.assessment.AssessmentForm.liveFeedback": {
+    "defaultMessage": "获取帮助"
+  },
   "course.assessment.AssessmentForm.maxInterval": {
     "defaultMessage": "最大间隔"
   },
@@ -1163,8 +1319,17 @@
   "course.assessment.AssessmentForm.minInterval": {
     "defaultMessage": "最小间隔"
   },
+  "course.assessment.AssessmentForm.minutes": {
+    "defaultMessage": "分钟"
+  },
   "course.assessment.AssessmentForm.modeSwitchingHint": {
     "defaultMessage": "你不能再更改评分模式，因为已经有此测验的提交。"
+  },
+  "course.assessment.AssessmentForm.needSUSAndSessionUnlockPassword": {
+    "defaultMessage": "您需要指定一个SUS和会话解锁密码才能启用此功能。"
+  },
+  "course.assessment.AssessmentForm.noProgrammingQuestion": {
+    "defaultMessage": "You need to add at least one programming question that can be supported by Codaveri to allow enabling live feedback for this Assessment"
   },
   "course.assessment.AssessmentForm.noTestCaseChosenError": {
     "defaultMessage": "至少选择一种类型的测试用例"
@@ -1190,11 +1355,17 @@
   "course.assessment.AssessmentForm.personalisedTimelines": {
     "defaultMessage": "个性化时间表"
   },
+  "course.assessment.AssessmentForm.proctorWithKoditsu": {
+    "defaultMessage": "使用Koditsu进行监考考试"
+  },
   "course.assessment.AssessmentForm.published": {
     "defaultMessage": "发布时间"
   },
   "course.assessment.AssessmentForm.publishedHint": {
     "defaultMessage": "每个人都可以看到这个评价。"
+  },
+  "course.assessment.AssessmentForm.questionsIncompatibleWithKoditsu": {
+    "defaultMessage": "请确保在激活Koditsu的监考之前，此评估中的所有问题与Koditsu兼容。"
   },
   "course.assessment.AssessmentForm.secret": {
     "defaultMessage": "UA子字符串密文（SUS）"
@@ -1204,9 +1375,6 @@
   },
   "course.assessment.AssessmentForm.sessionPassword": {
     "defaultMessage": "会话解锁密码"
-  },
-  "course.assessment.AssessmentForm.sessionPasswordHint": {
-    "defaultMessage": "理想情况下，不要将此密码提供给学生。"
   },
   "course.assessment.AssessmentForm.sessionProtection": {
     "defaultMessage": "启用会话保护"
@@ -1253,8 +1421,14 @@
   "course.assessment.AssessmentForm.timeBonusExp": {
     "defaultMessage": "额外时间奖励经验"
   },
+  "course.assessment.AssessmentForm.timeLimit": {
+    "defaultMessage": "时间限制"
+  },
   "course.assessment.AssessmentForm.title": {
     "defaultMessage": "标题"
+  },
+  "course.assessment.AssessmentForm.toggleLiveFeedbackDescription": {
+    "defaultMessage": "Enable live feedback feature for all programming questions"
   },
   "course.assessment.AssessmentForm.unavailableInAutograded": {
     "defaultMessage": "在自动评分测验中不可用。"
@@ -1331,6 +1505,69 @@
   "course.assessment.edit.update": {
     "defaultMessage": "保存"
   },
+  "course.assessment.generation.allFieldsLocked": {
+    "defaultMessage": "所有字段都已锁定，因此无法生成任何内容。"
+  },
+  "course.assessment.generation.confirmDeleteConversation": {
+    "defaultMessage": "您确定要删除\"{title}\"及其所有历史记录吗？此操作不可逆转！"
+  },
+  "course.assessment.generation.exportAction": {
+    "defaultMessage": "导出"
+  },
+  "course.assessment.generation.exportClose": {
+    "defaultMessage": "关闭"
+  },
+  "course.assessment.generation.exportDialogHeader": {
+    "defaultMessage": "导出问题（已选择{exportCount}个）"
+  },
+  "course.assessment.generation.exportError": {
+    "defaultMessage": "导出此问题时发生了错误。"
+  },
+  "course.assessment.generation.generateError": {
+    "defaultMessage": "生成问题\"{title}\"时发生错误。"
+  },
+  "course.assessment.generation.generatePage": {
+    "defaultMessage": "生成编程问题"
+  },
+  "course.assessment.generation.generateQuestion": {
+    "defaultMessage": "生成"
+  },
+  "course.assessment.generation.generateSuccess": {
+    "defaultMessage": "成功生成“{title}”的一代。"
+  },
+  "course.assessment.generation.languageField": {
+    "defaultMessage": "语言"
+  },
+  "course.assessment.generation.newTab": {
+    "defaultMessage": "新"
+  },
+  "course.assessment.generation.openExportDialog": {
+    "defaultMessage": "导出"
+  },
+  "course.assessment.generation.promptPlaceholder": {
+    "defaultMessage": "在这里输入一些内容..."
+  },
+  "course.assessment.generation.resetConversation": {
+    "defaultMessage": "重置"
+  },
+  "course.assessment.generation.showInactive": {
+    "defaultMessage": "显示非活动项目"
+  },
+  "course.assessment.liveFeedback.comments": {
+    "defaultMessage": "评论"
+  },
+  "course.assessment.liveFeedback.feedbackTimingTitle": {
+    "defaultMessage": "使用时间：{usedAt}"
+  },
+  "course.assessment.liveFeedback.lineHeader": {
+    "defaultMessage": "第 {lineNumber} 行"
+  },
+  "course.assessment.liveFeedback.questionTitle": {
+    "defaultMessage": "题目 {index}"
+  },
+  "course.assessment.monitoring.accessGrantedForThisSessionOnly": {
+    "defaultMessage": "只有在此浏览器会话期间才会授予访问权限。"
+  },
   "course.assessment.monitoring.alivePresenceHint": {
     "defaultMessage": "及时收到最后一次心跳"
   },
@@ -1340,14 +1577,29 @@
   "course.assessment.monitoring.blankField": {
     "defaultMessage": "（空）"
   },
+  "course.assessment.monitoring.blocksAccessesFromInvalidSUS": {
+    "defaultMessage": "阻止未授权浏览器访问"
+  },
+  "course.assessment.monitoring.blocksAccessesFromInvalidSUSHint": {
+    "defaultMessage": "如果启用，使用未经授权的浏览器的考生将无法访问此评估。教师可以使用会话解锁密码覆盖访问权限。覆盖浏览器会话的“心跳信号”（浏览器与服务器之间的定期通信）始终有效（绿色）在PulseGrid中。"
+  },
+  "course.assessment.monitoring.browserAuthorizationMethod": {
+    "defaultMessage": "浏览器授权方法"
+  },
+  "course.assessment.monitoring.browserAuthorizationMethodHint": {
+    "defaultMessage": "选择会话如何被授权为有效或无效。更改立即应用于所有会话和心跳“心跳信号”（浏览器与服务器之间的定期通信），并在PulseGrid中实时更新。"
+  },
   "course.assessment.monitoring.cannotConnectToLiveMonitoringChannel": {
     "defaultMessage": "连接到实时监控频道时发生错误"
   },
   "course.assessment.monitoring.connected": {
     "defaultMessage": "已连接"
   },
-  "course.assessment.monitoring.connectedToLiveMonitoringChannel": {
-    "defaultMessage": "连接到实时监控频道"
+  "course.assessment.monitoring.connecting": {
+    "defaultMessage": "连接"
+  },
+  "course.assessment.monitoring.deltaFromPreviousHeartbeat": {
+    "defaultMessage": "{ms} 毫秒前的上一个“心跳信号”（浏览器与服务器之间的定期通信）"
   },
   "course.assessment.monitoring.detailsOfNHeartbeats": {
     "defaultMessage": "最后 {n} 次心跳的详情"
@@ -1355,20 +1607,44 @@
   "course.assessment.monitoring.disconnected": {
     "defaultMessage": "已断开连接"
   },
-  "course.assessment.monitoring.disconnectedFromLiveMonitoringChannel": {
-    "defaultMessage": "与实时监控频道断开连接"
+  "course.assessment.monitoring.enableBrowserAuthorization": {
+    "defaultMessage": "授权访问此评估的浏览器"
+  },
+  "course.assessment.monitoring.enableBrowserAuthorizationHint": {
+    "defaultMessage": "如果启用，PulseGrid还将根据您选择的授权方法，额外检查考生是否从授权的浏览器访问此评估。"
+  },
+  "course.assessment.monitoring.examMonitoring": {
+    "defaultMessage": "启用考试监控"
+  },
+  "course.assessment.monitoring.examMonitoringHint": {
+    "defaultMessage": "如果启用，考生的会话将在他们尝试考试时实时监控，直到他们完成考试或自尝试以来的前24小时，以较早者为准。教师可以在 <pulsegrid>PulseGrid</pulsegrid> 中监控这些会话。"
+  },
+  "course.assessment.monitoring.expiredSession": {
+    "defaultMessage": "会话已过期。自提交以来已经过去至少24小时。"
   },
   "course.assessment.monitoring.filterByGroup": {
     "defaultMessage": "按组筛选"
   },
+  "course.assessment.monitoring.firstReceivedHeartbeat": {
+    "defaultMessage": "首次接收到的“心跳信号”（浏览器与服务器之间的定期通信）"
+  },
   "course.assessment.monitoring.generatedAt": {
     "defaultMessage": "生成于"
   },
+  "course.assessment.monitoring.intervalHint": {
+    "defaultMessage": "控制考生浏览器发送“心跳信号”（浏览器与服务器之间的定期通信）的频率。间隔在这两个范围之间随机化。"
+  },
+  "course.assessment.monitoring.invalidBrowser": {
+    "defaultMessage": "无效的浏览器配置"
+  },
+  "course.assessment.monitoring.invalidBrowserSubtitle": {
+    "defaultMessage": "您的当前浏览器或其配置不允许访问此评估。请联系您的教练寻求帮助。"
+  },
+  "course.assessment.monitoring.invalidHeartbeat": {
+    "defaultMessage": "无效的"
+  },
   "course.assessment.monitoring.ipAddress": {
     "defaultMessage": "IP地址"
-  },
-  "course.assessment.monitoring.lastHeartbeat": {
-    "defaultMessage": "最后一次心跳"
   },
   "course.assessment.monitoring.latePresenceHint": {
     "defaultMessage": "未及时收到下一次心跳，但仍在设定的心跳间隔内。"
@@ -1376,14 +1652,47 @@
   "course.assessment.monitoring.live": {
     "defaultMessage": "在线"
   },
+  "course.assessment.monitoring.liveHint": {
+    "defaultMessage": "这个“心跳信号”（浏览器与服务器之间的定期通信）立即被服务器接收。"
+  },
+  "course.assessment.monitoring.liveness": {
+    "defaultMessage": "活力"
+  },
+  "course.assessment.monitoring.loadAllHeartbeats": {
+    "defaultMessage": "加载全部"
+  },
+  "course.assessment.monitoring.maxInterval": {
+    "defaultMessage": "最大间隔"
+  },
+  "course.assessment.monitoring.milliseconds": {
+    "defaultMessage": "毫秒"
+  },
+  "course.assessment.monitoring.minInterval": {
+    "defaultMessage": "最小间隔"
+  },
   "course.assessment.monitoring.missingPresenceHint": {
     "defaultMessage": "没有及时收到下一次心跳。"
+  },
+  "course.assessment.monitoring.needSUSAndSessionUnlockPassword": {
+    "defaultMessage": "您必须启用浏览器授权并设置会话解锁密码才能启用此功能。"
   },
   "course.assessment.monitoring.noActiveSessions": {
     "defaultMessage": "没有活跃的会话。"
   },
+  "course.assessment.monitoring.offset": {
+    "defaultMessage": "“心跳信号”（浏览器与服务器之间的定期通信）间隔偏移"
+  },
+  "course.assessment.monitoring.offsetHint": {
+    "defaultMessage": "控制 PulseGrid 在频率间隔后等待多长时间，然后将会话标记为迟到。"
+  },
+  "course.assessment.monitoring.openSubmissionInNewTab": {
+    "defaultMessage": "在新标签页中打开提交"
+  },
+  "course.assessment.monitoring.overrideAccess": {
+    "defaultMessage": "覆盖访问"
+  },
   "course.assessment.monitoring.pulsegrid": {
-    "defaultMessage": "PulseGrid"
+    "defaultMessage": "脉冲网"
   },
   "course.assessment.monitoring.recentActivities": {
     "defaultMessage": "近期活动"
@@ -1391,8 +1700,41 @@
   "course.assessment.monitoring.recentActivitiesHint": {
     "defaultMessage": "关闭此选项卡会让这些日志消失"
   },
+  "course.assessment.monitoring.resetZoom": {
+    "defaultMessage": "重置缩放"
+  },
+  "course.assessment.monitoring.sebConfigKey": {
+    "defaultMessage": "安全考试浏览器（SEB）配置密钥"
+  },
+  "course.assessment.monitoring.sebConfigKeyFieldHint": {
+    "defaultMessage": "您的<sebConfigKey>SEB配置密钥</sebConfigKey>，而不是浏览器考试密钥，是从您特定的SEB配置生成的。它在操作系统和SEB版本之间保持不变。如果您更改了SEB配置，请确保更新此字段。"
+  },
+  "course.assessment.monitoring.sebConfigKeyFieldLabel": {
+    "defaultMessage": "SEB配置密钥"
+  },
+  "course.assessment.monitoring.sebConfigKeyHint": {
+    "defaultMessage": "如果考生使用有效配置使用 <seb>安全考试浏览器（SEB）</seb>，则将会话标记为有效。 SEB为特定配置生成唯一的 <sebConfigKey>配置密钥</sebConfigKey>。此方法需要 Windows 上的 SEB 3.4 和 iOS 及 macOS 上的 SEB 3.0 或更高版本。"
+  },
+  "course.assessment.monitoring.sebPayload": {
+    "defaultMessage": "安全考试浏览器（SEB）配置密钥哈希和URL"
+  },
+  "course.assessment.monitoring.secret": {
+    "defaultMessage": "秘密UA子字符串（SUS）"
+  },
+  "course.assessment.monitoring.secretHint": {
+    "defaultMessage": "如果考生的浏览器 User Agent (UA) 包含区分大小写的秘密信息，PulseGrid 将标记该会话为有效，否则标记为无效。如果您将此留空，所有会话都将被标记为有效。"
+  },
+  "course.assessment.monitoring.sessionUnlockPassword": {
+    "defaultMessage": "会话解锁密码"
+  },
   "course.assessment.monitoring.stale": {
     "defaultMessage": "陈旧的"
+  },
+  "course.assessment.monitoring.staleHint": {
+    "defaultMessage": "这个心跳信号没有立即被服务器接收，因为受检者的浏览器暂时无法访问。它被缓存在浏览器中，当浏览器再次可访问时发送到服务器。"
+  },
+  "course.assessment.monitoring.stoppedSession": {
+    "defaultMessage": "停止会话。学生可能已经完成了他们的提交。"
   },
   "course.assessment.monitoring.summaryCorrectAsAt": {
     "defaultMessage": "截至 {time} 的摘要是正确的"
@@ -1403,11 +1745,20 @@
   "course.assessment.monitoring.userAgent": {
     "defaultMessage": "用户代理（UA）"
   },
+  "course.assessment.monitoring.userAgentHint": {
+    "defaultMessage": "如果考生的浏览器的<ua>User Agent (UA)</ua>包含一个秘密子字符串，则将会标记该会话为有效。"
+  },
   "course.assessment.monitoring.userHeartbeatContinuedStreaming": {
     "defaultMessage": "{name}的心跳持续串流。"
   },
   "course.assessment.monitoring.userHeartbeatNotReceivedInTime": {
     "defaultMessage": "{name}的心跳没有被及时接收到。"
+  },
+  "course.assessment.monitoring.validHeartbeat": {
+    "defaultMessage": "有效"
+  },
+  "course.assessment.monitoring.zoomPanHint": {
+    "defaultMessage": "捏或滚动缩放。拖动以平移。"
   },
   "course.assessment.newAssessment": {
     "defaultMessage": "新测验"
@@ -1496,8 +1847,17 @@
   "course.assessment.question.multipleResponses.maximumGrade": {
     "defaultMessage": "得分最大值"
   },
+  "course.assessment.question.multipleResponses.mustBeLessThanMaxAttachmentSize": {
+    "defaultMessage": "最多 {defaultMax}MB。"
+  },
+  "course.assessment.question.multipleResponses.mustBeLessThanMaxAttachments": {
+    "defaultMessage": "必须最多为 {defaultMax}。"
+  },
   "course.assessment.question.multipleResponses.mustBeLessThanMaxMaximumGrade": {
     "defaultMessage": "必须小于1000。"
+  },
+  "course.assessment.question.multipleResponses.mustHaveAtLeastOneResponse": {
+    "defaultMessage": "您必须至少指定一个回复。"
   },
   "course.assessment.question.multipleResponses.mustSpecifyAtLeastOneCorrectChoice": {
     "defaultMessage": "你必须指定至少一个正确选项。"
@@ -1505,8 +1865,20 @@
   "course.assessment.question.multipleResponses.mustSpecifyChoice": {
     "defaultMessage": "你必须指定一个有效的选项标题。"
   },
+  "course.assessment.question.multipleResponses.mustSpecifyMaxAttachment": {
+    "defaultMessage": "您必须指定一个有效的正数最大附件数量。"
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyMaxAttachmentSize": {
+    "defaultMessage": "您必须指定一个有效且正数的最大附件大小。"
+  },
   "course.assessment.question.multipleResponses.mustSpecifyMaximumGrade": {
     "defaultMessage": "你必须指定一个有效且非负的奖励得分最大值。"
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachment": {
+    "defaultMessage": "附件的最大数量必顶是正数。"
+  },
+  "course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachmentSize": {
+    "defaultMessage": "最大尺寸必须是正数。"
   },
   "course.assessment.question.multipleResponses.mustSpecifyPositiveMaximumGrade": {
     "defaultMessage": "得分最大值必须非负。"
@@ -1622,6 +1994,9 @@
   "course.assessment.question.programming.codaveriEvaluatorHint": {
     "defaultMessage": "提交后，在默认评分的基础上，此判题器将提供基于 Codaveri 的自动代码反馈。这些反馈将以草稿注释的形式出现，供导师审阅、编辑和发布。"
   },
+  "course.assessment.question.programming.codaveriEvaluatorNotSupported": {
+    "defaultMessage": "Codaveri 评估器不支持{languageName}。"
+  },
   "course.assessment.question.programming.codeInserts": {
     "defaultMessage": "代码插入"
   },
@@ -1645,6 +2020,9 @@
   },
   "course.assessment.question.programming.defaultEvaluatorHint": {
     "defaultMessage": "无额外操作，只需按照下面的包运行代码，并报告测试结果即可。"
+  },
+  "course.assessment.question.programming.defaultEvaluatorNotSupported": {
+    "defaultMessage": "默认评估器不支持{languageName}。"
   },
   "course.assessment.question.programming.editOnline": {
     "defaultMessage": "在线创建/修改"
@@ -1685,6 +2063,9 @@
   "course.assessment.question.programming.expected": {
     "defaultMessage": "预期结果"
   },
+  "course.assessment.question.programming.expectedOutput": {
+    "defaultMessage": "预期输出"
+  },
   "course.assessment.question.programming.expression": {
     "defaultMessage": "表达式"
   },
@@ -1715,6 +2096,9 @@
   "course.assessment.question.programming.inlineCode": {
     "defaultMessage": "内联代码"
   },
+  "course.assessment.question.programming.input": {
+    "defaultMessage": "输入"
+  },
   "course.assessment.question.programming.javaTestCasesHint": {
     "defaultMessage": "表达式将在提交的代码的上下文中进行评估。返回值将使用 <code>expectEquals(expression, expected)</code> 与期望值进行比较。其简化定义如下，其中 <code>Object</code> 已被重载为 Java 原始类型。"
   },
@@ -1730,6 +2114,9 @@
   "course.assessment.question.programming.languageAndEvaluation": {
     "defaultMessage": "语言和评估"
   },
+  "course.assessment.question.programming.languageDeprecatedWarning": {
+    "defaultMessage": "您选择的语言已被弃用。请将其更改为其他语言。"
+  },
   "course.assessment.question.programming.lastUpdated": {
     "defaultMessage": "上次由 {by} 于 {on} 更新."
   },
@@ -1738,6 +2125,9 @@
   },
   "course.assessment.question.programming.liveFeedbackCustomPromptDescription": {
     "defaultMessage": "在此添加指导实时反馈生成的说明。如果不确定，可以留空。"
+  },
+  "course.assessment.question.programming.liveFeedbackNotSupported": {
+    "defaultMessage": "不支持为{languageName}生成实时反馈。"
   },
   "course.assessment.question.programming.lowestGradingPriority": {
     "defaultMessage": "最低评分优先级"
@@ -1805,6 +2195,9 @@
   "course.assessment.question.programming.questionSavedButPackageError": {
     "defaultMessage": "已保存更改，但包未成功导入。"
   },
+  "course.assessment.question.programming.rTestCasesHint": {
+    "defaultMessage": "每个测试用例都会启动一个单独的 R 控制台实例，并通过标准输入提供输入。该控制台将运行 <prepend>Prepend</prepend> 脚本、学生提交内容和 <append>Append</append> 脚本。这些脚本的标准输出将与测试用例的预期输出（作为字符串）进行比较。我们建议在这些脚本中处理标准输入。"
+  },
   "course.assessment.question.programming.savingChanges": {
     "defaultMessage": "正在保存你的修改"
   },
@@ -1853,6 +2246,9 @@
   "course.assessment.question.programming.timeLimit": {
     "defaultMessage": "时间限制"
   },
+  "course.assessment.question.programming.timeLimitDetail": {
+    "defaultMessage": "{timeLimit, plural, one {# 分钟} other {# 分钟}}"
+  },
   "course.assessment.question.programming.uploadNewPackage": {
     "defaultMessage": "提交一个新包"
   },
@@ -1872,10 +2268,12 @@
     "defaultMessage": "不能留空。"
   },
   "course.assessment.question.scribing.ScribingQuestionForm.chooseFileButton": {
-    "defaultMessage": "选择文件"
+    "defaultMessage": "选择文件",
+    "description": "Button for adding an image attachment."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.descriptionFieldLabel": {
-    "defaultMessage": "描述"
+    "defaultMessage": "描述",
+    "description": "Label for the description input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.fetchFailureMessage": {
     "defaultMessage": "发生错误，请重试。"
@@ -1890,10 +2288,12 @@
     "defaultMessage": "值必须大于 0。"
   },
   "course.assessment.question.scribing.ScribingQuestionForm.maximumGradeFieldLabel": {
-    "defaultMessage": "最高等级"
+    "defaultMessage": "最高等级",
+    "description": "Label for the maximum grade input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.noFileChosenMessage": {
-    "defaultMessage": "没有选中任何文件"
+    "defaultMessage": "没有选中任何文件",
+    "description": "Message to be displayed when no file is chosen for a file input."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.positiveNumberValidationError": {
     "defaultMessage": "必须为正值。"
@@ -1905,22 +2305,27 @@
     "defaultMessage": "注意：PDF 文件的每一页都将创建为单个 Scribing 问题，每个问题都采用相同的问题详细信息。你可以选择将可选输入留空并在创建后返回再次编辑问题。"
   },
   "course.assessment.question.scribing.ScribingQuestionForm.skillsFieldLabel": {
-    "defaultMessage": "技能"
+    "defaultMessage": "技能",
+    "description": "Label for the skills input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.staffOnlyCommentsFieldLabel": {
-    "defaultMessage": "仅限工作人员评论"
+    "defaultMessage": "仅限工作人员评论",
+    "description": "Label for the staff only comments input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.submitButton": {
-    "defaultMessage": "提交"
+    "defaultMessage": "提交",
+    "description": "Button for submitting the form."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.submitFailureMessage": {
     "defaultMessage": "发生错误，请重试。"
   },
   "course.assessment.question.scribing.ScribingQuestionForm.submittingMessage": {
-    "defaultMessage": "提交中..."
+    "defaultMessage": "提交中...",
+    "description": "Text to be displayed when waiting for server response after form submission."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.titleFieldLabel": {
-    "defaultMessage": "标题"
+    "defaultMessage": "标题",
+    "description": "Label for the title input field."
   },
   "course.assessment.question.scribing.ScribingQuestionForm.valueMoreThan1000Error": {
     "defaultMessage": "值必须小于 1000。"
@@ -1928,8 +2333,14 @@
   "course.assessment.question.textResponses.addSolution": {
     "defaultMessage": "添加一个新答案"
   },
-  "course.assessment.question.textResponses.allowFileUpload": {
-    "defaultMessage": "允许在回答中上传文件"
+  "course.assessment.question.textResponses.attachmentSettingRequired": {
+    "defaultMessage": "附件设置应该在这个问题中定义"
+  },
+  "course.assessment.question.textResponses.attachmentSettings": {
+    "defaultMessage": "附件设置"
+  },
+  "course.assessment.question.textResponses.attachmentSettingsDescription": {
+    "defaultMessage": "当学生尝试这个问题时，"
   },
   "course.assessment.question.textResponses.deleteSolution": {
     "defaultMessage": "删除答案"
@@ -1943,8 +2354,23 @@
   "course.assessment.question.textResponses.grade": {
     "defaultMessage": "得分"
   },
+  "course.assessment.question.textResponses.isAttachmentRequired": {
+    "defaultMessage": "此问题需要文件上传"
+  },
   "course.assessment.question.textResponses.keyword": {
     "defaultMessage": "关键词"
+  },
+  "course.assessment.question.textResponses.maxAttachmentSize": {
+    "defaultMessage": "每个附件的最大尺寸"
+  },
+  "course.assessment.question.textResponses.maxAttachments": {
+    "defaultMessage": "附件最大数量"
+  },
+  "course.assessment.question.textResponses.multipleAttachments": {
+    "defaultMessage": "多个附件"
+  },
+  "course.assessment.question.textResponses.multipleFileAttachmentDescription": {
+    "defaultMessage": "他们可以上传多个附件。"
   },
   "course.assessment.question.textResponses.mustSpecifyGrade": {
     "defaultMessage": "您必须设定一个有效成绩分数。"
@@ -1957,6 +2383,18 @@
   },
   "course.assessment.question.textResponses.newSolutionCannotUndo": {
     "defaultMessage": "这是一个新答案。如果在保存前删除，它会立即消失。"
+  },
+  "course.assessment.question.textResponses.noAttachment": {
+    "defaultMessage": "无附件"
+  },
+  "course.assessment.question.textResponses.noAttachmentDescription": {
+    "defaultMessage": "他们将无法上传任何附件。"
+  },
+  "course.assessment.question.textResponses.singleFileAttachment": {
+    "defaultMessage": "单个附件"
+  },
+  "course.assessment.question.textResponses.singleFileAttachmentDescription": {
+    "defaultMessage": "他们只能上传一个附件。"
   },
   "course.assessment.question.textResponses.solution": {
     "defaultMessage": "答案"
@@ -1981,6 +2419,9 @@
   },
   "course.assessment.question.textResponses.undoDeleteSolution": {
     "defaultMessage": "撤销删除答案"
+  },
+  "course.assessment.question.textResponses.validAttachmentSettingValues": {
+    "defaultMessage": "附件设置应为无附件、单个文件附件或多个文件附件之一"
   },
   "course.assessment.question.textResponses.zeroGrade": {
     "defaultMessage": "0.0"
@@ -2008,9 +2449,6 @@
   },
   "course.assessment.show.assessmentOnlyAvailableFrom": {
     "defaultMessage": "此测验仅可来自"
-  },
-  "course.assessment.show.audioResponse": {
-    "defaultMessage": "声音反馈"
   },
   "course.assessment.show.baseExp": {
     "defaultMessage": "基础经验值"
@@ -2044,6 +2482,9 @@
   },
   "course.assessment.show.chooseAssessmentToDuplicateInto": {
     "defaultMessage": "选择要复制到的测验"
+  },
+  "course.assessment.show.comprehension": {
+    "defaultMessage": "理解"
   },
   "course.assessment.show.delete": {
     "defaultMessage": "删除"
@@ -2102,8 +2543,14 @@
   "course.assessment.show.errorMovingQuestion": {
     "defaultMessage": "移动问题时出错。"
   },
+  "course.assessment.show.failedSyncingWithKoditsu": {
+    "defaultMessage": "与Koditsu不同步"
+  },
   "course.assessment.show.fileUpload": {
     "defaultMessage": "上传文件"
+  },
+  "course.assessment.show.fileUploadDescription": {
+    "defaultMessage": "允许的附件数量设置（无、一个或多个）"
   },
   "course.assessment.show.files": {
     "defaultMessage": "文件"
@@ -2116,6 +2563,9 @@
   },
   "course.assessment.show.forumPostResponse": {
     "defaultMessage": "论坛帖子回复"
+  },
+  "course.assessment.show.generate": {
+    "defaultMessage": "生成编程问题"
   },
   "course.assessment.show.gradedTestCases": {
     "defaultMessage": "为测试用例打分"
@@ -2134,6 +2584,9 @@
   },
   "course.assessment.show.hideOptions": {
     "defaultMessage": "隐藏选项"
+  },
+  "course.assessment.show.koditsuMode": {
+    "defaultMessage": "Koditsu"
   },
   "course.assessment.show.manageComponents": {
     "defaultMessage": "在课程设置中管理组件"
@@ -2261,6 +2714,12 @@
   "course.assessment.show.sureDeletingQuestion": {
     "defaultMessage": "你确定要删除这个问题吗？"
   },
+  "course.assessment.show.syncedWithKoditsu": {
+    "defaultMessage": "与Koditsu同步"
+  },
+  "course.assessment.show.syncingWithKoditsu": {
+    "defaultMessage": "与Koditsu同步"
+  },
   "course.assessment.show.textResponse": {
     "defaultMessage": "文字回复"
   },
@@ -2275,6 +2734,9 @@
   },
   "course.assessment.show.unsubmittingAndChangingQuestionType": {
     "defaultMessage": "正在取消提交并更改你的问题类型..."
+  },
+  "course.assessment.show.voiceResponse": {
+    "defaultMessage": "音频回应"
   },
   "course.assessment.show.whileHoldingToCancelMoving": {
     "defaultMessage": "按住取消移动。"
@@ -2378,23 +2840,47 @@
   "course.assessment.skills.SkillsTable.uncategorised": {
     "defaultMessage": "未分类技能"
   },
-  "course.assessment.liveFeedback.questionTitle": {
-    "defaultMessage": "题目 {index}"
+  "course.assessment.statistics.SubmissionStatusChart.attempting": {
+    "defaultMessage": "尝试"
   },
-  "course.assessment.liveFeedback.feedbackTimingTitle": {
-    "defaultMessage": "使用时间：{usedAt}"
+  "course.assessment.statistics.SubmissionStatusChart.datasetLabel": {
+    "defaultMessage": "学生提交状态"
   },
-  "course.assessment.liveFeedback.liveFeedbackName": {
-    "defaultMessage": "实时反馈"
+  "course.assessment.statistics.SubmissionStatusChart.graded": {
+    "defaultMessage": "已评分，未发布"
   },
-  "course.assessment.liveFeedback.comments": {
-    "defaultMessage": "评论"
+  "course.assessment.statistics.SubmissionStatusChart.published": {
+    "defaultMessage": "分级"
   },
-  "course.assessment.liveFeedback.lineHeader": {
-    "defaultMessage": "第 {lineNumber} 行"
+  "course.assessment.statistics.SubmissionStatusChart.submitted": {
+    "defaultMessage": "已提交"
+  },
+  "course.assessment.statistics.SubmissionStatusChart.unattempted": {
+    "defaultMessage": "未尝试"
+  },
+  "course.assessment.statistics.ancestorFail": {
+    "defaultMessage": "无法获取此测试的过去结果。"
+  },
+  "course.assessment.statistics.ancestorSelect.current": {
+    "defaultMessage": "当前"
+  },
+  "course.assessment.statistics.ancestorSelect.fromCourse": {
+    "defaultMessage": "来自{courseTitle}课程"
+  },
+  "course.assessment.statistics.ancestorSelect.subtitle": {
+    "defaultMessage": "与此评估的过去版本进行比较："
+  },
+  "course.assessment.statistics.ancestorSelect.title": {
+    "defaultMessage": "复制历史"
+  },
+  "course.assessment.statistics.ancestorStatisticsFail": {
+    "defaultMessage": "获取祖先统计数据失败。"
   },
   "course.assessment.statistics.answers": {
     "defaultMessage": "答案"
+  },
+  "course.assessment.statistics.attemptCount": {
+    "defaultMessage": "尝试次数"
   },
   "course.assessment.statistics.attempts.filename": {
     "defaultMessage": "{assessment} 的题目尝试统计"
@@ -2408,6 +2894,33 @@
   "course.assessment.statistics.closePrompt": {
     "defaultMessage": "关闭"
   },
+  "course.assessment.statistics.comments": {
+    "defaultMessage": "评论"
+  },
+  "course.assessment.statistics.duplicationHistory": {
+    "defaultMessage": "复制历史"
+  },
+  "course.assessment.statistics.email": {
+    "defaultMessage": "电子邮件"
+  },
+  "course.assessment.statistics.fail": {
+    "defaultMessage": "获取统计数据失败。"
+  },
+  "course.assessment.statistics.gradeDisplay": {
+    "defaultMessage": "等级: {grade} / {maxGrade}"
+  },
+  "course.assessment.statistics.gradeDistribution": {
+    "defaultMessage": "成绩分布"
+  },
+  "course.assessment.statistics.gradeViolin.datasetLabel": {
+    "defaultMessage": "分布"
+  },
+  "course.assessment.statistics.gradeViolin.xAxisLabel": {
+    "defaultMessage": "得分"
+  },
+  "course.assessment.statistics.gradeViolin.yAxisLabel": {
+    "defaultMessage": "提交"
+  },
   "course.assessment.statistics.grader": {
     "defaultMessage": "评分者"
   },
@@ -2417,11 +2930,20 @@
   "course.assessment.statistics.group": {
     "defaultMessage": "组别"
   },
+  "course.assessment.statistics.header": {
+    "defaultMessage": "{title} 的统计数据"
+  },
+  "course.assessment.statistics.includePhantom": {
+    "defaultMessage": "包括虚拟学生"
+  },
   "course.assessment.statistics.legendHigherusage": {
     "defaultMessage": "使用较多"
   },
   "course.assessment.statistics.legendLowerUsage": {
     "defaultMessage": "使用较少"
+  },
+  "course.assessment.statistics.liveFeedback": {
+    "defaultMessage": "实时反馈"
   },
   "course.assessment.statistics.liveFeedback.filename": {
     "defaultMessage": "{assessment} 的题目实时反馈统计"
@@ -2438,6 +2960,9 @@
   "course.assessment.statistics.marks.redCellLegend": {
     "defaultMessage": "< 0.5 * 最高分"
   },
+  "course.assessment.statistics.marksPerQuestion": {
+    "defaultMessage": "每题分数"
+  },
   "course.assessment.statistics.name": {
     "defaultMessage": "姓名"
   },
@@ -2447,11 +2972,17 @@
   "course.assessment.statistics.nameGroupsSearchText": {
     "defaultMessage": "按姓名或组别搜索"
   },
+  "course.assessment.statistics.noIncludePhantom": {
+    "defaultMessage": "此重复评估中的所有统计数据均不包括虚拟学生"
+  },
   "course.assessment.statistics.noSubmission": {
     "defaultMessage": "尚未提交"
   },
   "course.assessment.statistics.onlyForAutogradableAssessment": {
     "defaultMessage": "此表仅适用于包含至少一个自动评分问题的评估"
+  },
+  "course.assessment.statistics.pastAnswerTitle": {
+    "defaultMessage": "提交时间：{submittedAt}"
   },
   "course.assessment.statistics.questionDisplayTitle": {
     "defaultMessage": "{student} 的题目 {index}"
@@ -2459,53 +2990,14 @@
   "course.assessment.statistics.questionIndex": {
     "defaultMessage": "题目 {index}"
   },
-  "course.assessment.statistics.totalFeedbackCount": {
-    "defaultMessage": "总计"
-  },
-  "course.assessment.statistics.totalGrade": {
-    "defaultMessage": "总分"
-  },
-  "course.assessment.statistics.workflowState": {
-    "defaultMessage": "状态"
-  },
-  "course.assessment.statistics.ancestorFail": {
-    "defaultMessage": "无法获取此测试的过去结果。"
-  },
-  "course.assessment.statistics.ancestorStatisticsFail": {
-    "defaultMessage": "获取祖先统计数据失败。"
-  },
-  "course.assessment.statistics.fail": {
-    "defaultMessage": "获取统计数据失败。"
-  },
-  "course.assessment.statistics.gradeDistribution": {
-    "defaultMessage": "成绩分布"
-  },
-  "course.assessment.statistics.gradeViolin.datasetLabel": {
-    "defaultMessage": "分布"
-  },
-  "course.assessment.statistics.gradeViolin.xAxisLabel": {
-    "defaultMessage": "得分"
-  },
-  "course.assessment.statistics.gradeViolin.yAxisLabel": {
-    "defaultMessage": "提交"
-  },
-  "course.assessment.statistics.header": {
-    "defaultMessage": "{title} 的统计数据"
+  "course.assessment.statistics.questionTitle": {
+    "defaultMessage": "问题 {index}"
   },
   "course.assessment.statistics.statistics": {
     "defaultMessage": "统计数据"
   },
-  "course.assessment.statistics.SubmissionStatusChart.attempting": {
-    "defaultMessage": "尝试"
-  },
-  "course.assessment.statistics.SubmissionStatusChart.datasetLabel": {
-    "defaultMessage": "学生提交状态"
-  },
-  "course.assessment.statistics.SubmissionStatusChart.submitted": {
-    "defaultMessage": "已提交"
-  },
-  "course.assessment.statistics.SubmissionStatusChart.unattempted": {
-    "defaultMessage": "未尝试"
+  "course.assessment.statistics.submissionPage": {
+    "defaultMessage": "前往答案页面"
   },
   "course.assessment.statistics.submissionStatuses": {
     "defaultMessage": "提交状态"
@@ -2525,8 +3017,20 @@
   "course.assessment.statistics.submissionTimeGradeChart.xAxisLabel.withoutDeadline": {
     "defaultMessage": "提交日期"
   },
+  "course.assessment.statistics.total": {
+    "defaultMessage": "Total"
+  },
+  "course.assessment.statistics.workflowState": {
+    "defaultMessage": "状态"
+  },
   "course.assessment.submission.Annotations.comment": {
     "defaultMessage": "添加评论"
+  },
+  "course.assessment.submission.Answer.missingAnswer": {
+    "defaultMessage": "此问题没有已提交的答案——可能是因为提交之后又添加了新问题。"
+  },
+  "course.assessment.submission.Answer.rendererNotImplemented": {
+    "defaultMessage": "此问题类型的显示尚未实现。"
   },
   "course.assessment.submission.CodaveriFeedbackStatus.codaveriFeedbackStatus": {
     "defaultMessage": "Codaveri反馈状态"
@@ -2546,14 +3050,41 @@
   "course.assessment.submission.EvaluatorErrorPanel.emailSubject": {
     "defaultMessage": "[Bug Report] 评测错误"
   },
+  "course.assessment.submission.FileInput.exactlyOneFileUploadAllowed": {
+    "defaultMessage": "您必须为此问题上传1个文件"
+  },
+  "course.assessment.submission.FileInput.fileName": {
+    "defaultMessage": "{index}. {name}"
+  },
+  "course.assessment.submission.FileInput.fileTooLargeErrorMessage": {
+    "defaultMessage": "以下文件的大小超过了允许的大小 ({maxAttachmentSize} MB)"
+  },
+  "course.assessment.submission.FileInput.fileUploadErrorTitle": {
+    "defaultMessage": "上传文件错误"
+  },
+  "course.assessment.submission.FileInput.onlyOneFileUploadAllowed": {
+    "defaultMessage": "您只能为此问题上传最多{maxAttachments}个文件"
+  },
+  "course.assessment.submission.FileInput.requiredUploadLimitedNumberOfFiles": {
+    "defaultMessage": "您可以为此问题上传至少1个，最多{maxAttachments}个文件。"
+  },
+  "course.assessment.submission.FileInput.tooManyFilesErrorMessage": {
+    "defaultMessage": "您尝试上传{numFiles}个文件，但只能上传{maxAttachmentsAllowed}个{maxAttachmentsAllowed, plural, one {文件} other {文件}}，因为{numAttachments, plural, =0 {} one {之前已上传了1个文件} other {之前已上传了{numAttachments}个文件}}"
+  },
   "course.assessment.submission.FileInput.uploadDisabled": {
     "defaultMessage": "文件上传已禁用"
   },
   "course.assessment.submission.FileInput.uploadLabel": {
     "defaultMessage": "拖放或点击上传文件"
   },
+  "course.assessment.submission.ImportedFileView.delete": {
+    "defaultMessage": "删除"
+  },
   "course.assessment.submission.ImportedFileView.deleteConfirmation": {
     "defaultMessage": "你确定要删除此文件吗？"
+  },
+  "course.assessment.submission.ImportedFileView.deleteTitle": {
+    "defaultMessage": "删除文件"
   },
   "course.assessment.submission.ImportedFileView.noFiles": {
     "defaultMessage": "未上传文件。"
@@ -2561,17 +3092,11 @@
   "course.assessment.submission.ImportedFileView.uploadedFiles": {
     "defaultMessage": "上传的文件："
   },
-  "course.assessment.submission.Answer.missingAnswer": {
-    "defaultMessage": "此问题没有已提交的答案——可能是因为提交之后又添加了新问题。"
+  "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.hoursMinutesSeconds": {
+    "defaultMessage": "{hrs, plural, one {# 小时} other {# 小时}} {mins, plural, =0 {} one {# 分钟} other {# 分钟}} {secs, plural, =0 {} one {# 秒} other {# 秒}}"
   },
-  "course.assessment.submission.answers.AnswerHeader.noPastAnswers": {
-    "defaultMessage": "没有过去的答案。"
-  },
-  "course.assessment.submission.Answer.rendererNotImplemented": {
-    "defaultMessage": "此问题类型的显示尚未实现。"
-  },
-  "course.assessment.submission.SubmissionAnswer.viewPastAnswers": {
-    "defaultMessage": "查看过去的答案"
+  "course.assessment.submission.SubmissionEditIndex.TimeLimitBanner.minutesSeconds": {
+    "defaultMessage": "{secs, plural, one {# 秒} other {# 秒}}"
   },
   "course.assessment.submission.SubmissionsIndex.accessLogs": {
     "defaultMessage": "访问日志"
@@ -2605,6 +3130,9 @@
   },
   "course.assessment.submission.SubmissionsIndex.experiencePoints": {
     "defaultMessage": "获得的经验值"
+  },
+  "course.assessment.submission.SubmissionsIndex.fetchFromKoditsu": {
+    "defaultMessage": "从Koditsu获取提交内容"
   },
   "course.assessment.submission.SubmissionsIndex.forceSubmit": {
     "defaultMessage": "强制提交其余作业"
@@ -2654,6 +3182,9 @@
   "course.assessment.submission.SubmissionsIndex.userName": {
     "defaultMessage": "姓名"
   },
+  "course.assessment.submission.TestCaseView.allFailed": {
+    "defaultMessage": "全部失败了"
+  },
   "course.assessment.submission.TestCaseView.allPassed": {
     "defaultMessage": "全部通过"
   },
@@ -2693,8 +3224,17 @@
   "course.assessment.submission.TestCaseView.standardOutput": {
     "defaultMessage": "标准输出"
   },
+  "course.assessment.submission.TestCaseView.testCasesPassed": {
+    "defaultMessage": "{numPassed}/{numTestCases} 个测试通过"
+  },
   "course.assessment.submission.UploadedFileView.deleteConfirmation": {
     "defaultMessage": "你确定要删除此附件吗？"
+  },
+  "course.assessment.submission.UploadedFileView.deleteTitle": {
+    "defaultMessage": "删除文件"
+  },
+  "course.assessment.submission.UploadedFileView.deleting": {
+    "defaultMessage": "删除"
   },
   "course.assessment.submission.UploadedFileView.noFiles": {
     "defaultMessage": "没有文件上传。"
@@ -2751,7 +3291,7 @@
     "defaultMessage": "字体大小："
   },
   "course.assessment.submission.answer.scribing.georgia": {
-    "defaultMessage": "Georgia"
+    "defaultMessage": "乔治亚"
   },
   "course.assessment.submission.answer.scribing.impact": {
     "defaultMessage": "力度"
@@ -2814,7 +3354,7 @@
     "defaultMessage": "线宽："
   },
   "course.assessment.submission.answer.scribing.timesNewRoman": {
-    "defaultMessage": "Times New Roman"
+    "defaultMessage": "新罗马字体"
   },
   "course.assessment.submission.answer.scribing.undo": {
     "defaultMessage": "撤消"
@@ -2827,6 +3367,12 @@
   },
   "course.assessment.submission.answerSubmitted": {
     "defaultMessage": "答案已提交"
+  },
+  "course.assessment.submission.answers.AnswerHeader.noPastAnswers": {
+    "defaultMessage": "没有过去的答案。"
+  },
+  "course.assessment.submission.answers.AnswerHeader.viewPastAnswers": {
+    "defaultMessage": "过去的答案"
   },
   "course.assessment.submission.answers.ForumPostResponse.ForumCard.forumCardTitleTypeNoneSelected": {
     "defaultMessage": "论坛"
@@ -2900,11 +3446,23 @@
   "course.assessment.submission.answers.ForumPostResponse.TopicCard.viewTopicInNewTab": {
     "defaultMessage": "查看主题"
   },
-  "course.assessment.submission.answers.Programming.ProgrammingFile.downloadFile": {
-    "defaultMessage": "下载文件"
-  },
   "course.assessment.submission.answers.Programming.ProgrammingFile.sizeTooBig": {
     "defaultMessage": "文件太大，无法显示。"
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDelete": {
+    "defaultMessage": "忽略"
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDislike": {
+    "defaultMessage": "不喜欢"
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLike": {
+    "defaultMessage": "喜欢"
+  },
+  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLineHeading": {
+    "defaultMessage": "线 {linenum}"
+  },
+  "course.assessment.submission.attachmentRequired": {
+    "defaultMessage": "请至少上传1个文件以回答此问题"
   },
   "course.assessment.submission.attemptedAt": {
     "defaultMessage": "试图在"
@@ -2929,12 +3487,6 @@
   },
   "course.assessment.submission.codaveriAutogradeFailure": {
     "defaultMessage": "(T_T) 抱歉，codaveri 自动打分气罢工了。尝试在几分钟后再次提交你的代码或检查网络响应中的错误消息。"
-  },
-  "course.assessment.submission.liveFeedbackNoneGenerated": {
-    "defaultMessage": "问题 {questionIndex}：未生成反馈。"
-  },
-  "course.assessment.submission.liveFeedbackSuccess": {
-    "defaultMessage": "问题 {questionIndex}：反馈生成成功。"
   },
   "course.assessment.submission.comment.CodaveriCommentCard.finalise": {
     "defaultMessage": "完成并发布反馈"
@@ -2977,18 +3529,6 @@
   },
   "course.assessment.submission.comments": {
     "defaultMessage": "注释"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDelete": {
-    "defaultMessage": "忽略"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemDislike": {
-    "defaultMessage": "不喜欢"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLike": {
-    "defaultMessage": "喜欢"
-  },
-  "course.assessment.submission.answers.Programming.ProgrammingFiles.liveFeedbackItemLineHeading": {
-    "defaultMessage": "线 {linenum}"
   },
   "course.assessment.submission.continue": {
     "defaultMessage": "继续"
@@ -3035,6 +3575,9 @@
   "course.assessment.submission.emptyAssessment": {
     "defaultMessage": "此测验目前没有问题。"
   },
+  "course.assessment.submission.errorUnknown": {
+    "defaultMessage": "错误是未知的"
+  },
   "course.assessment.submission.examDialogMessage": {
     "defaultMessage": "请不要注销或关闭浏览器，否则你可能无法继续考试。"
   },
@@ -3043,6 +3586,15 @@
   },
   "course.assessment.submission.expAwarded": {
     "defaultMessage": "获得的经验值"
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuConfirmation": {
+    "defaultMessage": "您确定要从Koditsu获取所有提交吗？这里的所有现有答案将被新的答案覆盖。请注意，此操作是不可逆转的！"
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuPending": {
+    "defaultMessage": "请稍等，正在从Koditsu获取提交内容。"
+  },
+  "course.assessment.submission.fetchSubmissionsFromKoditsuSuccess": {
+    "defaultMessage": "所有提交已成功从Koditsu获取"
   },
   "course.assessment.submission.finalise": {
     "defaultMessage": "完成提交"
@@ -3083,9 +3635,6 @@
   "course.assessment.submission.gradeSummary": {
     "defaultMessage": "成绩总结"
   },
-  "course.assessment.submission.gradeUnsaved": {
-    "defaultMessage": "未保存"
-  },
   "course.assessment.submission.gradeUnsavedHint": {
     "defaultMessage": "该成绩尚未保存。单击页面末尾的\"保存成绩\"可保存所有更改。"
   },
@@ -3110,8 +3659,23 @@
   "course.assessment.submission.invalidFileUpload": {
     "defaultMessage": "文件上传失败：只能上传java文件"
   },
+  "course.assessment.submission.isSaved": {
+    "defaultMessage": "已保存"
+  },
+  "course.assessment.submission.isSaving": {
+    "defaultMessage": "保存"
+  },
+  "course.assessment.submission.isUnsaved": {
+    "defaultMessage": "未保存"
+  },
   "course.assessment.submission.lateSubmission": {
     "defaultMessage": "这次提交是迟到的！你可能想对迟交的学生进行处罚。"
+  },
+  "course.assessment.submission.liveFeedbackNoneGenerated": {
+    "defaultMessage": "问题 {questionIndex}：未生成反馈。"
+  },
+  "course.assessment.submission.liveFeedbackSuccess": {
+    "defaultMessage": "问题 {questionIndex}：反馈生成成功。"
   },
   "course.assessment.submission.loadingComment": {
     "defaultMessage": "正在加载评论字段..."
@@ -3161,6 +3725,24 @@
   "course.assessment.submission.ok": {
     "defaultMessage": "好的"
   },
+  "course.assessment.submission.onlyOneAttachmentAllowed": {
+    "defaultMessage": "此问题仅允许上传1个文件"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.attempting": {
+    "defaultMessage": "尝试中"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.graded": {
+    "defaultMessage": "已评分，未发布"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.published": {
+    "defaultMessage": "分级"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.submitted": {
+    "defaultMessage": "已提交"
+  },
+  "course.assessment.submission.pages.LogsIndex.LogsHead.unknown": {
+    "defaultMessage": "未知状态，请联系管理员"
+  },
   "course.assessment.submission.pastAnswers": {
     "defaultMessage": "过去的答案"
   },
@@ -3206,6 +3788,12 @@
   "course.assessment.submission.reevaluate": {
     "defaultMessage": "重新测验答案"
   },
+  "course.assessment.submission.remainingBufferTime": {
+    "defaultMessage": "最终时间：{timeLimit}"
+  },
+  "course.assessment.submission.remainingTime": {
+    "defaultMessage": "剩余时间：{timeLimit}"
+  },
   "course.assessment.submission.rendererNotImplemented": {
     "defaultMessage": "此问题类型的显示尚未实现。"
   },
@@ -3229,6 +3817,15 @@
   },
   "course.assessment.submission.saveGrade": {
     "defaultMessage": "保存成绩"
+  },
+  "course.assessment.submission.saved": {
+    "defaultMessage": "已保存"
+  },
+  "course.assessment.submission.saving": {
+    "defaultMessage": "保存"
+  },
+  "course.assessment.submission.savingFailed": {
+    "defaultMessage": "保存失败"
   },
   "course.assessment.submission.sendReminderEmailConfirmation": {
     "defaultMessage": "向未完成测验的 {unattempted} 未尝试和 {attempting} 尝试用户 ({selectedUsers}) 发送提醒邮件？"
@@ -3266,6 +3863,9 @@
   "course.assessment.submission.submissionBy": {
     "defaultMessage": "{name} 提交"
   },
+  "course.assessment.submission.submissionError": {
+    "defaultMessage": "提交问题时出现问题 {questions}"
+  },
   "course.assessment.submission.submissionsHeader": {
     "defaultMessage": "提交：{assessment}"
   },
@@ -3283,6 +3883,21 @@
   },
   "course.assessment.submission.submittedAt": {
     "defaultMessage": "提交于"
+  },
+  "course.assessment.submission.timeIsUp": {
+    "defaultMessage": "时间到了！"
+  },
+  "course.assessment.submission.timedAssessmentDialogMessage": {
+    "defaultMessage": "还有一些时间剩余。时间到期后，评估将自动完成。"
+  },
+  "course.assessment.submission.timedAssessmentDialogTitle": {
+    "defaultMessage": "{stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {剩余}} 完成此评估。} other {评估已结束!}}"
+  },
+  "course.assessment.submission.timedExamDialogMessage": {
+    "defaultMessage": "还有一些时间剩余。在尝试考试时，请不要退出或关闭浏览器。一旦时间到，评估将自动完成。"
+  },
+  "course.assessment.submission.timedExamDialogTitle": {
+    "defaultMessage": "{stillSomeTimeRemaining, select, true {{remainingTime} {isNewSubmission, select, true {} other {剩余}} 完成这次考试。} other {考试已结束!}}"
   },
   "course.assessment.submission.totalGrade": {
     "defaultMessage": "总成绩"
@@ -3319,6 +3934,9 @@
   },
   "course.assessment.submission.updateFailure": {
     "defaultMessage": "提交更新失败：{errors}"
+  },
+  "course.assessment.submission.updateIndividualSuccess": {
+    "defaultMessage": "成功更新{errors}的提交"
   },
   "course.assessment.submission.updateSuccess": {
     "defaultMessage": "提交已成功更新。"
@@ -3437,6 +4055,18 @@
   "course.assessments.index.hasTodo": {
     "defaultMessage": "显示待办事项"
   },
+  "course.assessments.index.inviteToKoditsu": {
+    "defaultMessage": "邀请用户参加Koditsu考试"
+  },
+  "course.assessments.index.invitingUserToKoditsu": {
+    "defaultMessage": "邀请用户参加Koditsu考试"
+  },
+  "course.assessments.index.invitingUserToKoditsuFailure": {
+    "defaultMessage": "在邀请用户加入Koditsu时出现问题。请稍后再试。"
+  },
+  "course.assessments.index.invitingUserToKoditsuSuccess": {
+    "defaultMessage": "成功邀请用户参加Koditsu考试"
+  },
   "course.assessments.index.neededFor": {
     "defaultMessage": "需要的"
   },
@@ -3463,6 +4093,9 @@
   },
   "course.assessments.index.submissions": {
     "defaultMessage": "提交"
+  },
+  "course.assessments.index.timeLimitIcon": {
+    "defaultMessage": "时间限制：{timeLimit, plural, one {# 分钟} other {# 分钟}}"
   },
   "course.assessments.index.title": {
     "defaultMessage": "标题"
@@ -3914,14 +4547,14 @@
   "course.duplication.Duplication.duplicateData": {
     "defaultMessage": "复制数据"
   },
-  "course.duplication.Duplication.fromCourse": {
-    "defaultMessage": "复制数据从{courseTitle}"
-  },
   "course.duplication.Duplication.duplicationDisabled": {
     "defaultMessage": "本课程禁止复制。"
   },
   "course.duplication.Duplication.existingCourse": {
     "defaultMessage": "现有课程"
+  },
+  "course.duplication.Duplication.fromCourse": {
+    "defaultMessage": "复制数据从{courseTitle}"
   },
   "course.duplication.Duplication.items": {
     "defaultMessage": "已选项目"
@@ -4046,6 +4679,9 @@
   "course.experiencePoints.disbursement.DisbursementIndex.disbursements": {
     "defaultMessage": "经验值发放"
   },
+  "course.experiencePoints.disbursement.DisbursementIndex.experienceTab": {
+    "defaultMessage": "历史"
+  },
   "course.experiencePoints.disbursement.DisbursementIndex.fetchDisbursementFailure": {
     "defaultMessage": "无法检索数据。"
   },
@@ -4079,6 +4715,15 @@
   "course.experiencePoints.disbursement.FilterForm.weeklyCap": {
     "defaultMessage": "每周上限"
   },
+  "course.experiencePoints.disbursement.ForumDisbursement.fetchDisbursementFailure": {
+    "defaultMessage": "无法检索数据。"
+  },
+  "course.experiencePoints.disbursement.ForumDisbursement.fetchForumPostsFailure": {
+    "defaultMessage": "无法获取论坛帖子。"
+  },
+  "course.experiencePoints.disbursement.ForumDisbursement.postListDialogHeader": {
+    "defaultMessage": "在{startDate}和{endDate}之间创建的帖子"
+  },
   "course.experiencePoints.disbursement.ForumDisbursementForm.createDisbursementFailure": {
     "defaultMessage": "奖励经验值失败。"
   },
@@ -4087,9 +4732,6 @@
   },
   "course.experiencePoints.disbursement.ForumDisbursementForm.fetchForumPostsFailure": {
     "defaultMessage": "无法获取论坛帖子。"
-  },
-  "course.experiencePoints.disbursement.ForumDisbursementForm.postListDialogHeader": {
-    "defaultMessage": "从 {startDate} 到 {endDate} 创建的帖子，由"
   },
   "course.experiencePoints.disbursement.ForumDisbursementForm.reason": {
     "defaultMessage": "发放原因"
@@ -4129,6 +4771,27 @@
   },
   "course.experiencePoints.disbursement.ForumPostTable.voteTally": {
     "defaultMessage": "点赞总数"
+  },
+  "course.experiencePoints.disbursement.GeneralDisbursement.fetchDisbursementFailure": {
+    "defaultMessage": "无法检索数据。"
+  },
+  "course.experiencePoints.downloadCsvButton": {
+    "defaultMessage": "下载CSV"
+  },
+  "course.experiencePoints.downloadFailure": {
+    "defaultMessage": "在下载请求过程中发生了错误。"
+  },
+  "course.experiencePoints.downloadPending": {
+    "defaultMessage": "请等待您的下载请求正在处理中。"
+  },
+  "course.experiencePoints.downloadRequestSuccess": {
+    "defaultMessage": "您的下载请求已成功"
+  },
+  "course.experiencePoints.fetchRecordsFailure": {
+    "defaultMessage": "获取记录失败"
+  },
+  "course.experiencePoints.filterByNameButton": {
+    "defaultMessage": "按名称筛选"
   },
   "course.forum.FormShow.fetchTopicsFailure": {
     "defaultMessage": "无法检索论坛主题数据。"
@@ -4367,20 +5030,17 @@
   "course.forum.HideButton.hide": {
     "defaultMessage": "隐藏"
   },
-  "course.forum.HideButton.hideTooltip": {
-    "defaultMessage": "对学生隐藏主题"
-  },
   "course.forum.HideButton.hideFailure": {
     "defaultMessage": "未能隐藏主题\"{title}\"- {error}"
   },
   "course.forum.HideButton.hideSuccess": {
     "defaultMessage": "主题\"{title}\"已成功隐藏。"
   },
+  "course.forum.HideButton.hideTooltip": {
+    "defaultMessage": "对学生隐藏主题"
+  },
   "course.forum.HideButton.unhide": {
     "defaultMessage": "取消隐藏"
-  },
-  "course.forum.HideButton.unhideTooltip": {
-    "defaultMessage": "向学生显示主题"
   },
   "course.forum.HideButton.unhideFailure": {
     "defaultMessage": "未能取消隐藏主题\"{title}\"- {error}"
@@ -4388,11 +5048,14 @@
   "course.forum.HideButton.unhideSuccess": {
     "defaultMessage": "主题\"{title}\"已成功取消隐藏。"
   },
-  "course.forum.LockButton.locked": {
-    "defaultMessage": "锁定"
+  "course.forum.HideButton.unhideTooltip": {
+    "defaultMessage": "向学生显示主题"
   },
   "course.forum.LockButton.lockTooltip": {
     "defaultMessage": "锁定以禁止学生在此主题中发帖"
+  },
+  "course.forum.LockButton.locked": {
+    "defaultMessage": "锁定"
   },
   "course.forum.LockButton.lockedFailure": {
     "defaultMessage": "无法锁定主题\"{title}\"- {error}"
@@ -4400,11 +5063,11 @@
   "course.forum.LockButton.lockedSuccess": {
     "defaultMessage": "主题\"{title}\"已成功锁定。"
   },
-  "course.forum.LockButton.unlocked": {
-    "defaultMessage": "解锁"
-  },
   "course.forum.LockButton.unlockTooltip": {
     "defaultMessage": "解锁以允许学生在此主题中发帖"
+  },
+  "course.forum.LockButton.unlocked": {
+    "defaultMessage": "解锁"
   },
   "course.forum.LockButton.unlockedFailure": {
     "defaultMessage": "无法解锁主题\"{title}\" - {error}"
@@ -4584,7 +5247,7 @@
     "defaultMessage": "没有可用的描述。"
   },
   "course.group.GroupShow.CategoryCard.subtitle": {
-    "defaultMessage": "{numGroups} {numGroups, plural, one {group} other {groups}}"
+    "defaultMessage": "{numGroups, plural, one {组} other {组}}"
   },
   "course.group.GroupShow.CategoryCard.updateFailure": {
     "defaultMessage": "无法更新 {categoryName}。"
@@ -4659,7 +5322,7 @@
     "defaultMessage": "保存更改"
   },
   "course.group.GroupShow.GroupManager.GroupManager.subtitle": {
-    "defaultMessage": "{numGroups} {numGroups, plural, one {group} other {groups}}"
+    "defaultMessage": "{numGroups, plural, one {组} other {组}}"
   },
   "course.group.GroupShow.GroupManager.GroupManager.title": {
     "defaultMessage": "管理 {categoryName} 的群组"
@@ -4698,7 +5361,7 @@
     "defaultMessage": "按名称搜索（以逗号分隔以搜索多个）"
   },
   "course.group.GroupShow.GroupManager.GroupUserManager.subtitle": {
-    "defaultMessage": "{numMembers} {numMembers, plural, one {member} other {members}}"
+    "defaultMessage": "{numMembers, plural, one {成员} other {成员}}"
   },
   "course.group.GroupShow.GroupManager.GroupUserManager.updateFailure": {
     "defaultMessage": "无法更新 {groupName}。"
@@ -4746,7 +5409,7 @@
     "defaultMessage": "序列号"
   },
   "course.group.GroupShow.GroupTableCard.subtitle": {
-    "defaultMessage": "{numMembers} {numMembers, plural, one {member} other {members}}"
+    "defaultMessage": "{numMembers, plural, one {一名成员} other {# 名成员}}"
   },
   "course.group.GroupShow.fetchFailure": {
     "defaultMessage": "获取组数据失败！请重新加载并重试。"
@@ -4787,8 +5450,26 @@
   "course.leaderboard.LeaderboardTable.average": {
     "defaultMessage": "平均的"
   },
+  "course.leaderboard.LeaderboardTable.averageAchievements": {
+    "defaultMessage": "平均成就"
+  },
+  "course.leaderboard.LeaderboardTable.averageExperience": {
+    "defaultMessage": "平均经验"
+  },
   "course.leaderboard.LeaderboardTable.experience": {
     "defaultMessage": "经验"
+  },
+  "course.leaderboard.LeaderboardTable.level": {
+    "defaultMessage": "级别"
+  },
+  "course.leaderboard.LeaderboardTable.members": {
+    "defaultMessage": "成员"
+  },
+  "course.leaderboard.LeaderboardTable.name": {
+    "defaultMessage": "名字"
+  },
+  "course.leaderboard.LeaderboardTable.rank": {
+    "defaultMessage": "排名"
   },
   "course.leaderboard.LeaderboardTable.titleAchievements": {
     "defaultMessage": "按成就"
@@ -4809,7 +5490,7 @@
     "defaultMessage": "删除此条件"
   },
   "course.learningMap.responseDashboardMessage": {
-    "defaultMessage": "{responseMessage}"
+    "defaultMessage": "回应信息"
   },
   "course.learningMap.selectedArrowDashboardMessage": {
     "defaultMessage": "已选中条件：{fromNode} --> {toNode}"
@@ -4818,7 +5499,7 @@
     "defaultMessage": "为{node}选择的门"
   },
   "course.learningMap.summaryGateContent": {
-    "defaultMessage": "{numerator}/{denominator}"
+    "defaultMessage": "{分子}/{分母}"
   },
   "course.learningMap.toggleSatisfiabilityType": {
     "defaultMessage": "将可满足性类型切换为 {satisfiabilityType}"
@@ -4958,11 +5639,23 @@
   "course.level.Level.levelHeader": {
     "defaultMessage": "等级"
   },
+  "course.level.Level.orderedIncorrectly": {
+    "defaultMessage": "无论这里的顺序如何，保存时级别都会自动排序。"
+  },
+  "course.level.Level.placeholder": {
+    "defaultMessage": "0"
+  },
+  "course.level.Level.reset": {
+    "defaultMessage": "重置"
+  },
+  "course.level.Level.resetTooltip": {
+    "defaultMessage": "重置更改"
+  },
+  "course.level.Level.saveChanges": {
+    "defaultMessage": "保存"
+  },
   "course.level.Level.saveFailure": {
     "defaultMessage": "等级保存失败，请重试。"
-  },
-  "course.level.Level.saveLevels": {
-    "defaultMessage": "保存"
   },
   "course.level.Level.saveSuccess": {
     "defaultMessage": "等级已保存"
@@ -4970,8 +5663,32 @@
   "course.level.Level.thresholdHeader": {
     "defaultMessage": "阈值"
   },
-  "course.level.LevelRow.zeroThresholdError": {
-    "defaultMessage": "经验值阈值不能为0"
+  "course.level.Level.unsavedChanges": {
+    "defaultMessage": "您有未保存的更改"
+  },
+  "course.material.files.DownloadingFilePage.clickToDownloadFile": {
+    "defaultMessage": "下载{name}"
+  },
+  "course.material.files.DownloadingFilePage.clickToDownloadFileDescription": {
+    "defaultMessage": "在启动自动下载时发生了一些问题。请点击下面的链接立即下载文件。"
+  },
+  "course.material.files.DownloadingFilePage.downloading": {
+    "defaultMessage": "下载中 {name}"
+  },
+  "course.material.files.DownloadingFilePage.downloadingDescription": {
+    "defaultMessage": "这个文件现在应该自动开始下载。如果没有，请尝试点击下面的链接或刷新此页面。"
+  },
+  "course.material.files.DownloadingFilePage.tryDownloadingAgain": {
+    "defaultMessage": "请再次下载"
+  },
+  "course.material.files.ErrorRetrievingFilePage.goToTheWorkbin": {
+    "defaultMessage": "去工作箱"
+  },
+  "course.material.files.ErrorRetrievingFilePage.problemRetrievingFile": {
+    "defaultMessage": "检索文件时出现问题"
+  },
+  "course.material.files.ErrorRetrievingFilePage.problemRetrievingFileDescription": {
+    "defaultMessage": "文件夹可能已不存在，您没有访问权限，或系统检索时出现意外错误。"
   },
   "course.material.folders.DownloadFolderButton.downloadFolderErrorMessage": {
     "defaultMessage": "下载失败。请稍后再试。"
@@ -4981,6 +5698,15 @@
   },
   "course.material.folders.DownloadFolderButton.downloading": {
     "defaultMessage": "正在下载..."
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.goToMainFolder": {
+    "defaultMessage": "前往主文件夹"
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolder": {
+    "defaultMessage": "检索文件夹时出现问题"
+  },
+  "course.material.folders.ErrorRetrievingFolderPage.problemRetrievingFolderDescription": {
+    "defaultMessage": "文件夹可能已不存在，您没有访问权限，或系统检索时出现意外错误。"
   },
   "course.material.folders.FolderEdit.editSubfolderTitle": {
     "defaultMessage": "编辑文件夹"
@@ -5020,6 +5746,9 @@
   },
   "course.material.folders.FolderShow.defaultHeader": {
     "defaultMessage": "材料"
+  },
+  "course.material.folders.FolderShow.folderNotFound": {
+    "defaultMessage": "找不到文件夹"
   },
   "course.material.folders.MaterialEdit.editMaterialTitle": {
     "defaultMessage": "编辑材料"
@@ -5066,6 +5795,15 @@
   "course.material.folders.UploadFilesButton.uploadFilesTooltip": {
     "defaultMessage": "上传"
   },
+  "course.material.folders.WorkbinTable.lastModified": {
+    "defaultMessage": "最后修改"
+  },
+  "course.material.folders.WorkbinTable.name": {
+    "defaultMessage": "名字"
+  },
+  "course.material.folders.WorkbinTable.startAt": {
+    "defaultMessage": "开始"
+  },
   "course.material.folders.WorkbinTableButtons.DeletionFailure": {
     "defaultMessage": "无法删除"
   },
@@ -5078,20 +5816,65 @@
   "course.material.folders.WorkbinTableButtons.tableButtonDeleteTooltip": {
     "defaultMessage": "删除"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.achievementCount": {
-    "defaultMessage": "成就数（总计：{courseAchievementCount}）"
+  "course.statistics.StatisticsIndex.assessments.averageGrade": {
+    "defaultMessage": "平均成绩"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.ascending": {
-    "defaultMessage": "升序"
+  "course.statistics.StatisticsIndex.assessments.averageTimeTaken": {
+    "defaultMessage": "平均时间"
+  },
+  "course.statistics.StatisticsIndex.assessments.category": {
+    "defaultMessage": "类别"
+  },
+  "course.statistics.StatisticsIndex.assessments.csvFileTitle": {
+    "defaultMessage": "评估统计"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadCsv": {
+    "defaultMessage": "下载以下评估的分数摘要？"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummaryFailure": {
+    "defaultMessage": "下载分数摘要时发生错误"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummaryPending": {
+    "defaultMessage": "请等待您的下载请求正在处理中"
+  },
+  "course.statistics.StatisticsIndex.assessments.downloadScoreSummarySuccess": {
+    "defaultMessage": "成功下载了分数摘要"
+  },
+  "course.statistics.StatisticsIndex.assessments.numLateStudents": {
+    "defaultMessage": "# 晚了"
+  },
+  "course.statistics.StatisticsIndex.assessments.numSubmittedStudents": {
+    "defaultMessage": "# 尝试"
+  },
+  "course.statistics.StatisticsIndex.assessments.searchBar": {
+    "defaultMessage": "按评估标题、选项或类别搜索"
+  },
+  "course.statistics.StatisticsIndex.assessments.selectedNUsers": {
+    "defaultMessage": "下载分数摘要（{n，复数，=1 {# 评估} other {# 评估}}）"
+  },
+  "course.statistics.StatisticsIndex.assessments.startAt": {
+    "defaultMessage": "开始"
+  },
+  "course.statistics.StatisticsIndex.assessments.stdevGrade": {
+    "defaultMessage": "标准差等级"
+  },
+  "course.statistics.StatisticsIndex.assessments.stdevTimeTaken": {
+    "defaultMessage": "标准偏差时间"
+  },
+  "course.statistics.StatisticsIndex.assessments.tab": {
+    "defaultMessage": "标签"
+  },
+  "course.statistics.StatisticsIndex.assessments.tableTitle": {
+    "defaultMessage": "评估统计 ({numStudents} 学生)"
+  },
+  "course.statistics.StatisticsIndex.assessments.title": {
+    "defaultMessage": "标题"
+  },
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.achievementCountDetails": {
+    "defaultMessage": "成就数量（总计：{courseAchievementCount}）"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.correctness": {
     "defaultMessage": "正确率"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.correctnessHint": {
-    "defaultMessage": "该学生所有已批改测验的平均成绩（百分比）"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.descending": {
-    "defaultMessage": "降序"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.experiencePoints": {
     "defaultMessage": "经验值"
@@ -5105,14 +5888,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.learningRate": {
     "defaultMessage": "学习率"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.learningRateHint": {
-    "defaultMessage": "200%的学习率意味着他们可以用一半的时间完成课程。"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.level": {
-    "defaultMessage": "等级 (最高: {maxLevel})"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.levelFilter": {
-    "defaultMessage": "等级: {name}"
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.levelInfo": {
+    "defaultMessage": "等级（最高：{maxLevel}）"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.name": {
     "defaultMessage": "姓名"
@@ -5120,11 +5897,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.noData": {
     "defaultMessage": "无数据"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.numSubmissions": {
-    "defaultMessage": "提交的数量 (总计: {courseAssessmentCount})"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.phantom": {
-    "defaultMessage": "包括旁听学生"
+  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.numSubmissionsDetails": {
+    "defaultMessage": "提交次数（总计：{courseAssessmentCount}次）"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.studentType": {
     "defaultMessage": "学生类型"
@@ -5135,17 +5909,8 @@
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.studentType.phantom": {
     "defaultMessage": "旁听学生"
   },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.tableTitle": {
-    "defaultMessage": "学生以 {direction} {column} 排序"
-  },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.title": {
     "defaultMessage": "学生表现"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.tutorFilter": {
-    "defaultMessage": "讲师：{name}"
-  },
-  "course.statistics.StatisticsIndex.course.StudentPerformanceTable.videoPercentWatched": {
-    "defaultMessage": "视频 % 数量"
   },
   "course.statistics.StatisticsIndex.course.StudentPerformanceTable.videoPercentWatchedHeader": {
     "defaultMessage": "平均视频 % 已观看"
@@ -5183,14 +5948,14 @@
   "course.statistics.StatisticsIndex.course.StudentProgressionChart.yAxisLabel": {
     "defaultMessage": "测验 (按截止日期排序)"
   },
-  "course.statistics.StatisticsIndex.course.error": {
-    "defaultMessage": "获取课程统计时出了点问题！ 请刷新重试。"
+  "course.statistics.StatisticsIndex.course.csvFileTitle": {
+    "defaultMessage": "学生表现统计"
   },
-  "course.statistics.StatisticsIndex.course.performanceError": {
-    "defaultMessage": "获取课程表现统计时出现问题！ 请刷新重试。"
+  "course.statistics.StatisticsIndex.course.searchBar": {
+    "defaultMessage": "按学生姓名搜索"
   },
-  "course.statistics.StatisticsIndex.course.progressionError": {
-    "defaultMessage": "获取课程进度统计时出了点问题！ 请刷新重试。"
+  "course.statistics.StatisticsIndex.header.assessments": {
+    "defaultMessage": "评估"
   },
   "course.statistics.StatisticsIndex.header.statistics": {
     "defaultMessage": "数据"
@@ -5198,8 +5963,8 @@
   "course.statistics.StatisticsIndex.staff.averageMarkingTime": {
     "defaultMessage": "平均时间/测验"
   },
-  "course.statistics.StatisticsIndex.staff.error": {
-    "defaultMessage": "获取员工统计信息时出了点问题！请刷新重试。"
+  "course.statistics.StatisticsIndex.staff.csvFileTitle": {
+    "defaultMessage": "员工统计"
   },
   "course.statistics.StatisticsIndex.staff.name": {
     "defaultMessage": "姓名"
@@ -5210,17 +5975,17 @@
   "course.statistics.StatisticsIndex.staff.numStudents": {
     "defaultMessage": "# 学生"
   },
+  "course.statistics.StatisticsIndex.staff.searchBar": {
+    "defaultMessage": "按员工姓名搜索"
+  },
   "course.statistics.StatisticsIndex.staff.stddev": {
     "defaultMessage": "标准偏差"
   },
   "course.statistics.StatisticsIndex.staff.tableTitle": {
     "defaultMessage": "员工统计"
   },
-  "course.statistics.StatisticsIndex.staffFailure": {
-    "defaultMessage": "获取员工数据失败！"
-  },
-  "course.statistics.StatisticsIndex.students.error": {
-    "defaultMessage": "获取学生数据时出了点问题！请刷新重试。"
+  "course.statistics.StatisticsIndex.students.csvFileTitle": {
+    "defaultMessage": "学生统计"
   },
   "course.statistics.StatisticsIndex.students.experiencePoints": {
     "defaultMessage": "经验值"
@@ -5234,20 +5999,14 @@
   "course.statistics.StatisticsIndex.students.name": {
     "defaultMessage": "姓名"
   },
-  "course.statistics.StatisticsIndex.students.noStudents": {
-    "defaultMessage": "该课程还没有学生"
-  },
-  "course.statistics.StatisticsIndex.students.showMyStudentsOnly": {
-    "defaultMessage": "只显示我的学生"
+  "course.statistics.StatisticsIndex.students.searchBar": {
+    "defaultMessage": "按学生姓名或学生类型搜索"
   },
   "course.statistics.StatisticsIndex.students.studentsType": {
     "defaultMessage": "学生类型"
   },
   "course.statistics.StatisticsIndex.students.tableTitle": {
     "defaultMessage": "学生统计"
-  },
-  "course.statistics.StatisticsIndex.students.tutorFilter": {
-    "defaultMessage": "讲师：{name}"
   },
   "course.statistics.StatisticsIndex.students.videoPercentWatched": {
     "defaultMessage": "平均 % 已观看"
@@ -5273,14 +6032,26 @@
   "course.statistics.course.studentProgressionChart.startAt": {
     "defaultMessage": "开始于：{startAt}"
   },
-  "course.statistics.failures.coursePerformance": {
-    "defaultMessage": "无法获取课程表现数据！"
-  },
-  "course.statistics.failures.courseProgression": {
-    "defaultMessage": "无法获取课程进度数据！"
-  },
   "course.statistics.tabs.course": {
     "defaultMessage": "课程"
+  },
+  "course.statistics.tabs.coursePerformance": {
+    "defaultMessage": "课程表现"
+  },
+  "course.statistics.tabs.courseProgression": {
+    "defaultMessage": "课程进度"
+  },
+  "course.stories.CikgoErrorPage.errorFetching": {
+    "defaultMessage": "可能本来就没有内容，也可能是出了一些问题。"
+  },
+  "course.stories.CikgoErrorPage.errorFetchingDescription": {
+    "defaultMessage": "<cikgo>Cikgo</cikgo> 是我们的合作伙伴，为这一体验提供支持。他们可以联系，但目前没有为这个请求提供任何资源。请稍后再试，如果问题仍然存在，请<link>联系我们</link>。"
+  },
+  "course.stories.pages.LearnPage": {
+    "defaultMessage": "学习"
+  },
+  "course.stories.pages.MissionControlPage": {
+    "defaultMessage": "任务控制"
   },
   "course.survey.DeleteSectionButton.deleteSection": {
     "defaultMessage": "删除部分"
@@ -5939,6 +6710,9 @@
   "course.userInvitation.InviteUsersRegistrationCode.registrationCodeNote": {
     "defaultMessage": "已被邀请并使用此邀请代码注册课程的用户，不会在邀请页面中显示正确状态。"
   },
+  "course.userInvitations.IndividualInvitations.addRowsByEmail": {
+    "defaultMessage": "通过电子邮件添加行"
+  },
   "course.userInvitations.IndividualInvitations.appendNewRow": {
     "defaultMessage": "添加行"
   },
@@ -5947,6 +6721,12 @@
   },
   "course.userInvitations.IndividualInvitations.invite": {
     "defaultMessage": "邀请所有用户"
+  },
+  "course.userInvitations.IndividualInvitations.malformedEmail": {
+    "defaultMessage": "{n, plural, one {这封电子邮件是} other {这些电子邮件是}}错误格式：{emails}"
+  },
+  "course.userInvitations.IndividualInvitations.nameEmailInput": {
+    "defaultMessage": "John Doe '<john.doe@example.org>'; 'Doe, Jane' '<jane.doe@example.org>'; ..."
   },
   "course.userInvitations.IndividualInvitations.namePlaceholder": {
     "defaultMessage": "很棒的用户"
@@ -6115,12 +6895,6 @@
   },
   "course.users.ExperiencePointsRecords.experiencePointsHistoryHeader": {
     "defaultMessage": "经验值历史：{for}"
-  },
-  "course.users.ExperiencePointsRecords.fetchUsersFailure": {
-    "defaultMessage": "无法获取记录"
-  },
-  "course.users.ExperiencePointsTable.fetchRecordsFailure": {
-    "defaultMessage": "无法获取记录"
   },
   "course.users.ManageStaff.noStaff": {
     "defaultMessage": "课程中没有助教。"
@@ -6437,8 +7211,26 @@
   "course.video.VideoShow.videoTitle": {
     "defaultMessage": "视频 - {title}"
   },
+  "course.video.VideoTable.actions": {
+    "defaultMessage": "行动"
+  },
+  "course.video.VideoTable.averageWatched": {
+    "defaultMessage": "平均观看百分率"
+  },
   "course.video.VideoTable.noVideo": {
     "defaultMessage": "没有视频"
+  },
+  "course.video.VideoTable.published": {
+    "defaultMessage": "已发布"
+  },
+  "course.video.VideoTable.startAt": {
+    "defaultMessage": "开始"
+  },
+  "course.video.VideoTable.title": {
+    "defaultMessage": "标题"
+  },
+  "course.video.VideoTable.watchCount": {
+    "defaultMessage": "观看次数"
   },
   "course.video.VideosIndex.fetchVideosFailure": {
     "defaultMessage": "无法检索视频。"
@@ -6589,6 +7381,21 @@
   },
   "landing_page.create_an_account": {
     "defaultMessage": "创建一个账户"
+  },
+  "landing_page.iconEngaging": {
+    "defaultMessage": "吸引人的"
+  },
+  "landing_page.iconEngagingSubtitle": {
+    "defaultMessage": "它是为所有教师设计的。您不需要具备任何编程知识来掌握这个平台。Coursemology对于教师和学生来说易于使用且直观。"
+  },
+  "landing_page.iconGeneral": {
+    "defaultMessage": "通用"
+  },
+  "landing_page.iconGeneralSubtitle": {
+    "defaultMessage": "它适用于所有学科。Coursemology的游戏化系统不对学科做任何假设。通过Coursemology，任何教授任何学科的教师都可以将他的课程练习转变为在线游戏。"
+  },
+  "landing_page.iconSimple": {
+    "defaultMessage": "简单"
   },
   "landing_page.new_to_coursemology": {
     "defaultMessage": "第一次访问 Coursemology ？"
@@ -7011,7 +7818,7 @@
     "defaultMessage": "主机名"
   },
   "lib.translations.table.column.id": {
-    "defaultMessage": "ID"
+    "defaultMessage": "身份证"
   },
   "lib.translations.table.column.instance": {
     "defaultMessage": "实例"
@@ -7111,9 +7918,6 @@
   },
   "lib.translations.yes": {
     "defaultMessage": "是的"
-  },
-  "material.attemptLoader.errorAccessingMaterial": {
-    "defaultMessage": "获取该资料时发生错误，请稍后再试。"
   },
   "sysstem.admin.instance.instance.InstanceAdminNavigator.announcements": {
     "defaultMessage": "公告"
@@ -7229,14 +8033,23 @@
   "system.admin.admin.InstancesTable.updateSuccess": {
     "defaultMessage": "已将 {field} 从 {prevValue} 重命名为 {newValue}"
   },
+  "system.admin.admin.UsersButton.associatedInstances": {
+    "defaultMessage": "{index}. {instanceName}"
+  },
   "system.admin.admin.UsersButton.deleteTooltip": {
     "defaultMessage": "删除用户"
   },
   "system.admin.admin.UsersButton.deletionConfirm": {
     "defaultMessage": "你确定要删除{role} {name} ({email}) 吗？"
   },
+  "system.admin.admin.UsersButton.deletionConfirmTitle": {
+    "defaultMessage": "删除 {role} {name} ({email})"
+  },
   "system.admin.admin.UsersButton.deletionFailure": {
     "defaultMessage": "无法删除用户 - {error}"
+  },
+  "system.admin.admin.UsersButton.deletionPromptContent": {
+    "defaultMessage": "删除此用户后，以下实例中的所有关联实例用户将被删除。"
   },
   "system.admin.admin.UsersButton.deletionSuccess": {
     "defaultMessage": "用户已被删除。"


### PR DESCRIPTION
### Summary
This pull request addresses missing translation keys across all supported locales, ensuring consistency and preventing fallback issues.

### Changes Made
- Added missing keys to locale files for modules such as `course`, `assessment`, and `submission`.
- Verified alignment between locales to ensure completeness.
- Improved the overall quality and reliability of the internationalization (i18n) setup.

### Impact
- Enhances the localization experience for all supported languages.
- Prevents incomplete translations and improves the user experience in non-default locales.