### PR TITLE
fix(course/users_controller): eager load groups to prevent N+1 queries

### DIFF
--- a/app/controllers/course/users_controller.rb
+++ b/app/controllers/course/users_controller.rb
@@ -35,7 +35,7 @@ class Course::UsersController < Course::ComponentController
         @user_options = course_users.order_alphabetically.pluck(:id, :name, :role)
       else
         @course_users ||= course_users.without_phantom_users.students.
-                          includes(user: [:emails]).order_alphabetically
+                          includes(:groups, user: [:emails]).order_alphabetically
       end
 
     else


### PR DESCRIPTION
# Description
`/courses/<course-id>/users` currently causes N+1 query.

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/bfce6327-046b-4e19-bf24-43546e84168f" />

# Changes
Eager load the groups association for course users in the index action to eliminate N+1 queries.