### PR TITLE
feat(ssid): enable linking to past assessments for plagiarism check

### DIFF
--- a/app/controllers/concerns/course/assessment/duplication_tree_concern.rb
+++ b/app/controllers/concerns/course/assessment/duplication_tree_concern.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module Course::Assessment::DuplicationTreeConcern
+  extend ActiveSupport::Concern
+
+  # Gets all assessments in the duplicaiton tree containing the given assessment.
+  def get_all_assessments_in_duplication_tree(assessment)
+    root_assessment = find_assessment_root_in_duplication_tree(assessment)
+
+    assessments = Course.find_by_sql(<<~SQL.squish
+      WITH RECURSIVE duplication_tree_assessments AS (
+        SELECT dta.assessment_id
+        FROM duplication_traceable_assessments dta
+        INNER JOIN duplication_traceables dt ON dt.actable_id = dta.id
+        WHERE dt.source_id = #{root_assessment.id}
+
+        UNION ALL
+
+        SELECT dta.assessment_id
+        FROM duplication_traceable_assessments dta
+        INNER JOIN duplication_traceables dt ON dt.actable_id = dta.id
+        INNER JOIN duplication_tree_assessments tree ON tree.assessment_id = dt.source_id
+      )
+      SELECT assessment_id FROM duplication_tree_assessments
+    SQL
+                                    )
+    assessment_ids = assessments.map(&:assessment_id) + [root_assessment.id]
+    Course::Assessment.where(id: assessment_ids).includes(:course)
+  end
+
+  private
+
+  # Finds the root assessment in the duplication tree by traversing up the parent chain.
+  def find_assessment_root_in_duplication_tree(assessment)
+    current = assessment
+    while current.duplication_traceable.present? && current.duplication_traceable.source_id.present?
+      current = current.duplication_traceable.source
+    end
+    current
+  end
+end

--- a/app/controllers/course/plagiarism/assessments_controller.rb
+++ b/app/controllers/course/plagiarism/assessments_controller.rb
@@ -2,29 +2,35 @@
 class Course::Plagiarism::AssessmentsController < Course::Plagiarism::Controller
   include Course::UsersHelper
   include Course::Statistics::CountsConcern
+  include Course::Assessment::DuplicationTreeConcern
 
   def index
-    @assessments = current_course.assessments.includes(:plagiarism_check).published.ordered_by_date_and_title
+    @assessments = current_course.assessments.
+                   includes(:plagiarism_check, :linked_assessments).
+                   published.ordered_by_date_and_title
     @all_students = current_course.course_users.students
 
     fetch_all_assessment_related_statistics_hash
   end
 
   def plagiarism_data
-    @assessment = current_course.assessments.find(params[:assessment_id])
-    @course_users_hash = preload_course_users_hash(current_course)
-    @plagiarism_check = @assessment.plagiarism_check || @assessment.build_plagiarism_check
+    main_assessment = current_course.assessments.find(params[:id])
+    @course_users_hash = main_assessment.all_linked_assessments.to_h do |assessment|
+      [assessment.course_id, preload_course_users_hash(assessment.course)]
+    end
+    @plagiarism_check = main_assessment.plagiarism_check || main_assessment.build_plagiarism_check
 
     if @plagiarism_check.completed?
-      service = Course::Assessment::Submission::SsidPlagiarismService.new(current_course, @assessment)
+      service = Course::Assessment::Submission::SsidPlagiarismService.new(current_course, main_assessment)
       @results = service.fetch_plagiarism_result
+      fetch_can_manage_course_hash(get_all_assessments_in_duplication_tree(main_assessment))
     else
       @results = []
     end
   end
 
   def plagiarism_check
-    assessment = current_course.assessments.find(params[:assessment_id])
+    assessment = current_course.assessments.find(params[:id])
     plagiarism_check = assessment.plagiarism_check || assessment.create_plagiarism_check
 
     plagiarism_job = Course::Assessment::PlagiarismCheckJob.perform_later(current_course, assessment).tap do |job|
@@ -51,23 +57,40 @@ class Course::Plagiarism::AssessmentsController < Course::Plagiarism::Controller
   end
 
   def download_submission_pair_result
-    assessment = current_course.assessments.find(params[:assessment_id])
+    assessment = current_course.assessments.find(params[:id])
     submission_pair_id = params[:submission_pair_id]
     service = Course::Assessment::Submission::SsidPlagiarismService.new(current_course, assessment)
     render json: { html: service.download_submission_pair_result(submission_pair_id).html_safe }
   end
 
   def share_submission_pair_result
-    assessment = current_course.assessments.find(params[:assessment_id])
+    assessment = current_course.assessments.find(params[:id])
     submission_pair_id = params[:submission_pair_id]
     service = Course::Assessment::Submission::SsidPlagiarismService.new(current_course, assessment)
     render json: { url: service.share_submission_pair_result(submission_pair_id) }
   end
 
   def share_assessment_result
-    assessment = current_course.assessments.find(params[:assessment_id])
+    assessment = current_course.assessments.find(params[:id])
     service = Course::Assessment::Submission::SsidPlagiarismService.new(current_course, assessment)
     render json: { url: service.share_assessment_result }
+  end
+
+  def linked_and_unlinked_assessments
+    assessment = current_course.assessments.find(params[:id])
+    all_assessments = get_all_assessments_in_duplication_tree(assessment)
+    fetch_can_manage_course_hash(all_assessments)
+    @linked_assessments = assessment.all_linked_assessments
+    @unlinked_assessments = all_assessments - @linked_assessments
+  end
+
+  def update_assessment_links
+    assessment = current_course.assessments.find(params[:id])
+    linked_assessment_ids = params[:linked_assessment_ids].map(&:to_i)
+    assessment.linked_assessment_ids = linked_assessment_ids
+    assessment.save!
+
+    head :ok
   end
 
   private
