### PR TITLE
[File Upload Question] change FE validation for multiple file attachments

### DIFF
--- a/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
+++ b/client/app/bundles/course/assessment/question/text-responses/commons/validations.ts
@@ -34,7 +34,7 @@ export const questionSchema = (
       is: AttachmentType.MULTIPLE_ATTACHMENT,
       then: number()
         .required()
-        .min(1, translations.mustSpecifyPositiveMaxAttachment)
+        .min(2, translations.mustSpecifyPositiveMaxAttachment)
         .max(
           defaultMaxAttachments,
           t(translations.mustBeLessThanMaxAttachments, {

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -816,7 +816,7 @@ const translations = defineMessages({
   },
   mustSpecifyPositiveMaxAttachment: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachment',
-    defaultMessage: 'Maximum Number of Attachments has to be positive.',
+    defaultMessage: 'Max Number of Attachments has to be at least 2.',
   },
   mustSpecifyPositiveMaxAttachmentSize: {
     id: 'course.assessment.question.multipleResponses.mustSpecifyPositiveMaxAttachmentSize',


### PR DESCRIPTION
- if multiple file attachments are chosen, need to put at least 2 for Max Number of Attachments
- previously if it's set to 1, then the option will automatically switched to Single File Attachment upon saving