### PR TITLE
fix(sign_up): fix incorrect tenant url on devise emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ password: `Coursemology!`
 
 ### Running using HTTPS locally
 
+If you followed the above instructions, then Coursemology should be running on HTTP. This is sufficient for most development work, but it can be helpful to run on HTTPS locally in some cases. To do so, follow these instructions:
+
 These commands should be run from the repository root directory, unless otherwise noted.
 
-`lvh.me` is a public domain that resolves to `127.0.0.1`. It is used instead of `localhost` because browsers enforce stricter security policies on `localhost` that can break the OAuth redirect flow over HTTPS.
+`lvh.me` is a public domain that resolves to `127.0.0.1`. It is used instead of `localhost` because it supports subdomains (which simulate our multitenancy setup) while being compatible with our Keycloak integration.
 
-1. Generate a self-signed certificate and key for `lvh.me`:
+1. Generate a self-signed certificate and key for `*.lvh.me`:
 
    ```sh
    openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
@@ -90,7 +92,7 @@ Access the app at `https://lvh.me:8080`. Your browser will show a certificate wa
    rm config/credentials/server.crt config/credentials/server.key
    ```
 
-2. Restore the Keycloak redirect URIs:
+2. Restore the default Keycloak uri configuration:
 
    ```sh
    bundle exec rake "keycloak:push_redirect_uris"

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# Override Devise::Mailer to set the host for Devise emails
+class DeviseMailer < Devise::Mailer
+  def confirmation_instructions(record, token, opts = {})
+    @tenant_host = opts.delete(:host)
+    super
+  end
+
+  def reset_password_instructions(record, token, opts = {})
+    @tenant_host = opts.delete(:host)
+    super
+  end
+
+  private
+
+  def default_url_options
+    @tenant_host ? super.merge(host: @tenant_host) : super
+  end
+end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -44,7 +44,7 @@ class Instance < ApplicationRecord
     end
   end
 
-  after_commit :push_redirect_uris_to_keycloak, unless: -> { Rails.env.test? }
+  after_commit -> { KeycloakAdminService.push_redirect_uris }, unless: -> { Rails.env.test? }
 
   validates :host, hostname: true, if: :should_validate_host?
   validates :name, length: { maximum: 255 }, presence: true
@@ -133,56 +133,23 @@ class Instance < ApplicationRecord
 
   # Replace the hostname of the default instance.
   def host
-    return Application::Application.config.x.default_host if default?
+    default_host = Application::Application.config.x.default_host || ENV.fetch('RAILS_HOSTNAME', 'localhost:8080')
+    return default_host if default?
 
-    super
+    read_attribute(:host).gsub('coursemology.org', default_host)
   end
 
   def redirect_uri
-    default_host = ENV.fetch('RAILS_HOSTNAME', 'localhost:8080')
-
-    redirect_host = if read_attribute(:host) == '*'
-                      default_host
-                    else
-                      host.gsub('coursemology.org', default_host)
-                    end
-
     protocol = if Rails.env.development? && ENV['RAILS_USE_HTTP']
                  'http'
                else
                  'https'
                end
 
-    "#{protocol}://#{redirect_host}"
-  end
-
-  def push_redirect_uris_to_keycloak
-    access_token = token_from_client_credentials
-    frontend_client_uuid = keycloak_frontend_client_uuid(access_token)
-    raise "Keycloak frontend client not found for client_id: #{frontend_client_id}" if frontend_client_uuid.blank?
-
-    service = "clients/#{frontend_client_uuid}"
-    redirect_uris = Instance.all.map(&:redirect_uri).map { |uri| "#{uri}/*" }
-    Keycloak::Admin.generic_put(service, nil, { redirectUris: redirect_uris }, access_token)
+    "#{protocol}://#{host}"
   end
 
   private
