### PR TITLE
fix(submissions): fix 500 on course user type requests for admins

### DIFF
--- a/app/controllers/course/assessment/assessments_controller.rb
+++ b/app/controllers/course/assessment/assessments_controller.rb
@@ -193,7 +193,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
 
   def remind
     authorize!(:manage, @assessment)
-    return head :bad_request unless CourseUser.valid_course_user_type?(params[:course_users])
+    return head :bad_request unless Course.valid_course_user_type?(params[:course_users])
 
     Course::Assessment::ReminderService.
       send_closing_reminder(@assessment, student_course_users.pluck(:id), include_unsubscribed: true)
@@ -441,7 +441,7 @@ class Course::Assessment::AssessmentsController < Course::Assessment::Controller
   end
 
   def student_course_users
-    current_course_user.users_in_course_by_type(params[:course_users])
+    current_course.course_users_by_type(params[:course_users], current_course_user)
   end
 
   def can_access_assessment?

--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -394,7 +394,8 @@ class Course::Assessment::Submission::SubmissionsController < # rubocop:disable 
   end
 
   def course_user_ids
-    @course_user_ids ||= current_course_user.users_in_course_by_type(params[:course_users]).select(:user_id)
+    @course_user_ids ||=
+      current_course.course_users_by_type(params[:course_users], current_course_user).select(:user_id)
   end
 
   def user_ids_without_submission

--- a/app/controllers/course/survey/surveys_controller.rb
+++ b/app/controllers/course/survey/surveys_controller.rb
@@ -45,7 +45,7 @@ class Course::Survey::SurveysController < Course::Survey::Controller
 
   def remind
     authorize!(:manage, @survey)
-    return head :bad_request unless CourseUser.valid_course_user_type?(params[:course_users])
+    return head :bad_request unless Course.valid_course_user_type?(params[:course_users])
 
     Course::Survey::ReminderService.
       send_closing_reminder(
@@ -68,7 +68,7 @@ class Course::Survey::SurveysController < Course::Survey::Controller
   private
 
   def student_course_users
-    current_course_user.users_in_course_by_type(params[:course_users])
+    current_course.course_users_by_type(params[:course_users], current_course_user)
   end
 
   def render_survey_with_questions_json

--- a/app/models/concerns/course/course_user_type_concern.rb
+++ b/app/models/concerns/course/course_user_type_concern.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Course::CourseUserTypeConcern
+  extend ActiveSupport::Concern
+
+  COURSE_USER_TYPES = {
+    my_students: 'my_students',
+    my_students_w_phantom: 'my_students_w_phantom',
+    students: 'students',
+    students_w_phantom: 'students_w_phantom',
+    staff: 'staff',
+    staff_w_phantom: 'staff_w_phantom'
+  }.freeze
+
+  module ClassMethods
+    def valid_course_user_type?(type)
+      COURSE_USER_TYPES.value?(type)
+    end
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def course_users_by_type(type, user)
+    case type
+    when COURSE_USER_TYPES[:my_students]
+      user&.my_students&.without_phantom_users || CourseUser.none
+    when COURSE_USER_TYPES[:my_students_w_phantom]
+      user&.my_students || CourseUser.none
+    when COURSE_USER_TYPES[:students_w_phantom]
+      students
+    when COURSE_USER_TYPES[:staff]
+      staff.without_phantom_users
+    when COURSE_USER_TYPES[:staff_w_phantom]
+      staff
+    else
+      students.without_phantom_users # :students is the default type
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,6 +5,7 @@ class Course < ApplicationRecord
   include Course::CourseComponentsConcern
   include TimeZoneConcern
   include Generic::CollectionConcern
+  include Course::CourseUserTypeConcern
 
   acts_as_tenant :instance, inverse_of: :courses
   has_settings_on :settings do |s|

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -170,15 +170,6 @@ class CourseUser < ApplicationRecord
     where(user_id: user.id)
   end)
 
