### PR TITLE
fix: resolve breadcrumb label mismatch

### DIFF
--- a/client/app/bundles/course/material/folders/handles.ts
+++ b/client/app/bundles/course/material/folders/handles.ts
@@ -11,6 +11,10 @@ const translations = defineMessages({
     id: 'course.material.folders.FolderShow.folderNotFound',
     defaultMessage: 'Folder not found',
   },
+  error: {
+    id: 'course.material.folders.FolderShow.error',
+    defaultMessage: '(Error)',
+  },
 });
 
 const getFolderTitle = async (
@@ -22,13 +26,16 @@ const getFolderTitle = async (
     .then((response) => response.data.breadcrumbs)
     .catch((error) => {
       const response = (error as AxiosError<FolderData>).response;
-      if (!response?.data.breadcrumbs) throw new Error('Root folder not found');
-      return [...response.data.breadcrumbs, { id: -1, name: '' }];
+      const placeholderCrumb = { id: -1, name: '' };
+      if (!response?.data.breadcrumbs) {
+        return [placeholderCrumb];
+      }
+      return [...response.data.breadcrumbs, placeholderCrumb];
     })
     .then((breadcrumbs) => ({
       activePath: `${courseUrl}/materials/folders/${breadcrumbs[0].id}`,
       content: breadcrumbs.map((crumb) => ({
-        title: crumb.id < 0 ? translations.folderNotFound : crumb.name,
+        title: crumb.id < 0 ? translations.error : crumb.name,
         url: `materials/folders/${crumb.id < 0 ? '' : crumb.id}`,
       })),
     }));

--- a/client/app/bundles/course/stories/pages/LearnPage.tsx
+++ b/client/app/bundles/course/stories/pages/LearnPage.tsx
@@ -4,6 +4,7 @@ import CourseAPI from 'api/course';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import { useSetFooter } from 'lib/components/wrappers/FooterProvider';
 import Preload from 'lib/components/wrappers/Preload';
+import { CrumbPath, DataHandle } from 'lib/hooks/router/dynamicNest';
 
 import CikgoChatsPage from '../components/CikgoChatsPage';
 import CikgoErrorPage from '../components/CikgoErrorPage';
@@ -24,9 +25,17 @@ const LearnPage = (): JSX.Element => {
   );
 };
 
-export default Object.assign(LearnPage, {
-  handle: defineMessage({
-    id: 'course.stories.pages.LearnPage',
-    defaultMessage: 'Learn',
-  }),
-});
+export const learnHandle: DataHandle = (match) => {
+  const courseId = match.params.courseId;
+  return {
+    getData: async (): Promise<CrumbPath> => {
+      const { data } = await CourseAPI.admin.stories.index();
+      return {
+        activePath: `/courses/${courseId}/learn`,
+        content: { title: data.title || 'Learn' },
+      };
+    },
+  };
+};
+
+export default Object.assign(LearnPage, { handle: learnHandle });


### PR DESCRIPTION
- fix breadcrumb label for stories/learn
![image](https://github.com/user-attachments/assets/8e63e365-af5c-4ee0-ad2e-3a3eb0740dad)

- add placeholder crumb to handle errors cases (reused existing `folderNotFound` message)
![image](https://github.com/user-attachments/assets/c16adcb5-6e19-4818-ae5d-9dcfe2439287)
