### PR TITLE
fix(folder): pass rootFolderId when folderId params is null

### DIFF
--- a/app/controllers/course/material/folders_controller.rb
+++ b/app/controllers/course/material/folders_controller.rb
@@ -15,7 +15,7 @@ class Course::Material::FoldersController < Course::Material::Controller
 
   def update
     if @folder.update(folder_params)
-      @folder = @folder.parent || @folder
+      @folder = params[:is_current_folder] == 'true' ? @folder : @folder.parent
       load_subfolders
       render 'show'
     else

--- a/client/app/bundles/course/material/folders/components/forms/FolderForm.tsx
+++ b/client/app/bundles/course/material/folders/components/forms/FolderForm.tsx
@@ -90,6 +90,7 @@ const FolderForm: FC<Props> = (props) => {
             name="name"
             render={({ field, fieldState }): JSX.Element => (
               <FormTextField
+                autoFocus
                 disabled={formState.isSubmitting}
                 field={field}
                 fieldState={fieldState}

--- a/client/app/bundles/course/material/folders/operations.ts
+++ b/client/app/bundles/course/material/folders/operations.ts
@@ -16,34 +16,39 @@ const DOWNLOAD_FOLDER_JOB_POLL_INTERVAL_MS = 2000;
 const formatFolderAttributes = (data: FolderFormData): FormData => {
   const payload = new FormData();
 
-  ['name', 'description', 'canStudentUpload', 'startAt', 'endAt'].forEach(
-    (field) => {
-      if (data[field] !== undefined && data[field] !== null) {
-        switch (field) {
-          case 'startAt':
-            payload.append('material_folder[start_at]', data[field].toString());
-            break;
-          case 'endAt':
-            if (data[field]) {
-              payload.append(
-                'material_folder[end_at]',
-                data[field]!.toString(),
-              );
-            }
-            break;
-          case 'canStudentUpload':
-            payload.append(
-              'material_folder[can_student_upload]',
-              `${data[field]}`,
-            );
-            break;
-          default:
-            payload.append(`material_folder[${field}]`, data[field]);
-            break;
-        }
+  [
+    'name',
+    'description',
+    'canStudentUpload',
+    'startAt',
+    'endAt',
+    'isCurrentFolder',
+  ].forEach((field) => {
+    if (data[field] !== undefined && data[field] !== null) {
+      switch (field) {
+        case 'startAt':
+          payload.append('material_folder[start_at]', data[field].toString());
+          break;
+        case 'endAt':
+          if (data[field]) {
+            payload.append('material_folder[end_at]', data[field]!.toString());
+          }
+          break;
+        case 'canStudentUpload':
+          payload.append(
+            'material_folder[can_student_upload]',
+            `${data[field]}`,
+          );
+          break;
+        case 'isCurrentFolder':
+          payload.append('is_current_folder', `${data[field]}`);
+          break;
+        default:
+          payload.append(`material_folder[${field}]`, data[field]);
+          break;
       }
-    },
-  );
+    }
+  });
   return payload;
 };
 

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -119,6 +119,7 @@ const FolderShow: FC = () => {
     startAt: new Date(currFolderInfo.startAt),
     endAt:
       currFolderInfo.endAt !== null ? new Date(currFolderInfo.endAt) : null,
+    isCurrentFolder: true,
   };
 
   return (

--- a/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
+++ b/client/app/bundles/course/material/folders/pages/FolderShow/index.tsx
@@ -142,7 +142,7 @@ const FolderShow: FC = () => {
       />
 
       <FolderNew
-        folderId={+folderId!}
+        folderId={currFolderInfo.id}
         isOpen={isNewFolderOpen}
         onClose={(): void => setIsNewFolderOpen(false)}
       />

--- a/client/app/lib/components/form/dialog/FormDialog.tsx
+++ b/client/app/lib/components/form/dialog/FormDialog.tsx
@@ -76,6 +76,7 @@ const FormDialog = (props: Props): JSX.Element => {
       <Dialog
         className="top-10"
         disableEnforceFocus
+        disableRestoreFocus
         maxWidth="md"
         onClose={(_event: object, reason: string): void => {
           if (reason === 'backdropClick' && formState.isSubmitting) return;

--- a/client/app/types/course/material/folders.ts
+++ b/client/app/types/course/material/folders.ts
@@ -88,6 +88,7 @@ export interface FolderFormData {
   canStudentUpload: boolean;
   startAt: Date;
   endAt: Date | null;
+  isCurrentFolder?: boolean;
 }
 
 export interface MaterialUploadFormData {

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
 
   with_tenant(:instance) do
     let(:course) { create(:course) }
-    let(:parent_folder) { create(:folder, course: course) }
+    let(:parent_folder) { course.root_folder }
     let(:unpublished_started_folder) do
       folder = create(:assessment, course: course, start_at: 1.day.ago).folder
       create(:material, folder: folder)
@@ -30,12 +30,11 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
       folders << create(:folder, :ended, parent: parent_folder, course: course)
     end
 
-    before { login_as(user, scope: :user) }
+    before { login_as(user, scope: :user, redirect_url: course_material_folders_path(course)) }
 
     context 'As a Course Manager' do
       let(:user) { create(:course_manager, course: course).user }
       scenario 'I can view all the subfolders' do
-        visit course_material_folder_path(course, parent_folder)
         concrete_subfolders.each do |subfolder|
           expect(page).to have_selector("#subfolder-#{subfolder.id}")
           expect(page).to have_selector("#subfolder-edit-button-#{subfolder.id}")
@@ -55,7 +54,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
       end
 
       scenario 'I can create a subfolder' do
-        visit course_material_folder_path(course, parent_folder)
         find('#new-subfolder-button').click
 
         new_folder = build(:folder, course: course)
@@ -75,7 +73,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
 
       scenario 'I can edit a subfolder' do
         sample_folder = concrete_subfolders.sample
-        visit course_material_folder_path(course, parent_folder)
         find("#subfolder-edit-button-#{sample_folder.id}").click
 
         find('input[name="name"]').set(' ')
@@ -93,7 +90,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
       end
 
       scenario 'I can delete a subfolder' do
-        visit course_material_folder_path(course, parent_folder)
         sample_folder = concrete_subfolders.sample
 
         find("#subfolder-delete-button-#{sample_folder.id}").click
@@ -110,7 +106,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
         file1 = File.join(Rails.root, '/spec/fixtures/files/text.txt')
         file2 = File.join(Rails.root, '/spec/fixtures/files/text2.txt')
 
-        visit course_material_folder_path(course, parent_folder)
         find('#upload-files-button').click
         find('input[type="file"]', visible: false).attach_file([file1, file2], make_visible: true)
 
@@ -121,7 +116,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
       end
 
       scenario 'I can download the folder' do
-        visit course_material_folder_path(course, parent_folder)
         expect(page).to have_selector('#download-folder-button')
       end
 
@@ -140,8 +134,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
       let(:user) { create(:course_student, course: course).user }
 
       scenario 'I can view the Material Sidebar item' do
-        visit course_path(course)
-
         expect(find_sidebar).to have_text(I18n.t('course.material.sidebar_title'))
       end
 


### PR DESCRIPTION
## Problem Statement

Folder could not be created when we just entered the `Materials` page through clicking in Sidebar
![image](https://github.com/user-attachments/assets/ee8f67ef-e630-4576-8f33-512804314eee)

## Root Cause
Before PR https://github.com/Coursemology/coursemology2/pull/7626, we don't have any notions of `undefined` folderId, which means when we navigate to any folders inside any course, we always pass on the valid `folderId` as URL parameter. However, the mentioned PR introduced the notion of `undefined` folderId in which it's actually referring to root folder.

Even though we handled the case of when `folderId` is undefined by redirecting to root Folder page, the value `folderId` itself remains `undefined` and hence it's rendered as `NaN` when being passed on to backend for root parent Id

## Resolving the Issue
When creating the New Folder, instead of merely relying on `folderId`, we modified that line to be using `folderId` if it's defined, otherwise we use `currFolderInfo.id` which is what's supposed to be the `folderId` in the first place (in case of `folderId` is undefined, `currFolderInfo` refers to root folder)