-
-  def frontend_client_id
-    Rails.application.credentials.dig(:keycloak, :frontend, :client_id)
-  end
-
-  def token_from_client_credentials
-    client_id = Rails.application.credentials.dig(:keycloak, :backend, :client_id)
-    client_secret = Rails.application.credentials.dig(:keycloak, :backend, :client_secret)
-    credentials = Keycloak::Client.get_token_by_client_credentials(client_id, client_secret)
-    JSON.parse(credentials)['access_token']
-  end
-
-  def keycloak_frontend_client_uuid(access_token)
-    clients = Keycloak::Admin.get_clients({ clientId: frontend_client_id }, access_token)
-    JSON.parse(clients).dig(0, 'id')
-  end
 
   def should_validate_host?
     new_record? || changed_attributes.keys.include?('host')

--- a/app/services/keycloak_admin_service.rb
+++ b/app/services/keycloak_admin_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+class KeycloakAdminService
+  class << self
+    delegate :push_redirect_uris, to: :new
+  end
+
+  def push_redirect_uris
+    frontend_client_uuid = keycloak_frontend_client_uuid(access_token)
+    raise "Keycloak frontend client not found for client_id: #{frontend_client_id}" if frontend_client_uuid.blank?
+
+    service = "clients/#{frontend_client_uuid}"
+    redirect_uris = Instance.all.map(&method(:keycloak_redirect_uri))
+    Keycloak::Admin.generic_put(service, nil, { redirectUris: redirect_uris }, access_token)
+  end
+
+  # this is called "Home URL" in the keycloak UI, but the json field is "baseUrl"
+  def push_base_url
+    frontend_client_uuid = keycloak_frontend_client_uuid(access_token)
+    raise "Keycloak frontend client not found for client_id: #{frontend_client_id}" if frontend_client_uuid.blank?
+
+    service = "clients/#{frontend_client_uuid}"
+    base_url = Instance.default.redirect_uri
+    Keycloak::Admin.generic_put(service, nil, { baseUrl: base_url }, access_token)
+  end
+
+  private
+
+  def frontend_client_id
+    Rails.application.credentials.dig(:keycloak, :frontend, :client_id)
+  end
+
+  def access_token
+    unless @access_token
+      client_id = Rails.application.credentials.dig(:keycloak, :backend, :client_id)
+      client_secret = Rails.application.credentials.dig(:keycloak, :backend, :client_secret)
+      credentials = Keycloak::Client.get_token_by_client_credentials(client_id, client_secret)
+      @access_token = JSON.parse(credentials)['access_token']
+    end
+
+    @access_token
+  end
+
+  def keycloak_frontend_client_uuid(access_token)
+    clients = Keycloak::Admin.get_clients({ clientId: frontend_client_id }, access_token)
+    JSON.parse(clients).dig(0, 'id')
+  end
+
+  def keycloak_redirect_uri(instance)
+    "#{instance.redirect_uri}/*"
+  end
+end