-  COURSE_USER_TYPES = {
-    my_students: 'my_students',
-    my_students_w_phantom: 'my_students_w_phantom',
-    students: 'students',
-    students_w_phantom: 'students_w_phantom',
-    staff: 'staff',
-    staff_w_phantom: 'staff_w_phantom'
-  }.freeze
-
   # Test whether the current scope includes the current user.
   #
   # @param [User] user The user to check
@@ -253,27 +244,6 @@ class CourseUser < ApplicationRecord
 
   def latest_learning_rate_record
     learning_rate_records.limit(1).first
-  end
-
-  def self.valid_course_user_type?(type)
-    COURSE_USER_TYPES.value?(type)
-  end
-
-  def users_in_course_by_type(type)
-    case type
-    when COURSE_USER_TYPES[:my_students]
-      my_students.without_phantom_users
-    when COURSE_USER_TYPES[:my_students_w_phantom]
-      my_students
-    when COURSE_USER_TYPES[:students_w_phantom]
-      course.students
-    when COURSE_USER_TYPES[:staff]
-      course.staff.without_phantom_users
-    when COURSE_USER_TYPES[:staff_w_phantom]
-      course.staff
-    else
-      course.students.without_phantom_users # :students is the default type
-    end
   end
 
   private

--- a/app/services/course/assessment/submission/csv_download_service.rb
+++ b/app/services/course/assessment/submission/csv_download_service.rb
@@ -3,14 +3,14 @@ require 'csv'
 class Course::Assessment::Submission::CsvDownloadService
   include TmpCleanupHelper
 
-  # @param [CourseUser] current_course_user The course user downloading the submissions.
+  # @param [CourseUser|nil] current_course_user The course user downloading the submissions.
   # @param [Course::Assessment] assessment The assessments to download submissions from.
-  # @param [String|nil] course_users_type The subset of course users whose submissions to download.
+  # @param [String|nil] course_user_type The subset of course users whose submissions to download.
   # Accepted values: 'my_students', 'my_students_w_phantom', 'students', 'students_w_phantom'
   #   'staff', 'staff_w_phantom'
-  def initialize(current_course_user, assessment, course_users_type)
+  def initialize(current_course_user, assessment, course_user_type)
     @current_course_user = current_course_user
-    @course_users_type = course_users_type
+    @course_user_type = course_user_type
     @assessment = assessment
 
     @question_assessments = Course::QuestionAssessment.where(assessment_id: assessment.id).
@@ -108,7 +108,8 @@ class Course::Assessment::Submission::CsvDownloadService
 
   def course_users
     # We cannot use ORDER BY because it conflicts with the selection
-    @course_users ||= @current_course_user.users_in_course_by_type(@course_users_type).
+    source_course = @current_course_user&.course || @assessment.course
+    @course_users ||= source_course.course_users_by_type(@course_user_type, @current_course_user).
                       includes(user: :emails).sort_by { |cu| [cu.phantom? ? 0 : 1, cu.name] }
   end
 end

--- a/app/services/course/assessment/submission/zip_download_service.rb
+++ b/app/services/course/assessment/submission/zip_download_service.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 class Course::Assessment::Submission::ZipDownloadService < Course::Assessment::Submission::BaseZipDownloadService
-  # @param [CourseUser] course_user The course user downloading the submissions.
+  # @param [CourseUser|nil] current_course_user The course user downloading the submissions.
   # @param [Course::Assessment] assessment The assessments to download submissions from.
-  # @param [String|nil] course_users The subset of course users whose submissions to download.
+  # @param [String|nil] course_user_type The subset of course users whose submissions to download.
   # Accepted values: 'my_students', 'my_students_w_phantom', 'students', 'students_w_phantom'
   #   'staff', 'staff_w_phantom'
-  def initialize(course_user, assessment, course_users)
+  def initialize(current_course_user, assessment, course_user_type)
     super()
-    @course_user = course_user
+    @current_course_user = current_course_user
     @assessment = assessment
     @questions = assessment.questions.to_h { |q| [q.id, q] }
