### PR TITLE
fix(invite): clearer errors and progress feedback for CSV invitations

### DIFF
--- a/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
+++ b/app/services/concerns/course/user_invitation_service/parse_invitation_concern.rb
@@ -130,22 +130,34 @@ module Course::UserInvitationService::ParseInvitationConcern
     header_map = nil
     blank_header_indices = []
     @blank_header_warning = false
-    [].tap do |invites|
-      CSV.foreach(file, encoding: 'utf-8').with_index(1) do |row, row_number|
-        row_num = row_number
-        row[0] = remove_utf8_byte_order_mark(row[0]) if row_number == 1 && row[0]
-        row = strip_row(row)
-        if row_number == 1
-          header_map, blank_header_indices = build_header_map!(row)
-          next
-        end
-        @blank_header_warning ||= blank_header_indices.any? { |idx| row[idx].present? }
-        invite = parse_file_row(row, header_map)
-        invites << invite if invite
+    @parse_failed_users = []
+    invites = []
+    CSV.foreach(file, encoding: 'utf-8').with_index(1) do |row, row_number|
+      row_num = row_number
+      row[0] = remove_utf8_byte_order_mark(row[0]) if row_number == 1 && row[0]
+      row = strip_row(row)
+      if row_number == 1
+        header_map, blank_header_indices = build_header_map!(row)
+        next
       end
+      @blank_header_warning ||= blank_header_indices.any? { |idx| row[idx].present? }
+      collect_parsed_row(parse_file_row(row, header_map), invites)
     end
+    raise I18n.t('errors.course.user_invitations.no_valid_rows') if invites.empty? && @parse_failed_users.empty?
+
+    invites
   rescue StandardError => e
     raise CSV::MalformedCSVError.new(e.message, row_num), e.message
+  end
+
+  # Routes a parsed row into the right bucket: a +nil+ row is skipped, a row tagged with
+  # a +:reason+ is a parse-time failure (e.g. missing email), and any other row is a valid
+  # invite. Failures accumulate in +@parse_failed_users+ so the caller can merge them into
+  # the overall failed-users list shown to the user.
+  def collect_parsed_row(invite, invites)
+    return unless invite
+
+    invite[:reason] ? (@parse_failed_users << invite) : (invites << invite)
   end
 
   # Strips a row of whitespaces.
@@ -170,28 +182,42 @@ module Course::UserInvitationService::ParseInvitationConcern
   end
 
   def build_header_map!(row)
-    resolved = {}
-    blank_indices = []
-    row.each_with_index do |cell, idx|
-      if cell.blank?
-        blank_indices << idx
-        next
-      end
-
-      canonical = header_alias_map[normalize_header(cell)]
-      raise_non_canonical_header_error!(cell) unless canonical
-      raise_duplicate_header_error!(canonical) if resolved.key?(canonical)
-
-      resolved[canonical] = idx
-    end
-
+    resolved, blank_indices, unrecognized = scan_header_row(row)
+    raise_non_canonical_header_error!(unrecognized) if unrecognized.any?
     validate_required_headers!(resolved)
     [resolved, blank_indices]
   end
 
-  def raise_non_canonical_header_error!(cell)
-    accepted = CANONICAL_COLUMNS.map { |col| I18n.t("csv.course_user_invitations.headers.#{col}") }.join(', ')
-    raise I18n.t('errors.course.user_invitations.invalid_headers', header: cell, accepted: accepted)
+  # Single pass over the header row, partitioning cells into resolved canonical columns,
+  # blank-header indices, and unrecognized headers. All unrecognized headers are collected
+  # (rather than failing on the first) so the user can fix them in one round-trip.
+  def scan_header_row(row)
+    resolved = {}
+    blank_indices = []
+    unrecognized = []
+    row.each_with_index do |cell, idx|
+      if cell.blank?
+        blank_indices << idx
+      elsif (canonical = header_alias_map[normalize_header(cell)])
+        raise_duplicate_header_error!(canonical) if resolved.key?(canonical)
+        resolved[canonical] = idx
+      else
+        unrecognized << cell
+      end
+    end
+    [resolved, blank_indices, unrecognized]
+  end
+
+  def raise_non_canonical_header_error!(unrecognized)
+    headers = unrecognized.map { |cell| %("#{cell}") }.join(', ')
+    accepted = CANONICAL_COLUMNS.map { |col| header_label(col) }.join(', ')
+    raise I18n.t('errors.course.user_invitations.invalid_headers', headers: headers, accepted: accepted)
+  end
+
+  # The current display label for a canonical column. Single source of truth so the alias
+  # accepted-list (and future per-course relabeling) stay in sync.
+  def header_label(col)
+    I18n.t("csv.course_user_invitations.headers.#{col}")
   end
 
   def raise_duplicate_header_error!(canonical)
@@ -208,23 +234,35 @@ module Course::UserInvitationService::ParseInvitationConcern
   # Parses the given CSV row (array) and returns attributes for a user invitation.
   #   - Columns are resolved by position via +header_map+, not by fixed order.
   #   - Sets the name as the given email if a name was not provided.
+  #   - A blank-email row that still carries identifying data (name or external ID) is the
+  #     row a user meant to invite but forgot the email for: it is returned tagged with
+  #     +reason: :missing_email+ so the caller can surface it as a failure rather than
+  #     silently dropping it. A row with neither email nor identity carries no intent
+  #     (blank line, stray attribute cell) and is skipped (+nil+).
   #
   # @param [Array] row The row's cells as read from the CSV file.
   # @param [Hash{Symbol=>Integer}] header_map Maps each resolved canonical column
   #   (a subset of +CANONICAL_COLUMNS+) to its index in +row+. Only +:name+ and
   #   +:email+ are guaranteed present; optional columns are absent when not in the file.
-  # @return [Hash] The parsed invitation attributes given the row.
+  # @return [Hash, nil] The parsed invitation attributes, a missing-email failure hash, or
+  #   +nil+ when the row should be skipped.
   def parse_file_row(row, header_map)
     email = row[header_map[:email]]
-    return nil if email.blank?
-
     name = row[header_map[:name]]
-    name = email if name.blank?
+    external_id = parse_file_external_id(row_cell(row, header_map, :external_id))
 
     role = parse_file_role(row_cell(row, header_map, :role))
     phantom = parse_file_phantom(row_cell(row, header_map, :phantom))
     timeline_algorithm = parse_file_timeline_algorithm(row_cell(row, header_map, :personal_timeline))
-    external_id = parse_file_external_id(row_cell(row, header_map, :external_id))
+
+    if email.blank?
+      return nil if name.blank? && external_id.blank?
+
+      return { name: name, email: nil, role: role, phantom: phantom,
+               timeline_algorithm: timeline_algorithm, external_id: external_id, reason: :missing_email }
+    end
+
+    name = email if name.blank?
 
     { name: name, email: email, role: role, phantom: phantom,
       timeline_algorithm: timeline_algorithm, external_id: external_id }

--- a/app/services/course/user_invitation_service.rb
+++ b/app/services/course/user_invitation_service.rb
@@ -111,7 +111,7 @@ class Course::UserInvitationService
                               select { |u| u[:user].present? }.
                               to_set { |u| u[:email].downcase }
     unique_users, parse_duplicates = partition_unique_users(user_hashes, existing_account_emails)
-    @failed_users = parse_duplicates
+    @failed_users = parse_duplicates + (@parse_failed_users || [])
     @updated_invitations = []
     @updated_course_users = []
     @pending_invitation_updates = []

