### PR TITLE
fix(rag-wise-forum): fix topic creation when rag-wise is not enabled

### DIFF
--- a/app/controllers/concerns/course/forum/auto_answering_concern.rb
+++ b/app/controllers/concerns/course/forum/auto_answering_concern.rb
@@ -31,10 +31,10 @@ module Course::Forum::AutoAnsweringConcern
   end
 
   def rag_settings
-    rag_component = current_component_host[:course_rag_wise_component].settings
+    rag_component = current_component_host[:course_rag_wise_component]&.settings
     {
-      response_workflow: rag_component.response_workflow,
-      roleplay: rag_component.roleplay
+      response_workflow: rag_component&.response_workflow,
+      roleplay: rag_component&.roleplay
     }
   end
 

--- a/spec/features/course/forum/topic_management_spec.rb
+++ b/spec/features/course/forum/topic_management_spec.rb
@@ -252,6 +252,7 @@ RSpec.feature 'Course: Forum: Topic: Management', js: true do
         find('button.btn-submit').click
         wait_for_page
 
+        expect_toastify("Topic #{topic.title} has been created.")
         expect(forum.topics.last.topic_type).to eq('normal')
         expect(forum.topics.last.posts.first.text).to eq('<p>test</p>')
 
@@ -267,6 +268,7 @@ RSpec.feature 'Course: Forum: Topic: Management', js: true do
         find('button.btn-submit').click
         wait_for_page
 
+        expect_toastify("Topic #{topic.title} has been created.")
         expect(forum.topics.last.topic_type).to eq('question')
       end
 


### PR DESCRIPTION
- error message will pop up when creating new forum topic
- error arises due to nil error in ragwise settings for courses where rag wise is not enabled