### PR TITLE
fix(codaveri): use utf8 for .java supporting files

### DIFF
--- a/app/services/course/assessment/question/programming_codaveri/java/java_package_service.rb
+++ b/app/services/course/assessment/question/programming_codaveri/java/java_package_service.rb
@@ -108,10 +108,16 @@ class Course::Assessment::Question::ProgrammingCodaveri::Java::JavaPackageServic
 
     supporting_file_object[:type] = 'internal' # 'external' s3 upload not yet implemented by codaveri
     supporting_file_object[:path] = filename.to_s
-    # TODO: re-implement content.force_encoding('UTF-8').valid_encoding? check
-    # Pending Codaveri 'utf8' encoding support for compiled languages
-    supporting_file_object[:content] = Base64.strict_encode64(content)
-    supporting_file_object[:encoding] = 'base64'
+    # TODO: remove filename.to_s.downcase.end_with?('.java') check
+    # For now, only plaintext files that require compiling (e.g. *.java) will use 'utf8' ecoding
+    # Pending Codaveri 'utf8' encoding support for all plaintext files in compiled languages
+    if content.force_encoding('UTF-8').valid_encoding? && filename.to_s.downcase.end_with?('.java')
+      supporting_file_object[:content] = content
+      supporting_file_object[:encoding] = 'utf8'
+    else
+      supporting_file_object[:content] = Base64.strict_encode64(content)
+      supporting_file_object[:encoding] = 'base64'
+    end
 
     @data_files.append(supporting_file_object)
   end


### PR DESCRIPTION
Current limitation of piston in Codaveri, files that need to be compiled in javac step require plaintext.