### PR TITLE
feat: add clickable user names and instance role display for staff/admin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,14 +9,19 @@ class UsersController < ApplicationController
       course_users = @user.course_users.with_course_statistics.from_instance(current_tenant)
       @current_courses = course_users.merge(Course.current).order(created_at: :desc)
       @completed_courses = course_users.merge(Course.completed).order(created_at: :desc)
-      @instances = other_instances
+
+      tenant_id = current_tenant.id
+
+      ActsAsTenant.without_tenant do
+        all_instance_users = InstanceUser.includes(:instance).
+                             where(user_id: @user.id).
+                             to_a
+
+        instance_users, @instances =
+          all_instance_users.partition { |iu| iu.instance_id == tenant_id }
+
+        @instance_user = instance_users.first
+      end
     end
-  end
-
-  private
-
-  def other_instances
-    tenant = current_tenant
-    ActsAsTenant.without_tenant { Instance.containing_user(@user) - [tenant] }
   end
 end

--- a/app/views/course/users/_user_list_data.json.jbuilder
+++ b/app/views/course/users/_user_list_data.json.jbuilder
@@ -3,6 +3,9 @@ should_show_timeline ||= false
 should_show_phantom ||= false
 
 json.id course_user.id if course_user.id
+if current_course_user&.staff? || can?(:manage, course_user) || course_user.user_id == current_user.id
+  json.userId course_user.user_id
+end
 json.name course_user.name.strip
 json.imageUrl user_image(course_user.user)
 json.email course_user.user.primary_email&.email || course_user.user.email

--- a/app/views/instance_user_role_requests/_instance_user_role_request_list_data.json.jbuilder
+++ b/app/views/instance_user_role_requests/_instance_user_role_request_list_data.json.jbuilder
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 json.id role_request.id
+json.userId role_request.user.id
 json.name role_request.user.name
 json.email role_request.user.email
 json.organization role_request.organization

--- a/app/views/users/_instance_list_data.json.jbuilder
+++ b/app/views/users/_instance_list_data.json.jbuilder
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
-json.id instance.id
-json.name instance.name
-json.host instance.host
+json.id instance_user.instance.id
+json.name instance_user.instance.name
+json.host instance_user.instance.host
+json.instanceRole instance_user.role

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -3,6 +3,7 @@ json.user do
   json.id @user.id
   json.name @user.name.strip
   json.imageUrl user_image(@user)
+  json.instanceRole @instance_user&.role
 end
 
 if @current_courses.any?
@@ -18,7 +19,7 @@ if @completed_courses.any?
 end
 
 if current_user&.administrator? && @instances.any?
-  json.instances @instances.each do |instance|
-    json.partial! 'instance_list_data', instance: instance
+  json.instances @instances.each do |instance_user|
+    json.partial! 'instance_list_data', instance_user: instance_user
   end
 end

