### PR TITLE
fix(codaveri): include prefix/suffix for Java test-case resources in Codaveri API

### DIFF
--- a/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/language_package_service.rb
@@ -18,9 +18,10 @@ class Course::Assessment::Question::ProgrammingCodaveri::LanguagePackageService
     @test_case_files = []
     @template_files = []
     @data_files = []
+    @evaluator_config = {}
   end
 
-  attr_reader :solution_files, :test_case_files, :template_files, :data_files
+  attr_reader :solution_files, :test_case_files, :template_files, :data_files, :evaluator_config
 
   # Returns an array containing the solution files for Codaveri problem object.
   #
@@ -48,6 +49,14 @@ class Course::Assessment::Question::ProgrammingCodaveri::LanguagePackageService
   # @return [Array]
   def process_data
     raise NotImplementedError, 'You must implement this'
+  end
+
+  # Returns the EvaluatorConfig for Codaveri problem object.
+  # Expected to be overriden in the concrete language package service if needed.
+  #
+  # @return [Hash]
+  def process_evaluator
+    {}
   end
 
   private

--- a/app/services/course/assessment/question/programming_codaveri/programming_codaveri_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/programming_codaveri_package_service.rb
@@ -34,6 +34,11 @@ class Course::Assessment::Question::ProgrammingCodaveri::ProgrammingCodaveriPack
     @language_codaveri_package_service.data_files
   end
 
+  def process_evaluator
+    @language_codaveri_package_service.process_evaluator
+    @language_codaveri_package_service.evaluator_config
+  end
+
   private
 
   # @param [Course::Assessment::Question::Programming] question The programming question with the

--- a/app/services/course/assessment/question/programming_codaveri_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri_service.rb
@@ -91,6 +91,8 @@ class Course::Assessment::Question::ProgrammingCodaveriService
     @problem_object.delete(:IOTestcases) if @problem_object[:IOTestcases].empty?
     resources_object[:exprTestcases] = all_test_cases.filter { |tc| tc[:type] == 'expression' }
     resources_object.delete(:exprTestcases) if resources_object[:exprTestcases].empty?
+    resources_object[:evaluator] = codaveri_package.process_evaluator
+    resources_object.delete(:evaluator) if resources_object[:evaluator].empty?
     resources_object[:templates] = codaveri_package.process_templates
     @problem_object[:additionalFiles] = codaveri_package.process_data
 


### PR DESCRIPTION
We encountered some bugs while trying to create the Codaveri problem for Java Programming Language, mainly due to the different concept of Prepend and Append that Coursemology had compared with Codaveri
- In Coursemology, we treated Prepend and Append inside the Programming Form as the Autograder file prepend/append (which is quite unconventional; for Python (the one we already had), those prepend and append are for File Submission
- In Codaveri, they treated Prepend and Append as the definition for the separate class.

Therefore, we requested for Codaveri Team to adjust their API to add 2 more fields to better support the integration; prefix and suffix for expression test cases, in which prefix will be put before the class definition, and suffix will be put within the class definition

Note: to be reviewed after Codaveri finishes their API functions implementation and end-to-end tests have been conducted thoroughly and successfully