### PR TITLE
fix(codaveri): allow sync codaveri question even when language deprecated

### DIFF
--- a/app/models/course/assessment/question/programming.rb
+++ b/app/models/course/assessment/question/programming.rb
@@ -32,7 +32,7 @@ class Course::Assessment::Question::Programming < ApplicationRecord # rubocop:di
   validates :import_job_id, uniqueness: { allow_nil: true, if: :import_job_id_changed? }
 
   validates :language, presence: true
-  validate :validate_language_enabled, unless: :duplicating?
+  validate :validate_language_enabled, unless: :skip_process_package?
 
   validate -> { validate_time_limit }
   validate :validate_codaveri_question


### PR DESCRIPTION
Fix error when user tries to evaluate question that is not synced with codaveri and is using deprecated language.

To recreate error and verify fix behavior:
- Create programming question
- set language to deprecated language (e.g. "Python 3.5") and is_synced_with_codaveri to false
- Create submission and attempt to submit for auto grading

UI behavior on update programming question page unchanged (page will refuse to save changes when question language is deprecated)