### PR TITLE
fix(GetHelpController): add support for non-default instance data

### DIFF
--- a/app/controllers/course/statistics/assessments_controller.rb
+++ b/app/controllers/course/statistics/assessments_controller.rb
@@ -55,17 +55,19 @@ class Course::Statistics::AssessmentsController < Course::Statistics::Controller
   end
 
   def live_feedback_history
-    user_id = CourseUser.joins(:user).where(id: params[:course_user_id]).pluck('users.id').first
-    @submissions = Course::Assessment::Submission.where(assessment_id: assessment_params[:id], creator_id: user_id)
-    @question = Course::Assessment::Question.find(params[:question_id])
+    ActsAsTenant.without_tenant do
+      user_id = CourseUser.joins(:user).where(id: params[:course_user_id]).pluck('users.id').first
+      @submissions = Course::Assessment::Submission.where(assessment_id: assessment_params[:id], creator_id: user_id)
+      @question = Course::Assessment::Question.find(params[:question_id])
 
-    create_submission_question_id_hash([@question])
+      create_submission_question_id_hash([@question])
 
-    @messages = Course::Assessment::LiveFeedback::Message.
-                joins(:thread).
-                where(live_feedback_threads: { submission_question_id: @submission_question_id_hash.values }).
-                includes(message_options: :option, message_files: :file).
-                order(:created_at)
+      @messages = Course::Assessment::LiveFeedback::Message.
+                  joins(:thread).
+                  where(live_feedback_threads: { submission_question_id: @submission_question_id_hash.values }).
+                  includes(message_options: :option, message_files: :file).
+                  order(:created_at)
+    end
   end
 
   private

--- a/client/app/bundles/system/admin/admin/components/tables/SystemGetHelpActivityTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/SystemGetHelpActivityTable.tsx
@@ -96,11 +96,10 @@ const SystemGetHelpActivityTable: FC<SystemGetHelpActivityTableProps> = ({
       sortable: true,
       searchable: true,
       cell: (getHelpDatum) => (
-        // TODO: To fix link for non-default instance course
         <Link
           key={getHelpDatum.id}
           opensInNewTab
-          to={getCourseURL(getHelpDatum.courseId)}
+          href={`//${getHelpDatum.instanceHost}${getCourseURL(getHelpDatum.courseId)}`}
         >
           {getHelpDatum.courseTitle}
         </Link>
@@ -115,11 +114,11 @@ const SystemGetHelpActivityTable: FC<SystemGetHelpActivityTableProps> = ({
         <Link
           key={getHelpDatum.id}
           opensInNewTab
-          to={getEditSubmissionURL(
+          href={`//${getHelpDatum.instanceHost}${getEditSubmissionURL(
             getHelpDatum.courseId,
             getHelpDatum.assessmentId,
             getHelpDatum.submissionId,
-          )}
+          )}`}
         >
           {getHelpDatum.assessmentTitle}
         </Link>
@@ -134,12 +133,12 @@ const SystemGetHelpActivityTable: FC<SystemGetHelpActivityTableProps> = ({
         <Link
           key={getHelpDatum.id}
           opensInNewTab
-          to={getEditSubmissionQuestionURL(
+          href={`//${getHelpDatum.instanceHost}${getEditSubmissionQuestionURL(
             getHelpDatum.courseId,
             getHelpDatum.assessmentId,
             getHelpDatum.submissionId,
             getHelpDatum.questionNumber,
-          )}
+          )}`}
         >
           Question {getHelpDatum.questionNumber}
           {getHelpDatum.questionTitle ? `: ${getHelpDatum.questionTitle}` : ''}
@@ -152,7 +151,11 @@ const SystemGetHelpActivityTable: FC<SystemGetHelpActivityTableProps> = ({
       sortable: true,
       searchable: true,
       cell: (getHelpDatum) => (
-        <Link key={getHelpDatum.id} opensInNewTab to={getHelpDatum.nameLink}>
+        <Link
+          key={getHelpDatum.id}
+          opensInNewTab
+          href={`//${getHelpDatum.instanceHost}${getHelpDatum.nameLink}`}
+        >
           {getHelpDatum.name}
         </Link>
       ),


### PR DESCRIPTION
- Add instance host to links in the System Get Help Activity page.
- Wrap relevant queries in `ActsAsTenant.without_tenant` to remove current tenant scoping, allowing data fetch across all instances.