### PR TITLE
fix(getHelp): version mismatch with Codaveri

### DIFF
--- a/app/services/course/assessment/answer/live_feedback/thread_service.rb
+++ b/app/services/course/assessment/answer/live_feedback/thread_service.rb
@@ -23,8 +23,8 @@ class Course::Assessment::Answer::LiveFeedback::ThreadService
         },
         problem: { id: @question.codaveri_id },
         runtime: {
-          language: question.language.polyglot_name,
-          version: question.language.extend(CodaveriLanguageConcern).polyglot_version
+          language: question.language.extend(CodaveriLanguageConcern).codaveri_language,
+          version: question.language.extend(CodaveriLanguageConcern).codaveri_version
         }
       }
     }


### PR DESCRIPTION
- there were some refactoring which requires the usage of codaveri_version instead of polyglot_version
- that changes were not reflected in Get Help service, and hence it creates the error when creating a new thread chat