### PR TITLE
fix: remove upper bound EXP validation

### DIFF
--- a/app/models/course/experience_points_record.rb
+++ b/app/models/course/experience_points_record.rb
@@ -95,10 +95,8 @@ class Course::ExperiencePointsRecord < ApplicationRecord
 
   def validate_lesson_plan_item_points(lesson_plan_item_specific)
     max_exp_points = lesson_plan_item_specific.base_exp + lesson_plan_item_specific.time_bonus_exp
-    if points_awarded && points_awarded > max_exp_points
-      errors.add(:base, "Points awarded cannot exceed the upper bound exp: #{max_exp_points}")
-    elsif points_awarded && points_awarded < 0
-      errors.add(:base, 'Points awarded cannot be negative')
-    end
+    return unless points_awarded && points_awarded < 0
+
+    errors.add(:base, 'Points awarded cannot be negative')
   end
 end

--- a/spec/models/course/experience_points_record_spec.rb
+++ b/spec/models/course/experience_points_record_spec.rb
@@ -34,13 +34,6 @@ RSpec.describe Course::ExperiencePointsRecord do
     describe 'validation for assessment' do
       let!(:assessment1) { create(:assessment, time_bonus_exp: 300) }
       subject { create(:submission, assessment: assessment1) }
-      context 'when points awarded from this assessment is more than upper bound' do
-        before { subject.points_awarded = assessment1.base_exp + assessment1.time_bonus_exp + 1 }
-        it 'is invalid' do
-          expect(subject).to be_invalid
-        end
-      end
-
       context 'when points awarded from this assessment is negative' do
         before { subject.points_awarded = -1 }
         it 'is invalid' do
@@ -52,13 +45,6 @@ RSpec.describe Course::ExperiencePointsRecord do
     describe 'validation for survey' do
       let!(:survey1) { create(:survey, base_exp: 100, time_bonus_exp: 50) }
       subject { create(:response, survey: survey1) }
-      context 'when points awarded from this survey is more than upper bound' do
-        before { subject.points_awarded = survey1.base_exp + survey1.time_bonus_exp + 1 }
-        it 'is invalid' do
-          expect(subject).to be_invalid
-        end
-      end
-
       context 'when points awarded from this survey is negative' do
         before { subject.points_awarded = -1 }
         it 'is invalid' do


### PR DESCRIPTION
### Problem

When **delayed graded publishing** was used and a submission was awarded EXP exceeding the assignment threshold, an incorrect error message was shown. This was caused by an **upper bound validation** on EXP, which did not account for valid use cases where instructors may want to award bonus EXP.

### Solution

This PR **removes the upper bound validation** on awarded EXP, allowing instructors to grant EXP above the configured threshold.  
The **lower bound validation** (EXP must be non-negative) is still enforced to prevent invalid values.

Closes #7764