-    @course_users = course_users
+    @course_user_type = course_user_type
   end
 
   private
@@ -38,6 +38,7 @@ class Course::Assessment::Submission::ZipDownloadService < Course::Assessment::S
   end
 
   def course_user_ids
-    @course_user_ids ||= @course_user.users_in_course_by_type(@course_users).select(:user_id)
+    source_course = @current_course_user&.course || @assessment.course
+    @course_user_ids ||= source_course.course_users_by_type(@course_user_type, @current_course_user).select(:user_id)
   end
 end

--- a/spec/controllers/course/assessment/assessments_controller_spec.rb
+++ b/spec/controllers/course/assessment/assessments_controller_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Course::Assessment::AssessmentsController do
         get :auto_feedback_count, as: :json, params: {
           course_id: course,
           id: assessment,
-          course_users: CourseUser::COURSE_USER_TYPES[:students]
+          course_users: Course::COURSE_USER_TYPES[:students]
         }
       end
 
@@ -269,7 +269,7 @@ RSpec.describe Course::Assessment::AssessmentsController do
         patch :publish_auto_feedback, as: :json, params: {
           course_id: course,
           id: assessment,
-          course_users: CourseUser::COURSE_USER_TYPES[:students],
+          course_users: Course::COURSE_USER_TYPES[:students],
           rating: 4
         }
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -201,6 +201,135 @@ RSpec.describe Course, type: :model do
       end
     end
 
+    describe Course::CourseUserTypeConcern do
+      let(:course) { create(:course) }
+      let!(:group_manager) { create(:course_manager, course: course) }
+      let!(:student) { create(:course_student, course: course) }
+      let!(:phantom_student) { create(:course_student, :phantom, course: course) }
+      let!(:ta) { create(:course_teaching_assistant, course: course) }
+      let!(:phantom_ta) { create(:course_teaching_assistant, :phantom, course: course) }
+      let!(:group) do
+        grp = create(:course_group, course: course)
+        create(:course_group_manager, course: course, group: grp, course_user: group_manager)
+        create(:course_group_student, course: course, group: grp, course_user: student)
+        create(:course_group_student, course: course, group: grp, course_user: phantom_student)
+        grp
+      end
+
+      describe '.valid_course_user_type?' do
+        it 'returns true for all valid type strings' do
+          %w[students students_w_phantom my_students my_students_w_phantom staff staff_w_phantom].each do |type|
+            expect(Course.valid_course_user_type?(type)).to be true
+          end
+        end
+
+        it 'returns false for nil' do
+          expect(Course.valid_course_user_type?(nil)).to be false
+        end
+
+        it 'returns false for unknown strings' do
+          expect(Course.valid_course_user_type?('invalid')).to be false
+        end
+
+        it 'returns false for symbol versions of valid types' do
+          expect(Course.valid_course_user_type?(:students)).to be false
+        end
+      end
+
+      describe '#course_users_by_type' do
+        context 'when user is a course user' do
+          it "returns non-phantom students for 'students'" do
+            result = course.course_users_by_type('students', group_manager)
+            expect(result).to include(student)
+            expect(result).not_to include(phantom_student, ta)
+          end
+
+          it "returns all students including phantoms for 'students_w_phantom'" do
+            result = course.course_users_by_type('students_w_phantom', group_manager)
+            expect(result).to include(student, phantom_student)
+            expect(result).not_to include(ta)
+          end
+
+          it "returns non-phantom group students for 'my_students'" do
+            result = course.course_users_by_type('my_students', group_manager)
+            expect(result).to include(student)
+            expect(result).not_to include(phantom_student, ta)
+          end
+
+          it "returns all group students including phantoms for 'my_students_w_phantom'" do
+            result = course.course_users_by_type('my_students_w_phantom', group_manager)
+            expect(result).to include(student, phantom_student)
+            expect(result).not_to include(ta)
+          end
+
+          it "returns non-phantom staff for 'staff'" do
+            result = course.course_users_by_type('staff', group_manager)
+            expect(result).to include(ta)
+            expect(result).not_to include(phantom_ta, student)
+          end
+
+          it "returns all staff including phantoms for 'staff_w_phantom'" do
+            result = course.course_users_by_type('staff_w_phantom', group_manager)
+            expect(result).to include(ta, phantom_ta)
+            expect(result).not_to include(student)
+          end
+
+          it 'defaults to non-phantom students for unknown types' do
+            result = course.course_users_by_type(nil, group_manager)
+            expect(result).to include(student)
+            expect(result).not_to include(phantom_student, ta)
+          end
+        end
+
+        # Regression: admins not enrolled in a course have nil as current_course_user,
+        # which previously caused a 500 when the old CourseUser#users_in_course_by_type
+        # was called on nil.
+        context 'when user is nil (e.g. a system administrator not enrolled in the course)' do
+          it "returns non-phantom students for 'students'" do
+            result = course.course_users_by_type('students', nil)
+            expect(result).to include(student)
+            expect(result).not_to include(phantom_student, ta)
+          end
+
+          it "returns all students including phantoms for 'students_w_phantom'" do
+            result = course.course_users_by_type('students_w_phantom', nil)
+            expect(result).to include(student, phantom_student)
+            expect(result).not_to include(ta)
+          end
+
+          it "returns an empty result for 'my_students'" do
+            result = course.course_users_by_type('my_students', nil)
+            expect(result).to be_a(ActiveRecord::Relation)
+            expect(result).to be_empty
+          end
+
+          it "returns an empty result for 'my_students_w_phantom'" do
+            result = course.course_users_by_type('my_students_w_phantom', nil)
+            expect(result).to be_a(ActiveRecord::Relation)
+            expect(result).to be_empty
+          end
+
+          it "returns non-phantom staff for 'staff'" do
+            result = course.course_users_by_type('staff', nil)
+            expect(result).to include(ta)
+            expect(result).not_to include(phantom_ta, student)
+          end
+
+          it "returns all staff including phantoms for 'staff_w_phantom'" do
+            result = course.course_users_by_type('staff_w_phantom', nil)
+            expect(result).to include(ta, phantom_ta)
+            expect(result).not_to include(student)
+          end
+
+          it 'defaults to non-phantom students for unknown types' do
+            result = course.course_users_by_type(nil, nil)
+            expect(result).to include(student)
+            expect(result).not_to include(phantom_student, ta)
+          end
+        end
+      end
+    end
+
     describe 'calculated attributes' do
       let(:course) { create(:course) }
       let!(:course_users) { create_list(:course_user, 2, course: course) }

