### PR TITLE
(2/2) Get Help Refinement

### DIFF
--- a/app/controllers/concerns/course/assessment/live_feedback/file_concern.rb
+++ b/app/controllers/concerns/course/assessment/live_feedback/file_concern.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Course::Assessment::LiveFeedback::FileConcern
+  extend ActiveSupport::Concern
+
+  def snapshot_files_hash(file_ids)
+    Course::Assessment::LiveFeedback::File.where(id: file_ids).to_h do |file|
+      [file.filename, file]
+    end
+  end
+
+  def answer_files_hash
+    @answer.actable.files.to_h do |file|
+      [file.filename, file]
+    end
+  end
+
+  def fetch_all_unchanged_files(file_hash, current_answer_file_hash)
+    file_hash.each_with_object([]) do |(filename, file), unchanged|
+      if current_answer_file_hash[filename] && current_answer_file_hash[filename].content == file.content
+        unchanged << file
+      end
+    end
+  end
+
+  def fetch_all_modified_files(file_hash, current_answer_file_hash)
+    current_answer_file_hash.each_with_object([]) do |(filename, file), modified|
+      if !file_hash[filename] || file_hash[filename].content != file.content
+        modified << { filename: file.filename,
+                      content: file.content }
+      end
+    end
+  end
+
+  def fetch_all_files_to_be_associated(file_ids)
+    file_hash = snapshot_files_hash(file_ids)
+    current_answer_file_hash = answer_files_hash
+
+    unchanged_files = fetch_all_unchanged_files(file_hash, current_answer_file_hash)
+    modified_files = fetch_all_modified_files(file_hash, current_answer_file_hash)
+
+    [unchanged_files, modified_files]
+  end
+end

--- a/app/controllers/concerns/course/assessment/live_feedback/message_concern.rb
+++ b/app/controllers/concerns/course/assessment/live_feedback/message_concern.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module Course::Assessment::LiveFeedback::MessageConcern
+  extend ActiveSupport::Concern
+  include Course::Assessment::LiveFeedback::MessageFileConcern
+
+  def handle_save_user_message
+    @thread = Course::Assessment::LiveFeedback::Thread.where(codaveri_thread_id: @thread_id).first
+
+    @thread.class.transaction do
+      new_message = create_new_message
+
+      associate_new_message_with_new_or_existing_files(new_message)
+    end
+  end
+
+  def create_new_message
+    new_message = Course::Assessment::LiveFeedback::Message.create({
+      thread_id: @thread.id,
+      is_error: false,
+      content: @message,
+      creator_id: current_user.id,
+      created_at: Time.zone.now,
+      option_id: nil # TODO: change after we handle the suggestion passing to BE
+    })
+
+    raise ActiveRecord::Rollback unless new_message.persisted?
+
+    new_message
+  end
+end

--- a/app/controllers/concerns/course/assessment/live_feedback/message_file_concern.rb
+++ b/app/controllers/concerns/course/assessment/live_feedback/message_file_concern.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Course::Assessment::LiveFeedback::MessageFileConcern
+  extend ActiveSupport::Concern
+  include Course::Assessment::LiveFeedback::FileConcern
+
+  def associate_new_message_with_new_or_existing_files(new_message)
+    file_ids = associated_file_ids_with_last_message(new_message)
+    unchanged_files, modified_files = fetch_all_files_to_be_associated(file_ids)
+    new_files = Course::Assessment::LiveFeedback::File.insert_all(modified_files)
+
+    raise ActiveRecord::Rollback if !modified_files.empty? && (new_files.nil? || new_files.rows.empty?)
+
+    associated_file_ids = unchanged_files.map(&:id) + new_files.rows.flatten
+    save_message_file_association(new_message, associated_file_ids)
+  end
+
+  def associated_file_ids_with_last_message(new_message)
+    last_message = @thread.messages.where.not(id: new_message.id).order(id: :desc).first
+
+    if last_message
+      Course::Assessment::LiveFeedback::MessageFile.where(message_id: last_message.id).pluck(:file_id)
+    else
+      []
+    end
+  end
+
+  def save_message_file_association(new_message, associated_file_ids)
+    new_message_files = associated_file_ids.map do |file_id|
+      {
+        message_id: new_message.id,
+        file_id: file_id
+      }
+    end
+
+    files = Course::Assessment::LiveFeedback::MessageFile.insert_all(new_message_files)
+    raise ActiveRecord::Rollback if !new_message_files.empty? && (files.nil? || files.rows.empty?)
+  end
+end

--- a/app/controllers/concerns/course/assessment/live_feedback/thread_concern.rb
+++ b/app/controllers/concerns/course/assessment/live_feedback/thread_concern.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Course::Assessment::LiveFeedback::ThreadConcern
+  extend ActiveSupport::Concern
+
+  def safe_create_and_save_thread_info
+    submission_question = Course::Assessment::SubmissionQuestion.where(
+      submission_id: @submission, question_id: @answer.question
+    ).first
+
+    submission_question.with_lock do
+      existing_active_threads = Course::Assessment::LiveFeedback::Thread.
+                                where(submission_question_id: submission_question.id, is_active: true)
+
+      return existing_thread_status(existing_active_threads.first) unless existing_active_threads.empty?
+
+      create_and_save_thread_if_empty(submission_question)
+    end
+  end
+
+  def existing_thread_status(thread)
+    thread_status = thread.is_active? ? 'active' : 'expired'
+
+    [200, 'thread' => { 'id' => thread.codaveri_thread_id, 'status' => thread_status }]
+  end
+
+  def create_and_save_thread_if_empty(submission_question)
+    status, body = @answer.create_live_feedback_chat
+
+    save_thread_info(body['thread'], submission_question.id)
+
+    [status, body]
+  end
+
+  def save_thread_info(thread_info, submission_question_id)
+    Course::Assessment::LiveFeedback::Thread.create!({
+      submission_question_id: submission_question_id,
+      codaveri_thread_id: thread_info['id'],
+      is_active: thread_info['status'] == 'active',
+      submission_creator_id: @submission.creator_id,
+      created_at: Time.zone.now
+    })
+  end
+end

--- a/app/controllers/course/assessment/submission/live_feedback_controller.rb
+++ b/app/controllers/course/assessment/submission/live_feedback_controller.rb
@@ -3,37 +3,47 @@
 class Course::Assessment::Submission::LiveFeedbackController <
   Course::Assessment::Submission::Controller
   def save_live_feedback
