### PR TITLE
fix(attemptCount): correctness not match when submission is attempting

### DIFF
--- a/app/controllers/concerns/course/statistics/submissions_concern.rb
+++ b/app/controllers/concerns/course/statistics/submissions_concern.rb
@@ -90,7 +90,7 @@ module Course::Statistics::SubmissionsConcern
     fetch_personal_and_reference_timeline_hash
 
     submissions.map do |submission|
-      submitter_course_user = submission.creator.course_users.select { |u| u.course_id == @assessment.course_id }.first
+      submitter_course_user = @course_users_hash[submission.creator_id]
       next unless submitter_course_user&.student?
 
       answers = answers_hash[submission.id]
@@ -105,7 +105,7 @@ module Course::Statistics::SubmissionsConcern
     fetch_personal_and_reference_timeline_hash
 
     submissions.map do |submission|
-      submitter_course_user = submission.creator.course_users.select { |u| u.course_id == @assessment.course_id }.first
+      submitter_course_user = @course_users_hash[submission.creator_id]
       next unless submitter_course_user&.student?
 
       end_at = @personal_end_at_hash[[@assessment.id, submitter_course_user.id]] ||

--- a/app/controllers/concerns/course/statistics/submissions_concern.rb
+++ b/app/controllers/concerns/course/statistics/submissions_concern.rb
@@ -37,7 +37,7 @@ module Course::Statistics::SubmissionsConcern
               caa_inner.submission_id,
               caa_inner.correct,
               caa_inner.grade,
-              cas_inner.workflow_state,
+              caa_inner.workflow_state,
               ROW_NUMBER() OVER (PARTITION BY caa_inner.question_id, caa_inner.submission_id ORDER BY caa_inner.created_at DESC) AS row_num
             FROM
               course_assessment_answers caa_inner


### PR DESCRIPTION
- previously, we only show the attempt counts for submitted/published submission
- hence, usage of workflow_state from answer or submission doesn't matter (it will be not attempting (can be submitted or published if displayed)
- now that we also display attempting submission, we need to use answer's workflow state instead of submission's to properly reflect on the correctness of the solution