### PR TITLE
fix(instance_admin_ability_component): grant instance admin full access to "Manage Users" page

### DIFF
--- a/app/models/components/system/admin/instance_admin_ability_component.rb
+++ b/app/models/components/system/admin/instance_admin_ability_component.rb
@@ -26,9 +26,11 @@ module System::Admin::InstanceAdminAbilityComponent
   end
 
   def allow_instance_admin_manage_courses
-    can :manage, Course do |course|
-      course.instance.instance_users.administrator.exists?(user_id: user.id)
-    end
+    admin_instance_ids = user.instance_users.administrator.pluck(:instance_id)
+    can :manage, Course, instance_id: admin_instance_ids
+    can :manage_users, Course, instance_id: admin_instance_ids
+    can :manage, CourseUser, course: { instance_id: admin_instance_ids }
+    can :manage, Course::EnrolRequest, course: { instance_id: admin_instance_ids }
   end
 
   def allow_instance_admin_manage_role_requests


### PR DESCRIPTION
# Description

- Currently, an `instance_admin` cannot access a lot of components within a course page. Hoever, similar to a `system_admin`, an `instance_admin` should be able access everything within the courses that belong to the same instance.
- The current workaround is to let the `instance_admin` invites himself as a `course_user` using the "Manage Users" tab on the sidebar, but the default page when accessing the tab is `courses/<id>/students` which cannot be entered by an `instance admin` (although users can still enter the URL `courses/<id>/user_invitations` directly).

# Changes made

Added the necessary permissions for `instance_admin` to access the rest of "Manage Users" tab. 


# Notes

Unlike the `system_admin` where the permission is set to be `can :manage, :all if user&.administrator?`, I am not sure how to easily add the permissions for the `instance_admin` for everything that belongs to the same instance besides adding permissions for each model one by one like what I did for the "Manage Users" page. Might need to discuss more on this.