### PR TITLE
fix(getHelp): bug on expiring / new thread

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -125,8 +125,8 @@ class Course::Assessment::Submission::SubmissionsController < # rubocop:disable 
     submission_question = Course::Assessment::SubmissionQuestion.where(submission_id: submission.id,
                                                                        question_id: question.id).first
 
-    @thread = Course::Assessment::LiveFeedback::Thread.where(submission_question_id: submission_question.id,
-                                                             is_active: true).preload(:messages).first
+    @thread = Course::Assessment::LiveFeedback::Thread.where(submission_question_id: submission_question.id).
+              order(created_at: :desc).preload(:messages).first
   end
 
   def create_live_feedback_chat

--- a/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/index.tsx
+++ b/client/app/bundles/course/assessment/submission/components/GetHelpChatPage/index.tsx
@@ -34,14 +34,13 @@ const GetHelpChatPage: FC<GetHelpChatPageProps> = (props) => {
   );
 
   const isLiveFeedbackChatLoaded = liveFeedbackChats?.isLiveFeedbackChatLoaded;
+  const currentThreadId = liveFeedbackChats?.currentThreadId;
 
   const isRequestingLiveFeedback = liveFeedbackChats?.isRequestingLiveFeedback;
   const isPollingLiveFeedback = liveFeedbackChats?.pendingFeedbackToken;
 
   const isRenderingSuggestionChips =
-    !isRequestingLiveFeedback &&
-    !isPollingLiveFeedback &&
-    liveFeedbackChats?.currentThreadId;
+    !isRequestingLiveFeedback && !isPollingLiveFeedback && currentThreadId;
 
   useEffect(() => {
     if (!liveFeedbackChats || liveFeedbackChats?.chats.length === 0) return;
@@ -61,10 +60,10 @@ const GetHelpChatPage: FC<GetHelpChatPageProps> = (props) => {
   }, [liveFeedbackChats?.chats]);
 
   useEffect(() => {
-    if (!answerId || isLiveFeedbackChatLoaded) return;
+    if (!answerId || !currentThreadId || isLiveFeedbackChatLoaded) return;
 
     fetchLiveFeedbackChat(dispatch, answerId);
-  }, [answerId, isLiveFeedbackChatLoaded]);
+  }, [answerId, isLiveFeedbackChatLoaded, currentThreadId]);
 
   if (!answerId) return null;
 


### PR DESCRIPTION
- fetch the oldest thread instead of only active thread -> mitigate issue of user not immediately creating new chatroom when thread is expired
- prevent fetching get help chat when thread has not been created yet