### PR TITLE
fix(ui): add z-index to TimeLimitBanner to prevent overlap by sticky headers

### DIFF
--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/TimeLimitBanner.tsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/TimeLimitBanner.tsx
@@ -88,7 +88,7 @@ const TimeLimitBanner: FC<Props> = (props) => {
   if (currentRemainingTime > 0) {
     TimeBanner = (
       <Banner
-        className="bg-red-700 text-white border-only-b-fuchsia-200 fixed top-0 right-0"
+        className="bg-red-700 text-white border-only-b-fuchsia-200 fixed top-0 right-0 z-dropdown"
         icon={<HourglassTop />}
       >
         <FormattedMessage
@@ -100,7 +100,7 @@ const TimeLimitBanner: FC<Props> = (props) => {
   } else {
     TimeBanner = (
       <Banner
-        className="bg-yellow-700 text-white border-only-b-fuchsia-200 fixed top-0 right-0"
+        className="bg-yellow-700 text-white border-only-b-fuchsia-200 fixed top-0 right-0 z-dropdown"
         icon={<HourglassTop />}
       >
         {currentBufferTime > 0 ? (


### PR DESCRIPTION
## Summary

The `TimeLimitBanner` during timed assessments renders with `fixed top-0 right-0` but **has no z-index**, causing sticky elements like `AnswerHeader` (`z-10`) to overlap and obscure it.

During a practical exam today (Apr 16), I had to keep scrolling back to the top just to check remaining time. The timer kept getting buried behind the sticky answer headers. This shouldn't happen during a timed exam where every second matters.

### Changes

- Added `z-dropdown` (z-index: 1000) to both the active timer banner (red) and the buffer/expired banner (yellow)
- Uses the z-index tier system introduced in #5397

### Before

Timer banner hidden behind sticky `AnswerHeader` elements. Students can't see remaining time without scrolling up.

### After

Timer banner renders above all content and sticky headers, always visible during timed assessments.

## Test plan

- [ ] Open a timed assessment submission page
- [ ] Scroll down past multiple questions with sticky answer headers
- [ ] Verify the red timer banner stays visible above all content
- [ ] Let timer expire and verify yellow buffer banner also stays visible