### PR TITLE
feat(grading): add prefill-to-0 and per-type prefill policies

### DIFF
--- a/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
+++ b/client/app/bundles/course/assessment/submission/containers/QuestionGrade.tsx
@@ -141,7 +141,7 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
 
   if (!grading) return null;
 
-  const dirty = (grading.originalGrade ?? 0) !== (grading.grade ?? 0);
+  const dirty = grading.originalGrade !== grading.grade;
 
   let savingIndicator: React.ReactNode | null = null;
 
@@ -270,8 +270,8 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
       </div>
 
       <div className="px-4 space-x-4">
-        {grading.prefilled && (
-          <Tooltip title={t(translations.gradePrefilledHint)}>
+        {grading.prefillStatus === 'full' && (
+          <Tooltip title={t(translations.gradePrefilledFullHint)}>
             <Chip
               className="slot-1-neutral-400 border-slot-1 text-slot-1"
               label={t(translations.gradePrefilled)}
@@ -281,6 +281,16 @@ const QuestionGrade: FC<QuestionGradeProps> = (props) => {
           </Tooltip>
         )}
 
+        {grading.prefillStatus === 'zero' && (
+          <Tooltip title={t(translations.gradePrefilledZeroHint)}>
+            <Chip
+              className="slot-1-neutral-400 border-slot-1 text-slot-1"
+              label={t(translations.gradePrefilled)}
+              size="small"
+              variant="outlined"
+            />
+          </Tooltip>
+        )}
         {savingIndicator}
       </div>
     </div>

--- a/client/app/bundles/course/assessment/submission/reducers/grading/__test__/index.test.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading/__test__/index.test.js
@@ -1,0 +1,288 @@
+import { dispatch, store } from 'store';
+
+import actions, { questionTypes } from '../../../constants';
+
+const getPrefillStatus = () =>
+  store.getState().assessments.submission.grading.questions[1].prefillStatus;
+
+const getPrefilled = () =>
+  store.getState().assessments.submission.grading.questions[1].prefilled;
+
+const answerId = 3;
+
+const buildPayload = ({ questionType, grade, correct, testCases } = {}) => ({
+  submission: {
+    pointsAwarded: null,
+    basePoints: 1000,
+    submittedAt: '2017-05-11T17:02:17.000+08:00',
+    bonusEndAt: '2017-05-11T17:02:17.000+08:00',
+    bonusPoints: 0,
+  },
+  assessment: {},
+  annotations: [],
+  posts: [],
+  topics: [],
+  questions: [{ id: 1, type: questionType, maximumGrade: 10 }],
+  answers: [
+    {
+      id: answerId,
+      fields: {
+        id: answerId,
+        questionId: 1,
+      },
+      questionId: 1,
+      grading: {
+        grade,
+        id: answerId,
+      },
+      explanation: correct !== undefined ? { correct } : undefined,
+      testCases,
+    },
+  ],
+});
+
+const dispatchFetchSuccess = (payload) =>
+  dispatch({ type: actions.FETCH_SUBMISSION_SUCCESS, payload });
+
+const getGrade = () =>
+  store.getState().assessments.submission.grading.questions[1].grade;
+
+describe('getPrefillResult via FETCH_SUBMISSION_SUCCESS', () => {
+  describe('general behavior', () => {
+    it('preserves existing grade and sets prefillStatus to none even if answer is correct', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.MultipleChoice,
+          grade: 5,
+          correct: true,
+        }),
+      );
+
+      expect(getGrade()).toBe(5);
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+
+    it('preserves existing grade and sets prefillStatus to none even if answer is incorrect', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.MultipleChoice,
+          grade: 8,
+          correct: false,
+        }),
+      );
+
+      expect(getGrade()).toBe(8);
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+
+    it('leaves grade as null and sets prefillStatus to none when there is no explanation', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.MultipleChoice,
+          grade: null,
+          correct: undefined,
+        }),
+      );
+
+      expect(getGrade()).toBeNull();
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+  });
+
+  describe('Question Types with ALWAYS_PREFILL_POLICY', () => {
+    it('prefills maximum grade and sets prefillStatus to full for an ungraded correct answer', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.MultipleChoice,
+          grade: null,
+          correct: true,
+        }),
+      );
+
+      expect(getGrade()).toBe(10);
+      expect(getPrefillStatus()).toBe('full');
+      expect(getPrefilled()).toBe(true);
+    });
+
+    it('prefills 0 and sets prefillStatus to zero for an ungraded incorrect answer', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.MultipleChoice,
+          grade: null,
+          correct: false,
+        }),
+      );
+
+      expect(getGrade()).toBe(0);
+      expect(getPrefillStatus()).toBe('zero');
+      expect(getPrefilled()).toBe(true);
+    });
+  });
+
+  describe('Question Types with NEVER_PREFILL_POLICY', () => {
+    it('leaves grade as null and sets prefillStatus to none for an ungraded correct answer', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.VoiceResponse,
+          grade: null,
+          correct: true,
+        }),
+      );
+
+      expect(getGrade()).toBeNull();
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+
+    it('leaves grade as null and sets prefillStatus to none for an ungraded incorrect answer', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.VoiceResponse,
+          grade: null,
+          correct: false,
+        }),
+      );
+
+      expect(getGrade()).toBeNull();
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+  });
+
+  describe('Question Types with ONLY_PREFILL_FULL_POLICY', () => {
+    it('prefills maximum grade and sets prefillStatus to full for an ungraded correct answer', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.TextResponse,
+          grade: null,
+          correct: true,
+        }),
+      );
+
+      expect(getGrade()).toBe(10);
+      expect(getPrefillStatus()).toBe('full');
+      expect(getPrefilled()).toBe(true);
+    });
+
+    it('leaves grade as null and sets prefillStatus to none for an ungraded incorrect answer', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.TextResponse,
+          grade: null,
+          correct: false,
+        }),
+      );
+
+      expect(getGrade()).toBeNull();
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+  });
+
+  describe('Programming', () => {
+    const withTestCases = {
+      public_test: [{ identifier: 'test1' }],
+    };
+
+    it('prefills maximum grade and sets prefillStatus to full when test cases exist and answer is correct', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.Programming,
+          grade: null,
+          correct: true,
+          testCases: withTestCases,
+        }),
+      );
+
+      expect(getGrade()).toBe(10);
+      expect(getPrefillStatus()).toBe('full');
+      expect(getPrefilled()).toBe(true);
+    });
+
+    it('leaves grade as null and sets prefillStatus to none when test cases exist and answer is incorrect', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.Programming,
+          grade: null,
+          correct: false,
+          testCases: withTestCases,
+        }),
+      );
+
+      expect(getGrade()).toBeNull();
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+
+    it('prefills maximum grade when only private_test cases exist and answer is correct', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.Programming,
+          grade: null,
+          correct: true,
+          testCases: { private_test: [{ identifier: 'test1' }] },
+        }),
+      );
+
+      expect(getGrade()).toBe(10);
+      expect(getPrefillStatus()).toBe('full');
+      expect(getPrefilled()).toBe(true);
+    });
+
+    it('prefills maximum grade when only evaluation_test cases exist and answer is correct', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.Programming,
+          grade: null,
+          correct: true,
+          testCases: { evaluation_test: [{ identifier: 'test1' }] },
+        }),
+      );
+
+      expect(getGrade()).toBe(10);
+      expect(getPrefillStatus()).toBe('full');
+      expect(getPrefilled()).toBe(true);
+    });
+
+    it('leaves grade as null and sets prefillStatus to none when no test cases exist, even if answer is correct', () => {
+      dispatchFetchSuccess(
+        buildPayload({
+          questionType: questionTypes.Programming,
+          grade: null,
+          correct: true,
+          testCases: null,
+        }),
+      );
+
+      expect(getGrade()).toBeNull();
+      expect(getPrefillStatus()).toBe('none');
+      expect(getPrefilled()).toBe(false);
+    });
+  });
+});
+
+describe('UPDATE_GRADING', () => {
+  it('resets grade, prefillStatus, and prefilled after manual edit', () => {
+    dispatchFetchSuccess(
+      buildPayload({
+        questionType: questionTypes.MultipleChoice,
+        grade: null,
+        correct: true,
+      }),
+    );
+
+    dispatch({
+      type: actions.UPDATE_GRADING,
+      id: 1,
+      grade: 7,
+      bonusAwarded: 0,
+    });
+
+    expect(getGrade()).toBe(7);
+    expect(getPrefillStatus()).toBe('none');
+    expect(getPrefilled()).toBe(false);
+  });
+});

