### PR TITLE
fix(studentView): Standardize grader's student view to match actual student experience

### DIFF
--- a/app/views/course/assessment/answer/rubric_based_responses/_rubric_based_response.json.jbuilder
+++ b/app/views/course/assessment/answer/rubric_based_responses/_rubric_based_response.json.jbuilder
@@ -30,23 +30,27 @@ if attempt.submitted? && !attempt.auto_grading
   end
 end
 
-json.categoryGrades answer.selections.includes(:criterion).map do |selection|
-  criterion = selection.criterion
+if can_grade || (@assessment.show_rubric_to_students? && @submission.published?)
+  json.categoryGrades answer.selections.includes(:criterion).map do |selection|
+    criterion = selection.criterion
 
-  json.id selection.id
-  json.gradeId criterion&.id
-  json.categoryId selection.category_id
-  json.grade criterion ? criterion.grade : selection.grade
-  json.explanation criterion ? nil : selection.explanation
+    json.id selection.id
+    json.gradeId criterion&.id
+    json.categoryId selection.category_id
+    json.grade criterion ? criterion.grade : selection.grade
+    json.explanation criterion ? nil : selection.explanation
+  end
 end
 
-posts = answer.submission.submission_questions.find_by(question_id: answer.question_id)&.discussion_topic&.posts
-ai_generated_comment = posts&.select do |post|
-  post.is_ai_generated && post.workflow_state == 'draft'
-end&.last
-if ai_generated_comment
-  json.aiGeneratedComment do
-    json.partial! ai_generated_comment
+if can_grade
+  posts = answer.submission.submission_questions.find_by(question_id: answer.question_id)&.discussion_topic&.posts
+  ai_generated_comment = posts&.select do |post|
+    post.is_ai_generated && post.workflow_state == 'draft'
+  end&.last
+  if ai_generated_comment
+    json.aiGeneratedComment do
+      json.partial! ai_generated_comment
+    end
   end
 end
 

--- a/app/views/course/assessment/question/rubric_based_responses/_rubric_based_response.json.jbuilder
+++ b/app/views/course/assessment/question/rubric_based_responses/_rubric_based_response.json.jbuilder
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
-json.aiGradingEnabled question.ai_grading_enabled?
-json.categories question.categories.each do |category|
-  json.id category.id
-  json.name category.name
-  json.maximumGrade category.criterions.map(&:grade).compact.max
-  json.isBonusCategory category.is_bonus_category
+json.aiGradingEnabled question.ai_grading_enabled? if can_grade
+if can_grade || (@assessment.show_rubric_to_students? && answer.submission.published?)
+  json.categories question.categories.each do |category|
+    json.id category.id
+    json.name category.name
+    json.maximumGrade category.criterions.map(&:grade).compact.max
+    json.isBonusCategory category.is_bonus_category
 
-  json.grades category.criterions.each do |criterion|
-    json.id criterion.id
-    json.grade criterion.grade
-    json.explanation format_ckeditor_rich_text(criterion.explanation)
+    json.grades category.criterions.each do |criterion|
+      json.id criterion.id
+      json.grade criterion.grade
+      json.explanation format_ckeditor_rich_text(criterion.explanation)
+    end
   end
+else
+  json.categories []
 end

--- a/app/views/course/assessment/submission/answer/answers/show.json.jbuilder
+++ b/app/views/course/assessment/submission/answer/answers/show.json.jbuilder
@@ -15,9 +15,9 @@ json.question do
   json.description format_ckeditor_rich_text(question.description)
   json.type question.question_type
 
-  json.partial! question, question: question.specific, can_grade: false, answer: @answer
+  json.partial! question, question: question.specific, can_grade: can_grade, answer: @answer
 end
-json.partial! specific_answer, answer: specific_answer, can_grade: false
+json.partial! specific_answer, answer: specific_answer, can_grade: can_grade
 
 if can_grade || @answer.submission.published?
   json.grading do
