### PR TITLE
fix(TanStackTableBuilder): correctly align CSV columns

### DIFF
--- a/client/app/lib/components/table/TanStackTableBuilder/csvGenerator.ts
+++ b/client/app/lib/components/table/TanStackTableBuilder/csvGenerator.ts
@@ -5,6 +5,7 @@ import { unparse } from 'papaparse';
 import { ColumnTemplate, Data } from '../builder';
 
 interface CsvGenerator<D extends Data> {
+  initialColumnsLength: number;
   headers: string[];
   rows: () => Row<D>[];
   getRealColumn: (index: number) => ColumnTemplate<D> | undefined;
@@ -19,6 +20,7 @@ const generateCsv = <D extends Data>(
     options.rows().forEach((row) => {
       const rowData = row
         .getAllCells()
+        .slice(options.initialColumnsLength)
         .reduce<string[]>((cells, cell, index) => {
           const realColumn = options.getRealColumn(index);
           const csvDownloadable = realColumn?.csvDownloadable;

--- a/client/app/lib/components/table/TanStackTableBuilder/useTanStackTableBuilder.tsx
+++ b/client/app/lib/components/table/TanStackTableBuilder/useTanStackTableBuilder.tsx
@@ -30,7 +30,7 @@ type TanStackTableProps<D> = TableProps<
 const useTanStackTableBuilder = <D extends object>(
   props: TableTemplate<D>,
 ): TanStackTableProps<D> => {
-  const [columns, getRealColumn] = buildTanStackColumns(
+  const [columns, getRealColumn, initialColumnsLength] = buildTanStackColumns(
     props.columns,
     props.indexing?.rowSelectable,
     props.indexing?.indices,
@@ -85,18 +85,17 @@ const useTanStackTableBuilder = <D extends object>(
   });
 
   const generateAndDownloadCsv = async (): Promise<void> => {
-    const headers = table.options.columns.reduce<string[]>(
-      (acc, column, index) => {
+    const headers = table.options.columns
+      .slice(initialColumnsLength)
+      .reduce<string[]>((acc, column, index) => {
         const header = column.header || column.id;
         if (header && (getRealColumn(index)?.csvDownloadable ?? false)) {
           acc.push(header as string);
         }
         return acc;
-      },
-      [],
-    );
-
+      }, []);
     const csvData = await generateCsv({
+      initialColumnsLength,
       headers,
       rows: () => table.getCoreRowModel().rows,
       getRealColumn,

--- a/client/app/lib/components/table/builder/buildColumns.ts
+++ b/client/app/lib/components/table/builder/buildColumns.ts
@@ -4,7 +4,11 @@ type TemplateAccessor<D extends Data> = (
   builtColumnIndex: number,
 ) => ColumnTemplate<D> | undefined;
 
-export type BuiltColumns<D extends Data, C> = [C[], TemplateAccessor<D>];
+export type BuiltColumns<D extends Data, C> = [
+  C[],
+  TemplateAccessor<D>,
+  number,
+];
 
 export const buildColumns = <D extends Data, C>(
   columns: ColumnTemplate<D>[],
@@ -24,5 +28,9 @@ export const buildColumns = <D extends Data, C>(
     return columnDefs;
   }, initial);
 
-  return [defColumns, (index): ColumnTemplate<D> => defToColumns[index]];
+  return [
+    defColumns,
+    (index): ColumnTemplate<D> => defToColumns[index],
+    initialColumnsLength,
+  ];
 };


### PR DESCRIPTION
# Description
This PR fixes an issue where the "Download CSV" feature would sometimes produce incorrect or misaligned CSV files due to a mismatch between csv columns and table columns. This issue happened after #7901 updated the alignment in `defToColumns`.

# Changes made:
- Return `initialColumnsLength` from `buildTanStackColumns`, and use it to skip these columns (i.e indexing or rowSelectables) when aligning headers and csv columns.