### PR TITLE
Stabilize / improve codecov coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,20 +227,19 @@ commands:
       - run:
           name: Wait for Rails coverage results
           no_output_timeout: 5m
-          command: until [ -f coverage/coverage.xml ]; do sleep 1; done
+          command: until [ -f coverage/coursemology.lcov ]; do sleep 1; done
 
-  upload_coverage_report:
+  persist_coverage_reports:
     steps:
       - run:
           name: Assign unique coverage filename
           command: |
-            mv coverage/coverage.xml coverage/cov-<< parameters.prefix >>-${CIRCLE_NODE_INDEX}.xml
-            stat coverage/cov-<< parameters.prefix >>-${CIRCLE_NODE_INDEX}.xml
+            mv coverage/coursemology.lcov coverage/cov-<< parameters.prefix >>-${CIRCLE_NODE_INDEX}.lcov
 
-      - codecov/upload:
-          upload_name: << parameters.prefix >>-${CIRCLE_NODE_INDEX}
-          files: coverage/cov-<< parameters.prefix >>-${CIRCLE_NODE_INDEX}.xml
-          flags: backend
+      - persist_to_workspace:
+          root: coverage
+          paths:
+            - cov-*.lcov
 
     parameters:
       prefix:
@@ -319,24 +318,23 @@ jobs:
           command: yarn coverage
 
       - terminate_rails_and_wait_for_coverage_results
-      - upload_coverage_report:
+      - persist_coverage_reports:
           prefix: playwright-rails
-
-      - run:
-          name: Zip test results
-          when: always
-          working_directory: tests
-          command: |
-            zip -r test-results.zip test-results playwright-report
 
       - store_test_results:
           path: ~/repo/tests/results.xml
 
-      - store_artifacts:
-          path: ~/repo/tests/results.xml
+      - run:
+          name: Assign unique test results filename
+          when: always
+          working_directory: tests
+          command: |
+            mv test-results test-results-${CIRCLE_NODE_INDEX}
 
-      - store_artifacts:
-          path: ~/repo/tests/test-results.zip
+      - persist_to_workspace:
+          root: tests
+          paths:
+            - test-results-*
 
   test_rspec:
     executor:
@@ -363,11 +361,41 @@ jobs:
             mkdir ~/rspec
             circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml" --verbose --split-by=timings
 
-      - upload_coverage_report:
+      - persist_coverage_reports:
           prefix: rspec-rails
 
       - store_test_results:
           path: ~/rspec
