### PR TITLE
fix(rag-workflow): add question to evaluation service during get_assistant_response

### DIFF
--- a/app/services/rag_wise/rag_workflow_service.rb
+++ b/app/services/rag_wise/rag_workflow_service.rb
@@ -22,6 +22,7 @@ class RagWise::RagWorkflowService
 
   def get_assistant_response(post, topic)
     query_payload = "query title: #{topic.title} query text: #{post.text} "
+    @evaluation.question = query_payload
     first_attachment = post.attachments.first
     if first_attachment
       data = Base64.strict_encode64(File.read(first_attachment.path))


### PR DESCRIPTION
- tool calling is automatic in rag_worklfow_service, which may cause question in evalution_service to be empty when no tool is called
- add question to evaluation_service at the start before tool calling, making it independent of whether a tool is called