### PR TITLE
fix(getHelp): allow TA to open get help from students' page

### DIFF
--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -158,6 +158,7 @@ module Course::Assessment::AssessmentAbility
     allow_teaching_staff_manage_assessments
     allow_teaching_staff_grade_assessment_submissions
     allow_teaching_staff_manage_assessment_annotations
+    allow_teaching_staff_interact_with_live_feedback
     disallow_teaching_staff_publish_assessment_submission_grades
     disallow_teaching_staff_force_submit_assessment_submissions
     disallow_teaching_staff_delete_assessment_submissions
@@ -194,10 +195,15 @@ module Course::Assessment::AssessmentAbility
   end
 
   def allow_teaching_staff_grade_assessment_submissions
-    can [:update, :reload_answer, :grade, :reevaluate_answer, :generate_feedback, :fetch_submitted_feedback],
+    can [:update, :reload_answer, :grade, :reevaluate_answer, :generate_feedback],
         Course::Assessment::Submission, assessment: assessment_course_hash
     can :grade, Course::Assessment::Answer,
         submission: { assessment: assessment_course_hash }
+  end
+
+  def allow_teaching_staff_interact_with_live_feedback
+    can [:generate_live_feedback, :save_live_feedback, :create_live_feedback_chat, :fetch_live_feedback_status],
+        Course::Assessment::Submission, assessment: assessment_course_hash
   end
 
   def allow_teaching_staff_manage_assessment_annotations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,7 +250,6 @@ Rails.application.routes.draw do
               post :reload_answer, on: :member
               post :reevaluate_answer, on: :member
               post :generate_feedback, on: :member
-              get :fetch_submitted_feedback, on: :member
               post :generate_live_feedback, on: :member
               post :create_live_feedback_chat, on: :member
               get :fetch_live_feedback_status, on: :collection


### PR DESCRIPTION
- previously, only student can use get help from his submission page
- if TA, manager, or owner tried to get help from student's submission page, they will be caught in 403 permission error page