### PR TITLE
Fix Mis-Alignment between Rendered Cell and its Assigned ClassName in Customised TanStack Table

### DIFF
--- a/client/app/lib/components/table/builder/buildColumns.ts
+++ b/client/app/lib/components/table/builder/buildColumns.ts
@@ -11,6 +11,7 @@ export const buildColumns = <D extends Data, C>(
   getColumn: (column: ColumnTemplate<D>) => C,
   initial: C[] = [],
 ): BuiltColumns<D, C> => {
+  const initialColumnsLength = initial.length;
   const defToColumns: Record<number, ColumnTemplate<D>> = {};
 
   const defColumns = columns.reduce<C[]>((columnDefs, column) => {
@@ -18,7 +19,7 @@ export const buildColumns = <D extends Data, C>(
 
     columnDefs.push(getColumn(column));
 
-    defToColumns[columnDefs.length - 1] = column;
+    defToColumns[columnDefs.length - 1 - initialColumnsLength] = column;
 
     return columnDefs;
   }, initial);


### PR DESCRIPTION
## Problem

When we enabled either indexing or rowSelectables inside our customised Table component (derived from TanStack Table), the className assigned to each column got shifted by 1 index. As a result, we have improper alignment being rendered. Like in the table below, we activated indexing and hence, while it's supposed to be all scores having `text-right` alignment and `workflowState` having `text-left` alignment, it becomes `workflowState` having undefined className and `Q1` having `text-left`, while other questions having `text-right`

<img width="1517" alt="Screenshot 2025-04-29 at 2 46 26 PM" src="https://github.com/user-attachments/assets/55424672-64e3-4724-af0d-cb8bed817da4" />

## Root Cause

In TanStack, we build the columns based on the input columns and also, should we activate either indexing or rowSelectables (or both), we push some of those respective columns into `initialColumn`. However, while building the hash map, we assume that initially is always an empty columns and hence the hash map's indexing got shifted by either 1 or 2.

## Approach

We take into account also on how many columns are there initially, and then do the proper adjustment for the mentioned hashmap.

<img width="1517" alt="Screenshot 2025-04-29 at 2 52 13 PM" src="https://github.com/user-attachments/assets/3cfb9cf3-e07b-4549-9649-d7917359668e" />