@@ -75,5 +98,19 @@ class Course::Plagiarism::AssessmentsController < Course::Plagiarism::Controller
   def fetch_all_assessment_related_statistics_hash
     @num_submitted_students_hash = num_submitted_students_hash
     @latest_submission_time_hash = latest_submission_time_hash
+  end
+
+  def fetch_can_manage_course_hash(assessments)
+    course_users = CourseUser.where(
+      user_id: current_user.id,
+      course_id: assessments.map(&:course_id).uniq
+    ).index_by(&:course_id)
+    courses = assessments.map(&:course).uniq
+    @can_manage_course_hash = courses.to_h do |course|
+      [
+        course.id,
+        course_users[course.id]&.manager_or_owner?
+      ]
+    end
   end
 end

--- a/app/models/course/assessment/link.rb
+++ b/app/models/course/assessment/link.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Course::Assessment::Link < ApplicationRecord
+  belongs_to :assessment, class_name: 'Course::Assessment'
+  belongs_to :linked_assessment, class_name: 'Course::Assessment'
+
+  validates :assessment, :linked_assessment, presence: true
+  validates :linked_assessment_id, uniqueness: { scope: :assessment_id }
+end

--- a/app/services/course/assessment/submission/ssid_plagiarism_service.rb
+++ b/app/services/course/assessment/submission/ssid_plagiarism_service.rb
@@ -105,7 +105,9 @@ class Course::Assessment::Submission::SsidPlagiarismService # rubocop:disable Me
   end
 
   def sync_ssid_submissions
-    submissions_by_id = @assessment.submissions.index_by(&:id)
+    linked_assessments = Course::Assessment.where(id: @assessment.all_linked_assessments.pluck(:id)).
+                         includes(submissions: [assessment: :course])
+    submissions_by_id = linked_assessments.flat_map(&:submissions).index_by(&:id)
 
     fetch_ssid_submissions.filter_map do |ssid_submission|
       submission_id = ssid_submission['name'].split('_').first.to_i

--- a/app/services/course/assessment/submission/ssid_zip_download_service.rb
+++ b/app/services/course/assessment/submission/ssid_zip_download_service.rb
@@ -16,28 +16,33 @@ class Course::Assessment::Submission::SsidZipDownloadService < Course::Assessmen
   def initialize(assessment)
     super()
     @assessment = assessment
-    @questions = assessment.questions.to_h { |q| [q.id, q] }
+    @assessments = assessment.all_linked_assessments
+    @skeleton_dir = create_folder(@base_dir, 'skeleton')
   end
 
   # Downloads each submission to its own folder in the base directory.
-  def download_to_base_dir
-    submissions = @assessment.submissions.by_users(course_user_ids(@assessment)).
-                  includes(:answers, experience_points_record: :course_user)
-    submissions.find_each do |submission|
-      folder_name = "#{submission.id}_#{submission.course_user.name}"
-      submission_dir = create_folder(@base_dir, folder_name)
-      download_answers(submission, submission_dir)
+  def download_to_base_dir # rubocop:disable Metrics/AbcSize
+    @assessments.each do |assessment|
+      questions = assessment.questions.to_h { |q| [q.id, q] }
+      submissions = assessment.submissions.by_users(course_user_ids(assessment)).
+                    includes(:answers, experience_points_record: { course_user: :course })
+      submissions.find_each do |submission|
+        folder_name = "#{submission.id}_#{submission.course_user.name}_" \
+                      "#{assessment.title}_#{submission.course_user.course.title}"
+        submission_dir = create_folder(@base_dir, folder_name)
+        download_answers(submission, submission_dir, questions)
+      end
+      create_skeleton_folder(assessment, questions)
     end
-    create_skeleton_folder
   end
 
   # Downloads programming question template files to a 'skeleton' folder in the base directory.
-  def create_skeleton_folder
-    skeleton_dir = create_folder(@base_dir, 'skeleton')
-    @questions.each_value do |question|
+  def create_skeleton_folder(assessment, questions)
+    assessment_dir = create_folder(@skeleton_dir, "#{assessment.course.title} - #{assessment.title}")
+    questions.each_value do |question|
       next unless question.specific.is_a?(Course::Assessment::Question::Programming)
 
-      question_dir = create_folder(skeleton_dir, question.question_assessments.first.display_title)
+      question_dir = create_folder(assessment_dir, question.question_assessments.first.display_title)
       programming_question = question.specific
       programming_question.template_files.each do |template_file|
         file_path = File.join(question_dir, template_file.filename)
@@ -47,15 +52,15 @@ class Course::Assessment::Submission::SsidZipDownloadService < Course::Assessmen
   end
 
   # Downloads each answer to its own folder in the submission directory.
-  def download_answers(submission, submission_dir)
+  def download_answers(submission, submission_dir, questions)
     answers = submission.answers.includes(:question).latest_answers.
               select do |answer|
-                question = @questions[answer.question_id]
+                question = questions[answer.question_id]
                 question.plagiarism_checkable?
               end
     answers.each do |answer|
       question_assessment = submission.assessment.question_assessments.
-                            find_by!(question: @questions[answer.question_id])
+                            find_by!(question: questions[answer.question_id])
       answer_dir = create_folder(submission_dir, question_assessment.display_title)
       answer.specific.download(answer_dir)
     end