-    live_feedback = Course::Assessment::LiveFeedback.find_by(id: params[:live_feedback_id])
-    return head :bad_request if live_feedback.nil?
+    current_thread_id, content, is_error = params[:current_thread_id], params[:content], params[:is_error]
 
-    message = params[:message]
+    @thread = Course::Assessment::LiveFeedback::Thread.find_by(codaveri_thread_id: current_thread_id)
+    return head :bad_request if @thread.nil?
 
-    create_live_feedback_overall_comment_object(live_feedback, message[:content])
-    create_live_feedback_annotation_comment_object(live_feedback, message[:files])
-  end
+    @thread.class.transaction do
+      @new_message = save_new_feedback(content, is_error)
 
-  def create_live_feedback_overall_comment_object(live_feedback, content)
-    Course::Assessment::LiveFeedbackComment.create(
-      code_id: live_feedback.code.first.id,
-      line_number: 0,
-      comment: content
-    )
-  end
-
-  def create_live_feedback_annotation_comment_object(live_feedback, files)
-    files.each do |file|
-      filename = file[:path]
-      live_feedback_code = live_feedback.code.find_by(filename: filename)
-
-      next unless live_feedback_code
-
-      file[:annotations].each do |line|
-        Course::Assessment::LiveFeedbackComment.create(
-          code_id: live_feedback_code.id,
-          line_number: line[:line],
-          comment: line[:content]
-        )
-      end
+      associate_new_message_with_existing_files
     end
+  end
+
+  private
+
+  def save_new_feedback(content, is_error)
+    new_message = Course::Assessment::LiveFeedback::Message.create({
+      thread_id: @thread.id,
+      is_error: is_error,
+      content: content,
+      creator_id: 0,
+      created_at: Time.zone.now,
+      option_id: nil
+    })
+
+    raise ActiveRecord::Rollback unless new_message.persisted?
+
+    new_message
+  end
+
+  def associate_new_message_with_existing_files
+    last_message = @thread.messages.where.not(id: @new_message.id).max_by(&:id)
+    file_ids = Course::Assessment::LiveFeedback::MessageFile.where(message_id: last_message.id).pluck(:file_id)
+
+    new_message_files = file_ids.map do |file_id|
+      {
+        message_id: @new_message.id,
+        file_id: file_id
+      }
+    end
+
+    files = Course::Assessment::LiveFeedback::MessageFile.insert_all(new_message_files)
+    raise ActiveRecord::Rollback if !new_message_files.empty? && (files.nil? || files.rows.empty?)
   end
 end

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -105,7 +105,8 @@ class Course::Assessment::Submission::SubmissionsController < # rubocop:disable 
     @thread_id = live_feedback_params[:thread_id]
     @message = live_feedback_params[:message]
 
-    @thread = Course::Assessment::LiveFeedback::Thread.where(codaveri_thread_id: thread_id).first
+    @options = live_feedback_params[:options]
+    @option_id = live_feedback_params[:option_id]
 
     handle_save_user_message
 

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -73,7 +73,7 @@ module Course::Assessment::AssessmentAbility
   end
 
   def allow_create_assessment_submission
-    can :create, Course::Assessment::Submission,
+    can [:create, :fetch_live_feedback_chat], Course::Assessment::Submission,
         experience_points_record: { course_user: { user_id: user.id } }
     can [:update, :generate_live_feedback, :save_live_feedback,
          :create_live_feedback_chat, :fetch_live_feedback_status],
@@ -202,7 +202,8 @@ module Course::Assessment::AssessmentAbility
   end
 
   def allow_teaching_staff_interact_with_live_feedback
-    can [:generate_live_feedback, :save_live_feedback, :create_live_feedback_chat, :fetch_live_feedback_status],
+    can [:generate_live_feedback, :save_live_feedback, :create_live_feedback_chat,
+         :fetch_live_feedback_status, :fetch_live_feedback_chat],
         Course::Assessment::Submission, assessment: assessment_course_hash
   end
 

--- a/app/models/course/assessment/live_feedback/file.rb
+++ b/app/models/course/assessment/live_feedback/file.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedback::File < ApplicationRecord
+  self.table_name = 'live_feedback_files'
+
+  has_many :message_files, class_name: 'Course::Assessment::LiveFeedback::MessageFile',
+                           foreign_key: 'file_id', inverse_of: :file, dependent: :destroy
+
+  validates :filename, presence: true
+  validates :content, exclusion: { in: [nil] }
+end

--- a/app/models/course/assessment/live_feedback/message.rb
+++ b/app/models/course/assessment/live_feedback/message.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedback::Message < ApplicationRecord
+  self.table_name = 'live_feedback_messages'
+
+  belongs_to :thread, class_name: 'Course::Assessment::LiveFeedback::Thread',
+                      foreign_key: 'thread_id', inverse_of: :messages
+
+  has_many :message_files, class_name: 'Course::Assessment::LiveFeedback::MessageFile',
+                           foreign_key: 'message_id', inverse_of: :message, dependent: :destroy
+  has_many :message_options, class_name: 'Course::Assessment::LiveFeedback::MessageOption',
+                             foreign_key: 'message_id', inverse_of: :message, dependent: :destroy
+
+  validates :is_error, inclusion: { in: [true, false] }
+  validates :content, exclusion: { in: [nil] }
+  validates :creator_id, presence: true
+  validates :created_at, presence: true
+end

--- a/app/models/course/assessment/live_feedback/message_file.rb
+++ b/app/models/course/assessment/live_feedback/message_file.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedback::MessageFile < ApplicationRecord
+  self.table_name = 'live_feedback_message_files'
+
+  validates :message, presence: true
+  validates :file, presence: true
+
+  belongs_to :message, class_name: 'Course::Assessment::LiveFeedback::Message',
+                       inverse_of: :message_files
+  belongs_to :file, class_name: 'Course::Assessment::LiveFeedback::File',
+                    inverse_of: :message_files
+end

--- a/app/models/course/assessment/live_feedback/message_option.rb
+++ b/app/models/course/assessment/live_feedback/message_option.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedback::MessageOption < ApplicationRecord
+  self.table_name = 'live_feedback_message_options'
+
+  validates :message, presence: true
+  validates :option, presence: true
+
+  belongs_to :message, class_name: 'Course::Assessment::LiveFeedback::Message',
+                       inverse_of: :message_options
+  belongs_to :option, class_name: 'Course::Assessment::LiveFeedback::Option',
+                      inverse_of: :message_options
+end

