### PR TITLE
feat(RubricBasedResponse): add RubricBasedResponse to submission CSV and statistics table

### DIFF
--- a/app/models/course/assessment/question/rubric_based_response.rb
+++ b/app/models/course/assessment/question/rubric_based_response.rb
@@ -39,6 +39,10 @@ class Course::Assessment::Question::RubricBasedResponse < ApplicationRecord
     true
   end
 
+  def csv_downloadable?
+    true
+  end
+
   def attempt(submission, last_attempt = nil)
     answer = Course::Assessment::Answer::RubricBasedResponse.new(submission: submission, question: question)
     answer.answer_text = last_attempt.answer_text if last_attempt

--- a/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
+++ b/app/views/course/assessment/answer/forum_post_responses/_forum_post_response.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+json.questionType answer.question.question_type
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id

--- a/app/views/course/assessment/answer/multiple_responses/_multiple_response.json.jbuilder
+++ b/app/views/course/assessment/answer/multiple_responses/_multiple_response.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+json.questionType answer.question.question_type
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id

--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -20,6 +20,8 @@ if is_current_answer && !latest_answer.current_answer?
   end
 end
 
+json.questionType answer.question.question_type
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id

--- a/app/views/course/assessment/answer/rubric_based_responses/_rubric_based_response.json.jbuilder
+++ b/app/views/course/assessment/answer/rubric_based_responses/_rubric_based_response.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+json.questionType answer.question.question_type
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id

--- a/app/views/course/assessment/answer/scribing/_scribing.json.jbuilder
+++ b/app/views/course/assessment/answer/scribing/_scribing.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+json.questionType answer.question.question_type
+
 json.scribing_answer do
   json.image_url answer.question.actable.attachment_reference.generate_public_url
   json.user_id current_user.id

--- a/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
+++ b/app/views/course/assessment/answer/text_responses/_text_response.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+json.questionType answer.question.question_type
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id

--- a/app/views/course/assessment/answer/voice_responses/_voice_response.json.jbuilder
+++ b/app/views/course/assessment/answer/voice_responses/_voice_response.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+json.questionType answer.question.question_type
+
 json.fields do
   json.questionId answer.question_id
   json.id answer.acting_as.id