--- a/app/views/course/plagiarism/assessments/index.json.jbuilder
+++ b/app/views/course/plagiarism/assessments/index.json.jbuilder
@@ -11,6 +11,7 @@ json.assessments @assessments do |assessment|
   json.numCheckableQuestions assessment.num_plagiarism_checkable_questions
   json.numSubmitted num_submitted
   json.lastSubmittedAt @latest_submission_time_hash[assessment.id]&.iso8601
+  json.numLinkedAssessments assessment.all_linked_assessments.size
 
   json.workflowState assessment.plagiarism_check&.workflow_state || 'not_started'
   json.lastRunTime assessment.plagiarism_check&.last_started_at&.iso8601

--- a/app/views/course/plagiarism/assessments/linked_and_unlinked_assessments.json.jbuilder
+++ b/app/views/course/plagiarism/assessments/linked_and_unlinked_assessments.json.jbuilder
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+json.linkedAssessments @linked_assessments do |assessment|
+  json.id assessment.id
+  json.title assessment.title
+  json.courseId assessment.course.id
+  json.courseTitle assessment.course.title
+  json.url course_assessment_path(assessment.course, assessment)
+  json.canManage @can_manage_course_hash[assessment.course.id]
+end
+
+json.unlinkedAssessments @unlinked_assessments do |assessment|
+  json.id assessment.id
+  json.title assessment.title
+  json.courseId assessment.course.id
+  json.courseTitle assessment.course.title
+  json.url course_assessment_path(assessment.course, assessment)
+  json.canManage @can_manage_course_hash[assessment.course.id]
+end

--- a/app/views/course/plagiarism/assessments/plagiarism_data.json.jbuilder
+++ b/app/views/course/plagiarism/assessments/plagiarism_data.json.jbuilder
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-assessment = @assessment
 plagiarism_check = @plagiarism_check
 job = plagiarism_check.job
 
@@ -23,22 +22,30 @@ json.submissionPairs @results do |result|
 
   json.baseSubmission do
     json.id base_submission.id
-    course_user = @course_users_hash[base_submission.creator_id]
+    course_user = @course_users_hash[base_submission.assessment.course_id][base_submission.creator_id]
     json.courseUser do
       json.(course_user, :id, :name)
-      json.path course_user_path(current_course, course_user)
+      json.path course_user_path(course_user.course, course_user)
     end
-    json.submissionUrl edit_course_assessment_submission_path(current_course, assessment, base_submission)
+    json.assessmentTitle base_submission.assessment.title
+    json.courseTitle base_submission.assessment.course.title
+    json.submissionUrl edit_course_assessment_submission_path(course_user.course, base_submission.assessment,
+                                                              base_submission)
+    json.canManage @can_manage_course_hash[base_submission.assessment.course.id]
   end
 
   json.comparedSubmission do
     json.id compared_submission.id
-    course_user = @course_users_hash[compared_submission.creator_id]
+    course_user = @course_users_hash[compared_submission.assessment.course_id][compared_submission.creator_id]
     json.courseUser do
       json.(course_user, :id, :name)
-      json.path course_user_path(current_course, course_user)
+      json.path course_user_path(course_user.course, course_user)
     end
-    json.submissionUrl edit_course_assessment_submission_path(current_course, assessment, compared_submission)
+    json.assessmentTitle compared_submission.assessment.title
+    json.courseTitle compared_submission.assessment.course.title
+    json.submissionUrl edit_course_assessment_submission_path(course_user.course, compared_submission.assessment,
+                                                              compared_submission)
+    json.canManage @can_manage_course_hash[compared_submission.assessment.course.id]
   end
 
   json.similarityScore result[:similarity_score]

--- a/client/app/api/course/Plagiarism.ts
+++ b/client/app/api/course/Plagiarism.ts
@@ -1,4 +1,5 @@
 import {
+  AssessmentLinkData,
   AssessmentPlagiarism,
   PlagiarismAssessments,
 } from 'types/course/plagiarism';
