### PR TITLE
Remove react-emitter-factory

### DIFF
--- a/client/app/bundles/course/admin/pages/AnnouncementsSettings/AnnouncementsSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AnnouncementsSettings/AnnouncementsSettingsForm.tsx
@@ -1,33 +1,33 @@
-import { Emits } from 'react-emitter-factory';
+import { forwardRef } from 'react';
 import { Controller } from 'react-hook-form';
 import { Typography } from '@mui/material';
 import { AnnouncementsSettingsData } from 'types/course/admin/announcements';
 
 import Section from 'lib/components/core/layouts/Section';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import commonTranslations from '../../translations';
 
 import translations from './translations';
 
-interface AnnouncementsSettingsFormProps
-  extends Emits<FormEmitter<AnnouncementsSettingsData>> {
+interface AnnouncementsSettingsFormProps {
   data: AnnouncementsSettingsData;
   onSubmit: (data: AnnouncementsSettingsData) => void;
   disabled?: boolean;
 }
 
-const AnnouncementsSettingsForm = (
-  props: AnnouncementsSettingsFormProps,
-): JSX.Element => {
+const AnnouncementsSettingsForm = forwardRef<
+  FormRef<AnnouncementsSettingsData>,
+  AnnouncementsSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
 
   return (
     <Form
+      ref={ref}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
@@ -60,6 +60,8 @@ const AnnouncementsSettingsForm = (
       )}
     </Form>
   );
-};
+});
+
+AnnouncementsSettingsForm.displayName = 'AnnouncementsSettingsForm';
 
 export default AnnouncementsSettingsForm;

