### PR TITLE
fix(GroupTableCard): display manager and member counts separately

### DIFF
--- a/client/app/bundles/course/group/components/GroupCard.tsx
+++ b/client/app/bundles/course/group/components/GroupCard.tsx
@@ -10,14 +10,14 @@ import {
 } from '@mui/material';
 
 export interface GroupCardTitleButton {
-  label: ReactElement;
+  label: string | ReactElement;
   onClick: () => void;
   isDisabled?: boolean;
   icon?: ReactElement;
 }
 
 export interface GroupCardBottomButton {
-  label: ReactElement;
+  label: string | ReactElement;
   onClick: () => void;
   isDisabled?: boolean;
   icon?: ReactElement;
@@ -27,11 +27,12 @@ export interface GroupCardBottomButton {
 function mapButtonObjectToElement(
   button: GroupCardTitleButton | GroupCardBottomButton,
   isLast: boolean,
+  index: number,
 ): ReactElement {
   return button.icon ? (
-    <Tooltip key={`tooltip_${button.label.props.id}`} title={button.label}>
+    <Tooltip key={`tooltip_${index}`} title={button.label}>
       <IconButton
-        key={button.label.props.id}
+        key={index}
         className={`h-15 w-15 p-2.5 ${!isLast ? 'mr-4' : ''}`}
         onClick={button.onClick}
       >
@@ -40,7 +41,7 @@ function mapButtonObjectToElement(
     </Tooltip>
   ) : (
     <Button
-      key={button.label.props.id}
+      key={index}
       className={!isLast ? 'mr-4' : ''}
       color="primary"
       onClick={button.onClick}
@@ -85,6 +86,7 @@ const GroupCard: FC<GroupCardProps> = ({
                   mapButtonObjectToElement(
                     button,
                     index === titleButtons.length - 1,
+                    index,
                   ),
                 )}
               </div>
@@ -106,6 +108,7 @@ const GroupCard: FC<GroupCardProps> = ({
               mapButtonObjectToElement(
                 button,
                 index === titleButtons.length - 1,
+                index,
               ),
             )}
         </div>
@@ -116,6 +119,7 @@ const GroupCard: FC<GroupCardProps> = ({
               mapButtonObjectToElement(
                 button,
                 index === titleButtons.length - 1,
+                index,
               ),
             )}
         </div>

--- a/client/app/bundles/course/group/components/GroupCard.tsx
+++ b/client/app/bundles/course/group/components/GroupCard.tsx
@@ -24,48 +24,6 @@ export interface GroupCardBottomButton {
   isRight?: boolean;
 }
 
-const styles = {
-  card: {
-    marginBottom: '2rem',
-  },
-  cardHeader: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    width: '100%',
-  },
-  cardHeaderFullWidthTitle: {
-    width: '100%',
-    paddingRight: 0,
-  },
-  title: {
-    fontWeight: 'bold',
-    marginTop: '0.5rem',
-    marginBottom: 0,
-  },
-  body: {
-    paddingTop: 0,
-  },
-  actions: {
-    padding: 16,
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
-  buttonsContainer: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  nonLastButton: {
-    marginRight: '1rem',
-  },
-  iconButton: {
-    height: 36,
-    width: 36,
-    padding: 6,
-  },
-};
-
 function mapButtonObjectToElement(
   button: GroupCardTitleButton | GroupCardBottomButton,
   isLast: boolean,
@@ -74,8 +32,8 @@ function mapButtonObjectToElement(
     <Tooltip key={`tooltip_${button.label.props.id}`} title={button.label}>
       <IconButton
         key={button.label.props.id}
+        className={`h-15 w-15 p-2.5 ${!isLast ? 'mr-4' : ''}`}
         onClick={button.onClick}
-        style={{ ...styles.iconButton, ...(!isLast && styles.nonLastButton) }}
       >
         {button.icon}
       </IconButton>
@@ -83,9 +41,9 @@ function mapButtonObjectToElement(
   ) : (
     <Button
       key={button.label.props.id}
+      className={!isLast ? 'mr-4' : ''}
       color="primary"
       onClick={button.onClick}
-      style={isLast ? undefined : styles.nonLastButton}
       variant="contained"
     >
       {button.label}
@@ -113,16 +71,16 @@ const GroupCard: FC<GroupCardProps> = ({
   className = '',
   children,
 }) => (
-  <Card className={className} style={styles.card}>
+  <Card className={`mb-8 ${className}`}>
     {title || subtitle ? (
       <CardHeader
         subheader={subtitle}
         subheaderTypographyProps={{ variant: 'subtitle2' }}
         title={
-          <div style={styles.cardHeader}>
-            <h3 style={styles.title}>{title}</h3>
+          <div className="flex justify-between items-center w-full">
+            <h3 className="font-bold mt-2 mb-0">{title}</h3>
             {titleButtons.length > 0 && (
-              <div style={styles.buttonsContainer}>
+              <div className="flex justify-center items-center">
                 {titleButtons.map((button, index) =>
                   mapButtonObjectToElement(
                     button,
@@ -134,15 +92,13 @@ const GroupCard: FC<GroupCardProps> = ({
           </div>
         }
         titleTypographyProps={
-          titleButtons.length > 0
-            ? { style: styles.cardHeaderFullWidthTitle }
-            : {}
+          titleButtons.length > 0 ? { className: 'w-full pr-0' } : {}
         }
       />
     ) : null}
-    <CardContent style={styles.body}>{children}</CardContent>
+    <CardContent className="pt-0">{children}</CardContent>
     {bottomButtons.length > 0 ? (
-      <CardActions style={styles.actions}>
+      <CardActions className="p-6 flex justify-between">
         <div>
           {bottomButtons
             .filter((b) => !b.isRight)

--- a/client/app/bundles/course/group/components/GroupCard.tsx
+++ b/client/app/bundles/course/group/components/GroupCard.tsx
@@ -1,3 +1,4 @@
+import { FC, ReactElement, ReactNode } from 'react';
 import {
   Button,
   Card,
@@ -7,22 +8,21 @@ import {
   IconButton,
   Tooltip,
 } from '@mui/material';
-import PropTypes from 'prop-types';
 
-export const groupCardTitleButtonShape = PropTypes.shape({
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
-  onClick: PropTypes.func.isRequired,
-  isDisabled: PropTypes.bool,
-  icon: PropTypes.element,
-});
+export interface GroupCardTitleButton {
+  label: ReactElement;
+  onClick: () => void;
+  isDisabled?: boolean;
+  icon?: ReactElement;
+}
 
-export const groupCardBottomButtonShape = PropTypes.shape({
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
-  onClick: PropTypes.func.isRequired,
-  isDisabled: PropTypes.bool,
-  icon: PropTypes.element,
-  isRight: PropTypes.bool,
-});
+export interface GroupCardBottomButton {
+  label: ReactElement;
+  onClick: () => void;
+  isDisabled?: boolean;
+  icon?: ReactElement;
+  isRight?: boolean;
+}
 
 const styles = {
   card: {
@@ -66,24 +66,21 @@ const styles = {
   },
 };
 
-function mapButtonObjectToElement(button, isLast) {
-  if (button.icon) {
-    return (
-      <Tooltip key={`tooltip_${button.label.props.id}`} title={button.label}>
-        <IconButton
-          key={button.label.props.id}
-          onClick={button.onClick}
-          style={{
-            ...styles.iconButton,
-            ...(isLast ? {} : styles.nonLastButton),
-          }}
-        >
-          {button.icon}
-        </IconButton>
-      </Tooltip>
-    );
-  }
-  return (
+function mapButtonObjectToElement(
+  button: GroupCardTitleButton | GroupCardBottomButton,
+  isLast: boolean,
+): ReactElement {
+  return button.icon ? (
+    <Tooltip key={`tooltip_${button.label.props.id}`} title={button.label}>
+      <IconButton
+        key={button.label.props.id}
+        onClick={button.onClick}
+        style={{ ...styles.iconButton, ...(!isLast && styles.nonLastButton) }}
+      >
+        {button.icon}
+      </IconButton>
+    </Tooltip>
+  ) : (
     <Button
       key={button.label.props.id}
       color="primary"
@@ -96,10 +93,19 @@ function mapButtonObjectToElement(button, isLast) {
   );
 }
 
+interface GroupCardProps {
+  title?: string | ReactElement;
+  subtitle?: string | ReactElement;
+  titleButtons?: GroupCardTitleButton[];
+  bottomButtons?: GroupCardBottomButton[];
+  className?: string;
+  children: ReactNode;
+}
+
 /**
  * A wrapper around MUI card to help standardise styling for groups.
  */
-const GroupCard = ({
+const GroupCard: FC<GroupCardProps> = ({
   title,
   subtitle,
   titleButtons = [],
@@ -161,19 +167,5 @@ const GroupCard = ({
     ) : null}
   </Card>
 );
-
-GroupCard.propTypes = {
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  titleButtons: PropTypes.arrayOf(groupCardTitleButtonShape),
-  bottomButtons: PropTypes.arrayOf(groupCardBottomButtonShape),
-  className: PropTypes.string,
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.element,
-    PropTypes.string,
-    PropTypes.object,
-  ]).isRequired,
-};
 
 export default GroupCard;

--- a/client/app/bundles/course/group/components/GroupRoleChip.tsx
+++ b/client/app/bundles/course/group/components/GroupRoleChip.tsx
@@ -22,13 +22,8 @@ interface GroupRoleChipProps {
 
 const GroupRoleChip: FC<GroupRoleChipProps> = ({ user }) => (
   <Chip
+    className={`w-40 h-10 ${palette.groupRole[user.groupRole]} mr-2`}
     label={<FormattedMessage {...translations[user.groupRole]} />}
-    style={{
-      width: 100,
-      height: 25,
-      backgroundColor: palette.groupRole[user.groupRole],
-      marginRight: 5,
-    }}
   />
 );
 

--- a/client/app/bundles/course/group/components/GroupRoleChip.tsx
+++ b/client/app/bundles/course/group/components/GroupRoleChip.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages } from 'react-intl';
 import { Chip } from '@mui/material';
 import palette from 'theme/palette';
+
+import useTranslation from 'lib/hooks/useTranslation';
 
 import { GroupMember } from '../types';
 
@@ -20,11 +22,14 @@ interface GroupRoleChipProps {
   user: GroupMember;
 }
 
-const GroupRoleChip: FC<GroupRoleChipProps> = ({ user }) => (
-  <Chip
-    className={`w-40 h-10 ${palette.groupRole[user.groupRole]} mr-2`}
-    label={<FormattedMessage {...translations[user.groupRole]} />}
-  />
-);
+const GroupRoleChip: FC<GroupRoleChipProps> = ({ user }) => {
+  const { t } = useTranslation();
+  return (
+    <Chip
+      className={`w-40 h-10 ${palette.groupRole[user.groupRole]} mr-2`}
+      label={t(translations[user.groupRole])}
+    />
+  );
+};
 
 export default GroupRoleChip;

--- a/client/app/bundles/course/group/components/GroupRoleChip.tsx
+++ b/client/app/bundles/course/group/components/GroupRoleChip.tsx
@@ -1,8 +1,9 @@
+import { FC } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Chip } from '@mui/material';
 import palette from 'theme/palette';
 
-import { memberShape } from '../propTypes';
+import { GroupMember } from '../types';
 
 const translations = defineMessages({
   manager: {
@@ -15,7 +16,11 @@ const translations = defineMessages({
   },
 });
 
-const GroupRoleChip = ({ user }) => (
+interface GroupRoleChipProps {
+  user: GroupMember;
+}
+
+const GroupRoleChip: FC<GroupRoleChipProps> = ({ user }) => (
   <Chip
     label={<FormattedMessage {...translations[user.groupRole]} />}
     style={{
@@ -26,9 +31,5 @@ const GroupRoleChip = ({ user }) => (
     }}
   />
 );
-
-GroupRoleChip.propTypes = {
-  user: memberShape.isRequired,
-};
 
 export default GroupRoleChip;

--- a/client/app/bundles/course/group/pages/GroupShow/CategoryCard.tsx
+++ b/client/app/bundles/course/group/pages/GroupShow/CategoryCard.tsx
@@ -1,18 +1,22 @@
-import { useCallback, useMemo, useState } from 'react';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { FC, useCallback, useMemo, useState } from 'react';
+import {
+  defineMessages,
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps,
+} from 'react-intl';
 import Delete from '@mui/icons-material/Delete';
 import { red } from '@mui/material/colors';
-import PropTypes from 'prop-types';
 
+import { GroupCategory } from 'course/group/types';
 import ConfirmationDialog from 'lib/components/core/dialogs/ConfirmationDialog';
 import { useAppDispatch } from 'lib/hooks/store';
 
 import { deleteCategory, updateCategory } from '../../actions';
-import GroupCard from '../../components/GroupCard';
+import GroupCard, { GroupCardBottomButton } from '../../components/GroupCard';
 import actionTypes, { dialogTypes } from '../../constants';
 import GroupFormDialog from '../../forms/GroupFormDialog';
 import NameDescriptionForm from '../../forms/NameDescriptionForm';
-import { categoryShape } from '../../propTypes';
 
 const translations = defineMessages({
   updateSuccess: {
@@ -62,7 +66,14 @@ const translations = defineMessages({
   },
 });
 
-const CategoryCard = ({
+interface CategoryCardProps extends WrappedComponentProps {
+  category: GroupCategory;
+  numGroups: number;
+  onManageGroups: () => void;
+  canManageCategory: boolean;
+}
+
+const CategoryCard: FC<CategoryCardProps> = ({
   category,
   numGroups,
   intl,
@@ -126,7 +137,7 @@ const CategoryCard = ({
   ]);
 
   const bottomButtons = useMemo(() => {
-    const result = [];
+    const result: GroupCardBottomButton[] = [];
     if (canManageCategory) {
       result.push({
         label: <FormattedMessage {...translations.edit} />,
@@ -198,14 +209,6 @@ const CategoryCard = ({
       )}
     </>
   );
-};
-
-CategoryCard.propTypes = {
-  category: categoryShape.isRequired,
-  numGroups: PropTypes.number.isRequired,
-  onManageGroups: PropTypes.func.isRequired,
-  canManageCategory: PropTypes.bool.isRequired,
-  intl: PropTypes.object,
 };
 
 export default injectIntl(CategoryCard);

--- a/client/app/bundles/course/group/pages/GroupShow/CategoryCard.tsx
+++ b/client/app/bundles/course/group/pages/GroupShow/CategoryCard.tsx
@@ -1,16 +1,12 @@
 import { FC, useCallback, useMemo, useState } from 'react';
-import {
-  defineMessages,
-  FormattedMessage,
-  injectIntl,
-  WrappedComponentProps,
-} from 'react-intl';
+import { defineMessages, injectIntl, WrappedComponentProps } from 'react-intl';
 import Delete from '@mui/icons-material/Delete';
 import { red } from '@mui/material/colors';
 
 import { GroupCategory } from 'course/group/types';
 import ConfirmationDialog from 'lib/components/core/dialogs/ConfirmationDialog';
 import { useAppDispatch } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import { deleteCategory, updateCategory } from '../../actions';
 import GroupCard, { GroupCardBottomButton } from '../../components/GroupCard';
@@ -83,6 +79,7 @@ const CategoryCard: FC<CategoryCardProps> = ({
   const dispatch = useAppDispatch();
 
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+  const { t } = useTranslation();
 
   const onFormSubmit = useCallback(
     (data, setError) => {
@@ -140,19 +137,19 @@ const CategoryCard: FC<CategoryCardProps> = ({
     const result: GroupCardBottomButton[] = [];
     if (canManageCategory) {
       result.push({
-        label: <FormattedMessage {...translations.edit} />,
+        label: t(translations.edit),
         onClick: handleEdit,
       });
     }
     if (canManageCategory) {
       result.push({
-        label: <FormattedMessage {...translations.manage} />,
+        label: t(translations.manage),
         onClick: onManageGroups,
       });
     }
     if (canManageCategory) {
       result.push({
-        label: <FormattedMessage {...translations.delete} />,
+        label: t(translations.delete),
         onClick: () => setIsConfirmingDelete(true),
         isRight: true,
         icon: <Delete htmlColor={red[500]} />,
@@ -166,14 +163,12 @@ const CategoryCard: FC<CategoryCardProps> = ({
     <>
       <GroupCard
         bottomButtons={bottomButtons}
-        subtitle={
-          <FormattedMessage values={{ numGroups }} {...translations.subtitle} />
-        }
+        subtitle={t(translations.subtitle, {
+          numGroups,
+        })}
         title={category.name}
       >
-        {category.description ?? (
-          <FormattedMessage {...translations.noDescription} />
-        )}
+        {category.description ?? t(translations.noDescription)}
       </GroupCard>
       {canManageCategory && (
         <>

--- a/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.jsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.jsx
@@ -23,7 +23,9 @@ const translations = defineMessages({
   subtitle: {
     id: 'course.group.GroupShow.GroupTableCard.subtitle',
     defaultMessage:
-      '{numMembers} {numMembers, plural, one {member} other {members}}',
+      '{numMembers} total (' +
+      '{numManagers} {numManagers, plural, one {manager} other {managers}}, ' +
+      '{numNormals} {numNormals, plural, one {member} other {members}})',
   },
   serialNumber: {
     id: 'course.group.GroupShow.GroupTableCard.serialNumber',
@@ -72,6 +74,12 @@ const GroupTableCard = ({ group, onManageGroup, canManageCategory }) => {
   const hasPhantomMembers = allMembers.length !== membersWithoutPhantom.length;
   const members = hidePhantomStudents ? membersWithoutPhantom : allMembers;
 
+  const numMembers = members.length ?? 0;
+  const numManagers =
+    members.filter((m) => m.groupRole === 'manager').length ?? 0;
+  const numNormals =
+    members.filter((m) => m.groupRole === 'normal').length ?? 0;
+
   const titleButton = useMemo(
     () => [
       ...(canManageCategory
@@ -91,7 +99,7 @@ const GroupTableCard = ({ group, onManageGroup, canManageCategory }) => {
     <GroupCard
       subtitle={
         <FormattedMessage
-          values={{ numMembers: members.length ?? 0 }}
+          values={{ numMembers, numManagers, numNormals }}
           {...translations.subtitle}
         />
       }

--- a/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.tsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.tsx
@@ -9,7 +9,6 @@ import {
   TableHead,
   TableRow,
 } from '@mui/material';
-import { grey } from '@mui/material/colors';
 
 import GhostIcon from 'lib/components/icons/GhostIcon';
 
@@ -52,21 +51,6 @@ const translations = defineMessages({
     defaultMessage: 'Hide all phantom students',
   },
 });
-
-const styles = {
-  empty: {
-    paddingTop: '2rem',
-    textAlign: 'center' as const,
-    color: grey[700],
-  },
-  rowHeight: {
-    height: 36,
-  },
-  checkbox: {
-    width: 'auto',
-    padding: 0,
-  },
-};
 
 interface GroupTableCardProps {
   group: Group;
@@ -121,6 +105,7 @@ const GroupTableCard: FC<GroupTableCardProps> = ({
     >
       {hasPhantomMembers && (
         <FormControlLabel
+          className="w-auto p-0"
           control={
             <Checkbox
               checked={hidePhantomStudents}
@@ -128,34 +113,33 @@ const GroupTableCard: FC<GroupTableCardProps> = ({
             />
           }
           label={<FormattedMessage {...translations.hidePhantomStudents} />}
-          style={styles.checkbox}
         />
       )}
       <Table>
         <TableHead>
-          <TableRow style={styles.rowHeight}>
-            <TableCell style={styles.rowHeight}>
+          <TableRow className="h-9">
+            <TableCell className="h-9">
               <FormattedMessage {...translations.serialNumber} />
             </TableCell>
-            <TableCell style={styles.rowHeight}>
+            <TableCell className="h-9">
               <FormattedMessage {...translations.name} />
             </TableCell>
-            <TableCell style={styles.rowHeight}>
+            <TableCell className="h-9">
               <FormattedMessage {...translations.role} />
             </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {members.map((m, index) => (
-            <TableRow key={m.id} style={styles.rowHeight}>
-              <TableCell style={styles.rowHeight}>{index + 1}</TableCell>
-              <TableCell style={styles.rowHeight}>
+            <TableRow key={m.id} className="h-9">
+              <TableCell className="h-9">{index + 1}</TableCell>
+              <TableCell className="h-9">
                 <div className="flex grow items-center">
                   {m.name}
                   {m.isPhantom && <GhostIcon />}
                 </div>
               </TableCell>
-              <TableCell style={styles.rowHeight}>
+              <TableCell className="h-9">
                 <GroupRoleChip user={m} />
               </TableCell>
             </TableRow>
@@ -163,7 +147,7 @@ const GroupTableCard: FC<GroupTableCardProps> = ({
         </TableBody>
       </Table>
       {members.length === 0 ? (
-        <div style={styles.empty}>
+        <div className="pt-8 text-center text-gray-700">
           <FormattedMessage {...translations.noMembers} />
         </div>
       ) : null}

--- a/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.tsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import {
   Checkbox,
@@ -10,13 +10,12 @@ import {
   TableRow,
 } from '@mui/material';
 import { grey } from '@mui/material/colors';
-import PropTypes from 'prop-types';
 
 import GhostIcon from 'lib/components/icons/GhostIcon';
 
 import GroupCard from '../../components/GroupCard';
 import GroupRoleChip from '../../components/GroupRoleChip';
-import { groupShape } from '../../propTypes';
+import { Group } from '../../types';
 import { sortByGroupRole, sortByName, sortByPhantom } from '../../utils/sort';
 
 const translations = defineMessages({
@@ -57,15 +56,29 @@ const translations = defineMessages({
 const styles = {
   empty: {
     paddingTop: '2rem',
-    textAlign: 'center',
+    textAlign: 'center' as const,
     color: grey[700],
   },
   rowHeight: {
     height: 36,
   },
+  checkbox: {
+    width: 'auto',
+    padding: 0,
+  },
 };
 
-const GroupTableCard = ({ group, onManageGroup, canManageCategory }) => {
+interface GroupTableCardProps {
+  group: Group;
+  onManageGroup: () => void;
+  canManageCategory: boolean;
+}
+
+const GroupTableCard: FC<GroupTableCardProps> = ({
+  group,
+  onManageGroup,
+  canManageCategory,
+}) => {
   const [hidePhantomStudents, setHidePhantomStudents] = useState(true);
 
   const allMembers = [...group.members];
@@ -156,12 +169,6 @@ const GroupTableCard = ({ group, onManageGroup, canManageCategory }) => {
       ) : null}
     </GroupCard>
   );
-};
-
-GroupTableCard.propTypes = {
-  group: groupShape.isRequired,
-  onManageGroup: PropTypes.func.isRequired,
-  canManageCategory: PropTypes.bool.isRequired,
 };
 
 export default GroupTableCard;

--- a/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.tsx
+++ b/client/app/bundles/course/group/pages/GroupShow/GroupTableCard.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo, useState } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages } from 'react-intl';
 import {
   Checkbox,
   FormControlLabel,
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 
 import GhostIcon from 'lib/components/icons/GhostIcon';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import GroupCard from '../../components/GroupCard';
 import GroupRoleChip from '../../components/GroupRoleChip';
@@ -64,6 +65,7 @@ const GroupTableCard: FC<GroupTableCardProps> = ({
   canManageCategory,
 }) => {
   const [hidePhantomStudents, setHidePhantomStudents] = useState(true);
+  const { t } = useTranslation();
 
   const allMembers = [...group.members];
   allMembers.sort(sortByName).sort(sortByPhantom).sort(sortByGroupRole);
@@ -82,24 +84,23 @@ const GroupTableCard: FC<GroupTableCardProps> = ({
       ...(canManageCategory
         ? [
             {
-              label: <FormattedMessage {...translations.manageOneGroup} />,
+              label: t(translations.manageOneGroup),
               onClick: onManageGroup,
             },
           ]
         : []),
     ],
 
-    [onManageGroup, canManageCategory],
+    [onManageGroup, canManageCategory, t],
   );
 
   return (
     <GroupCard
-      subtitle={
-        <FormattedMessage
-          values={{ numMembers, numManagers, numNormals }}
-          {...translations.subtitle}
-        />
-      }
+      subtitle={t(translations.subtitle, {
+        numMembers,
+        numManagers,
+        numNormals,
+      })}
       title={group.name}
       titleButtons={titleButton}
     >
@@ -112,21 +113,17 @@ const GroupTableCard: FC<GroupTableCardProps> = ({
               onChange={(_, checked) => setHidePhantomStudents(checked)}
             />
           }
-          label={<FormattedMessage {...translations.hidePhantomStudents} />}
+          label={t(translations.hidePhantomStudents)}
         />
       )}
       <Table>
         <TableHead>
           <TableRow className="h-9">
             <TableCell className="h-9">
-              <FormattedMessage {...translations.serialNumber} />
+              {t(translations.serialNumber)}
             </TableCell>
-            <TableCell className="h-9">
-              <FormattedMessage {...translations.name} />
-            </TableCell>
-            <TableCell className="h-9">
-              <FormattedMessage {...translations.role} />
-            </TableCell>
+            <TableCell className="h-9">{t(translations.name)}</TableCell>
+            <TableCell className="h-9">{t(translations.role)}</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -148,7 +145,7 @@ const GroupTableCard: FC<GroupTableCardProps> = ({
       </Table>
       {members.length === 0 ? (
         <div className="pt-8 text-center text-gray-700">
-          <FormattedMessage {...translations.noMembers} />
+          {t(translations.noMembers)}
         </div>
       ) : null}
     </GroupCard>

--- a/client/app/bundles/course/group/types.ts
+++ b/client/app/bundles/course/group/types.ts
@@ -1,6 +1,6 @@
 import { CourseUserRoles, CourseUserShape } from 'types/course/courseUsers';
 
-interface GroupMember {
+export interface GroupMember {
   id: number;
   name: string;
   role: CourseUserRoles;
@@ -8,13 +8,13 @@ interface GroupMember {
   groupRole: 'manager' | 'normal';
 }
 
-interface GroupCategory {
+export interface GroupCategory {
   id: number;
   name: string;
   description?: string;
 }
 
-interface Group {
+export interface Group {
   id: number;
   name: string;
   description?: string;

--- a/client/app/theme/palette.js
+++ b/client/app/theme/palette.js
@@ -90,8 +90,8 @@ const palette = {
   },
 
   groupRole: {
-    [groupRole.Normal]: colors.green[100],
-    [groupRole.Manager]: colors.red[100],
+    [groupRole.Normal]: 'bg-green-200',
+    [groupRole.Manager]: 'bg-red-200',
   },
 
   submissionIcon: {

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -4893,7 +4893,7 @@
     "defaultMessage": "S/N"
   },
   "course.group.GroupShow.GroupTableCard.subtitle": {
-    "defaultMessage": "{numMembers} {numMembers, plural, one {member} other {members}}"
+    "defaultMessage": "{numMembers} total ({numManagers} {numManagers, plural, one {manager} other {managers}}, {numNormals} {numNormals, plural, one {member} other {members}})"
   },
   "course.group.GroupShow.fetchFailure": {
     "defaultMessage": "Failed to fetch group data! Please reload and try again."

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -4875,7 +4875,7 @@
     "defaultMessage": "일련 번호"
   },
   "course.group.GroupShow.GroupTableCard.subtitle": {
-    "defaultMessage": "{numMembers} {numMembers, plural, one {member} other {members}}"
+    "defaultMessage": "{numMembers} 전체 ({numManagers} 관리자, {numNormals} 멤버)"
   },
   "course.group.GroupShow.fetchFailure": {
     "defaultMessage": "그룹 데이터를 가져오는 데 실패했습니다! 새로 고침 후 다시 시도하세요."

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -4836,7 +4836,7 @@
     "defaultMessage": "序列号"
   },
   "course.group.GroupShow.GroupTableCard.subtitle": {
-    "defaultMessage": "{numMembers} {numMembers, plural, one {member} other {members}}"
+    "defaultMessage": "{numMembers} 总计 ({numManagers} 管理员, {numNormals} 成员)"
   },
   "course.group.GroupShow.fetchFailure": {
     "defaultMessage": "获取组数据失败！请重新加载并重试。"


### PR DESCRIPTION
Updates `GroupTableCard` to change the subtitle from 
```
# members
```
to 
```
# total (# managers, # members)
```
<img width="1233" alt="image" src="https://github.com/user-attachments/assets/51ad3e6c-903b-4f5a-89e8-2ec10a896b21" />