@@ -26,7 +27,7 @@ export default class PlagiarismAPI extends BaseCourseAPI {
   fetchAssessmentPlagiarism(
     assessmentId: number,
   ): APIResponse<AssessmentPlagiarism> {
-    return this.client.get(`${this.#urlPrefix}/assessment/${assessmentId}`);
+    return this.client.get(`${this.#urlPrefix}/assessments/${assessmentId}`);
   }
 
   /**
@@ -37,7 +38,7 @@ export default class PlagiarismAPI extends BaseCourseAPI {
     submissionPairId: number,
   ): APIResponse<{ html: string }> {
     return this.client.get(
-      `${this.#urlPrefix}/assessment/${assessmentId}/download_submission_pair_result`,
+      `${this.#urlPrefix}/assessments/${assessmentId}/download_submission_pair_result`,
       {
         params: { submission_pair_id: submissionPairId },
       },
@@ -52,7 +53,7 @@ export default class PlagiarismAPI extends BaseCourseAPI {
     submissionPairId: number,
   ): APIResponse<{ url: string }> {
     return this.client.post(
-      `${this.#urlPrefix}/assessment/${assessmentId}/share_submission_pair_result`,
+      `${this.#urlPrefix}/assessments/${assessmentId}/share_submission_pair_result`,
       {
         submission_pair_id: submissionPairId,
       },
@@ -64,7 +65,7 @@ export default class PlagiarismAPI extends BaseCourseAPI {
    */
   shareAssessmentResult(assessmentId: number): APIResponse<{ url: string }> {
     return this.client.post(
-      `${this.#urlPrefix}/assessment/${assessmentId}/share_assessment_result`,
+      `${this.#urlPrefix}/assessments/${assessmentId}/share_assessment_result`,
     );
   }
 
@@ -72,7 +73,7 @@ export default class PlagiarismAPI extends BaseCourseAPI {
    * Initiates plagiarism check on an assessment.
    */
   runAssessmentPlagiarism(assessmentId: number): APIResponse<JobSubmitted> {
-    return this.client.post(`${this.#urlPrefix}/assessment/${assessmentId}`);
+    return this.client.post(`${this.#urlPrefix}/assessments/${assessmentId}`);
   }
 
   /**
@@ -83,6 +84,32 @@ export default class PlagiarismAPI extends BaseCourseAPI {
       `${this.#urlPrefix}/assessments/plagiarism_checks`,
       {
         assessment_ids: assessmentIds,
+      },
+    );
+  }
+
+  /**
+   * Fetches linked and unlinked assessments for a given assessment.
+   */
+  fetchLinkedAndUnlinkedAssessments(
+    assessmentId: number,
+  ): APIResponse<AssessmentLinkData> {
+    return this.client.get(
+      `${this.#urlPrefix}/assessments/${assessmentId}/linked_and_unlinked_assessments`,
+    );
+  }
+
+  /**
+   * Updates the linked assessments for a given assessment.
+   */
+  updateAssessmentLinks(
+    assessmentId: number,
+    linkedAssessmentIds: number[],
+  ): APIResponse<void> {
+    return this.client.patch(
+      `${this.#urlPrefix}/assessments/${assessmentId}/update_assessment_links`,
+      {
+        linked_assessment_ids: linkedAssessmentIds,
       },
     );
   }

--- a/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/PlagiarismResultsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/PlagiarismResultsTable.tsx
@@ -2,7 +2,10 @@ import { FC } from 'react';
 import { defineMessages } from 'react-intl';
 import { OpenInNew, PictureAsPdf } from '@mui/icons-material';
 import { IconButton, Tooltip, Typography } from '@mui/material';
-import { AssessmentPlagiarismSubmissionPair } from 'types/course/plagiarism';
+import {
+  AssessmentPlagiarismSubmission,
+  AssessmentPlagiarismSubmissionPair,
+} from 'types/course/plagiarism';
 
 import Link from 'lib/components/core/Link';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
@@ -56,6 +59,10 @@ const translations = defineMessages({
     id: 'course.assessment.plagiarism.searchByStudentName',
     defaultMessage: 'Search by Student Name',
   },
+  cannotManageSubmission: {
+    id: 'course.assessment.plagiarism.cannotManageSubmission',
+    defaultMessage: 'You do not have permission to manage this submission.',
+  },
 });
 
 const PlagiarismResultsTable: FC<Props> = (props) => {
@@ -73,6 +80,37 @@ const PlagiarismResultsTable: FC<Props> = (props) => {
     return <LoadingIndicator />;
   }
 
+  const createSubmissionCell = (
+    submission: AssessmentPlagiarismSubmission,
+  ): JSX.Element => {
+    const link = (
+      <Link
+        className={!submission.canManage ? 'text-neutral-500' : ''}
+        opensInNewTab
+        to={submission.submissionUrl}
+      >
+        {submission.courseUser.name}
+      </Link>
+    );
+    return (
+      <div>
+        {submission.canManage ? (
+          link
+        ) : (
+          <Tooltip title={t(translations.cannotManageSubmission)}>
+            {link}
+          </Tooltip>
+        )}
+        <Typography className="text-gray-600" variant="body2">
+          {submission.assessmentTitle}
+        </Typography>
+        <Typography className="text-gray-600" variant="body2">
+          {submission.courseTitle}
+        </Typography>
+      </div>
+    );
+  };
+
   const columns: ColumnTemplate<AssessmentPlagiarismSubmissionPair>[] = [
     {
       of: 'baseSubmission',
@@ -82,11 +120,7 @@ const PlagiarismResultsTable: FC<Props> = (props) => {
       searchProps: {
         getValue: (datum) => datum.baseSubmission.courseUser.name,
       },
-      cell: (datum) => (
-        <Link opensInNewTab to={datum.baseSubmission.submissionUrl}>
-          {datum.baseSubmission.courseUser.name}
-        </Link>
-      ),
+      cell: (datum) => createSubmissionCell(datum.baseSubmission),
     },
     {
       of: 'comparedSubmission',
@@ -96,11 +130,7 @@ const PlagiarismResultsTable: FC<Props> = (props) => {
       searchProps: {
         getValue: (datum) => datum.comparedSubmission.courseUser.name,
       },
-      cell: (datum) => (
-        <Link opensInNewTab to={datum.comparedSubmission.submissionUrl}>
-          {datum.comparedSubmission.courseUser.name}
-        </Link>
-      ),
+      cell: (datum) => createSubmissionCell(datum.comparedSubmission),
     },
     {
       of: 'similarityScore',

--- a/client/app/bundles/course/group/utils/sort.js
+++ b/client/app/bundles/course/group/utils/sort.js
@@ -9,3 +9,11 @@ export function sortByGroupRole(a, b) {
 export function sortByPhantom(a, b) {
   return a.isPhantom - b.isPhantom;
 }
+
+export function sortByCourseTitleAndTitle(a, b) {
+  const courseTitleComparison = a.courseTitle.localeCompare(b.courseTitle);
+  if (courseTitleComparison !== 0) {
+    return courseTitleComparison;
+  }
+  return a.title.localeCompare(b.title);
+}

--- a/client/app/bundles/course/plagiarism/components/AssessmentLinkDialog.tsx
+++ b/client/app/bundles/course/plagiarism/components/AssessmentLinkDialog.tsx
@@ -1,0 +1,312 @@
+import { FC, useEffect, useMemo, useState } from 'react';
+import { defineMessages } from 'react-intl';
+import CompareArrows from '@mui/icons-material/CompareArrows';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { LinkedAssessment } from 'types/course/plagiarism';
+
+import CourseAPI from 'api/course';
+import { sortByCourseTitleAndTitle } from 'course/group/utils/sort';
+import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import { useAppDispatch } from 'lib/hooks/store';
+import toast from 'lib/hooks/toast';
+import useTranslation from 'lib/hooks/useTranslation';
+import formTranslations from 'lib/translations/form';
+
+import { plagiarismAssessmentsActions } from '../reducers/assessments';
+
+import AssessmentLinkList from './AssessmentLinkList';
+
+interface Props {
+  assessmentId: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+const translations = defineMessages({
+  linkAssessments: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkDialog.linkAssessments',
+    defaultMessage: 'Link Assessments',
+  },
+  linkedAssessments: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkDialog.linkedAssessments',
+    defaultMessage: 'Linked Assessments',
+  },
+  unlinkedAssessments: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkDialog.unlinkedAssessments',
+    defaultMessage: 'Available Assessments',
+  },
+  searchPlaceholder: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkDialog.searchPlaceholder',
+    defaultMessage: 'Search by Assessment Title',
+  },
+  updateLinksSuccess: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkDialog.updateLinksSuccess',
+    defaultMessage: 'Assessment links updated successfully',
+  },
+  updateLinksFailure: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkDialog.updateLinksFailure',
+    defaultMessage: 'Failed to update assessment links',
+  },
+});
+
+const filterByTitle = (
+  search: string,
+  assessments: LinkedAssessment[],
+): LinkedAssessment[] => {
+  if (!search) {
+    return assessments;
+  }
+  const searchLower = search.toLowerCase().trim();
+  return assessments.filter((assessment) =>
+    assessment.title.toLowerCase().includes(searchLower),
+  );
+};
+
+const groupAssessmentsByCourse = (
+  assessments: LinkedAssessment[],
+): Record<number, LinkedAssessment[]> => {
+  const grouped: Record<number, LinkedAssessment[]> = {};
+  assessments.forEach((assessment) => {
+    const courseId = assessment.courseId;
+    if (!grouped[courseId]) {
+      grouped[courseId] = [];
+    }
+    grouped[courseId].push(assessment);
+  });
+  return grouped;
+};
+
+const AssessmentLinkDialog: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+
+  const { open, onClose, assessmentId } = props;
+
+  const [originalLinkedAssessments, setOriginalLinkedAssessments] = useState<
+    LinkedAssessment[]
+  >([]);
+  const [originalUnlinkedAssessments, setOriginalUnlinkedAssessments] =
+    useState<LinkedAssessment[]>([]);
+  const [linkedAssessments, setLinkedAssessments] = useState<
+    LinkedAssessment[]
+  >([]);
+  const [unlinkedAssessments, setUnlinkedAssessments] = useState<
+    LinkedAssessment[]
+  >([]);
+  const [linkedSearch, setLinkedSearch] = useState('');
+  const [unlinkedSearch, setUnlinkedSearch] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const fetchAssessmentLinks = async (): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const response =
+        await CourseAPI.plagiarism.fetchLinkedAndUnlinkedAssessments(
+          assessmentId,
+        );
+      const sortedLinked = response.data.linkedAssessments.sort(
+        sortByCourseTitleAndTitle,
+      );
+      const sortedUnlinked = response.data.unlinkedAssessments.sort(
+        sortByCourseTitleAndTitle,
+      );
+
+      setOriginalLinkedAssessments(sortedLinked);
+      setOriginalUnlinkedAssessments(sortedUnlinked);
+      setLinkedAssessments(sortedLinked);
+      setUnlinkedAssessments(sortedUnlinked);
+    } catch (error) {
+      toast.error(t(translations.updateLinksFailure));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAssessmentLinks();
+  }, []);
+
+  const handleMoveToLinked = (assessment: LinkedAssessment): void => {
+    setUnlinkedAssessments((prev) =>
+      prev
+        .filter((a) => a.id !== assessment.id)
+        .sort(sortByCourseTitleAndTitle),
+    );
+    setLinkedAssessments((prev) =>
+      [...prev, assessment].sort(sortByCourseTitleAndTitle),
+    );
+  };
+
+  const handleMoveToUnlinked = (assessment: LinkedAssessment): void => {
+    setLinkedAssessments((prev) =>
+      prev
+        .filter((a) => a.id !== assessment.id)
+        .sort(sortByCourseTitleAndTitle),
+    );
+    setUnlinkedAssessments((prev) =>
+      [...prev, assessment].sort(sortByCourseTitleAndTitle),
+    );
+  };
+
+  const handleUpdateLinks = async (): Promise<void> => {
+    if (!assessmentId) return;
+
+    setIsUpdating(true);
+    try {
+      const linkedIds = linkedAssessments.map((assessment) => assessment.id);
+      await CourseAPI.plagiarism.updateAssessmentLinks(assessmentId, linkedIds);
+      toast.success(t(translations.updateLinksSuccess));
+      dispatch(
+        plagiarismAssessmentsActions.updateNumLinkedAssessments({
+          assessmentId,
+          numLinkedAssessments: linkedIds.length,
+        }),
+      );
+      onClose();
+    } catch (error) {
+      toast.error(t(translations.updateLinksFailure));
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const filteredLinkedAssessments = filterByTitle(
+    linkedSearch,
+    linkedAssessments,
+  );
+  const filteredUnlinkedAssessments = filterByTitle(
+    unlinkedSearch,
+    unlinkedAssessments,
+  );
+
+  const linkedAssessmentsByCourse = groupAssessmentsByCourse(
+    filteredLinkedAssessments,
+  );
+  const unlinkedAssessmentsByCourse = groupAssessmentsByCourse(
+    filteredUnlinkedAssessments,
+  );
+
+  const originalLinkedMap = useMemo(() => {
+    const result = new Map();
+    originalLinkedAssessments.forEach((assessment) => {
+      result.set(assessment.id, assessment);
+    });
+    return result;
+  }, [originalLinkedAssessments]);
+
+  const originalUnlinkedMap = useMemo(() => {
+    const result = new Map();
+    originalUnlinkedAssessments.forEach((assessment) => {
+      result.set(assessment.id, assessment);
+    });
+    return result;
+  }, [originalUnlinkedAssessments]);
+
+  const colourMap = useMemo(() => {
+    const result: Record<number, string> = {};
+    unlinkedAssessments.forEach((assessment) => {
+      if (originalLinkedMap.has(assessment.id)) {
+        result[assessment.id] = 'bg-red-100';
+      }
+    });
+    linkedAssessments.forEach((assessment) => {
+      if (originalUnlinkedMap.has(assessment.id)) {
+        result[assessment.id] = 'bg-green-100';
+      }
+    });
+    return result;
+  }, [
+    linkedAssessments,
+    unlinkedAssessments,
+    originalLinkedMap,
+    originalUnlinkedMap,
+  ]);
+
+  const hasChanges = useMemo(() => {
+    const currentLinkedIds = new Set(linkedAssessments.map((a) => a.id));
+    const originalLinkedIds = new Set(
+      originalLinkedAssessments.map((a) => a.id),
+    );
+    return (
+      currentLinkedIds.size !== originalLinkedIds.size ||
+      [...currentLinkedIds].some((id) => !originalLinkedIds.has(id))
+    );
+  }, [originalLinkedAssessments, linkedAssessments]);
+
+  return (
+    <Dialog fullWidth maxWidth="lg" onClose={onClose} open={open}>
+      <DialogTitle>{t(translations.linkAssessments)}</DialogTitle>
+      <DialogContent>
+        {isLoading ? (
+          <LoadingIndicator />
+        ) : (
+          <div className="flex items-end gap-4">
+            <div className="flex-1">
+              <Typography variant="h6">
+                {t(translations.unlinkedAssessments)}
+              </Typography>
+              <TextField
+                className="w-full mb-2"
+                label={t(translations.searchPlaceholder)}
+                onChange={(event) => setUnlinkedSearch(event.target.value)}
+                value={unlinkedSearch}
+                variant="standard"
+              />
+              <AssessmentLinkList
+                assessmentId={assessmentId}
+                assessmentsByCourse={unlinkedAssessmentsByCourse}
+                colourMap={colourMap}
+                onCheck={handleMoveToLinked}
+              />
+            </div>
+            <div className="border border-solid border-neutral-300 flex items-center h-96">
+              <CompareArrows />
+            </div>
+            <div className="flex-1">
+              <Typography variant="h6">
+                {t(translations.linkedAssessments)}
+              </Typography>
+              <TextField
+                className="w-full mb-2"
+                label={t(translations.searchPlaceholder)}
+                onChange={(event) => setLinkedSearch(event.target.value)}
+                value={linkedSearch}
+                variant="standard"
+              />
+              <AssessmentLinkList
+                assessmentId={assessmentId}
+                assessmentsByCourse={linkedAssessmentsByCourse}
+                colourMap={colourMap}
+                isChecked
+                onCheck={handleMoveToUnlinked}
+              />
+            </div>
+          </div>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button disabled={isUpdating} onClick={onClose}>
+          {t(formTranslations.cancel)}
+        </Button>
+        <Button
+          color="info"
+          disabled={isLoading || isUpdating || !hasChanges}
+          onClick={handleUpdateLinks}
+        >
+          {t(formTranslations.saveChanges)}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AssessmentLinkDialog;

--- a/client/app/bundles/course/plagiarism/components/AssessmentLinkList.tsx
+++ b/client/app/bundles/course/plagiarism/components/AssessmentLinkList.tsx
@@ -1,0 +1,132 @@
+import { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { OpenInNew } from '@mui/icons-material';
+import {
+  Checkbox,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  ListSubheader,
+  Tooltip,
+} from '@mui/material';
+import { LinkedAssessment } from 'types/course/plagiarism';
+
+import Link from 'lib/components/core/Link';
+import useTranslation from 'lib/hooks/useTranslation';
+
+interface Props {
+  assessmentId: number;
+  assessmentsByCourse: Record<number, LinkedAssessment[]>;
+  onCheck: (assessment: LinkedAssessment) => void;
+  colourMap: Record<number, string>;
+  isChecked?: boolean;
+}
+
+const translations = defineMessages({
+  noAssessmentsFound: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkList.noAssessmentsFound',
+    defaultMessage: 'No assessments found',
+  },
+  cannotManage: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.AssessmentLinkList.cannotManage',
+    defaultMessage: 'You do not have permission to manage this assessment.',
+  },
+});
+
+const AssessmentLinkList: FC<Props> = (props) => {
+  const { t } = useTranslation();
+
+  const {
+    assessmentId,
+    assessmentsByCourse,
+    onCheck,
+    colourMap = {},
+    isChecked,
+  } = props;
+
+  const courseIds = Object.keys(assessmentsByCourse).map(Number);
+
+  const renderAssessmentsListItems = (
+    courseId: number,
+    assessments: LinkedAssessment[],
+  ): JSX.Element => {
+    const courseTitle = assessments[0]?.courseTitle || '';
+    return (
+      <li key={courseId}>
+        <ul className="list-none p-0 m-0">
+          <ListSubheader className="bg-neutral-100 font-bold">
+            {courseTitle}
+          </ListSubheader>
+          {assessments.map((assessment) => {
+            return (
+              <ListItem
+                key={assessment.id}
+                disablePadding
+                secondaryAction={
+                  assessment.canManage ? (
+                    <IconButton
+                      component={Link}
+                      edge="end"
+                      href={assessment.url}
+                      target="_blank"
+                    >
+                      <OpenInNew color="primary" />
+                    </IconButton>
+                  ) : (
+                    <Tooltip title={t(translations.cannotManage)}>
+                      <span>
+                        <IconButton
+                          component={Link}
+                          edge="end"
+                          href={assessment.url}
+                          target="_blank"
+                        >
+                          <OpenInNew color="disabled" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )
+                }
+              >
+                <ListItemButton
+                  key={assessment.id}
+                  className={colourMap[assessment.id]}
+                  dense
+                  disabled={
+                    assessment.id === assessmentId || !assessment.canManage
+                  }
+                  onClick={() => onCheck(assessment)}
+                >
+                  <Checkbox
+                    checked={isChecked}
+                    disableRipple
+                    edge="start"
+                    tabIndex={-1}
+                  />
+                  <ListItemText primary={assessment.title} />
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
+        </ul>
+      </li>
+    );
+  };
+
+  return (
+    <List className="border border-solid border-neutral-300 overflow-y-scroll h-96 p-0">
+      {courseIds.length === 0 && (
+        <ListItemButton className="text-neutral-400">
+          <ListItemText>{t(translations.noAssessmentsFound)}</ListItemText>
+        </ListItemButton>
+      )}
+      {courseIds.map((courseId) =>
+        renderAssessmentsListItems(courseId, assessmentsByCourse[courseId]),
+      )}
+    </List>
+  );
+};
+
+export default AssessmentLinkList;

--- a/client/app/bundles/course/plagiarism/reducers/assessments.ts
+++ b/client/app/bundles/course/plagiarism/reducers/assessments.ts
@@ -19,6 +19,21 @@ export const plagiarismAssessmentsSlice = createSlice({
       state.assessments = action.payload.assessments;
     },
 
+    updateNumLinkedAssessments: (
+      state,
+      action: PayloadAction<{
+        assessmentId: number;
+        numLinkedAssessments: number;
+      }>,
+    ) => {
+      const assessment = state.assessments.find(
+        (a) => a.id === action.payload.assessmentId,
+      );
+      if (assessment) {
+        assessment.numLinkedAssessments = action.payload.numLinkedAssessments;
+      }
+    },
+
     reset: () => {
       return initialState;
     },

--- a/client/app/types/course/plagiarism.ts
+++ b/client/app/types/course/plagiarism.ts
@@ -4,21 +4,21 @@ import { ASSESSMENT_SIMILARITY_WORKFLOW_STATE } from 'lib/constants/sharedConsta
 
 import { UserInfo } from './statistics/assessmentStatistics';
 
+export interface AssessmentPlagiarismSubmission {
+  id: number;
+  courseUser: UserInfo;
+  assessmentTitle: string;
+  courseTitle: string;
+  submissionUrl: string;
+  canManage: boolean;
+}
+
 export interface AssessmentPlagiarismSubmissionPair {
-  baseSubmission: {
-    id: number;
-    courseUser: UserInfo;
-    submissionUrl: string;
-  };
-  comparedSubmission: {
-    id: number;
-    courseUser: UserInfo;
-    submissionUrl: string;
-  };
+  baseSubmission: AssessmentPlagiarismSubmission;
+  comparedSubmission: AssessmentPlagiarismSubmission;
   similarityScore: number;
   submissionPairId: number;
 }
-
 export interface AssessmentPlagiarismJobData {
   jobId: number;
   jobStatus: keyof typeof JobStatus;
@@ -37,14 +37,18 @@ export interface AssessmentPlagiarism {
   submissionPairs: AssessmentPlagiarismSubmissionPair[];
 }
 
-export interface PlagiarismAssessmentListData {
+interface BaseAssessment {
   id: number;
   title: string;
   url: string;
+}
+
+export interface PlagiarismAssessmentListData extends BaseAssessment {
   plagiarismUrl: string;
   submissionsUrl: string;
   numCheckableQuestions: number;
   numSubmitted: number;
+  numLinkedAssessments: number;
   lastSubmittedAt?: Date;
   workflowState: keyof typeof ASSESSMENT_SIMILARITY_WORKFLOW_STATE;
   lastRunTime?: Date;
@@ -53,6 +57,17 @@ export interface PlagiarismAssessmentListData {
 
 export interface PlagiarismAssessments {
   assessments: PlagiarismAssessmentListData[];
+}
+
+export interface LinkedAssessment extends BaseAssessment {
+  courseId: number;
+  courseTitle: string;
+  canManage: boolean;
+}
+
+export interface AssessmentLinkData {
+  linkedAssessments: LinkedAssessment[];
+  unlinkedAssessments: LinkedAssessment[];
 }
 
 export interface AssessmentPlagiarismState {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -480,13 +480,19 @@ Rails.application.routes.draw do
       end
 
       namespace :plagiarism do
-        get 'assessments' => 'assessments#index'
-        get 'assessment/:assessment_id' => 'assessments#plagiarism_data'
-        get 'assessment/:assessment_id/download_submission_pair_result' => 'assessments#download_submission_pair_result'
-        post 'assessment/:assessment_id/share_submission_pair_result' => 'assessments#share_submission_pair_result'
-        post 'assessment/:assessment_id/share_assessment_result' => 'assessments#share_assessment_result'
-        post 'assessment/:assessment_id' => 'assessments#plagiarism_check'
-        post 'assessments/plagiarism_checks' => 'assessments#plagiarism_checks'
+        resources :assessments, only: [:index] do
+          post 'plagiarism_checks', on: :collection
+          member do
+            get '' => 'assessments#plagiarism_data'
+            post '' => 'assessments#plagiarism_check'
+            get 'download_submission_pair_result'
+            post 'share_submission_pair_result'
+            post 'share_assessment_result'
+
+            get 'linked_and_unlinked_assessments'
+            patch 'update_assessment_links'
+          end
+        end
       end
 
       scope module: :video do

--- a/db/migrate/20250722082737_create_course_assessment_links.rb
+++ b/db/migrate/20250722082737_create_course_assessment_links.rb
@@ -1,0 +1,10 @@
+class CreateCourseAssessmentLinks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :course_assessment_links do |t|
+      t.references :assessment, null: false, foreign_key: { to_table: :course_assessments }, index: true
+      t.references :linked_assessment, null: false, foreign_key: { to_table: :course_assessments }, index: true
+    end
+
+    add_index :course_assessment_links, [:assessment_id, :linked_assessment_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_18_054540) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_22_082737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -237,6 +237,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_18_054540) do
     t.index ["updater_id"], name: "fk__course_assessment_categories_updater_id"
   end
 
+  create_table "course_assessment_links", force: :cascade do |t|
+    t.bigint "assessment_id", null: false
+    t.bigint "linked_assessment_id", null: false
+    t.index ["assessment_id", "linked_assessment_id"], name: "idx_on_assessment_id_linked_assessment_id_2fe527ec4a", unique: true
+    t.index ["assessment_id"], name: "index_course_assessment_links_on_assessment_id"
+    t.index ["linked_assessment_id"], name: "index_course_assessment_links_on_linked_assessment_id"
+  end
+
   create_table "course_assessment_live_feedback_code", force: :cascade do |t|
     t.bigint "feedback_id", null: false
     t.string "filename", null: false
@@ -265,8 +273,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_18_054540) do
   create_table "course_assessment_plagiarism_checks", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.string "workflow_state", limit: 255, default: "not_started", null: false
     t.datetime "last_started_at", precision: nil
+    t.string "workflow_state", limit: 255, default: "not_started", null: false
     t.bigint "assessment_id", null: false
     t.uuid "job_id"
     t.index ["assessment_id"], name: "fk__course_assessment_plagiarism_checks_assessment_id", unique: true
@@ -1679,6 +1687,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_18_054540) do
   add_foreign_key "course_assessment_categories", "courses", name: "fk_course_assessment_categories_course_id"
   add_foreign_key "course_assessment_categories", "users", column: "creator_id", name: "fk_course_assessment_categories_creator_id"
   add_foreign_key "course_assessment_categories", "users", column: "updater_id", name: "fk_course_assessment_categories_updater_id"
+  add_foreign_key "course_assessment_links", "course_assessments", column: "assessment_id"
+  add_foreign_key "course_assessment_links", "course_assessments", column: "linked_assessment_id"
   add_foreign_key "course_assessment_live_feedback_code", "course_assessment_live_feedbacks", column: "feedback_id"
   add_foreign_key "course_assessment_live_feedback_comments", "course_assessment_live_feedback_code", column: "code_id"
   add_foreign_key "course_assessment_live_feedbacks", "course_assessment_questions", column: "question_id"

--- a/spec/services/course/assessment/submission/ssid_zip_download_service_spec.rb
+++ b/spec/services/course/assessment/submission/ssid_zip_download_service_spec.rb
@@ -29,15 +29,19 @@ RSpec.describe Course::Assessment::Submission::SsidZipDownloadService do
       it 'downloads skeleton files and student submissions with correct directory names' do
         subject
 
-        student1_folder = "#{submission1.id}_#{student1.name}"
+        student1_folder = "#{submission1.id}_#{student1.name}_" \
+                          "#{assessment.title}_#{course.title}"
+        course_assessment_folder = "#{course.title} - #{assessment.title}"
         question = assessment.questions.first
         question_title = Pathname.normalize_filename(question.question_assessments.first.display_title)
         template_file = question.specific.template_files.first
 
         expect(Dir.exist?(File.join(dir, 'skeleton'))).to be_truthy
         expect(Dir.exist?(File.join(dir, student1_folder))).to be_truthy
-        expect(Dir.exist?(File.join(dir, 'skeleton', question_title))).to be_truthy
-        expect(File.exist?(File.join(dir, 'skeleton', question_title, template_file.filename))).to be_truthy
+        expect(Dir.exist?(File.join(dir, 'skeleton', course_assessment_folder))).to be_truthy
+        expect(Dir.exist?(File.join(dir, 'skeleton', course_assessment_folder, question_title))).to be_truthy
+        expect(File.exist?(File.join(dir, 'skeleton', course_assessment_folder, question_title,
+                                     template_file.filename))).to be_truthy
       end
     end
   end


### PR DESCRIPTION
# Description

- This PR is the 2nd phase of integrating SSID into Coursemology, continuing from https://github.com/Coursemology/coursemology2/pull/8023



# Changes Made

- All submissions from linked assessments are used to find similarities with submissions from the main assessment.
- All assessments reachable in the assessment duplication tree are available for linking
- Links are automatically copied when the assessment/course is duplicated

# Notes

- Currently, plagiarism run on an assessment with linked assessments would also run comparisions between submissions between the linked assessments (that do not involved the main assessment). Changes from SSID would be required for more efficient plagiarism where all comparisions should involve at least 1 submission from the main assessment. 