### PR TITLE
fix(RubricBasedQuestion): fix minor bugs

### DIFF
--- a/app/controllers/concerns/course/assessment/question/rubric_based_response_controller_concern.rb
+++ b/app/controllers/concerns/course/assessment/question/rubric_based_response_controller_concern.rb
@@ -3,6 +3,28 @@ module Course::Assessment::Question::RubricBasedResponseControllerConcern
   include Course::Assessment::Question::RubricBasedResponseQuestionConcern
   extend ActiveSupport::Concern
 
+  def create_new_category_grade_instances(new_category_ids)
+    answers = Course::Assessment::Answer.where(
+      actable_type: 'Course::Assessment::Answer::RubricBasedResponse',
+      question_id: @rubric_based_response_question.acting_as.id
+    ).includes(:actable).map(&:actable)
+
+    new_category_selections = answers.product(new_category_ids).map do |answer, category_id|
+      {
+        answer_id: answer.id,
+        category_id: category_id,
+        criterion_id: nil,
+        grade: nil,
+        explanation: nil
+      }
+    end
+
+    selections = Course::Assessment::Answer::RubricBasedResponseSelection.insert_all(new_category_selections)
+    raise ActiveRecord::Rollback if !new_category_selections.empty? && (selections.nil? || selections.rows.empty?)
+
+    true
+  end
+
   def update_all_submission_answer_grades
     all_assessment_submission_ids = @assessment.submissions.map(&:id)
     @all_rubric_based_response_answers = Course::Assessment::Answer.where(

--- a/app/controllers/course/assessment/question/rubric_based_responses_controller.rb
+++ b/app/controllers/course/assessment/question/rubric_based_responses_controller.rb
@@ -85,10 +85,13 @@ class Course::Assessment::Question::RubricBasedResponsesController < Course::Ass
 
   def update_rubric_based_response_question
     ActiveRecord::Base.transaction do
-      @rubric_based_response_question.update(
+      existing_category_ids = @rubric_based_response_question.categories.pluck(:id)
+      raise ActiveRecord::Rollback unless @rubric_based_response_question.update(
         rubric_based_response_question_params.except(:question_assessment)
       )
 
+      new_category_ids = @rubric_based_response_question.reload.categories.pluck(:id) - existing_category_ids
+      create_new_category_grade_instances(new_category_ids) if new_category_ids.present?
       update_all_submission_answer_grades
     end
   end

--- a/app/models/course/assessment/question/rubric_based_response.rb
+++ b/app/models/course/assessment/question/rubric_based_response.rb
@@ -2,7 +2,7 @@
 class Course::Assessment::Question::RubricBasedResponse < ApplicationRecord
   acts_as :question, class_name: 'Course::Assessment::Question'
 
-  validate :validate_no_reserved_category_names, on: :create
+  validate :validate_no_reserved_category_names
   validate :validate_unique_category_names
   validate :validate_at_least_one_category
 
@@ -53,11 +53,11 @@ class Course::Assessment::Question::RubricBasedResponse < ApplicationRecord
   private
 
   def validate_no_reserved_category_names
-    return nil if categories.reject(&:marked_for_destruction?).map(&:name).none? do |name|
+    reserved_names_count = categories.reject(&:marked_for_destruction?).map(&:name).count do |name|
       RESERVED_CATEGORY_NAMES.include?(name.downcase)
     end
-
-    errors.add(:categories, :reserved_category_name)
+    expected_count = new_record? ? 0 : 1
+    errors.add(:categories, :reserved_category_name) if reserved_names_count > expected_count
   end
 
   def validate_unique_category_names

--- a/app/services/course/assessment/answer/rubric_llm_service.rb
+++ b/app/services/course/assessment/answer/rubric_llm_service.rb
@@ -43,7 +43,7 @@ class Course::Assessment::Answer::RubricLlmService
   # @param [Course::Assessment::Question::TextResponse] question The question containing rubric categories
   # @return [String] Formatted string representation of rubric categories and criteria
   def format_rubric_categories(question)
-    question.categories.map do |category|
+    question.categories.includes(:criterions).map do |category|
       criterions = category.criterions.map do |criterion|
         "- [Grade: #{criterion.grade}, Criterion ID: #{criterion.id}]: #{criterion.explanation}"
       end

--- a/app/views/course/assessment/answer/rubric_based_responses/_rubric_based_response.json.jbuilder
+++ b/app/views/course/assessment/answer/rubric_based_responses/_rubric_based_response.json.jbuilder
@@ -30,7 +30,7 @@ if attempt.submitted? && !attempt.auto_grading
   end
 end
 
-json.categoryGrades answer.selections do |selection|
+json.categoryGrades answer.selections.includes(:criterion).map do |selection|
   criterion = selection.criterion
 
   json.id selection.id

--- a/client/app/bundles/course/assessment/question/rubric-based-responses/utils.ts
+++ b/client/app/bundles/course/assessment/question/rubric-based-responses/utils.ts
@@ -12,6 +12,7 @@ export const updateMaximumGrade = (
   setValue: UseFormSetValue<RubricBasedResponseFormData>,
 ): void => {
   const maximumCategoryGrade = Math.max(
+    0,
     ...cats[categoryIndex].grades
       .filter((cat) => !cat.toBeDeleted)
       .map((cat) => Number(cat.grade)),
@@ -28,6 +29,20 @@ export const updateMaximumGrade = (
   setValue('question.maximumGrade', `${maximumGrade}`);
 };
 
+const markGradeForDeletion = (
+  categories: CategoryEntity[],
+  categoryIndex: number,
+  gradeIndex: number,
+): CategoryEntity[] => {
+  return produce(categories, (draft) => {
+    draft[categoryIndex].grades[gradeIndex].toBeDeleted =
+      !draft[categoryIndex].grades[gradeIndex].toBeDeleted;
+    draft[categoryIndex].toBeDeleted = draft[categoryIndex].grades.every(
+      (grade) => grade.toBeDeleted,
+    );
+  });
+};
+
 export const handleDeleteGrade = (
   categories: CategoryEntity[],
   categoryIndex: number,
@@ -40,10 +55,11 @@ export const handleDeleteGrade = (
   if (countGrades === 0) return;
 
   if (!categories[categoryIndex].grades[gradeIndex].draft) {
-    const updatedCategories = produce(categories, (draft) => {
-      draft[categoryIndex].grades[gradeIndex].toBeDeleted =
-        !draft[categoryIndex].grades[gradeIndex].toBeDeleted;
-    });
+    const updatedCategories = markGradeForDeletion(
+      categories,
+      categoryIndex,
+      gradeIndex,
+    );
     setValue('categories', updatedCategories);
 
     updateMaximumGrade(updatedCategories, categoryIndex, setValue);

--- a/client/app/bundles/course/assessment/submission/components/comment/CommentCard.jsx
+++ b/client/app/bundles/course/assessment/submission/components/comment/CommentCard.jsx
@@ -228,7 +228,6 @@ export default class CommentCard extends Component {
             }
             titleTypographyProps={{
               display: 'block',
-              marginRight: 20,
               fontSize: '1.5rem',
             }}
           />

--- a/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
@@ -14,6 +14,7 @@ import useTranslation from 'lib/hooks/useTranslation';
 
 import { saveGrade, updateGrade } from '../actions/answers';
 import { workflowStates } from '../constants';
+import ReevaluateButton from '../pages/SubmissionEditIndex/components/button/ReevaluateButton';
 import { computeExp } from '../reducers/grading';
 import { QuestionGradeData } from '../reducers/grading/types';
 import { getRubricCategoryGradesForAnswerId } from '../selectors/answers';
@@ -80,6 +81,7 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
   const attempting = workflowState === workflowStates.Attempting;
   const published = workflowState === workflowStates.Published;
 
+  const isProgrammingQuestion = question.type === QuestionType.Programming;
   const editable = !attempting && graderView;
 
   const isNotGradedAndNotPublished =
@@ -299,6 +301,10 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
             question={question as SubmissionQuestionData<'RubricBasedResponse'>}
             setIsFirstRendering={setIsFirstRendering}
           />
+        )}
+
+        {editable && (isProgrammingQuestion || isRubricBasedResponse) && (
+          <ReevaluateButton questionId={questionId} />
         )}
 
         <Paper

--- a/client/app/bundles/course/assessment/submission/containers/RubricExplanation.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricExplanation.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import { Chip, MenuItem, Select, Typography } from '@mui/material';
 import { AnswerRubricGradeData } from 'types/course/assessment/question/rubric-based-responses';
 import {
@@ -116,7 +116,7 @@ const RubricExplanation: FC<RubricExplanationProps> = (props) => {
   if (category.isBonusCategory) {
     return (
       <TextField
-        className="w-full h-20 text-wrap"
+        className="w-full"
         disabled={isAutograding}
         id={`category-${category.id}`}
         multiline
@@ -129,7 +129,7 @@ const RubricExplanation: FC<RubricExplanationProps> = (props) => {
 
   return (
     <Select
-      className="w-full h-20 text-wrap"
+      className="w-full h-20"
       disabled={isAutograding}
       id={`category-${category.id}`}
       onChange={handleOnChange}
@@ -137,21 +137,23 @@ const RubricExplanation: FC<RubricExplanationProps> = (props) => {
         // Display the selected grade explanation only, excluding the grade chip
         const selected = category.grades.find((g) => g.id === selectedId);
         return (
-          <Typography
-            className="text-wrap"
-            dangerouslySetInnerHTML={{ __html: selected?.explanation ?? '' }}
-            variant="body2"
-          />
+          <div className="h-20">
+            <Typography
+              className="line-clamp-1 break-all text-wrap"
+              dangerouslySetInnerHTML={{ __html: selected?.explanation ?? '' }}
+              variant="body2"
+            />
+          </div>
         );
       }}
       value={categoryGrades[category.id].gradeId}
       variant="outlined"
     >
       {category.grades.map((grade) => (
-        <MenuItem key={grade.id} value={grade.id}>
+        <MenuItem key={grade.id} className="h-auto" value={grade.id}>
           <div className="flex items-center justify-between w-full">
             <Typography
-              className="text-wrap"
+              className="break-all text-wrap"
               dangerouslySetInnerHTML={{ __html: grade.explanation }}
               variant="body2"
             />

--- a/client/app/bundles/course/assessment/submission/containers/RubricGrade.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricGrade.tsx
@@ -72,10 +72,9 @@ const RubricGrade: FC<RubricGradeProps> = (props) => {
   );
 
   const handleOnChange = (event, isBonusCategory: boolean): void => {
-    const selectedGrade = Number(event.target.value);
-    const bonusGrade = Number.isNaN(selectedGrade)
-      ? event.target.value
-      : selectedGrade;
+    const value = event.target.value;
+    const selectedGrade = value === '' ? value : Number(value);
+    const bonusGrade = Number.isNaN(selectedGrade) ? value : selectedGrade;
 
     const newCategoryGrades = {
       ...categoryGrades,
@@ -110,7 +109,7 @@ const RubricGrade: FC<RubricGradeProps> = (props) => {
   if (category.isBonusCategory) {
     return (
       <NumberTextField
-        className="w-full h-20 max-w-3xl"
+        className="w-full max-w-3xl"
         disabled={isAutograding}
         id={`category-${category.id}`}
         InputProps={{

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/QuestionContent.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/QuestionContent.tsx
@@ -18,7 +18,6 @@ import { useAppSelector } from 'lib/hooks/store';
 import SubmissionAnswer from '../../../components/answers';
 import { ErrorStruct } from '../validations/types';
 
-import ReevaluateButton from './button/ReevaluateButton';
 import AutogradedActionButtonsRow from './AutogradedActionButtonsRow';
 import AutogradingErrorPanel from './AutogradingErrorPanel';
 import ExplanationPanel from './ExplanationPanel';
@@ -55,8 +54,6 @@ const QuestionContent: FC<Props> = (props) => {
   const topic = topics[topicId];
   const submissionErrors = errors as unknown as ErrorStruct[];
 
-  const isRubricBasedResponseQuestion =
-    type === questionTypes.RubricBasedResponse;
   const isProgrammingQuestion = type === questionTypes.Programming;
 
   const allErrors = answerId
@@ -92,11 +89,6 @@ const QuestionContent: FC<Props> = (props) => {
       )}
       <AutogradingErrorPanel questionId={questionId} />
       {isProgrammingQuestion && <TestCaseView questionId={questionId} />}
-      {!attempting &&
-        graderView &&
-        (isProgrammingQuestion || isRubricBasedResponseQuestion) && (
-          <ReevaluateButton questionId={questionId} />
-        )}
       <QuestionGrade isSaving={isSaving} questionId={questionId} />
       <Comments topic={topic} />
     </>

--- a/client/app/bundles/course/discussion/topics/components/cards/CommentCard.tsx
+++ b/client/app/bundles/course/discussion/topics/components/cards/CommentCard.tsx
@@ -273,7 +273,6 @@ const CommentCard: FC<Props> = (props) => {
           title={renderAuthorName()}
           titleTypographyProps={{
             display: 'block',
-            marginright: 20,
             fontSize: '1.5rem',
           }}
         />

--- a/spec/controllers/course/assessment/question/rubric_based_responses_controller_spec.rb
+++ b/spec/controllers/course/assessment/question/rubric_based_responses_controller_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::RubricBasedResponsesController, type: :controller do
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:rubric_based_response_question) { nil }
+    let(:user) { create(:user) }
+    let(:course) { create(:course, creator: user) }
+    let(:assessment) { create(:assessment, course: course) }
+    let(:immutable_rubric_based_response_question) do
+      create(:course_assessment_question_rubric_based_response, assessment: assessment).tap do |question|
+        allow(question).to receive(:save).and_return(false)
+        allow(question).to receive(:destroy).and_return(false)
+      end
+    end
+
+    before do
+      controller_sign_in(controller, user)
+      return unless rubric_based_response_question
+
+      controller.instance_variable_set(:@rubric_based_response_question, rubric_based_response_question)
+    end
+
+    describe '#update' do
+      context 'when adding a new category' do
+        let!(:rubric_based_response_question) do
+          create(:course_assessment_question_rubric_based_response, assessment: assessment)
+        end
+        let!(:submission) do
+          create(:submission, assessment: assessment, creator: user)
+        end
+        let!(:answer) do
+          answer = rubric_based_response_question.attempt(submission)
+          answer.finalise!
+          answer.save!
+          answer
+        end
+
+        subject do
+          question_params = {
+            maximum_grade: rubric_based_response_question.maximum_grade + 1,
+            question_assessment: { skill_ids: [''] },
+            categories_attributes: {
+              '0' => {
+                name: 'New Category',
+                criterions_attributes: {
+                  '0' => {
+                    grade: 0,
+                    explanation: nil
+                  },
+                  '1' => {
+                    grade: 1,
+                    explanation: nil
+                  }
+                }
+              }
+            }
+          }
+          patch :update, params: {
+            course_id: course, assessment_id: assessment, id: rubric_based_response_question,
+            question_rubric_based_response: question_params
+          }
+        end
+
+        it 'creates new selections for existing answers' do
+          selection_count_before = Course::Assessment::Answer::RubricBasedResponseSelection.count
+          subject
+          selection_count_after = Course::Assessment::Answer::RubricBasedResponseSelection.count
+          expect(selection_count_after).to eq(selection_count_before + 1)
+
+          new_category = rubric_based_response_question.reload.categories.find_by(name: 'New Category')
+          new_selection = Course::Assessment::Answer::RubricBasedResponseSelection.find_by(
+            answer_id: answer.actable.id,
+            category_id: new_category.id
+          )
+          expect(new_selection).not_to be_nil
+        end
+
+        it 'updates the question with the new category' do
+          subject
+          expect(rubric_based_response_question.reload.categories.map(&:name)).to include('New Category')
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
+++ b/spec/controllers/course/assessment/submission/submissions_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Course::Assessment::Submission::SubmissionsController do
         it 'renders the total grade' do
           expect(subject).to have_http_status(:success)
           json_result = JSON.parse(response.body)
-          expect(json_result['submission']['maximumGrade']).to eq(14)
+          expect(json_result['submission']['maximumGrade']).to eq(20)
         end
       end
 

--- a/spec/factories/course_assessment_question_rubric_based_response.rb
+++ b/spec/factories/course_assessment_question_rubric_based_response.rb
@@ -22,6 +22,8 @@ FactoryBot.define do
         end
         question.categories << category
       end
+      # override the maximum grade in :course_assessment_question
+      question.maximum_grade = evaluator.category_count * evaluator.criterion_count * 2
     end
   end
 end

--- a/spec/models/course/assessment/question/rubric_based_response_spec.rb
+++ b/spec/models/course/assessment/question/rubric_based_response_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Assessment::Question::RubricBasedResponse, type: :model do
+  it { is_expected.to act_as(Course::Assessment::Question) }
+
+  it 'has many categories' do
+    expect(subject).to have_many(:categories).
+      class_name(Course::Assessment::Question::RubricBasedResponseCategory.name).
+      dependent(:destroy)
+  end
+
+  it { is_expected.to accept_nested_attributes_for(:categories) }
+
+  let(:instance) { Instance.default }
+  with_tenant(:instance) do
+    describe '#auto_gradable?' do
+      subject { create(:course_assessment_question_rubric_based_response) }
+      it 'returns true' do
+        expect(subject.auto_gradable?).to be(true)
+      end
+    end
+  end
+
+  describe 'validations' do
+    describe '#validate_at_least_one_category' do
+      subject { build(:course_assessment_question_rubric_based_response) }
+
+      it 'is valid when there is at least one category' do
+        expect(subject).to be_valid
+      end
+
+      it 'is invalid when there are no categories' do
+        subject.categories.clear
+        expect(subject).not_to be_valid
+        expect(subject.errors[:categories]).to include(/at_least_one_category/)
+      end
+    end
+
+    describe '#validate_unique_category_names' do
+      subject { build(:course_assessment_question_rubric_based_response) }
+
+      it 'is valid when category names are unique' do
+        expect(subject).to be_valid
+      end
+
+      it 'is invalid when there are duplicate category names' do
+        subject.categories.build(name: subject.categories.first.name)
+        expect(subject).not_to be_valid
+        expect(subject.errors[:categories]).to include(/duplicate_category_names/)
+      end
+    end
+
+    describe '#validate_no_reserved_category_names' do
+      subject { build(:course_assessment_question_rubric_based_response) }
+
+      it 'is valid when no category has a reserved name' do
+        expect(subject).to be_valid
+      end
+
+      it 'is invalid when a category has a reserved name on creation' do
+        subject.categories.build(
+          name: Course::Assessment::Question::RubricBasedResponse::RESERVED_CATEGORY_NAMES.first,
+          is_bonus_category: true
+        )
+        expect(subject).not_to be_valid
+        expect(subject.errors[:categories]).to include(/reserved_category_name/)
+      end
+
+      it 'is valid when a category has a reserved name on update' do
+        subject.save!
+        subject.categories.build(
+          name: Course::Assessment::Question::RubricBasedResponse::RESERVED_CATEGORY_NAMES.first,
+          is_bonus_category: true
+        )
+        expect(subject).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
# BE Changes:

- Clamp total grade to valid range before saving during autograding (unbound existing moderation grade can cause total grade to exceed maximum grade)
- Add preloading to prevent N+1 queries
- Prevent users from adding reserved category names through editting the question
- Add new entries into `course_assessment_answer_rubric_based_response_selections` when new question categories are created through editting the question
- Update docstrings in `rubric_auto_grading_service.rb`

# FE Changes:

- Mark a category to be deleted when all its criterions are to be deleted (previously users cannot delete a category when all its criterions are deleted)
- Make moderation grade box to be blankable (previously it was always stuck at 0 which prevented users from typing negative sign initially)
- Remove unused `marginright` prop (typo) in `CommentCard`. It should have been `marginRight`, but fixing the typo will cause too much margin (so it wasn't used before so I erased it)
- Move the 'Re-evaluate Answer" button to be below the Rubric Panel
- Handle text overflow in Rubric Panel Explanation (previously it overflowed out of the container)

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/410e380a-2481-4830-bcd0-726402b0da83" />
