### PR TITLE
test(component_settings): isolate component settings tests instances

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -9,7 +9,7 @@ Our tests are written using the [RSpec](https://rspec.info/) framework for Ruby.
 First, make sure the test database is seeded before running any specs:
 
 ```bash
-RAILS_ENV=test bundle exec rake db:seed
+RAILS_ENV=test bundle exec rake db:setup
 ```
 
 Then, make sure the [authentication server](../authentication/README.md) is running.

--- a/spec/features/course/admin/component_settings_spec.rb
+++ b/spec/features/course/admin/component_settings_spec.rb
@@ -2,7 +2,15 @@
 require 'rails_helper'
 
 RSpec.feature 'Course: Administration: Components', js: true do
-  let!(:instance) { Instance.default }
+  let!(:instance) { create(:instance) }
+
+  around do |example|
+    RSpec::Mocks.with_temporary_scope do
+      allow(Instance).to receive(:find_tenant_by_host_or_default).and_return(instance)
+      allow(instance).to receive(:host).and_return(Instance.default.host)
+      example.run
+    end
+  end
 
   with_tenant(:instance) do
     let(:course) { create(:course) }

--- a/spec/features/system/admin/components_settings_spec.rb
+++ b/spec/features/system/admin/components_settings_spec.rb
@@ -2,7 +2,16 @@
 require 'rails_helper'
 
 RSpec.feature 'System: Administration: Components', type: :feature, js: true do
-  let!(:instance) { Instance.default }
+  let!(:instance) { create(:instance) }
+
+  # Allow requests to behave as if the isolated instance is mapped to localhost.
+  around do |example|
+    RSpec::Mocks.with_temporary_scope do
+      allow(Instance).to receive(:find_tenant_by_host_or_default).and_return(instance)
+      allow(instance).to receive(:host).and_return(Instance.default.host)
+      example.run
+    end
+  end
 
   with_tenant(:instance) do
     let(:admin) { create(:administrator) }


### PR DESCRIPTION
When feature tests for [course admin component settings](https://github.com/Coursemology/coursemology2/blob/master/spec/features/course/admin/components_settings_spec.rb) and [instance admin component settings](https://github.com/Coursemology/coursemology2/blob/master/spec/features/system/admin/components_settings_spec.rb) run, they operate on the default instance. This causes problems for other tests running in parallel if a relevant component gets disabled at the wrong time. Therefore, we are moving these tests to execute on isolated custom instances.

By default, custom instances are [assigned a custom host](https://github.com/Coursemology/coursemology2/blob/master/spec/factories/instances.rb) `local-#{base_time}-#{n}.lvh.me`. However, Keycloak auth flow fails to render because these hostnames are not considered [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). Migrating to `local-#{base_time}-#{n}.localhost`, which is a secure context, also doesn't work because DNS resolution will fail.

Therefore, we define mocks for these test cases such that `localhost` resolves to the isolated instance for these cases instead of default instance. The actual host defined in test DB is unchanged because because host uniqueness is a database constraint which cannot be bypassed via ActiveRecord validations alone. 

These mocks make use of `RSpec::Mocks.with_temporary_scope` to prevent leakage across parallel test runs.