### PR TITLE
feat(cpp-versioning): added support for versioned c++ images

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,9 +22,9 @@ GIT
 
 GIT
   remote: https://github.com/Coursemology/polyglot
-  revision: 04495a14656744200d6a617b72f0d715995a8fc1
+  revision: e7c766c1021ed2c33522940aed64bc2e5093d76b
   specs:
-    coursemology-polyglot (0.3.10)
+    coursemology-polyglot (0.3.11)
       activesupport (>= 4.2)
 
 GIT

--- a/app/controllers/concerns/course/assessment/question/koditsu_question_concern.rb
+++ b/app/controllers/concerns/course/assessment/question/koditsu_question_concern.rb
@@ -93,6 +93,11 @@ module Course::Assessment::Question::KoditsuQuestionConcern
         version: '10.2',
         filename: 'template.cpp'
       },
+      Coursemology::Polyglot::Language::CPlusPlus::CPlusPlus11 => {
+        language: 'cpp',
+        version: '10.2',
+        filename: 'template.cpp'
+      },
       Coursemology::Polyglot::Language::Python::Python3Point4 => {
         language: 'python',
         version: '3.4',

--- a/app/services/course/assessment/question/programming/cpp/cpp_makefile
+++ b/app/services/course/assessment/question/programming/cpp/cpp_makefile
@@ -1,8 +1,11 @@
 GTEST_HEADERS = $(GTEST_DIR)/include/gtest/*.h \
                 $(GTEST_DIR)/include/gtest/internal/*.h
 
+# Backward compatibility for legacy container
+CXX_STD ?= c++11
+
 CPPFLAGS += -isystem $(GTEST_DIR)/include
-CXXFLAGS += -g -w -Wall -Wextra -pthread -std=c++11
+CXXFLAGS += -g -w -Wall -Wextra -pthread -std=$(CXX_STD)
 
 prepare: answer.cc
 

--- a/app/services/course/assessment/question/programming/cpp/cpp_package_service.rb
+++ b/app/services/course/assessment/question/programming/cpp/cpp_package_service.rb
@@ -202,6 +202,24 @@ class Course::Assessment::Question::Programming::Cpp::CppPackageService < \
     data_files.sort_by { |file| file[:filename].downcase }
   end
 
+  # Get the hash of the files we add to the programming package, so that
+  # any changes made to those files would trigger a rebuild so package recompiles correctly.
+  def package_file_entry(package_file_path)
+    {
+      path: package_file_path,
+      hash: Digest::SHA256.file(get_file_path(package_file_path)).hexdigest
+    }
+  end
+
+  def package_files_meta
+    @package_files_meta ||= [
+      package_file_entry('cpp_autograde_include.cc'),
+      package_file_entry('cpp_autograde_pre.cc'),
+      package_file_entry('cpp_autograde_post.cc'),
+      package_file_entry('cpp_makefile')
+    ]
+  end
+
   def generate_meta(data_files_to_keep)
     meta = default_meta
 
@@ -213,6 +231,8 @@ class Course::Assessment::Question::Programming::Cpp::CppPackageService < \
     [:public, :private, :evaluation].each do |test_type|
       meta[:test_cases][test_type] = @test_params[:test_cases][test_type] || []
     end
+
+    meta[:package_files] = package_files_meta
 
     meta.as_json
   end

--- a/client/app/bundles/course/assessment/submission/utils.ts
+++ b/client/app/bundles/course/assessment/submission/utils.ts
@@ -1,5 +1,7 @@
 const ProgrammingLanguageMapper = {
   'C/C++': 'c_cpp',
+  'C++ 11': 'c_cpp',
+  'C++ 17': 'c_cpp',
   'Java 8': 'java',
   'Java 11': 'java',
   'Java 17': 'java',

--- a/lib/autoload/course/assessment/programming_test_case_report.rb
+++ b/lib/autoload/course/assessment/programming_test_case_report.rb
@@ -236,8 +236,12 @@ class Course::Assessment::ProgrammingTestCaseReport
       meta = @test_case.search('meta')
       if meta.present? && meta[0][attribute_name]
         meta[0][attribute_name]
+      elsif @test_case.attributes.key?(attribute_name)
+        @test_case[attribute_name]
+      elsif (named_property ||= @test_case.search("./properties/property[@name=\"#{attribute_name}\"]")).present?
+        named_property[0]['value']
       else
-        @test_case[attribute_name] || ''
+        ''
       end
     end
   end

--- a/lib/tasks/db/migrate_programming_question_languages.rake
+++ b/lib/tasks/db/migrate_programming_question_languages.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+namespace :db do
+  task migrate_programming_question_languages: :environment do
+    ActsAsTenant.without_tenant do
+      puts 'Input SOURCE programming language name or class name:'
+      src_query = $stdin.gets.strip
+      src_language = Coursemology::Polyglot::Language.where(name: src_query).first
+      src_language = Coursemology::Polyglot::Language.where(type: src_query).first if src_language.nil?
+      abort("SOURCE programming language \"#{src_query}\" not found") if src_language.nil?
+
+      puts 'Input DESTINATION programming language name or class name:'
+      dest_query = $stdin.gets.strip
+      dest_language = Coursemology::Polyglot::Language.where(name: dest_query).first
+      dest_language = Coursemology::Polyglot::Language.where(type: dest_query).first if dest_language.nil?
+      abort("DESTINATION programming language \"#{dest_query}\" not found") if dest_language.nil?
+
+      if src_language.id == dest_language.id
+        puts 'SOURCE and DESTINATION languages are identical'
+      else
+        migration_count = Course::Assessment::Question::Programming.where(language_id: src_language.id).count
+        puts "This operation will migrate all programming questions using language \"#{src_language.name}\" (language_id #{src_language.id})" # rubocop:disable Layout/LineLength
+        puts "to language \"#{dest_language.name}\" (language_id #{dest_language.id})."
+        puts "#{migration_count} programming questions will be affected."
+        puts 'Are you sure you wish to proceed? (Y/N): '
+        confirm = $stdin.gets.strip
+        if confirm == 'Y'
+          ActiveRecord::Base.transaction do
+            Course::Assessment::Question::Programming.
+              where(language_id: src_language.id).update_all(language_id: dest_language.id)
+          end
+
+          puts "#{migration_count} programming questions successfully migrated."
+        else
+          puts 'Programming language migration cancelled!'
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/db/set_polyglot_language_flags.rake
+++ b/lib/tasks/db/set_polyglot_language_flags.rake
@@ -13,6 +13,8 @@ namespace :db do
       Coursemology::Polyglot::Language::Python::Python3Point9,
       Coursemology::Polyglot::Language::Python::Python3Point10,
       Coursemology::Polyglot::Language::Python::Python3Point12,
+      Coursemology::Polyglot::Language::Java::Java17,
+      Coursemology::Polyglot::Language::Java::Java21,
       Coursemology::Polyglot::Language::R::R4Point1
     ].freeze
 
@@ -29,7 +31,7 @@ namespace :db do
 
   KODITSU_WHITELIST =
     [
-      Coursemology::Polyglot::Language::CPlusPlus,
+      Coursemology::Polyglot::Language::CPlusPlus::CPlusPlus11,
       Coursemology::Polyglot::Language::Python::Python3Point4,
       Coursemology::Polyglot::Language::Python::Python3Point5,
       Coursemology::Polyglot::Language::Python::Python3Point6,
@@ -44,12 +46,14 @@ namespace :db do
       Coursemology::Polyglot::Language::Python::Python2Point7,
       Coursemology::Polyglot::Language::Python::Python3Point4,
       Coursemology::Polyglot::Language::Python::Python3Point5,
-      Coursemology::Polyglot::Language::JavaScript
+      Coursemology::Polyglot::Language::JavaScript,
+      Coursemology::Polyglot::Language::CPlusPlus
     ].freeze
 
   EVALUATOR_UNSUPPORTED_LANGUAGES =
     [
       Coursemology::Polyglot::Language::JavaScript,
+      Coursemology::Polyglot::Language::CPlusPlus,
       Coursemology::Polyglot::Language::R::R4Point1
     ].freeze
 
@@ -61,22 +65,37 @@ namespace :db do
       Coursemology::Polyglot::Language.
         where(type: CODAVERI_EVALUATOR_WHITELIST.map(&:name)).
         update_all(codaveri_evaluator_whitelisted: true)
+      Coursemology::Polyglot::Language.
+        where.not(type: CODAVERI_EVALUATOR_WHITELIST.map(&:name)).
+        update_all(codaveri_evaluator_whitelisted: false)
 
       Coursemology::Polyglot::Language.
         where(type: QUESTION_GENERATION_WHITELIST.map(&:name)).
         update_all(question_generation_whitelisted: true)
+      Coursemology::Polyglot::Language.
+        where.not(type: QUESTION_GENERATION_WHITELIST.map(&:name)).
+        update_all(question_generation_whitelisted: false)
 
       Coursemology::Polyglot::Language.
         where(type: KODITSU_WHITELIST.map(&:name)).
         update_all(koditsu_whitelisted: true)
+      Coursemology::Polyglot::Language.
+        where.not(type: KODITSU_WHITELIST.map(&:name)).
+        update_all(koditsu_whitelisted: false)
 
       Coursemology::Polyglot::Language.
         where(type: DEPRECATED_LANGUAGES.map(&:name)).
         update_all(enabled: false)
+      Coursemology::Polyglot::Language.
+        where.not(type: DEPRECATED_LANGUAGES.map(&:name)).
+        update_all(enabled: true)
 
       Coursemology::Polyglot::Language.
         where(type: EVALUATOR_UNSUPPORTED_LANGUAGES.map(&:name)).
         update_all(default_evaluator_whitelisted: false)
+      Coursemology::Polyglot::Language.
+        where.not(type: EVALUATOR_UNSUPPORTED_LANGUAGES.map(&:name)).
+        update_all(default_evaluator_whitelisted: true)
     end
   end
 end

--- a/lib/tasks/db/set_polyglot_language_weights.rake
+++ b/lib/tasks/db/set_polyglot_language_weights.rake
@@ -6,9 +6,10 @@ namespace :db do
   LANGUAGE_ORDERING = [
     'python',
     'java',
-    'c/c++',
+    'c++',
     'r',
-    'javascript'
+    'javascript',
+    'c/c++'
   ].freeze
 
   def comparable_polyglot_version(language)

--- a/spec/fixtures/course/programming_properties_test_report.xml
+++ b/spec/fixtures/course/programming_properties_test_report.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="4" failures="3" disabled="0" errors="0" time="0.006" timestamp="2024-12-19T02:19:45" name="AllTests">
+  <testsuite name="Autograder" tests="4" failures="3" disabled="0" errors="0" time="0.004" timestamp="2024-12-19T02:19:45">
+    <testcase name="test_public_01" status="run" result="completed" time="0.003" timestamp="2024-12-19T02:19:45" classname="Autograder">
+      <failure message="answer.cc:25&#x0A;Expected equality of these values:&#x0A;  a&#x0A;    Which is: 1&#x0A;  b&#x0A;    Which is: 2" type=""><![CDATA[answer.cc:25
+Expected equality of these values:
+  a
+    Which is: 1
+  b
+    Which is: 2]]></failure>
+<properties>
+<property name="expression" value="rabbits_made(1)"/>
+<property name="output" value="2"/>
+<property name="expected" value="1"/>
+<property name="hint" value="Output on day 1"/>
+</properties>
+    </testcase>
+    <testcase name="test_public_02" status="run" result="completed" time="0.001" timestamp="2024-12-19T02:19:45" classname="Autograder">
+      <failure message="answer.cc:25&#x0A;Expected equality of these values:&#x0A;  a&#x0A;    Which is: 6&#x0A;  b&#x0A;    Which is: 4" type=""><![CDATA[answer.cc:25
+Expected equality of these values:
+  a
+    Which is: 6
+  b
+    Which is: 4]]></failure>
+<properties>
+<property name="expression" value="rabbits_made(3)"/>
+<property name="expected" value="6"/>
+</properties>
+    </testcase>
+    <testcase name="test_public_03" status="run" result="completed" time="0" timestamp="2024-12-19T02:19:45" classname="Autograder">
+      <failure message="answer.cc:25&#x0A;Expected equality of these values:&#x0A;  a&#x0A;    Which is: 28&#x0A;  b&#x0A;    Which is: 8" type=""><![CDATA[answer.cc:25
+Expected equality of these values:
+  a
+    Which is: 28
+  b
+    Which is: 8]]></failure>
+<properties>
+<property name="expression" value="rabbits_made(7)"/>
+<property name="output" value="8"/>
+<property name="expected" value="28"/>
+</properties>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/spec/libraries/course/assessment/programming_test_case_report_spec.rb
+++ b/spec/libraries/course/assessment/programming_test_case_report_spec.rb
@@ -279,8 +279,80 @@ RSpec.describe Course::Assessment::ProgrammingTestCaseReport do
       end
 
       describe '#output' do
-        it 'returns an empty string as the hint attribute' do
-          expect(subject.hint).to eq('')
+        it 'returns an empty string as the output attribute' do
+          expect(subject.output).to eq('')
+        end
+      end
+    end
+  end
+
+  context 'when given a report with information attached to test case properties' do
+    let(:report_path) do
+      File.join(Rails.root, 'spec/fixtures/course/'\
+                            'programming_properties_test_report.xml')
+    end
+
+    let(:report_xml) { File.read(report_path) }
+
+    let(:parsed_report) do
+      Course::Assessment::ProgrammingTestCaseReport.new(report_xml)
+    end
+    let(:test_cases) { parsed_report.test_suites.first.test_cases }
+
+    describe Course::Assessment::ProgrammingTestCaseReport::TestCase do
+      context 'test case with all fields' do
+        subject { test_cases.first }
+
+        describe '#expression' do
+          it 'returns the expression attribute' do
+            expect(subject.expression).to eq('rabbits_made(1)')
+          end
+        end
+
+        describe '#expected' do
+          it 'returns the expected attribute' do
+            expect(subject.expected).to eq('1')
+          end
+        end
+        describe '#hint' do
+          it 'returns the hint attribute' do
+            expect(subject.hint).to eq('Output on day 1')
+          end
+        end
+
+        describe '#output' do
+          it 'returns the output attribute' do
+            expect(subject.output).
+              to eq('2')
+          end
+        end
+      end
+
+      context 'test case with some fields missing' do
+        subject { test_cases.second }
+
+        describe '#expression' do
+          it 'returns the expression attribute' do
+            expect(subject.expression).to eq('rabbits_made(3)')
+          end
+        end
+
+        describe '#expected' do
+          it 'returns the expected attribute' do
+            expect(subject.expected).to eq('6')
+          end
+        end
+
+        describe '#hint' do
+          it 'returns an empty string as the hint attribute' do
+            expect(subject.hint).to eq('')
+          end
+        end
+
+        describe '#output' do
+          it 'returns an empty string as the output attribute' do
+            expect(subject.output).to eq('')
+          end
         end
       end
     end


### PR DESCRIPTION

Associated PRs:

- Adding new image Dockerfiles in [evaluator-images](https://github.com/Coursemology/evaluator-images/pull/39)
- Adding new language entries in [polyglot](https://github.com/Coursemology/polyglot/pull/35)

## Summary of Changes
- Expanded codebase to support new `C++ 11` and `C++ 17` programming languages.
- Modified existing rake tasks to mark legacy `C/C++` language as deprecated.
- Modified `cpp_makefile` to dynamically take in C++ standard to be used (the default remains `c++11`).
- Updated `.meta` file generation to include hashes of package files added to the user submission, to mark old packages where the new Makefile has to replace the old one.
- Updated test case report parser to address [format change in GoogleTest XML output.](https://github.com/google/googletest/issues/2989)
- Create a rakefile to migrate all existing programming questions using`C/C++` programming language to new `C++ 11` programming language. When this rake is executed:
  - New evaluations for questions created using GUI ("Create/edit online") will be run using `c_cpp:11` image instead of `c_cpp:legacy`. Since the package didn't change, these will be run using the old makefile, but it behaves identically to the new makefile in this case so users shouldn't be affected.
  - When the user makes an edit, a new package will be created using the new makefile so any lingering issues should be resolved. This also happens if the question is switched to `C++ 17` before saving.
  - For questions created by manually uploading ZIP ("Manually create/edit offline and upload"), there might be some inconsistency because the helper libraries (Boost and GoogleTest) are compiled using different standards compared to the student code. 
    - These questions are still working on the new C++ 11 evaluator, but on C++ 17 an error will be thrown if the makefile hardcodes it to c++11 (since the newer versions of GoogleTest have dropped support for it)
    - However, worth to note that this was already the case for the legacy image (GoogleTest was compiled using C++ 98, student code compiled using C++ 11).
  
  