--- a/spec/models/course_user_spec.rb
+++ b/spec/models/course_user_spec.rb
@@ -436,62 +436,6 @@ RSpec.describe CourseUser, type: :model do
       end
     end
 
-    describe '#users_in_course_by_type' do
-      let(:group_owner) { create(:course_manager, course: course) }
-      let!(:phantom_student) { create(:course_student, :phantom, course: course) }
-      let!(:ta) { create(:course_teaching_assistant, course: course) }
-      let!(:phantom_ta) { create(:course_teaching_assistant, :phantom, course: course) }
-      let!(:group) do
-        grp = create(:course_group, course: course)
-        create(:course_group_manager, course: course, group: grp, course_user: group_owner)
-        create(:course_group_student, course: course, group: grp, course_user: student)
-        create(:course_group_student, course: course, group: grp, course_user: phantom_student)
-        grp
-      end
-
-      it "returns non-phantom students for 'students'" do
-        result = group_owner.users_in_course_by_type('students')
-        expect(result).to include(student)
-        expect(result).not_to include(phantom_student, ta)
-      end
-
-      it "returns all students including phantoms for 'students_w_phantom'" do
-        result = group_owner.users_in_course_by_type('students_w_phantom')
-        expect(result).to include(student, phantom_student)
-        expect(result).not_to include(ta)
-      end
-
-      it "returns non-phantom group students for 'my_students'" do
-        result = group_owner.users_in_course_by_type('my_students')
-        expect(result).to include(student)
-        expect(result).not_to include(phantom_student, ta)
-      end
-
-      it "returns all group students including phantoms for 'my_students_w_phantom'" do
-        result = group_owner.users_in_course_by_type('my_students_w_phantom')
-        expect(result).to include(student, phantom_student)
-        expect(result).not_to include(ta)
-      end
-
-      it "returns non-phantom staff for 'staff'" do
-        result = group_owner.users_in_course_by_type('staff')
-        expect(result).to include(ta)
-        expect(result).not_to include(phantom_ta, student)
-      end
-
-      it "returns all staff including phantoms for 'staff_w_phantom'" do
-        result = group_owner.users_in_course_by_type('staff_w_phantom')
-        expect(result).to include(ta, phantom_ta)
-        expect(result).not_to include(student)
-      end
-
-      it 'defaults to non-phantom students for unknown types' do
-        result = group_owner.users_in_course_by_type(nil)
-        expect(result).to include(student)
-        expect(result).not_to include(phantom_student, ta)
-      end
-    end
-
     context 'when the same user is registered into the same course twice' do
       subject do
         create(:course_student, course: student.course, user: student.user, role: :student)

