### PR TITLE
fix(tests): fix flaky tests

### DIFF
--- a/spec/features/course/assessment_management_spec.rb
+++ b/spec/features/course/assessment_management_spec.rb
@@ -44,8 +44,7 @@ RSpec.feature 'Course: Assessments: Management', js: true do
 
         expect do
           find('svg[data-testid="DeleteIcon"]').click
-          Capybara.enable_aria_label = false
-          click_button 'Delete Assessment'
+          find('button.prompt-primary-btn').click
           expect_toastify('Assessment successfully deleted.')
         end.to change { course.reload.assessments.count }.by(-1)
 

--- a/spec/features/course/material/folder_management_spec.rb
+++ b/spec/features/course/material/folder_management_spec.rb
@@ -102,7 +102,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
       end
 
       scenario 'I can upload a file to the folder' do
-        Capybara.enable_aria_label = false
         file1 = File.join(Rails.root, '/spec/fixtures/files/text.txt')
         file2 = File.join(Rails.root, '/spec/fixtures/files/text2.txt')
 
@@ -110,7 +109,7 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
         find('input[type="file"]', visible: false).attach_file([file1, file2], make_visible: true)
 
         expect do
-          click_button 'Upload'
+          find('button#material-upload-form-upload-button').click
           wait_for_page
         end.to change { parent_folder.materials.count }.by(2)
       end
@@ -158,7 +157,6 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
       end
 
       scenario 'I can upload a file to the folder' do
-        Capybara.enable_aria_label = false
         folder = create(:folder, parent: parent_folder, course: course, can_student_upload: true)
         file1 = File.join(Rails.root, '/spec/fixtures/files/text.txt')
         file2 = File.join(Rails.root, '/spec/fixtures/files/text2.txt')
@@ -168,7 +166,7 @@ RSpec.feature 'Course: Material: Folders: Management', js: true do
         find('input[type="file"]', visible: false).attach_file([file1, file2], make_visible: true)
 
         expect do
-          click_button 'Upload'
+          find('button#material-upload-form-upload-button').click
           wait_for_page
         end.to change { folder.materials.count }.by(2)
 

--- a/spec/features/system/admin/course_management_spec.rb
+++ b/spec/features/system/admin/course_management_spec.rb
@@ -11,21 +11,23 @@ RSpec.feature 'System: Administration: Courses', js: true do
       courses.first.update_column(:instance_id, other_instance.id)
       Course.unscoped.ordered_by_title.first(15)
     end
-    let(:active_course) do
+    let!(:active_course) do
       course = create(:course)
       create_list(:course_student, 5, last_active_at: 1.day.ago, course: course)
       course
     end
-    let(:inactive_course) do
+    let!(:inactive_course) do
       Course.unscoped.where.not(id: Course.unscoped.active_in_past_7_days.pluck(:id)).sample || create(:course)
     end
+    # use ordered_by_title.first ensure course is the first in the list to delete without need to search
+    let!(:course_to_delete) { create(:course, title: Course.unscoped.ordered_by_title.first.title) }
+    let!(:course_to_search) { create(:course) }
 
     context 'As a System Administrator' do
       let(:admin) { create(:administrator) }
-      before { login_as(admin, scope: :user) }
+      before { login_as(admin, scope: :user, redirect_url: admin_courses_path) }
 
       scenario 'I can view courses in the system' do
-        visit admin_courses_path
         courses.each do |course|
           expect(page).to have_selector("tr.course_#{course.id}", text: course.title)
           expect(page).
@@ -34,11 +36,6 @@ RSpec.feature 'System: Administration: Courses', js: true do
       end
 
       scenario 'I can filter only active courses' do
-        active_course
-        inactive_course
-
-        visit admin_courses_path
-
         within find('p', text: 'Active Courses', exact_text: false) do
           find_all('a').first.click
         end
@@ -56,9 +53,6 @@ RSpec.feature 'System: Administration: Courses', js: true do
       end
 
       scenario 'I can delete a course' do
-        course_to_delete = create(:course, title: Course.unscoped.ordered_by_title.first.title)
-        visit admin_courses_path
-
         expect_delete_action = expect do
           find("button.course-delete-#{course_to_delete.id}").click
           expect(page).to have_button('Delete course', disabled: true)
@@ -71,18 +65,10 @@ RSpec.feature 'System: Administration: Courses', js: true do
       end
 
       scenario 'I can search courses' do
-        skip 'Flaky tests'
-        course_to_search = create(:course)
+        find_field('Search courses by title or owner').set(course_to_search.title)
 
-        visit admin_courses_path
-        wait_for_page
-        find_button('Search').click
-        find('div[aria-label="Search"]').find('input').set(course_to_search.title)
-
-        wait_for_field_debouncing # timeout for search debouncing
-
-        expect(page).to have_selector('p.course_title', text: course_to_search.title)
-        expect(all('.course').count).to eq(1)
+        expect(page).to have_xpath('//tr/td/a', text: course_to_search.title)
+        expect(page).to have_xpath('//tr[contains(@class, "course_")]', count: 1)
       end
     end
   end

--- a/spec/features/system/admin/user_management_spec.rb
+++ b/spec/features/system/admin/user_management_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'System: Administration: Users', js: true do
       end
 
       scenario "I can change a user's record" do
-        user_to_change = users.sample
+        user_to_change = User.human_users.normal.ordered_by_name.limit(5).sample
         new_name = 'updated user name'
         within find("tr.system_user_#{user_to_change.id}") do
           find('button.inline-edit-button', visible: false).click

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -78,7 +78,9 @@ module Capybara::TestGroupHelpers
 
     # Special helper to fill in MUI DateTimePicker defined by react.
     def fill_in_mui_datetime(field_name, date)
-      find_field(field_name).send_keys([:control, 'a']).send_keys(date)
+      # remove space in date DateTimePicker as space key causes input issues
+      # https://mui.com/x/react-data-grid/accessibility/#navigation
+      find_field(field_name).send_keys([:control, 'a']).send_keys(date.gsub(' ', ''))
     end
 
     # Special helper to find a react-toastify message


### PR DESCRIPTION
- Remove instances of `Capybara.enable_aria_label = false`, as this causes parallel tests which rely on `aria_label` to find elements to fail, e.g. fixes flakiness in `admin/user_management_spec`
- Re-enable `admin/course_management_spec` for searching courses, previously flaky due to the `aria_label` issue
- Fix flaky `features/course/experience_points/forum_disbursement_spec` "As a Course Teaching Assistant: I can compute and award forum participation points" due to MUI DateTimePicker space key behaviour
- Fix flaky `features/system/admin/user_management_spec.rb` "As a System Administrator: I can change a user's record" due to occasionally randomly sampling user who is already admin role.