@@ -25,6 +25,7 @@ if can_grade || @answer.submission.published?
   end
 end
 
+# hide unpublished annotations in answer details
 if @answer.actable_type == Course::Assessment::Answer::Programming.name
   files = @answer.specific.files
   json.partial! 'course/assessment/answer/programming/annotations', programming_files: files,

--- a/client/app/bundles/course/assessment/submission/components/AnswerDetails/ProgrammingComponent/TestCases.tsx
+++ b/client/app/bundles/course/assessment/submission/components/AnswerDetails/ProgrammingComponent/TestCases.tsx
@@ -86,8 +86,9 @@ const TestCaseComponent: FC<TestCaseComponentProps> = (props) => {
   const { testCaseResults, testCaseType } = props;
   const { t } = useTranslation();
 
+  // result.output might be undefined for private and evaluation test cases for students
   const isProgrammingAnswerEvaluated =
-    testCaseResults.filter((result) => !!result.output).length > 0;
+    testCaseResults.filter((result) => result.passed !== undefined).length > 0;
 
   const numPassedTestCases = testCaseResults.filter(
     (result) => result.passed,

--- a/client/app/bundles/course/assessment/submission/components/AnswerDetails/RubricBasedResponseDetails.tsx
+++ b/client/app/bundles/course/assessment/submission/components/AnswerDetails/RubricBasedResponseDetails.tsx
@@ -18,6 +18,7 @@ const RubricBasedResponseDetails = (
         answerCategoryGrades={answer.categoryGrades}
         answerId={answer.id}
         question={question}
+        readOnly
         setIsFirstRendering={() => {}} // Placeholder function since RubricPanel is not editable here
       />
     </>

--- a/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/ReadOnlyEditor/index.jsx
@@ -56,6 +56,17 @@ class ReadOnlyEditor extends Component {
 
       this.setState({ expanded: newExpanded });
     }
+
+    // Update editor mode when annotations length changes
+    if (prevProps.annotations.length !== this.props.annotations.length) {
+      const newEditorMode =
+        this.props.annotations.length > 0
+          ? EDITOR_MODE_WIDE
+          : EDITOR_MODE_NARROW;
+      if (this.state.editorMode !== newEditorMode) {
+        this.setState({ editorMode: newEditorMode });
+      }
+    }
   }
 
   setAllCommentStateCollapsed() {

--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleChoice/index.jsx
@@ -12,6 +12,7 @@ const MultipleChoiceOptions = ({
   readOnly,
   showMcqMrqSolution,
   graderView,
+  published,
   question,
   field: { onChange, value },
 }) => (
@@ -27,7 +28,9 @@ const MultipleChoiceOptions = ({
             <Typography
               dangerouslySetInnerHTML={{ __html: option.option.trim() }}
               style={
-                option.correct && readOnly && (showMcqMrqSolution || graderView)
+                option.correct &&
+                readOnly &&
+                (graderView || (published && showMcqMrqSolution))
                   ? {
                       backgroundColor: green[50],
                       verticalAlign: 'middle',
@@ -51,6 +54,7 @@ MultipleChoiceOptions.propTypes = {
   readOnly: PropTypes.bool,
   showMcqMrqSolution: PropTypes.bool,
   graderView: PropTypes.bool,
+  published: PropTypes.bool,
   field: PropTypes.shape({
     onChange: PropTypes.func,
     value: PropTypes.arrayOf(PropTypes.number),
@@ -62,8 +66,8 @@ const MemoMultipleChoiceOptions = memo(
   (prevProps, nextProps) => {
     const { id: prevId } = prevProps.question;
     const { id: nextId } = nextProps.question;
-    const { graderView: prevGraderView } = prevProps.graderView;
-    const { graderView: nextGraderView } = nextProps.graderView;
+    const prevGraderView = prevProps.graderView;
+    const nextGraderView = nextProps.graderView;
     const isQuestionIdUnchanged = prevId === nextId;
     const isGraderViewUnchanged = prevGraderView === nextGraderView;
     return (
@@ -78,6 +82,7 @@ const MultipleChoice = (props) => {
   const {
     answerId,
     graderView,
+    published,
     question,
     readOnly,
     saveAnswerAndUpdateClientVersion,
@@ -99,7 +104,7 @@ const MultipleChoice = (props) => {
             },
           }}
           fieldState={fieldState}
-          {...{ question, readOnly, showMcqMrqSolution, graderView }}
+          {...{ question, readOnly, showMcqMrqSolution, graderView, published }}
         />
       )}
     />
@@ -109,6 +114,7 @@ const MultipleChoice = (props) => {
 MultipleChoice.propTypes = {
   answerId: PropTypes.number.isRequired,
   graderView: PropTypes.bool.isRequired,
+  published: PropTypes.bool.isRequired,
   question: questionShape.isRequired,
   readOnly: PropTypes.bool.isRequired,
   saveAnswerAndUpdateClientVersion: PropTypes.func.isRequired,

--- a/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse/index.jsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/MultipleResponse/index.jsx
@@ -12,6 +12,7 @@ const MultipleResponseOptions = ({
   readOnly,
   showMcqMrqSolution,
   graderView,
+  published,
   question,
   field: { onChange, value },
 }) => (
@@ -27,7 +28,9 @@ const MultipleResponseOptions = ({
             <Typography
               dangerouslySetInnerHTML={{ __html: option.option.trim() }}
               style={
-                option.correct && readOnly && (showMcqMrqSolution || graderView)
+                option.correct &&
+                readOnly &&
+                (graderView || (published && showMcqMrqSolution))
                   ? {
                       backgroundColor: green[50],
                       verticalAlign: 'middle',
@@ -62,6 +65,7 @@ MultipleResponseOptions.propTypes = {
   readOnly: PropTypes.bool,
   showMcqMrqSolution: PropTypes.bool,
   graderView: PropTypes.bool,
+  published: PropTypes.bool,
   field: PropTypes.shape({
     onChange: PropTypes.func,
     value: PropTypes.arrayOf(PropTypes.number),
@@ -77,8 +81,8 @@ const MemoMultipleResponseOptions = memo(
   (prevProps, nextProps) => {
     const { id: prevId } = prevProps.question;
     const { id: nextId } = nextProps.question;
-    const { graderView: prevGraderView } = prevProps.graderView;
-    const { graderView: nextGraderView } = nextProps.graderView;
+    const prevGraderView = prevProps.graderView;
+    const nextGraderView = nextProps.graderView;
     const isQuestionIdUnchanged = prevId === nextId;
     const isGraderViewUnchanged = prevGraderView === nextGraderView;
     return (
@@ -93,6 +97,7 @@ const MultipleResponse = (props) => {
   const {
     answerId,
     graderView,
+    published,
     question,
     readOnly,
     saveAnswerAndUpdateClientVersion,
@@ -114,7 +119,7 @@ const MultipleResponse = (props) => {
             },
           }}
           fieldState={fieldState}
-          {...{ question, readOnly, showMcqMrqSolution, graderView }}
+          {...{ question, readOnly, showMcqMrqSolution, graderView, published }}
         />
       )}
     />
@@ -124,6 +129,7 @@ const MultipleResponse = (props) => {
 MultipleResponse.propTypes = {
   answerId: PropTypes.number.isRequired,
   graderView: PropTypes.bool.isRequired,
+  published: PropTypes.bool.isRequired,
   question: questionShape.isRequired,
   readOnly: PropTypes.bool.isRequired,
   saveAnswerAndUpdateClientVersion: PropTypes.func.isRequired,

--- a/client/app/bundles/course/assessment/submission/components/answers/adapters/MultipleChoiceAdapter.tsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/adapters/MultipleChoiceAdapter.tsx
@@ -7,6 +7,7 @@ const MultipleChoiceAdapter = (props: McqAnswerProps): JSX.Element => {
     answerId,
     readOnly,
     graderView,
+    published,
     showMcqMrqSolution,
     saveAnswerAndUpdateClientVersion,
   } = props;
@@ -15,6 +16,7 @@ const MultipleChoiceAdapter = (props: McqAnswerProps): JSX.Element => {
       key={`question_${question.id}`}
       answerId={answerId!}
       graderView={graderView}
+      published={published}
       question={question}
       readOnly={readOnly}
       saveAnswerAndUpdateClientVersion={saveAnswerAndUpdateClientVersion}

--- a/client/app/bundles/course/assessment/submission/components/answers/adapters/MultipleResponseAdapter.tsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/adapters/MultipleResponseAdapter.tsx
@@ -7,6 +7,7 @@ const MultipleResponseAdapter = (props: MrqAnswerProps): JSX.Element => {
     answerId,
     readOnly,
     graderView,
+    published,
     showMcqMrqSolution,
     saveAnswerAndUpdateClientVersion,
   } = props;
@@ -15,6 +16,7 @@ const MultipleResponseAdapter = (props: MrqAnswerProps): JSX.Element => {
       key={`question_${question.id}`}
       answerId={answerId!}
       graderView={graderView}
+      published={published}
       question={question}
       readOnly={readOnly}
       saveAnswerAndUpdateClientVersion={saveAnswerAndUpdateClientVersion}

--- a/client/app/bundles/course/assessment/submission/components/answers/index.tsx
+++ b/client/app/bundles/course/assessment/submission/components/answers/index.tsx
@@ -28,6 +28,7 @@ import translations from '../../translations';
 interface SubmissionAnswerProps<T extends keyof typeof QuestionType> {
   answerId: number | null;
   graderView: boolean;
+  published: boolean;
   allErrors: ErrorType[];
   question: SubmissionQuestionData<T>;
   questionType: T;
@@ -57,6 +58,7 @@ const SubmissionAnswer = <T extends keyof typeof QuestionType>(
     answerId,
     allErrors,
     graderView,
+    published,
     question,
     questionType,
     readOnly,
@@ -117,6 +119,7 @@ const SubmissionAnswer = <T extends keyof typeof QuestionType>(
       saveAnswerAndUpdateClientVersion,
       graderView,
       showMcqMrqSolution,
+      published,
     },
     MultipleResponse: {
       answerId,
@@ -125,6 +128,7 @@ const SubmissionAnswer = <T extends keyof typeof QuestionType>(
       saveAnswerAndUpdateClientVersion,
       graderView,
       showMcqMrqSolution,
+      published,
     },
     Programming: {
       answerId,

--- a/client/app/bundles/course/assessment/submission/components/answers/types.ts
+++ b/client/app/bundles/course/assessment/submission/components/answers/types.ts
@@ -17,11 +17,13 @@ export interface ScribingAnswerProps
 export interface McqAnswerProps extends AnswerCommonProps<'MultipleChoice'> {
   showMcqMrqSolution: boolean;
   graderView: boolean;
+  published: boolean;
 }
 
 export interface MrqAnswerProps extends AnswerCommonProps<'MultipleResponse'> {
   showMcqMrqSolution: boolean;
   graderView: boolean;
+  published: boolean;
 }
 
 export interface ProgrammingAnswerProps

--- a/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
@@ -92,7 +92,7 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
     question.type === QuestionType.RubricBasedResponse;
   const isRubricVisible =
     isRubricBasedResponse &&
-    (!submission.isStudent || assessment.showRubricToStudents);
+    (graderView || (published && assessment.showRubricToStudents));
   const isRubricBasedResponseAndAutogradable =
     isRubricBasedResponse &&
     (question as SubmissionQuestionData<QuestionType.RubricBasedResponse>)

--- a/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/ReadOnlyEditor.jsx
@@ -5,9 +5,11 @@ import { Warning } from '@mui/icons-material';
 import { Paper, Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 
+import { POST_WORKFLOW_STATE } from 'lib/constants/sharedConstants';
+
 import ProgrammingFileDownloadChip from '../components/answers/Programming/ProgrammingFileDownloadChip';
 import ReadOnlyEditorComponent from '../components/ReadOnlyEditor';
-import { fileShape, topicShape } from '../propTypes';
+import { fileShape, postShape, topicShape } from '../propTypes';
 
 const translations = defineMessages({
   sizeTooBig: {
@@ -18,16 +20,39 @@ const translations = defineMessages({
 
 class ReadOnlyEditorContainer extends Component {
   shouldComponentUpdate(nextProps) {
-    return nextProps.annotations !== this.props.annotations;
+    return (
+      nextProps.annotations !== this.props.annotations ||
+      nextProps.posts !== this.props.posts ||
+      nextProps.graderView !== this.props.graderView
+    );
   }
 
   render() {
-    const { answerId, file, annotations } = this.props;
+    const { answerId, file, annotations, posts, graderView } = this.props;
 
     if (file.highlightedContent !== null) {
+      const filteredAnnotations = graderView
+        ? Object.values(annotations)
+        : // Students should only see published posts
+          Object.values(annotations)
+            .map((annotation) => {
+              const publishedPostIds =
+                annotation.postIds.filter(
+                  (postId) =>
+                    posts[postId]?.workflowState ===
+                    POST_WORKFLOW_STATE.published,
+                ) || [];
+
+              return {
+                ...annotation,
+                postIds: publishedPostIds,
+              };
+            })
+            .filter((annotation) => annotation.postIds.length > 0);
+
       return (
         <ReadOnlyEditorComponent
-          annotations={Object.values(annotations)}
+          annotations={filteredAnnotations}
           answerId={answerId}
           file={file}
           isUpdatingAnnotationAllowed
@@ -51,8 +76,10 @@ class ReadOnlyEditorContainer extends Component {
 
 ReadOnlyEditorContainer.propTypes = {
   annotations: PropTypes.objectOf(topicShape),
+  posts: PropTypes.objectOf(postShape),
   answerId: PropTypes.number.isRequired,
   file: fileShape.isRequired,
+  graderView: PropTypes.bool.isRequired,
 };
 
 function mapStateToProps({ assessments: { submission } }, ownProps) {
@@ -60,6 +87,8 @@ function mapStateToProps({ assessments: { submission } }, ownProps) {
 
   return {
     annotations: submission.annotations[file.id].topics,
+    posts: submission.posts,
+    graderView: submission.submission.graderView,
   };
 }
 

--- a/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
@@ -35,7 +35,7 @@ const RubricPanel: FC<RubricPanelProps> = (props) => {
   } = props;
 
   const categoryGrades = useMemo(() => {
-    const categoryGradeHash = answerCategoryGrades.reduce(
+    const categoryGradeHash = (answerCategoryGrades ?? []).reduce(
       (obj, category) => ({
         ...obj,
         [category.categoryId]: {

--- a/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
@@ -21,12 +21,18 @@ interface RubricPanelProps {
   answerCategoryGrades: AnswerDetailsMap['RubricBasedResponse']['categoryGrades'];
   question: SubmissionQuestionData<'RubricBasedResponse'>;
   setIsFirstRendering: (isFirstRendering: boolean) => void;
+  readOnly?: boolean;
 }
 
 const RubricPanel: FC<RubricPanelProps> = (props) => {
   const { t } = useTranslation();
-  const { answerId, answerCategoryGrades, question, setIsFirstRendering } =
-    props;
+  const {
+    answerId,
+    answerCategoryGrades,
+    question,
+    setIsFirstRendering,
+    readOnly,
+  } = props;
 
   const categoryGrades = useMemo(() => {
     const categoryGradeHash = answerCategoryGrades.reduce(
@@ -89,6 +95,7 @@ const RubricPanel: FC<RubricPanelProps> = (props) => {
               category={category}
               categoryGrades={categoryGrades}
               question={question}
+              readOnly={readOnly}
               setIsFirstRendering={setIsFirstRendering}
             />
           ))}

--- a/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricPanel.tsx
@@ -48,7 +48,7 @@ const RubricPanel: FC<RubricPanelProps> = (props) => {
       {},
     );
 
-    return question.categories.reduce(
+    return (question.categories ?? []).reduce(
       (obj, category) => ({
         ...obj,
         [category.id]: {
@@ -88,7 +88,7 @@ const RubricPanel: FC<RubricPanelProps> = (props) => {
         </TableHead>
 
         <TableBody>
-          {question?.categories.map((category) => (
+          {(question?.categories ?? []).map((category) => (
             <RubricPanelRow
               key={category.id}
               answerId={answerId}

--- a/client/app/bundles/course/assessment/submission/containers/RubricPanelRow.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/RubricPanelRow.tsx
@@ -31,6 +31,7 @@ interface RubricPanelRowProps {
   category: RubricBasedResponseCategoryQuestionData;
   categoryGrades: Record<number, AnswerRubricGradeData>;
   setIsFirstRendering: (isFirstRendering: boolean) => void;
+  readOnly?: boolean;
 }
 
 function buildCategoryGradeExplanationMap(
@@ -144,7 +145,13 @@ const MaxGradeCell: FC<{ maxGrade?: number }> = ({ maxGrade }) => (
 );
 
 const RubricPanelRow: FC<RubricPanelRowProps> = (props) => {
-  const { answerId, question, category, categoryGrades } = props;
+  const {
+    answerId,
+    question,
+    category,
+    categoryGrades,
+    readOnly = false,
+  } = props;
 
   const dispatch = useAppDispatch();
   const submission = useAppSelector(getSubmission);
@@ -158,7 +165,7 @@ const RubricPanelRow: FC<RubricPanelRowProps> = (props) => {
 
   const attempting = workflowState === workflowStates.Attempting;
   const published = workflowState === workflowStates.Published;
-  const editable = !attempting && graderView;
+  const editable = !attempting && graderView && !readOnly;
 
   const bonusAwarded =
     new Date(submittedAt) < new Date(bonusEndAt) ? bonusPoints : 0;

--- a/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/TestCaseView/index.jsx
@@ -126,9 +126,10 @@ export class VisibleTestCaseView extends Component {
     );
   }
 
-  renderTestCaseRow(testCase) {
+  renderTestCaseRow(testCase, testCaseType) {
     const {
       testCases: { canReadTests },
+      graderView,
     } = this.props;
     const { showPublicTestCasesOutput } = this.props;
 
@@ -175,7 +176,9 @@ export class VisibleTestCaseView extends Component {
             <ExpandableCode>{testCase.expected || ''}</ExpandableCode>
           </TableCell>
 
-          {(canReadTests || showPublicTestCasesOutput) && (
+          {((graderView && canReadTests) ||
+            (showPublicTestCasesOutput &&
+              testCaseType === 'publicTestCases')) && (
             <TableCell className="w-full pt-1">
               <ExpandableCode>{testCase.output || ''}</ExpandableCode>
             </TableCell>
@@ -199,8 +202,9 @@ export class VisibleTestCaseView extends Component {
       return null;
     }
 
+    // testCase.output might be undefined for private and evaluation test cases for students
     const isProgrammingAnswerEvaluated =
-      testCases.filter((testCase) => !!testCase.output).length > 0;
+      testCases.filter((testCase) => testCase.passed !== undefined).length > 0;
 
     const numPassedTestCases = testCases.filter(
       (testCase) => testCase.passed,
@@ -298,7 +302,9 @@ export class VisibleTestCaseView extends Component {
                 <FormattedMessage {...translations.expected} />
               </TableCell>
 
-              {((graderView && canReadTests) || showPublicTestCasesOutput) && (
+              {((graderView && canReadTests) ||
+                (showPublicTestCasesOutput &&
+                  testCaseType === 'publicTestCases')) && (
                 <TableCell className="w-full">
                   <FormattedMessage {...translations.output} />
                 </TableCell>
@@ -309,7 +315,9 @@ export class VisibleTestCaseView extends Component {
           </TableHead>
 
           <TableBody>
-            {testCases.map(this.renderTestCaseRow.bind(this))}
+            {testCases.map((testCase) =>
+              this.renderTestCaseRow(testCase, testCaseType),
+            )}
           </TableBody>
         </Table>
       </Accordion>

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/QuestionContent.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/components/QuestionContent.tsx
@@ -47,6 +47,7 @@ const QuestionContent: FC<Props> = (props) => {
   const { isSaving } = submissionFlags;
 
   const attempting = workflowState === workflowStates.Attempting;
+  const published = workflowState === workflowStates.Published;
 
   const questionId = questionIds[stepIndex];
   const question = questions[questionId];
@@ -71,6 +72,7 @@ const QuestionContent: FC<Props> = (props) => {
           questionType: question.type,
           submissionId: submission.id,
           graderView,
+          published,
           showMcqMrqSolution,
           openAnswerHistoryView,
           questionNumber: stepIndex + 1,

--- a/client/app/types/course/assessment/submission/answer/rubricBasedResponse.ts
+++ b/client/app/types/course/assessment/submission/answer/rubricBasedResponse.ts
@@ -25,7 +25,7 @@ export interface RubricBasedResponseAnswerData extends AnswerBaseData {
     path?: string;
   };
   latestAnswer?: RubricBasedResponseAnswerData;
-  categoryGrades: {
+  categoryGrades?: {
     id: number | null | undefined;
     categoryId: number;
     grade: number;

--- a/client/app/types/course/assessment/submission/question/types.ts
+++ b/client/app/types/course/assessment/submission/question/types.ts
@@ -78,7 +78,7 @@ export interface RubricBasedResponseCategoryQuestionData
 }
 
 interface RubricBasedResponseQuestionData {
-  aiGradingEnabled: boolean;
+  aiGradingEnabled?: boolean;
   categories: RubricBasedResponseCategoryQuestionData[];
 }
 


### PR DESCRIPTION
# Description

<img width="180" alt="image" src="https://github.com/user-attachments/assets/7adad4e2-f9bd-4928-bce1-75e226b799ad" />

Currently, the student's view feature for graders do not accurately represent what the student is actually seeing at the same time. What students actually see is due to what data is returned from back end, while what graders' student view see is due to the conditional check in the front end (through the `graderView` state) 

# Changes made

- Make rubric panel to be not editable in answer details view.
- Add missing access control for rubric-based response view, preventing category grades from being sent to students from API responses.
- Standardize the grader's student view to match actual student experience. It is mainly in ~3~ 2 parts:
    1. question-specific information:
        - assessment settings (students can see this data when both the submission is published and the setting is on): 
            - `showPrivateTestCases`
            - `showEvaluationTestCases`
            -  `showMcqMrqSolution`
            -  `showRubricBreakdown` 
        - course settings (students can see these information when the setting is on):
            - `showPublicTestCasesOutput`
            -  `showStdoutAndStderr` 
    2. comments and annotations: 
        - students should only see the `published` comments and annotations at all times
        - only graders can see`Codaveri`, `delayed`, `draft` comments
    3. <del>past attempts view (through the "All answers" button): 
        - same standard as question-specific information, but this part affects the `AnswerDetails` component which is also used in the assessment statistics page through `LastAttempt`</del>