+
+  process_test_results:
+    docker:
+      - image: cimg/base:2025.06
+    steps:
+      # Need the source code to be present in the workspace for codecov to accept the report
+      - checkout
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: Combine all lcov reports
+          command: |
+            sudo apt-get update
+            sudo apt-get install lcov
+            lcov $(printf -- '--add-tracefile %s ' workspace/cov-*.lcov) --output-file workspace/coverage-combined.lcov --branch-coverage --ignore-errors inconsistent
+
+      - codecov/upload:
+          upload_name: coverage-combined
+          disable_search: true
+          files: workspace/coverage-combined.lcov
+          flags: backend
+
+      - run:
+          name: Zip all test results
+          command: |
+            zip -r test-results.zip workspace/*
+
+      - store_artifacts:
+          path: test-results.zip
 
   factorybot_lint:
     executor: ruby_with_postgres
@@ -475,3 +503,7 @@ workflows:
       - test_playwright:
           requires:
             - build_client
+      - process_test_results:
+          requires:
+            - test_rspec
+            - test_playwright

--- a/Gemfile
+++ b/Gemfile
@@ -130,9 +130,9 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
 
-  # Code Coverage reporters
+  # Code coverage reporter and formatter
   gem 'simplecov'
-  gem 'simplecov-cobertura'
+  gem 'simplecov-lcov', '>= 0.8.0'
 
   gem 'dotenv-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -622,10 +622,8 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-cobertura (2.1.0)
-      rexml
-      simplecov (~> 0.19)
     simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     slim (5.2.1)
       temple (~> 0.10.0)
@@ -773,7 +771,7 @@ DEPENDENCIES
   sidekiq
   sidekiq-cron
   simplecov
-  simplecov-cobertura
+  simplecov-lcov (>= 0.8.0)
   slim-rails
   spring
   stackprof

--- a/config/initializers/coverage.rb
+++ b/config/initializers/coverage.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 if Rails.env.test? && ENV['COLLECT_COVERAGE'] == 'true'
   require 'simplecov'
-  require 'simplecov-cobertura'
+  require 'simplecov-lcov'
 
-  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+  SimpleCov::Formatter::LcovFormatter.config do |c|
+    c.report_with_single_file = true
+    c.single_report_path = 'coverage/coursemology.lcov'
+  end
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 
   SimpleCov.start('rails') do
+    enable_coverage :branch
     add_filter '/lib/extensions/legacy/active_record/connection_adapters/table_definition.rb'
     add_filter '/lib/tasks/coursemology/stats_setup.rake'
     add_filter '/lib/tasks/coursemology/seed.rake'


### PR DESCRIPTION
## Summary

Our reported test coverage on Codecov has been unstable and consistently underreporting since [this commit](https://app.codecov.io/github/Coursemology/coursemology2/commit/8b14293098fca1feed0067646fbd26c9e5030a0e). After investigation, we identified the root cause: incorrect merging of Cobertura coverage reports. The issue is resolved by migrating to LCOV format and merging coverage reports within CircleCI before uploading to Codecov.

#### Other Changes

This PR also enables branch coverage tracking. This slightly lowers the reported coverage percentage (since partially covered branches are now visible), but provides a more accurate picture of test coverage.

### Results

- **Line coverage only:** [87%](https://app.codecov.io/github/Coursemology/coursemology2/commit/afe208c0f1d5d6037ce199a7c64490d05ffdac0f) (consistent with pre-issue values)
- **Line + branch coverage:** [84%](https://app.codecov.io/github/Coursemology/coursemology2/commit/3e706ccddb06d4a822126f3afa2b1b44ff809884)

## Background and Investigation

We migrated to the [Codecov uploader orb](https://circleci.com/developer/orbs/orb/codecov/codecov) in [this commit](https://github.com/Coursemology/coursemology2/commit/8803520b7801678321810efac8ae5dbee96cc428), replacing the [codecov gem](https://github.com/codecov/codecov-ruby) (deprecated since February 1, 2022). This required switching from RSpec’s built-in JSON coverage format to a supported format. We initially chose `simplecov-cobertura` based on the [migration guide](https://docs.codecov.com/docs/deprecated-uploader-migration-guide).

Our CircleCI tests run with parallelism (30 executors for RSpec, 10 for playwright). This is *not* the same as the `parallel_tests` gem, each executor is given its own environment running a subset of the tests. This means each executor produces a separate coverage report, and all 40 reports are uploaded to Codecov separately. Codecov’s default behavior incorrectly merges these reports by averaging coverage across reports instead of performing a union (where a line is covered if any shard covers it).

To determine the "correct" coverage value, tests were ran locally using `parallel_tests`, disabling playwright and tests in `spec/features/*` (see Notes section below) consistently reported \~81% coverage. When the tests were ran on CI (with the same skipped tests disabled), we found:
- each individual report reported an overall line coverage around 40-50%,
- the line coverage (both overall and per-file) displayed on Codecov UI aligned with the average of the reports,
- when the reports were manually combined using a custom script, the result had similar line coverage values to the local test runs.

## Resolution

We explored existing Cobertura merging tools like `cobertura-merge`, but they all produced incorrect results.

Switching to LCOV solved the issue:

- LCOV is supported by Codecov.
- While the default Codecov merge behavior is still incorrect,
LCOV’s native tooling (`lcov --add-tracefile`) correctly performs union merges out-of-the-box.

Therefore we can merge the reports ourselves in CircleCI before uploading the singular combined report to Codecov.

We also updated the pipeline to collect all coverage reports into a single CircleCI artifact for easier debugging. This should be kept for future investigations.

## Notes

### Current State of Parallel Tests

`parallel_tests` works with our RSpec tests, except the ones with frontend integration (in `spec/features/*`). This is because each test thread uses a separate database, but we cannot route frontend requests to the correct test thread.

To set up for parallel local runs:

```bash
RAILS_ENV=test bundle exec rake parallel:setup
```

Example run:

```bash
RAILS_ENV=test PARALLEL_TEST_PROCESSORS=10 COLLECT_COVERAGE=true bundle exec rake "parallel:spec[^spec/\(?\!f\)]"
```

### Locally Flaky Tests

Some tests are flaky locally (but stable on CI), especially those involving mailers. One specific suite was addressed in this PR, but mailer-related specs like this one are a recurring issue:

```ruby
subject # calls deliver_later

expect(ActionMailer::Base.deliveries.count).to eq(1)
```

Our `deliver_later` override in [spec/support/active_job.rb](https://github.com/Coursemology/coursemology2/blob/master/spec/support/active_job.rb) causes `deliver_now` to sometimes execute concurrently, occasionally incrementing the mail count twice.

The proper fix is to remove this override and instead use:

```ruby
ActiveJob::Base.queue_adapter.wait_for_jobs
```

This change would affect many tests and should be addressed in a future PR.