--- a/spec/services/course/assessment/submission/zip_download_service_spec.rb
+++ b/spec/services/course/assessment/submission/zip_download_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Course::Assessment::Submission::ZipDownloadService do
         group
       end
 
-      types = CourseUser::COURSE_USER_TYPES
+      types = Course::COURSE_USER_TYPES
 
       before do
         submission1
@@ -80,7 +80,7 @@ RSpec.describe Course::Assessment::Submission::ZipDownloadService do
 
       context 'when downloading submissions by my students' do
         it 'downloads the correct submissions' do
-          service.instance_variable_set(:@course_users, types[:my_students])
+          service.instance_variable_set(:@course_user_type, types[:my_students])
           subject
 
           file_names = Dir.entries(dir)
@@ -94,7 +94,7 @@ RSpec.describe Course::Assessment::Submission::ZipDownloadService do
 
       context 'when downloading submissions by my students (incl phantom)' do
         it 'downloads the correct submissions' do
-          service.instance_variable_set(:@course_users, types[:my_students_w_phantom])
+          service.instance_variable_set(:@course_user_type, types[:my_students_w_phantom])
           subject
 
           file_names = Dir.entries(dir)
@@ -121,7 +121,7 @@ RSpec.describe Course::Assessment::Submission::ZipDownloadService do
 
       context 'when downloading submissions including phantom students' do
         it 'downloads the correct submissions' do
-          service.instance_variable_set(:@course_users, types[:students_w_phantom])
+          service.instance_variable_set(:@course_user_type, types[:students_w_phantom])
           subject
 
           file_names = Dir.entries(dir)
@@ -135,7 +135,7 @@ RSpec.describe Course::Assessment::Submission::ZipDownloadService do
 
       context 'when downloading submissions by staff' do
         it 'downloads the correct submissions' do
-          service.instance_variable_set(:@course_users, types[:staff])
+          service.instance_variable_set(:@course_user_type, types[:staff])
           subject
 
           file_names = Dir.entries(dir)
@@ -149,7 +149,7 @@ RSpec.describe Course::Assessment::Submission::ZipDownloadService do
 
       context 'when downloading submissions by staff' do
         it 'downloads the correct submissions' do
-          service.instance_variable_set(:@course_users, types[:staff_w_phantom])
+          service.instance_variable_set(:@course_user_type, types[:staff_w_phantom])
           subject
 
           file_names = Dir.entries(dir)


### PR DESCRIPTION
- Moved CourseUser::users_in_course_by_type -> Course::course_users_by_type
- Standardized variable names for CsvDownloadService and ZipDownloadService, handle case where current_course_user is nil


Issue was `CourseUser::users_in_course_by_type` returning 500 when admin accesses the page, since they have no course user.

Real course instructors were not affected.