### PR TITLE
fix(ssid): ensure jobs cannot hang indefinitely in running state

### DIFF
--- a/app/jobs/course/assessment/plagiarism_check_job.rb
+++ b/app/jobs/course/assessment/plagiarism_check_job.rb
@@ -8,8 +8,8 @@ class Course::Assessment::PlagiarismCheckJob < ApplicationJob
     instance = Course.unscoped { course.instance }
     ActsAsTenant.with_tenant(instance) do
       service = Course::Assessment::Submission::SsidPlagiarismService.new(course, assessment)
-      service.run_plagiarism_check
-      assessment.plagiarism_check.update!(workflow_state: :completed)
+      service.start_plagiarism_check
+      assessment.plagiarism_check.update!(workflow_state: :running)
     rescue StandardError => e
       assessment.plagiarism_check.update!(workflow_state: :failed)
       raise e

--- a/app/models/course/assessment/plagiarism_check.rb
+++ b/app/models/course/assessment/plagiarism_check.rb
@@ -4,17 +4,23 @@ class Course::Assessment::PlagiarismCheck < ApplicationRecord
 
   workflow do
     state :not_started do
+      event :start, transitions_to: :starting
+    end
+    # "starting" covers the state before the actual scan on SSID is run
+    # (creating folders, uploading submissions, etc.)
+    state :starting do
       event :run, transitions_to: :running
+      event :fail, transitions_to: :failed
     end
     state :running do
       event :complete, transitions_to: :completed
       event :fail, transitions_to: :failed
     end
     state :completed do
-      event :run, transitions_to: :running
+      event :start, transitions_to: :starting
     end
     state :failed do
-      event :run, transitions_to: :running
+      event :start, transitions_to: :starting
     end
   end
 

