### PR TITLE
chore(config): update root README with course seeding

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -25,7 +25,13 @@ These commands should be run with the repository root directory (one level up fr
    bundle exec rake db:setup
    ```
 
-4. Initialize .env file
+4. Seed the prefilled courses and assessments
+
+   ```sh
+   bundle exec rake coursemology:seed
+   ```
+
+5. Initialize .env file
 
    ```sh
    cp env .env
@@ -33,7 +39,7 @@ These commands should be run with the repository root directory (one level up fr
 
    You may need to add specific API keys (such as the [GOOGLE_RECAPTCHA_SITE_KEY](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do)) to the .env files for testing specific features.
 
-5. To start the app server, run
+6. To start the app server, run
 
    ```
    bundle exec rails s -p 3000

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,6 +72,7 @@ Rails.application.configure do
 
   config.x.default_app_host = ENV.fetch('RAILS_HOSTNAME', 'localhost:8080').gsub(/:\d+/, '')
   config.x.default_host = ENV.fetch('RAILS_HOSTNAME', 'localhost:8080')
+  config.x.default_user_password = 'Coursemology!'
 
   config.action_mailer.default_url_options = { host: config.x.default_app_host }
 


### PR DESCRIPTION
<img width="796" height="119" alt="telegram-cloud-photo-size-5-6064538352632926292-x" src="https://github.com/user-attachments/assets/11edecd3-fdf0-4ddd-a6fa-3503bb227f45" />

Previously, running `coursemology:seed` didn't work because in test env, password is NIL. Fix with addition of`default_user_password` in dev config. Update root directory README with course & assessment seeding command too.