### PR TITLE
feat(AssessmentsIndex): display submitted / total student count

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -22,7 +22,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   def index
     @assessments = @assessments.ordered_by_date_and_title.with_submissions_by(current_user)
 
-    load_assessment_submission_counts if current_course_user&.staff?
+    load_assessment_submission_counts if !@assessments.empty? && can?(:manage, @assessments.first)
 
     @items_hash = @course.lesson_plan_items.where(actable_id: @assessments.pluck(:id),
                                                   actable_type: Course::Assessment.name).

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -9,7 +9,7 @@ class User::RegistrationsController < Devise::RegistrationsController
     if @invitation&.confirmed?
       message = @invitation.confirmer ? t('.used_with_email', email: @invitation.confirmer.email) : t('.used')
       render json: { message: message }, status: :conflict and return
-    elsif @invitation
+    elsif @invitation.is_a?(Course::UserInvitation)
       course = @invitation.course
 
       render json: {
@@ -17,6 +17,13 @@ class User::RegistrationsController < Devise::RegistrationsController
         email: @invitation.email,
         courseTitle: course.title,
         courseId: course.id
+      }
+    elsif @invitation.is_a?(Instance::UserInvitation)
+      render json: {
+        name: @invitation.name,
+        email: @invitation.email,
+        instanceName: @invitation.instance.name,
+        instanceHost: @invitation.instance.host
       }
     else
       head :no_content

--- a/app/models/course/assessment/assessment_ability.rb
+++ b/app/models/course/assessment/assessment_ability.rb
@@ -10,6 +10,7 @@ module Course::Assessment::AssessmentAbility
       define_teaching_staff_assessment_permissions if course_user.teaching_staff?
       define_manager_assessment_permissions if course_user.manager_or_owner?
     end
+    allow_instance_admin_manage_assessments if user
 
     super
   end
@@ -284,5 +285,12 @@ module Course::Assessment::AssessmentAbility
 
   def allow_manager_update_assessment_answer
     can [:update, :submit_answer], Course::Assessment::Answer, submission: { assessment: assessment_course_hash }
+  end
+
+  def allow_instance_admin_manage_assessments
+    admin_instance_ids = user.instance_users.administrator.pluck(:instance_id)
+    can :manage, Course::Assessment, tab: { category: { course: { instance_id: admin_instance_ids } } }
+    can :manage, Course::Assessment::Tab, category: { course: { instance_id: admin_instance_ids } }
+    can :manage, Course::Assessment::Category, course: { instance_id: admin_instance_ids }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ApplicationRecord
 
   # Update the user using the info from invitation.
   #
-  # @param [Course::UserInvitation]
+  # @param [Course::UserInvitation|Instance::UserInvitation]
   def build_from_invitation(invitation)
     self.name = invitation.name
     self.email = invitation.email

--- a/app/views/course/assessment/assessments/index.json.jbuilder
+++ b/app/views/course/assessment/assessments/index.json.jbuilder
@@ -29,6 +29,7 @@ json.display do
   json.isKoditsuExamEnabled current_course.component_enabled?(Course::KoditsuPlatformComponent)
 end
 
+json.totalStudentCount @total_count if defined?(@total_count)
 json.assessments @assessments do |assessment|
   json.id assessment.id
   json.title assessment.title
@@ -41,6 +42,10 @@ json.assessments @assessments do |assessment|
   json.affectsPersonalTimes current_course.show_personalized_timeline_features && assessment.affects_personal_times?
   json.url course_assessment_path(current_course, assessment)
   json.timeLimit assessment.time_limit
+  if defined?(@assessment_counts)
+    submitted_count = @assessment_counts[assessment.id] || 0
+    json.submittedCount submitted_count
+  end
 
   if current_course.component_enabled?(Course::KoditsuPlatformComponent)
     json.isKoditsuAssessmentEnabled assessment.is_koditsu_enabled

