### PR TITLE
fix(liveFeedbackStats): chip does not have link

### DIFF
--- a/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
+++ b/app/views/course/statistics/assessments/live_feedback_statistics.json.jbuilder
@@ -3,8 +3,10 @@ json.array! @student_live_feedback_hash.each do |course_user, (submission, live_
   json.partial! 'course_user', course_user: course_user
   if submission.nil?
     json.workflowState 'unstarted'
+    json.submissionId nil
   else
     json.workflowState submission.workflow_state
+    json.submissionId submission.id
   end
 
   json.groups @group_names_hash[course_user.id] do |name|

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/LiveFeedbackStatisticsTable.tsx
@@ -10,6 +10,7 @@ import Link from 'lib/components/core/Link';
 import GhostIcon from 'lib/components/icons/GhostIcon';
 import Table, { ColumnTemplate } from 'lib/components/table';
 import { DEFAULT_TABLE_ROWS_PER_PAGE } from 'lib/constants/sharedConstants';
+import { getEditSubmissionURL } from 'lib/helpers/url-builders';
 import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
@@ -26,7 +27,7 @@ interface Props {
 
 const LiveFeedbackStatisticsTable: FC<Props> = (props) => {
   const { t } = useTranslation();
-  const { courseId } = useParams();
+  const { courseId, assessmentId } = useParams();
   const { includePhantom, liveFeedbackStatistics } = props;
 
   const statistics = useAppSelector(getAssessmentStatistics);
@@ -193,6 +194,11 @@ const LiveFeedbackStatisticsTable: FC<Props> = (props) => {
       sortable: true,
       cell: (datum) => (
         <SubmissionWorkflowState
+          linkTo={getEditSubmissionURL(
+            courseId,
+            assessmentId,
+            datum.submissionId,
+          )}
           opensInNewTab
           workflowState={datum.workflowState ?? workflowStates.Unstarted}
         />

--- a/client/app/types/course/statistics/assessmentStatistics.ts
+++ b/client/app/types/course/statistics/assessmentStatistics.ts
@@ -138,6 +138,7 @@ export interface AssessmentLiveFeedbackStatistics {
   courseUser: StudentInfo;
   groups: { name: string }[];
   workflowState?: WorkflowState;
+  submissionId?: number;
   liveFeedbackCount?: number[]; // Will already be ordered by question
   totalFeedbackCount?: number;
   questionIds: number[];

--- a/spec/controllers/course/statistics/assessment_controller_spec.rb
+++ b/spec/controllers/course/statistics/assessment_controller_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe Course::Statistics::AssessmentsController, type: :controller do
           expect(first_result['courseUser']).to have_key('isPhantom')
 
           expect(first_result).to have_key('workflowState')
+          expect(first_result).to have_key('submissionId')
           expect(first_result).to have_key('groups')
           expect(first_result).to have_key('liveFeedbackCount')
           expect(first_result).to have_key('questionIds')
@@ -244,6 +245,7 @@ RSpec.describe Course::Statistics::AssessmentsController, type: :controller do
           expect(first_result['courseUser']).to have_key('isPhantom')
 
           expect(first_result).to have_key('workflowState')
+          expect(first_result).to have_key('submissionId')
           expect(first_result).to have_key('groups')
           expect(first_result).to have_key('liveFeedbackCount')
           expect(first_result).to have_key('questionIds')


### PR DESCRIPTION
- every chip rendered by SubmissionWorkflowState should have hyperlink
- previously, the submissionId is missed when fetching data from BE to FE
- fix is to include submissionId, then add linkTo to the component