--- a/client/app/bundles/course/admin/pages/AnnouncementsSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/AnnouncementsSettings/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { ComponentRef, useRef, useState } from 'react';
 import { AnnouncementsSettingsData } from 'types/course/admin/announcements';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -19,7 +18,7 @@ import {
 const AnnouncementsSettings = (): JSX.Element => {
   const reloadItems = useItemsReloader();
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<AnnouncementsSettingsData>>();
+  const formRef = useRef<ComponentRef<typeof AnnouncementsSettingsForm>>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = (data: AnnouncementsSettingsData): void => {
@@ -28,11 +27,11 @@ const AnnouncementsSettings = (): JSX.Element => {
     updateAnnouncementsSettings(data)
       .then((newData) => {
         if (!newData) return;
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         reloadItems();
         toast.success(t(translations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -40,9 +39,9 @@ const AnnouncementsSettings = (): JSX.Element => {
     <Preload render={<LoadingIndicator />} while={fetchAnnouncementsSettings}>
       {(data): JSX.Element => (
         <AnnouncementsSettingsForm
+          ref={formRef}
           data={data}
           disabled={submitting}
-          emitsVia={setForm}
           onSubmit={handleSubmit}
         />
       )}

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/AssessmentSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { Emits } from 'react-emitter-factory';
+import { forwardRef } from 'react';
 import { Controller } from 'react-hook-form';
 import { InputAdornment, Typography } from '@mui/material';
 import { AssessmentSettingsData } from 'types/course/admin/assessments';
@@ -8,22 +8,22 @@ import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import AssessmentCategoriesManager from './AssessmentCategoriesManager';
 import translations from './translations';
 
-interface AssessmentsSettingsFormProps
-  extends Emits<FormEmitter<AssessmentSettingsData>> {
+interface AssessmentsSettingsFormProps {
   data: AssessmentSettingsData;
   onSubmit?: (data: AssessmentSettingsData) => void;
   disabled?: boolean;
 }
 
-const AssessmentsSettingsForm = (
-  props: AssessmentsSettingsFormProps,
-): JSX.Element => {
+const AssessmentsSettingsForm = forwardRef<
+  FormRef<AssessmentSettingsData>,
+  AssessmentsSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
   const validationSchema = yup.object({
     maxProgrammingTimeLimit: yup
@@ -35,8 +35,8 @@ const AssessmentsSettingsForm = (
 
   return (
     <Form
+      ref={ref}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
@@ -158,6 +158,8 @@ const AssessmentsSettingsForm = (
       )}
     </Form>
   );
-};
+});
+
+AssessmentsSettingsForm.displayName = 'AssessmentsSettingsForm';
 
 export default AssessmentsSettingsForm;

--- a/client/app/bundles/course/admin/pages/AssessmentSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/AssessmentSettings/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { ComponentRef, useRef, useState } from 'react';
 import { AssessmentSettingsData } from 'types/course/admin/assessments';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -35,7 +34,7 @@ const LoadedAssessmentSettings = (
   props: LoadedAssessmentSettingsProps,
 ): JSX.Element | null => {
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<AssessmentSettingsData>>();
+  const formRef = useRef<ComponentRef<typeof AssessmentSettingsForm>>(null);
   const [settings, setSettings] = useState(props.data);
   const [submitting, setSubmitting] = useState(false);
 
@@ -45,7 +44,7 @@ const LoadedAssessmentSettings = (
   ): void => {
     if (!data) return;
     setSettings(data);
-    form?.resetTo?.(data);
+    formRef.current?.resetTo?.(data);
     toast.success(message);
   };
 
@@ -56,7 +55,7 @@ const LoadedAssessmentSettings = (
       .then((newData) => {
         updateFormAndToast(newData, t(formTranslations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -167,9 +166,9 @@ const LoadedAssessmentSettings = (
   return (
     <AssessmentSettingsProvider value={assessmentSettings}>
       <AssessmentSettingsForm
+        ref={formRef}
         data={settings}
         disabled={submitting}
-        emitsVia={setForm}
         onSubmit={handleSubmit}
       />
     </AssessmentSettingsProvider>

--- a/client/app/bundles/course/admin/pages/CodaveriSettings/components/forms/CodaveriSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/CodaveriSettings/components/forms/CodaveriSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { RadioGroup } from '@mui/material';
 import { CodaveriSettingsEntity } from 'types/course/admin/codaveri';
@@ -6,7 +6,7 @@ import { CodaveriSettingsEntity } from 'types/course/admin/codaveri';
 import RadioButton from 'lib/components/core/buttons/RadioButton';
 import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
 import formTranslations from 'lib/translations/form';
@@ -24,7 +24,7 @@ const CodaveriSettingsForm = (
   const { settings } = props;
   const { t } = useTranslation();
   const [submitting, setSubmitting] = useState(false);
-  const [form, setForm] = useState<FormEmitter<CodaveriSettingsEntity>>();
+  const formRef = useRef<FormRef<CodaveriSettingsEntity>>(null);
   const disabled = submitting;
 
   const handleSubmit = (data: CodaveriSettingsEntity): void => {
@@ -33,18 +33,18 @@ const CodaveriSettingsForm = (
     updateCodaveriSettings(data)
       .then((newData) => {
         if (!newData) return;
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         toast.success(t(formTranslations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
   return (
     <Form
+      ref={formRef}
       className="!pb-0"
       disabled={disabled}
-      emitsVia={setForm}
       headsUp
       initialValues={settings}
       onSubmit={handleSubmit}

--- a/client/app/bundles/course/admin/pages/CommentsSettings/CommentsSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/CommentsSettings/CommentsSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { Emits } from 'react-emitter-factory';
+import { forwardRef } from 'react';
 import { Controller } from 'react-hook-form';
 import { Typography } from '@mui/material';
 import { CommentsSettingsData } from 'types/course/admin/comments';
@@ -6,15 +6,14 @@ import { number, object, string } from 'yup';
 
 import Section from 'lib/components/core/layouts/Section';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import commonTranslations from '../../translations';
 
 import translations from './translations';
 
-interface CommentsSettingsFormProps
-  extends Emits<FormEmitter<CommentsSettingsData>> {
+interface CommentsSettingsFormProps {
   data: CommentsSettingsData;
   onSubmit: (data: CommentsSettingsData) => void;
   disabled?: boolean;
@@ -27,15 +26,16 @@ const validationSchema = object({
     .positive(commonTranslations.paginationMustBePositive),
 });
 
-const CommentsSettingsForm = (
-  props: CommentsSettingsFormProps,
-): JSX.Element => {
+const CommentsSettingsForm = forwardRef<
+  FormRef<CommentsSettingsData>,
+  CommentsSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
 
   return (
     <Form
+      ref={ref}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
@@ -85,6 +85,8 @@ const CommentsSettingsForm = (
       )}
     </Form>
   );
-};
+});
+
+CommentsSettingsForm.displayName = 'CommentsSettingsForm';
 
 export default CommentsSettingsForm;

--- a/client/app/bundles/course/admin/pages/CommentsSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/CommentsSettings/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { ComponentRef, useRef, useState } from 'react';
 import { CommentsSettingsData } from 'types/course/admin/comments';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -16,7 +15,7 @@ import { fetchCommentsSettings, updateCommentsSettings } from './operations';
 const CommentsSettings = (): JSX.Element => {
   const reloadItems = useItemsReloader();
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<CommentsSettingsData>>();
+  const formRef = useRef<ComponentRef<typeof CommentsSettingsForm>>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = (data: CommentsSettingsData): void => {
@@ -25,11 +24,11 @@ const CommentsSettings = (): JSX.Element => {
     updateCommentsSettings(data)
       .then((newData) => {
         if (!newData) return;
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         reloadItems();
         toast.success(t(translations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -37,9 +36,9 @@ const CommentsSettings = (): JSX.Element => {
     <Preload render={<LoadingIndicator />} while={fetchCommentsSettings}>
       {(data): JSX.Element => (
         <CommentsSettingsForm
+          ref={formRef}
           data={data}
           disabled={submitting}
-          emitsVia={setForm}
           onSubmit={handleSubmit}
         />
       )}

--- a/client/app/bundles/course/admin/pages/CourseSettings/CourseSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/CourseSettings/CourseSettingsForm.tsx
@@ -1,5 +1,4 @@
-import { useMemo, useState } from 'react';
-import { Emits } from 'react-emitter-factory';
+import { forwardRef, useMemo, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { Button, Grid, RadioGroup, Typography } from '@mui/material';
 import { CourseInfo, TimeOffset, TimeZones } from 'types/course/admin/course';
@@ -15,7 +14,7 @@ import FormDateTimePickerField from 'lib/components/form/fields/DateTimePickerFi
 import FormRichTextField from 'lib/components/form/fields/RichTextField';
 import FormSelectField from 'lib/components/form/fields/SelectField';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import DeleteCoursePrompt from './DeleteCoursePrompt';
@@ -23,7 +22,7 @@ import OffsetTimesPrompt from './OffsetTimesPrompt';
 import translations from './translations';
 import validationSchema from './validationSchema';
 
-interface CourseSettingsFormProps extends Emits<FormEmitter<CourseInfo>> {
+interface CourseSettingsFormProps {
   data: CourseInfo;
   timeZones: TimeZones;
   onSubmit: (data: CourseInfo, timeOffset?: TimeOffset) => void;
@@ -32,7 +31,10 @@ interface CourseSettingsFormProps extends Emits<FormEmitter<CourseInfo>> {
   disabled: boolean;
 }
 
-const CourseSettingsForm = (props: CourseSettingsFormProps): JSX.Element => {
+const CourseSettingsForm = forwardRef<
+  FormRef<CourseInfo>,
+  CourseSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
   const [offsetTimesPrompt, setOffsetTimesPrompt] = useState(false);
   const [deletingCourse, setDeletingCourse] = useState(false);
@@ -72,9 +74,9 @@ const CourseSettingsForm = (props: CourseSettingsFormProps): JSX.Element => {
 
   return (
     <Form
+      ref={ref}
       dirty={Boolean(stagedLogo)}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onReset={(): void => setStagedLogo(undefined)}
@@ -351,6 +353,8 @@ const CourseSettingsForm = (props: CourseSettingsFormProps): JSX.Element => {
       )}
     </Form>
   );
-};
+});
+
+CourseSettingsForm.displayName = 'CourseSettingsForm';
 
 export default CourseSettingsForm;

--- a/client/app/bundles/course/admin/pages/CourseSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/CourseSettings/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { ComponentRef, useRef, useState } from 'react';
 import { CourseInfo, TimeOffset, TimeZones } from 'types/course/admin/course';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -26,13 +25,13 @@ const fetchSettingsAndTimeZones = (): Promise<[CourseInfo, TimeZones]> =>
 const CourseSettings = (): JSX.Element => {
   const reloadItems = useItemsReloader();
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<CourseInfo>>();
+  const formRef = useRef<ComponentRef<typeof CourseSettingsForm>>(null);
   const [reloadForm, setReloadForm] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const updateForm = (data?: CourseInfo): void => {
     if (!data) return;
-    form?.resetTo?.(data);
+    formRef.current?.resetTo?.(data);
   };
 
   const updateFormAndToast = (message: string, data?: CourseInfo): void => {
@@ -49,7 +48,7 @@ const CourseSettings = (): JSX.Element => {
         updateFormAndToast(t(formTranslations.changesSaved), newData);
         setReloadForm((value) => !value);
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -94,9 +93,9 @@ const CourseSettings = (): JSX.Element => {
     >
       {([settings, timeZones]): JSX.Element => (
         <CourseSettingsForm
+          ref={formRef}
           data={settings}
           disabled={submitting}
-          emitsVia={setForm}
           onDeleteCourse={handleDeleteCourse}
           onSubmit={handleSubmit}
           onUploadCourseLogo={handleUploadCourseLogo}

--- a/client/app/bundles/course/admin/pages/ForumsSettings/ForumsSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/ForumsSettings/ForumsSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { Emits } from 'react-emitter-factory';
+import { forwardRef } from 'react';
 import { Controller } from 'react-hook-form';
 import { RadioGroup, Typography } from '@mui/material';
 import { ForumsSettingsData } from 'types/course/admin/forums';
@@ -9,15 +9,14 @@ import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import commonTranslations from '../../translations';
 
 import translations from './translations';
 
-interface ForumsSettingsFormProps
-  extends Emits<FormEmitter<ForumsSettingsData>> {
+interface ForumsSettingsFormProps {
   data: ForumsSettingsData;
   onSubmit: (data: ForumsSettingsData) => void;
   disabled?: boolean;
@@ -30,13 +29,16 @@ const validationSchema = object({
     .positive(commonTranslations.paginationMustBePositive),
 });
 
-const ForumsSettingsForm = (props: ForumsSettingsFormProps): JSX.Element => {
+const ForumsSettingsForm = forwardRef<
+  FormRef<ForumsSettingsData>,
+  ForumsSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
 
   return (
     <Form
+      ref={ref}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
@@ -132,6 +134,8 @@ const ForumsSettingsForm = (props: ForumsSettingsFormProps): JSX.Element => {
       )}
     </Form>
   );
-};
+});
+
+ForumsSettingsForm.displayName = 'ForumsSettingsForm';
 
 export default ForumsSettingsForm;

--- a/client/app/bundles/course/admin/pages/ForumsSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/ForumsSettings/index.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ForumsSettingsData } from 'types/course/admin/forums';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
+import { FormRef } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -16,7 +16,7 @@ import { fetchForumsSettings, updateForumsSettings } from './operations';
 const ForumsSettings = (): JSX.Element => {
   const reloadItems = useItemsReloader();
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<ForumsSettingsData>>();
+  const formRef = useRef<FormRef<ForumsSettingsData>>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = (data: ForumsSettingsData): void => {
@@ -25,11 +25,11 @@ const ForumsSettings = (): JSX.Element => {
     updateForumsSettings(data)
       .then((newData) => {
         if (!newData) return;
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         reloadItems();
         toast.success(t(translations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -37,9 +37,9 @@ const ForumsSettings = (): JSX.Element => {
     <Preload render={<LoadingIndicator />} while={fetchForumsSettings}>
       {(data): JSX.Element => (
         <ForumsSettingsForm
+          ref={formRef}
           data={data}
           disabled={submitting}
-          emitsVia={setForm}
           onSubmit={handleSubmit}
         />
       )}

--- a/client/app/bundles/course/admin/pages/LeaderboardSettings/LeaderboardSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/LeaderboardSettings/LeaderboardSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { Emits } from 'react-emitter-factory';
+import { forwardRef } from 'react';
 import { Controller } from 'react-hook-form';
 import { Typography } from '@mui/material';
 import { LeaderboardSettingsData } from 'types/course/admin/leaderboard';
@@ -6,29 +6,29 @@ import { LeaderboardSettingsData } from 'types/course/admin/leaderboard';
 import Section from 'lib/components/core/layouts/Section';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import commonTranslations from '../../translations';
 
 import translations from './translations';
 
-interface LeaderboardSettingsFormProps
-  extends Emits<FormEmitter<LeaderboardSettingsData>> {
+interface LeaderboardSettingsFormProps {
   data: LeaderboardSettingsData;
   onSubmit: (data: LeaderboardSettingsData) => void;
   disabled?: boolean;
 }
 
-const LeaderboardSettingsForm = (
-  props: LeaderboardSettingsFormProps,
-): JSX.Element => {
+const LeaderboardSettingsForm = forwardRef<
+  FormRef<LeaderboardSettingsData>,
+  LeaderboardSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
 
   return (
     <Form
+      ref={ref}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
@@ -109,6 +109,8 @@ const LeaderboardSettingsForm = (
       )}
     </Form>
   );
-};
+});
+
+LeaderboardSettingsForm.displayName = 'LeaderboardSettingsForm';
 
 export default LeaderboardSettingsForm;

--- a/client/app/bundles/course/admin/pages/LeaderboardSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/LeaderboardSettings/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { ComponentRef, useRef, useState } from 'react';
 import { LeaderboardSettingsData } from 'types/course/admin/leaderboard';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -19,7 +18,7 @@ import {
 const LeaderboardSettings = (): JSX.Element => {
   const reloadItems = useItemsReloader();
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<LeaderboardSettingsData>>();
+  const formRef = useRef<ComponentRef<typeof LeaderboardSettingsForm>>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = (data: LeaderboardSettingsData): void => {
@@ -28,11 +27,11 @@ const LeaderboardSettings = (): JSX.Element => {
     updateLeaderboardSettings(data)
       .then((newData) => {
         if (!newData) return;
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         reloadItems();
         toast.success(t(translations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -40,9 +39,9 @@ const LeaderboardSettings = (): JSX.Element => {
     <Preload render={<LoadingIndicator />} while={fetchLeaderboardSettings}>
       {(data): JSX.Element => (
         <LeaderboardSettingsForm
+          ref={formRef}
           data={data}
           disabled={submitting}
-          emitsVia={setForm}
           onSubmit={handleSubmit}
         />
       )}

--- a/client/app/bundles/course/admin/pages/MaterialsSettings/MaterialsSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/MaterialsSettings/MaterialsSettingsForm.tsx
@@ -1,33 +1,33 @@
-import { Emits } from 'react-emitter-factory';
+import { forwardRef } from 'react';
 import { Controller } from 'react-hook-form';
 import { Typography } from '@mui/material';
 import { MaterialsSettingsData } from 'types/course/admin/materials';
 
 import Section from 'lib/components/core/layouts/Section';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import commonTranslations from '../../translations';
 
 import translations from './translations';
 
-interface MaterialsSettingsFormProps
-  extends Emits<FormEmitter<MaterialsSettingsData>> {
+interface MaterialsSettingsFormProps {
   data: MaterialsSettingsData;
   onSubmit: (data: MaterialsSettingsData) => void;
   disabled?: boolean;
 }
 
-const MaterialsSettingsForm = (
-  props: MaterialsSettingsFormProps,
-): JSX.Element => {
+const MaterialsSettingsForm = forwardRef<
+  FormRef<MaterialsSettingsData>,
+  MaterialsSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
 
   return (
     <Form
+      ref={ref}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
@@ -60,6 +60,8 @@ const MaterialsSettingsForm = (
       )}
     </Form>
   );
-};
+});
+
+MaterialsSettingsForm.displayName = 'MaterialsSettingsForm';
 
 export default MaterialsSettingsForm;

--- a/client/app/bundles/course/admin/pages/MaterialsSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/MaterialsSettings/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { ComponentRef, useRef, useState } from 'react';
 import { MaterialsSettingsData } from 'types/course/admin/materials';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -16,7 +15,7 @@ import { fetchMaterialsSettings, updateMaterialsSettings } from './operations';
 const MaterialsSettings = (): JSX.Element => {
   const reloadItems = useItemsReloader();
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<MaterialsSettingsData>>();
+  const formRef = useRef<ComponentRef<typeof MaterialsSettingsForm>>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = (data: MaterialsSettingsData): void => {
@@ -25,11 +24,11 @@ const MaterialsSettings = (): JSX.Element => {
     updateMaterialsSettings(data)
       .then((newData) => {
         if (!newData) return;
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         reloadItems();
         toast.success(t(translations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -37,9 +36,9 @@ const MaterialsSettings = (): JSX.Element => {
     <Preload render={<LoadingIndicator />} while={fetchMaterialsSettings}>
       {(data): JSX.Element => (
         <MaterialsSettingsForm
+          ref={formRef}
           data={data}
           disabled={submitting}
-          emitsVia={setForm}
           onSubmit={handleSubmit}
         />
       )}

--- a/client/app/bundles/course/admin/pages/RagWiseSettings/components/forms/RagWiseSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/RagWiseSettings/components/forms/RagWiseSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { Chip, RadioGroup, Slider } from '@mui/material';
 import { RagWiseSettings } from 'types/course/admin/ragWise';
@@ -7,7 +7,7 @@ import RadioButton from 'lib/components/core/buttons/RadioButton';
 import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
 import formTranslations from 'lib/translations/form';
@@ -24,7 +24,7 @@ const RagWiseSettingsForm = ({
 }: RagWiseSettingsFormProps): JSX.Element => {
   const { t } = useTranslation();
   const [submitting, setSubmitting] = useState(false);
-  const [form, setForm] = useState<FormEmitter<RagWiseSettings>>();
+  const formRef = useRef<FormRef<RagWiseSettings>>(null);
 
   const handleSubmit = (data: RagWiseSettings): void => {
     setSubmitting(true);
@@ -32,10 +32,10 @@ const RagWiseSettingsForm = ({
     updateRagWiseSettings(data)
       .then((newData) => {
         if (!newData) return;
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         toast.success(t(formTranslations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -78,9 +78,9 @@ const RagWiseSettingsForm = ({
 
   return (
     <Form
+      ref={formRef}
       className="!pb-0"
       disabled={submitting}
-      emitsVia={setForm}
       headsUp
       initialValues={settings}
       onSubmit={handleSubmit}

--- a/client/app/bundles/course/admin/pages/StoriesSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/StoriesSettings/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
 import { Alert } from '@mui/material';
@@ -8,7 +8,7 @@ import Section from 'lib/components/core/layouts/Section';
 import Link from 'lib/components/core/Link';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -91,7 +91,7 @@ const PingResultAlert = (
 
 const StoriesSettings = (): JSX.Element => {
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<StoriesSettingsData>>();
+  const formRef = useRef<FormRef<StoriesSettingsData>>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = (data: StoriesSettingsData): void => {
@@ -101,10 +101,10 @@ const StoriesSettings = (): JSX.Element => {
       .then((newData) => {
         if (!newData) return;
 
-        form?.resetTo?.(newData);
+        formRef.current?.resetTo?.(newData);
         toast.success(t(formTranslations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -112,8 +112,8 @@ const StoriesSettings = (): JSX.Element => {
     <Preload render={<LoadingIndicator />} while={fetchStoriesSettings}>
       {(data) => (
         <Form
+          ref={formRef}
           disabled={submitting}
-          emitsVia={setForm}
           headsUp
           initialValues={data}
           onSubmit={handleSubmit}

--- a/client/app/bundles/course/admin/pages/VideosSettings/VideosSettingsForm.tsx
+++ b/client/app/bundles/course/admin/pages/VideosSettings/VideosSettingsForm.tsx
@@ -1,11 +1,11 @@
-import { Emits } from 'react-emitter-factory';
+import { forwardRef } from 'react';
 import { Controller } from 'react-hook-form';
 import { Typography } from '@mui/material';
 import { VideosSettingsData, VideosTab } from 'types/course/admin/videos';
 
 import Section from 'lib/components/core/layouts/Section';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import commonTranslations from '../../translations';
@@ -13,8 +13,7 @@ import commonTranslations from '../../translations';
 import translations from './translations';
 import VideosTabsManager from './VideosTabsManager';
 
-interface VideosSettingsFormProps
-  extends Emits<FormEmitter<VideosSettingsData>> {
+interface VideosSettingsFormProps {
   data: VideosSettingsData;
   onSubmit: (data: VideosSettingsData) => void;
   onCreateTab: (title: VideosTab['title'], weight: VideosTab['weight']) => void;
@@ -23,13 +22,16 @@ interface VideosSettingsFormProps
   disabled?: boolean;
 }
 
-const VideosSettingsForm = (props: VideosSettingsFormProps): JSX.Element => {
+const VideosSettingsForm = forwardRef<
+  FormRef<VideosSettingsData>,
+  VideosSettingsFormProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
 
   return (
     <Form
+      ref={ref}
       disabled={props.disabled}
-      emitsVia={props.emitsVia}
       headsUp
       initialValues={props.data}
       onSubmit={props.onSubmit}
@@ -85,6 +87,8 @@ const VideosSettingsForm = (props: VideosSettingsFormProps): JSX.Element => {
       )}
     </Form>
   );
-};
+});
+
+VideosSettingsForm.displayName = 'VideosSettingsForm';
 
 export default VideosSettingsForm;

--- a/client/app/bundles/course/admin/pages/VideosSettings/index.tsx
+++ b/client/app/bundles/course/admin/pages/VideosSettings/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { ComponentRef, useRef, useState } from 'react';
 import { VideosSettingsData, VideosTab } from 'types/course/admin/videos';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -23,7 +22,7 @@ import VideosSettingsForm from './VideosSettingsForm';
 const VideosSettings = (): JSX.Element => {
   const reloadItems = useItemsReloader();
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<VideosSettingsData>>();
+  const formRef = useRef<ComponentRef<typeof VideosSettingsForm>>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const updateFormAndToast = (
@@ -31,7 +30,7 @@ const VideosSettings = (): JSX.Element => {
     message: string,
   ): void => {
     if (!data) return;
-    form?.resetTo?.(data);
+    formRef.current?.resetTo?.(data);
     toast.success(message);
   };
 
@@ -43,7 +42,7 @@ const VideosSettings = (): JSX.Element => {
         reloadItems();
         updateFormAndToast(newData, t(formTranslations.changesSaved));
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -83,10 +82,10 @@ const VideosSettings = (): JSX.Element => {
     <Preload render={<LoadingIndicator />} while={fetchVideosSettings}>
       {(data): JSX.Element => (
         <VideosSettingsForm
+          ref={formRef}
           canCreateTabs={data.canCreateTabs}
           data={data}
           disabled={submitting}
-          emitsVia={setForm}
           onCreateTab={handleCreateTab}
           onDeleteTab={handleDeleteTab}
           onSubmit={handleSubmit}

--- a/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import useEmitterFactory from 'react-emitter-factory';
 import { Controller } from 'react-hook-form';
 import {
   Block as DraftIcon,
@@ -54,6 +53,7 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
     isQuestionsValidForKoditsu,
     modeSwitching,
     onSubmit,
+    onDirtyChange,
     pulsegridUrl,
     // Randomized Assessment is temporarily hidden (PR#5406)
     // randomizationAllowed,
@@ -117,13 +117,9 @@ const AssessmentForm = (props: AssessmentFormProps): JSX.Element => {
     dispatch(fetchTabs(t(translations.fetchTabFailure)));
   }, [dispatch]);
 
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   const renderPasswordFields = (): JSX.Element => (
     <>

--- a/client/app/bundles/course/assessment/components/AssessmentForm/types.ts
+++ b/client/app/bundles/course/assessment/components/AssessmentForm/types.ts
@@ -1,4 +1,3 @@
-import { Emits } from 'react-emitter-factory';
 import { FieldValues, UseFormSetError } from 'react-hook-form';
 import { connect, ConnectedProps } from 'react-redux';
 import { ConditionsData } from 'types/course/conditions';
@@ -20,20 +19,15 @@ interface FolderAttributes {
   enable_materials_action?: boolean;
 }
 
-export interface AssessmentFormEmitter {
-  isDirty?: boolean;
-}
-
 // @ts-ignore until Assessment store is fully typed
 export const connector = connect(({ assessments }) => ({
   tabs: assessments.editPage.tabs,
 }));
 
-export interface AssessmentFormProps
-  extends ConnectedProps<typeof connector>,
-    Emits<AssessmentFormEmitter> {
+export interface AssessmentFormProps extends ConnectedProps<typeof connector> {
   tabs: Tab[];
   onSubmit: (data: FieldValues, setError: UseFormSetError<FieldValues>) => void;
+  onDirtyChange?: (isDirty: boolean) => void;
 
   initialValues?;
   isKoditsuExamEnabled: boolean;

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/NewAssessmentFormButton.jsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/NewAssessmentFormButton.jsx
@@ -24,7 +24,7 @@ class NewAssessmentFormButton extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      assessmentForm: undefined,
+      isDirty: false,
       redirectUrl: undefined,
     };
   }
@@ -55,7 +55,7 @@ class NewAssessmentFormButton extends Component {
   };
 
   handleClose = () => {
-    if (this.state.assessmentForm?.isDirty) {
+    if (this.state.isDirty) {
       this.props.dispatch({
         type: actionTypes.ASSESSMENT_FORM_CANCEL,
       });
@@ -87,11 +87,11 @@ class NewAssessmentFormButton extends Component {
     const formActions = [
       <Button
         key="assessment-popup-dialog-cancel-button"
-        color={this.state.assessmentForm?.isDirty ? 'error' : 'primary'}
+        color={this.state.isDirty ? 'error' : 'primary'}
         disabled={disabled}
         onClick={this.handleClose}
       >
-        {this.state.assessmentForm?.isDirty ? (
+        {this.state.isDirty ? (
           <FormattedMessage {...formTranslations.discard} />
         ) : (
           <FormattedMessage {...formTranslations.cancel} />
@@ -166,12 +166,12 @@ class NewAssessmentFormButton extends Component {
             <AssessmentForm
               canManageMonitor={canManageMonitor}
               disabled={disabled}
-              emitsVia={(assessmentForm) => this.setState({ assessmentForm })}
               gamified={gamified}
               initialValues={initialValues}
               isKoditsuExamEnabled={isKoditsuExamEnabled}
               modeSwitching
               monitoringEnabled={monitoringEnabled}
+              onDirtyChange={(isDirty) => this.setState({ isDirty })}
               onSubmit={this.onFormSubmit}
               randomizationAllowed={randomizationAllowed}
             />

--- a/client/app/bundles/course/assessment/question/forum-post-responses/components/ForumPostResponseForm.tsx
+++ b/client/app/bundles/course/assessment/question/forum-post-responses/components/ForumPostResponseForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import {
   ForumPostResponseData,
@@ -8,7 +8,7 @@ import {
 import Section from 'lib/components/core/layouts/Section';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
 import FormTextField from 'lib/components/form/fields/TextField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../../translations';
@@ -28,7 +28,7 @@ const ForumPostResponseForm = <T extends 'new' | 'edit'>(
   const { t } = useTranslation();
 
   const [submitting, setSubmitting] = useState(false);
-  const [form, setForm] = useState<FormEmitter>();
+  const formRef = useRef<FormRef>(null);
 
   const handleSubmit = async (
     question: ForumPostResponseData['question'],
@@ -39,14 +39,14 @@ const ForumPostResponseForm = <T extends 'new' | 'edit'>(
 
     props.onSubmit(newData).catch((errors) => {
       setSubmitting(false);
-      form?.receiveErrors?.(errors);
+      formRef.current?.receiveErrors?.(errors);
     });
   };
 
   return (
     <Form
+      ref={formRef}
       disabled={submitting}
-      emitsVia={setForm}
       headsUp
       initialValues={data.question!}
       onSubmit={handleSubmit}

--- a/client/app/bundles/course/assessment/question/multiple-responses/components/McqMrqForm.tsx
+++ b/client/app/bundles/course/assessment/question/multiple-responses/components/McqMrqForm.tsx
@@ -8,7 +8,7 @@ import {
 
 import Section from 'lib/components/core/layouts/Section';
 import FormCheckboxField from 'lib/components/form/fields/CheckboxField';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import ConvertMcqMrqButton from '../../../components/ConvertMcqMrqButton';
@@ -39,8 +39,8 @@ const McqMrqForm = <T extends 'new' | 'edit'>(
 
   const [submitting, setSubmitting] = useState(false);
   const [isOptionsDirty, setIsOptionsDirty] = useState(false);
-  const [form, setForm] = useState<FormEmitter>();
 
+  const formRef = useRef<FormRef>(null);
   const optionsRef = useRef<OptionsManagerRef>(null);
 
   const prepareOptions = async (
@@ -74,7 +74,7 @@ const McqMrqForm = <T extends 'new' | 'edit'>(
 
     props.onSubmit(newData).catch((errors) => {
       setSubmitting(false);
-      form?.receiveErrors?.(errors);
+      formRef.current?.receiveErrors?.(errors);
     });
   };
 
@@ -82,9 +82,9 @@ const McqMrqForm = <T extends 'new' | 'edit'>(
 
   return (
     <Form
+      ref={formRef}
       dirty={isOptionsDirty}
       disabled={submitting}
-      emitsVia={setForm}
       headsUp
       initialValues={data.question!}
       onReset={optionsRef.current?.reset}

--- a/client/app/bundles/course/assessment/question/programming/ProgrammingForm.tsx
+++ b/client/app/bundles/course/assessment/question/programming/ProgrammingForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ProgrammingFormData,
@@ -6,7 +6,7 @@ import {
 } from 'types/course/assessment/question/programming';
 
 import Section from 'lib/components/core/layouts/Section';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import { loadingToast } from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -42,7 +42,7 @@ const ProgrammingForm = (props: ProgrammingFormProps): JSX.Element => {
   const { t } = useTranslation();
 
   const [submitting, setSubmitting] = useState(false);
-  const [form, setForm] = useState<FormEmitter<ProgrammingFormData>>();
+  const formRef = useRef<FormRef<ProgrammingFormData>>(null);
   const [pending, setPending] = useState<() => void>();
 
   const { languageOptions, getDataFromId } = useLanguageMode(data.languages);
@@ -85,7 +85,7 @@ const ProgrammingForm = (props: ProgrammingFormProps): JSX.Element => {
           const newData = await props.revalidate?.(response, rawData);
           if (newData) {
             setData(newData);
-            form?.resetTo?.(newData, true);
+            formRef.current?.resetTo?.(newData, true);
           }
 
           toast.error(t(translations.questionSavedButPackageError));
@@ -113,10 +113,10 @@ const ProgrammingForm = (props: ProgrammingFormProps): JSX.Element => {
   return (
     <ProgrammingFormDataProvider from={data}>
       <Form
+        ref={formRef}
         contextual
         dirty={props.dirty}
         disabled={submitting}
-        emitsVia={setForm}
         headsUp
         initialValues={data}
         onSubmit={(rawData): void => {

--- a/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
+++ b/client/app/bundles/course/assessment/question/text-responses/components/TextResponseForm.tsx
@@ -10,7 +10,7 @@ import {
 
 import Section from 'lib/components/core/layouts/Section';
 import Subsection from 'lib/components/core/layouts/Subsection';
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../../../translations';
@@ -54,9 +54,9 @@ const TextResponseForm = <T extends 'new' | 'edit'>(
   };
 
   const [submitting, setSubmitting] = useState(false);
-  const [form, setForm] = useState<FormEmitter>();
   const [isSolutionsDirty, setIsSolutionsDirty] = useState(false);
 
+  const formRef = useRef<FormRef>(null);
   const solutionsRef = useRef<SolutionsManagerRef>(null);
 
   const prepareSolutions = async (
@@ -101,16 +101,16 @@ const TextResponseForm = <T extends 'new' | 'edit'>(
     setSubmitting(true);
     props.onSubmit(newData).catch((errors) => {
       setSubmitting(false);
-      form?.receiveErrors?.(errors);
+      formRef.current?.receiveErrors?.(errors);
     });
   };
 
   return (
     <Form
+      ref={formRef}
       contextual
       dirty={isSolutionsDirty}
       disabled={submitting}
-      emitsVia={setForm}
       headsUp
       initialValues={formattedData.question!}
       onSubmit={handleSubmit}

--- a/client/app/bundles/course/assessment/question/voice-responses/components/VoiceForm.tsx
+++ b/client/app/bundles/course/assessment/question/voice-responses/components/VoiceForm.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   VoiceResponseData,
   VoiceResponseFormData,
 } from 'types/course/assessment/question/voice-responses';
 
-import Form, { FormEmitter } from 'lib/components/form/Form';
+import Form, { FormRef } from 'lib/components/form/Form';
 
 import CommonQuestionFields, {
   commonQuestionFieldsValidation,
@@ -21,7 +21,7 @@ const VoiceForm = <T extends 'new' | 'edit'>(
   const { with: data } = props;
 
   const [submitting, setSubmitting] = useState(false);
-  const [form, setForm] = useState<FormEmitter>();
+  const formRef = useRef<FormRef>(null);
 
   const handleSubmit = async (
     question: VoiceResponseData['question'],
@@ -34,14 +34,14 @@ const VoiceForm = <T extends 'new' | 'edit'>(
 
     props.onSubmit(newData).catch((errors) => {
       setSubmitting(false);
-      form?.receiveErrors?.(errors);
+      formRef.current?.receiveErrors?.(errors);
     });
   };
 
   return (
     <Form
+      ref={formRef}
       disabled={submitting}
-      emitsVia={setForm}
       headsUp
       initialValues={data.question!}
       onSubmit={handleSubmit}

--- a/client/app/bundles/course/group/forms/GroupCreationForm.jsx
+++ b/client/app/bundles/course/group/forms/GroupCreationForm.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from 'react';
-import useEmitterFactory from 'react-emitter-factory';
 import { Controller, useForm } from 'react-hook-form';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -113,7 +112,9 @@ const getConflictingNames = (name, numToCreate, existingGroups) => {
 };
 
 const GroupCreationForm = (props) => {
-  const { dispatch, existingGroups, initialValues, onSubmit } = props;
+  const { dispatch, existingGroups, initialValues, onSubmit, onDirtyChange } =
+    props;
+
   const {
     control,
     handleSubmit,
@@ -126,13 +127,10 @@ const GroupCreationForm = (props) => {
     mode: 'onChange',
     resolver: yupResolver(validationSchema),
   });
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   const name = watch('name');
   const numToCreate = Number.parseInt(watch('num_to_create'), 10);
@@ -294,6 +292,7 @@ GroupCreationForm.propTypes = {
   dispatch: PropTypes.func.isRequired,
   initialValues: PropTypes.object.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  onDirtyChange: PropTypes.func,
 };
 
 export default connect(({ groups }) => ({

--- a/client/app/bundles/course/group/forms/NameDescriptionForm.jsx
+++ b/client/app/bundles/course/group/forms/NameDescriptionForm.jsx
@@ -1,4 +1,4 @@
-import useEmitterFactory from 'react-emitter-factory';
+import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -44,7 +44,7 @@ const validationSchema = yup.object({
 });
 
 const NameDescriptionForm = (props) => {
-  const { initialValues, onSubmit } = props;
+  const { initialValues, onSubmit, onDirtyChange } = props;
   const {
     control,
     handleSubmit,
@@ -55,13 +55,9 @@ const NameDescriptionForm = (props) => {
     resolver: yupResolver(validationSchema),
   });
 
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   return (
     <form
@@ -119,6 +115,7 @@ const NameDescriptionForm = (props) => {
 NameDescriptionForm.propTypes = {
   initialValues: PropTypes.object,
   onSubmit: PropTypes.func.isRequired,
+  onDirtyChange: PropTypes.func,
 };
 
 export default NameDescriptionForm;

--- a/client/app/bundles/course/group/pages/GroupNew/index.jsx
+++ b/client/app/bundles/course/group/pages/GroupNew/index.jsx
@@ -56,13 +56,11 @@ const PopupDialog = ({ dispatch, intl, isManagingGroups }) => {
         skipConfirmation={!isDirty}
       >
         <NameDescriptionForm
-          emitsVia={(nameDescriptionForm) =>
-            setIsDirty(nameDescriptionForm.isDirty)
-          }
           initialValues={{
             name: '',
             description: '',
           }}
+          onDirtyChange={setIsDirty}
           onSubmit={onFormSubmit}
         />
       </GroupFormDialog>

--- a/client/app/bundles/course/group/pages/GroupShow/CategoryCard.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/CategoryCard.jsx
@@ -172,13 +172,11 @@ const CategoryCard = ({
             skipConfirmation={!isDirty}
           >
             <NameDescriptionForm
-              emitsVia={(nameDescriptionForm) =>
-                setIsDirty(nameDescriptionForm.isDirty)
-              }
               initialValues={{
                 name: category.name,
                 description: category.description,
               }}
+              onDirtyChange={setIsDirty}
               onSubmit={onFormSubmit}
             />
           </GroupFormDialog>

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupManager.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupManager.jsx
@@ -321,9 +321,6 @@ const GroupManager = ({
         skipConfirmation={!isDirty}
       >
         <GroupCreationForm
-          emitsVia={(nameDescriptionForm) =>
-            setIsDirty(nameDescriptionForm.isDirty)
-          }
           existingGroups={groups}
           initialValues={{
             name: '',
@@ -331,6 +328,7 @@ const GroupManager = ({
             num_to_create: 0,
             is_single: true,
           }}
+          onDirtyChange={setIsDirty}
           onSubmit={onCreateFormSubmit}
         />
       </GroupFormDialog>

--- a/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManager.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupManager/GroupUserManager.jsx
@@ -496,13 +496,11 @@ const GroupUserManager = ({
         skipConfirmation={!isDirty}
       >
         <NameDescriptionForm
-          emitsVia={(nameDescriptionForm) =>
-            setIsDirty(nameDescriptionForm.isDirty)
-          }
           initialValues={{
             name: group.name,
             description: group.description,
           }}
+          onDirtyChange={setIsDirty}
           onSubmit={onFormSubmit}
         />
       </GroupFormDialog>

--- a/client/app/bundles/course/lesson-plan/containers/EventFormDialog/EventForm.jsx
+++ b/client/app/bundles/course/lesson-plan/containers/EventFormDialog/EventForm.jsx
@@ -1,4 +1,4 @@
-import useEmitterFactory from 'react-emitter-factory';
+import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -61,8 +61,15 @@ const validationSchema = yup.object({
 });
 
 const EventForm = (props) => {
-  const { onSubmit, initialValues, disabled, eventTypes, eventLocations } =
-    props;
+  const {
+    onSubmit,
+    initialValues,
+    disabled,
+    eventTypes,
+    eventLocations,
+    onDirtyChange,
+  } = props;
+
   const {
     control,
     handleSubmit,
@@ -73,13 +80,9 @@ const EventForm = (props) => {
     resolver: yupResolver(validationSchema),
   });
 
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   return (
     <form
@@ -210,6 +213,7 @@ EventForm.propTypes = {
   eventLocations: PropTypes.arrayOf(PropTypes.string),
   initialValues: PropTypes.object,
   onSubmit: PropTypes.func.isRequired,
+  onDirtyChange: PropTypes.func,
 };
 
 export default EventForm;

--- a/client/app/bundles/course/lesson-plan/containers/EventFormDialog/index.jsx
+++ b/client/app/bundles/course/lesson-plan/containers/EventFormDialog/index.jsx
@@ -44,9 +44,9 @@ const EventFormDialog = ({
     >
       <EventForm
         {...{ initialValues, onSubmit, disabled }}
-        emitsVia={(eventForm) => setIsDirty(eventForm.isDirty)}
         eventLocations={[...new Set(eventLocations)]}
         eventTypes={[...new Set(eventTypes)]}
+        onDirtyChange={setIsDirty}
       />
     </FormDialogue>
   );

--- a/client/app/bundles/course/lesson-plan/containers/MilestoneFormDialog/MilestoneForm.jsx
+++ b/client/app/bundles/course/lesson-plan/containers/MilestoneFormDialog/MilestoneForm.jsx
@@ -1,4 +1,4 @@
-import useEmitterFactory from 'react-emitter-factory';
+import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -27,7 +27,8 @@ const validationSchema = yup.object({
 });
 
 const MilestoneForm = (props) => {
-  const { onSubmit, initialValues, disabled } = props;
+  const { onSubmit, initialValues, disabled, onDirtyChange } = props;
+
   const {
     control,
     handleSubmit,
@@ -38,13 +39,9 @@ const MilestoneForm = (props) => {
     resolver: yupResolver(validationSchema),
   });
 
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   return (
     <form
@@ -110,6 +107,7 @@ MilestoneForm.propTypes = {
   disabled: PropTypes.bool,
   initialValues: PropTypes.object,
   onSubmit: PropTypes.func.isRequired,
+  onDirtyChange: PropTypes.func,
 };
 
 export default MilestoneForm;

--- a/client/app/bundles/course/lesson-plan/containers/MilestoneFormDialog/index.jsx
+++ b/client/app/bundles/course/lesson-plan/containers/MilestoneFormDialog/index.jsx
@@ -29,7 +29,7 @@ const MilestoneFormDialog = ({
     >
       <MilestoneForm
         {...{ initialValues, onSubmit, disabled }}
-        emitsVia={(milestoneForm) => setIsDirty(milestoneForm.isDirty)}
+        onDirtyChange={setIsDirty}
       />
     </FormDialogue>
   );

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionForm.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/QuestionForm.jsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import useEmitterFactory from 'react-emitter-factory';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -193,7 +192,8 @@ const validationSchema = yup.object({
 });
 
 const QuestionForm = (props) => {
-  const { disabled, initialValues, onSubmit, intl } = props;
+  const { disabled, initialValues, onSubmit, intl, onDirtyChange } = props;
+
   const {
     control,
     handleSubmit,
@@ -204,6 +204,7 @@ const QuestionForm = (props) => {
     defaultValues: initialValues,
     resolver: yupResolver(validationSchema),
   });
+
   const {
     fields: optionsFields,
     append: optionsAppend,
@@ -213,13 +214,9 @@ const QuestionForm = (props) => {
     name: 'options',
   });
 
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   const {
     fields: deletedOptionsFields,
@@ -473,6 +470,7 @@ QuestionForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   initialValues: PropTypes.object.isRequired,
   intl: PropTypes.object.isRequired,
+  onDirtyChange: PropTypes.func,
 };
 
 export default injectIntl(QuestionForm);

--- a/client/app/bundles/course/survey/containers/QuestionFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/QuestionFormDialogue/index.jsx
@@ -53,7 +53,7 @@ const QuestionFormDialogue = ({
           initialValues,
           onSubmit,
         }}
-        emitsVia={(questionForm) => setIsDirty(questionForm.isDirty)}
+        onDirtyChange={setIsDirty}
       />
     </FormDialogue>
   );

--- a/client/app/bundles/course/survey/containers/SectionFormDialogue/SectionForm.jsx
+++ b/client/app/bundles/course/survey/containers/SectionFormDialogue/SectionForm.jsx
@@ -1,4 +1,4 @@
-import useEmitterFactory from 'react-emitter-factory';
+import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -16,7 +16,8 @@ const validationSchema = yup.object({
 });
 
 const SectionForm = (props) => {
-  const { onSubmit, disabled, initialValues } = props;
+  const { onSubmit, disabled, initialValues, onDirtyChange } = props;
+
   const {
     control,
     handleSubmit,
@@ -27,13 +28,9 @@ const SectionForm = (props) => {
     resolver: yupResolver(validationSchema),
   });
 
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   return (
     <form
@@ -87,6 +84,7 @@ SectionForm.propTypes = {
   disabled: PropTypes.bool,
   initialValues: PropTypes.object.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  onDirtyChange: PropTypes.func,
 };
 
 export default SectionForm;

--- a/client/app/bundles/course/survey/containers/SectionFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/SectionFormDialogue/index.jsx
@@ -35,7 +35,7 @@ const SectionFormDialogue = ({
     >
       <SectionForm
         {...{ initialValues, onSubmit, disabled }}
-        emitsVia={(sectionForm) => setIsDirty(sectionForm.isDirty)}
+        onDirtyChange={setIsDirty}
       />
     </FormDialogue>
   );

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/SurveyForm.jsx
@@ -1,4 +1,4 @@
-import useEmitterFactory from 'react-emitter-factory';
+import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { injectIntl } from 'react-intl';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -56,8 +56,15 @@ const validationSchema = yup.object({
 });
 
 const SurveyForm = (props) => {
-  const { intl, onSubmit, disabled, disableAnonymousToggle, initialValues } =
-    props;
+  const {
+    intl,
+    onSubmit,
+    disabled,
+    disableAnonymousToggle,
+    initialValues,
+    onDirtyChange,
+  } = props;
+
   const {
     control,
     handleSubmit,
@@ -68,13 +75,9 @@ const SurveyForm = (props) => {
     resolver: yupResolver(validationSchema),
   });
 
-  useEmitterFactory(
-    props,
-    {
-      isDirty,
-    },
-    [isDirty],
-  );
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty]);
 
   return (
     <form
@@ -276,6 +279,7 @@ SurveyForm.propTypes = {
   initialValues: PropTypes.object.isRequired,
   intl: PropTypes.object.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  onDirtyChange: PropTypes.func,
 };
 
 export default injectIntl(SurveyForm);

--- a/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
+++ b/client/app/bundles/course/survey/containers/SurveyFormDialogue/index.jsx
@@ -60,10 +60,7 @@ const SurveyFormDialogue = ({
       skipConfirmation={!isDirty}
       title={formTitle}
     >
-      <SurveyForm
-        {...surveyFormProps}
-        emitsVia={(surveyForm) => setIsDirty(surveyForm.isDirty)}
-      />
+      <SurveyForm {...surveyFormProps} onDirtyChange={setIsDirty} />
     </FormDialogue>
   );
 };

--- a/client/app/bundles/user/AccountSettings/index.tsx
+++ b/client/app/bundles/user/AccountSettings/index.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { TimeZones } from 'types/course/admin/course';
 import { EmailData } from 'types/users';
 
 import Page from 'lib/components/core/layouts/Page';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
-import { FormEmitter } from 'lib/components/form/Form';
+import { FormRef } from 'lib/components/form/Form';
 import Preload from 'lib/components/wrappers/Preload';
 import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
@@ -31,7 +31,7 @@ const fetchAccountSettingsAndTimeZones = (): Promise<
 
 const AccountSettings = (): JSX.Element => {
   const { t } = useTranslation();
-  const [form, setForm] = useState<FormEmitter<AccountSettingsData>>();
+  const formRef = useRef<FormRef<AccountSettingsData>>(null);
   const [reloadForm, setReloadForm] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
@@ -43,7 +43,7 @@ const AccountSettings = (): JSX.Element => {
 
     updateAccountSettings(data)
       .then((newData) => {
-        form?.resetByMerging?.(newData);
+        formRef.current?.resetByMerging?.(newData);
         toast.success(t(formTranslations.changesSaved));
         setReloadForm((value) => !value);
 
@@ -54,7 +54,7 @@ const AccountSettings = (): JSX.Element => {
           }, 1000);
         }
       })
-      .catch(form?.receiveErrors)
+      .catch(formRef.current?.receiveErrors)
       .finally(() => setSubmitting(false));
   };
 
@@ -70,7 +70,7 @@ const AccountSettings = (): JSX.Element => {
         success: t(translations.profilePictureUpdated),
       })
       .then((newData) => {
-        form?.resetByMerging?.(newData);
+        formRef.current?.resetByMerging?.(newData);
         onSuccess();
       })
       .catch((error: Error) => {
@@ -88,7 +88,7 @@ const AccountSettings = (): JSX.Element => {
 
     addEmail(email)
       .then((emails) => {
-        form?.mutate?.(emails);
+        formRef.current?.mutate?.(emails);
         toast.success(t(translations.emailAdded, { email }));
         onSuccess();
       })
@@ -110,7 +110,7 @@ const AccountSettings = (): JSX.Element => {
 
     removeEmail(id)
       .then((emails) => {
-        form?.mutate?.(emails);
+        formRef.current?.mutate?.(emails);
         toast.success(t(translations.emailRemoved, { email }));
       })
       .catch(() => {
@@ -127,7 +127,7 @@ const AccountSettings = (): JSX.Element => {
 
     setEmailAsPrimary(url)
       .then((emails) => {
-        form?.mutate?.(emails);
+        formRef.current?.mutate?.(emails);
         toast.success(t(translations.emailSetAsPrimary, { email }));
       })
       .catch(() => {
@@ -161,8 +161,8 @@ const AccountSettings = (): JSX.Element => {
       >
         {([settings, timeZones]): JSX.Element => (
           <AccountSettingsForm
+            ref={formRef}
             disabled={submitting}
-            emitsVia={setForm}
             onAddEmail={handleAddEmail}
             onRemoveEmail={handleRemoveEmail}
             onResendConfirmationEmail={handleResendConfirmationEmail}

--- a/client/app/bundles/user/components/AddEmailSubsection.tsx
+++ b/client/app/bundles/user/components/AddEmailSubsection.tsx
@@ -1,5 +1,11 @@
-import { KeyboardEventHandler, useRef, useState } from 'react';
-import useEmitterFactory, { Emits } from 'react-emitter-factory';
+import {
+  forwardRef,
+  KeyboardEventHandler,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { Add } from '@mui/icons-material';
 import { Button, Collapse } from '@mui/material';
 import { EmailData } from 'types/users';
@@ -11,11 +17,11 @@ import useTranslation from 'lib/hooks/useTranslation';
 
 import translations from '../translations';
 
-export interface AddEmailSubsectionEmitter {
+export interface AddEmailSubsectionRef {
   reset?: () => void;
 }
 
-interface AddEmailSubsectionProps extends Emits<AddEmailSubsectionEmitter> {
+interface AddEmailSubsectionProps {
   disabled?: boolean;
   onClickAddEmail?: (
     email: EmailData['email'],
@@ -24,17 +30,20 @@ interface AddEmailSubsectionProps extends Emits<AddEmailSubsectionEmitter> {
   ) => void;
 }
 
-const AddEmailSubsection = (props: AddEmailSubsectionProps): JSX.Element => {
+const AddEmailSubsection = forwardRef<
+  AddEmailSubsectionRef,
+  AddEmailSubsectionProps
+>((props, ref): JSX.Element => {
   const { t } = useTranslation();
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
   const [expanded, setExpanded] = useState(false);
   const emailInputRef = useRef<HTMLInputElement>(null);
 
-  const resetField = (): void => {
+  const resetField = useCallback(() => {
     setEmail('');
     setError('');
-  };
+  }, []);
 
   const expandAndFocusField = (): void => {
     setExpanded((wasExpanded) => !wasExpanded);
@@ -61,7 +70,7 @@ const AddEmailSubsection = (props: AddEmailSubsectionProps): JSX.Element => {
     }
   };
 
-  useEmitterFactory(props, { reset: resetField });
+  useImperativeHandle(ref, () => ({ reset: resetField }), [resetField]);
 
   return (
     <div className="!mt-10 space-y-5">
@@ -97,6 +106,8 @@ const AddEmailSubsection = (props: AddEmailSubsectionProps): JSX.Element => {
       </Button>
     </div>
   );
-};
+});
+
+AddEmailSubsection.displayName = 'AddEmailSubsection';
 
 export default AddEmailSubsection;

--- a/client/app/lib/components/core/dialogs/ImageCropDialog.tsx
+++ b/client/app/lib/components/core/dialogs/ImageCropDialog.tsx
@@ -1,8 +1,8 @@
-import { ComponentProps, useState } from 'react';
+import { ComponentProps, useRef, useState } from 'react';
 
 import Prompt from 'lib/components/core/dialogs/Prompt';
 import ImageCropper, {
-  ImageCropperEmitter,
+  ImageCropperRef,
 } from 'lib/components/core/ImageCropper';
 import useTranslation from 'lib/hooks/useTranslation';
 import formTranslations from 'lib/translations/form';
@@ -23,7 +23,7 @@ interface ImageCropDialogProps {
 const ImageCropDialog = (props: ImageCropDialogProps): JSX.Element => {
   const { t } = useTranslation();
   const [disabled, setDisabled] = useState(false);
-  const [imageCropper, setImageCropper] = useState<ImageCropperEmitter>();
+  const imageCropperRef = useRef<ImageCropperRef>(null);
 
   const handleLoadError = (): void => {
     props.onLoadError?.();
@@ -31,7 +31,7 @@ const ImageCropDialog = (props: ImageCropDialogProps): JSX.Element => {
   };
 
   const handleConfirmImage = async (): Promise<void> => {
-    const image = await imageCropper?.getImage?.();
+    const image = await imageCropperRef.current?.getImage?.();
     if (!image) throw new Error(`ImageCropper returned: ${image} image data.`);
 
     props.onConfirmImage?.(image);
@@ -51,10 +51,10 @@ const ImageCropDialog = (props: ImageCropDialogProps): JSX.Element => {
       title={props.title}
     >
       <ImageCropper
+        ref={imageCropperRef}
         alt={props.alt}
         aspect={props.aspect}
         circular={props.circular}
-        emitsVia={setImageCropper}
         onLoadError={handleLoadError}
         src={props.src}
         type={props.type}

--- a/client/package.json
+++ b/client/package.json
@@ -80,7 +80,6 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.6",
     "react-dropzone": "^14.2.3",
-    "react-emitter-factory": "^1.1.2",
     "react-google-recaptcha": "^3.1.0",
     "react-hook-form": "^7.51.1",
     "react-hot-keys": "^2.7.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3883,7 +3883,12 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@2.x, classnames@^2.2.1, classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.0:
+classnames@2.x, classnames@^2.2.1, classnames@^2.2.6, classnames@^2.3.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
+classnames@^2.2.5, classnames@^2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -4649,9 +4654,9 @@ dom-accessibility-api@^0.6.3:
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
 dom-align@^1.7.0:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.12.3.tgz#a36d02531dae0eefa2abb0c4db6595250526f103"
-  integrity sha512-Gj9hZN3a07cbR6zviMUBOMPdWxYhbMI+x+WS0NAIu2zFZmbK8ys9R79g+iG9qLnlCwpFoaB+fKy8Pdv470GsPA==
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.12.4.tgz#3503992eb2a7cfcb2ed3b2a6d21e0b9c00d54511"
+  integrity sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -9119,25 +9124,24 @@ raw-body@2.5.2:
     unpipe "1.0.0"
 
 rc-align@^4.0.0:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-4.0.12.tgz#065b5c68a1cc92a00800c9239320d9fdf5f16207"
-  integrity sha512-3DuwSJp8iC/dgHzwreOQl52soj40LchlfUHtgACOUtwGuoFIOVh6n/sCpfqCU8kO5+iz6qR0YKvjgB8iPdE3aQ==
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-4.0.15.tgz#2bbd665cf85dfd0b0244c5a752b07565e9098577"
+  integrity sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
     dom-align "^1.7.0"
-    lodash "^4.17.21"
-    rc-util "^5.3.0"
+    rc-util "^5.26.0"
     resize-observer-polyfill "^1.5.1"
 
 rc-motion@^2.0.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.6.0.tgz#c60c3e7f15257f55a8cd7794a539f0e2cc751399"
-  integrity sha512-1MDWA9+i174CZ0SIDenSYm2Wb9YbRkrexjZWR0CUFu7D6f23E8Y0KsTgk9NGOLJsGak5ELZK/Y5lOlf5wQdzbw==
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.9.5.tgz#12c6ead4fd355f94f00de9bb4f15df576d677e0c"
+  integrity sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==
   dependencies:
     "@babel/runtime" "^7.11.1"
     classnames "^2.2.1"
-    rc-util "^5.21.0"
+    rc-util "^5.44.0"
 
 rc-slider@^9.7.5:
   version "9.7.5"
@@ -9151,17 +9155,18 @@ rc-slider@^9.7.5:
     shallowequal "^1.1.0"
 
 rc-tooltip@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-5.1.1.tgz#94178ed162d0252bc4993b725f5dc2ac0fccf154"
-  integrity sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-5.3.1.tgz#3dde4e1865f79cd23f202bba4e585c2a1173024b"
+  integrity sha512-e6H0dMD38EPaSPD2XC8dRfct27VvT2TkPdoBSuNl3RRZ5tspiY/c5xYEmGC0IrABvMBgque4Mr2SMZuliCvoiQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    rc-trigger "^5.0.0"
+    classnames "^2.3.1"
+    rc-trigger "^5.3.1"
 
-rc-trigger@^5.0.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-5.3.1.tgz#acafadf3eaf384e7f466c303bfa0f34c8137d7b8"
-  integrity sha512-5gaFbDkYSefZ14j2AdzucXzlWgU2ri5uEjkHvsf1ynRhdJbKxNOnw4PBZ9+FVULNGFiDzzlVF8RJnR9P/xrnKQ==
+rc-trigger@^5.3.1:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-5.3.4.tgz#6b4b26e32825677c837d1eb4d7085035eecf9a61"
+  integrity sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==
   dependencies:
     "@babel/runtime" "^7.18.3"
     classnames "^2.2.6"
@@ -9169,14 +9174,13 @@ rc-trigger@^5.0.0:
     rc-motion "^2.0.0"
     rc-util "^5.19.2"
 
-rc-util@^5.16.1, rc-util@^5.19.2, rc-util@^5.21.0, rc-util@^5.3.0:
-  version "5.22.5"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.22.5.tgz#d4d6d886c5ecb6a2a51dde1840d780a2b70f5179"
-  integrity sha512-awD2TGMGU97OZftT2R3JwrHWjR8k/xIwqjwcivPskciweUdgXE7QsyXkBKVSBHXS+c17AWWMDWuKWsJSheQy8g==
+rc-util@^5.16.1, rc-util@^5.19.2, rc-util@^5.26.0, rc-util@^5.44.0:
+  version "5.44.4"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.44.4.tgz#89ee9037683cca01cd60f1a6bbda761457dd6ba5"
+  integrity sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==
   dependencies:
     "@babel/runtime" "^7.18.3"
-    react-is "^16.12.0"
-    shallowequal "^1.1.0"
+    react-is "^18.2.0"
 
 rc@^1.2.7:
   version "1.2.8"
@@ -9268,12 +9272,12 @@ react-dom@^17.0.0:
     scheduler "^0.20.2"
 
 react-dom@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "^0.23.2"
 
 react-draggable@^4.0.3, react-draggable@^4.4.6:
   version "4.4.6"
@@ -9291,11 +9295,6 @@ react-dropzone@^14.2.3:
     attr-accept "^2.2.2"
     file-selector "^0.6.0"
     prop-types "^15.8.1"
-
-react-emitter-factory@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-emitter-factory/-/react-emitter-factory-1.1.2.tgz#35020bd0477c653003c7b760bef8ef42d5f67f5f"
-  integrity sha512-lGf6MEFGiZjBQs2GI/UuaMs65X2riyuW5sMVy9j4A+TaRmZFHZUnh+MrjvjYfIKiX66MTZjS3lMEsW63qpmQXw==
 
 react-fast-compare@^3.0.1:
   version "3.2.0"
@@ -9557,9 +9556,9 @@ react@^17.0.0:
     object-assign "^4.1.1"
 
 react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -9974,10 +9973,10 @@ scheduler@^0.20.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
We’re removing this dependency as it’s not needed with React’s native APIs for refs.