--- a/client/app/bundles/course/user-invitations/components/misc/ExternalIdConflictPrompt.tsx
+++ b/client/app/bundles/course/user-invitations/components/misc/ExternalIdConflictPrompt.tsx
@@ -22,6 +22,7 @@ interface Props {
   onKeepExisting: () => void;
   onReplaceAll: () => void;
   onCancel: () => void;
+  disabled?: boolean;
 }
 
 const translations = defineMessages({
@@ -62,6 +63,7 @@ const ExternalIdConflictPrompt: FC<Props> = ({
   onKeepExisting,
   onReplaceAll,
   onCancel,
+  disabled = false,
 }) => {
   const { t } = useTranslation();
 
@@ -70,6 +72,7 @@ const ExternalIdConflictPrompt: FC<Props> = ({
       disableEscapeKeyDown
       maxWidth="md"
       onClose={(_event, reason) => {
+        if (disabled) return;
         if (reason !== 'backdropClick') onCancel();
       }}
       open
@@ -105,13 +108,17 @@ const ExternalIdConflictPrompt: FC<Props> = ({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel} variant="outlined">
+        <Button disabled={disabled} onClick={onCancel} variant="outlined">
           {t(translations.goBack)}
         </Button>
-        <Button onClick={onKeepExisting} variant="contained">
+        <Button
+          disabled={disabled}
+          onClick={onKeepExisting}
+          variant="contained"
+        >
           {t(translations.keepExisting)}
         </Button>
-        <Button onClick={onReplaceAll} variant="contained">
+        <Button disabled={disabled} onClick={onReplaceAll} variant="contained">
           {t(translations.replace)}
         </Button>
       </DialogActions>

--- a/client/app/bundles/course/user-invitations/components/tables/InvitationResultFailedTable.tsx
+++ b/client/app/bundles/course/user-invitations/components/tables/InvitationResultFailedTable.tsx
@@ -27,6 +27,10 @@ const translations = defineMessages({
     id: 'course.userInvitations.InvitationResultFailedTable.externalIdTaken',
     defaultMessage: 'External ID is taken by another course member',
   },
+  missingEmail: {
+    id: 'course.userInvitations.InvitationResultFailedTable.missingEmail',
+    defaultMessage: 'Missing email',
+  },
   failedToSend: {
     id: 'course.userInvitations.InvitationResultFailedTable.failedToSend',
     defaultMessage:
@@ -43,6 +47,7 @@ const REASON_MAP: Record<InvitationFailureReason, keyof typeof translations> = {
   duplicate_email_in_file: 'duplicateEmailInFile',
   duplicate_external_id_in_file: 'duplicateExternalIdInFile',
   external_id_taken: 'externalIdTaken',
+  missing_email: 'missingEmail',
   failed_to_send: 'failedToSend',
 };
 

--- a/client/app/bundles/course/user-invitations/components/tables/__test__/InvitationResultFailedTable.test.tsx
+++ b/client/app/bundles/course/user-invitations/components/tables/__test__/InvitationResultFailedTable.test.tsx
@@ -65,6 +65,16 @@ describe('InvitationResultFailedTable', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders reason label for missing_email', async () => {
+    render(
+      <InvitationResultFailedTable
+        users={[{ ...baseUser, email: '', reason: 'missing_email' }]}
+      />,
+    );
+    await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+    expect(screen.getByText('Missing email')).toBeInTheDocument();
+  });
+
   it('renders reason label for failed_to_send', async () => {
     render(<InvitationResultFailedTable users={[baseUser]} />);
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));

--- a/client/app/bundles/course/user-invitations/pages/InviteUsersFileUpload/__test__/index.test.tsx
+++ b/client/app/bundles/course/user-invitations/pages/InviteUsersFileUpload/__test__/index.test.tsx
@@ -5,11 +5,19 @@ import { InvitationFileEntity } from 'types/course/userInvitations';
 import InviteUsersFileUpload from '../index';
 
 const mockToastError = jest.fn();
+const mockToastLoading = jest.fn(
+  (..._args: unknown[]): string => 'loading-toast-id',
+);
+const mockToastDismiss = jest.fn();
+const mockToastUpdate = jest.fn();
 jest.mock('lib/hooks/toast', () => ({
   __esModule: true,
   default: {
     error: (...args: unknown[]): void => mockToastError(...args),
     success: jest.fn(),
+    loading: (...args: unknown[]): unknown => mockToastLoading(...args),
+    dismiss: (...args: unknown[]): void => mockToastDismiss(...args),
+    update: (...args: unknown[]): void => mockToastUpdate(...args),
   },
 }));
 
@@ -70,6 +78,8 @@ jest.mock('../../../operations', () => ({
 }));
 
 const MOCK_FILE_SUBMIT_TESTID = 'mock-file-submit';
+const CONFLICT_PROMPT_TITLE = 'Confirm External ID Updates';
+const KEEP_EXISTING_BUTTON = 'Keep Existing';
 
 const TEST_FILE_ENTITY: InvitationFileEntity = {
   name: 'invites.csv',
@@ -131,6 +141,9 @@ describe('<InviteUsersFileUpload />', () => {
     capturedOnSubmit = null;
     mockInviteUsersFromFile.mockClear();
     mockToastError.mockClear();
+    mockToastLoading.mockClear();
+    mockToastDismiss.mockClear();
+    mockToastUpdate.mockClear();
     noop.mockClear();
   });
 
@@ -176,6 +189,23 @@ describe('<InviteUsersFileUpload />', () => {
     expect(firstArg.file).toBeInstanceOf(Blob);
   });
 
+  it('toasts an error and does not import when submitted without a file', async () => {
+    render(
+      <InviteUsersFileUpload onClose={noop} open openResultDialog={noop} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId(MOCK_FILE_SUBMIT_TESTID)).toBeInTheDocument(),
+    );
+
+    // Reproduces the select-then-remove state: dirty form, but no Blob.
+    await capturedOnSubmit!({ file: { name: '', url: '', file: undefined } });
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Please select a CSV file to upload.',
+    );
+    expect(mockInviteUsersFromFile).not.toHaveBeenCalled();
+  });
+
   it('shows ExternalIdConflictPrompt when server returns a conflict', async () => {
     mockInviteUsersFromFile.mockImplementationOnce(
       () =>
@@ -193,9 +223,7 @@ describe('<InviteUsersFileUpload />', () => {
     await capturedOnSubmit!({ file: TEST_FILE_ENTITY });
 
     await waitFor(() =>
-      expect(
-        screen.getByText('Confirm External ID Updates'),
-      ).toBeInTheDocument(),
+      expect(screen.getByText(CONFLICT_PROMPT_TITLE)).toBeInTheDocument(),
     );
   });
 
@@ -353,16 +381,14 @@ describe('<InviteUsersFileUpload />', () => {
       );
       await capturedOnSubmit!({ file: TEST_FILE_ENTITY });
       await waitFor(() =>
-        expect(
-          screen.getByText('Confirm External ID Updates'),
-        ).toBeInTheDocument(),
+        expect(screen.getByText(CONFLICT_PROMPT_TITLE)).toBeInTheDocument(),
       );
     };
 
     it('passes keep_existing resolution when Keep Existing is clicked', async () => {
       await setupConflict();
       await userEvent.click(
-        screen.getByRole('button', { name: 'Keep Existing' }),
+        screen.getByRole('button', { name: KEEP_EXISTING_BUTTON }),
       );
       expect(mockInviteUsersFromFile).toHaveBeenCalledTimes(2);
       expect((mockInviteUsersFromFile.mock.calls as unknown[][])[1][1]).toBe(
@@ -377,6 +403,180 @@ describe('<InviteUsersFileUpload />', () => {
       expect((mockInviteUsersFromFile.mock.calls as unknown[][])[1][1]).toBe(
         'replace_all',
       );
+    });
+  });
+
+  describe('import progress feedback', () => {
+    it('shows a loading toast while the initial upload is in progress', async () => {
+      render(
+        <InviteUsersFileUpload onClose={noop} open openResultDialog={noop} />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId(MOCK_FILE_SUBMIT_TESTID)).toBeInTheDocument(),
+      );
+
+      await capturedOnSubmit!({ file: TEST_FILE_ENTITY });
+
+      expect(mockToastLoading).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismisses the loading toast after a successful upload', async () => {
+      render(
+        <InviteUsersFileUpload onClose={noop} open openResultDialog={noop} />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId(MOCK_FILE_SUBMIT_TESTID)).toBeInTheDocument(),
+      );
+
+      await capturedOnSubmit!({ file: TEST_FILE_ENTITY });
+
+      expect(mockToastDismiss).toHaveBeenCalledWith('loading-toast-id');
+    });
+
+    it('dismisses the loading toast when the upload fails', async () => {
+      mockInviteUsersFromFile.mockImplementationOnce(
+        () =>
+          (_dispatch: unknown): Promise<object> =>
+            Promise.reject(
+              Object.assign(new Error('Upload failed'), {
+                response: { data: {} },
+              }),
+            ),
+      );
+
+      render(
+        <InviteUsersFileUpload onClose={noop} open openResultDialog={noop} />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId(MOCK_FILE_SUBMIT_TESTID)).toBeInTheDocument(),
+      );
+
+      await capturedOnSubmit!({ file: TEST_FILE_ENTITY });
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+      expect(mockToastDismiss).toHaveBeenCalledWith('loading-toast-id');
+    });
+  });
+
+  describe('conflict resolution keeps the prompt open', () => {
+    const deferred = (): {
+      promise: Promise<object>;
+      resolve: (value: object) => void;
+    } => {
+      let resolve!: (value: object) => void;
+      const promise = new Promise<object>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    };
+
+    // First submit returns a conflict; the resolution submit stays pending so we
+    // can assert what the UI looks like *during* the import wait.
+    const setupPendingResolution = async (): Promise<{
+      resolve: (value: object) => void;
+    }> => {
+      const pending = deferred();
+      mockInviteUsersFromFile.mockImplementationOnce(
+        () =>
+          (_dispatch: unknown): Promise<object> =>
+            Promise.resolve(conflictResponse),
+      );
+      mockInviteUsersFromFile.mockImplementationOnce(
+        () =>
+          (_dispatch: unknown): Promise<object> =>
+            pending.promise,
+      );
+
+      render(
+        <InviteUsersFileUpload onClose={noop} open openResultDialog={noop} />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId(MOCK_FILE_SUBMIT_TESTID)).toBeInTheDocument(),
+      );
+      await capturedOnSubmit!({ file: TEST_FILE_ENTITY });
+      await waitFor(() =>
+        expect(screen.getByText(CONFLICT_PROMPT_TITLE)).toBeInTheDocument(),
+      );
+      return pending;
+    };
+
+    it('does not reopen the upload form while the resolution is in progress', async () => {
+      await setupPendingResolution();
+
+      await userEvent.click(
+        screen.getByRole('button', { name: KEEP_EXISTING_BUTTON }),
+      );
+
+      // The prompt must remain; the original upload form must NOT reappear.
+      expect(screen.getByText(CONFLICT_PROMPT_TITLE)).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(MOCK_FILE_SUBMIT_TESTID),
+      ).not.toBeInTheDocument();
+    });
+
+    it('disables the conflict prompt buttons while the resolution is in progress', async () => {
+      await setupPendingResolution();
+
+      await userEvent.click(
+        screen.getByRole('button', { name: KEEP_EXISTING_BUTTON }),
+      );
+
+      expect(
+        screen.getByRole('button', { name: KEEP_EXISTING_BUTTON }),
+      ).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Replace' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Go Back' })).toBeDisabled();
+    });
+
+    it('shows a loading toast when resolving a conflict', async () => {
+      await setupPendingResolution();
+      mockToastLoading.mockClear();
+
+      await userEvent.click(
+        screen.getByRole('button', { name: KEEP_EXISTING_BUTTON }),
+      );
+
+      expect(mockToastLoading).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the prompt and opens the result dialog once resolution succeeds', async () => {
+      const openResultDialog = jest.fn();
+      const onClose = jest.fn();
+      const pending = deferred();
+      mockInviteUsersFromFile.mockImplementationOnce(
+        () =>
+          (_dispatch: unknown): Promise<object> =>
+            Promise.resolve(conflictResponse),
+      );
+      mockInviteUsersFromFile.mockImplementationOnce(
+        () =>
+          (_dispatch: unknown): Promise<object> =>
+            pending.promise,
+      );
+
+      render(
+        <InviteUsersFileUpload
+          onClose={onClose}
+          open
+          openResultDialog={openResultDialog}
+        />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId(MOCK_FILE_SUBMIT_TESTID)).toBeInTheDocument(),
+      );
+      await capturedOnSubmit!({ file: TEST_FILE_ENTITY });
+      await waitFor(() =>
+        expect(screen.getByText(CONFLICT_PROMPT_TITLE)).toBeInTheDocument(),
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', { name: KEEP_EXISTING_BUTTON }),
+      );
+      pending.resolve(successResponse);
+
+      await waitFor(() => expect(openResultDialog).toHaveBeenCalledTimes(1));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockToastDismiss).toHaveBeenCalledWith('loading-toast-id');
     });
   });
 });

