### PR TITLE
fix(ssid): fetch submission pairs on-demand

### DIFF
--- a/client/app/api/course/Plagiarism.ts
+++ b/client/app/api/course/Plagiarism.ts
@@ -35,8 +35,12 @@ export default class PlagiarismAPI extends BaseCourseAPI {
    */
   fetchAssessmentPlagiarism(
     assessmentId: number,
+    limit: number,
+    offset: number,
   ): APIResponse<AssessmentPlagiarism> {
-    return this.client.get(`${this.#urlPrefix}/assessments/${assessmentId}`);
+    return this.client.get(`${this.#urlPrefix}/assessments/${assessmentId}`, {
+      params: { limit, offset },
+    });
   }
 
   /**

--- a/client/app/bundles/course/assessment/operations/plagiarism.ts
+++ b/client/app/bundles/course/assessment/operations/plagiarism.ts
@@ -1,19 +1,23 @@
 import { AxiosError } from 'axios';
-import { dispatch } from 'store';
-import { PlagiarismCheck } from 'types/course/plagiarism';
+import { AssessmentPlagiarism, PlagiarismCheck } from 'types/course/plagiarism';
 
 import CourseAPI from 'api/course';
 
-import { plagiarismActions as actions } from '../reducers/plagiarism';
+// 2 pages, 100 rows per page.
+export const INITIAL_SUBMISSION_PAIR_QUERY_SIZE = 200;
 
 export const fetchAssessmentPlagiarism = async (
   assessmentId: number,
-): Promise<void> => {
+  limit: number,
+  offset: number,
+): Promise<AssessmentPlagiarism> => {
   try {
-    dispatch(actions.reset());
-    const response =
-      await CourseAPI.plagiarism.fetchAssessmentPlagiarism(assessmentId);
-    dispatch(actions.initialize(response.data));
+    const response = await CourseAPI.plagiarism.fetchAssessmentPlagiarism(
+      assessmentId,
+      limit,
+      offset,
+    );
+    return response.data;
   } catch (error) {
     if (error instanceof AxiosError) throw error.response?.data?.errors;
     throw error;

--- a/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/AssessmentPlagiarismPage.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/AssessmentPlagiarismPage.tsx
@@ -1,35 +1,66 @@
-import { FC, useEffect, useRef } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { PaginationState } from '@tanstack/react-table';
 
 import { PLAGIARISM_JOB_POLL_INTERVAL_MS } from 'course/assessment/constants';
 import {
   downloadSubmissionPairResult,
   fetchAssessmentPlagiarism,
+  INITIAL_SUBMISSION_PAIR_QUERY_SIZE,
   shareAssessmentResult,
   shareSubmissionPairResult,
 } from 'course/assessment/operations/plagiarism';
 import { ASSESSMENT_SIMILARITY_WORKFLOW_STATE } from 'lib/constants/sharedConstants';
-import { useAppSelector } from 'lib/hooks/store';
+import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
+
+import { plagiarismActions } from '../../reducers/plagiarism';
 
 import PlagiarismResultsTable from './PlagiarismResultsTable';
 import { getAssessmentPlagiarism } from './selectors';
 
 const AssessmentPlagiarismPage: FC = () => {
+  const dispatch = useAppDispatch();
   const { assessmentId } = useParams();
   const parsedAssessmentId = parseInt(assessmentId!, 10);
 
-  const { data } = useAppSelector(getAssessmentPlagiarism);
+  const { data, isAllSubmissionPairsLoaded } = useAppSelector(
+    getAssessmentPlagiarism,
+  );
   const isRunning =
     data.status.workflowState ===
       ASSESSMENT_SIMILARITY_WORKFLOW_STATE.starting ||
     data.status.workflowState === ASSESSMENT_SIMILARITY_WORKFLOW_STATE.running;
+  const [rowsToLoad, setRowsToLoad] = useState(
+    INITIAL_SUBMISSION_PAIR_QUERY_SIZE,
+  );
+
+  const shouldQuery =
+    isRunning ||
+    (data.status.workflowState === 'completed' &&
+      !isAllSubmissionPairsLoaded &&
+      data.submissionPairs.length < rowsToLoad);
 
   const plagiarismPollerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const handlePlagiarismPolling = (): void => {
-    if (isRunning) {
-      fetchAssessmentPlagiarism(parsedAssessmentId);
+  const handlePlagiarismPolling = async (): Promise<void> => {
+    if (shouldQuery) {
+      const plagiarismData = await fetchAssessmentPlagiarism(
+        parsedAssessmentId,
+        rowsToLoad - data.submissionPairs.length,
+        data.submissionPairs.length,
+      );
+      if (isRunning) {
+        dispatch(plagiarismActions.initialize(plagiarismData));
+      } else {
+        dispatch(plagiarismActions.addSubmissionPairs(plagiarismData));
+      }
     }
+  };
+
+  const onPaginationChange = (newValue: PaginationState): void => {
+    const { pageIndex, pageSize } = newValue;
+    // Load at least up to the full next page.
+    setRowsToLoad(Math.max((pageIndex + 2) * pageSize, rowsToLoad));
   };
 
   useEffect(() => {
@@ -77,8 +108,10 @@ const AssessmentPlagiarismPage: FC = () => {
 
   return (
     <PlagiarismResultsTable
+      allLoaded={isAllSubmissionPairsLoaded}
       downloadSubmissionPairResult={handleDownloadSubmissionPairResult}
       isLoading={isRunning}
+      onPaginationChange={onPaginationChange}
       shareAssessmentResult={handleShareAssessmentResult}
       shareSubmissionPairResult={handleShareSubmissionPairResult}
       submissionPairs={data.submissionPairs}

--- a/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/PlagiarismResultsTable.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/PlagiarismResultsTable.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { defineMessages } from 'react-intl';
 import { OpenInNew, PictureAsPdf } from '@mui/icons-material';
 import { IconButton, Tooltip, Typography } from '@mui/material';
+import { PaginationState } from '@tanstack/react-table';
 import {
   AssessmentPlagiarismSubmission,
   AssessmentPlagiarismSubmissionPair,
@@ -18,9 +19,11 @@ import {
 import useTranslation from 'lib/hooks/useTranslation';
 
 interface Props {
+  allLoaded: boolean;
   isLoading: boolean;
   submissionPairs: AssessmentPlagiarismSubmissionPair[];
   downloadSubmissionPairResult: (submissionPairId: number) => void;
+  onPaginationChange: (newValue: PaginationState) => void;
   shareSubmissionPairResult: (submissionPairId: number) => void;
   shareAssessmentResult: () => void;
 }
@@ -69,9 +72,11 @@ const PlagiarismResultsTable: FC<Props> = (props) => {
   const { t } = useTranslation();
 
   const {
+    allLoaded,
     isLoading,
     submissionPairs,
     downloadSubmissionPairResult,
+    onPaginationChange,
     shareSubmissionPairResult,
     shareAssessmentResult,
   } = props;
@@ -210,7 +215,9 @@ const PlagiarismResultsTable: FC<Props> = (props) => {
         indexing={{ indices: true }}
         pagination={{
           rowsPerPage: [DEFAULT_TABLE_ROWS_PER_PAGE],
-          showAllRows: true,
+          showAllRows: false,
+          showTotalPlus: !allLoaded,
+          onPaginationChange,
         }}
         search={{
           searchPlaceholder: t(translations.searchByStudentName),

--- a/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/index.tsx
+++ b/client/app/bundles/course/assessment/pages/AssessmentPlagiarism/index.tsx
@@ -4,8 +4,13 @@ import { useParams } from 'react-router-dom';
 
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
 import Preload from 'lib/components/wrappers/Preload';
+import { useAppDispatch } from 'lib/hooks/store';
 
-import { fetchAssessmentPlagiarism } from '../../operations/plagiarism';
+import {
+  fetchAssessmentPlagiarism,
+  INITIAL_SUBMISSION_PAIR_QUERY_SIZE,
+} from '../../operations/plagiarism';
+import { plagiarismActions } from '../../reducers/plagiarism';
 
 import AssessmentPlagiarismPage from './AssessmentPlagiarismPage';
 
@@ -18,10 +23,17 @@ const translations = defineMessages({
 
 const AssessmentPlagiarism: FC = () => {
   const { assessmentId } = useParams();
+  const dispatch = useAppDispatch();
   const parsedAssessmentId = parseInt(assessmentId!, 10);
 
-  const fetchAssessmentPlagiarismDetails = (): Promise<void> =>
-    fetchAssessmentPlagiarism(parsedAssessmentId);
+  const fetchAssessmentPlagiarismDetails = async (): Promise<void> => {
+    const plagiarismData = await fetchAssessmentPlagiarism(
+      parsedAssessmentId,
+      INITIAL_SUBMISSION_PAIR_QUERY_SIZE,
+      0,
+    );
+    dispatch(plagiarismActions.initialize(plagiarismData));
+  };
 
   return (
     <Preload

--- a/client/app/bundles/course/assessment/reducers/plagiarism.ts
+++ b/client/app/bundles/course/assessment/reducers/plagiarism.ts
@@ -15,6 +15,9 @@ const initialState: AssessmentPlagiarismState = {
     },
     submissionPairs: [],
   },
+  // After the first query populates submissionPairs with the completed state,
+  // subsequent queries should add to the list until a query returns with no more results.
+  isAllSubmissionPairsLoaded: false,
 };
 
 export const plagiarismSlice = createSlice({
@@ -23,21 +26,15 @@ export const plagiarismSlice = createSlice({
   reducers: {
     initialize: (state, action: PayloadAction<AssessmentPlagiarism>) => {
       state.data = action.payload;
+      state.isAllSubmissionPairsLoaded = false;
     },
-    runPlagiarismCheckSuccess: (
-      state,
-      action: PayloadAction<AssessmentPlagiarismStatus>,
-    ) => {
-      state.data.status = action.payload;
-    },
-    pollPlagiarismJobFinished: (
+    addSubmissionPairs: (
       state,
       action: PayloadAction<AssessmentPlagiarism>,
     ) => {
-      state.data = action.payload;
-    },
-    reset: () => {
-      return initialState;
+      state.data.submissionPairs.push(...action.payload.submissionPairs);
+      state.isAllSubmissionPairsLoaded =
+        action.payload.submissionPairs.length === 0;
     },
   },
 });

--- a/client/app/lib/components/table/MuiTableAdapter/MuiTablePagination.tsx
+++ b/client/app/lib/components/table/MuiTableAdapter/MuiTablePagination.tsx
@@ -34,6 +34,9 @@ const MuiTablePagination = (props: PaginationProps): JSX.Element => {
     <TablePagination
       component="div"
       count={props.total}
+      labelDisplayedRows={({ from, to, count }) =>
+        `${from}-${to} of ${count}${props.showTotalPlus ? '+' : ''}`
+      }
       onPageChange={(_, newPage): void => props.onPageChange?.(newPage)}
       onRowsPerPageChange={(e): void => {
         const pageSize = parseInt(e.target.value, 10);

--- a/client/app/lib/components/table/TanStackTableBuilder/useTanStackTableBuilder.tsx
+++ b/client/app/lib/components/table/TanStackTableBuilder/useTanStackTableBuilder.tsx
@@ -69,7 +69,14 @@ const useTanStackTableBuilder = <D extends object>(
     onRowSelectionChange: setRowSelection,
     onColumnFiltersChange: setColumnFilters,
     onGlobalFilterChange: setSearchKeyword,
-    onPaginationChange: setPagination,
+    onPaginationChange: (current) => {
+      setPagination(current);
+      if (props.pagination?.onPaginationChange) {
+        const newValue =
+          typeof current === 'function' ? current(pagination) : pagination;
+        props.pagination.onPaginationChange(newValue, pagination);
+      }
+    },
     autoResetPageIndex: false,
     state: {
       rowSelection,
@@ -180,6 +187,9 @@ const useTanStackTableBuilder = <D extends object>(
       page: table.getState().pagination.pageIndex,
       pages: props.pagination.rowsPerPage,
       total: table.getFilteredRowModel().rows.length,
+      // TODO: Replace use(s) of tables with this feature with TanStack Virtual
+      // https://tanstack.com/virtual/latest
+      showTotalPlus: props.pagination.showTotalPlus,
       pageSize: table.getState().pagination.pageSize,
       onPageChange: (page): void => table.setPageIndex(page),
       onPageSizeChange: (size): void => table.setPageSize(size),

--- a/client/app/lib/components/table/adapters/Pagination.ts
+++ b/client/app/lib/components/table/adapters/Pagination.ts
@@ -2,6 +2,7 @@ interface PaginationProps {
   page: number;
   pageSize: number;
   total: number;
+  showTotalPlus?: boolean;
   pages?: number[];
   allowShowAll?: boolean;
   onPageChange?: (index: number) => void;

--- a/client/app/lib/components/table/builder/featureTemplates.ts
+++ b/client/app/lib/components/table/builder/featureTemplates.ts
@@ -1,11 +1,18 @@
+import { PaginationState } from '@tanstack/react-table';
+
 import { Data } from './ColumnTemplate';
 
 export interface PaginationTemplate {
   initialPageSize?: number;
   initialPageIndex?: number;
+  onPaginationChange?: (
+    newValue: PaginationState,
+    oldValue: PaginationState,
+  ) => void;
   rowsPerPage?: number[];
   showAllRows?: boolean;
   showAllRowsLabel?: string;
+  showTotalPlus?: boolean;
 }
 
 interface SearchProps<D> {

--- a/client/app/types/course/plagiarism.ts
+++ b/client/app/types/course/plagiarism.ts
@@ -77,6 +77,7 @@ export interface AssessmentLinkData {
 
 export interface AssessmentPlagiarismState {
   data: AssessmentPlagiarism;
+  isAllSubmissionPairsLoaded: boolean;
 }
 
 export interface PlagiarismAssessmentsState {

--- a/spec/services/course/assessment/submission/ssid_plagiarism_service_spec.rb
+++ b/spec/services/course/assessment/submission/ssid_plagiarism_service_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Course::Assessment::Submission::SsidPlagiarismService do
     end
 
     describe '#fetch_plagiarism_result' do
+      let(:limit) { 100 }
+      let(:offset) { 200 }
       before do
         stubs.get(/folders\/.*\/submissions/) do |env|
           expect(env[:url].to_s).to include("/folders/#{assessment.ssid_folder_id}/submissions")
@@ -79,8 +81,12 @@ RSpec.describe Course::Assessment::Submission::SsidPlagiarismService do
            { 'Content-Type': 'application/json' },
            Ssid::ApiStubs::FETCH_SSID_SUBMISSIONS_SUCCESS[:body]]
         end
-        stubs.get(/folders\/.*\/plagiarism-checks\/latest/) do |env|
-          expect(env[:url].to_s).to include("/folders/#{assessment.ssid_folder_id}/plagiarism-checks/latest")
+        stubs.get(/folders\/.*\/plagiarism-checks\/latest\/submission-pairs/) do |env|
+          expect(env[:url].to_s).to include(
+            "/folders/#{assessment.ssid_folder_id}/plagiarism-checks/latest/submission-pairs"
+          )
+          expect(env[:params]['limit'].to_s).to eq('100')
+          expect(env[:params]['offset'].to_s).to eq('200')
           [Ssid::ApiStubs::FETCH_SSID_SUBMISSION_PAIR_DATA_SUCCESS[:status],
            { 'Content-Type' => 'application/json' },
            Ssid::ApiStubs::FETCH_SSID_SUBMISSION_PAIR_DATA_SUCCESS[:body]]
@@ -88,7 +94,7 @@ RSpec.describe Course::Assessment::Submission::SsidPlagiarismService do
       end
 
       it 'fetches plagiarism results successfully' do
-        results = subject.fetch_plagiarism_result
+        results = subject.fetch_plagiarism_result(limit, offset)
         expect(results).to be_an(Array)
       end
     end

--- a/spec/support/stubs/ssid/api_stubs.rb
+++ b/spec/support/stubs/ssid/api_stubs.rb
@@ -54,44 +54,14 @@ module Ssid::ApiStubs # rubocop:disable Metrics/ModuleLength
     status: 200,
     body: {
       payload: {
-        data: {
-          language: 'javascript',
-          submissionPairs: [
-            {
-              id: '185ek301-eecb-44ce-838e-bf1234f990e1',
-              baseSubmission: '185ek301-eecb-44ce-838e-bf1234f990e1',
-              comparedSubmission: '185ek301-eecb-44ce-838e-bf1234f990e1',
-              similarityScore: 0.5846153846153846
-            }
-          ],
-          ranAt: '2025-07-31T18:23:24.341104+08:00',
-          completedAt: '2025-07-31T18:23:24.341104+08:00',
-          statistics: {
-            total: 12,
-            bins: [
-              6,
-              0,
-              0,
-              0,
-              0,
-              0,
-              1,
-              0,
-              1,
-              3,
-              0,
-              1,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
-            ]
+        data: [
+          {
+            id: '185ek301-eecb-44ce-838e-bf1234f990e1',
+            baseSubmission: '185ek301-eecb-44ce-838e-bf1234f990e1',
+            comparedSubmission: '185ek301-eecb-44ce-838e-bf1234f990e1',
+            similarityScore: 0.5846153846153846
           }
-        }
+        ]
       }
     }.to_json
   }.freeze


### PR DESCRIPTION
Table will show (+) sign if there are still more rows to load.
<img width="1258" height="696" alt="Screenshot 2025-10-22 at 23 02 25" src="https://github.com/user-attachments/assets/f6de8a9f-62a4-4497-8a63-7cc260a361eb" />

Page will load new rows periodically (according to existing polling function, 5 second intervals, actual query takes ~2s)

When all rows loaded, + sign will disappear.