### PR TITLE
fix(sidebar): fix bug where home button is highlighted when not at home page

### DIFF
--- a/client/app/bundles/course/container/Sidebar/SidebarItem.tsx
+++ b/client/app/bundles/course/container/Sidebar/SidebarItem.tsx
@@ -90,11 +90,11 @@ const SidebarItem = (props: SidebarItemProps): JSX.Element => {
 const HomeSidebarItem = (props: { to: string }): JSX.Element => {
   return (
     <SidebarItem
-      exact
       of={{
         key: 'sidebar_home',
         icon: 'home',
         path: props.to,
+        exact: true,
       }}
     />
   );


### PR DESCRIPTION
<img width="504" height="80" alt="image" src="https://github.com/user-attachments/assets/d2e34249-f936-4b1a-a2d1-df4ff2dcb536" />

HomeSidebarItem was created with props exact = true rather than item.exact = true. because of that, isActive always remains true, so Home Button is always highlighted. fixed by removing outer exact prop pass and adding exact: true into of, ensuring that its only highlighted if activeUrl === item.path, not just that it starts with item.path.