--- a/authentication/README.md
+++ b/authentication/README.md
@@ -59,18 +59,29 @@ The local setup requires the authentication provider container to connect to the
 
   ```
 
-To ensure the smoothness in signing-in to Coursemology, you must ensure that the configuration for `KEYCLOAK_BE_CLIENT_SECRET` inside `.env` matches with the settings inside Keycloak. To do so, you can simply do the following instructions:
+For certain operations within Coursemology (such as adding/editing instances), you must ensure that the client_secret defined in the Rails credentials matches with the settings inside Keycloak. To do so, you can simply do the following instructions:
 
-1. Sign-in to authentication pages by inputting the following credentials:
+1. Sign-in to the Keycloak admin authentication page
 
-> Username: `admin` (whatever defined in KEYCLOAK_ADMIN inside ./.env)
+> Username: `admin` (defined in `KEYCLOAK_ADMIN` inside ./.env)
 >
-> Password: `password` (whatever defined in KEYCLOAK_ADMIN_PASSWORD inside ./.env)
+> Password: `password` (defined in `KEYCLOAK_ADMIN_PASSWORD` inside ./.env)
 
-2. Navigate to coursemology realm by choosing Coursemology in the top-left dropdown box, or simply access Coursemology [realm](http://localhost:8443/admin/master/console/#/coursemology)
+2. Navigate to [the Coursemology realm](http://localhost:8443/admin/master/console/#/coursemology), or by choosing `coursemology` in the top-left dropdown box
 
-3. Navigate to Client, then click on the Client ID in which name is `coursemology-backend`
+3. Navigate to Clients, then click on the Client ID named `coursemology-backend`
 
-4. Over there, navigate to Credentials and you will see the Client Secret. If whatever is defined there does not match with the Client Secret defined in your environment setup, simply copy-paste the client secret inside the page (you can possibly regenerate it if you want), then copy-paste it to `KEYCLOAK_BE_CLIENT_SECRET` inside `../.env`
+4. Navigate to Credentials and you will see the Client Secret. Regenerate it if necessary.
+
+Following the instructions in the [Rails credentials config](../config/credentials/README.md), copy-paste the client secret in the appropriate section:
+```yaml
+...
+keycloak:
+  ...
+  backend:
+    client_id: <value from Keycloak configuration>
+    client_secret: <value from Keycloak configuration>
+...
+```
 
 5. Finally, your Keycloak setup for Coursemology is finished and you are safe to proceed to the next step inside the Coursemology setup guide.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,7 +70,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.x.default_app_host = ENV.fetch('RAILS_HOSTNAME', 'localhost:8080').gsub(/:\d+/, '')
+  config.x.default_app_host = ENV.fetch('RAILS_HOSTNAME', 'localhost:8080').gsub(/:\d+$/, '')
   config.x.default_host = ENV.fetch('RAILS_HOSTNAME', 'localhost:8080')
   config.x.default_user_password = 'Coursemology!'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  config.x.default_host = 'localhost'
+  config.x.default_host = 'localhost:7979'
   config.x.client_port = 3200
   config.x.server_port = 7979
   config.x.default_user_password = 'lolololol'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,7 +15,7 @@ Devise.setup do |config|
   config.mailer_sender = ENV['RAILS_MAILER_DEFAULT_FROM_ADDRESS']
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'DeviseMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/lib/extensions/devise_async_email/devise/models/authenticatable.rb
+++ b/lib/extensions/devise_async_email/devise/models/authenticatable.rb
@@ -2,7 +2,9 @@
 module Extensions::DeviseAsyncEmail::Devise::Models::Authenticatable
   module PrependMethods
     def send_devise_notification(notification, *args)
-      devise_mailer.send(notification, self, *args).deliver_later(queue: :highest) # default :mailers
+      opts = args.extract_options!
+      opts[:host] = ActsAsTenant.current_tenant.host if ActsAsTenant.current_tenant
+      devise_mailer.send(notification, self, *args, opts).deliver_later(queue: :highest) # default :mailers
     end
   end
 end

--- a/lib/tasks/keycloak/push_redirect_uris.rake
+++ b/lib/tasks/keycloak/push_redirect_uris.rake
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 namespace :keycloak do
+  # Run to update configuration on Keycloak side on non-production environments.
   task :push_redirect_uris, [:default_host_url] => :environment do |_, args|
     default_host_url = args[:default_host_url] || 'http://localhost:8080'
 
-    ENV['RAILS_HOSTNAME'] = default_host_url.gsub(/https?:\/\//, '')
+    Application::Application.config.x.default_host = default_host_url.gsub(/https?:\/\//, '')
     ENV['RAILS_USE_HTTP'] = '1' unless default_host_url.start_with?('https://')
 
-    Instance.new.push_redirect_uris_to_keycloak
+    service = KeycloakAdminService.new
+    service.push_base_url
+    service.push_redirect_uris
   end
 end

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DeviseMailer, type: :mailer do
+  let(:instance) { Instance.default }
+
+  with_tenant(:instance) do
+    let(:user) { create(:user) }
+
+    describe '#confirmation_instructions' do
+      context 'when a tenant host is provided' do
+        let(:tenant_instance) { create(:instance) }
+        let(:mail) { DeviseMailer.confirmation_instructions(user, 'token', host: tenant_instance.host) }
+
+        it 'uses the tenant host in the confirmation URL' do
+          expect(mail.body.encoded).to include(tenant_instance.host)
+        end
+      end
+
+      context 'when no host is provided' do
+        let(:mail) { DeviseMailer.confirmation_instructions(user, 'token') }
+
+        it 'falls back to the default URL options host' do
+          expect(mail.body.encoded).to include(ActionMailer::Base.default_url_options[:host])
+        end
+      end
+    end
+
+    describe '#reset_password_instructions' do
+      context 'when a tenant host is provided' do
+        let(:tenant_instance) { create(:instance) }
+        let(:mail) { DeviseMailer.reset_password_instructions(user, 'token', host: tenant_instance.host) }
+
+        it 'uses the tenant host in the reset password URL' do
+          expect(mail.body.encoded).to include(tenant_instance.host)
+        end
+      end
+
+      context 'when no host is provided' do
+        let(:mail) { DeviseMailer.reset_password_instructions(user, 'token') }
+
+        it 'falls back to the default URL options host' do
+          expect(mail.body.encoded).to include(ActionMailer::Base.default_url_options[:host])
+        end
+      end
+    end
+  end
+end

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -119,43 +119,43 @@ RSpec.describe Instance do
 
   describe '#redirect_uri' do
     around do |example|
-      orig_hostname = ENV.fetch('RAILS_HOSTNAME', nil)
+      orig_default_host = Application::Application.config.x.default_host
       orig_use_http = ENV.fetch('RAILS_USE_HTTP', nil)
       example.run
     ensure
-      orig_hostname.nil? ? ENV.delete('RAILS_HOSTNAME') : (ENV['RAILS_HOSTNAME'] = orig_hostname)
+      Application::Application.config.x.default_host = orig_default_host
       orig_use_http.nil? ? ENV.delete('RAILS_USE_HTTP') : (ENV['RAILS_USE_HTTP'] = orig_use_http)
     end
 
     context 'when the instance is the default instance' do
       subject(:instance) { Instance.default }
 
-      context 'when RAILS_HOSTNAME is not set' do
-        before { ENV.delete('RAILS_HOSTNAME') }
+      context 'when config.x.default_host is nil' do
+        before { Application::Application.config.x.default_host = nil }
 
         it 'falls back to https://localhost:8080' do
           expect(instance.redirect_uri).to eq('https://localhost:8080')
         end
       end
 
-      context 'when RAILS_HOSTNAME is "coursemology.org"' do
-        before { ENV['RAILS_HOSTNAME'] = 'coursemology.org' }
+      context 'when config.x.default_host is "coursemology.org"' do
+        before { Application::Application.config.x.default_host = 'coursemology.org' }
 
         it 'returns https://coursemology.org' do
           expect(instance.redirect_uri).to eq('https://coursemology.org')
         end
       end
 
-      context 'when RAILS_HOSTNAME is "staging.coursemology.org"' do
-        before { ENV['RAILS_HOSTNAME'] = 'staging.coursemology.org' }
+      context 'when config.x.default_host is "staging.coursemology.org"' do
+        before { Application::Application.config.x.default_host = 'staging.coursemology.org' }
 
         it 'returns https://staging.coursemology.org' do
           expect(instance.redirect_uri).to eq('https://staging.coursemology.org')
         end
       end
 
-      context 'when RAILS_HOSTNAME is "lvh.me:8080"' do
-        before { ENV['RAILS_HOSTNAME'] = 'lvh.me:8080' }
+      context 'when config.x.default_host is "lvh.me:8080"' do
+        before { Application::Application.config.x.default_host = 'lvh.me:8080' }
 
         it 'returns https://lvh.me:8080' do
           expect(instance.redirect_uri).to eq('https://lvh.me:8080')
@@ -166,24 +166,24 @@ RSpec.describe Instance do
     context 'when the instance has host "coursemology.org"' do
       subject(:instance) { build(:instance, host: 'coursemology.org') }
 
-      context 'when RAILS_HOSTNAME is not set' do
-        before { ENV.delete('RAILS_HOSTNAME') }
+      context 'when config.x.default_host is nil' do
+        before { Application::Application.config.x.default_host = nil }
 
         it 'falls back to https://localhost:8080' do
           expect(instance.redirect_uri).to eq('https://localhost:8080')
         end
       end
 
-      context 'when RAILS_HOSTNAME is "coursemology.org"' do
-        before { ENV['RAILS_HOSTNAME'] = 'coursemology.org' }
+      context 'when config.x.default_host is "coursemology.org"' do
+        before { Application::Application.config.x.default_host = 'coursemology.org' }
 
         it 'returns https://coursemology.org' do
           expect(instance.redirect_uri).to eq('https://coursemology.org')
         end
       end
 
-      context 'when RAILS_HOSTNAME is "staging.coursemology.org"' do
-        before { ENV['RAILS_HOSTNAME'] = 'staging.coursemology.org' }
+      context 'when config.x.default_host is "staging.coursemology.org"' do
+        before { Application::Application.config.x.default_host = 'staging.coursemology.org' }
 
         it 'returns https://staging.coursemology.org' do
           expect(instance.redirect_uri).to eq('https://staging.coursemology.org')
@@ -194,16 +194,16 @@ RSpec.describe Instance do
     context 'when the instance has host "tenant.coursemology.org"' do
       subject(:instance) { build(:instance, host: 'tenant.coursemology.org') }
 
-      context 'when RAILS_HOSTNAME is "coursemology.org"' do
-        before { ENV['RAILS_HOSTNAME'] = 'coursemology.org' }
+      context 'when config.x.default_host is "coursemology.org"' do
+        before { Application::Application.config.x.default_host = 'coursemology.org' }
 
         it 'preserves the subdomain' do
           expect(instance.redirect_uri).to eq('https://tenant.coursemology.org')
         end
       end
 
-      context 'when RAILS_HOSTNAME is "staging.coursemology.org"' do
-        before { ENV['RAILS_HOSTNAME'] = 'staging.coursemology.org' }
+      context 'when config.x.default_host is "staging.coursemology.org"' do
+        before { Application::Application.config.x.default_host = 'staging.coursemology.org' }
 
         it 'maps the subdomain to the staging host' do
           expect(instance.redirect_uri).to eq('https://tenant.staging.coursemology.org')
@@ -214,7 +214,7 @@ RSpec.describe Instance do
     describe 'protocol selection' do
       subject(:instance) { Instance.default }
 
-      before { ENV.delete('RAILS_HOSTNAME') }
+      before { Application::Application.config.x.default_host = nil }
 
       context 'in a non-development environment' do
         it 'uses https' do
@@ -243,57 +243,6 @@ RSpec.describe Instance do
           expect(instance.redirect_uri).to start_with('http://')
         end
       end
-    end
-  end
-
-  describe '#push_redirect_uris_to_keycloak' do
-    subject(:instance) { Instance.default }
-
-    let(:access_token) { 'test-access-token' }
-    let(:client_uuid) { 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }
-    let(:frontend_client_id) { 'coursemology-frontend' }
-
-    before do
-      creds = Rails.application.credentials
-      allow(creds).to receive(:dig).with(:keycloak, :backend, :client_id).and_return('backend-client')
-      allow(creds).to receive(:dig).with(:keycloak, :backend, :client_secret).and_return('backend-secret')
-      allow(creds).to receive(:dig).with(:keycloak, :frontend, :client_id).and_return(frontend_client_id)
-      allow(Keycloak::Client).to receive(:get_token_by_client_credentials).
-        and_return({ access_token: access_token }.to_json)
-      allow(Keycloak::Admin).to receive(:get_clients).
-        and_return([{ 'id' => client_uuid, 'clientId' => frontend_client_id }].to_json)
-      allow(Keycloak::Admin).to receive(:generic_put).and_return(true)
-    end
-
-    describe '#keycloak_frontend_client_uuid' do
-      it 'queries Keycloak using the frontend client ID' do
-        instance.push_redirect_uris_to_keycloak
-        expect(Keycloak::Admin).to have_received(:get_clients).with({ clientId: frontend_client_id }, access_token)
-      end
-
-      it 'extracts the UUID from the first result' do
-        instance.push_redirect_uris_to_keycloak
-        expect(Keycloak::Admin).to have_received(:generic_put).
-          with("clients/#{client_uuid}", anything, anything, anything)
-      end
-
-      context 'when the client list response is empty' do
-        before do
-          allow(Keycloak::Admin).to receive(:get_clients).and_return([].to_json)
-        end
-
-        it 'raises an error' do
-          expect { instance.push_redirect_uris_to_keycloak }.
-            to raise_error(RuntimeError, /Keycloak frontend client not found/)
-        end
-      end
-    end
-
-    it 'pushes redirect URIs for all instances' do
-      instance.push_redirect_uris_to_keycloak
-      expected_uris = Instance.all.map { |i| "#{i.redirect_uri}/*" }
-      expect(Keycloak::Admin).to have_received(:generic_put).
-        with("clients/#{client_uuid}", nil, { redirectUris: expected_uris }, access_token)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -202,6 +202,20 @@ RSpec.describe User do
             have_enqueued_job.on_queue('highest')
         end
       end
+
+      context 'with a non-default instance tenant' do
+        let(:instance) { create(:instance) }
+
+        with_tenant(:instance) do
+          before { ActionMailer::Base.deliveries.clear }
+
+          it 'uses the current tenant host in the reset password URL' do
+            subject.send_reset_password_instructions
+            email = ActionMailer::Base.deliveries.last
+            expect(email.body.encoded).to include(instance.host)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/keycloak_admin_service_spec.rb
+++ b/spec/services/keycloak_admin_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe KeycloakAdminService do
+  subject(:service) { KeycloakAdminService.new }
+
+  let(:access_token) { 'test-access-token' }
+  let(:client_uuid) { 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }
+  let(:frontend_client_id) { 'coursemology-frontend' }
+
+  before do
+    creds = Rails.application.credentials
+    allow(creds).to receive(:dig).with(:keycloak, :backend, :client_id).and_return('backend-client')
+    allow(creds).to receive(:dig).with(:keycloak, :backend, :client_secret).and_return('backend-secret')
+    allow(creds).to receive(:dig).with(:keycloak, :frontend, :client_id).and_return(frontend_client_id)
+    allow(Keycloak::Client).to receive(:get_token_by_client_credentials).
+      and_return({ access_token: access_token }.to_json)
+    allow(Keycloak::Admin).to receive(:get_clients).
+      and_return([{ 'id' => client_uuid, 'clientId' => frontend_client_id }].to_json)
+    allow(Keycloak::Admin).to receive(:generic_put).and_return(true)
+  end
+
+  shared_examples 'a Keycloak admin action' do
+    it 'queries Keycloak using the frontend client ID' do
+      subject_action
+      expect(Keycloak::Admin).to have_received(:get_clients).with({ clientId: frontend_client_id }, access_token)
+    end
+
+    it 'targets the correct Keycloak client service path' do
+      subject_action
+      expect(Keycloak::Admin).to have_received(:generic_put).
+        with("clients/#{client_uuid}", anything, anything, anything)
+    end
+
+    context 'when the client list response is empty' do
+      before { allow(Keycloak::Admin).to receive(:get_clients).and_return([].to_json) }
+
+      it 'raises an error' do
+        expect { subject_action }.to raise_error(RuntimeError, /Keycloak frontend client not found/)
+      end
+    end
+  end
+
+  describe '#push_redirect_uris' do
+    let(:subject_action) { service.push_redirect_uris }
+
+    include_examples 'a Keycloak admin action'
+
+    it 'pushes redirect URIs for all instances' do
+      service.push_redirect_uris
+      expected_uris = Instance.all.map { |i| "#{i.redirect_uri}/*" }
+      expect(Keycloak::Admin).to have_received(:generic_put).
+        with("clients/#{client_uuid}", nil, { redirectUris: expected_uris }, access_token)
+    end
+  end
+
+  describe '#push_base_url' do
+    let(:subject_action) { service.push_base_url }
+
+    include_examples 'a Keycloak admin action'
+
+    it 'pushes the default instance redirect URI as the base URL' do
+      service.push_base_url
+      expect(Keycloak::Admin).to have_received(:generic_put).
+        with("clients/#{client_uuid}", nil, { baseUrl: Instance.default.redirect_uri }, access_token)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,6 +124,8 @@ Capybara.configure do |config|
   config.server = :puma, { Silent: true }
   config.default_max_wait_time = 10
   config.enable_aria_label = true
-  config.server_host = Application::Application.config.x.default_host
-  config.server_port = Application::Application.config.x.server_port
+  server_host, server_port = Application::Application.config.x.default_host.split(':', 2)
+  config.server_host = server_host
+  config.server_port = server_port.to_i
+  p("Using server host #{config.server_host} and port #{config.server_port}")
 end

--- a/spec/support/acts_as_tenant.rb
+++ b/spec/support/acts_as_tenant.rb
@@ -3,7 +3,7 @@
 module ActsAsTenant::TestGroupHelpers
   def self.build_host(instance)
     if (port = Application::Application.config.x.client_port)
-      "http://#{instance.host}:#{port}"
+      "http://#{instance.host.gsub(/:\d+$/, '')}:#{port}"
     else
       "http://#{instance.host}"
     end

--- a/tests/tests/users/sign-up.spec.ts
+++ b/tests/tests/users/sign-up.spec.ts
@@ -1,7 +1,8 @@
 import { expect, expectLastSentEmail, manufacture, test } from 'helpers';
+import { servers } from '../../package.json';
 
 const getHrefURLFromString = (string: string): string | undefined =>
-  string.match(/href="(.*(?="))/)?.[1];
+  string.match(/href="(.*(?="))/)?.[1].replace(servers.serverURL, servers.clientURL);
 
 test.describe('unregistered user', () => {
   test('can sign up', async ({ signUpPage: page }) => {
@@ -27,6 +28,7 @@ test.describe('unregistered user', () => {
     const confirmationURL = getHrefURLFromString(confirmationEmail.body);
     expect(confirmationURL).toBeTruthy();
 
+    console.log('Confirmation URL:', confirmationURL);
     await page.goto(confirmationURL!);
 
     await expect.soft(page.getByText(email)).toBeVisible();


### PR DESCRIPTION
- refactored keycloak admin API functions from Instance to separate class
- add Devise::Mailer subclass to override email
- override Instance.host with domain substitution logic in non-prod environments
- updated documentation

Before this, Devise was unaware of our multitenancy model, so Devise emails were sent with URLs pointing back to the default tenant. This can lead to non-default-tenant users signing up to the wrong tenant, causing unnecessary confusion.
<img width="734" height="290" alt="Screenshot 2026-05-17 at 12 39 02" src="https://github.com/user-attachments/assets/a93e4c61-c773-4406-bf92-752f3f50b481" />

There is likely a separate issue on FE redirection, which specifies the default tenant as a fallback redirect uri, leading to occasional unexpected redirects.
A reproducible method to trigger this fallback mechanism is still under investigation.
