### PR TITLE
fix(s3): s3 config updates

### DIFF
--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 CarrierWave.configure do |config|
-  config.storage = :file
+  if Rails.env.production?
+    require 'carrierwave/storage/fog'
+
+    config.storage = :fog
+    config.fog_credentials = { provider: 'AWS' }
+    config.fog_attributes = { s3_client: S3_CLIENT } # reuse credentials from aws.rb
+    config.fog_directory = ENV['AWS_BUCKET']
+    config.fog_public = false
+  else
+    config.storage = :file
+  end
   config.cache_dir = Rails.root.join('tmp/uploads')
 end

--- a/lib/autoload/send_file.rb
+++ b/lib/autoload/send_file.rb
@@ -43,6 +43,6 @@ module SendFile
     end
 
     signer = Aws::S3::Presigner.new(client: S3_CLIENT)
-    signer.presigned_url(:get_object, bucket: S3_BUCKET.name, key: s3_key)
+    signer.presigned_url(:get_object, bucket: ENV.fetch('AWS_BUCKET', nil), key: s3_key)
   end
 end


### PR DESCRIPTION
- fix uninitialized constant error caused by refactoring out `S3_BUCKET` in https://github.com/Coursemology/coursemology2/pull/7804
- moved and refactored fog-aws config from [file in dockerfiles repo](https://github.com/Coursemology/dockerfiles/blob/master/files/config/initializers/carrier_wave.rb)

When this PR is deployed, that file should be deleted from the dockerfiles repo.