### PR TITLE
fix(answerView): programming answer shown as too big when empty

### DIFF
--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/AnswerDetails/ProgrammingComponent/FileContent.tsx
@@ -25,7 +25,7 @@ const FileContent: FC<Props> = (props) => {
   const { answerId, annotations, file } = props;
   const fileAnnotation = annotations.find((a) => a.fileId === file.id);
 
-  return file.highlightedContent ? (
+  return file.highlightedContent !== null ? (
     <ReadOnlyEditor
       annotations={fileAnnotation?.topics ?? ([] as AnnotationTopic[])}
       answerId={answerId}

--- a/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
@@ -24,7 +24,7 @@ class ReadOnlyEditorContainer extends Component {
   render() {
     const { answerId, file, annotations } = this.props;
 
-    if (file.highlightedContent) {
+    if (file.highlightedContent !== null) {
       return (
         <ReadOnlyEditorComponent
           annotations={Object.values(annotations)}


### PR DESCRIPTION
## Issue

When student submit empty code, the warning of "File Size Too Big" appears in their answer

## Root Cause

- We detected if the size of the code is too big or not from BE, and send `nil` instead to Frontend
- In frontend, we differentiate between the display of "File Size Too Big" or the actual content by seeing if the content is null or not, by using gatekeeping `if (file.highlightedContent)`
- However, this gatekeeping will also render false if the value is actually empty string as well (in addition to the value being `null`)

## Approach

Simple modification of the gatekeeping to `if (file.highlightedContent !== null)`