--- a/client/app/bundles/course/users/components/misc/UserProfileCard.tsx
+++ b/client/app/bundles/course/users/components/misc/UserProfileCard.tsx
@@ -112,7 +112,13 @@ const UserProfileCard: FC<Props> = ({ user }) => {
             direction="column"
             item
           >
-            <Typography variant="h5">{user.name}</Typography>
+            {user.userId ? (
+              <Link to={`/users/${user.userId}`}>
+                <Typography variant="h5">{user.name}</Typography>
+              </Link>
+            ) : (
+              <Typography variant="h5">{user.name}</Typography>
+            )}
             <Typography>
               <strong>{t(roleTranslations[user.role])}</strong>
             </Typography>

--- a/client/app/bundles/course/users/components/misc/__test__/UserProfileCard.test.tsx
+++ b/client/app/bundles/course/users/components/misc/__test__/UserProfileCard.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitForElementToBeRemoved } from 'test-utils';
+
+import UserProfileCard from '../UserProfileCard';
+
+const baseUser = {
+  id: 2,
+  name: 'test',
+  email: 'test@example.org',
+  role: 'student' as const,
+  level: 0,
+  exp: 0,
+  isSuspended: false,
+  canReadStatistics: false,
+  referenceTimelineId: null,
+};
+
+describe('<UserProfileCard />', () => {
+  describe('when the viewer is staff (userId present)', () => {
+    it('renders the name as a link to the global user profile', async () => {
+      render(<UserProfileCard user={{ ...baseUser, userId: 3 }} />);
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      const link = screen.getByRole('link', { name: 'test' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/users/3');
+    });
+  });
+
+  describe('when the viewer is a student (userId absent)', () => {
+    it('renders the name as plain text without a link', async () => {
+      render(<UserProfileCard user={baseUser} />);
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByText('test')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: 'test' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/bundles/system/admin/admin/components/tables/UsersTable.tsx
+++ b/client/app/bundles/system/admin/admin/components/tables/UsersTable.tsx
@@ -280,7 +280,7 @@ const UsersTable: FC<Props> = (props) => {
               {user.instances.map((instance) => (
                 <li key={instance.name} className="list-none">
                   <Link
-                    href={`//${instance.host}/admin/users`}
+                    href={`//${instance.host}/users/${user.id}`}
                     underline="hover"
                   >
                     {t(translations.userInstanceEntry, {

--- a/client/app/bundles/system/admin/instance/instance/components/tables/InstanceUserRoleRequestsTable.tsx
+++ b/client/app/bundles/system/admin/instance/instance/components/tables/InstanceUserRoleRequestsTable.tsx
@@ -9,6 +9,7 @@ import {
 } from 'types/system/instance/roleRequests';
 
 import DataTable from 'lib/components/core/layouts/DataTable';
+import Link from 'lib/components/core/Link';
 import Note from 'lib/components/core/Note';
 import { ROLE_REQUEST_ROLES } from 'lib/constants/sharedConstants';
 import rebuildObjectFromRow from 'lib/helpers/mui-datatables-helpers';
@@ -120,10 +121,12 @@ const InstanceUserRoleRequestsTable: FC<Props> = (props) => {
         alignCenter: false,
         customBodyRenderLite: (dataIndex): JSX.Element => {
           const roleRequest = roleRequests[dataIndex];
-          return (
-            <Typography key={`name-${roleRequest.id}`} variant="body2">
-              {roleRequest.name}
-            </Typography>
+          return roleRequest.userId ? (
+            <Link to={`/users/${roleRequest.userId}`}>
+              <Typography variant="body2">{roleRequest.name}</Typography>
+            </Link>
+          ) : (
+            <Typography variant="body2">{roleRequest.name}</Typography>
           );
         },
       },

--- a/client/app/bundles/system/admin/instance/instance/components/tables/__test__/InstanceUserRoleRequestsTable.test.tsx
+++ b/client/app/bundles/system/admin/instance/instance/components/tables/__test__/InstanceUserRoleRequestsTable.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitForElementToBeRemoved } from 'test-utils';
+
+import InstanceUserRoleRequestsTable from '../InstanceUserRoleRequestsTable';
+
+const baseRequest = {
+  id: 1,
+  userId: 5,
+  name: 'Alex',
+  email: 'a@example.org',
+  role: 'instructor' as const,
+  organization: 'NUS',
+  designation: 'Lecturer',
+  reason: 'To teach',
+  status: 'pending',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  confirmedBy: null,
+  confirmedAt: null,
+};
+
+describe('<InstanceUserRoleRequestsTable />', () => {
+  describe('name column', () => {
+    it('renders the requester name as a link to their user profile', async () => {
+      render(
+        <InstanceUserRoleRequestsTable
+          pendingRoleRequests
+          roleRequests={[baseRequest]}
+          title="Pending Role Requests"
+        />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      const link = screen.getByRole('link', { name: 'Alex' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/users/5');
+    });
+
+    it('links to the correct user profile when multiple requests are shown', async () => {
+      const secondRequest = { ...baseRequest, id: 2, userId: 99, name: 'Ben' };
+      render(
+        <InstanceUserRoleRequestsTable
+          approvedRoleRequests
+          roleRequests={[baseRequest, secondRequest]}
+          title="Approved Role Requests"
+        />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByRole('link', { name: 'Alex' })).toHaveAttribute(
+        'href',
+        '/users/5',
+      );
+      expect(screen.getByRole('link', { name: 'Ben' })).toHaveAttribute(
+        'href',
+        '/users/99',
+      );
+    });
+
+    it('renders the name as plain text when userId is absent', async () => {
+      const requestWithoutUser = { ...baseRequest, userId: undefined };
+      render(
+        <InstanceUserRoleRequestsTable
+          pendingRoleRequests
+          roleRequests={[requestWithoutUser]}
+          title="Pending Role Requests"
+        />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByText('Alex')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: 'Alex' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/bundles/users/components/tables/InstancesTable.tsx
+++ b/client/app/bundles/users/components/tables/InstancesTable.tsx
@@ -13,6 +13,7 @@ import {
 import { InstanceBasicMiniEntity } from 'types/system/instances';
 
 import Link from 'lib/components/core/Link';
+import { INSTANCE_USER_ROLES } from 'lib/constants/sharedConstants';
 import tableTranslations from 'lib/translations/table';
 
 interface Props extends WrappedComponentProps {
@@ -32,6 +33,7 @@ const InstancesTable: FC<Props> = ({ title, instances, intl }: Props) => {
             <TableCell>
               {intl.formatMessage(tableTranslations.instance)}
             </TableCell>
+            <TableCell>{intl.formatMessage(tableTranslations.role)}</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -45,6 +47,13 @@ const InstancesTable: FC<Props> = ({ title, instances, intl }: Props) => {
                   >
                     {instance.name}
                   </Link>
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Typography className="instance_role" variant="body2">
+                  {instance.instanceRole
+                    ? INSTANCE_USER_ROLES[instance.instanceRole]
+                    : '-'}
                 </Typography>
               </TableCell>
             </TableRow>

--- a/client/app/bundles/users/components/tables/__test__/InstancesTable.test.tsx
+++ b/client/app/bundles/users/components/tables/__test__/InstancesTable.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitForElementToBeRemoved } from 'test-utils';
+
+import InstancesTable from '../InstancesTable';
+
+const baseInstance = {
+  id: 1,
+  name: 'Raffles Institution',
+  host: 'raffles.coursemology.org',
+  redirectUri: '',
+};
+
+describe('<InstancesTable />', () => {
+  describe('role column', () => {
+    it('renders a Role column header', async () => {
+      render(
+        <InstancesTable instances={[baseInstance]} title="Other Instances" />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByText('Role')).toBeInTheDocument();
+    });
+
+    it('displays the correct role label for a normal user', async () => {
+      render(
+        <InstancesTable
+          instances={[{ ...baseInstance, instanceRole: 'normal' }]}
+          title="Other Instances"
+        />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByText('Normal')).toBeInTheDocument();
+    });
+
+    it('displays the correct role label for an instructor', async () => {
+      render(
+        <InstancesTable
+          instances={[{ ...baseInstance, instanceRole: 'instructor' }]}
+          title="Other Instances"
+        />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByText('Instructor')).toBeInTheDocument();
+    });
+
+    it('displays the correct role label for an administrator', async () => {
+      render(
+        <InstancesTable
+          instances={[{ ...baseInstance, instanceRole: 'administrator' }]}
+          title="Other Instances"
+        />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByText('Administrator')).toBeInTheDocument();
+    });
+
+    it('displays a dash when instanceRole is absent', async () => {
+      render(
+        <InstancesTable instances={[baseInstance]} title="Other Instances" />,
+      );
+      await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+
+      expect(screen.getByText('-')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/bundles/users/pages/UserShow.tsx
+++ b/client/app/bundles/users/pages/UserShow.tsx
@@ -5,6 +5,7 @@ import { Avatar, Grid, Typography } from '@mui/material';
 
 import Page from 'lib/components/core/layouts/Page';
 import LoadingIndicator from 'lib/components/core/LoadingIndicator';
+import { INSTANCE_USER_ROLES } from 'lib/constants/sharedConstants';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
 
 import CoursesTable from '../components/tables/CoursesTable';
@@ -66,6 +67,7 @@ const UserShow: FC<Props> = (props) => {
   return (
     <Page>
       <Grid
+        alignItems="center"
         className="global-user-profile"
         container
         direction="row"
@@ -84,13 +86,26 @@ const UserShow: FC<Props> = (props) => {
           <Avatar src={user.imageUrl} style={styles.image} />
         </Grid>
         <Grid
-          alignItems="center"
           container
           direction="row"
           item
           justifyContent={{ xs: 'center', sm: 'start' }}
         >
-          <Typography variant="h5">{user.name}</Typography>
+          <Grid
+            alignItems={{ xs: 'center', sm: 'start' }}
+            container
+            direction="column"
+            item
+          >
+            <Typography variant="h5">{user.name}</Typography>
+            <Typography>
+              <strong>
+                {user.instanceRole
+                  ? INSTANCE_USER_ROLES[user.instanceRole]
+                  : '-'}
+              </strong>
+            </Typography>
+          </Grid>
         </Grid>
       </Grid>
       {currentCourses.length > 0 && (

--- a/client/app/bundles/users/pages/__test__/UserShow.test.tsx
+++ b/client/app/bundles/users/pages/__test__/UserShow.test.tsx
@@ -1,0 +1,80 @@
+import { Route, Routes } from 'react-router-dom';
+import { createMockAdapter } from 'mocks/axiosMock';
+import { render, screen, waitFor } from 'test-utils';
+
+import GlobalAPI from 'api';
+
+import UserShow from '../UserShow';
+
+const mock = createMockAdapter(GlobalAPI.users.client);
+
+beforeEach(() => {
+  mock.reset();
+});
+
+const baseUser = {
+  id: 3,
+  name: 'Caitlyn',
+  imageUrl: '',
+};
+
+const renderUserShow = (): void => {
+  render(
+    <Routes>
+      <Route element={<UserShow />} path="/users/:userId" />
+    </Routes>,
+    { at: ['/users/3'] },
+  );
+};
+
+describe('<UserShow />', () => {
+  describe('instance role display', () => {
+    it('displays the instance role under the user name', async () => {
+      mock.onGet('/users/3').reply(200, {
+        user: { ...baseUser, instanceRole: 'instructor' },
+        currentCourses: [],
+        completedCourses: [],
+        instances: [],
+      });
+
+      renderUserShow();
+
+      await waitFor(() =>
+        expect(screen.getByText('Caitlyn')).toBeInTheDocument(),
+      );
+      expect(screen.getByText('Instructor')).toBeInTheDocument();
+    });
+
+    it('displays Normal for a normal instance user', async () => {
+      mock.onGet('/users/3').reply(200, {
+        user: { ...baseUser, instanceRole: 'normal' },
+        currentCourses: [],
+        completedCourses: [],
+        instances: [],
+      });
+
+      renderUserShow();
+
+      await waitFor(() =>
+        expect(screen.getByText('Caitlyn')).toBeInTheDocument(),
+      );
+      expect(screen.getByText('Normal')).toBeInTheDocument();
+    });
+
+    it('displays a dash when instanceRole is absent', async () => {
+      mock.onGet('/users/3').reply(200, {
+        user: baseUser,
+        currentCourses: [],
+        completedCourses: [],
+        instances: [],
+      });
+
+      renderUserShow();
+
+      await waitFor(() =>
+        expect(screen.getByText('Caitlyn')).toBeInTheDocument(),
+      );
+      expect(screen.getByText('-')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/types/course/courseUsers.ts
+++ b/client/app/types/course/courseUsers.ts
@@ -39,6 +39,7 @@ export interface CourseUserShape {
 
 export interface CourseUserBasicListData {
   id: number;
+  userId?: number;
   name: string;
   userUrl?: string;
   imageUrl?: string;
@@ -55,6 +56,7 @@ export interface CourseUserListData extends CourseUserBasicListData {
 
 export interface CourseUserBasicMiniEntity {
   id: CourseUserBasicListData['id'];
+  userId?: CourseUserBasicListData['userId'];
   name: CourseUserBasicListData['name'];
   userUrl?: CourseUserBasicListData['userUrl'];
   imageUrl?: CourseUserBasicListData['userUrl'];

--- a/client/app/types/system/instance/roleRequests.ts
+++ b/client/app/types/system/instance/roleRequests.ts
@@ -2,6 +2,7 @@ import { RoleRequestRoles } from './users';
 
 export interface RoleRequestBasicListData {
   id: number;
+  userId?: number;
   role: RoleRequestRoles;
   organization: string;
   designation: string;

--- a/client/app/types/system/instances.ts
+++ b/client/app/types/system/instances.ts
@@ -1,5 +1,7 @@
 import { Permissions } from 'types';
 
+import { InstanceUserRoles } from './instance/users';
+
 export type InstancePermissions = Permissions<
   'canCreateInstances' | 'canCreateAnnouncement'
 >;
@@ -13,6 +15,7 @@ export interface InstanceBasicListData {
   name: string;
   host: string;
   redirectUri: string;
+  instanceRole?: InstanceUserRoles;
 }
 
 export interface InstanceListData extends InstanceBasicListData {
@@ -28,6 +31,7 @@ export interface InstanceBasicMiniEntity {
   name: string;
   host: string;
   redirectUri: string;
+  instanceRole?: InstanceUserRoles;
 }
 
 export interface InstanceMiniEntity extends InstanceBasicMiniEntity {

--- a/client/app/types/users.ts
+++ b/client/app/types/users.ts
@@ -1,5 +1,6 @@
 import { CourseUserRole } from './course/courseUsers';
 import { EnrolRequestListData } from './course/enrolRequests';
+import { InstanceUserRoles } from './system/instance/users';
 
 export type UserRoles = 'normal' | 'administrator';
 
@@ -7,6 +8,7 @@ export interface UserBasicListData {
   id: number;
   name: string;
   imageUrl?: string;
+  instanceRole?: InstanceUserRoles;
 }
 export interface UserListData {
   id: number;
@@ -27,6 +29,7 @@ export interface UserBasicMiniEntity {
   id: number;
   name: string;
   imageUrl?: string;
+  instanceRole?: InstanceUserRoles;
 }
 
 export interface UserMiniEntity extends UserBasicMiniEntity {

--- a/spec/controllers/course/instance_user_role_requests_controller_spec.rb
+++ b/spec/controllers/course/instance_user_role_requests_controller_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe InstanceUserRoleRequestsController, type: :controller do
 
     before { controller_sign_in(controller, user) }
 
+    describe '#index' do
+      render_views
+
+      let!(:pending_request) { create(:instance_user_role_request, :pending, instance: instance, user: user) }
+
+      before { controller_sign_in(controller, admin) }
+      subject { get :index, format: :json }
+
+      it 'includes userId for each role request' do
+        subject
+        json = JSON.parse(response.body, symbolize_names: true)
+        request_json = json[:roleRequests].find { |r| r[:id] == pending_request.id }
+        expect(request_json[:userId]).to eq(user.id)
+      end
+    end
+
     describe '#create' do
       subject do
         post :create, params: { user_role_request:

--- a/spec/controllers/course/users_controller_spec.rb
+++ b/spec/controllers/course/users_controller_spec.rb
@@ -365,5 +365,56 @@ RSpec.describe Course::UsersController, type: :controller do
         end
       end
     end
+    describe '#show' do
+      render_views
+
+      let(:student) { create(:course_student, course: course) }
+
+      before { controller_sign_in(controller, user) }
+
+      subject do
+        get :show, as: :json, params: { course_id: course, id: student }
+      end
+
+      context 'when the viewer is a staff member' do
+        let!(:viewer) { create(:course_manager, course: course, user: user) }
+
+        it 'includes userId in the response' do
+          subject
+          user_data = JSON.parse(response.body)['user']
+          expect(user_data['userId']).to eq(student.user_id)
+        end
+      end
+
+      context 'when the viewer is a system administrator' do
+        let(:user) { create(:administrator) }
+
+        it 'includes userId in the response' do
+          subject
+          user_data = JSON.parse(response.body)['user']
+          expect(user_data['userId']).to eq(student.user_id)
+        end
+      end
+
+      context 'when the viewer is an instance administrator' do
+        let(:user) { create(:instance_administrator, instance: instance).user }
+
+        it 'includes userId in the response' do
+          subject
+          user_data = JSON.parse(response.body)['user']
+          expect(user_data['userId']).to eq(student.user_id)
+        end
+      end
+
+      context 'when the viewer is a student' do
+        let!(:viewer) { create(:course_student, course: course, user: user) }
+
+        it 'does not include userId in the response' do
+          subject
+          user_data = JSON.parse(response.body)['user']
+          expect(user_data).not_to have_key('userId')
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe UsersController, type: :controller do
   let(:instance) { Instance.default }
 
   with_tenant(:instance) do
+    render_views
+
     let!(:user) { create(:user) }
 
     describe '#show' do
       before { controller_sign_in(controller, user) }
-      subject { get :show, params: { id: user_id } }
+      subject { get :show, as: :json, params: { id: user_id } }
 
       context 'When user is system user' do
         let(:user_id) { User::SYSTEM_USER_ID }
@@ -26,6 +28,48 @@ RSpec.describe UsersController, type: :controller do
           subject
 
           expect(response.status).to eq(404)
+        end
+      end
+
+      context 'when viewing a normal user profile' do
+        let(:user_id) { user.id }
+
+        context 'when the user is an instructor on the current instance' do
+          before { user.instance_users.find_by(instance: instance).update!(role: :instructor) }
+
+          it 'returns instructor as the instanceRole in the user JSON' do
+            subject
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:user][:instanceRole]).to eq('instructor')
+          end
+        end
+
+        context 'when the user is a normal user on the current instance' do
+          it 'returns normal as the instanceRole in the user JSON' do
+            subject
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:user][:instanceRole]).to eq('normal')
+          end
+        end
+
+        context 'when the user is an administrator on the current instance' do
+          before { user.instance_users.find_by(instance: instance).update!(role: :administrator) }
+
+          it 'returns administrator as the instanceRole in the user JSON' do
+            subject
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:user][:instanceRole]).to eq('administrator')
+          end
+        end
+
+        context 'when the user has no instance_user record' do
+          before { user.instance_users.where(instance: instance).destroy_all }
+
+          it 'returns nil as the instanceRole in the user JSON' do
+            subject
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:user][:instanceRole]).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
1. Persona: staff and admin use these features to access admin student profiles, role requester profiles and learn about roles of users at each instance more easily.

2. To access admin student profiles directly, userId (rather than CourseUserId) must be propogated to the site. (needs to ensure that userId is only passed to the site for admin/staff to prevent students from seeing their own userId.) for role requester profiles, the userId of the requester is necessary. for roles of users at each instance, we now need both every instance the user is present in AND their role in each instance instead of only the instances. 

3 and 4. userId only fetched if user is staff/admin. user name is clickable only if userId is fetched. 
for role requester profiles, if fail to fetch, the name will be unclickable. (that should never happen? should an error be flagged if this happens? right now, the name will just be unclickable)
for instance role display, if instance role cannot be fetched, the display will be '-' instead.