--- a/app/models/course/assessment/live_feedback/option.rb
+++ b/app/models/course/assessment/live_feedback/option.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedback::Option < ApplicationRecord
+  self.table_name = 'live_feedback_options'
+
+  has_many :message_options, class_name: 'Course::Assessment::LiveFeedback::MessageOption',
+                             inverse_of: :option, dependent: :destroy
+
+  enum :option_type, { suggestion: 0, fix: 1 }
+  validates :option_type, presence: true
+  validates :is_enabled, inclusion: { in: [true, false] }
+end

--- a/app/models/course/assessment/live_feedback/thread.rb
+++ b/app/models/course/assessment/live_feedback/thread.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class Course::Assessment::LiveFeedback::Thread < ApplicationRecord
+  self.table_name = 'live_feedback_threads'
+
+  belongs_to :submission_question, class_name: 'Course::Assessment::SubmissionQuestion',
+                                   foreign_key: 'submission_question_id', inverse_of: :threads
+  has_many :messages, class_name: 'Course::Assessment::LiveFeedback::Message',
+                      foreign_key: 'thread_id', inverse_of: :thread, dependent: :destroy
+
+  validate :validate_at_most_one_active_thread_per_submission_question
+  validates :codaveri_thread_id, presence: true
+  validates :is_active, inclusion: { in: [true, false] }
+  validates :submission_creator_id, presence: true
+  validates :created_at, presence: true
+
+  def validate_at_most_one_active_thread_per_submission_question
+    return unless is_active
+
+    active_thread_count = Course::Assessment::LiveFeedback::Thread.where(
+      submission_question_id: submission_question_id, is_active: true
+    ).count
+
+    return if active_thread_count <= 1
+
+    errors.add(:base, I18n.t('course.assessment.live_feedback.thread.only_one_active_thread'))
+  end
+end

--- a/app/models/course/assessment/submission_question.rb
+++ b/app/models/course/assessment/submission_question.rb
@@ -13,6 +13,8 @@ class Course::Assessment::SubmissionQuestion < ApplicationRecord
   belongs_to :question, class_name: 'Course::Assessment::Question',
                         inverse_of: :submission_questions
 
+  has_many :threads, class_name: 'Course::Assessment::LiveFeedback::Thread',
+                     inverse_of: :submission_question, dependent: :destroy
   after_initialize :set_course, if: :new_record?
   before_validation :set_course, if: :new_record?
 

--- a/app/views/course/assessment/submission/submissions/fetch_live_feedback_chat.json.jbuilder
+++ b/app/views/course/assessment/submission/submissions/fetch_live_feedback_chat.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+json.id @thread.id
+json.answerId @answer_id
+json.threadId @thread.codaveri_thread_id
+json.creatorId @thread.submission_creator_id
+
+json.messages @thread.messages.each do |message|
+  json.content message.content
+  json.creatorId message.creator_id
+  json.isError message.is_error
+  json.createdAt message.created_at&.iso8601
+end

--- a/client/app/api/course/Assessment/Submissions.js
+++ b/client/app/api/course/Assessment/Submissions.js
@@ -152,10 +152,17 @@ export default class SubmissionsAPI extends BaseAssessmentAPI {
     });
   }
 
-  saveLiveFeedback(liveFeedbackId, message) {
+  fetchLiveFeedbackChat(answerId) {
+    return this.client.get(`${this.#urlPrefix}/fetch_live_feedback_chat`, {
+      params: { answer_id: answerId },
+    });
+  }
+
+  saveLiveFeedback(currentThreadId, content, isError) {
     return this.client.post(`${this.#urlPrefix}/save_live_feedback`, {
-      live_feedback_id: liveFeedbackId,
-      message,
+      current_thread_id: currentThreadId,
+      content,
+      is_error: isError,
     });
   }
 

--- a/client/app/api/course/Assessment/Submissions.js
+++ b/client/app/api/course/Assessment/Submissions.js
@@ -122,10 +122,23 @@ export default class SubmissionsAPI extends BaseAssessmentAPI {
     );
   }
 