--- a/client/app/bundles/course/assessment/submission/reducers/grading/index.js
+++ b/client/app/bundles/course/assessment/submission/reducers/grading/index.js
@@ -4,6 +4,30 @@ import { arrayToObjectWithKey } from 'utilities/array';
 
 import actions, { questionTypes } from '../../constants';
 
+/**
+ * Represents a student's answer to a question, as returned by the server.
+ *
+ * @typedef {Object} Answer
+ * @property {number} questionId
+ * @property {{ grade: number|null, id: number }} grading
+ * @property {{ correct: boolean }} [explanation]
+ * @property {Object} [testCases]
+ */
+
+/**
+ * Defines the prefill behaviour for a question type.
+ * `isFullCreditPrefillable` determines whether the maximum grade should be prefilled for a correct answer.
+ * `isZeroCreditPrefillable` determines whether 0 should be prefilled for an incorrect answer.
+ *
+ * @typedef {{ isFullCreditPrefillable: (answer: Answer) => boolean, isZeroCreditPrefillable: boolean }} PrefillPolicy
+ */
+
+/**
+ * The initial Redux state for the grading slice.
+ *
+ * @type {{ questions: Record<number, Object>, expMultiplier: number, exp: number, basePoints: number,
+ *   maximumGrade: number }}
+ */
 const initialState = {
   questions: {},
   expMultiplier: 1,
@@ -12,8 +36,24 @@ const initialState = {
   maximumGrade: 0,
 };
 
+/**
+ * Sums all truthy values in an array, ignoring nulls and undefineds.
+ *
+ * @param {Array<number|null|undefined>} array
+ * @returns {number}
+ */
 const sum = (array) => array.filter((i) => i).reduce((acc, i) => acc + i, 0);
 
+/**
+ * Computes the EXP awarded for a submission based on the total grade achieved.
+ *
+ * @param {Record<number, { grade: number|null }>} questions
+ * @param {number} maximumGrade
+ * @param {number} basePoints
+ * @param {number} expMultiplier
+ * @param {number} [bonusAwarded]
+ * @returns {number}
+ */
 export const computeExp = (
   questions,
   maximumGrade,
@@ -29,6 +69,12 @@ export const computeExp = (
   );
 };
 
+/**
+ * Extracts grades from a list of answers, keyed by question ID.
+ *
+ * @param {Answer[]} answers
+ * @returns {Record<number, Object>}
+ */
 const extractGrades = (answers) =>
   answers.reduce((draft, { questionId, grading }) => {
     draft[questionId] = {
@@ -39,64 +85,159 @@ const extractGrades = (answers) =>
     return draft;
   }, {});
 
-const isSpecificAnswerGradePrefillableMap = {
-  [questionTypes.MultipleChoice]: () => true,
-  [questionTypes.MultipleResponse]: () => true,
-  [questionTypes.Programming]: (answer) => {
-    const { testCases } = answer;
-    const isPublicTestCasesExist = testCases?.public_test?.length > 0;
-    const isPrivateTestCasesExist = testCases?.private_test?.length > 0;
-    const isEvaluationTestCasesExist = testCases?.evaluation_test?.length > 0;
-    return (
-      isPublicTestCasesExist ||
-      isPrivateTestCasesExist ||
-      isEvaluationTestCasesExist
-    );
-  },
-  [questionTypes.RubricBasedResponse]: () => false,
-  [questionTypes.TextResponse]: () => false,
-  [questionTypes.Comprehension]: () => false,
-  [questionTypes.FileUpload]: () => false,
-  [questionTypes.Scribing]: () => false,
-  [questionTypes.VoiceResponse]: () => false,
-  [questionTypes.ForumPostResponse]: () => false,
-};
-
-const isAnswerGradePrefillable = (answer, questionType) => {
-  const isAnswerPrefillable =
-    answer.grading.grade === null && answer.explanation?.correct;
-  const isSpecificAnswerPrefillable =
-    isSpecificAnswerGradePrefillableMap[questionType](answer);
-  return isAnswerPrefillable && isSpecificAnswerPrefillable;
+/**
+ * Never prefills any grade regardless of correctness.
+ * Used for question types where auto-grading is not applicable.
+ *
+ * @type {PrefillPolicy}
+ */
+const NEVER_PREFILL_POLICY = {
+  isFullCreditPrefillable: () => false,
+  isZeroCreditPrefillable: false,
 };
 
 /**
- * Extracts grades from `payload.answer`, and pre-fills the maximum grade for correct
- * answers that have not been graded. "Correct" follows the definition of
- * `explanation.correct` from the server.
+ * Prefills maximum grade for correct answers and 0 for incorrect answers.
+ * Used for question types with no partial credit.
+ *
+ * @type {PrefillPolicy}
+ */
+const ALWAYS_PREFILL_POLICY = {
+  isFullCreditPrefillable: () => true,
+  isZeroCreditPrefillable: true,
+};
+
+/**
+ * Prefills maximum grade for correct answers, but does not prefill 0 for incorrect answers.
+ * Used for question types where partial credit is possible.
+ *
+ * @type {PrefillPolicy}
+ */
+const ONLY_PREFILL_FULL_POLICY = {
+  isFullCreditPrefillable: () => true,
+  isZeroCreditPrefillable: false,
+};
+
+/**
+ * Prefills maximum grade for correct programming answers only when test cases exist.
+ * Does not prefill 0 since partial grading is possible.
+ *
+ * @type {PrefillPolicy}
+ */
+const PROGRAMMING_PREFILL_POLICY = {
+  isFullCreditPrefillable: ({ testCases }) =>
+    (testCases?.public_test?.length ?? 0) > 0 ||
+    (testCases?.private_test?.length ?? 0) > 0 ||
+    (testCases?.evaluation_test?.length ?? 0) > 0,
+
+  // Partial grading is possible
+  isZeroCreditPrefillable: false,
+};
+
+/**
+ * Maps each question type to its prefill policy.
+ *
+ * @type {Record<string, PrefillPolicy>}
+ */
+const PrefillPolicyMapper = {
+  [questionTypes.MultipleChoice]: ALWAYS_PREFILL_POLICY,
+  [questionTypes.MultipleResponse]: ONLY_PREFILL_FULL_POLICY,
+  [questionTypes.Programming]: PROGRAMMING_PREFILL_POLICY,
+  [questionTypes.TextResponse]: ONLY_PREFILL_FULL_POLICY,
+  [questionTypes.Comprehension]: ONLY_PREFILL_FULL_POLICY,
+  [questionTypes.FileUpload]: NEVER_PREFILL_POLICY,
+  [questionTypes.Scribing]: NEVER_PREFILL_POLICY,
+  [questionTypes.VoiceResponse]: NEVER_PREFILL_POLICY,
+  [questionTypes.ForumPostResponse]: NEVER_PREFILL_POLICY,
+  [questionTypes.RubricBasedResponse]: NEVER_PREFILL_POLICY,
+};
+
+/**
+ * Returns the grade to prefill for an answer based on its question type's policy.
+ * Returns the existing grade if one is already set, otherwise applies the policy.
+ * Returns null if no prefill is applicable.
+ *
+ * @param {Answer} answer
+ * @param {string} questionType
+ * @param {number} maxGrade
+ * @returns {{ grade: number|null, prefillStatus: string }}
+ */
+const getPrefillResult = (answer, questionType, maxGrade) => {
+  const existingGrade = answer?.grading?.grade;
+  if (existingGrade != null) {
+    return {
+      grade: existingGrade,
+      prefillStatus: 'none',
+    };
+  }
+
+  const policy = PrefillPolicyMapper[questionType];
+
+  if (
+    answer?.explanation?.correct === true &&
+    policy?.isFullCreditPrefillable(answer)
+  ) {
+    return {
+      grade: maxGrade,
+      prefillStatus: 'full',
+    };
+  }
+
+  if (
+    answer?.explanation?.correct === false &&
+    policy?.isZeroCreditPrefillable
+  ) {
+    return {
+      grade: 0,
+      prefillStatus: 'zero',
+    };
+  }
+
+  return { grade: null, prefillStatus: 'none' };
+};
+
+/**
+ * Extracts grades from `payload.answers` and pre-fills them where applicable based on each
+ * question type's prefill policy:
+ * - maximum grade for correct answers (where the policy allows full-credit prefill)
+ * - 0 for incorrect answers (where the policy allows zero-credit prefill)
+ * Answers that have already been graded are left unchanged.
+ * "Correct" and "incorrect" follows the definition of `explanation.correct` from the server.
+ *
+ * @param {{ questions: Object[], answers: Answer[] }} payload
+ * @returns {Record<number, Object>}
  */
 const extractPrefillableGrades = (payload) => {
   const mapQuestionIdToQuestion = arrayToObjectWithKey(payload.questions, 'id');
 
   return payload.answers.reduce((draft, answer) => {
     const { questionId, grading } = answer;
-    const prefillable = isAnswerGradePrefillable(
+    const question = mapQuestionIdToQuestion[questionId];
+    const { grade, prefillStatus } = getPrefillResult(
       answer,
-      mapQuestionIdToQuestion[questionId].type,
+      question.type,
+      question.maximumGrade,
     );
     draft[questionId] = {
       ...grading,
       originalGrade: grading.grade,
-      grade: prefillable
-        ? mapQuestionIdToQuestion[questionId].maximumGrade
-        : grading.grade,
-      prefilled: prefillable,
+      grade,
+      prefillStatus,
+      // for backwards compatibility, to be removed after prefillStatus is fully adopted
+      prefilled: prefillStatus !== 'none',
     };
 
     return draft;
   }, {});
 };
 
+/**
+ * Grading reducer. Manages per-question grades, EXP, and base points for a submission.
+ *
+ * @param {typeof initialState} state
+ * @param {{ type: string, [key: string]: any }} action
+ * @returns {typeof initialState}
+ */
 export default function (state = initialState, action) {
   switch (action.type) {
     case actions.FETCH_SUBMISSION_SUCCESS: {
@@ -185,7 +326,8 @@ export default function (state = initialState, action) {
         [action.id]: {
           ...state.questions[action.id],
           grade: action.grade,
-          autofilled: false,
+          prefilled: false,
+          prefillStatus: 'none',
         },
       };
 

--- a/client/app/bundles/course/assessment/submission/reducers/grading/types.ts
+++ b/client/app/bundles/course/assessment/submission/reducers/grading/types.ts
@@ -1,7 +1,10 @@
+export type QuestionGradePrefillStatus = 'none' | 'zero' | 'full';
+
 export interface QuestionGradeData {
   originalGrade: number | null | undefined;
   grade: number | null | undefined;
-  prefilled: boolean;
+  prefilled: boolean; // backwards compatibility, to be removed after the prefillStatus is fully adopted
+  prefillStatus: QuestionGradePrefillStatus;
   id: number; // answer ID
   grader?: {
     name: string;

--- a/client/app/bundles/course/assessment/submission/translations.ts
+++ b/client/app/bundles/course/assessment/submission/translations.ts
@@ -103,10 +103,15 @@ const translations = defineMessages({
     id: 'course.assessment.submission.gradePrefilled',
     defaultMessage: 'Pre-filled',
   },
-  gradePrefilledHint: {
-    id: 'course.assessment.submission.gradePrefilledHint',
+  gradePrefilledFullHint: {
+    id: 'course.assessment.submission.gradePrefilledFullHint',
     defaultMessage:
       'The maximum grade has been pre-filled for you because it was deemed correct by the autograder.',
+  },
+  gradePrefilledZeroHint: {
+    id: 'course.assessment.submission.gradePrefilledZeroHint',
+    defaultMessage:
+      'The grade of 0 has been pre-filled for you because it was deemed incorrect by the autograder.',
   },
   submit: {
     id: 'course.asssessment.submission.submit',

--- a/client/app/bundles/course/assessment/submission/types.ts
+++ b/client/app/bundles/course/assessment/submission/types.ts
@@ -23,6 +23,8 @@ type TestCaseTypes = 'public_test' | 'private_test' | 'evaluation_test';
 
 type JobStatus = 'submitted' | 'completed' | 'errored';
 
+export type QuestionGradePrefillStatus = 'none' | 'zero' | 'full';
+
 export interface AssessmentState {
   allowPartialSubmission: boolean;
   autograded: boolean;
@@ -155,6 +157,7 @@ export interface GradeWithPrefilledStatus {
   originalGrade: number;
   grade: number;
   prefilled: boolean;
+  prefillStatus: QuestionGradePrefillStatus;
 }
 
 export interface GradingState {

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -3651,8 +3651,11 @@
   "course.assessment.submission.gradePrefilled": {
     "defaultMessage": "Pre-filled"
   },
-  "course.assessment.submission.gradePrefilledHint": {
+  "course.assessment.submission.gradePrefilledFullHint": {
     "defaultMessage": "The maximum grade has been pre-filled for you because it was deemed correct by the autograder."
+  },
+  "course.assessment.submission.gradePrefilledZeroHint": {
+    "defaultMessage": "The grade of 0 has been pre-filled for you because it was deemed incorrect by the autograder."
   },
   "course.assessment.submission.gradeSummary": {
     "defaultMessage": "Grade Summary"

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -3629,8 +3629,11 @@
   "course.assessment.submission.gradePrefilled": {
     "defaultMessage": "미리 채워진"
   },
-  "course.assessment.submission.gradePrefilledHint": {
+  "course.assessment.submission.gradePrefilledFullHint": {
     "defaultMessage": "자동 채점기가 정답으로 판단한 최대 점수가 미리 채워져 있습니다."
+  },
+  "course.assessment.submission.gradePrefilledZeroHint": {
+    "defaultMessage": "자동 채점기가 오답으로 판단했기 때문에 0점이 미리 채워져 있습니다."
   },
   "course.assessment.submission.gradeSummary": {
     "defaultMessage": "등급 요약"

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -3638,8 +3638,11 @@
   "course.assessment.submission.gradePrefilled": {
     "defaultMessage": "预先填写"
   },
-  "course.assessment.submission.gradePrefilledHint": {
+  "course.assessment.submission.gradePrefilledFullHint": {
     "defaultMessage": "已为你预填最高成绩，因为自动评分器认为它是正确的。"
+  },
+  "course.assessment.submission.gradePrefilledZeroHint": {
+    "defaultMessage": "已为你预填0分，因为自动评分器认为它是不正确的。"
   },
   "course.assessment.submission.gradeSummary": {
     "defaultMessage": "成绩总结"


### PR DESCRIPTION
## Summary

Extends the grade pre-fill feature to support prefilling 0 for incorrect answers, and introduces per-question-type prefill policies that control when and what to prefill. Previously, the prefill logic used a single boolean gate (`isSpecificAnswerGradePrefillableMap`) that only handled full-credit prefills. This PR replaces that with named policy objects (`ALWAYS_PREFILL_POLICY`, `ONLY_PREFILL_FULL_POLICY`, `PROGRAMMING_PREFILL_POLICY`, `NEVER_PREFILL_POLICY`) and adds a `prefillStatus` discriminant (`'none' | 'zero' | 'full'`) so the UI can render the correct tooltip for each case. Dirty-flag logic is updated to now detect zero-prefilled grades as dirty too,

The prefill chip is only relevant for manually-graded assessments. In autograded mode, the backend sets the grade server-side before the page loads, so `existingGrade != null` and the prefill path is skipped entirely.

## Design decisions

- `prefillStatus: 'none' | 'zero' | 'full'` instead of extending the boolean `prefilled` - three states are needed and a boolean cannot express them without a second flag; the old `prefilled` is retained for backwards compatibility and marked for removal.
- Named policy objects over a map of functions - each policy is a self-contained object with `isFullCreditPrefillable` and `isZeroCreditPrefillable`, making it easy to see at a glance what each question type does and to add new types without touching existing logic.
- MRQ and TextResponse use `ONLY_PREFILL_FULL_POLICY` (not `ALWAYS_PREFILL_POLICY`) - partial credit is possible for these types, so prefilling 0 for an incorrect answer would be misleading; only full credit is safe to prefill.
- Removed `?? 0` from the `dirty` comparison - null and 0 must be distinguishable now that prefill-to-zero sets `grade = 0` from `originalGrade = null`; treating them as equal silently broke the unsaved indicator.

## Regression prevention

Tests cover: `ALWAYS_PREFILL_POLICY` (MCQ), `ONLY_PREFILL_FULL_POLICY` (MRQ, TextResponse), `PROGRAMMING_PREFILL_POLICY` (with and without test cases), `NEVER_PREFILL_POLICY` types, existing-grade preservation, and missing-explanation handling.

Manual testing confirmed: MCQ correct answer shows full-credit prefill chip + unsaved chip; MCQ wrong answer shows zero-credit prefill chip + unsaved chip; MRQ wrong answer shows no chip; editing a prefilled grade removes the prefill chip; already-graded answers show no chip.

Backward compatibility: `prefilled` boolean is preserved on `QuestionGradeData` and the Redux state alongside `prefillStatus`.

<img width="692" height="846" alt="telegram-cloud-photo-size-5-6107116098604961353-y" src="https://github.com/user-attachments/assets/91e2107d-7911-4493-b6ac-0d68dcc6ca00" />