### PR TITLE
[File Upload UI/UX] Default to Initial Value when Navigating to Multiple File Attachments

### DIFF
--- a/client/app/bundles/course/assessment/question/text-responses/NewTextResponsePage.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/NewTextResponsePage.tsx
@@ -2,6 +2,8 @@ import { ElementType } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   AttachmentType,
+  INITIAL_MAX_ATTACHMENT_SIZE,
+  INITIAL_MAX_ATTACHMENTS,
   TextResponseData,
   TextResponseFormData,
 } from 'types/course/assessment/question/text-responses';
@@ -19,9 +21,6 @@ import TextResponseForm, {
   TextResponseFormProps,
 } from './components/TextResponseForm';
 import { create, fetchNewFileUpload, fetchNewTextResponse } from './operations';
-
-const INITIAL_MAX_ATTACHMENTS = 3;
-const INITIAL_MAX_ATTACHMENT_SIZE = 10;
 
 const NEW_TEXT_RESPONSE_VALUE = {
   ...commonQuestionFieldsInitialValues,

--- a/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/FileUploadManager.tsx
@@ -25,6 +25,23 @@ const FileUploadManager = (props: Props): JSX.Element => {
 
   return (
     <>
+      <div className="mt-5 mb-5">
+        <Controller
+          control={control}
+          name="isAttachmentRequired"
+          render={({ field, fieldState }): JSX.Element => (
+            <FormCheckboxField
+              disabled={
+                disabled ||
+                watch('attachmentType') === AttachmentType.NO_ATTACHMENT
+              }
+              field={field}
+              fieldState={fieldState}
+              label={t(translations.isAttachmentRequired)}
+            />
+          )}
+        />
+      </div>
       <Controller
         control={control}
         name="attachmentType"
@@ -54,49 +71,6 @@ const FileUploadManager = (props: Props): JSX.Element => {
         )}
       />
 
-      {watch('attachmentType') !== AttachmentType.NO_ATTACHMENT && (
-        <>
-          <div className="mt-5">
-            <Controller
-              control={control}
-              name="isAttachmentRequired"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormCheckboxField
-                  disabled={disabled}
-                  field={field}
-                  fieldState={fieldState}
-                  label={t(translations.isAttachmentRequired)}
-                />
-              )}
-            />
-          </div>
-          <div className="mt-5">
-            <Controller
-              control={control}
-              name="maxAttachmentSize"
-              render={({ field, fieldState }): JSX.Element => (
-                <FormTextField
-                  className="w-1/2"
-                  disabled={disabled}
-                  disableMargins
-                  field={field}
-                  fieldState={fieldState}
-                  InputProps={{
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        {t(translations.megabytes)}
-                      </InputAdornment>
-                    ),
-                  }}
-                  label={t(translations.maxAttachmentSize)}
-                  variant="filled"
-                />
-              )}
-            />
-          </div>
-        </>
-      )}
-
       {watch('attachmentType') === AttachmentType.MULTIPLE_ATTACHMENT && (
         <div className="mt-5">
           <Controller
@@ -110,6 +84,33 @@ const FileUploadManager = (props: Props): JSX.Element => {
                 field={field}
                 fieldState={fieldState}
                 label={t(translations.maxAttachments)}
+                variant="filled"
+              />
+            )}
+          />
+        </div>
+      )}
+
+      {watch('attachmentType') !== AttachmentType.NO_ATTACHMENT && (
+        <div className="mt-5">
+          <Controller
+            control={control}
+            name="maxAttachmentSize"
+            render={({ field, fieldState }): JSX.Element => (
+              <FormTextField
+                className="w-1/2"
+                disabled={disabled}
+                disableMargins
+                field={field}
+                fieldState={fieldState}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {t(translations.megabytes)}
+                    </InputAdornment>
+                  ),
+                }}
+                label={t(translations.maxAttachmentSize)}
                 variant="filled"
               />
             )}

--- a/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
@@ -2,6 +2,8 @@ import { useRef, useState } from 'react';
 import { Alert } from '@mui/material';
 import {
   AttachmentType,
+  INITIAL_MAX_ATTACHMENT_SIZE,
+  INITIAL_MAX_ATTACHMENTS,
   TextResponseData,
   TextResponseFormData,
 } from 'types/course/assessment/question/text-responses';
@@ -40,6 +42,14 @@ const TextResponseForm = <T extends 'new' | 'edit'>(
       attachmentType:
         data.question?.attachmentType ??
         getAttachmentTypeFromMaxAttachment(data.question?.maxAttachments),
+      maxAttachments:
+        data.question && data.question.maxAttachments <= 1
+          ? INITIAL_MAX_ATTACHMENTS
+          : data.question!.maxAttachments,
+      maxAttachmentSize:
+        data.question && !data.question.maxAttachmentSize
+          ? INITIAL_MAX_ATTACHMENT_SIZE
+          : data.question!.maxAttachmentSize,
     },
   };
 

--- a/client/app/types/course/assessment/question/text-responses.ts
+++ b/client/app/types/course/assessment/question/text-responses.ts
@@ -19,6 +19,9 @@ export enum AttachmentType {
   MULTIPLE_ATTACHMENT = 'multiple_attachment',
 }
 
+export const INITIAL_MAX_ATTACHMENTS = 3;
+export const INITIAL_MAX_ATTACHMENT_SIZE = 10;
+
 export interface TextResponseQuestionFormData extends QuestionFormData {
   attachmentType: AttachmentType;
   maxAttachments: number;


### PR DESCRIPTION
## Background

When user wants to edit the pre-existing text response question, to modify the file-upload related matters (maximum number of attachments and maximum number of attachment sizes), we encountered unexpected behaviour when we switch over from No/Single Attachment to Multiple Attachments.

For Max Attachments, navigating from No Attachment to Multiple Attachments will have the box of Max Attachment be having number 0. Similarly, navigating from Single Attachment to Multiple Attachments will have that box be filled in with 1. Sometimes, when user navigate to Multiple Attachments, they don't really care about how many attachments they want, and hence proceeding to save the question almost immediately.

We fixed this behaviour by introducing the initial value for both max attachments and also max attachment size upon editing the questions, be it text response or file upload

## Approach

Upon editing, we do the following:
- Navigating from No/Single Attachment to Multiple Attachment -> initial value of max attachments will be set to 3
- Navigating from No Attachment to Single/Multiple Attachment -> initial value of max attachment size will be set to 10