### PR TITLE
fix(codaveri): include file_object encoding codaveri qns creation

### DIFF
--- a/app/services/course/assessment/question/programming_codaveri/java/java_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/java/java_package_service.rb
@@ -106,9 +106,15 @@ class Course::Assessment::Question::ProgrammingCodaveri::Java::JavaPackageServic
   def extract_supporting_file(filename, content)
     supporting_solution_object = default_codaveri_data_file_template
 
-    supporting_solution_object[:type] = 'internal'
+    supporting_solution_object[:type] = 'internal' # 'external' s3 upload not yet implemented by codaveri
     supporting_solution_object[:path] = filename.to_s
-    supporting_solution_object[:content] = content
+    if content.force_encoding('UTF-8').valid_encoding?
+      supporting_file_object[:content] = content
+      supporting_file_object[:encoding] = 'utf8'
+    else
+      supporting_file_object[:content] = Base64.strict_encode64(content)
+      supporting_file_object[:encoding] = 'base64'
+    end
 
     @data_files.append(supporting_solution_object)
   end


### PR DESCRIPTION
Update in Codaveri API allows for file encoding to be specified `utf8` / `base64` / `hex`.

Our `default_codaveri_data_file_template` has a default empty-string value `''` hence  
`programming_codaveri/java/java_package_service.rb` requires to explicitly set the file encoding for question-attached-files to upload to Codaveri correctly.

Explicit declaration of file encodings are similarly found in `programming_codaveri/python/python_package_service.rb` and `programming_codaveri/r/r_package_service.rb`.