--- a/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentGradesPerQuestionTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentStatistics/StudentGradesPerQuestionTable.tsx
@@ -43,7 +43,6 @@ const StudentGradesPerQuestionTable: FC<Props> = (props) => {
   const { t } = useTranslation();
   const { courseId, assessmentId } = useParams();
   const { includePhantom } = props;
-
   const statistics = useAppSelector(getAssessmentStatistics);
   const [openAnswer, setOpenAnswer] = useState(false);
   const [answerDisplayInfo, setAnswerDisplayInfo] = useState<AnswerInfoState>({

--- a/client/app/bundles/course/assessment/submission/components/AnswerDetails/AnswerDetails.tsx
+++ b/client/app/bundles/course/assessment/submission/components/AnswerDetails/AnswerDetails.tsx
@@ -15,6 +15,7 @@ import ForumPostResponseDetails from './ForumPostResponseDetails';
 import MultipleChoiceDetails from './MultipleChoiceDetails';
 import MultipleResponseDetails from './MultipleResponseDetails';
 import ProgrammingAnswerDetails from './ProgrammingAnswerDetails';
+import RubricBasedResponseDetails from './RubricBasedResponseDetails';
 import TextResponseDetails from './TextResponseDetails';
 
 const translations = defineMessages({
@@ -58,10 +59,10 @@ export const AnswerDetailsMapper = {
   Programming: (props: AnswerDetailsProps<'Programming'>): JSX.Element => (
     <ProgrammingAnswerDetails {...props} />
   ),
-  // TODO: define component for Voice Response, Scribing, Rubric Based Response
   RubricBasedResponse: (
-    _props: AnswerDetailsProps<'RubricBasedResponse'>,
-  ): JSX.Element => <AnswerNotImplemented />,
+    props: AnswerDetailsProps<'RubricBasedResponse'>,
+  ): JSX.Element => <RubricBasedResponseDetails {...props} />,
+  // TODO: define component for Voice Response, Scribing
   VoiceResponse: (_props: AnswerDetailsProps<'VoiceResponse'>): JSX.Element => (
     <AnswerNotImplemented />
   ),

--- a/client/app/bundles/course/assessment/submission/components/AnswerDetails/RubricBasedResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/submission/components/AnswerDetails/RubricBasedResponseDetails.tsx
@@ -1,20 +1,26 @@
 import { Typography } from '@mui/material';
 import { QuestionType } from 'types/course/assessment/question';
 
+import RubricPanel from '../../containers/RubricPanel';
 import { AnswerDetailsProps } from '../../types';
-
-import AttachmentDetails from './AttachmentDetails';
 
 const RubricBasedResponseDetails = (
   props: AnswerDetailsProps<QuestionType.RubricBasedResponse>,
 ): JSX.Element => {
   const { question, answer } = props;
-
   return (
-    <Typography
-      dangerouslySetInnerHTML={{ __html: answer.fields.answer_text }}
-      variant="body2"
-    />
+    <>
+      <Typography
+        dangerouslySetInnerHTML={{ __html: answer.fields.answer_text }}
+        variant="body2"
+      />
+      <RubricPanel
+        answerCategoryGrades={answer.categoryGrades}
+        answerId={answer.id}
+        question={question}
+        setIsFirstRendering={() => {}} // Placeholder function since RubricPanel is not editable here
+      />
+    </>
   );
 };
 

--- a/client/app/bundles/course/assessment/submission/components/AnswerDetails/RubricBasedResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/submission/components/AnswerDetails/RubricBasedResponseDetails.tsx
@@ -1,0 +1,21 @@
+import { Typography } from '@mui/material';
+import { QuestionType } from 'types/course/assessment/question';
+
+import { AnswerDetailsProps } from '../../types';
+
+import AttachmentDetails from './AttachmentDetails';
+
+const RubricBasedResponseDetails = (
+  props: AnswerDetailsProps<QuestionType.RubricBasedResponse>,
+): JSX.Element => {
+  const { question, answer } = props;
+
+  return (
+    <Typography
+      dangerouslySetInnerHTML={{ __html: answer.fields.answer_text }}
+      variant="body2"
+    />
+  );
+};
+
+export default RubricBasedResponseDetails;

--- a/client/app/bundles/course/assessment/submission/containers/RubricExplanation.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricExplanation.tsx
@@ -1,5 +1,5 @@
-import { FC } from 'react';
-import { MenuItem, Select, Typography } from '@mui/material';
+import { FC, useState } from 'react';
+import { Chip, MenuItem, Select, Typography } from '@mui/material';
 import { AnswerRubricGradeData } from 'types/course/assessment/question/rubric-based-responses';
 import {
   RubricBasedResponseCategoryQuestionData,
@@ -8,6 +8,7 @@ import {
 
 import TextField from 'lib/components/core/fields/TextField';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
+import useTranslation from 'lib/hooks/useTranslation';
 
 import {
   updateGrade as updateGradeState,
@@ -19,6 +20,7 @@ import { getQuestionFlags } from '../selectors/questionFlags';
 import { getQuestions } from '../selectors/questions';
 import { getSubmissionFlags } from '../selectors/submissionFlags';
 import { getSubmission } from '../selectors/submissions';
+import translations from '../translations';
 import { GradeWithPrefilledStatus } from '../types';
 import { transformRubric } from '../utils/rubrics';
 
@@ -44,6 +46,8 @@ const RubricExplanation: FC<RubricExplanationProps> = (props) => {
     setIsFirstRendering,
     updateGrade,
   } = props;
+
+  const { t } = useTranslation();
 
   const questionWithGrades = useAppSelector(getQuestionWithGrades);
   const submission = useAppSelector(getSubmission);
@@ -129,18 +133,36 @@ const RubricExplanation: FC<RubricExplanationProps> = (props) => {
       disabled={isAutograding}
       id={`category-${category.id}`}
       onChange={handleOnChange}
+      renderValue={(selectedId) => {
+        // Display the selected grade explanation only, excluding the grade chip
+        const selected = category.grades.find((g) => g.id === selectedId);
+        return (
+          <Typography
+            className="text-wrap"
+            dangerouslySetInnerHTML={{ __html: selected?.explanation ?? '' }}
+            variant="body2"
+          />
+        );
+      }}
       value={categoryGrades[category.id].gradeId}
       variant="outlined"
     >
       {category.grades.map((grade) => (
         <MenuItem key={grade.id} value={grade.id}>
-          <Typography
-            className="w-full text-wrap"
-            dangerouslySetInnerHTML={{
-              __html: grade.explanation,
-            }}
-            variant="body2"
-          />
+          <div className="flex items-center justify-between w-full">
+            <Typography
+              className="text-wrap"
+              dangerouslySetInnerHTML={{ __html: grade.explanation }}
+              variant="body2"
+            />
+            <Chip
+              label={t(translations.gradeDisplay, {
+                grade: grade?.grade ?? '--',
+              })}
+              size="small"
+              variant="filled"
+            />
+          </div>
         </MenuItem>
       ))}
     </Select>

--- a/client/app/bundles/course/assessment/submission/containers/RubricGrade.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricGrade.tsx
@@ -113,6 +113,11 @@ const RubricGrade: FC<RubricGradeProps> = (props) => {
         className="w-full h-20 max-w-3xl"
         disabled={isAutograding}
         id={`category-${category.id}`}
+        InputProps={{
+          classes: {
+            input: 'text-center',
+          },
+        }}
         onChange={(event) => handleOnChange(event, category.isBonusCategory)}
         value={categoryGrades[category.id].grade}
         variant="outlined"
@@ -131,7 +136,7 @@ const RubricGrade: FC<RubricGradeProps> = (props) => {
     >
       {category.grades.map((catGrade) => (
         <MenuItem key={catGrade.id} value={catGrade.id}>
-          {catGrade.grade}
+          {catGrade.grade} / {category.maximumGrade}
         </MenuItem>
       ))}
     </Select>

--- a/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
@@ -9,40 +9,27 @@ import {
 } from '@mui/material';
 import { SubmissionQuestionData } from 'types/course/assessment/submission/question/types';
 
-import { useAppSelector } from 'lib/hooks/store';
 import useTranslation from 'lib/hooks/useTranslation';
 
-import { getRubricCategoryGradesForAnswerId } from '../selectors/answers';
-import { getQuestionWithGrades } from '../selectors/grading';
-import { getQuestions } from '../selectors/questions';
 import translations from '../translations';
+import { AnswerDetailsMap } from '../types';
 
 import RubricPanelRow from './RubricPanelRow';
 
 interface RubricPanelProps {
+  answerId: number;
+  answerCategoryGrades: AnswerDetailsMap['RubricBasedResponse']['categoryGrades'];
+  question: SubmissionQuestionData<'RubricBasedResponse'>;
   setIsFirstRendering: (isFirstRendering: boolean) => void;
-  questionId: number;
 }
 
 const RubricPanel: FC<RubricPanelProps> = (props) => {
-  const { setIsFirstRendering, questionId } = props;
-
   const { t } = useTranslation();
-  const questions = useAppSelector(getQuestions);
-
-  const question = questions[
-    questionId
-  ] as SubmissionQuestionData<'RubricBasedResponse'>;
-  const questionWithGrades = useAppSelector(getQuestionWithGrades);
-
-  const answerId = questionWithGrades[questionId].id;
-
-  const categoryGrade = useAppSelector((state) =>
-    getRubricCategoryGradesForAnswerId(state, answerId),
-  );
+  const { answerId, answerCategoryGrades, question, setIsFirstRendering } =
+    props;
 
   const categoryGrades = useMemo(() => {
-    const categoryGradeHash = categoryGrade.reduce(
+    const categoryGradeHash = answerCategoryGrades.reduce(
       (obj, category) => ({
         ...obj,
         [category.categoryId]: {
@@ -68,7 +55,7 @@ const RubricPanel: FC<RubricPanelProps> = (props) => {
       }),
       {},
     );
-  }, [categoryGrade, question.categories]);
+  }, [answerCategoryGrades, question.categories]);
 
   return (
     <div className="w-full p-2">
@@ -84,20 +71,24 @@ const RubricPanel: FC<RubricPanelProps> = (props) => {
             <TableCell className="w-[80%] text-wrap">
               {t(translations.explanation)}
             </TableCell>
-            <TableCell className="w-[10%] text-wrap">
+            <TableCell className="w-[5%] text-wrap px-0 text-center">
               {t(translations.grade)}
+            </TableCell>
+            <TableCell className="px-0 text-center">/</TableCell>
+            <TableCell className="w-[5%] text-wrap px-0 text-center">
+              {t(translations.max)}
             </TableCell>
           </TableRow>
         </TableHead>
 
         <TableBody>
-          {question.categories.map((category) => (
+          {question?.categories.map((category) => (
             <RubricPanelRow
               key={category.id}
               answerId={answerId}
               category={category}
               categoryGrades={categoryGrades}
-              questionId={questionId}
+              question={question}
               setIsFirstRendering={setIsFirstRendering}
             />
           ))}

--- a/client/app/bundles/course/assessment/submission/translations.ts
+++ b/client/app/bundles/course/assessment/submission/translations.ts
@@ -611,6 +611,14 @@ const translations = defineMessages({
     id: 'course.assessment.submission.grade',
     defaultMessage: 'Grade',
   },
+  gradeDisplay: {
+    id: 'course.assessment.submission.gradeDisplay',
+    defaultMessage: 'Grade: {grade}',
+  },
+  max: {
+    id: 'course.assessment.submission.max',
+    defaultMessage: 'Max',
+  },
   group: {
     id: 'course.assessment.submission.group',
     defaultMessage: 'Group',

--- a/client/app/types/course/assessment/submission/answer/rubricBasedResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/rubricBasedResponse.ts
@@ -25,11 +25,12 @@ export interface RubricBasedResponseAnswerData extends AnswerBaseData {
     path?: string;
   };
   latestAnswer?: RubricBasedResponseAnswerData;
-  categoryScores: {
-    canReadRubric: boolean;
+  categoryGrades: {
     id: number | null | undefined;
     categoryId: number;
-    score: number;
+    grade: number;
+    gradeId: number;
+    explanation: string | null;
   }[];
 }
 

--- a/client/app/types/course/assessment/submission/question/types.ts
+++ b/client/app/types/course/assessment/submission/question/types.ts
@@ -99,6 +99,7 @@ export interface SubmissionQuestionBaseData extends QuestionData {
   questionTitle: string;
   submissionQuestionId: number;
   topicId: number;
+  type: QuestionType;
   answerId?: number;
   isCodaveri?: boolean;
   // Derived within redux reducer


### PR DESCRIPTION
- Add RubricPanel to Course > Assessment > Statistics > Grades Per Question > Rubric Based Response Question
  - Extracted data fetching logic outside of RubricPanel
  - RubricPanel now receives all required data via props — making it more extensible and easier to reuse
  - Past answer now displays student answers for Rubric Based Response questions as well as Rubric Panel
  - In Rubric edit mode, display rubric grade in dropdown
  - Display category max grade in RubricPanel
![image](https://github.com/user-attachments/assets/1ea1864d-7e07-4f02-85bc-8789b762b591)
![image](https://github.com/user-attachments/assets/f1ab9504-09d3-4878-a205-a4fc9ef5b312)




- Add CSV export for RubricBasedResponse answers in Assessment > Submissions > Download Answers (CSV)
  - In the exported CSV file, answers for Rubric Based Response questions will now appear similar to Text Response answers.
  ![image](https://github.com/user-attachments/assets/fd546032-4b14-40a8-b4ed-1fc778238bcc)

