### PR TITLE
fix(programming-answer-file): high cpu usage when highlight large files

### DIFF
--- a/lib/autoload/preformatted_text_line_numbers_filter.rb
+++ b/lib/autoload/preformatted_text_line_numbers_filter.rb
@@ -19,7 +19,10 @@ class PreformattedTextLineNumbersFilter < HTML::Pipeline::Filter
   #
   # @param [Nokogiri::XML::Node] pre The +pre+ tag being processed.
   def process_pre_tag(pre)
-    content_tag = pre.children.filter('code').first || pre
+    # TODO: monitor for any impact of removing the code filter, or
+    #       restore once https://gitlab.gnome.org/GNOME/libxml2/-/issues/130 resolved
+    # content_tag = pre.children.filter('code').first || pre
+    content_tag = pre
     lines = content_tag.inner_html.split(NEWLINE_REGEX, -1)
 
     pre.add_next_sibling(build_table_tag(lines, pre))

--- a/lib/autoload/preformatted_text_line_split_filter.rb
+++ b/lib/autoload/preformatted_text_line_split_filter.rb
@@ -19,7 +19,10 @@ class PreformattedTextLineSplitFilter < HTML::Pipeline::Filter
   #
   # @param [Nokogiri::XML::Node] pre The +pre+ tag being processed.
   def process_pre_tag(pre)
-    content_tag = pre.children.filter('code').first || pre
+    # TODO: monitor for any impact of removing the code filter, or
+    #       restore once https://gitlab.gnome.org/GNOME/libxml2/-/issues/130 resolved
+    # content_tag = pre.children.filter('code').first || pre
+    content_tag = pre
     lines = content_tag.inner_html.split(NEWLINE_REGEX, -1)
 
     pre.add_previous_sibling(lines.join("\n"))


### PR DESCRIPTION
Related upstream issues from Nokogiri gem and libxml2
- Xpath search time for nodes with classes increases exponentially with document size [#1861](https://github.com/sparklemotion/nokogiri/issues/1861)
- xmlXPathEvalExpression - runtime increases quadratically with number of nodes in the document [#130](https://gitlab.gnome.org/GNOME/libxml2/-/issues/130)