-  generateLiveFeedback(submissionId, answerId, threadId, message) {
+  generateLiveFeedback(
+    submissionId,
+    answerId,
+    threadId,
+    message,
+    options,
+    optionId,
+  ) {
     return this.client.post(
       `${this.#urlPrefix}/${submissionId}/generate_live_feedback`,
-      { thread_id: threadId, answer_id: answerId, message },
+      {
+        thread_id: threadId,
+        answer_id: answerId,
+        message,
+        options,
+        option_id: optionId,
+      },
     );
   }
 

--- a/client/app/bundles/course/assessment/submission/actions/answers/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/answers/index.js
@@ -327,7 +327,7 @@ export function fetchLiveFeedback({
   answerId,
   feedbackUrl,
   feedbackToken,
-  liveFeedbackId,
+  currentThreadId,
   noFeedbackMessage,
   errorMessage,
 }) {
@@ -337,8 +337,9 @@ export function fetchLiveFeedback({
       .then((response) => {
         if (response.status === 200) {
           CourseAPI.assessment.submissions.saveLiveFeedback(
-            liveFeedbackId,
-            response.data?.data?.message ?? { content: '', files: [] },
+            currentThreadId,
+            response.data?.data?.message.content ?? '',
+            false,
           );
           handleFeedbackOKResponse({
             answerId,
@@ -349,6 +350,11 @@ export function fetchLiveFeedback({
         }
       })
       .catch(() => {
+        CourseAPI.assessment.submissions.saveLiveFeedback(
+          currentThreadId,
+          errorMessage,
+          true,
+        );
         dispatch(
           getFailureFeedbackFromCodaveri({
             answerId,

--- a/client/app/bundles/course/assessment/submission/actions/answers/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/answers/index.js
@@ -238,10 +238,19 @@ export function generateLiveFeedback({
   threadId,
   message,
   errorMessage,
+  options,
+  optionId,
 }) {
   return (dispatch) =>
     CourseAPI.assessment.submissions
-      .generateLiveFeedback(submissionId, answerId, threadId, message)
+      .generateLiveFeedback(
+        submissionId,
+        answerId,
+        threadId,
+        message,
+        options,
+        optionId,
+      )
       .then((response) => {
         if (response.status === 201) {
           dispatch(
@@ -269,6 +278,11 @@ export function generateLiveFeedback({
         }
       })
       .catch(() => {
+        CourseAPI.assessment.submissions.saveLiveFeedback(
+          threadId,
+          errorMessage,
+          true,
+        );
         dispatch(
           getFailureFeedbackFromCodaveri({
             answerId,
@@ -338,7 +352,7 @@ export function fetchLiveFeedback({
         if (response.status === 200) {
           CourseAPI.assessment.submissions.saveLiveFeedback(
             currentThreadId,
-            response.data?.data?.message.content ?? '',
+            response.data?.data?.message.content ?? noFeedbackMessage,
             false,
           );
           handleFeedbackOKResponse({

--- a/client/app/bundles/course/assessment/submission/actions/live_feedback.ts
+++ b/client/app/bundles/course/assessment/submission/actions/live_feedback.ts
@@ -1,0 +1,21 @@
+import { AppDispatch } from 'store';
+
+import CourseAPI from 'api/course';
+
+import { storeInitialLiveFeedbackChats } from '../reducers/liveFeedbackChats';
+import { LiveFeedbackThread } from '../types';
+
+const fetchLiveFeedbackChat = async (
+  dispatch: AppDispatch,
+  answerId: number,
+): Promise<void> => {
+  const response =
+    await CourseAPI.assessment.submissions.fetchLiveFeedbackChat(answerId);
+  dispatch(
+    storeInitialLiveFeedbackChats({
+      thread: response.data as LiveFeedbackThread,
+    }),
+  );
+};
+
+export default fetchLiveFeedbackChat;

--- a/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/ChatInputArea.tsx
+++ b/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/ChatInputArea.tsx
@@ -53,6 +53,7 @@ const ChatInputArea: FC<ChatInputAreaProps> = (props) => {
     liveFeedbackChatsForAnswer?.isRequestingLiveFeedback ?? false;
   const isPollingLiveFeedback =
     (liveFeedbackChatsForAnswer?.pendingFeedbackToken ?? false) !== false;
+  const suggestions = liveFeedbackChatsForAnswer?.suggestions ?? [];
 
   const textFieldDisabled =
     isResetting ||
@@ -74,6 +75,8 @@ const ChatInputArea: FC<ChatInputAreaProps> = (props) => {
         threadId: currentThreadId,
         message: input,
         errorMessage: t(translations.requestFailure),
+        options: suggestions.map((option) => option.index),
+        optionId: null,
       }),
     );
     setInput('');

--- a/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/ConversationArea.tsx
+++ b/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/ConversationArea.tsx
@@ -25,13 +25,15 @@ const ConversationArea: FC<ConversationAreaProps> = (props) => {
   const isCurrentThreadExpired = liveFeedbackChats?.isCurrentThreadExpired;
   const { t } = useTranslation();
 
+  const isLiveFeedbackChatLoaded = liveFeedbackChats?.isLiveFeedbackChatLoaded;
+
   const isRequestingLiveFeedback = liveFeedbackChats?.isRequestingLiveFeedback;
   const isPollingLiveFeedback = liveFeedbackChats?.pendingFeedbackToken;
 
   const isRenderingSuggestionChips =
     !isRequestingLiveFeedback && !isPollingLiveFeedback;
 
-  if (!liveFeedbackChats) return null;
+  if (!liveFeedbackChats || !isLiveFeedbackChatLoaded) return null;
 
   const justifyPosition = (isStudent: boolean, isError: boolean): string => {
     if (isStudent) {

--- a/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/SuggestionChips.tsx
+++ b/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/SuggestionChips.tsx
@@ -10,6 +10,7 @@ import { generateLiveFeedback } from '../../actions/answers';
 import { sendPromptFromStudent } from '../../reducers/liveFeedbackChats';
 import { getLiveFeedbackChatsForAnswerId } from '../../selectors/liveFeedbackChats';
 import translations from '../../translations';
+import { Suggestion } from '../../types';
 
 interface SuggestionChipsProps {
   answerId: number;
@@ -33,7 +34,12 @@ const SuggestionChips: FC<SuggestionChipsProps> = (props) => {
 
   const suggestions = liveFeedbackChatsForAnswer?.suggestions ?? [];
 
-  const sendHelpRequest = (message: string): void => {
+  const sendHelpRequest = (suggestion: Suggestion): void => {
+    const message = t({
+      id: suggestion.id,
+      defaultMessage: suggestion.defaultMessage,
+    });
+
     dispatch(sendPromptFromStudent({ answerId, message }));
     dispatch(
       generateLiveFeedback({
@@ -42,6 +48,8 @@ const SuggestionChips: FC<SuggestionChipsProps> = (props) => {
         threadId: currentThreadId,
         message,
         errorMessage: t(translations.requestFailure),
+        options: suggestions.map((option) => option.index),
+        optionId: suggestion.index,
       }),
     );
   };
@@ -53,10 +61,13 @@ const SuggestionChips: FC<SuggestionChipsProps> = (props) => {
           key={suggestion.id}
           className="bg-white text-xl shrink-0"
           disabled={syncStatus === SYNC_STATUS.Failed || isCurrentThreadExpired}
-          onClick={() => sendHelpRequest(t(suggestion))}
+          onClick={() => sendHelpRequest(suggestion)}
           variant="outlined"
         >
-          {t(suggestion)}
+          {t({
+            id: suggestion.id,
+            defaultMessage: suggestion.defaultMessage,
+          })}
         </Button>
       ))}
     </div>

--- a/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/index.tsx
+++ b/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/index.tsx
@@ -2,8 +2,9 @@ import { FC, useEffect, useRef, useState } from 'react';
 import { Divider, Paper } from '@mui/material';
 
 import { SYNC_STATUS } from 'lib/constants/sharedConstants';
-import { useAppSelector } from 'lib/hooks/store';
+import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 
+import fetchLiveFeedbackChat from '../../actions/live_feedback';
 import { getLiveFeedbackChatsForAnswerId } from '../../selectors/liveFeedbackChats';
 import { ChatSender } from '../../types';
 
@@ -26,9 +27,13 @@ const GetHelpChatPage: FC<GetHelpChatPageProps> = (props) => {
     getLiveFeedbackChatsForAnswerId(state, answerId),
   );
 
+  const dispatch = useAppDispatch();
+
   const [syncStatus, setSyncStatus] = useState<keyof typeof SYNC_STATUS>(
     SYNC_STATUS.Syncing,
   );
+
+  const isLiveFeedbackChatLoaded = liveFeedbackChats?.isLiveFeedbackChatLoaded;
 
   const isRequestingLiveFeedback = liveFeedbackChats?.isRequestingLiveFeedback;
   const isPollingLiveFeedback = liveFeedbackChats?.pendingFeedbackToken;
@@ -54,6 +59,12 @@ const GetHelpChatPage: FC<GetHelpChatPageProps> = (props) => {
       });
     }
   }, [liveFeedbackChats?.chats]);
+
+  useEffect(() => {
+    if (!answerId || isLiveFeedbackChatLoaded) return;
+
+    fetchLiveFeedbackChat(dispatch, answerId);
+  }, [answerId, isLiveFeedbackChatLoaded]);
 
   if (!answerId) return null;
 

--- a/client/app/bundles/course/assessment/submission/localStorage/liveFeedbackChat/operations.ts
+++ b/client/app/bundles/course/assessment/submission/localStorage/liveFeedbackChat/operations.ts
@@ -1,21 +1,21 @@
-import { LiveFeedbackChatData } from '../../types';
+import { LiveFeedbackLocalStorage } from '../../types';
 
 const getLocalStorageKey = (answerId: string | number): string =>
   `liveFeedbackChat-${answerId}`;
 
 export const getLocalStorageValue = (
   answerId: number,
-): LiveFeedbackChatData | null => {
+): LiveFeedbackLocalStorage | null => {
   const key = getLocalStorageKey(answerId);
   const value = localStorage.getItem(key);
   if (!value) return null;
 
-  return JSON.parse(value) as LiveFeedbackChatData;
+  return JSON.parse(value) as LiveFeedbackLocalStorage;
 };
 
 export const setLocalStorageValue = (
   answerId: number,
-  storedValue: LiveFeedbackChatData,
+  storedValue: LiveFeedbackLocalStorage,
 ): void => {
   const key = getLocalStorageKey(answerId);
   if (!key) return;
@@ -25,7 +25,7 @@ export const setLocalStorageValue = (
 
 export const modifyLocalStorageValue = (
   answerId: number,
-  changes: Partial<LiveFeedbackChatData>,
+  changes: Partial<LiveFeedbackLocalStorage>,
 ): void => {
   const value = getLocalStorageValue(answerId);
 
@@ -34,7 +34,7 @@ export const modifyLocalStorageValue = (
     ...Object.fromEntries(
       Object.entries(changes).filter(([_, v]) => v !== undefined),
     ),
-  } as LiveFeedbackChatData;
+  } as LiveFeedbackLocalStorage;
 
   setLocalStorageValue(answerId, modifiedValue);
 };

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionForm.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionForm.tsx
@@ -91,7 +91,7 @@ const SubmissionForm: FC<Props> = (props) => {
       liveFeedbackChats.liveFeedbackChatPerAnswer.entities[answerId];
     if (!liveFeedbackChatsForAnswer) return;
 
-    const liveFeedbackId = liveFeedbackChatsForAnswer.liveFeedbackId;
+    const currentThreadId = liveFeedbackChatsForAnswer.currentThreadId;
     const feedbackToken = liveFeedbackChatsForAnswer.pendingFeedbackToken;
     const feedbackUrl = liveFeedbackChats.liveFeedbackChatUrl;
     const noFeedbackMessage = t(translations.liveFeedbackNoneGenerated);
@@ -101,7 +101,7 @@ const SubmissionForm: FC<Props> = (props) => {
         answerId,
         feedbackUrl,
         feedbackToken,
-        liveFeedbackId,
+        currentThreadId,
         noFeedbackMessage,
         errorMessage,
       }),

--- a/client/app/bundles/course/assessment/submission/reducers/liveFeedbackChats/index.ts
+++ b/client/app/bundles/course/assessment/submission/reducers/liveFeedbackChats/index.ts
@@ -15,8 +15,8 @@ import {
   setLocalStorageValue,
 } from '../../localStorage/liveFeedbackChat/operations';
 import {
-  suggestionFixesTranslations,
-  suggestionsTranslations,
+  suggestionFixesMapping,
+  suggestionMapping,
 } from '../../suggestionTranslations';
 import {
   AnswerFile,
@@ -44,18 +44,23 @@ const initialState: LiveFeedbackChatState = {
 const sampleSuggestions = (
   isIncludingSuggestionFixes: boolean,
 ): Suggestion[] => {
-  const suggestions = Object.values(suggestionsTranslations);
-  const suggestionFixes = Object.values(suggestionFixesTranslations);
+  const suggestionIndexes = Object.keys(suggestionMapping);
+  const suggestionFixIndexes = Object.keys(suggestionFixesMapping);
 
-  const chosenSuggestions = isIncludingSuggestionFixes
-    ? shuffle(suggestions)
+  const chosenSuggestionIndexes = isIncludingSuggestionFixes
+    ? shuffle(suggestionIndexes)
         .slice(0, 2)
-        .concat(shuffle(suggestionFixes).slice(0, 1))
-    : shuffle(suggestions).slice(0, 3);
+        .concat(shuffle(suggestionFixIndexes).slice(0, 1))
+    : shuffle(suggestionIndexes).slice(0, 3);
 
-  return chosenSuggestions.map((suggestion) => {
+  return chosenSuggestionIndexes.map((index) => {
+    const suggestionIndex = Number(index);
+    const suggestion =
+      suggestionMapping[suggestionIndex] ??
+      suggestionFixesMapping[suggestionIndex];
     return {
       id: suggestion.id,
+      index: suggestionIndex,
       defaultMessage: suggestion.defaultMessage,
     };
   });

--- a/client/app/bundles/course/assessment/submission/suggestionTranslations.ts
+++ b/client/app/bundles/course/assessment/submission/suggestionTranslations.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl';
 
-export const suggestionsTranslations = defineMessages({
+const suggestionsTranslations = defineMessages({
   iAmStuck: {
     id: 'course.assessment.submission.suggestions.iAmStuck',
     defaultMessage: 'I am stuck',
@@ -23,9 +23,22 @@ export const suggestionsTranslations = defineMessages({
   },
 });
 
-export const suggestionFixesTranslations = defineMessages({
+const suggestionFixesTranslations = defineMessages({
   looksWrong: {
     id: 'course.assessment.submission.suggestions.looksWrong',
-    defaultMessage: 'Your advice is wrong',
+    defaultMessage: 'This looks wrong',
   },
 });
+
+// NOTE: the index key in suggestionsMapping follow the assigned index in DB table live_feedback_options
+export const suggestionMapping = {
+  1: suggestionsTranslations.iAmStuck,
+  2: suggestionsTranslations.howDoIFixThis,
+  3: suggestionsTranslations.questionUnclear,
+  4: suggestionsTranslations.optimizeThisCode,
+  5: suggestionsTranslations.whereAmIWrong,
+};
+
+export const suggestionFixesMapping = {
+  6: suggestionFixesTranslations.looksWrong,
+};

--- a/client/app/bundles/course/assessment/submission/types.ts
+++ b/client/app/bundles/course/assessment/submission/types.ts
@@ -189,6 +189,7 @@ export interface AnswerFile {
 export interface Suggestion {
   id: string;
   defaultMessage: string;
+  index: number;
 }
 
 export interface LiveFeedbackChatData {

--- a/client/app/bundles/course/assessment/submission/types.ts
+++ b/client/app/bundles/course/assessment/submission/types.ts
@@ -194,6 +194,7 @@ export interface Suggestion {
 export interface LiveFeedbackChatData {
   id: string | number;
   isLiveFeedbackChatOpen: boolean;
+  isLiveFeedbackChatLoaded: boolean;
   isRequestingLiveFeedback: boolean;
   pendingFeedbackToken: string | null;
   liveFeedbackId: number | null;
@@ -202,4 +203,26 @@ export interface LiveFeedbackChatData {
   chats: ChatShape[];
   answerFiles: AnswerFile[];
   suggestions: Suggestion[];
+}
+
+export interface LiveFeedbackLocalStorage {
+  isLiveFeedbackChatOpen: boolean;
+  isRequestingLiveFeedback: boolean;
+  pendingFeedbackToken: string | null;
+  feedbackUrl: string | null;
+}
+
+export interface LiveFeedbackThread {
+  id: number;
+  answerId: number;
+  threadId: string;
+  creatorId: number;
+  messages: LiveFeedbackMessage[];
+}
+
+export interface LiveFeedbackMessage {
+  content: string;
+  isError: boolean;
+  creatorId: number;
+  createdAt: string;
 }

--- a/config/locales/en/course/assessment/live_feedback/thread.yml
+++ b/config/locales/en/course/assessment/live_feedback/thread.yml
@@ -1,0 +1,6 @@
+en:
+  course:
+    assessment:
+      live_feedback:
+        thread:
+          only_one_active_thread: 'There can be only one active thread per submission question'

--- a/config/locales/ko/course/assessment/live_feedback/thread.yml
+++ b/config/locales/ko/course/assessment/live_feedback/thread.yml
@@ -1,0 +1,6 @@
+ko:
+  course:
+    assessment:
+      live_feedback:
+        thread:
+          only_one_active_thread: '제출 질문당 활성화된 스레드는 하나만 존재할 수 있습니다'

--- a/config/locales/zh/course/assessment/live_feedback/thread.yml
+++ b/config/locales/zh/course/assessment/live_feedback/thread.yml
@@ -1,0 +1,6 @@
+zh:
+  course:
+    assessment:
+      live_feedback:
+        thread:
+          only_one_active_thread: '每个提交问题只能有一个活动线程'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ Rails.application.routes.draw do
               post :generate_feedback, on: :member
               post :generate_live_feedback, on: :member
               post :create_live_feedback_chat, on: :member
+              get :fetch_live_feedback_chat, on: :collection
               get :fetch_live_feedback_status, on: :collection
               post 'save_live_feedback', to: 'live_feedback#save_live_feedback', on: :collection
               get :download_all, on: :collection

--- a/db/migrate/20250212162346_create_live_feedback_chat_table.rb
+++ b/db/migrate/20250212162346_create_live_feedback_chat_table.rb
@@ -1,0 +1,40 @@
+class CreateLiveFeedbackChatTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :live_feedback_threads do |t|
+      t.references :submission_question, null: false, index: true, foreign_key: { to_table: :course_assessment_submission_questions }
+      t.references :submission_creator, null: false, index: true, foreign_key: { to_table: :users }
+      t.string :codaveri_thread_id, null: false
+      t.boolean :is_active, null: false, default: true
+      t.datetime :created_at, null: false
+    end
+
+    create_table :live_feedback_options do |t|
+      t.integer :option_type, null: false
+      t.boolean :is_enabled, null: false, default: false
+    end
+
+    create_table :live_feedback_messages do |t|
+      t.references :thread, null: false, index: true, foreign_key: { to_table: :live_feedback_threads }
+      t.references :option, null: true, index: true, foreign_key: { to_table: :live_feedback_options }
+      t.references :creator, null: true, index: true, foreign_key: { to_table: :users }
+      t.boolean :is_error, null: false, default: false
+      t.string :content, null: false
+      t.datetime :created_at, null: false
+    end
+
+    create_table :live_feedback_files do |t|
+      t.string :filename, null: false
+      t.text :content, null: false
+    end
+
+    create_table :live_feedback_message_files do |t|
+      t.references :message, null: false, index: true, foreign_key: { to_table: :live_feedback_messages }
+      t.references :file, null: false, index: true, foreign_key: { to_table: :live_feedback_files }
+    end
+
+    create_table :live_feedback_message_options do |t|
+      t.references :message, null: false, index: true, foreign_key: { to_table: :live_feedback_messages }
+      t.references :option, null: false, index: true, foreign_key: { to_table: :live_feedback_options }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_12_162346) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -1352,6 +1352,52 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
     t.datetime "updated_at", precision: nil
   end
 
+  create_table "live_feedback_files", force: :cascade do |t|
+    t.string "filename", null: false
+    t.text "content", null: false
+  end
+
+  create_table "live_feedback_message_files", force: :cascade do |t|
+    t.bigint "message_id", null: false
+    t.bigint "file_id", null: false
+    t.index ["file_id"], name: "index_live_feedback_message_files_on_file_id"
+    t.index ["message_id"], name: "index_live_feedback_message_files_on_message_id"
+  end
+
+  create_table "live_feedback_message_options", force: :cascade do |t|
+    t.bigint "message_id", null: false
+    t.bigint "option_id", null: false
+    t.index ["message_id"], name: "index_live_feedback_message_options_on_message_id"
+    t.index ["option_id"], name: "index_live_feedback_message_options_on_option_id"
+  end
+
+  create_table "live_feedback_messages", force: :cascade do |t|
+    t.bigint "thread_id", null: false
+    t.bigint "option_id"
+    t.bigint "creator_id"
+    t.boolean "is_error", default: false, null: false
+    t.string "content", null: false
+    t.datetime "created_at", null: false
+    t.index ["creator_id"], name: "index_live_feedback_messages_on_creator_id"
+    t.index ["option_id"], name: "index_live_feedback_messages_on_option_id"
+    t.index ["thread_id"], name: "index_live_feedback_messages_on_thread_id"
+  end
+
+  create_table "live_feedback_options", force: :cascade do |t|
+    t.integer "option_type", null: false
+    t.boolean "is_enabled", default: false, null: false
+  end
+
+  create_table "live_feedback_threads", force: :cascade do |t|
+    t.bigint "submission_question_id", null: false
+    t.bigint "submission_creator_id", null: false
+    t.string "codaveri_thread_id", null: false
+    t.boolean "is_active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.index ["submission_creator_id"], name: "index_live_feedback_threads_on_submission_creator_id"
+    t.index ["submission_question_id"], name: "index_live_feedback_threads_on_submission_question_id"
+  end
+
   create_table "oauth_access_grants", force: :cascade do |t|
     t.bigint "resource_owner_id", null: false
     t.bigint "application_id", null: false
@@ -1692,6 +1738,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_104132) do
   add_foreign_key "instance_user_role_requests", "users", name: "fk_instance_user_role_requests_user_id"
   add_foreign_key "instance_users", "instances", name: "fk_instance_users_instance_id"
   add_foreign_key "instance_users", "users", name: "fk_instance_users_user_id"
+  add_foreign_key "live_feedback_message_files", "live_feedback_files", column: "file_id"
+  add_foreign_key "live_feedback_message_files", "live_feedback_messages", column: "message_id"
+  add_foreign_key "live_feedback_message_options", "live_feedback_messages", column: "message_id"
+  add_foreign_key "live_feedback_message_options", "live_feedback_options", column: "option_id"
+  add_foreign_key "live_feedback_messages", "live_feedback_options", column: "option_id"
+  add_foreign_key "live_feedback_messages", "live_feedback_threads", column: "thread_id"
+  add_foreign_key "live_feedback_messages", "users", column: "creator_id"
+  add_foreign_key "live_feedback_threads", "course_assessment_submission_questions", column: "submission_question_id"
+  add_foreign_key "live_feedback_threads", "users", column: "submission_creator_id"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/lib/tasks/db/populate_live_feedback_options.rake
+++ b/lib/tasks/db/populate_live_feedback_options.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+namespace :db do
+  task populate_live_feedback_options: :environment do
+    ActsAsTenant.without_tenant do
+      puts 'Start populating the options for live feedback'
+
+      ActiveRecord::Base.connection.exec_query(<<-SQL)
+        INSERT INTO live_feedback_options
+          (option_type, is_enabled)
+        VALUES
+          (0, TRUE),
+          (0, TRUE),
+          (0, TRUE),
+          (0, TRUE),
+          (0, TRUE),
+          (1, TRUE)
+      SQL
+    end
+  end
+end

--- a/spec/controllers/concerns/course/assessment/live_feedback/message_concern_spec.rb
+++ b/spec/controllers/concerns/course/assessment/live_feedback/message_concern_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::LiveFeedback::MessageConcern do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let!(:student) { create(:user, name: 'Student') }
+
+    class self::DummyController < ApplicationController
+      include Course::Assessment::LiveFeedback::MessageConcern
+    end
+
+    let!(:dummy_controller) { self.class::DummyController.new }
+    let!(:course) { create(:course) }
+    let!(:course_user) { create(:course_student, course: course, user: student) }
+    let!(:assessment) { create(:course_assessment_assessment, :with_programming_question, course: course) }
+    let!(:submission) do
+      create(:course_assessment_submission, :attempting, assessment: assessment, creator: student)
+    end
+    let!(:answer) { submission.answers.where(actable_type: 'Course::Assessment::Answer::Programming').first }
+    let!(:question) { answer.question }
+    let!(:submission_question) do
+      Course::Assessment::SubmissionQuestion.create!(submission_id: submission.id, question_id: question.id)
+    end
+
+    let!(:codaveri_thread_id) { SecureRandom.hex(12) }
+    let!(:thread) do
+      Course::Assessment::LiveFeedback::Thread.create!(codaveri_thread_id: codaveri_thread_id,
+                                                       submission_question: submission_question,
+                                                       is_active: true,
+                                                       submission_creator_id: submission.creator_id,
+                                                       created_at: Time.zone.now)
+    end
+    let!(:message) { 'This is a message' }
+    let!(:option_id) { 2 }
+    let!(:options) { [1, 2, 3] }
+
+    let!(:second_message) { 'This is a second message' }
+    let!(:second_option_id) { 3 }
+
+    before do
+      controller_sign_in(dummy_controller, student)
+
+      options.each do |_|
+        Course::Assessment::LiveFeedback::Option.create!(option_type: 0, is_enabled: true)
+      end
+
+      dummy_controller.instance_variable_set(:@thread_id, codaveri_thread_id)
+      dummy_controller.instance_variable_set(:@message, message)
+      dummy_controller.instance_variable_set(:@option_id, option_id)
+      dummy_controller.instance_variable_set(:@options, options)
+      dummy_controller.instance_variable_set(:@answer, answer)
+    end
+
+    context 'in saving message inside thread' do
+      it 'update thread, message, and file accordingly' do
+        # Calling handle_save_user_message method first time
+        dummy_controller.send(:handle_save_user_message)
+
+        current_thread = dummy_controller.instance_variable_get(:@thread)
+        current_answer = dummy_controller.instance_variable_get(:@answer)
+
+        expect(current_thread.messages.count).to eq(1)
+        expect(current_thread.messages.first.content).to eq(message)
+        expect(current_thread.messages.first.option_id).to eq(option_id)
+        expect(current_thread.messages.first.creator_id).to eq(student.id)
+
+        message = current_thread.messages.first
+        expect(message.message_files.count).to eq(current_answer.actable.files.count)
+
+        message.message_files.each do |message_file|
+          programming_file = current_answer.actable.files.find do |file|
+            file.filename == message_file.file.filename &&
+              file.content == message_file.file.content
+          end
+          expect(programming_file).not_to be_nil
+        end
+      end
+    end
+
+    context 'when answer not updated while sending new message' do
+      it 'associates new message with existing files' do
+        dummy_controller.send(:handle_save_user_message)
+
+        current_thread = dummy_controller.instance_variable_get(:@thread)
+        current_answer = dummy_controller.instance_variable_get(:@answer)
+
+        # Calling handle_save_user_message method second time
+        dummy_controller.instance_variable_set(:@message, second_message)
+        dummy_controller.instance_variable_set(:@option_id, second_option_id)
+
+        dummy_controller.send(:handle_save_user_message)
+        expect(current_thread.messages.count).to eq(2)
+        expect(current_thread.messages.last.content).to eq(second_message)
+        expect(current_thread.messages.last.option_id).to eq(second_option_id)
+        expect(current_thread.messages.last.creator_id).to eq(student.id)
+
+        message = current_thread.messages.last
+        expect(message.message_files.count).to eq(current_answer.actable.files.count)
+
+        message.message_files.each do |message_file|
+          programming_file = current_answer.actable.files.find do |file|
+            file.filename == message_file.file.filename &&
+              file.content == message_file.file.content
+          end
+          expect(programming_file).not_to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/course/assessment/live_feedback/thread_concern_spec.rb
+++ b/spec/controllers/concerns/course/assessment/live_feedback/thread_concern_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::LiveFeedback::ThreadConcern do
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    let!(:student) { create(:user, name: 'Student') }
+
+    class self::DummyController < ApplicationController
+      include Course::Assessment::LiveFeedback::ThreadConcern
+    end
+
+    let!(:dummy_controller) { self.class::DummyController.new }
+    let!(:course) { create(:course) }
+    let!(:course_user) { create(:course_student, course: course, user: student) }
+    let!(:assessment) { create(:course_assessment_assessment, :with_programming_question, course: course) }
+    let!(:submission) do
+      create(:course_assessment_submission, :attempting, assessment: assessment, creator: student)
+    end
+    let!(:answer) { submission.answers.where(actable_type: 'Course::Assessment::Answer::Programming').first }
+    let!(:question) { answer.question }
+    let!(:submission_question) do
+      Course::Assessment::SubmissionQuestion.create!(submission: submission, question: question)
+    end
+
+    let!(:thread_info) { { 'id' => SecureRandom.hex(12), 'status' => 'active' } }
+
+    before do
+      controller_sign_in(dummy_controller, student)
+
+      dummy_controller.instance_variable_set(:@submission, submission)
+      dummy_controller.instance_variable_set(:@answer, answer)
+    end
+
+    context 'when creating thread' do
+      it 'save thread accordingly, and upon second time, return existing thread' do
+        dummy_controller.send(:save_thread_info, thread_info, submission_question.id)
+
+        new_thread = Course::Assessment::LiveFeedback::Thread.find_by(submission_question_id: submission_question.id)
+        expect(new_thread).to be_present
+
+        expect(new_thread.codaveri_thread_id).to eq(thread_info['id'])
+        expect(new_thread.is_active).to eq(thread_info['status'] == 'active')
+        expect(new_thread.submission_creator_id).to eq(submission.creator_id)
+        expect(new_thread.created_at).to be_within(1.second).of(Time.zone.now)
+
+        status, body = dummy_controller.send(:safe_create_and_save_thread_info)
+        expect(status).to eq(200)
+        expect(body['thread']['id']).to eq(thread_info['id'])
+        expect(body['thread']['status']).to eq(thread_info['status'])
+      end
+    end
+  end
+end

--- a/spec/controllers/course/assessment/submission/live_feedback_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/live_feedback_controller_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Submission::LiveFeedbackController, type: :controller do
+  let!(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let!(:user) { create(:user) }
+    let!(:student) { create(:user, name: 'Student') }
+
+    let!(:course) { create(:course, creator: user) }
+    let!(:course_student) { create(:course_student, course: course, user: student) }
+    let!(:assessment) { create(:assessment, :published_with_programming_question, course: course) }
+    let!(:submission) { create(:submission, :attempting, assessment: assessment, creator: student) }
+    let!(:answer) { submission.answers.where(actable_type: 'Course::Assessment::Answer::Programming').first }
+    let!(:question) { answer.question }
+    let!(:submission_question) do
+      create(:submission_question, submission: submission, question: question)
+    end
+
+    let!(:codaveri_thread_id) { SecureRandom.hex(12) }
+    let!(:student_prompt) { 'This is a student prompt' }
+    let!(:feedback) { 'This is a feedback' }
+
+    before do
+      controller_sign_in(controller, student)
+
+      new_thread = Course::Assessment::LiveFeedback::Thread.create!({
+        codaveri_thread_id: codaveri_thread_id,
+        submission_question: submission_question,
+        is_active: true,
+        submission_creator_id: submission.creator_id,
+        created_at: Time.zone.now
+      })
+
+      message = Course::Assessment::LiveFeedback::Message.create!({
+        thread: new_thread,
+        is_error: false,
+        content: student_prompt,
+        creator_id: student.id,
+        created_at: Time.zone.now,
+        option_id: nil
+      })
+
+      answer.actable.files.each do |file|
+        live_feedback_file = Course::Assessment::LiveFeedback::File.create!({
+          filename: file.filename,
+          content: file.content
+        })
+
+        Course::Assessment::LiveFeedback::MessageFile.create!({
+          message: message,
+          file: live_feedback_file
+        })
+      end
+    end
+
+    describe '#save_live_feedback' do
+      context 'when saving new feedback' do
+        it 'saves new feedback and associates with existing files' do
+          post :save_live_feedback, params: {
+            course_id: course.id,
+            assessment_id: assessment.id,
+            current_thread_id: codaveri_thread_id,
+            content: feedback,
+            is_error: false
+          }
+
+          expect(response).to have_http_status(:no_content)
+
+          new_thread = Course::Assessment::LiveFeedback::Thread.find_by(codaveri_thread_id: codaveri_thread_id)
+          expect(new_thread).to be_present
+
+          new_message = new_thread.messages.last
+          expect(new_message).to be_present
+          expect(new_message.content).to eq(feedback)
+          expect(new_message.is_error).to be_falsey
+          expect(new_message.creator_id).to eq(0)
+
+          new_message_files = new_message.message_files
+          expect(new_message_files.count).to eq(1)
+          expect(new_message_files.first.message_id).to eq(new_message.id)
+
+          existing_files = Course::Assessment::LiveFeedback::File.find(new_message_files.first.file_id)
+          expect(existing_files).to be_present
+
+          expect(existing_files.filename).to eq(answer.actable.files.first.filename)
+          expect(existing_files.content).to eq(answer.actable.files.first.content)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Referring to https://github.com/Coursemology/coursemology2/pull/7791, we store all the information regarding the get help chat interaction between student and system into our DB, and hence we got rid of almost all the data dumping into the local storage. Only those info that do not make sense to be put inside DB (feedback token, chat open status, feedback URL, request state) that are being put inside the local storage

The DB architecture to support this get help feature is the following
<img width="1697" alt="Screenshot 2025-02-20 at 11 45 59 AM" src="https://github.com/user-attachments/assets/5122afad-5663-4179-ac43-524ceb949f44" />

## Other Supported Features

We also support the recording of the suggestions provided to student from time to time, and also whether student send the prompt to the Get Help bot using our suggestions or they typed it themselves. This recording will be useful should we conduct the analysis later on to evaluate if the currently existing suggestions are useful or if it needs some revamping