### PR TITLE
feat(python-3.13-support): add python 3.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,9 +22,9 @@ GIT
 
 GIT
   remote: https://github.com/Coursemology/polyglot
-  revision: 1a975cdfcc9765226389f06e8bb11c5f72200d35
+  revision: 7cf1c55b530fd50950144d24524b0647f2d98f76
   specs:
-    coursemology-polyglot (0.4.0)
+    coursemology-polyglot (0.4.1)
       activesupport (>= 4.2)
 
 GIT
@@ -159,8 +159,8 @@ GEM
     baran (0.1.12)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
     builder (3.3.0)
     bullet (8.0.7)
       activesupport (>= 3.0.0)
@@ -220,7 +220,7 @@ GEM
     dotenv-rails (3.1.7)
       dotenv (= 3.1.7)
       railties (>= 6.1)
-    drb (2.2.1)
+    drb (2.2.3)
     edge (0.6.1)
       activerecord (>= 5.0.0)
     email_spec (2.3.0)

--- a/app/controllers/concerns/course/assessment/question/koditsu_question_concern.rb
+++ b/app/controllers/concerns/course/assessment/question/koditsu_question_concern.rb
@@ -132,6 +132,11 @@ module Course::Assessment::Question::KoditsuQuestionConcern
         language: 'python',
         version: '3.12',
         filename: 'main.py'
+      },
+      Coursemology::Polyglot::Language::Python::Python3Point13 => {
+        language: 'python',
+        version: '3.13',
+        filename: 'main.py'
       }
     }
   end

--- a/app/services/course/assessment/question/programming/python/python_autograde_post.py
+++ b/app/services/course/assessment/question/programming/python/python_autograde_post.py
@@ -1,8 +1,10 @@
 
 # Do not modify beyond this line
 if __name__ == '__main__':
-    unittest.main(
-            testRunner=xmlrunner.XMLTestRunner(open('report.xml', 'wb'), outsuffix = ''),
+    with open('report.xml', 'wb') as output:
+        unittest.main(
+            testRunner=xmlrunner.XMLTestRunner(output, outsuffix=''),
             failfast=False,
             buffer=False,
-            catchbreak=False)
+            catchbreak=False
+        )

--- a/lib/tasks/db/set_polyglot_language_flags.rake
+++ b/lib/tasks/db/set_polyglot_language_flags.rake
@@ -13,6 +13,7 @@ namespace :db do
       Coursemology::Polyglot::Language::Python::Python3Point9,
       Coursemology::Polyglot::Language::Python::Python3Point10,
       Coursemology::Polyglot::Language::Python::Python3Point12,
+      Coursemology::Polyglot::Language::Python::Python3Point13,
       Coursemology::Polyglot::Language::Java::Java17,
       Coursemology::Polyglot::Language::Java::Java21,
       Coursemology::Polyglot::Language::R::R4Point1
@@ -27,6 +28,7 @@ namespace :db do
       Coursemology::Polyglot::Language::Python::Python3Point9,
       Coursemology::Polyglot::Language::Python::Python3Point10,
       Coursemology::Polyglot::Language::Python::Python3Point12,
+      Coursemology::Polyglot::Language::Python::Python3Point13,
       Coursemology::Polyglot::Language::Java::Java17,
       Coursemology::Polyglot::Language::Java::Java21,
       Coursemology::Polyglot::Language::R::R4Point1
@@ -41,7 +43,8 @@ namespace :db do
       Coursemology::Polyglot::Language::Python::Python3Point7,
       Coursemology::Polyglot::Language::Python::Python3Point9,
       Coursemology::Polyglot::Language::Python::Python3Point10,
-      Coursemology::Polyglot::Language::Python::Python3Point12
+      Coursemology::Polyglot::Language::Python::Python3Point12,
+      Coursemology::Polyglot::Language::Python::Python3Point13
     ].freeze
 
   DEPRECATED_LANGUAGES =


### PR DESCRIPTION
# Changes made

This PR adds two new libraries for a new Python 3.13 image

- PuLP
- sympy

This is on top of the existing libraries in python 3.12

# Related PRs
- https://github.com/Coursemology/evaluator-images/pull/41
- https://github.com/Coursemology/polyglot/pull/37