--- a/client/app/bundles/course/assessment/constants.js
+++ b/client/app/bundles/course/assessment/constants.js
@@ -29,6 +29,7 @@ const actionTypes = mirrorCreator([
 
 export const plagiarismWorkflowStates = {
   NotStarted: 'not_started',
+  Starting: 'starting',
   Running: 'running',
   Completed: 'completed',
   Failed: 'failed',

--- a/client/app/bundles/course/plagiarism/operations.ts
+++ b/client/app/bundles/course/plagiarism/operations.ts
@@ -1,9 +1,7 @@
 import { AxiosError } from 'axios';
 import { Operation } from 'store';
-import { PlagiarismCheck } from 'types/course/plagiarism';
 
 import CourseAPI from 'api/course';
-import { ASSESSMENT_SIMILARITY_WORKFLOW_STATE } from 'lib/constants/sharedConstants';
 
 import { plagiarismAssessmentsActions } from './reducers/assessments';
 

--- a/client/app/bundles/course/plagiarism/pages/PlagiarismIndex/assessments/AssessmentsPlagiarismTable.tsx
+++ b/client/app/bundles/course/plagiarism/pages/PlagiarismIndex/assessments/AssessmentsPlagiarismTable.tsx
@@ -74,6 +74,10 @@ const translations = defineMessages({
     id: 'course.plagiarism.PlagiarismIndex.assessments.statusNotStarted',
     defaultMessage: 'Not Started',
   },
+  statusStarting: {
+    id: 'course.plagiarism.PlagiarismIndex.assessments.statusStarting',
+    defaultMessage: 'Starting',
+  },
   statusRunning: {
     id: 'course.plagiarism.PlagiarismIndex.assessments.statusRunning',
     defaultMessage: 'Running',
@@ -248,6 +252,8 @@ const AssessmentsPlagiarismTable: FC = () => {
     switch (workflowState) {
       case ASSESSMENT_SIMILARITY_WORKFLOW_STATE.not_started:
         return t(translations.statusNotStarted);
+      case ASSESSMENT_SIMILARITY_WORKFLOW_STATE.starting:
+        return t(translations.statusStarting);
       case ASSESSMENT_SIMILARITY_WORKFLOW_STATE.running:
         return t(translations.statusRunning);
       case ASSESSMENT_SIMILARITY_WORKFLOW_STATE.completed:
@@ -290,11 +296,18 @@ const AssessmentsPlagiarismTable: FC = () => {
       ASSESSMENT_SIMILARITY_WORKFLOW_STATE.completed &&
     !hasNewSubmissionsSinceLastRun(assessment);
 
+  const isPlagiarismCheckInProgress = (
+    assessment: PlagiarismAssessmentListData,
+  ): boolean =>
+    assessment.plagiarismCheck?.workflowState ===
+      ASSESSMENT_SIMILARITY_WORKFLOW_STATE.starting ||
+    assessment.plagiarismCheck?.workflowState ===
+      ASSESSMENT_SIMILARITY_WORKFLOW_STATE.running;
+
   const canRunPlagiarismCheck = (
     assessment: PlagiarismAssessmentListData,
   ): boolean =>
-    assessment.plagiarismCheck?.workflowState !==
-      ASSESSMENT_SIMILARITY_WORKFLOW_STATE.running &&
+    !isPlagiarismCheckInProgress(assessment) &&
     assessment.numCheckableQuestions > 0 &&
     assessment.numSubmitted >= 2;
 
@@ -368,8 +381,7 @@ const AssessmentsPlagiarismTable: FC = () => {
             <Chip
               className={`w-fit py-1.5 h-auto ${palette.assessmentPlagiarismStatus[assessment.plagiarismCheck?.workflowState]}`}
               icon={
-                assessment.plagiarismCheck?.workflowState ===
-                ASSESSMENT_SIMILARITY_WORKFLOW_STATE.running ? (
+                isPlagiarismCheckInProgress(assessment) ? (
                   <LoadingIndicator bare size={15} />
                 ) : undefined
               }
@@ -433,10 +445,7 @@ const AssessmentsPlagiarismTable: FC = () => {
             <span>
               <IconButton
                 color="primary"
-                disabled={
-                  assessment.plagiarismCheck?.workflowState ===
-                  ASSESSMENT_SIMILARITY_WORKFLOW_STATE.running
-                }
+                disabled={isPlagiarismCheckInProgress(assessment)}
                 onClick={() => handleOpenLinkDialog(assessment.id)}
                 size="small"
               >

--- a/client/app/bundles/course/plagiarism/reducers/assessments.ts
+++ b/client/app/bundles/course/plagiarism/reducers/assessments.ts
@@ -5,8 +5,6 @@ import {
   PlagiarismCheck,
 } from 'types/course/plagiarism';
 
-import { ASSESSMENT_SIMILARITY_WORKFLOW_STATE } from 'lib/constants/sharedConstants';
-
 const initialState: PlagiarismAssessmentsState = {
   assessments: {},
 };

--- a/client/app/lib/constants/sharedConstants.ts
+++ b/client/app/lib/constants/sharedConstants.ts
@@ -83,6 +83,7 @@ export const POST_WORKFLOW_STATE = mirrorCreator([
 
 export const ASSESSMENT_SIMILARITY_WORKFLOW_STATE = mirrorCreator([
   'not_started',
+  'starting',
   'running',
   'completed',
   'failed',

--- a/client/app/theme/palette.js
+++ b/client/app/theme/palette.js
@@ -97,6 +97,7 @@ const palette = {
 
   assessmentPlagiarismStatus: {
     [plagiarismWorkflowStates.NotStarted]: 'bg-grey-200',
+    [plagiarismWorkflowStates.Starting]: 'bg-blue-200',
     [plagiarismWorkflowStates.Running]: 'bg-blue-200',
     [plagiarismWorkflowStates.Completed]: 'bg-green-200',
     [plagiarismWorkflowStates.Failed]: 'bg-red-200',

--- a/spec/controllers/course/plagiarism/assessments_controller_spec.rb
+++ b/spec/controllers/course/plagiarism/assessments_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Course::Plagiarism::AssessmentsController, type: :controller do
           end.to change(Course::Assessment::PlagiarismCheck, :count).by(1)
           expect(response).to have_http_status(:success)
           plagiarism_check = assessment.reload.plagiarism_check
-          expect(plagiarism_check.workflow_state).to eq('running')
+          expect(plagiarism_check.workflow_state).to eq('starting')
           expect(plagiarism_check.job).to eq(job)
         end
       end
@@ -113,7 +113,7 @@ RSpec.describe Course::Plagiarism::AssessmentsController, type: :controller do
             post :plagiarism_check, as: :json, params: { course_id: course, id: assessment }
           end.not_to change(Course::Assessment::PlagiarismCheck, :count)
           existing_check.reload
-          expect(existing_check.workflow_state).to eq('running')
+          expect(existing_check.workflow_state).to eq('starting')
           expect(existing_check.job).to eq(job)
         end
       end
@@ -133,7 +133,7 @@ RSpec.describe Course::Plagiarism::AssessmentsController, type: :controller do
           post :plagiarism_checks, as: :json, params: { course_id: course, assessment_ids: assessment_ids }
         end.to change(Course::Assessment::PlagiarismCheck, :count).by(1)
         expect(response).to have_http_status(:accepted)
-        expect(assessment.reload.plagiarism_check.workflow_state).to eq('running')
+        expect(assessment.reload.plagiarism_check.workflow_state).to eq('starting')
       end
     end
 

--- a/spec/jobs/course/assessment/plagiarism_check_job_spec.rb
+++ b/spec/jobs/course/assessment/plagiarism_check_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Course::Assessment::PlagiarismCheckJob do
     let(:course) { create(:course) }
     let(:assessment) { create(:assessment, course: course) }
 
-    context 'when running plagiarism check' do
+    context 'when starting plagiarism check' do
       let(:service) { instance_double(Course::Assessment::Submission::SsidPlagiarismService) }
 
       before do
@@ -19,20 +19,20 @@ RSpec.describe Course::Assessment::PlagiarismCheckJob do
 
       context 'when plagiarism check succeeds' do
         before do
-          assessment.create_plagiarism_check(workflow_state: :running)
-          allow(service).to receive(:run_plagiarism_check)
+          assessment.create_plagiarism_check(workflow_state: :starting)
+          allow(service).to receive(:start_plagiarism_check)
         end
 
-        it 'updates state to completed' do
+        it 'updates state to running' do
           subject.perform_now(course, assessment)
-          expect(assessment.plagiarism_check.reload.workflow_state).to eq('completed')
+          expect(assessment.plagiarism_check.reload.workflow_state).to eq('running')
         end
       end
 
       context 'when plagiarism check fails' do
         before do
-          allow(service).to receive(:run_plagiarism_check).and_raise(SsidError.new('error'))
-          assessment.create_plagiarism_check(workflow_state: :running)
+          allow(service).to receive(:start_plagiarism_check).and_raise(SsidError.new('error'))
+          assessment.create_plagiarism_check(workflow_state: :starting)
         end
 
         it 'updates state to failed' do

--- a/spec/services/course/assessment/submission/ssid_plagiarism_service_spec.rb
+++ b/spec/services/course/assessment/submission/ssid_plagiarism_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Course::Assessment::Submission::SsidPlagiarismService do
       end
     end
 
-    describe '#run_plagiarism_check' do
+    describe '#start_plagiarism_check' do
       before do
         stubs.post('/folders') do
           [Ssid::ApiStubs::CREATE_FOLDER_SUCCESS[:status],
@@ -65,7 +65,8 @@ RSpec.describe Course::Assessment::Submission::SsidPlagiarismService do
       end
 
       it 'completes similarity check successfully' do
-        response = subject.run_plagiarism_check
+        subject.start_plagiarism_check
+        response = subject.fetch_plagiarism_check_result
         expect(response['status']).to eq('successful')
       end
     end


### PR DESCRIPTION
- Added a new `starting` workflow state, to cover when the job is still processing from our side before being sent to SSID.
- Querying plagiarism check will now trigger state updates, to either resolve running checks or timeout starting checks if the job takes too long.