### PR TITLE
fix(auth): fix overridden default host handling/redirect

### DIFF
--- a/app/controllers/concerns/application_multitenancy.rb
+++ b/app/controllers/concerns/application_multitenancy.rb
@@ -15,7 +15,7 @@ module ApplicationMultitenancy
     tenant_host = deduce_tenant_host
     instance = Instance.find_tenant_by_host_or_default(tenant_host)
 
-    if Rails.env.production? && instance.default? && instance.host.casecmp(tenant_host) != 0
+    if instance.default? && tenant_host.casecmp(Instance.default.host) != 0
       raise ActionController::RoutingError, 'Instance Not Found'
     end
 
@@ -25,14 +25,24 @@ module ApplicationMultitenancy
   # Deduces the current host. We strip any leading www from the host.
   # @return [String] The host, with www removed.
   def deduce_tenant_host
-    stripped_host = request.host.downcase.start_with?('www.') ? request.host[4..] : request.host
-    default_host = Application::Application.config.x.default_host&.gsub(/:\d+$/, '')
+    stripped_host = normalize_tenant_host(request.host)
+    default_host = normalize_tenant_host(Instance.default.host)
 
-    if default_host && stripped_host.downcase.ends_with?(default_host)
+    if default_host && stripped_host == default_host
+      Instance.default.host
+    elsif default_host && stripped_host.ends_with?(default_host)
       stripped_host.sub(default_host, 'coursemology.org')
     else
       stripped_host
     end
+  end
+
+  # We store "host" strings in database without port modifiers,
+  # even when Coursemology is configured with them as part of the host (in local development).
+  def normalize_tenant_host(host)
+    return nil unless host
+
+    (host.starts_with?('www.') ? host[4..] : host).gsub(/:\d+$/, '').downcase
   end
 
   module ClassMethods

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -133,7 +133,7 @@ class Instance < ApplicationRecord
 
   # Replace the hostname of the default instance.
   def host
-    default_host = Application::Application.config.x.default_host || ENV.fetch('RAILS_HOSTNAME', 'localhost:8080')
+    default_host = Application::Application.config.x.default_host
     return default_host if default?
 
     read_attribute(:host).gsub('coursemology.org', default_host)

--- a/client/app/api/ErrorHandling.ts
+++ b/client/app/api/ErrorHandling.ts
@@ -1,9 +1,6 @@
 import { AxiosResponse } from 'axios';
 