--- a/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentsIndex/AssessmentsTable.tsx
@@ -20,7 +20,7 @@ interface AssessmentsTableProps {
 }
 
 const AssessmentsTable = (props: AssessmentsTableProps): JSX.Element => {
-  const { display, assessments } = props.assessments;
+  const { display, assessments, totalStudentCount } = props.assessments;
   const { t } = useTranslation();
 
   const columns: ColumnTemplate<AssessmentListData>[] = [
@@ -122,6 +122,22 @@ const AssessmentsTable = (props: AssessmentsTableProps): JSX.Element => {
       ),
       unless: !display.endTimes,
       className: 'whitespace-nowrap pointer-coarse:max-sm:!hidden',
+    },
+    {
+      of: 'submittedCount',
+      title: t(translations.submittedCount),
+      cell: (assessment): JSX.Element | null => {
+        if (typeof assessment.submittedCount === 'number') {
+          return (
+            <span className={assessment.published ? '' : 'text-neutral-400'}>
+              {assessment.submittedCount} / {totalStudentCount}
+            </span>
+          );
+        }
+        return null;
+      },
+      unless: typeof totalStudentCount !== 'number',
+      className: 'max-lg:!hidden text-right whitespace-nowrap',
     },
     {
       id: 'actions',

--- a/client/app/bundles/course/assessment/translations.ts
+++ b/client/app/bundles/course/assessment/translations.ts
@@ -90,6 +90,10 @@ const translations = defineMessages({
     id: 'course.assessments.index.bonusEndsAt',
     defaultMessage: 'Bonus ends at',
   },
+  submittedCount: {
+    id: 'course.assessments.index.submittedCount',
+    defaultMessage: 'Submissions',
+  },
   actions: {
     id: 'course.assessments.index.actions',
     defaultMessage: 'Actions',

--- a/client/app/bundles/users/pages/SignUpPage.tsx
+++ b/client/app/bundles/users/pages/SignUpPage.tsx
@@ -22,6 +22,16 @@ import { getValidationErrors, signUpValidationSchema } from '../validations';
 
 type InvitedSignUpLoaderData = null | (InvitedSignUpData & { token: string });
 
+function getInvitationJoinTitle(invitation: InvitedSignUpData): string {
+  if (invitation.courseTitle) {
+    return invitation.courseTitle;
+  }
+  if (invitation.instanceName === 'Default') {
+    return `${invitation.instanceHost}`;
+  }
+  return `${invitation.instanceName} @ ${invitation.instanceHost}`;
+}
+
 const SignUpPage = (): JSX.Element => {
   const { t } = useTranslation();
 
@@ -83,10 +93,14 @@ const SignUpPage = (): JSX.Element => {
 
       if (invitation) {
         authenticate();
-        navigate(`/courses/${invitation.courseId}`);
+        if (invitation.courseId) {
+          navigate(`/courses/${invitation.courseId}`);
+        } else {
+          navigate(`/auth`);
+        }
         toast.success(
-          t(translations.signUpWelcomeToCourse, {
-            course: invitation.courseTitle,
+          t(translations.signUpWelcome, {
+            course: getInvitationJoinTitle(invitation),
           }),
         );
 
@@ -126,8 +140,8 @@ const SignUpPage = (): JSX.Element => {
       <Widget.Body>
         {invitation && (
           <Alert severity="info">
-            {t(translations.completeSignUpToJoinCourse, {
-              course: invitation.courseTitle,
+            {t(translations.completeSignUpToJoin, {
+              course: getInvitationJoinTitle(invitation),
               strong: (chunk) => <strong>{chunk}</strong>,
             })}
           </Alert>

--- a/client/app/bundles/users/translations.ts
+++ b/client/app/bundles/users/translations.ts
@@ -213,13 +213,13 @@ const translations = defineMessages({
     defaultMessage:
       'Manage all your email addresses in <link>Account Settings</link>.',
   },
-  completeSignUpToJoinCourse: {
-    id: 'users.completeSignUpToJoinCourse',
+  completeSignUpToJoin: {
+    id: 'users.completeSignUpToJoin',
     defaultMessage:
       'Almost there! Complete your sign up to join <strong>{course}</strong>.',
   },
-  signUpWelcomeToCourse: {
-    id: 'users.signUpWelcomeToCourse',
+  signUpWelcome: {
+    id: 'users.signUpWelcome',
     defaultMessage: 'Welcome to {course}!',
   },
   signUpSuccessful: {

--- a/client/app/types/course/assessment/assessments.ts
+++ b/client/app/types/course/assessment/assessments.ts
@@ -50,6 +50,7 @@ export interface AssessmentListData extends AssessmentActionsData {
   isEndTimePassed?: boolean;
   remainingConditionalsCount?: number;
   topConditionals?: AchievementBadgeData[];
+  submittedCount?: number;
 }
 
 export interface AssessmentsListData {
@@ -77,7 +78,7 @@ export interface AssessmentsListData {
       }[];
     };
   };
-
+  totalStudentCount?: number;
   assessments: AssessmentListData[];
 }
 

--- a/client/app/types/users.ts
+++ b/client/app/types/users.ts
@@ -145,6 +145,8 @@ export interface PasswordPostData {
 export interface InvitedSignUpData {
   name: string;
   email: string;
-  courseTitle: string;
-  courseId: string;
+  courseTitle?: string;
+  courseId?: string;
+  instanceName?: string;
+  instanceHost?: string;
 }

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -8193,7 +8193,7 @@
   "users.checkYourEmail": {
     "defaultMessage": "Almost there; check your email!"
   },
-  "users.completeSignUpToJoinCourse": {
+  "users.completeSignUpToJoin": {
     "defaultMessage": "Almost there! Complete your sign up to join <strong>{course}</strong>."
   },
   "users.confirmEmailLinkInvalidOrExpired": {
@@ -8331,7 +8331,7 @@
   "users.signUpSuccessful": {
     "defaultMessage": "Your account was successfully created."
   },
-  "users.signUpWelcomeToCourse": {
+  "users.signUpWelcome": {
     "defaultMessage": "Welcome to {course}!"
   },
   "users.suddenlyRememberPassword": {

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -3747,6 +3747,9 @@
   "course.assessments.index.submissions": {
     "defaultMessage": "Submissions"
   },
+  "course.assessments.index.submittedCount": {
+    "defaultMessage": "Submissions"
+  },
   "course.assessments.index.title": {
     "defaultMessage": "Title"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -3728,6 +3728,9 @@
   "course.assessments.index.submissions": {
     "defaultMessage": "제출물"
   },
+  "course.assessments.index.submittedCount": {
+    "defaultMessage": "제출물"
+  },
   "course.assessments.index.title": {
     "defaultMessage": "제목"
   },

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -8189,7 +8189,7 @@
   "users.checkYourEmail": {
     "defaultMessage": "거의 완료되었습니다. 이메일을 확인하세요!"
   },
-  "users.completeSignUpToJoinCourse": {
+  "users.completeSignUpToJoin": {
     "defaultMessage": "거의 끝났습니다! <strong>{course}</strong>에 가입하려면 회원가입을 완료하세요."
   },
   "users.confirmEmailLinkInvalidOrExpired": {
@@ -8327,7 +8327,7 @@
   "users.signUpSuccessful": {
     "defaultMessage": "계정이 성공적으로 생성되었습니다."
   },
-  "users.signUpWelcomeToCourse": {
+  "users.signUpWelcome": {
     "defaultMessage": "{course}에 오신 것을 환영합니다!"
   },
   "users.suddenlyRememberPassword": {

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -3707,6 +3707,9 @@
   "course.assessments.index.submissions": {
     "defaultMessage": "提交"
   },
+  "course.assessments.index.submittedCount": {
+    "defaultMessage": "提交"
+  },
   "course.assessments.index.title": {
     "defaultMessage": "标题"
   },

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -8168,7 +8168,7 @@
   "users.checkYourEmail": {
     "defaultMessage": "请查看你的电子邮箱"
   },
-  "users.completeSignUpToJoinCourse": {
+  "users.completeSignUpToJoin": {
     "defaultMessage": "注册成功，欢迎加入 <strong>{course}</strong>。"
   },
   "users.confirmEmailLinkInvalidOrExpired": {
@@ -8306,7 +8306,7 @@
   "users.signUpSuccessful": {
     "defaultMessage": "你的账户已创建成功。"
   },
-  "users.signUpWelcomeToCourse": {
+  "users.signUpWelcome": {
     "defaultMessage": "欢迎来到 {course}!"
   },
   "users.suddenlyRememberPassword": {

--- a/spec/controllers/user/registration_controller_spec.rb
+++ b/spec/controllers/user/registration_controller_spec.rb
@@ -5,6 +5,63 @@ RSpec.describe User::RegistrationsController, type: :controller do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
+    describe '#new' do
+      context 'when there is no invitation key' do
+        requires_login
+        subject { get :new }
+
+        it 'succeeds with no response body' do
+          subject
+          expect(response.status).to eq(204)
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when there is an invitation key' do
+        requires_login
+        subject { get :new, params: { invitation: invitation_key } }
+
+        context 'when the key is invalid' do
+          let(:invitation_key) { '#########' }
+          it 'succeeds with no response body' do
+            subject
+            expect(response.status).to eq(204)
+            expect(response.body).to be_empty
+          end
+        end
+
+        context 'when the key is a valid course invitation' do
+          let(:course) { create(:course) }
+          let(:invitation) { create(:course_user_invitation, course: course) }
+          let(:invitation_key) { invitation.invitation_key }
+          it 'succeeds and returns course details' do
+            subject
+            expect(response.status).to eq(200)
+            response_body = JSON.parse(response.body)
+            expect(response_body['courseId']).to eq(course.id)
+            expect(response_body['courseTitle']).to eq(course.title)
+            expect(response_body['name']).to eq(invitation.name)
+            expect(response_body['email']).to eq(invitation.email)
+          end
+        end
+
+        context 'when the key is a valid instance invitation' do
+          let(:invitation) { create(:instance_user_invitation, instance: instance) }
+          let(:invitation_key) { invitation.invitation_key }
+          it 'succeeds and returns instance details' do
+            subject
+            expect(response.status).to eq(200)
+
+            response_body = JSON.parse(response.body)
+            expect(response_body['instanceName']).to eq(Instance.default.name)
+            expect(response_body['instanceHost']).to eq(Instance.default.host)
+            expect(response_body['name']).to eq(invitation.name)
+            expect(response_body['email']).to eq(invitation.email)
+          end
+        end
+      end
+    end
+
     describe '#create' do
       subject do
         valid_user = attributes_for(:user).reverse_merge(email: generate(:email))
@@ -19,9 +76,7 @@ RSpec.describe User::RegistrationsController, type: :controller do
       end
 
       context 'user registration is successful' do
-        before do
-          @request.env['devise.mapping'] = Devise.mappings[:user]
-        end
+        requires_login
 
         it 'creates a new account' do
           allow(controller).to receive(:verify_recaptcha).and_return(true)
@@ -30,9 +85,7 @@ RSpec.describe User::RegistrationsController, type: :controller do
       end
 
       context 'recaptcha is not validated' do
-        before do
-          @request.env['devise.mapping'] = Devise.mappings[:user]
-        end
+        requires_login
 
         it 'does not register any new users' do
           allow(controller).to receive(:verify_recaptcha).and_return(false)

--- a/spec/models/course/assessment/assessment_ability_spec.rb
+++ b/spec/models/course/assessment/assessment_ability_spec.rb
@@ -229,5 +229,18 @@ RSpec.describe Course::Assessment do
       it { is_expected.to be_able_to(:delete_submission, attempting_submission) }
       it { is_expected.to be_able_to(:delete_submission, coursemate_attempting_submission) }
     end
+
+    context 'when the user is an Instance Admin' do
+      let(:user) { create(:instance_administrator).user }
+      let(:course_user) { nil }
+
+      # Course Tabs and Categories
+      it { is_expected.to be_able_to(:manage, tab) }
+      it { is_expected.to be_able_to(:manage, category) }
+
+      # Course Assessments
+      it { is_expected.to be_able_to(:publish_grades, published_started_assessment) }
+      it { is_expected.to be_able_to(:force_submit_assessment_submission, published_started_assessment) }
+    end
   end
 end


### PR DESCRIPTION
Added column to view at a glance, how many students have _submitted_ each given assessment.

<img width="1212" height="706" alt="Screenshot 2025-09-28 at 17 56 19" src="https://github.com/user-attachments/assets/710d9830-2ad4-47a1-a5af-026f2d2d9c07" />

~~No data is shown for draft assessments~~ Count is grayed out for draft assessments, as students cannot access them to submit.

Column is not shown and data is not returned for students viewing the page.

Also included:

- Fix instance admins unable to view Assessment index page
- Fix incorrect handling of instance user invitations