--- a/client/app/bundles/course/user-invitations/pages/InviteUsersFileUpload/index.tsx
+++ b/client/app/bundles/course/user-invitations/pages/InviteUsersFileUpload/index.tsx
@@ -11,6 +11,7 @@ import {
 import { getCourseUserInviteTemplatePath } from 'course/helper';
 import Link from 'lib/components/core/Link';
 import { useAppDispatch, useAppSelector } from 'lib/hooks/store';
+import toast from 'lib/hooks/toast';
 import useTranslation from 'lib/hooks/useTranslation';
 
 import FileUploadForm from '../../components/forms/InviteUsersFileUploadForm';
@@ -32,6 +33,11 @@ const translations = defineMessages({
   fileUploadInfo: {
     id: 'course.userInvitations.InviteUsersFileUpload.fileUploadInfo',
     defaultMessage: 'Upload a .csv file with the following format:',
+  },
+  fileUploadInfoRequired: {
+    id: 'course.userInvitations.InviteUsersFileUpload.fileUploadInfoRequired',
+    defaultMessage:
+      'The CSV must include both a "Name" and "Email" column. All other columns are optional.',
   },
   fileUploadInfoRole: {
     id: 'course.userInvitations.InviteUsersFileUpload.fileUploadInfoRole',
@@ -65,7 +71,7 @@ const translations = defineMessages({
   fileUploadInfoExternalId: {
     id: 'course.userInvitations.InviteUsersFileUpload.fileUploadInfoExternalId',
     defaultMessage:
-      'External ID is optional. If provided, it overwrites any existing external ID for the user and must be unique within the course.',
+      'If external IDs are provided, they must be unique within the course.',
   },
   exampleHeader: {
     id: 'course.userInvitations.InviteUsersFileUpload.exampleHeader',
@@ -99,6 +105,14 @@ const translations = defineMessages({
     defaultMessage:
       'Failed to invite users. Please ensure your data is formatted correctly.',
   },
+  importInProgress: {
+    id: 'course.userInvitations.InviteUsersFileUpload.importInProgress',
+    defaultMessage: 'Importing users, please wait…',
+  },
+  fileRequired: {
+    id: 'course.userInvitations.InviteUsersFileUpload.fileRequired',
+    defaultMessage: 'Please select a CSV file to upload.',
+  },
 });
 
 const InviteUsersFileUpload: FC<Props> = (props) => {
@@ -110,6 +124,7 @@ const InviteUsersFileUpload: FC<Props> = (props) => {
   const fileRef = useRef<InvitationFileEntity | null>(null);
   const [conflictData, setConflictData] =
     useState<PendingExternalIdConflict | null>(null);
+  const [isResolving, setIsResolving] = useState(false);
 
   const sharedData = useAppSelector(getManageCourseUsersSharedData);
   const permissions = useAppSelector(getManageCourseUserPermissions);
@@ -124,37 +139,58 @@ const InviteUsersFileUpload: FC<Props> = (props) => {
     return null;
   }
 
+  // Drives all imports (initial submit + conflict resolution). The conflict
+  // prompt is kept mounted until the server responds; clearing it eagerly would
+  // flip the FileUploadForm back open (open && !conflictData) mid-import.
   const submitWithResolution = (
     fileEntity: InvitationFileEntity,
     resolution?: 'keep_existing' | 'replace_all',
-  ): Promise<void> =>
-    dispatch(inviteUsersFromFile(fileEntity, resolution))
+  ): Promise<void> => {
+    // Not loadingToast(): this flow dismisses the spinner on every outcome
+    // (success → result dialog, conflict → prompt, error → useInviteErrorHandler's
+    // persistent parsed toast) rather than morphing it into success/error.
+    const toastId = toast.loading(t(translations.importInProgress));
+    setIsResolving(true);
+    return dispatch(inviteUsersFromFile(fileEntity, resolution))
       .then((response) => {
+        toast.dismiss(toastId);
         if ('conflict' in response) {
           setConflictData(response.conflict);
         } else {
+          setConflictData(null);
           onClose();
           openResultDialog(response as InvitationResult);
         }
       })
-      .catch(handleError);
+      .catch((error) => {
+        toast.dismiss(toastId);
+        setConflictData(null);
+        handleError(error);
+      })
+      .finally(() => setIsResolving(false));
+  };
 
   const onSubmit = (data: { file: InvitationFileEntity }): Promise<void> => {
+    // The form's submit unlocks once the field is dirty, which a select-then-remove
+    // leaves true with no file. Surface that as a toast rather than firing an empty import.
+    if (!data.file?.file) {
+      toast.error(t(translations.fileRequired));
+      return Promise.resolve();
+    }
     fileRef.current = data.file;
     return submitWithResolution(data.file);
   };
 
   const handleKeepExisting = (): void => {
-    setConflictData(null);
     if (fileRef.current) submitWithResolution(fileRef.current, 'keep_existing');
   };
 
   const handleReplaceAll = (): void => {
-    setConflictData(null);
     if (fileRef.current) submitWithResolution(fileRef.current, 'replace_all');
   };
 
   const handleCancel = (): void => {
+    if (isResolving) return;
     setConflictData(null);
     fileRef.current = null;
   };
@@ -162,7 +198,12 @@ const InviteUsersFileUpload: FC<Props> = (props) => {
   const formSubtitle = (
     <>
       <Typography variant="body2">{t(translations.fileUploadInfo)}</Typography>
-      <ul>
+      <ul className="m-0 mt-2 pl-6">
+        <li>
+          <Typography variant="body2">
+            {t(translations.fileUploadInfoRequired)}
+          </Typography>
+        </li>
         <li>
           <Typography variant="body2">
             {t(translations.fileUploadInfoEmail)}
@@ -231,6 +272,7 @@ const InviteUsersFileUpload: FC<Props> = (props) => {
     <>
       {conflictData && (
         <ExternalIdConflictPrompt
+          disabled={isResolving}
           onCancel={handleCancel}
           onKeepExisting={handleKeepExisting}
           onReplaceAll={handleReplaceAll}

--- a/client/app/lib/hooks/toast/toast.tsx
+++ b/client/app/lib/hooks/toast/toast.tsx
@@ -102,6 +102,10 @@ const loading: Toaster = (message, options?) =>
 const update = (id: Id, options?: NodeOnlyUpdateOptions): void =>
   toastify.update(id, customize(options));
 
+const dismiss = (id?: Id): void => {
+  toastify.dismiss(id);
+};
+
 const promise = <T,>(
   data: Promise<T>,
   messages: PromisedToastMessages,
@@ -139,5 +143,6 @@ export default Object.assign(toast, {
   error,
   loading,
   update,
+  dismiss,
   promise,
 });

--- a/client/app/types/course/userInvitations.ts
+++ b/client/app/types/course/userInvitations.ts
@@ -15,6 +15,7 @@ export type InvitationFailureReason =
   | 'duplicate_email_in_file'
   | 'duplicate_external_id_in_file'
   | 'external_id_taken'
+  | 'missing_email'
   | 'failed_to_send';
 
 export interface FailedInvitationRowData extends CourseUserListData {

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -7061,6 +7061,9 @@
   "course.userInvitations.InvitationResultFailedTable.failedToSend": {
     "defaultMessage": "Failed to send invitation email, please try again - if failures persist, contact us for assistance"
   },
+  "course.userInvitations.InvitationResultFailedTable.missingEmail": {
+    "defaultMessage": "Missing email"
+  },
   "course.userInvitations.InvitationResultSkippedTable.no": {
     "defaultMessage": "No"
   },
@@ -7112,11 +7115,14 @@
   "course.userInvitations.InviteUsersFileUpload.fileUploadExamplePersonalTimeline": {
     "defaultMessage": "Name,Email,External ID,Role,Phantom,Personal Timeline{br}John,test1@example.com,A0123456,student,y,otot{br}Mary,test2@example.com,A0123457,teaching_assistant,n,fixed"
   },
+  "course.userInvitations.InviteUsersFileUpload.fileUploadInfoRequired": {
+    "defaultMessage": "The CSV must include both a \"Name\" and \"Email\" column. All other columns are optional."
+  },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoEmail": {
     "defaultMessage": "Each invitation must use a unique email address within the course. Duplicate emails will be skipped."
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoExternalId": {
-    "defaultMessage": "External ID is optional. If provided, it overwrites any existing external ID for the user and must be unique within the course."
+    "defaultMessage": "If external IDs are provided, they must be unique within the course."
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfo": {
     "defaultMessage": "Upload a .csv file with the following format:"
@@ -7129,6 +7135,12 @@
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoRole": {
     "defaultMessage": "Roles can be <code>[student, observer, teaching_assistant, manager, owner]</code>, and defaults to student if omitted. Teaching assistants can only invite users as students."
+  },
+  "course.userInvitations.InviteUsersFileUpload.importInProgress": {
+    "defaultMessage": "Importing users, please wait…"
+  },
+  "course.userInvitations.InviteUsersFileUpload.fileRequired": {
+    "defaultMessage": "Please select a CSV file to upload."
   },
   "course.userInvitations.InviteUsersFileUpload.template": {
     "defaultMessage": "(Template File)"

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -7100,11 +7100,14 @@
   "course.userInvitations.InviteUsersFileUpload.fileUploadExamplePersonalTimeline": {
     "defaultMessage": "이름,이메일,외부 ID,역할,팬텀,개인 타임라인{br}John,test1@example.com,A0123456,student,y,otot{br}Mary,test2@example.com,A0123457,teaching_assistant,n,fixed"
   },
+  "course.userInvitations.InviteUsersFileUpload.fileUploadInfoRequired": {
+    "defaultMessage": "CSV에는 \"이름\"과 \"이메일\" 열이 모두 포함되어야 합니다. 다른 모든 열은 선택 사항입니다."
+  },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoEmail": {
     "defaultMessage": "각 초대는 과정 내에서 고유한 이메일 주소를 사용해야 합니다. 중복된 이메일은 건너뜁니다."
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoExternalId": {
-    "defaultMessage": "외부 ID는 선택 사항입니다. 입력된 경우 해당 사용자의 기존 외부 ID를 덮어쓰며, 과정 내에서 고유해야 합니다."
+    "defaultMessage": "외부 ID가 제공된 경우, 해당 외부 ID는 과정 내에서 고유해야 합니다."
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfo": {
     "defaultMessage": "다음 형식으로 .csv 파일을 업로드하세요:"
@@ -7117,6 +7120,12 @@
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoRole": {
     "defaultMessage": "역할은 <code>[학생, 관찰자, 티칭 어시스턴트, 관리자, 소유자]</code>로 설정할 수 있으며, 생략 시 기본값은 학생입니다. 티칭 어시스턴트는 사용자 초대를 학생으로만 할 수 있습니다."
+  },
+  "course.userInvitations.InviteUsersFileUpload.importInProgress": {
+    "defaultMessage": "사용자를 가져오는 중입니다. 잠시만 기다려 주세요…"
+  },
+  "course.userInvitations.InviteUsersFileUpload.fileRequired": {
+    "defaultMessage": "업로드할 CSV 파일을 선택해 주세요."
   },
   "course.userInvitations.InviteUsersFileUpload.template": {
     "defaultMessage": "(템플릿 파일)"

--- a/client/locales/zh.json
+++ b/client/locales/zh.json
@@ -7094,11 +7094,14 @@
   "course.userInvitations.InviteUsersFileUpload.fileUploadExamplePersonalTimeline": {
     "defaultMessage": "姓名,电子邮件,外部编号,角色,旁听学生,个人时间线{br}John,test1@example.com,A0123456,student,y,otot{br}Mary,test2@example.com,A0123457,teaching_assistant,n,fixed"
   },
+  "course.userInvitations.InviteUsersFileUpload.fileUploadInfoRequired": {
+    "defaultMessage": "CSV 必须同时包含“姓名”和“电子邮件”列。所有其他列均为可选。"
+  },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoEmail": {
-    "defaultMessage": "每个邀请必须使用课程内唯一的电子邮件地址。重复的电子邮件将被跳过。"
+    "defaultMessage": "每个邀请在课程内必须使用唯一的电子邮件地址。重复的电子邮件将被跳过。"
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoExternalId": {
-    "defaultMessage": "外部编号为可选项。如填写，将取代该用户现有的外部编号，且不得与本课程内其他用户重复。"
+    "defaultMessage": "如果提供了外部编号，则这些外部编号在课程内必须唯一。"
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfo": {
     "defaultMessage": "上传具有以下格式的 .csv 文件："
@@ -7111,6 +7114,12 @@
   },
   "course.userInvitations.InviteUsersFileUpload.fileUploadInfoRole": {
     "defaultMessage": "角色可以是<code>[student, observer, teaching_assistant, manager, owner]</code>，如果省略则默认为学生。用户只能被助教邀请为学生。"
+  },
+  "course.userInvitations.InviteUsersFileUpload.importInProgress": {
+    "defaultMessage": "正在导入用户，请稍候…"
+  },
+  "course.userInvitations.InviteUsersFileUpload.fileRequired": {
+    "defaultMessage": "请选择要上传的 CSV 文件。"
   },
   "course.userInvitations.InviteUsersFileUpload.template": {
     "defaultMessage": "（模板文件）"

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -20,9 +20,10 @@ en:
         invalid_email: '%{email} could not be processed: invalid email: %{message}.'
         duplicate_external_id: '%{email} could not be processed: external ID "%{external_id}" is already taken.'
         other_error: '%{email} could not be processed: %{message}.'
-        invalid_headers: 'Unrecognized CSV header "%{header}". Accepted headers: %{accepted}.'
+        invalid_headers: 'Unrecognized CSV header(s): %{headers}. Accepted headers: %{accepted}.'
         missing_required_headers: 'CSV must include both a "Name" and "Email" column.'
         duplicate_headers: 'Duplicate CSV column: "%{column}". Each column must appear only once.'
+        no_valid_rows: 'The CSV file has no rows to invite.'
       user_registrations:
         invalid_code: 'You have entered an invalid invitation code.'
         code_taken: >

--- a/config/locales/ko/errors.yml
+++ b/config/locales/ko/errors.yml
@@ -20,9 +20,10 @@ ko:
         invalid_email: '%{email}을(를) 처리할 수 없습니다: 유효하지 않은 이메일: %{message}.'
         duplicate_external_id: '%{email}을(를) 처리할 수 없습니다: 외부 ID "%{external_id}"는 이미 사용 중입니다.'
         other_error: '%{email}을(를) 처리할 수 없습니다: %{message}.'
-        invalid_headers: '인식되지 않는 CSV 헤더: "%{header}". 허용되는 헤더: %{accepted}.'
+        invalid_headers: '인식되지 않는 CSV 헤더: %{headers}. 허용되는 헤더: %{accepted}.'
         missing_required_headers: 'CSV에는 "이름"과 "이메일" 열이 모두 포함되어야 합니다.'
         duplicate_headers: '중복된 CSV 열: "%{column}". 각 열은 한 번만 나타나야 합니다.'
+        no_valid_rows: 'CSV 파일에 초대할 행이 없습니다.'
       user_registrations:
         invalid_code: '잘못된 초대 코드를 입력하셨습니다.'
         code_taken: >

--- a/config/locales/zh/errors.yml
+++ b/config/locales/zh/errors.yml
@@ -20,9 +20,10 @@ zh:
         invalid_email: '%{email}无法处理：邮箱无效：%{message}。'
         duplicate_external_id: '%{email}无法处理：外部编号"%{external_id}"已被使用。'
         other_error: '%{email}无法处理：%{message}。'
-        invalid_headers: 'CSV 标题 "%{header}" 无法识别。接受的标题：%{accepted}。'
+        invalid_headers: '无法识别的 CSV 标题：%{headers}。接受的标题：%{accepted}。'
         missing_required_headers: 'CSV 必须包含"姓名"和"电子邮件"列。'
         duplicate_headers: '重复的 CSV 列："%{column}"。每一列只能出现一次。'
+        no_valid_rows: 'CSV 文件中没有可邀请的行。'
       user_registrations:
         invalid_code: '你输入了一个无效的邀请码。'
         code_taken: >

--- a/spec/services/course/user_invitation_service_spec.rb
+++ b/spec/services/course/user_invitation_service_spec.rb
@@ -294,6 +294,36 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
       end
 
+      context 'when the CSV has unrecognized headers' do
+        def csv_with_extra_headers(*extra_headers)
+          Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
+            file.write(CSV.generate do |c|
+              c << (['Name', 'Email'] + extra_headers)
+              c << (['Alice', generate(:email)] + extra_headers.map { 'value' })
+            end)
+            file.rewind
+          end
+        end
+
+        it 'names the unrecognized header and lists the accepted ones' do
+          csv = csv_with_extra_headers('Emial')
+          expect { subject.invite(csv) }.to raise_error(CSV::MalformedCSVError) do |error|
+            expect(error.message).to include('Emial')
+            expect(error.message).to include(I18n.t('csv.course_user_invitations.headers.email'))
+          end
+          csv.close!
+        end
+
+        it 'reports every unrecognized header, not just the first' do
+          csv = csv_with_extra_headers('Emial', 'Phantum')
+          expect { subject.invite(csv) }.to raise_error(CSV::MalformedCSVError) do |error|
+            expect(error.message).to include('Emial')
+            expect(error.message).to include('Phantum')
+          end
+          csv.close!
+        end
+      end
+
       context 'when the CSV has duplicate column headers' do
         it 'raises CSV::MalformedCSVError for same-language duplicates' do
           csv = Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
@@ -316,6 +346,114 @@ RSpec.describe Course::UserInvitationService, type: :service do
             file.rewind
           end
           expect { subject.invite(csv) }.to raise_error(CSV::MalformedCSVError)
+          csv.close!
+        end
+      end
+
+      context 'when the CSV has a header but no valid rows' do
+        it 'raises CSV::MalformedCSVError when only a header row is present' do
+          csv = Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
+            file.write(CSV.generate { |c| c << ['Name', 'Email', 'External ID', 'Role', 'Phantom'] })
+            file.rewind
+          end
+          expect { subject.invite(csv) }.to raise_error(
+            CSV::MalformedCSVError,
+            /#{Regexp.escape(I18n.t('errors.course.user_invitations.no_valid_rows'))}/
+          )
+          csv.close!
+        end
+
+        it 'raises CSV::MalformedCSVError when all data rows lack both email and identity' do
+          csv = Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
+            file.write(CSV.generate do |c|
+              c << ['Name', 'Email', 'External ID', 'Role', 'Phantom']
+              c << ['', '', '', 'student', 'false']
+              c << ['', '', '', '', '']
+            end)
+            file.rewind
+          end
+          expect { subject.invite(csv) }.to raise_error(
+            CSV::MalformedCSVError,
+            /#{Regexp.escape(I18n.t('errors.course.user_invitations.no_valid_rows'))}/
+          )
+          csv.close!
+        end
+
+        it 'raises CSV::MalformedCSVError when the file is truly empty' do
+          csv = Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
+            file.write('')
+            file.rewind
+          end
+          expect { subject.invite(csv) }.to raise_error(CSV::MalformedCSVError)
+          csv.close!
+        end
+
+        it 'does not raise when a header and one valid row are present' do
+          csv = Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
+            file.write(CSV.generate do |c|
+              c << ['Name', 'Email', 'External ID', 'Role', 'Phantom']
+              c << ['Alice', generate(:email), '', 'student', 'false']
+            end)
+            file.rewind
+          end
+          result = subject.invite(csv)
+          expect(result).not_to be_nil
+          new_invitations, = result
+          expect(new_invitations.size).to eq(1)
+          csv.close!
+        end
+      end
+
+      context 'when a CSV row is missing its email but has identifying data' do
+        def csv_with_rows(*data_rows)
+          Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
+            file.write(CSV.generate do |c|
+              c << ['Name', 'Email', 'External ID', 'Role', 'Phantom']
+              data_rows.each { |row| c << row }
+            end)
+            file.rewind
+          end
+        end
+
+        it 'surfaces a row with a name but no email as a missing_email failure' do
+          csv = csv_with_rows(['Alice', generate(:email), '', 'student', 'false'],
+                              ['No Email', '', '', 'student', 'false'])
+          new_invitations, _, _, _, failed_users = subject.invite(csv)
+          expect(new_invitations.size).to eq(1)
+          expect(failed_users.size).to eq(1)
+          expect(failed_users.first[:reason]).to eq(:missing_email)
+          expect(failed_users.first[:name]).to eq('No Email')
+          csv.close!
+        end
+
+        it 'surfaces a row with an external ID but no email as a missing_email failure' do
+          csv = csv_with_rows(['Alice', generate(:email), '', 'student', 'false'],
+                              ['', '', 'EXT999', 'student', 'false'])
+          new_invitations, _, _, _, failed_users = subject.invite(csv)
+          expect(new_invitations.size).to eq(1)
+          expect(failed_users.size).to eq(1)
+          expect(failed_users.first[:reason]).to eq(:missing_email)
+          expect(failed_users.first[:external_id]).to eq('EXT999')
+          csv.close!
+        end
+
+        it 'silently skips rows with neither email nor identity (blank or attribute-only)' do
+          csv = csv_with_rows(['Alice', generate(:email), '', 'student', 'false'],
+                              ['', '', '', '', ''],
+                              ['', '', '', 'student', 'false'])
+          new_invitations, _, _, _, failed_users = subject.invite(csv)
+          expect(new_invitations.size).to eq(1)
+          expect(failed_users).to be_empty
+          csv.close!
+        end
+
+        it 'does not raise no_valid_rows when every data row is a missing_email failure' do
+          csv = csv_with_rows(['No Email One', '', '', 'student', 'false'],
+                              ['No Email Two', '', '', 'student', 'false'])
+          new_invitations, _, _, _, failed_users = subject.invite(csv)
+          expect(new_invitations).to be_empty
+          expect(failed_users.size).to eq(2)
+          expect(failed_users.map { |u| u[:reason] }).to all(eq(:missing_email))
           csv.close!
         end
       end
@@ -351,441 +489,514 @@ RSpec.describe Course::UserInvitationService, type: :service do
         end
       end
 
-      context 'when a CSV (without personalized timelines) has a duplicate external_id for an existing course user' do
-        before { course.update!(show_personalized_timeline_features: false) }
-        let!(:existing_course_user) { create(:course_student, course: course, external_id: 'taken-id') }
+      describe 'external ID conflict resolution' do
+        context 'when a CSV (without personalized timelines) has a duplicate external_id for an existing course user' do
+          before { course.update!(show_personalized_timeline_features: false) }
+          let!(:existing_course_user) { create(:course_student, course: course, external_id: 'taken-id') }
 
-        def csv_with_external_id_no_timeline(entries)
-          Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
-            file.write(CSV.generate do |csv|
-              csv << ['Name', 'Email', 'External ID', 'Role', 'Phantom']
-              entries.each do |entry|
-                csv << [entry[:name], entry[:email], entry[:external_id], 'student', 'false']
-              end
-            end)
-            file.rewind
+          def csv_with_external_id_no_timeline(entries)
+            Tempfile.new(File.basename(__FILE__, '.*')).tap do |file|
+              file.write(CSV.generate do |csv|
+                csv << ['Name', 'Email', 'External ID', 'Role', 'Phantom']
+                entries.each do |entry|
+                  csv << [entry[:name], entry[:email], entry[:external_id], 'student', 'false']
+                end
+              end)
+              file.rewind
+            end
+          end
+
+          it 'does not abort the batch' do
+            csv = csv_with_external_id_no_timeline(
+              [name: 'New User', email: generate(:email), external_id: 'taken-id']
+            )
+            result = subject.invite(csv)
+            expect(result).not_to be_nil
+            _, _, _, _, failed_users = result
+            expect(failed_users.size).to eq(1)
+            expect(failed_users.first[:reason]).to eq(:external_id_taken)
+            csv.close!
           end
         end
 
-        it 'does not abort the batch' do
-          csv = csv_with_external_id_no_timeline(
-            [name: 'New User', email: generate(:email), external_id: 'taken-id']
-          )
-          result = subject.invite(csv)
-          expect(result).not_to be_nil
-          _, _, _, _, failed_users = result
-          expect(failed_users.size).to eq(1)
-          expect(failed_users.first[:reason]).to eq(:external_id_taken)
-          csv.close!
-        end
-      end
-
-      context 'when re-inviting a pending invitation with a new external_id (current nil, CSV value free)' do
-        let!(:pending_invitation) do
-          create(:course_user_invitation, course: course,
-                                          email: 'pending@example.com', external_id: nil)
-        end
-        let(:invitation_attributes) do
-          { '0' => { name: 'Pending User', email: 'pending@example.com', role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
-        end
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'raises PendingExternalIdUpdates without resolution' do
-          expect { invitation_service.invite(invitation_attributes) }.
-            to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-        end
-
-        it 'surfaces the pending invitation with correct IDs in the error' do
-          err = begin
-            invitation_service.invite(invitation_attributes)
-          rescue Course::UserInvitationService::PendingExternalIdUpdates => e
-            e
+        context 'when re-inviting a pending invitation with a new external_id (current nil, CSV value free)' do
+          let!(:pending_invitation) do
+            create(:course_user_invitation, course: course,
+                                            email: 'pending@example.com', external_id: nil)
           end
-          entry = err.pending_invitation_updates.find { |u| u[:record] == pending_invitation }
-          expect(entry[:new_external_id]).to eq('new-id')
-          expect(entry[:previous_external_id]).to be_nil
-        end
-
-        it 'updates the invitation external_id with resolution :replace_all' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all)
-          expect(pending_invitation.reload.external_id).to eq('new-id')
-        end
-
-        it 'keeps nil external_id with resolution :keep_existing' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
-          expect(pending_invitation.reload.external_id).to be_nil
-        end
-      end
-
-      context 'when re-inviting a failed invitation (is_retryable: false) with a new external_id' do
-        let!(:failed_invitation) do
-          create(:course_user_invitation, course: course,
-                                          email: 'failed@example.com',
-                                          external_id: 'old-id',
-                                          is_retryable: false)
-        end
-        let(:invitation_attributes) do
-          { '0' => { name: 'Failed User', email: 'failed@example.com', role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
-        end
-        subject(:result) { invitation_service.invite(invitation_attributes) }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'does not update the external_id' do
-          result
-          expect(failed_invitation.reload.external_id).to eq('old-id')
-        end
-
-        it 'puts the invitation in existing_invitations, not updated_invitations' do
-          existing_invitations = result[1]
-          updated_invitations = result[5]
-          expect(existing_invitations).to include(failed_invitation)
-          expect(updated_invitations.map { |u| u[:record] }).not_to include(failed_invitation)
-        end
-
-        it 'does not create a failed_users entry' do
-          _, _, _, _, failed_users = result
-          expect(failed_users).to be_empty
-        end
-      end
-
-      context 'when an existing course user is re-invited with a new external_id (current nil, CSV value free)' do
-        let!(:enrolled_user) { create(:user) }
-        let!(:course_user_record) { create(:course_student, course: course, user: enrolled_user, external_id: nil) }
-        let(:invitation_attributes) do
-          { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
-        end
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'raises PendingExternalIdUpdates without resolution' do
-          expect { invitation_service.invite(invitation_attributes) }.
-            to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-        end
-
-        it 'surfaces the course user with correct IDs in the error' do
-          err = begin
-            invitation_service.invite(invitation_attributes)
-          rescue Course::UserInvitationService::PendingExternalIdUpdates => e
-            e
+          let(:invitation_attributes) do
+            { '0' => { name: 'Pending User', email: 'pending@example.com', role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
           end
-          entry = err.pending_course_user_updates.find { |u| u[:record] == course_user_record }
-          expect(entry[:new_external_id]).to eq('new-id')
-          expect(entry[:previous_external_id]).to be_nil
-        end
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
 
-        it 'updates the course_user external_id with resolution :replace_all' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all)
-          expect(course_user_record.reload.external_id).to eq('new-id')
-        end
-
-        it 'keeps nil external_id with resolution :keep_existing' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
-          expect(course_user_record.reload.external_id).to be_nil
-        end
-      end
-
-      context 'when an existing course user with a non-nil external_id is re-invited with a different free value' do
-        let!(:enrolled_user) { create(:user) }
-        let!(:course_user_record) do
-          create(:course_student, course: course, user: enrolled_user, external_id: 'old-id')
-        end
-        let(:invitation_attributes) do
-          { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
-        end
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'updates the course_user external_id with resolution :replace_all' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all)
-          expect(course_user_record.reload.external_id).to eq('new-id')
-        end
-
-        it 'keeps the old external_id with resolution :keep_existing' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
-          expect(course_user_record.reload.external_id).to eq('old-id')
-        end
-      end
-
-      context 'when an existing course user is re-invited and the external_id is already taken' do
-        let!(:other_user) { create(:course_student, course: course, external_id: 'taken-id') }
-        let!(:enrolled_user) { create(:user) }
-        let!(:course_user_record) { create(:course_student, course: course, user: enrolled_user, external_id: nil) }
-        let(:invitation_attributes) do
-          { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
-        end
-        subject(:result) { invitation_service.invite(invitation_attributes) }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'does not abort the batch' do
-          expect(result).not_to be_nil
-        end
-
-        it 'puts the user in failed_users with :external_id_taken reason' do
-          _, _, _, _, failed_users = result
-          expect(failed_users.map { |u| u[:reason] }).to include(:external_id_taken)
-        end
-
-        it 'does not update the course_user external_id' do
-          result
-          expect(course_user_record.reload.external_id).to be_nil
-        end
-      end
-
-      context 'when a new user is invited but the external_id matches an existing course user' do
-        let!(:existing_course_user_ext) { create(:course_student, course: course, external_id: 'taken-id') }
-        let(:new_user) { create(:user) }
-        let(:invitation_attributes) do
-          { '0' => { name: new_user.name, email: new_user.email, role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
-        end
-        subject(:result) { invitation_service.invite(invitation_attributes) }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'does not abort the batch' do
-          expect(result).not_to be_nil
-        end
-
-        it 'puts the row in failed_users with :external_id_taken reason' do
-          _, _, _, _, failed_users = result
-          expect(failed_users.first[:reason]).to eq(:external_id_taken)
-        end
-
-        it 'does not enroll the user' do
-          _, _, new_course_users, = result
-          expect(new_course_users).to be_empty
-        end
-      end
-
-      context 'when a new user is enrolled but the external_id matches a pending invitation' do
-        let!(:pending_inv) { create(:course_user_invitation, course: course, external_id: 'taken-id') }
-        let(:new_user) { create(:user) }
-        let(:invitation_attributes) do
-          { '0' => { name: new_user.name, email: new_user.email, role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
-        end
-        subject(:result) { invitation_service.invite(invitation_attributes) }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'puts the row in failed_users with :external_id_taken reason' do
-          _, _, _, _, failed_users = result
-          expect(failed_users.first[:reason]).to eq(:external_id_taken)
-        end
-
-        it 'does not enroll the user' do
-          _, _, new_course_users, = result
-          expect(new_course_users).to be_empty
-        end
-      end
-
-      context 'when an existing course user is re-invited and the external_id is taken by a pending invitation' do
-        let!(:pending_inv) { create(:course_user_invitation, course: course, external_id: 'taken-id') }
-        let!(:enrolled_user) { create(:user) }
-        let!(:course_user_record) { create(:course_student, course: course, user: enrolled_user, external_id: nil) }
-        let(:invitation_attributes) do
-          { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
-        end
-        subject(:result) { invitation_service.invite(invitation_attributes) }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'puts the user in failed_users with :external_id_taken reason' do
-          _, _, _, _, failed_users = result
-          expect(failed_users.map { |u| u[:reason] }).to include(:external_id_taken)
-        end
-
-        it 'does not update the course_user external_id' do
-          result
-          expect(course_user_record.reload.external_id).to be_nil
-        end
-      end
-
-      context 'when re-inviting a pending invitation whose CSV ext_id is taken by another member' do
-        let!(:other_user) { create(:course_student, course: course, external_id: 'taken-id') }
-        let!(:pending_invitation) do
-          create(:course_user_invitation, course: course,
-                                          email: 'pending@example.com', name: 'Pending User', external_id: 'old-id')
-        end
-        let(:invitation_attributes) do
-          { '0' => { name: 'Pending User', email: 'pending@example.com', role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
-        end
-        subject(:result) { invitation_service.invite(invitation_attributes) }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'puts the user in failed_users with :external_id_taken reason' do
-          _, _, _, _, failed_users = result
-          expect(failed_users.map { |u| u[:reason] }).to include(:external_id_taken)
-        end
-
-        it 'does not update the pending invitation external_id' do
-          result
-          expect(pending_invitation.reload.external_id).to eq('old-id')
-        end
-      end
-
-      context 'when re-inviting a pending invitation with a non-nil ext_id and CSV provides a free different value' do
-        let!(:pending_invitation) do
-          create(:course_user_invitation, course: course,
-                                          email: 'pending@example.com', name: 'Pending User', external_id: 'old-id')
-        end
-        let(:invitation_attributes) do
-          { '0' => { name: 'Pending User', email: 'pending@example.com', role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
-        end
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'raises PendingExternalIdUpdates without resolution' do
-          expect { invitation_service.invite(invitation_attributes) }.
-            to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-        end
-
-        it 'surfaces the pending invitation with correct IDs in the error' do
-          err = begin
-            invitation_service.invite(invitation_attributes)
-          rescue Course::UserInvitationService::PendingExternalIdUpdates => e
-            e
+          it 'raises PendingExternalIdUpdates without resolution' do
+            expect { invitation_service.invite(invitation_attributes) }.
+              to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
           end
-          entry = err.pending_invitation_updates.find { |u| u[:record] == pending_invitation }
-          expect(entry[:new_external_id]).to eq('new-id')
-          expect(entry[:previous_external_id]).to eq('old-id')
+
+          it 'surfaces the pending invitation with correct IDs in the error' do
+            err = begin
+              invitation_service.invite(invitation_attributes)
+            rescue Course::UserInvitationService::PendingExternalIdUpdates => e
+              e
+            end
+            entry = err.pending_invitation_updates.find { |u| u[:record] == pending_invitation }
+            expect(entry[:new_external_id]).to eq('new-id')
+            expect(entry[:previous_external_id]).to be_nil
+          end
+
+          it 'updates the invitation external_id with resolution :replace_all' do
+            result = invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all)
+            updated_invitations = result[5]
+            expect(updated_invitations.map { |u| u[:record] }).to include(pending_invitation)
+            expect(pending_invitation.reload.external_id).to eq('new-id')
+          end
+
+          it 'keeps nil external_id with resolution :keep_existing' do
+            invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
+            expect(pending_invitation.reload.external_id).to be_nil
+          end
         end
 
-        it 'updates the invitation external_id with resolution :replace_all' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all)
-          expect(pending_invitation.reload.external_id).to eq('new-id')
-        end
+        context 'when re-inviting a failed invitation (is_retryable: false) with a new external_id' do
+          let!(:failed_invitation) do
+            create(:course_user_invitation, course: course,
+                                            email: 'failed@example.com',
+                                            external_id: 'old-id',
+                                            is_retryable: false)
+          end
+          let(:invitation_attributes) do
+            { '0' => { name: 'Failed User', email: 'failed@example.com', role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
+          end
+          subject(:result) { invitation_service.invite(invitation_attributes) }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
 
-        it 'keeps the old external_id with resolution :keep_existing' do
-          invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
-          expect(pending_invitation.reload.external_id).to eq('old-id')
-        end
-      end
-
-      context 'when a batch changes an existing invitation ext_id and a later row claims the freed id' do
-        let!(:alice_invitation) do
-          create(:course_user_invitation, course: course,
-                                          email: 'alice@example.com', name: 'Alice', external_id: 'freed-id')
-        end
-        let(:bob_email) { generate(:email) }
-        let(:invitation_attributes) do
-          { '0' => { name: 'Alice', email: 'alice@example.com', role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' },
-            '1' => { name: 'Bob', email: bob_email, role: :student,
-                     phantom: false, timeline_algorithm: :fixed, external_id: 'freed-id' } }
-        end
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'raises PendingExternalIdUpdates without resolution (Alice has existing ext_id)' do
-          expect { invitation_service.invite(invitation_attributes) }.
-            to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-        end
-
-        context 'with resolution :replace_all' do
-          subject(:result) { invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all) }
-
-          it 'updates Alice to new-id' do
+          it 'does not update the external_id' do
             result
-            expect(alice_invitation.reload.external_id).to eq('new-id')
+            expect(failed_invitation.reload.external_id).to eq('old-id')
           end
 
-          it 'creates a new invitation for Bob with the freed id' do
-            new_invitations, = result
-            expect(new_invitations.map(&:external_id)).to include('freed-id')
+          it 'puts the invitation in existing_invitations, not updated_invitations' do
+            existing_invitations = result[1]
+            updated_invitations = result[5]
+            expect(existing_invitations).to include(failed_invitation)
+            expect(updated_invitations.map { |u| u[:record] }).not_to include(failed_invitation)
           end
 
-          it 'produces no failed_users entries' do
+          it 'does not create a failed_users entry' do
             _, _, _, _, failed_users = result
             expect(failed_users).to be_empty
           end
         end
-      end
 
-      context 'cross-type freed-id: existing course user frees id, new invitation claims it in same batch' do
-        # invite_new_users runs before add_existing_users, so the new invitation is processed
-        # first and sees the id as still taken. The existing course user is then updated
-        # successfully, but the new invitation has already been rejected.
-        let!(:enrolled_user_freeing) { create(:user) }
-        let!(:course_user_freeing) do
-          create(:course_student, course: course, user: enrolled_user_freeing, external_id: 'freed-id')
-        end
-        let(:new_user_email) { generate(:email) }
-        let(:invitation_attributes) do
-          { '0' => { name: enrolled_user_freeing.name, email: enrolled_user_freeing.email,
-                     role: :student, phantom: false, timeline_algorithm: :fixed,
-                     external_id: 'new-id' },
-            '1' => { name: 'New Person', email: new_user_email,
-                     role: :student, phantom: false, timeline_algorithm: :fixed,
-                     external_id: 'freed-id' } }
-        end
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        it 'raises PendingExternalIdUpdates without resolution' do
-          expect { invitation_service.invite(invitation_attributes) }.
-            to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-        end
-
-        context 'with resolution :replace_all' do
-          subject(:result) { invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all) }
-
-          it 'updates the existing course user to new-id' do
-            result
-            expect(course_user_freeing.reload.external_id).to eq('new-id')
+        context 'when re-inviting a failed invitation (is_retryable: false) whose CSV ext_id is taken' do
+          let!(:other_member) { create(:course_student, course: course, external_id: 'taken-id') }
+          let!(:failed_invitation) do
+            create(:course_user_invitation, course: course,
+                                            email: 'failed@example.com',
+                                            external_id: 'old-id',
+                                            is_retryable: false)
           end
-
-          it 'rejects the new invitation because it is processed before the id is freed' do
-            _, _, _, _, failed_users = result
-            expect(failed_users.map { |u| u[:email] }).to include(new_user_email)
-            expect(failed_users.find { |u| u[:email] == new_user_email }[:reason]).to eq(:external_id_taken)
-          end
-        end
-      end
-
-      context 'when a new direct enrollee (existing account, not yet in course) ' \
-              'has an ext_id already taken by another course member' do
-        let!(:other_member) { create(:course_student, course: course, external_id: 'taken-id') }
-        let!(:enrollee) { create(:instance_user).user }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
-
-        subject(:result) do
-          invitation_service.invite(
-            { '0' => { name: enrollee.name, email: enrollee.email, role: :student,
+          let(:invitation_attributes) do
+            { '0' => { name: 'Failed User', email: 'failed@example.com', role: :student,
                        phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
-          )
+          end
+          subject(:result) { invitation_service.invite(invitation_attributes) }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'surfaces it as an existing invitation rather than an external_id_taken failure' do
+            existing_invitations = result[1]
+            _, _, _, _, failed_users = result
+            expect(existing_invitations).to include(failed_invitation)
+            expect(failed_users).to be_empty
+          end
+
+          it 'does not change the external_id' do
+            result
+            expect(failed_invitation.reload.external_id).to eq('old-id')
+          end
         end
 
-        it 'puts the enrollee in failed_users with :external_id_taken' do
-          _, _, _, _, failed_users = result
-          expect(failed_users.size).to eq(1)
-          expect(failed_users.first[:reason]).to eq(:external_id_taken)
+        context 'when an existing course user is re-invited with a new external_id (current nil, CSV value free)' do
+          let!(:enrolled_user) { create(:user) }
+          let!(:course_user_record) { create(:course_student, course: course, user: enrolled_user, external_id: nil) }
+          let(:invitation_attributes) do
+            { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
+          end
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'raises PendingExternalIdUpdates without resolution' do
+            expect { invitation_service.invite(invitation_attributes) }.
+              to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
+          end
+
+          it 'surfaces the course user with correct IDs in the error' do
+            err = begin
+              invitation_service.invite(invitation_attributes)
+            rescue Course::UserInvitationService::PendingExternalIdUpdates => e
+              e
+            end
+            entry = err.pending_course_user_updates.find { |u| u[:record] == course_user_record }
+            expect(entry[:new_external_id]).to eq('new-id')
+            expect(entry[:previous_external_id]).to be_nil
+          end
+
+          it 'updates the course_user external_id with resolution :replace_all' do
+            result = invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all)
+            updated_course_users = result[6]
+            expect(updated_course_users.map { |u| u[:record] }).to include(course_user_record)
+            expect(course_user_record.reload.external_id).to eq('new-id')
+          end
+
+          it 'keeps nil external_id with resolution :keep_existing' do
+            invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
+            expect(course_user_record.reload.external_id).to be_nil
+          end
         end
 
-        it 'does not enroll the user' do
-          _, _, new_course_users, = result
-          expect(new_course_users).to be_empty
+        context 'when an existing course user with a non-nil external_id is re-invited with a different free value' do
+          let!(:enrolled_user) { create(:user) }
+          let!(:course_user_record) do
+            create(:course_student, course: course, user: enrolled_user, external_id: 'old-id')
+          end
+          let(:invitation_attributes) do
+            { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
+          end
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'raises PendingExternalIdUpdates without resolution' do
+            expect { invitation_service.invite(invitation_attributes) }.
+              to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
+          end
+
+          context 'with resolution :replace_all' do
+            subject(:result) { invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all) }
+
+            it 'updates the course_user external_id' do
+              result
+              expect(course_user_record.reload.external_id).to eq('new-id')
+            end
+
+            it 'puts the user in updated_course_users with the previous ext_id captured' do
+              updated_course_users = result[6]
+              entry = updated_course_users.find { |u| u[:record] == course_user_record }
+              expect(entry).not_to be_nil
+              expect(entry[:previous_external_id]).to eq('old-id')
+            end
+
+            it 'produces no failed_users entry' do
+              _, _, _, _, failed_users = result
+              expect(failed_users).to be_empty
+            end
+          end
+
+          it 'keeps the old external_id with resolution :keep_existing' do
+            invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
+            expect(course_user_record.reload.external_id).to eq('old-id')
+          end
         end
 
-        it 'does not create an invitation' do
-          new_invitations, = result
-          expect(new_invitations).to be_empty
+        context 'when an existing course user is re-invited and the external_id is already taken' do
+          let!(:other_user) { create(:course_student, course: course, external_id: 'taken-id') }
+          let!(:enrolled_user) { create(:user) }
+          let!(:course_user_record) { create(:course_student, course: course, user: enrolled_user, external_id: nil) }
+          let(:invitation_attributes) do
+            { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
+          end
+          subject(:result) { invitation_service.invite(invitation_attributes) }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'does not abort the batch' do
+            expect(result).not_to be_nil
+          end
+
+          it 'puts the user in failed_users with :external_id_taken reason' do
+            _, _, _, _, failed_users = result
+            expect(failed_users.map { |u| u[:reason] }).to include(:external_id_taken)
+          end
+
+          it 'does not update the course_user external_id' do
+            result
+            expect(course_user_record.reload.external_id).to be_nil
+          end
         end
-      end
 
-      context 'when a new invitation ext_id conflicts with a course user ext_id (not a pending invitation)' do
-        let!(:existing_member) { create(:course_student, course: course, external_id: 'cu-taken-id') }
-        let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+        context 'when a new user is invited but the external_id matches an existing course user' do
+          let!(:existing_course_user_ext) { create(:course_student, course: course, external_id: 'taken-id') }
+          let(:new_user) { create(:user) }
+          let(:invitation_attributes) do
+            { '0' => { name: new_user.name, email: new_user.email, role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
+          end
+          subject(:result) { invitation_service.invite(invitation_attributes) }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
 
-        it 'puts the row in failed_users with :external_id_taken and does not create an invitation' do
-          result = invitation_service.invite(
-            { '0' => { name: 'New Person', email: generate(:email), role: :student,
-                       phantom: false, timeline_algorithm: :fixed, external_id: 'cu-taken-id' } }
-          )
-          new_invitations, _, _, _, failed_users = result
-          expect(failed_users.size).to eq(1)
-          expect(failed_users.first[:reason]).to eq(:external_id_taken)
-          expect(new_invitations).to be_empty
+          it 'does not abort the batch' do
+            expect(result).not_to be_nil
+          end
+
+          it 'puts the row in failed_users with :external_id_taken reason' do
+            _, _, _, _, failed_users = result
+            expect(failed_users.first[:reason]).to eq(:external_id_taken)
+          end
+
+          it 'does not enroll the user' do
+            _, _, new_course_users, = result
+            expect(new_course_users).to be_empty
+          end
+        end
+
+        context 'when a new user is enrolled but the external_id matches a pending invitation' do
+          let!(:pending_inv) { create(:course_user_invitation, course: course, external_id: 'taken-id') }
+          let(:new_user) { create(:user) }
+          let(:invitation_attributes) do
+            { '0' => { name: new_user.name, email: new_user.email, role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
+          end
+          subject(:result) { invitation_service.invite(invitation_attributes) }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'puts the row in failed_users with :external_id_taken reason' do
+            _, _, _, _, failed_users = result
+            expect(failed_users.first[:reason]).to eq(:external_id_taken)
+          end
+
+          it 'does not enroll the user' do
+            _, _, new_course_users, = result
+            expect(new_course_users).to be_empty
+          end
+        end
+
+        context 'when an existing course user is re-invited and the external_id is taken by a pending invitation' do
+          let!(:pending_inv) { create(:course_user_invitation, course: course, external_id: 'taken-id') }
+          let!(:enrolled_user) { create(:user) }
+          let!(:course_user_record) { create(:course_student, course: course, user: enrolled_user, external_id: nil) }
+          let(:invitation_attributes) do
+            { '0' => { name: enrolled_user.name, email: enrolled_user.email, role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
+          end
+          subject(:result) { invitation_service.invite(invitation_attributes) }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'puts the user in failed_users with :external_id_taken reason' do
+            _, _, _, _, failed_users = result
+            expect(failed_users.map { |u| u[:reason] }).to include(:external_id_taken)
+          end
+
+          it 'does not update the course_user external_id' do
+            result
+            expect(course_user_record.reload.external_id).to be_nil
+          end
+        end
+
+        context 'when re-inviting a pending invitation whose CSV ext_id is taken by another member' do
+          let!(:other_user) { create(:course_student, course: course, external_id: 'taken-id') }
+          let!(:pending_invitation) do
+            create(:course_user_invitation, course: course,
+                                            email: 'pending@example.com', name: 'Pending User', external_id: 'old-id')
+          end
+          let(:invitation_attributes) do
+            { '0' => { name: 'Pending User', email: 'pending@example.com', role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
+          end
+          subject(:result) { invitation_service.invite(invitation_attributes) }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'puts the user in failed_users with :external_id_taken reason' do
+            _, _, _, _, failed_users = result
+            expect(failed_users.map { |u| u[:reason] }).to include(:external_id_taken)
+          end
+
+          it 'does not update the pending invitation external_id' do
+            result
+            expect(pending_invitation.reload.external_id).to eq('old-id')
+          end
+        end
+
+        context 'when re-inviting a pending invitation with a non-nil ext_id and CSV provides a free different value' do
+          let!(:pending_invitation) do
+            create(:course_user_invitation, course: course,
+                                            email: 'pending@example.com', name: 'Pending User', external_id: 'old-id')
+          end
+          let(:invitation_attributes) do
+            { '0' => { name: 'Pending User', email: 'pending@example.com', role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' } }
+          end
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'raises PendingExternalIdUpdates without resolution' do
+            expect { invitation_service.invite(invitation_attributes) }.
+              to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
+          end
+
+          it 'surfaces the pending invitation with correct IDs in the error' do
+            err = begin
+              invitation_service.invite(invitation_attributes)
+            rescue Course::UserInvitationService::PendingExternalIdUpdates => e
+              e
+            end
+            entry = err.pending_invitation_updates.find { |u| u[:record] == pending_invitation }
+            expect(entry[:new_external_id]).to eq('new-id')
+            expect(entry[:previous_external_id]).to eq('old-id')
+          end
+
+          it 'updates the invitation external_id with resolution :replace_all' do
+            invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all)
+            expect(pending_invitation.reload.external_id).to eq('new-id')
+          end
+
+          it 'keeps the old external_id with resolution :keep_existing' do
+            invitation_service.invite(invitation_attributes, external_id_resolution: :keep_existing)
+            expect(pending_invitation.reload.external_id).to eq('old-id')
+          end
+        end
+
+        context 'when a batch changes an existing invitation ext_id and a later row claims the freed id' do
+          let!(:alice_invitation) do
+            create(:course_user_invitation, course: course,
+                                            email: 'alice@example.com', name: 'Alice', external_id: 'freed-id')
+          end
+          let(:bob_email) { generate(:email) }
+          let(:invitation_attributes) do
+            { '0' => { name: 'Alice', email: 'alice@example.com', role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'new-id' },
+              '1' => { name: 'Bob', email: bob_email, role: :student,
+                       phantom: false, timeline_algorithm: :fixed, external_id: 'freed-id' } }
+          end
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'raises PendingExternalIdUpdates without resolution (Alice has existing ext_id)' do
+            expect { invitation_service.invite(invitation_attributes) }.
+              to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
+          end
+
+          context 'with resolution :replace_all' do
+            subject(:result) { invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all) }
+
+            it 'updates Alice to new-id' do
+              result
+              expect(alice_invitation.reload.external_id).to eq('new-id')
+            end
+
+            it 'creates a new invitation for Bob with the freed id' do
+              new_invitations, = result
+              expect(new_invitations.map(&:external_id)).to include('freed-id')
+            end
+
+            it 'produces no failed_users entries' do
+              _, _, _, _, failed_users = result
+              expect(failed_users).to be_empty
+            end
+          end
+        end
+
+        context 'cross-type freed-id: existing course user frees id, new invitation claims it in same batch' do
+          # invite_new_users runs before add_existing_users, so the new invitation is processed
+          # first and sees the id as still taken. The existing course user is then updated
+          # successfully, but the new invitation has already been rejected.
+          let!(:enrolled_user_freeing) { create(:user) }
+          let!(:course_user_freeing) do
+            create(:course_student, course: course, user: enrolled_user_freeing, external_id: 'freed-id')
+          end
+          let(:new_user_email) { generate(:email) }
+          let(:invitation_attributes) do
+            { '0' => { name: enrolled_user_freeing.name, email: enrolled_user_freeing.email,
+                       role: :student, phantom: false, timeline_algorithm: :fixed,
+                       external_id: 'new-id' },
+              '1' => { name: 'New Person', email: new_user_email,
+                       role: :student, phantom: false, timeline_algorithm: :fixed,
+                       external_id: 'freed-id' } }
+          end
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'raises PendingExternalIdUpdates without resolution' do
+            expect { invitation_service.invite(invitation_attributes) }.
+              to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
+          end
+
+          context 'with resolution :replace_all' do
+            subject(:result) { invitation_service.invite(invitation_attributes, external_id_resolution: :replace_all) }
+
+            it 'updates the existing course user to new-id' do
+              result
+              expect(course_user_freeing.reload.external_id).to eq('new-id')
+            end
+
+            it 'rejects the new invitation because it is processed before the id is freed' do
+              _, _, _, _, failed_users = result
+              expect(failed_users.map { |u| u[:email] }).to include(new_user_email)
+              expect(failed_users.find { |u| u[:email] == new_user_email }[:reason]).to eq(:external_id_taken)
+            end
+          end
+        end
+
+        context 'when a new direct enrollee (existing account, not yet in course) ' \
+                'has an ext_id already taken by another course member' do
+          let!(:other_member) { create(:course_student, course: course, external_id: 'taken-id') }
+          let!(:enrollee) { create(:instance_user).user }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          subject(:result) do
+            invitation_service.invite(
+              { '0' => { name: enrollee.name, email: enrollee.email, role: :student,
+                         phantom: false, timeline_algorithm: :fixed, external_id: 'taken-id' } }
+            )
+          end
+
+          it 'puts the enrollee in failed_users with :external_id_taken' do
+            _, _, _, _, failed_users = result
+            expect(failed_users.size).to eq(1)
+            expect(failed_users.first[:reason]).to eq(:external_id_taken)
+          end
+
+          it 'does not enroll the user' do
+            _, _, new_course_users, = result
+            expect(new_course_users).to be_empty
+          end
+
+          it 'does not create an invitation' do
+            new_invitations, = result
+            expect(new_invitations).to be_empty
+          end
+        end
+
+        context 'when a new direct enrollee (existing account, not yet in course) has a free ext_id' do
+          let!(:enrollee) { create(:instance_user).user }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          subject(:result) do
+            invitation_service.invite(
+              { '0' => { name: enrollee.name, email: enrollee.email, role: :student,
+                         phantom: false, timeline_algorithm: :fixed, external_id: 'free-id' } }
+            )
+          end
+
+          it 'enrols the user with the external_id stored' do
+            _, _, new_course_users, = result
+            expect(new_course_users.size).to eq(1)
+            expect(new_course_users.first.external_id).to eq('free-id')
+          end
+        end
+
+        context 'when a new invitation ext_id conflicts with a course user ext_id (not a pending invitation)' do
+          let!(:existing_member) { create(:course_student, course: course, external_id: 'cu-taken-id') }
+          let(:invitation_service) { Course::UserInvitationService.new(course_user, user, course) }
+
+          it 'puts the row in failed_users with :external_id_taken and does not create an invitation' do
+            result = invitation_service.invite(
+              { '0' => { name: 'New Person', email: generate(:email), role: :student,
+                         phantom: false, timeline_algorithm: :fixed, external_id: 'cu-taken-id' } }
+            )
+            new_invitations, _, _, _, failed_users = result
+            expect(failed_users.size).to eq(1)
+            expect(failed_users.first[:reason]).to eq(:external_id_taken)
+            expect(new_invitations).to be_empty
+          end
         end
       end
 
@@ -952,108 +1163,6 @@ RSpec.describe Course::UserInvitationService, type: :service do
       end
     end
 
-    describe 'ext_id handling on existing records' do
-      let(:course) { create(:course) }
-      let(:manager) { create(:course_manager, course: course) }
-      subject { Course::UserInvitationService.new(manager, manager.user, course) }
-
-      # An existing pending invitation with nil ext_id; CSV provides EXT001 (free)
-      let!(:existing_inv_nil_ext) { create(:course_user_invitation, course: course, external_id: nil) }
-      let(:inv_nil_ext_user_attrs) do
-        { '0' => { name: existing_inv_nil_ext.name, email: existing_inv_nil_ext.email,
-                   role: :student, phantom: false, timeline_algorithm: :fixed, external_id: 'EXT001' } }
-      end
-
-      # Another invitation that already holds 'TAKEN' so EXT_TAKEN is not free
-      let!(:other_inv) { create(:course_user_invitation, course: course, external_id: 'TAKEN') }
-      # An existing pending invitation with nil ext_id; CSV provides TAKEN (already in DB)
-      let!(:existing_inv_taken_ext) { create(:course_user_invitation, course: course, external_id: nil) }
-      let(:inv_taken_ext_user_attrs) do
-        { '0' => { name: existing_inv_taken_ext.name, email: existing_inv_taken_ext.email,
-                   role: :student, phantom: false, timeline_algorithm: :fixed, external_id: 'TAKEN' } }
-      end
-
-      # An existing enrolled course user with nil ext_id; CSV provides EXT002 (free)
-      let!(:enrolled_nil) { create(:course_student, course: course, external_id: nil) }
-      let(:enrolled_nil_user_attrs) do
-        { '0' => { name: enrolled_nil.name, email: enrolled_nil.user.email,
-                   role: :student, phantom: false, timeline_algorithm: :fixed, external_id: 'EXT002' } }
-      end
-
-      # An existing enrolled course user with ext_id 'EXISTING'; CSV provides 'DIFFERENT'
-      let!(:enrolled_conflict) { create(:course_student, course: course, external_id: 'EXISTING') }
-      let(:enrolled_conflict_user_attrs) do
-        { '0' => { name: enrolled_conflict.name, email: enrolled_conflict.user.email,
-                   role: :student, phantom: false, timeline_algorithm: :fixed, external_id: 'DIFFERENT' } }
-      end
-
-      it 'raises PendingExternalIdUpdates when existing invitation has nil ext_id and CSV value is free' do
-        expect { subject.invite(inv_nil_ext_user_attrs) }.
-          to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-      end
-
-      it 'sets ext_id on existing invitation when current is nil and CSV value is free with :replace_all' do
-        result = subject.invite(inv_nil_ext_user_attrs, external_id_resolution: :replace_all)
-        expect(result).not_to be_nil
-        updated_invitations = result[5]
-        expect(updated_invitations.length).to eq(1)
-        expect(updated_invitations.map { |u| u[:record] }.first.external_id).to eq('EXT001')
-        expect(existing_inv_nil_ext.reload.external_id).to eq('EXT001')
-      end
-
-      it 'rejects with :external_id_taken when existing invitation has nil ext_id but CSV value is taken' do
-        result = subject.invite(inv_taken_ext_user_attrs)
-        expect(result).not_to be_nil
-        failed_users = result[4]
-        expect(failed_users.map { |u| u[:reason] }).to include(:external_id_taken)
-      end
-
-      it 'raises PendingExternalIdUpdates when existing course user has nil ext_id and CSV value is free' do
-        expect { subject.invite(enrolled_nil_user_attrs) }.
-          to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-      end
-
-      it 'sets ext_id on existing course user when current is nil and CSV value is free with :replace_all' do
-        result = subject.invite(enrolled_nil_user_attrs, external_id_resolution: :replace_all)
-        expect(result).not_to be_nil
-        updated_course_users = result[6]
-        expect(updated_course_users.length).to eq(1)
-        expect(updated_course_users.map { |u| u[:record] }.first.external_id).to eq('EXT002')
-        expect(enrolled_nil.reload.external_id).to eq('EXT002')
-      end
-
-      context 'when an existing course user has non-nil ext_id and CSV provides a free different value' do
-        it 'raises PendingExternalIdUpdates without resolution' do
-          expect { subject.invite(enrolled_conflict_user_attrs) }.
-            to raise_error(Course::UserInvitationService::PendingExternalIdUpdates)
-        end
-
-        it 'updates the course_user external_id with resolution :replace_all' do
-          subject.invite(enrolled_conflict_user_attrs, external_id_resolution: :replace_all)
-          expect(enrolled_conflict.reload.external_id).to eq('DIFFERENT')
-        end
-
-        it 'puts the user in updated_course_users with resolution :replace_all' do
-          result = subject.invite(enrolled_conflict_user_attrs, external_id_resolution: :replace_all)
-          updated_course_users = result[6]
-          expect(updated_course_users.map { |u| u[:record] }).to include(enrolled_conflict)
-        end
-
-        it 'captures the previous ext_id with resolution :replace_all' do
-          result = subject.invite(enrolled_conflict_user_attrs, external_id_resolution: :replace_all)
-          updated_course_users = result[6]
-          entry = updated_course_users.find { |u| u[:record] == enrolled_conflict }
-          expect(entry[:previous_external_id]).to eq('EXISTING')
-        end
-
-        it 'produces no failed_users entry with resolution :replace_all' do
-          result = subject.invite(enrolled_conflict_user_attrs, external_id_resolution: :replace_all)
-          _, _, _, _, failed_users = result
-          expect(failed_users).to be_empty
-        end
-      end
-    end
-
     describe '#resend_invitation' do
       let(:previous_sent_time) { 1.day.ago }
       let(:pending_invitations) do
@@ -1077,6 +1186,14 @@ RSpec.describe Course::UserInvitationService, type: :service do
 
       it 'returns true if there are no errors' do
         expect(subject.resend_invitation(pending_invitations)).to be_truthy
+      end
+
+      with_active_job_queue_adapter(:test) do
+        it 'returns true without sending anything when given no invitations', type: :mailer do
+          expect do
+            expect(subject.resend_invitation([])).to be_truthy
+          end.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
       end
     end
 
@@ -1175,6 +1292,19 @@ RSpec.describe Course::UserInvitationService, type: :service do
             f.rewind
             stubbed_user_invitation_service.send(:parse_from_file, f)
             expect(stubbed_user_invitation_service.blank_header_warning).to be false
+          end
+        end
+      end
+
+      context 'when a data row has an email but a blank name' do
+        it 'defaults the name to the email' do
+          Tempfile.create(['blank_name', '.csv']) do |f|
+            f.write("Name,Email\n,alice@example.com\n")
+            f.rewind
+            result = stubbed_user_invitation_service.send(:parse_from_file, f)
+            expect(result.length).to eq(1)
+            expect(result[0][:name]).to eq('alice@example.com')
+            expect(result[0][:email]).to eq('alice@example.com')
           end
         end
       end


### PR DESCRIPTION
## Summary

The CSV invitation upload flow had several paths that either gave no feedback or silently swallowed data. This PR addresses them together: long imports now show a loading toast; the external ID conflict prompt no longer vanishes mid-import; CSV rows with a blank email are surfaced as failures instead of being silently dropped; a file that yields no invitable rows returns a clear error instead of a misleading "0 invited / 0 skipped / 0 failed" summary; and all unrecognized headers are reported at once instead of one per round-trip. The upload help text was also reworded to match the actual requirements.

## Design decisions

- Surface a blank-email row as a "Missing email" failure only when it carries an identity column (Name or External ID); a row with neither is still skipped silently - a faceless row cannot be mapped back to a line in the user's CSV, so showing it would be noise.
- Collect every unrecognized header and report them in one error with the accepted list, rather than failing on the first - a multi-typo file is then fixable in a single round-trip. Strict rejection is kept (no auto-correct or "did you mean" guessing) to stay consistent with the flow's "never silently lose data" stance.
- Keep the conflict prompt mounted until the server responds and disable its buttons during resolution, rather than clearing it on click - clearing eagerly flipped the upload form (`open && !conflictData`) back open for the duration of the import.
- Guard the empty submit in `onSubmit` with a toast instead of form-level validation - the file input renders field errors awkwardly inside the dropzone and triggers a redundant generic error banner, neither of which a toast has.

## Regression prevention

Backend specs cover: blank-email-with-name and blank-email-with-external-id surfaced as missing-email failures, blank-with-no-identity skipped, an all-missing-email file not raising, unrecognized headers reported in full (not just the first), and the relaxed no-valid-rows guard. Frontend tests cover: the loading toast appearing and being dismissed on success and on error, the conflict prompt staying open during resolution, the missing-email reason label rendering, and the empty-submit toast firing without dispatching an import.

Manually tested: valid upload (loading toast then result dialog), multiple unrecognized headers reported together, missing-email rows shown in the failed table, empty/header-only CSV returning the no-rows error, and the conflict prompt staying put with disabled buttons during a slow import. The select-then-remove empty-submit path is not reachable through the UI (a file cannot be removed without discarding), so its guard is covered by the unit test only.

Backward compatible: valid CSVs behave exactly as before; the new handling only affects rows and files that previously produced no feedback or silent drops.