### PR TITLE
feat(AssessmentSubmission): improve navigation and section clarity

### DIFF
--- a/client/app/bundles/course/assessment/submission/components/Editor.jsx
+++ b/client/app/bundles/course/assessment/submission/components/Editor.jsx
@@ -7,8 +7,6 @@ import FormEditorField from 'lib/components/form/fields/EditorField';
 
 import { fileShape } from '../propTypes';
 
-import ProgrammingFileDownloadChip from './answers/Programming/ProgrammingFileDownloadChip';
-
 const Editor = (props) => {
   const {
     file,
@@ -22,9 +20,6 @@ const Editor = (props) => {
 
   return (
     <Stack spacing={0.5}>
-      <div>
-        <ProgrammingFileDownloadChip file={file} />
-      </div>
       <Controller
         control={control}
         name={fieldName}

--- a/client/app/bundles/course/assessment/submission/components/answers/AnswerHeader.tsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/AnswerHeader.tsx
@@ -78,12 +78,19 @@ const HistoryToggle: FC<HistoryToggleProps> = (props) => {
 interface AnswerHeaderProps {
   questionId: number;
   questionNumber: number;
+  questionTitle: string;
   answerId: number | null;
   openAnswerHistoryView: (questionId: number, questionNumber: number) => void;
 }
 
 const AnswerHeader: FC<AnswerHeaderProps> = (props) => {
-  const { answerId, questionId, questionNumber, openAnswerHistoryView } = props;
+  const {
+    answerId,
+    questionId,
+    questionNumber,
+    questionTitle,
+    openAnswerHistoryView,
+  } = props;
   const answerFlag = useAppSelector((state) =>
     getFlagForAnswerId(state, answerId),
   );
@@ -104,11 +111,16 @@ const AnswerHeader: FC<AnswerHeaderProps> = (props) => {
       : answerFlag?.savingStatus;
 
   return (
-    <div className="flex items-center justify-between">
-      <Typography variant="h6">
-        {t(submissionTranslations.questionHeading, { number: questionNumber })}
+    <div className="flex items-center justify-between sticky top-0 z-10 bg-white border-only-b-neutral-200 -mx-5 px-5">
+      <div className="absolute -left-6 flex items-center justify-center rounded-full wh-10 bg-neutral-500">
+        <Typography color="white" variant="body2">
+          {questionNumber}
+        </Typography>
+      </div>
+      <Typography className="line-clamp-2 xl:line-clamp-1" variant="h6">
+        {questionTitle ||
+          t(submissionTranslations.questionHeading, { number: questionNumber })}
       </Typography>
-
       <div className="flex items-center space-x-4">
         <SavingIndicator
           savingSize={answerFlag?.savingSize}

--- a/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/Programming/index.jsx
@@ -106,7 +106,7 @@ const Programming = (props) => {
 
   return (
     <>
-      <div className="mt-5 flex w-full relative gap-3 mb-1 max-h-[100%]">
+      <div className="flex w-full relative gap-3 mb-1 max-h-[100%]">
         <div
           className={`${isLiveFeedbackChatOpen && isAttempting ? 'w-1/2' : 'w-full'}`}
         >

--- a/client/app/bundles/course/assessment/submission/components/answers/index.tsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/index.tsx
@@ -179,8 +179,8 @@ const SubmissionAnswer = <T extends keyof typeof QuestionType>(
         openAnswerHistoryView={openAnswerHistoryView}
         questionId={question.id}
         questionNumber={questionNumber}
+        questionTitle={question.questionTitle}
       />
-      <Divider />
 
       {errorMessages.map((message) => (
         <Typography key={message} className="text-error" variant="body2">
@@ -188,17 +188,22 @@ const SubmissionAnswer = <T extends keyof typeof QuestionType>(
         </Typography>
       ))}
 
-      <Typography className="mt-2" variant="body1">
-        {question.questionTitle ?? ''}
+      {question.description && (
+        <>
+          <Typography color="text.secondary" variant="caption">
+            {t(translations.questionDescription)}
+          </Typography>
+          <Typography
+            dangerouslySetInnerHTML={{ __html: question.description }}
+            variant="body2"
+          />
+          <Divider />
+        </>
+      )}
+
+      <Typography color="text.secondary" variant="caption">
+        {t(translations.questionAnswer)}
       </Typography>
-
-      <Typography
-        dangerouslySetInnerHTML={{ __html: question.description }}
-        variant="body2"
-      />
-
-      <Divider />
-
       <Answer
         answerId={answerId}
         answerProps={answerPropsMap[questionType]}

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/TabbedViewQuestions.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/TabbedViewQuestions.tsx
@@ -44,9 +44,9 @@ const TabbedViewQuestions: FC<Props> = (props) => {
       questionIds.length > 1 && (
         <Stepper
           activeStep={stepIndex}
+          className="justify-center flex-wrap p-4 gap-y-10"
           connector={<div />}
           nonLinear
-          style={{ justifyContent: 'center', flexWrap: 'wrap', padding: 10 }}
         >
           {questionIds.map((id, index) => {
             if (shouldRenderActiveStepper(index)) {
@@ -56,6 +56,7 @@ const TabbedViewQuestions: FC<Props> = (props) => {
                   active={!autograded || index <= maxStep}
                 >
                   <StepButton
+                    className="p-4"
                     icon={
                       <StepperButton
                         questionId={id}

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/StepperButton.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/button/StepperButton.tsx
@@ -26,7 +26,10 @@ const StepperButton: FC<Props> = (props) => {
     stepButtonColor = isCurrentQuestion ? blue[800] : lightBlue[400];
   }
   return (
-    <SvgIcon htmlColor={stepButtonColor}>
+    <SvgIcon
+      fontSize={isCurrentQuestion ? 'large' : 'medium'}
+      htmlColor={stepButtonColor}
+    >
       <circle cx="12" cy="12" r="12" />
       <text fill="#fff" fontSize="12" textAnchor="middle" x="12" y="16">
         {questionIndex + 1}

--- a/client/app/bundles/course/assessment/submission/translations.ts
+++ b/client/app/bundles/course/assessment/submission/translations.ts
@@ -204,6 +204,14 @@ const translations = defineMessages({
     id: 'course.assessment.submission.questionNumber',
     defaultMessage: 'Q{number}',
   },
+  questionDescription: {
+    id: 'course.assessment.submission.questionDescription',
+    defaultMessage: 'Description',
+  },
+  questionAnswer: {
+    id: 'course.assessment.submission.questionAnswer',
+    defaultMessage: 'Answer',
+  },
   loadingComment: {
     id: 'course.assessment.submission.loadingComment',
     defaultMessage: 'Loading comment field...',

--- a/client/app/lib/components/core/indicators/SavingIndicator/index.tsx
+++ b/client/app/lib/components/core/indicators/SavingIndicator/index.tsx
@@ -75,7 +75,7 @@ const SavingIndicator = (props: SavingIndicatorProps): JSX.Element | null => {
         color={chipProps.color}
         icon={chipProps.icon}
         label={`${answerTooLarge ? t(translations.answerTooLarge) : t(chipProps.label)}${sizeFragment}`}
-        size="medium"
+        size="small"
         variant="outlined"
       />
     </Tooltip>

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -3341,6 +3341,12 @@
   "course.assessment.submission.questionNumber": {
     "defaultMessage": "Q{number}"
   },
+  "course.assessment.submission.questionDescription": {
+    "defaultMessage": "Description"
+  },
+  "course.assessment.submission.questionAnswer": {
+    "defaultMessage": "Answer"
+  },
   "course.assessment.submission.readOnlyEditor.expandComments": {
     "defaultMessage": "Expand all comments"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -3326,6 +3326,12 @@
   "course.assessment.submission.questionNumber": {
     "defaultMessage": "Q{number}"
   },
+  "course.assessment.submission.questionDescription": {
+    "defaultMessage": "설명"
+  },
+  "course.assessment.submission.questionAnswer": {
+    "defaultMessage": "응답"
+  },
   "course.assessment.submission.readOnlyEditor.expandComments": {
     "defaultMessage": "모든 댓글 확장"
   },

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -3287,6 +3287,12 @@
   "course.assessment.submission.questionNumber": {
     "defaultMessage": "Q{数字}"
   },
+  "course.assessment.submission.questionDescription": {
+    "defaultMessage": "描述"
+  },
+  "course.assessment.submission.questionAnswer": {
+    "defaultMessage": "作答"
+  },
   "course.assessment.submission.readOnlyEditor.expandComments": {
     "defaultMessage": "展开所有评论"
   },


### PR DESCRIPTION
# Changes made

1. Replace "<Question {number}>" in the header with just a number icon; move question title into the answer header (with clamping) and make it sticky for better visibility.
2. Make [Saved] chip smaller to match [Past Answers] chip.
3. Remove "Download" button for programming question editor mode (still present in read-only).
4. Change current question highlight from shaded background to a larger icon for clearer distinction.
6. Add "Description" and "Submission" headers with increased spacing to visually separate question description and student submission, improving readability when both are text.

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/5a2611f1-f290-4d85-b10f-05ca416a04da" />

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/b8016398-82b9-44ed-9694-a7bb25a70580" />