### PR TITLE
fix(sidekiq): move conditional satisfiability jobs to tracked queue

### DIFF
--- a/app/jobs/course/conditional/conditional_satisfiability_evaluation_job.rb
+++ b/app/jobs/course/conditional/conditional_satisfiability_evaluation_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Course::Conditional::ConditionalSatisfiabilityEvaluationJob < ApplicationJob
   include TrackableJob
+  queue_as :delayed_medium_high
 
   protected
 

--- a/app/jobs/course/conditional/coursewide_conditional_satisfiability_evaluation_job.rb
+++ b/app/jobs/course/conditional/coursewide_conditional_satisfiability_evaluation_job.rb
@@ -3,6 +3,7 @@ class Course::Conditional::CoursewideConditionalSatisfiabilityEvaluationJob < Ap
   DELTA = 1.0
 
   include TrackableJob
+  queue_as :delayed_medium_high
 
   protected
 


### PR DESCRIPTION
Move `ConditionalSatisfiabilityEvaluationJob` and `CoursewideConditionalSatisfiabilityEvaluationJob` to delayed_medium_high queue (were previously in default queue)

This is done so that workers will scale properly when high number of these jobs are queued. Our monitoring metrics only capture "grading" queues (highest, medium_high, delayed_highest, delayed_medium_high), so if these jobs run on default queue workers will not scale up in response, leading to abnormal behavior as grading jobs pile up and trigger erratic scale out/in events.