### PR TITLE
use yajl for JSON operations; fix unnecessary prompt when modifying attempt limit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'docker-api'
 
 gem 'recaptcha'
 gem 'rexml'
+gem 'yajl-ruby', '~> 1.4'
 
 # Page profiler
 gem 'rack-mini-profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -667,6 +667,7 @@ GEM
       workflow (~> 3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yajl-ruby (1.4.3)
     yard (0.9.37)
     zeitwerk (2.7.2)
 
@@ -772,6 +773,7 @@ DEPENDENCIES
   validates_hostname
   workflow
   workflow-activerecord (>= 4.1, < 7.0)
+  yajl-ruby (~> 1.4)
   yard
 
 RUBY VERSION

--- a/client/app/bundles/course/assessment/question/programming/commons/validation.ts
+++ b/client/app/bundles/course/assessment/question/programming/commons/validation.ts
@@ -166,7 +166,6 @@ export const isPackageFieldsDirty = (
   +before.question.languageId !== +after.question.languageId ||
   +before.question.memoryLimit !== +after.question.memoryLimit ||
   +before.question.timeLimit !== +after.question.timeLimit ||
-  +before.question.attemptLimit !== +after.question.attemptLimit ||
   before.question.autograded !== after.question.autograded ||
   before.question.editOnline !== after.question.editOnline ||
   before.question.isCodaveri !== after.question.isCodaveri ||

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,9 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Override default JSON parser/encoder to use Yajl
+require 'yajl/json_gem'
+
 # Load dotenv only in development environment
 Dotenv::Rails.load if ['development'].include? ENV['RAILS_ENV']
 


### PR DESCRIPTION
Default JSON gem uses excessive amounts of memory in encoding large payloads (around 500MB retained memory to generate 150MB payload). Use yajl-ruby gem as a workaround.

Frontend will no longer prompt if only attempt limit is modified (it already doesn't trigger regrades on backend)