-import {
-  AUTH_USER_MANAGER,
-  oidcConfig,
-} from 'lib/components/wrappers/AuthProvider';
+import { AUTH_USER_MANAGER } from 'lib/components/wrappers/AuthProvider';
 import {
   redirectToForbidden,
   redirectToNotFound,
@@ -33,7 +30,7 @@ const isSuspendedResponse = (response?: AxiosResponse): boolean =>
 
 export const redirectIfMatchesErrorIn = (response?: AxiosResponse): void => {
   if (isUnauthenticatedResponse(response))
-    AUTH_USER_MANAGER.signinRedirect({ redirect_uri: oidcConfig.redirect_uri });
+    AUTH_USER_MANAGER.signinRedirect({ redirect_uri: window.location.href });
   if (isSuspendedResponse(response)) redirectToSuspended();
   if (isUnauthorizedResponse(response))
     // Should open a new window and login

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # NGINX, varnish or squid.
   # config.action_dispatch.rack_cache = true
   # We will configure the host from the environment.
-  config.action_mailer.default_url_options = { host: ENV['RAILS_HOSTNAME'] }
+  config.action_mailer.default_url_options = { host: ENV.fetch('RAILS_HOSTNAME') }
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
@@ -134,7 +134,7 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
   #
-  config.x.default_host = ENV['RAILS_HOSTNAME']
+  config.x.default_host = ENV.fetch('RAILS_HOSTNAME')
   config.active_job.queue_adapter = :sidekiq
 
   # Rails 6.0.5.1 security patch

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
+  let(:instance) { create(:instance) }
   describe ApplicationControllerMultitenancyConcern do
     # These variables override the hostname in the selected tenant object before with_tenant gets
     # to execute. This effectively changes the host requested in the mock request.
@@ -25,10 +26,8 @@ RSpec.describe ApplicationController, type: :controller do
     with_tenant(:instance) do
       context 'when a nonexistent instance is specified' do
         let(:instance) { build_stubbed(:instance) }
-        it 'falls back to the default instance' do
-          get :index
-
-          expect(ActsAsTenant.current_tenant).to eq(Instance.default)
+        it 'raises a RoutingError' do
+          expect { get :index }.to raise_error(ActionController::RoutingError)
         end
       end
 
@@ -54,11 +53,8 @@ RSpec.describe ApplicationController, type: :controller do
 
         context 'when the host has a subdomain other than www' do
           let(:instance_host) { "random.#{instance.host.upcase}" }
-          it 'finds the actual host' do
-            get :index
-
-            expect(ActsAsTenant.current_tenant).not_to eq(instance)
-            expect(ActsAsTenant.current_tenant).to eq(Instance.default)
+          it 'raises a RoutingError' do
+            expect { get :index }.to raise_error(ActionController::RoutingError)
           end
         end
       end
@@ -69,8 +65,8 @@ RSpec.describe ApplicationController, type: :controller do
     subject { controller.send(:deduce_tenant_host) }
 
     before do
-      allow(Application::Application.config.x).to receive(:default_host).
-        and_return('staging.coursemology.org')
+      allow(Instance).to receive(:default).
+        and_return(instance_double(Instance, host: 'staging.coursemology.org'))
     end
 
     context 'when the host has a www prefix' do
@@ -79,10 +75,10 @@ RSpec.describe ApplicationController, type: :controller do
       it { is_expected.to eq('example.com') }
     end
 
-    context 'when the host matches the default host' do
+    context 'when the host exactly matches the default host' do
       before { @request.host = 'staging.coursemology.org' }
 
-      it { is_expected.to eq('coursemology.org') }
+      it { is_expected.to eq('staging.coursemology.org') }
     end
 
     context 'when the host is a subdomain of the default host' do
@@ -105,82 +101,88 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   describe ApplicationInternationalizationConcern do
-    before { @old_i18n_locale = I18n.locale }
-    after { I18n.locale = @old_i18n_locale }
+    with_tenant(:instance) do
+      before { @old_i18n_locale = I18n.locale }
+      after { I18n.locale = @old_i18n_locale }
 
-    pending 'when http accept language is present' do
-      before { @request.env['HTTP_ACCEPT_LANGUAGE'] = 'zh-cn' }
+      context 'when http accept language is present' do
+        before { @request.env['HTTP_ACCEPT_LANGUAGE'] = 'zh' }
 
-      it 'sets the correct locale' do
-        get :index
-        expect(I18n.locale).to eq(:'zh-CN')
-      end
-    end
-
-    context 'when http accept language is not present' do
-      before { @request.env['HTTP_ACCEPT_LANGUAGE'] = nil }
-
-      it 'sets the locale to default' do
-        get :index
-        expect(I18n.locale).to eq(I18n.default_locale)
-      end
-    end
-
-    context 'when http accept language is not available' do
-      before do
-        @request.env['HTTP_ACCEPT_LANGUAGE'] = 'jp'
-        get :index
+        it 'sets the correct locale' do
+          get :index
+          expect(I18n.locale).to eq(:zh)
+        end
       end
 
-      it 'sets the locale to default' do
-        expect(I18n.locale).to eq(I18n.default_locale)
+      context 'when http accept language is not present' do
+        before { @request.env['HTTP_ACCEPT_LANGUAGE'] = nil }
+
+        it 'sets the locale to default' do
+          get :index
+          expect(I18n.locale).to eq(I18n.default_locale)
+        end
       end
-    end
 
-    pending 'when http accept language belongs to the same region' do
-      before { @request.env['HTTP_ACCEPT_LANGUAGE'] = 'zh-tw' }
+      context 'when http accept language is not available' do
+        before do
+          @request.env['HTTP_ACCEPT_LANGUAGE'] = 'jp'
+          get :index
+        end
 
-      it 'sets the nearest locale' do
-        get :index
-        expect(I18n.locale).to eq(:'zh-CN')
+        it 'sets the locale to default' do
+          expect(I18n.locale).to eq(I18n.default_locale)
+        end
       end
-    end
 
-    pending 'when multiple http accept languages are present' do
-      before { @request.env['HTTP_ACCEPT_LANGUAGE'] = 'jp, zh-tw' }
+      pending 'when http accept language belongs to the same region' do
+        before { @request.env['HTTP_ACCEPT_LANGUAGE'] = 'zh-tw' }
 
-      it 'sets the nearest available locale' do
-        get :index
-        expect(I18n.locale).to eq(:'zh-CN')
+        it 'sets the nearest locale' do
+          get :index
+          expect(I18n.locale).to eq(:'zh-CN')
+        end
+      end
+
+      pending 'when multiple http accept languages are present' do
+        before { @request.env['HTTP_ACCEPT_LANGUAGE'] = 'jp, zh-tw' }
+
+        it 'sets the nearest available locale' do
+          get :index
+          expect(I18n.locale).to eq(:'zh-CN')
+        end
       end
     end
   end
 
   describe ApplicationUserConcern do
-    context 'when the action raises a CanCan::AccessDenied' do
-      run_rescue
+    with_tenant(:instance) do
+      context 'when the action raises a CanCan::AccessDenied' do
+        run_rescue
 
-      it 'returns HTTP status 403' do
-        post :create
-        expect(response.status).to eq(403)
+        it 'returns HTTP status 403' do
+          post :create
+          expect(response.status).to eq(403)
+        end
       end
     end
   end
 
   describe ApplicationComponentsConcern do
-    context 'when the action raises a Coursemology::ComponentNotFoundError' do
-      run_rescue
+    with_tenant(:instance) do
+      context 'when the action raises a Coursemology::ComponentNotFoundError' do
+        run_rescue
 
-      before do
-        def controller.index
-          raise ComponentNotFoundError
+        before do
+          def controller.index
+            raise ComponentNotFoundError
+          end
         end
-      end
 
-      it 'returns HTTP status 404' do
-        get :index
-        expect(response.status).to eq(404)
-        expect(response.body).to include('Component not found')
+        it 'returns HTTP status 404' do
+          get :index
+          expect(response.status).to eq(404)
+          expect(response.body).to include('Component not found')
+        end
       end
     end
   end
@@ -194,34 +196,38 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   context 'when the action raises an IllegalStateError' do
-    run_rescue
+    with_tenant(:instance) do
+      run_rescue
 
-    before do
-      def controller.index
-        raise IllegalStateError
+      before do
+        def controller.index
+          raise IllegalStateError
+        end
       end
-    end
 
-    it 'returns HTTP status 422' do
-      get :index
-      expect(response.status).to eq(422)
+      it 'returns HTTP status 422' do
+        get :index
+        expect(response.status).to eq(422)
+      end
     end
   end
 
   context 'when the action raises ActionController::InvalidAuthenticityToken' do
-    run_rescue
+    with_tenant(:instance) do
+      run_rescue
 
-    before do
-      def controller.index
-        raise ActionController::InvalidAuthenticityToken
+      before do
+        def controller.index
+          raise ActionController::InvalidAuthenticityToken
+        end
       end
-    end
 
-    it 'returns HTTP status 403' do
-      # Replaced specific error check due to potential false positives
-      # expect { get :index }.to_not raise_error ActionController::InvalidAuthenticityToken
-      expect { get :index }.to_not raise_error
-      expect(response.status).to eq(403)
+      it 'returns HTTP status 403' do
+        # Replaced specific error check due to potential false positives
+        # expect { get :index }.to_not raise_error ActionController::InvalidAuthenticityToken
+        expect { get :index }.to_not raise_error
+        expect(response.status).to eq(403)
+      end
     end
   end
 end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -10,62 +10,65 @@ RSpec.describe JobsController do
     controller.instance_variable_set(:@job, job)
   end
 
-  describe '#show' do
-    def self.expect_to_redirect_to_job_redirect_to
-      let(:job_traits) do
-        super_traits = *super()
-        super_traits + [{ redirect_to: redirect_path }]
-      end
-      it { is_expected.to redirect_to(redirect_path) }
-    end
-
-    before { get 'show', params: { id: job.id, format: format } }
-
-    context 'when the job is in progress' do
-      context 'when the requested format is json' do
-        render_views
-        let(:format) { :json }
-        let(:json_response) { JSON.parse(response.body) }
-
-        it 'responses with an errored job status' do
-          expect(response.status).to be(200)
-          expect(json_response['status']).to eq('submitted')
-          expect(json_response['jobUrl']).to eq(job_path(job))
-        end
-      end
-    end
-
-    context 'when the job has been completed' do
-      let(:job_traits) { [:completed] }
-
-      context 'when the requested format is json' do
-        render_views
+  let(:instance) { create(:instance) }
+  with_tenant(:instance) do
+    describe '#show' do
+      def self.expect_to_redirect_to_job_redirect_to
         let(:job_traits) do
           super_traits = *super()
           super_traits + [{ redirect_to: redirect_path }]
         end
-        let(:format) { :json }
-        let(:json_response) { JSON.parse(response.body) }
+        it { is_expected.to redirect_to(redirect_path) }
+      end
 
-        it 'responses with an errored job status' do
-          expect(response.status).to be(200)
-          expect(json_response['status']).to eq('completed')
-          expect(json_response['redirectUrl']).to eq(redirect_path)
+      before { get 'show', params: { id: job.id, format: format } }
+
+      context 'when the job is in progress' do
+        context 'when the requested format is json' do
+          render_views
+          let(:format) { :json }
+          let(:json_response) { JSON.parse(response.body) }
+
+          it 'responses with an errored job status' do
+            expect(response.status).to be(200)
+            expect(json_response['status']).to eq('submitted')
+            expect(json_response['jobUrl']).to eq(job_path(job))
+          end
         end
       end
-    end
 
-    context 'when the job has errored' do
-      let(:job_traits) { :errored }
+      context 'when the job has been completed' do
+        let(:job_traits) { [:completed] }
 
-      context 'when the requested format is json' do
-        render_views
-        let(:format) { :json }
-        let(:json_response) { JSON.parse(response.body) }
+        context 'when the requested format is json' do
+          render_views
+          let(:job_traits) do
+            super_traits = *super()
+            super_traits + [{ redirect_to: redirect_path }]
+          end
+          let(:format) { :json }
+          let(:json_response) { JSON.parse(response.body) }
 
-        it 'responses with an errored job status' do
-          expect(response.status).to be(200)
-          expect(json_response['status']).to eq('errored')
+          it 'responses with an errored job status' do
+            expect(response.status).to be(200)
+            expect(json_response['status']).to eq('completed')
+            expect(json_response['redirectUrl']).to eq(redirect_path)
+          end
+        end
+      end
+
+      context 'when the job has errored' do
+        let(:job_traits) { :errored }
+
+        context 'when the requested format is json' do
+          render_views
+          let(:format) { :json }
+          let(:json_response) { JSON.parse(response.body) }
+
+          it 'responses with an errored job status' do
+            expect(response.status).to be(200)
+            expect(json_response['status']).to eq('errored')
+          end
         end
       end
     end

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -130,14 +130,6 @@ RSpec.describe Instance do
     context 'when the instance is the default instance' do
       subject(:instance) { Instance.default }
 
-      context 'when config.x.default_host is nil' do
-        before { Application::Application.config.x.default_host = nil }
-
-        it 'falls back to https://localhost:8080' do
-          expect(instance.redirect_uri).to eq('https://localhost:8080')
-        end
-      end
-
       context 'when config.x.default_host is "coursemology.org"' do
         before { Application::Application.config.x.default_host = 'coursemology.org' }
 
@@ -159,34 +151,6 @@ RSpec.describe Instance do
 
         it 'returns https://lvh.me:8080' do
           expect(instance.redirect_uri).to eq('https://lvh.me:8080')
-        end
-      end
-    end
-
-    context 'when the instance has host "coursemology.org"' do
-      subject(:instance) { build(:instance, host: 'coursemology.org') }
-
-      context 'when config.x.default_host is nil' do
-        before { Application::Application.config.x.default_host = nil }
-
-        it 'falls back to https://localhost:8080' do
-          expect(instance.redirect_uri).to eq('https://localhost:8080')
-        end
-      end
-
-      context 'when config.x.default_host is "coursemology.org"' do
-        before { Application::Application.config.x.default_host = 'coursemology.org' }
-
-        it 'returns https://coursemology.org' do
-          expect(instance.redirect_uri).to eq('https://coursemology.org')
-        end
-      end
-
-      context 'when config.x.default_host is "staging.coursemology.org"' do
-        before { Application::Application.config.x.default_host = 'staging.coursemology.org' }
-
-        it 'returns https://staging.coursemology.org' do
-          expect(instance.redirect_uri).to eq('https://staging.coursemology.org')
         end
       end
     end

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -88,7 +88,7 @@ export const test = base.extend<TestFixtures>({
         await page.getByRole('button', { name: 'Sign in' }).click();
         try {
           await page.waitForURL(/\?from=auth/, { timeout: 1000 });
-          await page.waitForURL(/^(?!.*\?from=auth)/);
+          await page.waitForURL(/^(?!.*\?from=auth)/, { timeout: 1000 });
         } catch {}
       },
     } satisfies Omit<Page, keyof BasePage>);


### PR DESCRIPTION
Fixes 404 errors on staging due to `staging.coursemology.org` being incorrectly mapped to `coursemology.org`.

Also fix handling of explicit 401 from BE. For most routes that need authentication, the FE redirects users before sending to BE, but `/courses/:id` explicitly returns 401 since FE doesn't return early, because there are cases where this route is visible to unauthenticated users (e.g. published courses)