### PR TITLE
Push Submissions' Task Completions on read

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -20,6 +20,8 @@ class Course::Assessment::Submission::SubmissionsController < # rubocop:disable 
   # edited or updated.
   before_action :load_or_create_submission_questions, only: [:edit, :update]
 
+  after_action :publish_cikgo_task_completion, only: [:edit]
+
   signals :assessment_submissions, after: [:unsubmit, :delete]
   signals :assessment_submissions, after: [:update], if: -> { @submission.saved_change_to_workflow_state? }
 
@@ -402,5 +404,9 @@ class Course::Assessment::Submission::SubmissionsController < # rubocop:disable 
     existing_submissions = @assessment.submissions.by_users(course_user_ids.pluck(:user_id))
     user_ids_with_submission = existing_submissions.pluck(:creator_id)
     course_user_ids.pluck(:user_id) - user_ids_with_submission
+  end
+
+  def publish_cikgo_task_completion
+    @submission.publish_task_completion if @submission.should_publish_task_completion?
   end
 end

--- a/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
+++ b/app/models/concerns/course/assessment/submission/cikgo_task_completion_concern.rb
@@ -13,10 +13,6 @@ module Course::Assessment::Submission::CikgoTaskCompletionConcern
     after_save :publish_task_completion, if: -> { should_publish_task_completion? && saved_change_to_workflow_state? }
   end
 
-  private
-
-  delegate :edit_course_assessment_submission_url, to: 'Rails.application.routes.url_helpers'
-
   def publish_task_completion
     Cikgo::ResourcesService.mark_task!(status, lesson_plan_item, {
       user_id: creator_id_on_cikgo,
@@ -28,6 +24,15 @@ module Course::Assessment::Submission::CikgoTaskCompletionConcern
     raise e unless Rails.env.production?
   end
 
+  def should_publish_task_completion?
+    lesson_plan_item.course.component_enabled?(Course::StoriesComponent) &&
+      creator_id_on_cikgo.present? && status.present?
+  end
+
+  private
+
+  delegate :edit_course_assessment_submission_url, to: 'Rails.application.routes.url_helpers'
+
   def status
     WORKFLOW_STATE_TO_TASK_COMPLETION_STATUS[workflow_state.to_sym]
   end
@@ -36,11 +41,6 @@ module Course::Assessment::Submission::CikgoTaskCompletionConcern
     edit_course_assessment_submission_url(
       lesson_plan_item.course_id, assessment_id, id, host: lesson_plan_item.course.instance.host, protocol: :https
     )
-  end
-
-  def should_publish_task_completion?
-    lesson_plan_item.course.component_enabled?(Course::StoriesComponent) &&
-      creator_id_on_cikgo.present? && status.present?
   end
 
   def lesson_plan_item


### PR DESCRIPTION
This addresses the edge case when a user already has submissions before the Coursemology course is integrated with Cikgo or the user authenticated with Cikgo.